### PR TITLE
fix(install): ad-hoc codesign binary on macOS to prevent "modified" warning

### DIFF
--- a/docs/install.sh
+++ b/docs/install.sh
@@ -160,6 +160,9 @@ if [ "${PATH_HINT:-}" = "1" ]; then
 fi
 
 if [ "$OS" = "darwin" ]; then
-  # Unsigned binaries trigger macOS Gatekeeper warnings on first run.
   xattr -d com.apple.quarantine "${INSTALL_DIR}/sense" 2>/dev/null || true
+  # Ad-hoc codesign so macOS tracks by code identity, not raw checksum.
+  # Without this, each update triggers a "program has been modified" warning
+  # when Sense makes network requests.
+  codesign --force --sign - "${INSTALL_DIR}/sense" 2>/dev/null || true
 fi

--- a/install.sh
+++ b/install.sh
@@ -160,6 +160,9 @@ if [ "${PATH_HINT:-}" = "1" ]; then
 fi
 
 if [ "$OS" = "darwin" ]; then
-  # Unsigned binaries trigger macOS Gatekeeper warnings on first run.
   xattr -d com.apple.quarantine "${INSTALL_DIR}/sense" 2>/dev/null || true
+  # Ad-hoc codesign so macOS tracks by code identity, not raw checksum.
+  # Without this, each update triggers a "program has been modified" warning
+  # when Sense makes network requests.
+  codesign --force --sign - "${INSTALL_DIR}/sense" 2>/dev/null || true
 fi


### PR DESCRIPTION
## Summary

When Sense makes its first network request (e.g. to api.github.com), macOS
stores the binary's checksum for future identity checks. On reinstall or
update, the new binary has a different checksum, causing macOS to show a
scary "The program 'sense' has been modified" warning — implying possible
malware replacement. This PR ad-hoc codesigns the binary during installation
so macOS tracks it by code identity instead of raw checksum, replacing the
alarming warning with a clean first-run connection prompt.

## Changes

- Add `codesign --force --sign -` after binary installation on macOS in
  both `install.sh` and `docs/install.sh`
- The `--force` flag ensures any previous signature is replaced cleanly
- Fails silently (`|| true`) on the off chance codesign is unavailable

## Test Plan

- [x] Install sense on macOS via `install.sh`, confirm no "modified" warning
- [x] Update sense (run install again), confirm the prompt is a clean
      "wants to connect" dialog, not the "has been modified" warning
- [x] Install on Linux — codesign step is skipped, no change in behavior
- [x] `make ci` passes