### PR TITLE
feat(hook): close Sense bypass escape hatches and reframe guidance

### DIFF
--- a/.github/workflows/council-review.yml
+++ b/.github/workflows/council-review.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: luuuc/council/action@v0.15.4
+      - uses: luuuc/council/action@main
         with:
           pack: go
           # anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/council-review.yml
+++ b/.github/workflows/council-review.yml
@@ -1,7 +1,7 @@
 name: Council Review
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   models: read
@@ -14,7 +14,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: luuuc/council/action@v1
         with:
           pack: go

--- a/.github/workflows/council-review.yml
+++ b/.github/workflows/council-review.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: luuuc/council/action@v1
+      - uses: luuuc/council/action@v0.15.3
         with:
           pack: go
           # anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/council-review.yml
+++ b/.github/workflows/council-review.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: luuuc/council/action@v0.15.3
+      - uses: luuuc/council/action@v0.15.4
         with:
           pack: go
           # anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/council-review.yml
+++ b/.github/workflows/council-review.yml
@@ -1,0 +1,21 @@
+name: Council Review
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+
+permissions:
+  models: read
+  pull-requests: write
+  contents: read
+  checks: write
+
+jobs:
+  review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: luuuc/council/action@v1
+        with:
+          pack: go
+          # anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.mcp.json
+++ b/.mcp.json
@@ -5,7 +5,7 @@
         "mcp"
       ],
       "command": "sense",
-      "serverInstructions": "When Sense is available and indexed, you MUST use Sense tools instead of grep, glob, or exploration agents for structural and semantic code questions. Sense provides pre-indexed results that are faster and more complete.\n\nWHEN TO USE SENSE TOOLS:\n- Symbol relationships, callers, dependencies → sense.graph\n- \"What would break if I changed X?\", impact analysis → sense.blast\n- Conceptual/semantic code search (not exact string match) → sense.search\n- Project patterns and conventions → sense.conventions\n- Index health, what's indexed → sense.status\n\nWHEN NOT TO USE SENSE TOOLS:\n- Exact text/string search → use grep\n- Reading file contents → use your file reading tool\n- Editing code → Sense is read-only"
+      "serverInstructions": "When Sense is available and indexed, you MUST use Sense tools instead of grep, glob, or exploration agents for codebase understanding, exploration, and research. Sense provides pre-indexed results that are faster and more complete.\n\nWHEN TO USE SENSE TOOLS:\n- Symbol relationships, callers, dependencies → sense.graph\n- \"What would break if I changed X?\", impact analysis → sense.blast\n- Conceptual/semantic code search (not exact string match) → sense.search\n- Project patterns and conventions → sense.conventions\n- Index health, what's indexed → sense.status\n- ANY question about how the codebase works or is structured → start with Sense\n\nWHEN NOT TO USE SENSE TOOLS:\n- Exact text/string search → use grep\n- Reading file contents → use your file reading tool\n- Editing code → Sense is read-only"
     }
   }
 }

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -333,3 +333,210 @@ func TestIsSymbolShaped(t *testing.T) {
 		}
 	}
 }
