### PR TITLE
feat(cli): replace automatic version check with explicit `sense update` command

### DIFF
--- a/cmd/sense/main.go
+++ b/cmd/sense/main.go
@@ -39,6 +39,7 @@ Commands:
   doctor        Diagnose common index problems
   hook          Claude Code lifecycle hooks (pre-tool-use, pre-compact, etc.)
   mcp           Start the MCP server (stdio transport)
+  update        Check for and install the latest version
   version       Print version
   help          Show this help
 
@@ -50,7 +51,6 @@ func main() {
 
 	if len(os.Args) < 2 {
 		if isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()) {
-			versioncheck.CheckAndNotify(os.Stderr)
 			adapter, err := cli.OpenIndex(ctx, ".")
 			if err != nil {
 				if errors.Is(err, cli.ErrIndexMissing) {
@@ -73,25 +73,6 @@ func main() {
 	}
 
 	cmd := os.Args[1]
-
-	switch cmd {
-	case "version", "--version", "-v", "help", "--help", "-h", "mcp", "hook":
-		// no version check for these
-	default:
-		jsonMode := false
-		for _, a := range os.Args[2:] {
-			if a == "--" {
-				break
-			}
-			if a == "--json" || a == "-json" {
-				jsonMode = true
-				break
-			}
-		}
-		if !jsonMode {
-			versioncheck.CheckAndNotify(os.Stderr)
-		}
-	}
 
 	switch cmd {
 	case "version", "--version", "-v":
@@ -201,6 +182,9 @@ func main() {
 			fmt.Fprintln(os.Stderr, "sense mcp:", err)
 			os.Exit(1)
 		}
+
+	case "update":
+		os.Exit(versioncheck.Update(os.Stdout, os.Stderr))
 
 	default:
 		fmt.Fprintf(os.Stderr, "sense: unknown command %q. Run 'sense help'.\n", cmd)

--- a/internal/versioncheck/check.go
+++ b/internal/versioncheck/check.go
@@ -6,101 +6,14 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
-
-	"github.com/luuuc/sense/internal/version"
 )
 
 const (
-	repo         = "luuuc/sense"
-	checkInterval = 24 * time.Hour
-	httpTimeout   = 2 * time.Second
+	repo        = "luuuc/sense"
+	httpTimeout = 10 * time.Second
 )
-
-type state struct {
-	LastCheck     time.Time `json:"last_check"`
-	LatestVersion string    `json:"latest_version"`
-}
-
-func stateFile() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
-	return filepath.Join(home, ".sense", "version-check")
-}
-
-func readState() (state, error) {
-	var s state
-	path := stateFile()
-	if path == "" {
-		return s, fmt.Errorf("no home dir")
-	}
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return s, err
-	}
-	err = json.Unmarshal(data, &s)
-	return s, err
-}
-
-func writeState(s state) {
-	path := stateFile()
-	if path == "" {
-		return
-	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return
-	}
-	data, err := json.Marshal(s)
-	if err != nil {
-		return
-	}
-	_ = os.WriteFile(path, data, 0o644)
-}
-
-// CheckAndNotify performs a non-blocking version check. If a newer
-// release exists and the last check was more than 24 hours ago, it
-// prints a one-line notice to stderr. Never delays the caller — the
-// HTTP call has a 2s timeout and failures are silently ignored.
-func CheckAndNotify(stderr io.Writer) {
-	if version.Version == "0.0.0-dev" {
-		return
-	}
-
-	s, err := readState()
-	if err != nil {
-		// First run after install — seed the cache and skip the network
-		// call. The user just installed the latest version so there is
-		// nothing to report, and reaching out to api.github.com on first
-		// launch triggers a macOS firewall prompt.
-		writeState(state{LastCheck: time.Now(), LatestVersion: version.Version})
-		return
-	}
-
-	if time.Since(s.LastCheck) < checkInterval {
-		if s.LatestVersion != "" && isNewer(s.LatestVersion, version.Version) {
-			printNotice(stderr, s.LatestVersion)
-		}
-		return
-	}
-
-	// Fire-and-forget: update the cache in a goroutine so we never block.
-	// The notice prints on the next invocation from cached state, avoiding
-	// interleaved stderr output mid-command.
-	go func() {
-		latest, err := fetchLatestTag()
-		if err != nil {
-			return
-		}
-		writeState(state{
-			LastCheck:     time.Now(),
-			LatestVersion: latest,
-		})
-	}()
-}
 
 func fetchLatestTag() (string, error) {
 	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", repo)
@@ -141,9 +54,6 @@ func fetchLatestTag() (string, error) {
 	return strings.TrimPrefix(release.TagName, "v"), nil
 }
 
-// isNewer returns true if latest is a greater semver than current.
-// Only compares dotted numeric segments; pre-release suffixes make
-// the version "older" (e.g., 0.0.0-dev < 0.1.0).
 func isNewer(latest, current string) bool {
 	lp := parseSemver(latest)
 	cp := parseSemver(current)
@@ -157,7 +67,6 @@ func isNewer(latest, current string) bool {
 
 func parseSemver(v string) [3]int {
 	v = strings.TrimPrefix(v, "v")
-	// Strip pre-release suffix (e.g., "0.0.0-dev" → "0.0.0")
 	if idx := strings.IndexByte(v, '-'); idx >= 0 {
 		v = v[:idx]
 	}
@@ -172,9 +81,4 @@ func parseSemver(v string) [3]int {
 		parts[i] = n
 	}
 	return parts
-}
-
-func printNotice(w io.Writer, latest string) {
-	_, _ = fmt.Fprintf(w, "A new version of sense is available (v%s → v%s). Run: curl -fsSL https://raw.githubusercontent.com/%s/main/install.sh | sh\n",
-		version.Version, latest, repo)
 }

--- a/internal/versioncheck/update.go
+++ b/internal/versioncheck/update.go
@@ -1,0 +1,87 @@
+package versioncheck
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/luuuc/sense/internal/version"
+)
+
+const installScriptURL = "https://raw.githubusercontent.com/" + repo + "/main/install.sh"
+
+func Update(stdout, stderr io.Writer) int {
+	if version.Version == "0.0.0-dev" {
+		_, _ = fmt.Fprintln(stderr, "sense update: running a development build — update is not available.")
+		return 1
+	}
+
+	if isGoInstall() {
+		_, _ = fmt.Fprintln(stderr, "sense update: you installed via `go install`. Run:\n  go install github.com/luuuc/sense/cmd/sense@latest\nOr switch to the install script:\n  curl -fsSL "+installScriptURL+" | sh")
+		return 1
+	}
+
+	_, _ = fmt.Fprintln(stdout, "Checking for updates...")
+
+	latest, err := fetchLatestTag()
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense update: %v\n", err)
+		return 1
+	}
+
+	if !isNewer(latest, version.Version) {
+		_, _ = fmt.Fprintf(stdout, "sense v%s is already the latest version.\n", version.Version)
+		return 0
+	}
+
+	_, _ = fmt.Fprintf(stdout, "v%s → v%s available.\n", version.Version, latest)
+	_, _ = fmt.Fprintln(stdout, "Downloading and installing v"+latest+"...")
+
+	if err := runInstallScript(latest, stdout, stderr); err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense update: install failed: %v\n", err)
+		return 1
+	}
+
+	_, _ = fmt.Fprintln(stdout, "Updated successfully. Run 'sense version' to confirm.")
+	return 0
+}
+
+func runInstallScript(ver string, stdout, stderr io.Writer) error {
+	curlCmd := fmt.Sprintf("curl -fsSL %s | sh", installScriptURL)
+
+	cmd := exec.Command("sh", "-c", curlCmd)
+	cmd.Env = append(os.Environ(), "VERSION="+ver)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	return cmd.Run()
+}
+
+func isGoInstall() bool {
+	exe, err := os.Executable()
+	if err != nil {
+		return false
+	}
+	exe, err = filepath.EvalSymlinks(exe)
+	if err != nil {
+		return false
+	}
+
+	gopath := os.Getenv("GOPATH")
+	if gopath == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return false
+		}
+		gopath = filepath.Join(home, "go")
+	}
+
+	return inGopathBin(exe, gopath)
+}
+
+func inGopathBin(exe, gopath string) bool {
+	gopathBin := filepath.Join(gopath, "bin") + string(filepath.Separator)
+	return strings.HasPrefix(exe, gopathBin)
+}

