### PR TITLE
feat(scan): defer embeddings to background for instant structural index

### DIFF
--- a/cmd/sense/main.go
+++ b/cmd/sense/main.go
@@ -62,6 +62,7 @@ func main() {
 		fs := flag.NewFlagSet("sense scan", flag.ContinueOnError)
 		fs.SetOutput(os.Stderr)
 		watchFlag := fs.Bool("watch", false, "keep running and re-index on file changes")
+		embedFlag := fs.Bool("embed", false, "block until embeddings complete (default: defer to MCP server)")
 		quietFlag := fs.Bool("quiet", false, "suppress warnings")
 		initFlag := fs.Bool("init", false, "re-generate AI tool config files (.mcp.json, .claude/, CLAUDE.md)")
 		dir := fs.String("dir", ".", "project root")
@@ -103,6 +104,7 @@ func main() {
 				Root:              *dir,
 				Warnings:          warnSink,
 				EmbeddingsEnabled: cli.EmbeddingsEnabled(*dir),
+				Embed:             *embedFlag,
 				Init:              *initFlag,
 			}); err != nil {
 				fmt.Fprintln(os.Stderr, "sense scan:", err)

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -92,7 +92,7 @@ func RunSearch(args []string, cio IO) int {
 	}
 
 	engine := search.NewEngine(adapter, vectorIdx, embedder)
-	results, symbolCount, err := engine.Search(ctx, search.Options{
+	results, symbolCount, _, err := engine.Search(ctx, search.Options{
 		Query:    opts.Query,
 		Limit:    opts.Limit,
 		Language: opts.Language,

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -223,12 +223,22 @@ type Freshness struct {
 // sense.status schema has no `sense_metrics` footer — status is
 // metadata about the index itself, not the result of a query against
 type StatusResponse struct {
-	Index     StatusIndex               `json:"index"`
-	Languages map[string]StatusLanguage `json:"languages"`
-	Freshness Freshness                 `json:"freshness"`
-	Session   *StatusSession            `json:"session,omitempty"`
-	Lifetime  *StatusLifetime           `json:"lifetime,omitempty"`
-	Version   *StatusVersion            `json:"version,omitempty"`
+	Index             StatusIndex               `json:"index"`
+	Languages         map[string]StatusLanguage `json:"languages"`
+	Freshness         Freshness                 `json:"freshness"`
+	EmbeddingProgress *EmbeddingProgress        `json:"embedding_progress,omitempty"`
+	Session           *StatusSession            `json:"session,omitempty"`
+	Lifetime          *StatusLifetime           `json:"lifetime,omitempty"`
+	Version           *StatusVersion            `json:"version,omitempty"`
+}
+
+// EmbeddingProgress reports background embedding state. Present only
+// when there is embedding debt (symbols without embeddings). Omitted
+// when fully indexed.
+type EmbeddingProgress struct {
+	Total    int `json:"total"`
+	Embedded int `json:"embedded"`
+	Percent  int `json:"percent"`
 }
 
 // StatusSession holds in-memory session-scoped savings counters.
@@ -296,6 +306,7 @@ type StatusLanguage struct {
 // .doc/definition/06-mcp-and-cli.md exactly.
 type SearchResponse struct {
 	Results      []SearchResultEntry `json:"results"`
+	SearchMode   string              `json:"search_mode"`
 	SenseMetrics SearchMetrics       `json:"sense_metrics"`
 }
 

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -80,6 +80,7 @@ func RunWithOptions(opts RunOptions) error {
 			Output:            os.Stderr,
 			Warnings:          os.Stderr,
 			EmbeddingsEnabled: cli.EmbeddingsEnabled(dir),
+			Embed:             true,
 		}); err != nil {
 			return fmt.Errorf("sense mcp: rebuild scan: %w", err)
 		}
@@ -97,8 +98,10 @@ func RunWithOptions(opts RunOptions) error {
 
 	var vectorIdx search.VectorIndex
 	var embedder embed.Embedder
+	var hasDebt bool
 
-	if cli.EmbeddingsEnabled(dir) {
+	embeddingsEnabled := cli.EmbeddingsEnabled(dir)
+	if embeddingsEnabled {
 		hnswPath := filepath.Join(dir, ".sense", "hnsw.bin")
 		idx, loadErr := search.LoadHNSWIndex(hnswPath)
 		if loadErr == nil && idx != nil {
@@ -112,7 +115,11 @@ func RunWithOptions(opts RunOptions) error {
 				vectorIdx = search.BuildHNSWIndex(embeddings)
 			}
 		}
-		if vectorIdx != nil && vectorIdx.Len() > 0 {
+
+		debtCount, _ := adapter.EmbeddingDebtCount(ctx)
+		hasDebt = debtCount > 0
+
+		if (vectorIdx != nil && vectorIdx.Len() > 0) || hasDebt {
 			embedder, err = embed.NewBundledEmbedder(0)
 			if err != nil {
 				return fmt.Errorf("sense mcp: init embedder: %w", err)
@@ -122,6 +129,31 @@ func RunWithOptions(opts RunOptions) error {
 	}
 
 	engine := search.NewEngine(adapter, vectorIdx, embedder)
+
+	embedCtx, cancelEmbed := context.WithCancel(ctx)
+	defer cancelEmbed()
+
+	if embeddingsEnabled && hasDebt && opts.WatchState == nil {
+		senseDir := filepath.Join(dir, ".sense")
+		go func() {
+			n, err := scan.EmbedPending(embedCtx, adapter, dir, senseDir)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "sense mcp: background embed failed: %v\n", err)
+				return
+			}
+			if n == 0 {
+				return
+			}
+			hnswPath := filepath.Join(senseDir, "hnsw.bin")
+			newIdx, loadErr := search.LoadHNSWIndex(hnswPath)
+			if loadErr != nil {
+				fmt.Fprintf(os.Stderr, "sense mcp: load hnsw after embed: %v\n", loadErr)
+				return
+			}
+			engine.SetVectors(newIdx)
+			fmt.Fprintf(os.Stderr, "sense mcp: embeddings complete (%d symbols) — search upgraded to hybrid mode\n", n)
+		}()
+	}
 
 	tracker := metrics.NewTracker(adapter.DB())
 	defer tracker.Close()
@@ -347,7 +379,7 @@ func (h *handlers) handleSearch(ctx context.Context, req mcp.CallToolRequest) (*
 	language := req.GetString("language", "")
 	minScore := req.GetFloat("min_score", 0.0)
 
-	results, symbolCount, err := h.search.Search(ctx, search.Options{
+	results, symbolCount, searchMode, err := h.search.Search(ctx, search.Options{
 		Query:    query,
 		Limit:    limit,
 		Language: language,
@@ -385,7 +417,8 @@ func (h *handlers) handleSearch(ctx context.Context, req mcp.CallToolRequest) (*
 
 	filesAvoided := len(uniqueFiles)
 	resp := mcpio.SearchResponse{
-		Results: entries,
+		Results:    entries,
+		SearchMode: searchMode,
 		SenseMetrics: mcpio.SearchMetrics{
 			SymbolsSearched:           symbolCount,
 			EstimatedFileReadsAvoided: filesAvoided,
@@ -681,6 +714,18 @@ func buildStatusResponse(ctx context.Context, db *sql.DB, dir string, ws *mcpio.
 
 	if resp.Index.Symbols > 0 {
 		resp.Index.Coverage = float64(resp.Index.Embeddings) / float64(resp.Index.Symbols)
+	}
+
+	if debt := resp.Index.Symbols - resp.Index.Embeddings; debt > 0 {
+		pct := 0
+		if resp.Index.Symbols > 0 {
+			pct = resp.Index.Embeddings * 100 / resp.Index.Symbols
+		}
+		resp.EmbeddingProgress = &mcpio.EmbeddingProgress{
+			Total:    resp.Index.Symbols,
+			Embedded: resp.Index.Embeddings,
+			Percent:  pct,
+		}
 	}
 
 	langs, err := queryLanguageBreakdown(ctx, db)

--- a/internal/scan/embed.go
+++ b/internal/scan/embed.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"io"
 	"math"
 	"os"
 	"path/filepath"
@@ -18,6 +19,76 @@ import (
 )
 
 const maxEmbedWorkers = 8
+
+// EmbedPending generates embeddings for all symbols that lack them and
+// rebuilds the HNSW index. Designed for the MCP server's background
+// embedder — it constructs a minimal harness internally and clears the
+// embedding watermark on success. Returns the number of symbols embedded.
+func EmbedPending(ctx context.Context, idx *sqlite.Adapter, root, senseDir string) (int, error) {
+	syms, err := idx.SymbolsWithoutEmbeddings(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("query pending symbols: %w", err)
+	}
+	if len(syms) == 0 {
+		return 0, nil
+	}
+
+	h := &harness{ctx: ctx, idx: idx, root: root, out: io.Discard, warn: io.Discard}
+	h.extendMethodSnippets(syms)
+	contextMap := h.buildContextMap(syms)
+
+	inputs := make([]embed.EmbedInput, len(syms))
+	for i, s := range syms {
+		inputs[i] = embed.EmbedInput{
+			QualifiedName: s.Qualified,
+			Kind:          s.Kind,
+			Snippet:       s.Snippet,
+			Context:       contextMap[s.ID],
+		}
+	}
+
+	vecs, err := parallelEmbed(ctx, inputs)
+	if err != nil {
+		return 0, fmt.Errorf("generate embeddings: %w", err)
+	}
+
+	err = idx.InTx(ctx, func() error {
+		stmt, err := idx.PrepareEmbeddingStmt(ctx)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = stmt.Close() }()
+		for i, vec := range vecs {
+			blob := vectorToBlob(vec)
+			if _, err := stmt.ExecContext(ctx, syms[i].ID, blob); err != nil {
+				return fmt.Errorf("write embedding symbol=%d: %w", syms[i].ID, err)
+			}
+		}
+		if err := idx.WriteMeta(ctx, "embedding_model", embed.ModelID); err != nil {
+			return fmt.Errorf("write embedding model meta: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("write embeddings: %w", err)
+	}
+
+	hnswPath := filepath.Join(senseDir, "hnsw.bin")
+	embeddings, err := idx.LoadEmbeddings(ctx)
+	if err != nil {
+		return len(vecs), fmt.Errorf("load embeddings for hnsw: %w", err)
+	}
+	if len(embeddings) > 0 {
+		if err := search.SaveHNSWIndex(hnswPath, embeddings); err != nil {
+			return len(vecs), fmt.Errorf("save hnsw index: %w", err)
+		}
+	}
+
+	if err := idx.DeleteMeta(ctx, "embedding_watermark"); err != nil {
+		return len(vecs), fmt.Errorf("clear embedding watermark: %w", err)
+	}
+	return len(vecs), nil
+}
 
 // embedSymbols is pass 3: generate embeddings for symbols in changed files.
 // Only symbols whose file was re-indexed this scan get new embeddings.

--- a/internal/scan/embed_test.go
+++ b/internal/scan/embed_test.go
@@ -4,13 +4,17 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
+	"github.com/luuuc/sense/internal/index"
 	"github.com/luuuc/sense/internal/scan"
+	"github.com/luuuc/sense/internal/sqlite"
 )
 
 func skipWithoutORT(t *testing.T) {
@@ -52,6 +56,7 @@ func Logout(token string) {
 		Output:            &bytes.Buffer{},
 		Warnings:          io.Discard,
 		EmbeddingsEnabled: true,
+		Embed:             true,
 	}
 
 	res, err := scan.Run(ctx, opts)
@@ -111,6 +116,7 @@ func Format(tokens []string) string {
 		Output:            &bytes.Buffer{},
 		Warnings:          io.Discard,
 		EmbeddingsEnabled: true,
+		Embed:             true,
 	}
 
 	// First scan: both files
@@ -162,6 +168,244 @@ func Verify(token string) bool {
 	}
 }
 
+func TestEmbedPending(t *testing.T) {
+	skipWithoutORT(t)
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "auth.go"), `package auth
+
+func Login(email, password string) error {
+	return nil
+}
+
+func Logout(token string) {
+}
+`)
+
+	ctx := context.Background()
+
+	// Phase 1: scan without embedding (deferred)
+	res, err := scan.Run(ctx, scan.Options{
+		Root:              root,
+		Output:            &bytes.Buffer{},
+		Warnings:          io.Discard,
+		EmbeddingsEnabled: true,
+		Embed:             false,
+	})
+	if err != nil {
+		t.Fatalf("deferred scan: %v", err)
+	}
+	if res.EmbeddingDebt == 0 {
+		t.Fatal("expected embedding debt after deferred scan")
+	}
+
+	dbPath := filepath.Join(root, ".sense", "index.db")
+	senseDir := filepath.Join(root, ".sense")
+
+	// Phase 2: EmbedPending picks up the debt
+	adapter, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	sqliteAdapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open sqlite adapter: %v", err)
+	}
+	defer func() { _ = sqliteAdapter.Close() }()
+
+	n, err := scan.EmbedPending(ctx, sqliteAdapter, root, senseDir)
+	if err != nil {
+		t.Fatalf("EmbedPending: %v", err)
+	}
+	if n == 0 {
+		t.Fatal("EmbedPending should have embedded symbols")
+	}
+
+	// Verify embeddings now exist
+	if count := countEmbeddings(t, dbPath); count == 0 {
+		t.Fatal("no embeddings after EmbedPending")
+	}
+
+	// Verify watermark is cleared
+	watermark := readMeta(t, dbPath, "embedding_watermark")
+	if watermark != "" {
+		t.Errorf("embedding_watermark should be cleared after EmbedPending, got %q", watermark)
+	}
+
+	// Verify HNSW index was written
+	hnswPath := filepath.Join(senseDir, "hnsw.bin")
+	if _, err := os.Stat(hnswPath); err != nil {
+		t.Errorf("hnsw.bin should exist after EmbedPending: %v", err)
+	}
+}
+
+func TestScanEmbeddingsDeferred(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "auth.go"), `package auth
+
+func Login(email, password string) error {
+	return nil
+}
+
+func Logout(token string) {
+}
+`)
+
+	ctx := context.Background()
+	res, err := scan.Run(ctx, scan.Options{
+		Root:              root,
+		Output:            &bytes.Buffer{},
+		Warnings:          io.Discard,
+		EmbeddingsEnabled: true,
+		Embed:             false,
+	})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if res.Embedded != 0 {
+		t.Errorf("deferred scan should embed 0 symbols, got %d", res.Embedded)
+	}
+	if res.EmbeddingDebt == 0 {
+		t.Fatal("deferred scan should report embedding debt > 0")
+	}
+
+	dbPath := filepath.Join(root, ".sense", "index.db")
+	if count := countEmbeddings(t, dbPath); count != 0 {
+		t.Errorf("no embeddings should exist after deferred scan, got %d", count)
+	}
+
+	watermark := readMeta(t, dbPath, "embedding_watermark")
+	if watermark == "" {
+		t.Fatal("embedding_watermark should be set after deferred scan")
+	}
+}
+
+func TestEmbedPendingCancelSafe(t *testing.T) {
+	skipWithoutORT(t)
+
+	root := t.TempDir()
+	// Create enough symbols to make embedding take non-trivial time.
+	var src strings.Builder
+	src.WriteString("package bulk\n\n")
+	for i := range 30 {
+		fmt.Fprintf(&src, "func Fn%d() {}\n\n", i)
+	}
+	writeFile(t, filepath.Join(root, "bulk.go"), src.String())
+
+	ctx := context.Background()
+
+	res, err := scan.Run(ctx, scan.Options{
+		Root:              root,
+		Output:            &bytes.Buffer{},
+		Warnings:          io.Discard,
+		EmbeddingsEnabled: true,
+		Embed:             false,
+	})
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if res.EmbeddingDebt == 0 {
+		t.Fatal("expected embedding debt")
+	}
+
+	dbPath := filepath.Join(root, ".sense", "index.db")
+	senseDir := filepath.Join(root, ".sense")
+
+	// Cancel immediately — EmbedPending should exit without corrupting the index.
+	cancelCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open adapter: %v", err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	_, _ = scan.EmbedPending(cancelCtx, adapter, root, senseDir)
+	// EmbedPending may fail (cancelled) or succeed (race) — either is fine.
+	// What matters: the index is not corrupted.
+
+	syms, qerr := adapter.Query(ctx, index.Filter{})
+	if qerr != nil {
+		t.Fatalf("query after cancel: %v", qerr)
+	}
+	if len(syms) == 0 {
+		t.Fatal("symbols should survive cancelled embed")
+	}
+}
+
+func TestDeferredEmbedTransition(t *testing.T) {
+	skipWithoutORT(t)
+
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "svc.go"), `package svc
+
+func Process() error { return nil }
+func Validate() bool { return true }
+`)
+
+	ctx := context.Background()
+	dbPath := filepath.Join(root, ".sense", "index.db")
+	senseDir := filepath.Join(root, ".sense")
+
+	// State 1: Deferred scan — structural index exists, no embeddings.
+	res, err := scan.Run(ctx, scan.Options{
+		Root:              root,
+		Output:            &bytes.Buffer{},
+		Warnings:          io.Discard,
+		EmbeddingsEnabled: true,
+		Embed:             false,
+	})
+	if err != nil {
+		t.Fatalf("deferred scan: %v", err)
+	}
+	if res.Symbols == 0 {
+		t.Fatal("expected symbols from scan")
+	}
+	if res.EmbeddingDebt == 0 {
+		t.Fatal("state 1: expected embedding debt")
+	}
+	if countEmbeddings(t, dbPath) != 0 {
+		t.Fatal("state 1: expected 0 embeddings")
+	}
+	if wm := readMeta(t, dbPath, "embedding_watermark"); wm == "" {
+		t.Fatal("state 1: expected watermark set")
+	}
+
+	// State 2: EmbedPending completes — embeddings exist, watermark cleared.
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open adapter: %v", err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	n, err := scan.EmbedPending(ctx, adapter, root, senseDir)
+	if err != nil {
+		t.Fatalf("EmbedPending: %v", err)
+	}
+	if n == 0 {
+		t.Fatal("state 2: EmbedPending should embed symbols")
+	}
+
+	if count := countEmbeddings(t, dbPath); count != n {
+		t.Errorf("state 2: embeddings count %d != embedded %d", count, n)
+	}
+	if wm := readMeta(t, dbPath, "embedding_watermark"); wm != "" {
+		t.Errorf("state 2: watermark should be cleared, got %q", wm)
+	}
+
+	// State 3: No more debt — EmbedPending is a no-op.
+	n2, err := scan.EmbedPending(ctx, adapter, root, senseDir)
+	if err != nil {
+		t.Fatalf("second EmbedPending: %v", err)
+	}
+	if n2 != 0 {
+		t.Errorf("state 3: expected 0 symbols embedded on re-run, got %d", n2)
+	}
+}
+
 func countEmbeddings(t *testing.T, dbPath string) int {
 	t.Helper()
 	db, err := sql.Open("sqlite", dbPath)
@@ -188,4 +432,19 @@ func firstEmbeddingBlobSize(t *testing.T, dbPath string) int {
 		t.Fatalf("read embedding: %v", err)
 	}
 	return len(blob)
+}
+
+func readMeta(t *testing.T, dbPath, key string) string {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	var value string
+	err = db.QueryRow("SELECT value FROM sense_meta WHERE key = ?", key).Scan(&value)
+	if err != nil {
+		return ""
+	}
+	return value
 }

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -54,7 +54,8 @@ type Options struct {
 	Sense             string    // sense dir (default: "<Root>/.sense")
 	Output            io.Writer // summary-line sink (default: os.Stderr)
 	Warnings          io.Writer // per-file warning sink (default: os.Stderr)
-	EmbeddingsEnabled bool      // when true, pass 3 generates embeddings for changed symbols
+	EmbeddingsEnabled bool      // when true, embeddings are part of the index pipeline
+	Embed             bool      // block until embeddings complete; requires EmbeddingsEnabled. When false, embeddings are deferred and a watermark is written for the MCP server to pick up.
 	Init              bool      // force re-generation of AI tool config files
 }
 
@@ -79,6 +80,7 @@ type Result struct {
 	Symbols        int // symbols written to the index
 	Edges          int // edges resolved and written to sense_edges
 	Embedded       int // symbols whose embeddings were generated/updated
+	EmbeddingDebt  int // symbols needing embeddings (deferred to background)
 	Unresolved     int // edges whose target name matched no symbol; dropped
 	Ambiguous      int // edges resolved via ambiguous (multi-match) fallback
 	Warnings       int // per-file failures logged; scan continues past them
@@ -208,7 +210,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	}
 	phases.AssociateTests = time.Since(t0)
 
-	if opts.EmbeddingsEnabled {
+	if opts.EmbeddingsEnabled && opts.Embed {
 		t0 = time.Now()
 		if err := h.embedSymbols(); err != nil {
 			return nil, err
@@ -220,7 +222,23 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 			_, _ = fmt.Fprintf(warn, "warn: hnsw index build failed: %v\n", err)
 		}
 		phases.BuildHNSW = time.Since(t0)
+
+		if derr := idx.DeleteMeta(ctx, "embedding_watermark"); derr != nil {
+			_, _ = fmt.Fprintf(warn, "warn: clear embedding watermark: %v\n", derr)
+		}
 	}
+
+	var embeddingDebt int
+	if opts.EmbeddingsEnabled && !opts.Embed && h.changed > 0 {
+		ts := time.Now().UTC().Format(time.RFC3339)
+		if err := idx.WriteMeta(ctx, "embedding_watermark", ts); err != nil {
+			_, _ = fmt.Fprintf(warn, "warn: write embedding watermark: %v\n", err)
+		}
+		if debt, derr := idx.EmbeddingDebtCount(ctx); derr == nil {
+			embeddingDebt = debt
+		}
+	}
+
 	if err := idx.StampSchemaVersion(ctx); err != nil {
 		return nil, err
 	}
@@ -235,6 +253,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 		Symbols:        h.symbols,
 		Edges:          h.edges,
 		Embedded:       h.embedded,
+		EmbeddingDebt:  embeddingDebt,
 		Unresolved:     h.unresolved,
 		Ambiguous:      h.ambiguous,
 		Warnings:       h.warnings,
@@ -252,6 +271,9 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	if res.DefaultIgnored > 0 {
 		_, _ = fmt.Fprintf(out, "skipped %d directories (default ignores: %s)\n",
 			res.DefaultIgnored, strings.Join(ignore.DefaultPatterns(), ", "))
+	}
+	if embeddingDebt > 0 {
+		_, _ = fmt.Fprintf(out, "graph, blast, and conventions ready — embeddings deferred (%d symbols)\n", embeddingDebt)
 	}
 	if elapsed > time.Second {
 		printPhaseBreakdown(out, elapsed, phases)

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/luuuc/sense/internal/embed"
 	"github.com/luuuc/sense/internal/sqlite"
@@ -34,8 +35,10 @@ type Options struct {
 
 // Engine orchestrates hybrid search: keyword (FTS5) and vector (HNSW)
 // in parallel, fused with reciprocal rank fusion, re-ranked by graph
-// centrality.
+// centrality. The vector index can be swapped at runtime (e.g. after
+// background embedding completes) via SetVectors.
 type Engine struct {
+	mu       sync.RWMutex
 	adapter  *sqlite.Adapter
 	vectors  VectorIndex
 	embedder embed.Embedder
@@ -51,8 +54,22 @@ func NewEngine(adapter *sqlite.Adapter, vectors VectorIndex, embedder embed.Embe
 	}
 }
 
+// SetVectors swaps the in-memory vector index. Safe for concurrent use
+// with Search — the next query will pick up the new index.
+func (e *Engine) SetVectors(v VectorIndex) {
+	e.mu.Lock()
+	e.vectors = v
+	e.mu.Unlock()
+}
+
+const (
+	ModeHybrid  = "hybrid"
+	ModeKeyword = "keyword"
+)
+
 // Search runs hybrid search and returns fused, re-ranked results.
-func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, int, error) {
+// The mode string is "hybrid" when vector search was used, "keyword" otherwise.
+func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, int, string, error) {
 	if opts.Limit <= 0 {
 		opts.Limit = 10
 	}
@@ -62,7 +79,7 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, int, error
 
 	symbolCount, err := e.adapter.SymbolCount(ctx)
 	if err != nil {
-		return nil, 0, fmt.Errorf("search: %w", err)
+		return nil, 0, "", fmt.Errorf("search: %w", err)
 	}
 
 	// Fetch more candidates than requested so RRF has enough to fuse.
@@ -74,7 +91,11 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, int, error
 	var keywordResults []sqlite.SearchResult
 	var vectorResults []VectorResult
 
-	canVector := e.vectors != nil && e.vectors.Len() > 0 && e.embedder != nil
+	e.mu.RLock()
+	vectors := e.vectors
+	e.mu.RUnlock()
+
+	canVector := vectors != nil && vectors.Len() > 0 && e.embedder != nil
 
 	if canVector {
 		g, gctx := errgroup.WithContext(ctx)
@@ -90,17 +111,17 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, int, error
 			if err != nil {
 				return err
 			}
-			vectorResults = e.vectors.Search(queryVec, candidateLimit)
+			vectorResults = vectors.Search(queryVec, candidateLimit)
 			return nil
 		})
 
 		if err := g.Wait(); err != nil {
-			return nil, 0, fmt.Errorf("search: %w", err)
+			return nil, 0, "", fmt.Errorf("search: %w", err)
 		}
 	} else {
 		keywordResults, err = e.adapter.KeywordSearch(ctx, opts.Query, opts.Language, candidateLimit)
 		if err != nil {
-			return nil, 0, fmt.Errorf("search: %w", err)
+			return nil, 0, "", fmt.Errorf("search: %w", err)
 		}
 	}
 
@@ -108,7 +129,7 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, int, error
 
 	// Hydrate metadata for vector-only results that have no name/qualified.
 	if err := e.hydrateResults(ctx, fused); err != nil {
-		return nil, 0, fmt.Errorf("search: %w", err)
+		return nil, 0, "", fmt.Errorf("search: %w", err)
 	}
 
 	// Graph centrality re-ranking.
@@ -118,7 +139,7 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, int, error
 	}
 	centrality, err := e.adapter.InboundEdgeCounts(ctx, symbolIDs)
 	if err != nil {
-		return nil, 0, fmt.Errorf("search centrality: %w", err)
+		return nil, 0, "", fmt.Errorf("search centrality: %w", err)
 	}
 	applyGraphCentrality(fused, centrality)
 	applyKindWeights(fused)
@@ -134,7 +155,7 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, int, error
 	}
 	pathByID, err := e.adapter.FilePathsByIDs(ctx, fileIDs)
 	if err != nil {
-		return nil, 0, fmt.Errorf("search paths: %w", err)
+		return nil, 0, "", fmt.Errorf("search paths: %w", err)
 	}
 	applyPathWeights(fused, pathByID)
 
@@ -157,7 +178,11 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, int, error
 		}
 	}
 
-	return results, symbolCount, nil
+	mode := ModeKeyword
+	if canVector {
+		mode = ModeHybrid
+	}
+	return results, symbolCount, mode, nil
 }
 
 const rrfK = 60

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -157,7 +157,7 @@ func TestFusionBothBackendsRankHigher(t *testing.T) {
 
 	engine := search.NewEngine(a, vectorIdx, &paymentQueryEmbedder{})
 
-	results, symbolCount, err := engine.Search(ctx, search.Options{
+	results, symbolCount, _, err := engine.Search(ctx, search.Options{
 		Query: "payment",
 		Limit: 10,
 	})
@@ -199,7 +199,7 @@ func TestFusionKeywordOnly(t *testing.T) {
 	// No vector index, no embedder → keyword-only
 	engine := search.NewEngine(a, nil, nil)
 
-	results, _, err := engine.Search(ctx, search.Options{
+	results, _, _, err := engine.Search(ctx, search.Options{
 		Query: "payment",
 		Limit: 10,
 	})
@@ -280,7 +280,7 @@ func TestFusionCentralityBreaksTie(t *testing.T) {
 
 	engine := search.NewEngine(a, nil, nil)
 
-	results, _, err := engine.Search(ctx, search.Options{
+	results, _, _, err := engine.Search(ctx, search.Options{
 		Query: "handler",
 		Limit: 10,
 	})
@@ -316,7 +316,7 @@ func TestFusionMinScore(t *testing.T) {
 
 	engine := search.NewEngine(a, nil, nil)
 
-	results, _, err := engine.Search(ctx, search.Options{
+	results, _, _, err := engine.Search(ctx, search.Options{
 		Query:    "payment",
 		Limit:    10,
 		MinScore: 999, // absurdly high — should filter everything
@@ -347,7 +347,7 @@ func TestNormalizeScoresSpread(t *testing.T) {
 	vectorIdx := search.BuildHNSWIndex(embeddings)
 	engine := search.NewEngine(a, vectorIdx, &paymentQueryEmbedder{})
 
-	results, _, err := engine.Search(ctx, search.Options{
+	results, _, _, err := engine.Search(ctx, search.Options{
 		Query: "payment",
 		Limit: 10,
 	})
@@ -416,7 +416,7 @@ func TestKindWeightsDemotesModules(t *testing.T) {
 	}
 
 	engine := search.NewEngine(a, nil, nil)
-	results, _, err := engine.Search(ctx, search.Options{
+	results, _, _, err := engine.Search(ctx, search.Options{
 		Query: "payment",
 		Limit: 10,
 	})
@@ -441,6 +441,91 @@ func TestKindWeightsDemotesModules(t *testing.T) {
 	}
 	if !hasModule {
 		t.Error("module symbol missing from results entirely — test setup issue")
+	}
+}
+
+func TestSearchModeKeyword(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	a, err := sqlite.Open(ctx, filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	seedFusionIndex(t, ctx, a)
+
+	engine := search.NewEngine(a, nil, nil)
+	_, _, mode, err := engine.Search(ctx, search.Options{Query: "payment", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode != search.ModeKeyword {
+		t.Errorf("mode = %q, want %q", mode, search.ModeKeyword)
+	}
+}
+
+func TestSearchModeHybrid(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	a, err := sqlite.Open(ctx, filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	seedFusionIndex(t, ctx, a)
+
+	embeddings, err := a.LoadEmbeddings(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vectorIdx := search.BuildHNSWIndex(embeddings)
+	engine := search.NewEngine(a, vectorIdx, &paymentQueryEmbedder{})
+
+	_, _, mode, err := engine.Search(ctx, search.Options{Query: "payment", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode != search.ModeHybrid {
+		t.Errorf("mode = %q, want %q", mode, search.ModeHybrid)
+	}
+}
+
+func TestSearchModeUpgradeViaSetVectors(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	a, err := sqlite.Open(ctx, filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	seedFusionIndex(t, ctx, a)
+
+	engine := search.NewEngine(a, nil, &paymentQueryEmbedder{})
+
+	_, _, mode1, err := engine.Search(ctx, search.Options{Query: "payment", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode1 != search.ModeKeyword {
+		t.Errorf("before SetVectors: mode = %q, want %q", mode1, search.ModeKeyword)
+	}
+
+	embeddings, err := a.LoadEmbeddings(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vectorIdx := search.BuildHNSWIndex(embeddings)
+	engine.SetVectors(vectorIdx)
+
+	_, _, mode2, err := engine.Search(ctx, search.Options{Query: "payment", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode2 != search.ModeHybrid {
+		t.Errorf("after SetVectors: mode = %q, want %q", mode2, search.ModeHybrid)
 	}
 }
 
@@ -498,7 +583,7 @@ func TestPathWeightsDemotesMigrationsAndScripts(t *testing.T) {
 	}
 
 	engine := search.NewEngine(a, nil, nil)
-	results, _, err := engine.Search(ctx, search.Options{
+	results, _, _, err := engine.Search(ctx, search.Options{
 		Query: "post moderation flagging",
 		Limit: 10,
 	})

--- a/internal/smoke/smoke_test.go
+++ b/internal/smoke/smoke_test.go
@@ -216,7 +216,7 @@ func TestSmoke(t *testing.T) {
 
 		for _, sq := range gt.Search {
 			queryStart := time.Now()
-			results, _, err := engine.Search(ctx, search.Options{
+			results, _, _, err := engine.Search(ctx, search.Options{
 				Query: sq.Query,
 				Limit: 10,
 			})
@@ -404,7 +404,7 @@ func generateGroundTruth(t *testing.T, ctx context.Context, adapter *sqlite.Adap
 
 	engine := search.NewEngine(adapter, nil, nil)
 	for _, sq := range gt.Search {
-		results, _, err := engine.Search(ctx, search.Options{Query: sq.Query, Limit: 5})
+		results, _, _, err := engine.Search(ctx, search.Options{Query: sq.Query, Limit: 5})
 		if err != nil {
 			t.Logf("REVIEW search %q: error: %v", sq.Query, err)
 			continue

--- a/internal/sqlite/adapter.go
+++ b/internal/sqlite/adapter.go
@@ -776,6 +776,38 @@ type EmbedSymbol struct {
 	LineEnd    int
 }
 
+// SymbolsWithoutEmbeddings returns all symbols that have no embedding yet,
+// with the same fields as SymbolsForFiles. Used by the background embedder
+// to process embedding debt.
+func (a *Adapter) SymbolsWithoutEmbeddings(ctx context.Context) ([]EmbedSymbol, error) {
+	const q = `SELECT s.id, s.file_id, s.qualified, s.kind, COALESCE(p.name, ''),
+		       s.snippet, s.line_start, s.line_end
+		FROM sense_symbols s
+		LEFT JOIN sense_symbols p ON s.parent_id = p.id
+		LEFT JOIN sense_embeddings e ON e.symbol_id = s.id
+		WHERE e.symbol_id IS NULL
+		ORDER BY s.id ASC`
+
+	rows, err := a.db.QueryContext(ctx, q)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite SymbolsWithoutEmbeddings: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var syms []EmbedSymbol
+	for rows.Next() {
+		var s EmbedSymbol
+		var snippet sql.NullString
+		if err := rows.Scan(&s.ID, &s.FileID, &s.Qualified, &s.Kind, &s.ParentName,
+			&snippet, &s.LineStart, &s.LineEnd); err != nil {
+			return nil, fmt.Errorf("sqlite SymbolsWithoutEmbeddings scan: %w", err)
+		}
+		s.Snippet = snippet.String
+		syms = append(syms, s)
+	}
+	return syms, rows.Err()
+}
+
 // WriteEmbedding upserts a single embedding vector into sense_embeddings.
 func (a *Adapter) WriteEmbedding(ctx context.Context, symbolID int64, vector []byte) error {
 	const q = `INSERT INTO sense_embeddings (symbol_id, vector)
@@ -820,6 +852,28 @@ func (a *Adapter) ReadMeta(ctx context.Context, key string) (string, error) {
 		return "", fmt.Errorf("sqlite ReadMeta: %w", err)
 	}
 	return value, nil
+}
+
+// EmbeddingDebtCount returns the number of symbols that lack embeddings.
+func (a *Adapter) EmbeddingDebtCount(ctx context.Context) (int, error) {
+	var count int
+	err := a.db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM sense_symbols s
+		 LEFT JOIN sense_embeddings e ON e.symbol_id = s.id
+		 WHERE e.symbol_id IS NULL`).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("sqlite EmbeddingDebtCount: %w", err)
+	}
+	return count, nil
+}
+
+// DeleteMeta removes a key from sense_meta.
+func (a *Adapter) DeleteMeta(ctx context.Context, key string) error {
+	_, err := a.db.ExecContext(ctx, "DELETE FROM sense_meta WHERE key = ?", key)
+	if err != nil {
+		return fmt.Errorf("sqlite DeleteMeta: %w", err)
+	}
+	return nil
 }
 
 func (a *Adapter) Clear(ctx context.Context) error {

--- a/internal/watch/run.go
+++ b/internal/watch/run.go
@@ -113,9 +113,56 @@ func Run(ctx context.Context, opts RunOptions) error {
 	parsers := scan.NewParserCache()
 	defer parsers.Close()
 
+	// Background embed management: the watch loop owns all embedding.
+	// The MCP server skips its own background embed when WatchState is set.
+	var embedCancel context.CancelFunc
+	var embedDone chan struct{}
+
+	startEmbed := func() {
+		if !opts.EmbeddingsEnabled || ctx.Err() != nil {
+			return
+		}
+		debt, derr := writeAdapter.EmbeddingDebtCount(ctx)
+		if derr != nil {
+			log("sense: check embedding debt: %v", derr)
+			return
+		}
+		if debt == 0 {
+			return
+		}
+		var embedCtx context.Context
+		embedCtx, embedCancel = context.WithCancel(ctx)
+		embedDone = make(chan struct{})
+		go func() {
+			defer close(embedDone)
+			n, err := scan.EmbedPending(embedCtx, writeAdapter, root, senseDir)
+			if err != nil {
+				if embedCtx.Err() == nil {
+					log("sense: background embed error: %v", err)
+				}
+				return
+			}
+			if n > 0 {
+				log("sense: background embed complete (%d symbols)", n)
+			}
+		}()
+	}
+
+	cancelEmbed := func() {
+		if embedCancel != nil {
+			embedCancel()
+			<-embedDone
+			embedCancel = nil
+			embedDone = nil
+		}
+	}
+	defer cancelEmbed()
+
 	// Mark watch start for status reporting
 	ws.Set(true, time.Now().UTC())
 	defer ws.Set(false, time.Time{})
+
+	startEmbed()
 
 	log("sense: watching for changes (debounce=%dms)", debounceMs)
 
@@ -132,17 +179,17 @@ func Run(ctx context.Context, opts RunOptions) error {
 			if total == 0 {
 				continue
 			}
+			cancelEmbed()
 			res, err := scan.RunIncremental(ctx, scan.IncrementalOptions{
-				Root:              root,
-				Idx:               writeAdapter,
-				Matcher:           matcher,
-				MaxFileSizeKB:     cfg.Scan.MaxFileSizeKB,
-				EmbeddingsEnabled: opts.EmbeddingsEnabled,
-				Output:            io.Discard,
-				Warnings:          os.Stderr,
-				Changed:           batch.Changed,
-				Removed:           batch.Removed,
-				Parsers:           parsers,
+				Root:          root,
+				Idx:           writeAdapter,
+				Matcher:       matcher,
+				MaxFileSizeKB: cfg.Scan.MaxFileSizeKB,
+				Output:        io.Discard,
+				Warnings:      os.Stderr,
+				Changed:       batch.Changed,
+				Removed:       batch.Removed,
+				Parsers:       parsers,
 			})
 			if err != nil {
 				log("sense: re-index error: %v", err)
@@ -150,6 +197,7 @@ func Run(ctx context.Context, opts RunOptions) error {
 			}
 			log("sense: re-indexed %d files (%d changed, %d removed, %d symbols) in %s",
 				total, res.Changed, res.Removed, res.Symbols, res.Duration)
+			startEmbed()
 		}
 	}
 }


### PR DESCRIPTION
## Problem

`sense scan` blocks until the entire pipeline finishes — including embeddings, which are 79-89% of total scan time. On a 3,000-file project, the structural phase takes seconds while embeddings take minutes. Three of four Sense capabilities (graph, blast, conventions) never touch embeddings, but users wait minutes before they can ask a single question.

## Summary

Split `sense scan` into two phases: structural (blocking) and embeddings (background/deferred). The structural index is available immediately; embeddings run in the background within the MCP server or watch loop.

## Changes

**Scan pipeline**
- `scan.Options` gains `Embed bool` — without it, scan returns after the structural phase and writes an embedding watermark to `sense_meta`
- New `EmbedPending` exported function generates embeddings for all symbols with debt, rebuilds the HNSW index, and clears the watermark
- CLI gains `--embed` flag on `sense scan` to preserve blocking behavior
- New SQLite adapter methods: `SymbolsWithoutEmbeddings`, `EmbeddingDebtCount`, `DeleteMeta`

**MCP server**
- On startup, checks for embedding debt and runs `EmbedPending` in a background goroutine with cancellable context
- On completion, swaps the search engine's vector index via `SetVectors` and logs the upgrade to hybrid mode
- `sense.status` reports `embedding_progress` block (total/embedded/percent) when debt exists
- `sense.search` returns `search_mode` field (`"hybrid"` or `"keyword"`)

**Watch mode**
- Watch loop owns all embedding with cancel/restart on file changes
- Background embed cancels before incremental scans, restarts after
- MCP server suppresses its own background embed when `WatchState` is set

**Search engine**
- `search.Engine` gains `sync.RWMutex` + `SetVectors` for concurrent-safe vector index swap at runtime
- `Search` returns mode string indicating whether vector search was used

## Test Plan

- [x] `TestScanEmbeddingsDeferred` — deferred scan skips embeddings, sets watermark, reports debt
- [x] `TestEmbedPending` — background embed clears debt and watermark, writes HNSW
- [x] `TestEmbedPendingCancelSafe` — cancelled embed doesn't corrupt the index
- [x] `TestDeferredEmbedTransition` — full debt → embed → no-op state machine
- [x] `TestSearchModeKeyword` / `TestSearchModeHybrid` — mode string correctness
- [x] `TestSearchModeUpgradeViaSetVectors` — runtime keyword → hybrid upgrade
- [x] `go test ./...` passes (30 packages)
- [x] `make lint` passes
- [x] `make build` produces working binary