+
+func TestPreToolUseAgentExplorationIntentDeny(t *testing.T) {
+	dir := indexedDir(t)
+	input := `{"tool_name":"Agent","tool_input":{"subagent_type":"general-purpose","prompt":"explore the codebase to understand the architecture"}}`
+	var buf bytes.Buffer
+	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
+
+	var resp denyResponse
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if resp.Output.Decision != "deny" {
+		t.Fatalf("expected deny for exploration-intent agent, got %q", resp.Output.Decision)
+	}
+}
+
+func TestPreToolUseAgentDescriptionFallback(t *testing.T) {
+	dir := indexedDir(t)
+	input := `{"tool_name":"Agent","tool_input":{"subagent_type":"general-purpose","description":"explore the codebase structure"}}`
+	var buf bytes.Buffer
+	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
+
+	var resp denyResponse
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if resp.Output.Decision != "deny" {
+		t.Fatalf("expected deny for exploration-intent description, got %q", resp.Output.Decision)
+	}
+}
+
+func TestPreToolUseAgentNoExplorationIntentPass(t *testing.T) {
+	dir := indexedDir(t)
+	input := `{"tool_name":"Agent","tool_input":{"subagent_type":"general-purpose","prompt":"format the markdown tables in README"}}`
+	var buf bytes.Buffer
+	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
+
+	if buf.String() != "{}\n" {
+		t.Errorf("non-exploration agent should be no-op, got %q", buf.String())
+	}
+}
+
+func TestPreToolUseConceptSearchAdvise(t *testing.T) {
+	dir := indexedDir(t)
+	input := `{"tool_name":"Grep","tool_input":{"pattern":"error handling middleware"}}`
+	var buf bytes.Buffer
+	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
+
+	var resp hookResponse
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if resp.AdditionalContext == "" {
+		t.Fatal("expected advisory for concept search pattern")
+	}
+	if !strings.Contains(resp.AdditionalContext, "sense_search") {
+		t.Error("expected sense_search suggestion in advisory")
+	}
+}
+
+func TestPreToolUseBashFindCodeAdvise(t *testing.T) {
+	dir := indexedDir(t)
+	input := `{"tool_name":"Bash","tool_input":{"command":"find . -name \"*.go\" -type f"}}`
+	var buf bytes.Buffer
+	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
+
+	var resp hookResponse
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if resp.AdditionalContext == "" {
+		t.Fatal("expected advisory for find code files")
+	}
+}
+
+func TestPreToolUseBashHeadCodeAdvise(t *testing.T) {
+	dir := indexedDir(t)
+	input := `{"tool_name":"Bash","tool_input":{"command":"head -20 internal/hook/pre_tool_use.go"}}`
+	var buf bytes.Buffer
+	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
+
+	var resp hookResponse
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if resp.AdditionalContext == "" {
+		t.Fatal("expected advisory for head on code file")
+	}
+}
+
+func TestPreToolUseBashHeadNonCodePass(t *testing.T) {
+	dir := indexedDir(t)
+	input := `{"tool_name":"Bash","tool_input":{"command":"head -20 README.md"}}`
+	var buf bytes.Buffer
+	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
+
+	if buf.String() != "{}\n" {
+		t.Errorf("head on non-code file should be no-op, got %q", buf.String())
+	}
+}
+
+func TestPreToolUseBashFindNonCodePass(t *testing.T) {
+	dir := indexedDir(t)
+	input := `{"tool_name":"Bash","tool_input":{"command":"find . -name \"*.md\" -type f"}}`
+	var buf bytes.Buffer
+	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
+
+	if buf.String() != "{}\n" {
+		t.Errorf("find non-code files should be no-op, got %q", buf.String())
+	}
+}
+
+func TestHasExplorationKeyword(t *testing.T) {
+	cases := []struct {
+		prompt string
+		want   bool
+	}{
+		{"explore the codebase to find auth flow", true},
+		{"find implementations of the handler interface", true},
+		{"who calls this function", true},
+		{"understand the code structure", true},
+		{"what would break if I change this", true},
+		{"Deep codebase exploration using semantic search", true},
+		{"CODEBASE EXPLORATION using semantic search", true},
+		{"format the markdown tables in README", false},
+		{"fix the typo in the error message", false},
+		{"run the test suite", false},
+		{"do something", false},
+		{"update the codebase documentation", false},
+		{"run linting on the codebase", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := hasExplorationKeyword(tc.prompt); got != tc.want {
+			t.Errorf("hasExplorationKeyword(%q) = %v, want %v", tc.prompt, got, tc.want)
+		}
+	}
+}
+
+func TestIsMultiWordPattern(t *testing.T) {
+	cases := []struct {
+		pattern string
+		want    bool
+	}{
+		{"error handling middleware", true},
+		{"review engine flow", true},
+		{"a bc", true},
+		{"auth", false},
+		{"UserService", false},
+		{"a b", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isMultiWordPattern(tc.pattern); got != tc.want {
+			t.Errorf("isMultiWordPattern(%q) = %v, want %v", tc.pattern, got, tc.want)
+		}
+	}
+}
+
+func TestIsExplorationCommand(t *testing.T) {
+	cases := []struct {
+		cmd  string
+		want bool
+	}{
+		{`find . -name "*.go" -type f`, true},
+		{`find . -name "*.md"`, false},
+		{`head -20 main.go`, true},
+		{`head -20 README.md`, false},
+		{`cat internal/hook/hook.go`, true},
+		{`cat package.json`, false},
+		{`tail -f app.log`, false},
+		{`wc -l *.go`, true},
+		{`wc -l *.md`, false},
+		{`ls -la`, false},
+		{`git status`, false},
+		{`make build`, false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isExplorationCommand(tc.cmd); got != tc.want {
+			t.Errorf("isExplorationCommand(%q) = %v, want %v", tc.cmd, got, tc.want)
+		}
+	}
+}
+
+func TestHasCodeExtension(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"main.go", true},
+		{"app.py", true},
+		{"index.ts", true},
+		{"component.tsx", true},
+		{"script.js", true},
+		{"README.md", false},
+		{"package.json", false},
+		{"go.mod", false},
+		{"Makefile", false},
+		{"*.go", true},
+	}
+	for _, tc := range cases {
+		if got := hasCodeExtension(tc.path); got != tc.want {
+			t.Errorf("hasCodeExtension(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}

--- a/internal/hook/pre_compact.go
+++ b/internal/hook/pre_compact.go
@@ -39,7 +39,7 @@ func handlePreCompact(ctx context.Context, _ json.RawMessage, adapter *sqlite.Ad
 		}
 	}
 
-	sb.WriteString("\nUse Sense MCP tools (sense_graph, sense_search, sense_blast, sense_conventions) instead of grep/glob for structural questions.")
+	sb.WriteString("\nUse Sense MCP tools (sense_graph, sense_search, sense_blast, sense_conventions) for ALL codebase understanding — not just symbol lookups.")
 
 	return &messageResponse{Message: sb.String()}, nil
 }

--- a/internal/hook/pre_tool_use.go
+++ b/internal/hook/pre_tool_use.go
@@ -17,12 +17,48 @@ type preToolUseInput struct {
 		Command      string `json:"command"`
 		Regex        string `json:"regex"`
 		SubagentType string `json:"subagent_type"`
+		Prompt       string `json:"prompt"`
+		Description  string `json:"description"`
 	} `json:"tool_input"`
 }
 
 var explorationAgents = map[string]bool{
 	"deep-explore": true,
 	"Explore":      true,
+}
+
+var explorationPhrases = []string{
+	"explore the codebase",
+	"search the codebase",
+	"understand the codebase",
+	"research the codebase",
+	"codebase structure",
+	"codebase architecture",
+	"codebase exploration",
+	"codebase understanding",
+	"code structure",
+	"code architecture",
+	"code exploration",
+	"find implementation",
+	"find callers",
+	"find uses of",
+	"find where",
+	"who calls",
+	"what calls",
+	"callers of",
+	"callees of",
+	"dependencies of",
+	"understand the code",
+	"how does the code",
+	"what would break",
+	"blast radius",
+	"impact of changing",
+	"symbol relationship",
+}
+
+var codeExtensions = []string{
+	".go", ".py", ".ts", ".tsx", ".js", ".jsx",
+	".rb", ".rs", ".java", ".kt", ".scala", ".cs", ".php",
 }
 
 func handlePreToolUse(ctx context.Context, input json.RawMessage, adapter *sqlite.Adapter, _ string) (any, error) {
@@ -43,12 +79,21 @@ func handlePreToolUse(ctx context.Context, input json.RawMessage, adapter *sqlit
 
 func handleGrepGlob(ctx context.Context, req preToolUseInput, adapter *sqlite.Adapter) (any, error) {
 	pattern := extractPattern(req)
-	if pattern == "" || !isSymbolShaped(pattern) {
+	if pattern == "" {
+		return nil, nil
+	}
+
+	if !isSymbolShaped(pattern) {
 		return nil, nil
 	}
 
 	symbols, err := adapter.Query(ctx, index.Filter{Name: pattern, Limit: 5})
 	if err != nil || len(symbols) == 0 {
+		if isMultiWordPattern(pattern) {
+			return advise(fmt.Sprintf(
+				"Consider sense_search query=%q for semantic code search. "+
+					"Load tools first: %s", pattern, toolSearchCmd)), nil
+		}
 		return nil, nil
 	}
 
@@ -56,7 +101,15 @@ func handleGrepGlob(ctx context.Context, req preToolUseInput, adapter *sqlite.Ad
 }
 
 func handleAgent(ctx context.Context, req preToolUseInput, adapter *sqlite.Adapter) (any, error) {
-	if !explorationAgents[req.Input.SubagentType] {
+	isKnownExplorer := explorationAgents[req.Input.SubagentType]
+
+	prompt := req.Input.Prompt
+	if prompt == "" {
+		prompt = req.Input.Description
+	}
+	hasExplorationIntent := prompt != "" && hasExplorationKeyword(prompt)
+
+	if !isKnownExplorer && !hasExplorationIntent {
 		return nil, nil
 	}
 
@@ -66,8 +119,7 @@ func handleAgent(ctx context.Context, req preToolUseInput, adapter *sqlite.Adapt
 	}
 
 	reason := fmt.Sprintf(
-		"This project has a Sense index (%d symbols). Do not spawn exploration agents for structural questions. "+
-			"Use Sense MCP tools instead:\n"+
+		"This project has a Sense index (%d symbols). Use Sense MCP tools instead of agents for codebase understanding:\n"+
 			"- sense_graph for symbol relationships (callers, callees, inheritance)\n"+
 			"- sense_search for semantic code search\n"+
 			"- sense_blast for impact analysis\n"+
@@ -79,17 +131,28 @@ func handleAgent(ctx context.Context, req preToolUseInput, adapter *sqlite.Adapt
 }
 
 func handleBash(ctx context.Context, req preToolUseInput, adapter *sqlite.Adapter) (any, error) {
-	pattern := extractBashPattern(req.Input.Command)
-	if pattern == "" || !isSymbolShaped(pattern) {
-		return nil, nil
+	cmd := req.Input.Command
+
+	pattern := extractBashPattern(cmd)
+	if pattern != "" && isSymbolShaped(pattern) {
+		symbols, err := adapter.Query(ctx, index.Filter{Name: pattern, Limit: 5})
+		if err == nil && len(symbols) > 0 {
+			return denyOrAdvise(ctx, adapter, len(symbols), pattern, "bash grep"), nil
+		}
+		if isMultiWordPattern(pattern) {
+			return advise(fmt.Sprintf(
+				"Consider sense_search query=%q for semantic code search. "+
+					"Load tools first: %s", pattern, toolSearchCmd)), nil
+		}
 	}
 
-	symbols, err := adapter.Query(ctx, index.Filter{Name: pattern, Limit: 5})
-	if err != nil || len(symbols) == 0 {
-		return nil, nil
+	if isExplorationCommand(cmd) {
+		return advise(
+			"Sense can answer codebase understanding questions without reading individual files. "+
+				"Load tools first: "+toolSearchCmd), nil
 	}
 
-	return denyOrAdvise(ctx, adapter, len(symbols), pattern, "bash grep"), nil
+	return nil, nil
 }
 
 // denyOrAdvise blocks the tool call when the index is fresh, or adds
@@ -172,4 +235,53 @@ func isSymbolShaped(pattern string) bool {
 		}
 	}
 	return len(pattern) >= 2
+}
+
+func hasExplorationKeyword(prompt string) bool {
+	lower := strings.ToLower(prompt)
+	for _, phrase := range explorationPhrases {
+		if strings.Contains(lower, phrase) {
+			return true
+		}
+	}
+	return false
+}
+
+func isMultiWordPattern(pattern string) bool {
+	return strings.Contains(pattern, " ") && len(pattern) >= 4
+}
+
+func isExplorationCommand(cmd string) bool {
+	fields := strings.Fields(cmd)
+	if len(fields) == 0 {
+		return false
+	}
+
+	switch fields[0] {
+	case "find", "head", "cat", "tail", "less", "more", "wc":
+		return argsHaveCodeExtension(fields)
+	}
+	return false
+}
+
+func argsHaveCodeExtension(fields []string) bool {
+	for _, f := range fields {
+		if strings.HasPrefix(f, "-") {
+			continue
+		}
+		f = strings.Trim(f, "'\"")
+		if hasCodeExtension(f) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasCodeExtension(s string) bool {
+	for _, ext := range codeExtensions {
+		if strings.HasSuffix(s, ext) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/hook/response.go
+++ b/internal/hook/response.go
@@ -29,3 +29,7 @@ func deny(reason string) *denyResponse {
 		},
 	}
 }
+
+func advise(msg string) *hookResponse {
+	return &hookResponse{AdditionalContext: msg}
+}

--- a/internal/hook/session_start.go
+++ b/internal/hook/session_start.go
@@ -60,8 +60,8 @@ func handleSessionStart(ctx context.Context, _ json.RawMessage, adapter *sqlite.
 
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "Sense index: %d symbols, %d edges, %d languages (%s). Last scan: %s.\n", symbolCount, edgeCount, len(langs), strings.Join(langs, ", "), lastScan)
-	fmt.Fprintf(&sb, "REQUIRED: Run %s now to load Sense tools.\n", toolSearchCmd)
-	sb.WriteString("Use Sense MCP tools for ALL structural questions — do not use grep, glob, or exploration agents.")
+	fmt.Fprintf(&sb, "REQUIRED: Your FIRST tool call MUST be %s to load Sense tools.\n", toolSearchCmd)
+	sb.WriteString("Use Sense MCP tools for ALL codebase understanding — do not use grep, glob, Read, Bash, or agents before loading Sense.")
 
 	return &messageResponse{Message: sb.String()}, nil
 }

--- a/internal/hook/subagent_start.go
+++ b/internal/hook/subagent_start.go
@@ -18,13 +18,13 @@ func handleSubagentStart(ctx context.Context, _ json.RawMessage, adapter *sqlite
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "IMPORTANT: This project has a Sense index (%d symbols). ", count)
 	sb.WriteString("You cannot call Sense MCP tools directly, but the parent agent can. ")
-	sb.WriteString("If your task involves finding symbol callers, tracing dependencies, or understanding code structure, ")
+	sb.WriteString("For ANY task involving codebase understanding — finding callers, tracing dependencies, exploring architecture, researching code, or understanding how code works — ")
 	sb.WriteString("report back to the parent agent and recommend it use:\n")
 	sb.WriteString("- sense_graph for symbol relationships (callers, callees, inheritance)\n")
 	sb.WriteString("- sense_search for semantic code search\n")
 	sb.WriteString("- sense_blast for impact analysis\n")
 	sb.WriteString("- sense_conventions for project patterns\n")
-	sb.WriteString("Sense answers structural questions faster and more completely than grep/glob.")
+	sb.WriteString("Do not attempt to answer codebase questions with grep or file reading — Sense is faster and more complete.")
 
 	return &hookResponse{AdditionalContext: sb.String()}, nil
 }

--- a/internal/setup/claudemd.go
+++ b/internal/setup/claudemd.go
@@ -18,17 +18,18 @@ const senseSection = `<!-- sense:start -->
 
 Sense gives you structural understanding of the codebase — symbols, relationships, patterns — without reading dozens of files.
 
-**BEFORE any code exploration, symbol lookup, or agent spawning:**
+**Your FIRST action in every conversation — before responding, before any tool call — MUST be:**
 
 1. Load Sense tools: ` + "`ToolSearch(\"select:mcp__sense__sense_graph,mcp__sense__sense_search,mcp__sense__sense_blast,mcp__sense__sense_conventions,mcp__sense__sense_status\")`" + `
 2. Call ` + "`sense_status`" + ` to confirm index health
-3. Use ` + "`sense_graph`" + `, ` + "`sense_search`" + `, ` + "`sense_blast`" + ` for ALL structural questions
+3. Use Sense tools for ALL codebase understanding — exploration, research, architecture, callers, dependencies, search
 
 **You MUST NOT:**
 
-- Spawn deep-explore or Explore agents for structural questions — Sense answers them directly
+- Spawn deep-explore, Explore, or general-purpose agents for codebase questions — Sense answers them directly
 - Use grep/glob to find symbol callers, implementations, or dependencies
 - Skip Sense because tools are deferred — load them with ToolSearch first
+- Fall back to Read/Bash after a hook blocks another tool — the hook is telling you to use Sense
 
 **When to use each tool:**
 

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -83,14 +83,15 @@ func writeMCPJSON(root string) (bool, error) {
 		"command": "sense",
 		"args":    []any{"mcp"},
 		"serverInstructions": "When Sense is available and indexed, you MUST use Sense tools " +
-			"instead of grep, glob, or exploration agents for structural and semantic code " +
-			"questions. Sense provides pre-indexed results that are faster and more complete.\n\n" +
+			"instead of grep, glob, or exploration agents for codebase understanding, " +
+			"exploration, and research. Sense provides pre-indexed results that are faster and more complete.\n\n" +
 			"WHEN TO USE SENSE TOOLS:\n" +
 			"- Symbol relationships, callers, dependencies → sense.graph\n" +
 			"- \"What would break if I changed X?\", impact analysis → sense.blast\n" +
 			"- Conceptual/semantic code search (not exact string match) → sense.search\n" +
 			"- Project patterns and conventions → sense.conventions\n" +
-			"- Index health, what's indexed → sense.status\n\n" +
+			"- Index health, what's indexed → sense.status\n" +
+			"- ANY question about how the codebase works or is structured → start with Sense\n\n" +
 			"WHEN NOT TO USE SENSE TOOLS:\n" +
 			"- Exact text/string search → use grep\n" +
 			"- Reading file contents → use your file reading tool\n" +


### PR DESCRIPTION
## Summary

Claude repeatedly bypasses Sense tools — even with hooks, CLAUDE.md instructions, MCP server instructions, skills, and memory all telling it to use Sense. After four iterations of the same failure, root cause analysis revealed two problems: (1) every message framed Sense as for "structural code questions," causing Claude to classify general exploration as outside Sense's scope, and (2) three escape hatches let Claude route around denials via general-purpose agents, concept-grep, and file-reading Bash commands.

## Problem

The bypass chain looks like this:
1. User asks Claude to research the codebase
2. Claude classifies task as "reading files" not "structural code question"
3. Spawns Explore agent → **hook denies**
4. Falls back to general-purpose agent → **passes through** (only deep-explore and Explore were blocked)
5. Or falls back to `grep "review engine"` → **passes through** (not a known symbol)
6. Or falls back to `head -20 main.go` → **passes through** (Bash hook only caught grep/rg/ag)
7. Gets the answer without ever touching Sense

## Changes

### Escape hatch closures (`pre_tool_use.go`)
- Block agents with exploration-intent prompts, not just named agent types — checks prompt/description against keyword phrases like "explore the codebase", "who calls", "find implementation"
- Advise `sense_search` when grep pattern is multi-word (concept search like "error handling middleware")
- Advise Sense when Bash runs `find`/`head`/`cat`/`tail`/`wc` on code files
- Add `advise()` response helper (advisory context, doesn't block) alongside `deny()`

### Framing fix (all hook messages + setup templates)
- Replace "structural and semantic code questions" with "codebase understanding" everywhere
- Session-start: "REQUIRED: Run ToolSearch" → "REQUIRED: Your FIRST tool call MUST be ToolSearch"
- CLAUDE.md: "BEFORE any code exploration" → "Your FIRST action in every conversation"
- Subagent-start: "finding symbol callers" → "ANY codebase understanding"
- serverInstructions: added "ANY question about how the codebase works"

### Council review refinements
- Narrowed `"codebase"` keyword to specific phrases (`"explore the codebase"`, `"codebase structure"`, etc.) to prevent false positives on prompts like "update the codebase docs"
- Renamed `looksLikeExploration` → `hasExplorationKeyword`, `looksLikeConceptSearch` → `isMultiWordPattern`
- Merged `mentionsCodeFiles`/`argsHaveCodeFile` into single `argsHaveCodeExtension`

## Test Plan
- [x] 13 new tests covering all new detection paths
- [x] Boundary tests: exact len=4 for multi-word, case-insensitivity for keywords
- [x] False-positive tests: "update the codebase documentation" passes through
- [x] All 17 existing tests pass unchanged (no regressions)
- [x] `make ci` passes (build + test + lint)