--- a/internal/versioncheck/update_test.go
+++ b/internal/versioncheck/update_test.go
@@ -1,0 +1,27 @@
+package versioncheck
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestInGopathBin(t *testing.T) {
+	tests := []struct {
+		name   string
+		exe    string
+		gopath string
+		want   bool
+	}{
+		{"normal install path", "/usr/local/bin/sense", "/home/user/go", false},
+		{"gopath bin", "/home/user/go/bin/sense", "/home/user/go", true},
+		{"similar prefix", "/home/user/go-tools/bin/sense", "/home/user/go", false},
+		{"home local bin", filepath.Join("/home/user/.local/bin", "sense"), "/home/user/go", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := inGopathBin(tt.exe, tt.gopath); got != tt.want {
+				t.Errorf("inGopathBin(%q, %q) = %v, want %v", tt.exe, tt.gopath, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The architecture doc states: "No network calls. Sense is fully offline in default mode."

This was false. `CheckAndNotify` made an HTTP call to GitHub's releases API every 24 hours, triggered automatically on most CLI invocations via a fire-and-forget goroutine. Two callsites in `main.go` — the no-arg TUI path and the default command path — meant nearly every `sense` invocation could phone home without the user asking.

This violated two principles: the "no network calls" contract, and user agency (the binary decides when to check, not the user).

## Summary

Replace the implicit 24h version check with an explicit `sense update` command. The user decides when to check for updates — the binary never makes network calls unless asked.

## Changes

- **New `sense update` subcommand** — checks GitHub releases API, compares versions, and installs via the existing install script with `VERSION` set
- **Go-install detection** — detects `$GOPATH/bin` installs and warns with the correct `go install` command instead of silently installing to the wrong path
- **Remove automatic version checking** — delete both `CheckAndNotify` callsites, the 24h cache, state file management, and fire-and-forget goroutine
- **Bump HTTP timeout** — 2s → 10s, appropriate for a user-initiated command vs. background fire-and-forget
- **Retained utilities** — `fetchLatestTag`, `isNewer`, `parseSemver` kept for reuse

## Test Plan

- [x] `TestInGopathBin` — unit tests for go-install path detection
- [x] `TestParseSemver` / `TestIsNewer` — existing semver tests still pass
- [x] `make ci` passes (build + all tests + lint)
- [x] `grep -rn CheckAndNotify` returns zero results