### PR TITLE
feat(mcp): add next-step hints to MCP tool responses

### DIFF
--- a/internal/mcpio/conventions.go
+++ b/internal/mcpio/conventions.go
@@ -5,6 +5,7 @@ package mcpio
 type ConventionsResponse struct {
 	Conventions  []ConventionEntry    `json:"conventions"`
 	SenseMetrics ConventionsMetrics   `json:"sense_metrics"`
+	NextSteps    []NextStep           `json:"next_steps"`
 }
 
 // ConventionEntry is a single detected convention in the wire response.
@@ -28,6 +29,9 @@ type ConventionsMetrics struct {
 func MarshalConventions(r ConventionsResponse) ([]byte, error) {
 	if r.Conventions == nil {
 		r.Conventions = []ConventionEntry{}
+	}
+	if r.NextSteps == nil {
+		r.NextSteps = []NextStep{}
 	}
 	return marshalPretty(r)
 }

--- a/internal/mcpio/marshal.go
+++ b/internal/mcpio/marshal.go
@@ -30,6 +30,9 @@ func MarshalStatus(r StatusResponse) ([]byte, error) {
 	if r.Languages == nil {
 		r.Languages = map[string]StatusLanguage{}
 	}
+	if r.NextSteps == nil {
+		r.NextSteps = []NextStep{}
+	}
 	return marshalPretty(r)
 }
 
@@ -82,12 +85,18 @@ func normalizeGraphResponse(r *GraphResponse) {
 	if r.Edges.Tests == nil {
 		r.Edges.Tests = []TestEdgeRef{}
 	}
+	if r.NextSteps == nil {
+		r.NextSteps = []NextStep{}
+	}
 }
 
 // normalizeSearchResponse replaces nil Results with an empty slice.
 func normalizeSearchResponse(r *SearchResponse) {
 	if r.Results == nil {
 		r.Results = []SearchResultEntry{}
+	}
+	if r.NextSteps == nil {
+		r.NextSteps = []NextStep{}
 	}
 }
 
@@ -105,5 +114,8 @@ func normalizeBlastResponse(r *BlastResponse) {
 	}
 	if r.AffectedTests == nil {
 		r.AffectedTests = []string{}
+	}
+	if r.NextSteps == nil {
+		r.NextSteps = []NextStep{}
 	}
 }

--- a/internal/mcpio/marshal_test.go
+++ b/internal/mcpio/marshal_test.go
@@ -38,6 +38,7 @@ func TestMarshalGraphRoundTrip(t *testing.T) {
 			Tests:    []TestEdgeRef{{File: "test/services/checkout_service_test.rb", Confidence: 0.8}},
 		},
 		SenseMetrics: GraphMetrics{SymbolsReturned: 3},
+		NextSteps:    []NextStep{},
 	}
 
 	raw, err := MarshalGraph(in)
@@ -69,6 +70,7 @@ func TestMarshalBlastRoundTrip(t *testing.T) {
 		AffectedTests: []string{"test/models/user_test.rb"},
 		TotalAffected: 2,
 		SenseMetrics:  BlastMetrics{SymbolsTraversed: 5},
+		NextSteps:     []NextStep{},
 	}
 
 	raw, err := MarshalBlast(in)
@@ -99,12 +101,12 @@ func TestMarshalZeroValueEmptySlices(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MarshalGraph: %v", err)
 	}
-	for _, field := range []string{`"calls": []`, `"called_by": []`, `"inherits": []`, `"composes": []`, `"includes": []`, `"imports": []`, `"tests": []`} {
+	for _, field := range []string{`"calls": []`, `"called_by": []`, `"inherits": []`, `"composes": []`, `"includes": []`, `"imports": []`, `"tests": []`, `"next_steps": []`} {
 		if !strings.Contains(string(graphBytes), field) {
 			t.Errorf("GraphResponse zero-value missing %s\ngot:\n%s", field, graphBytes)
 		}
 	}
-	for _, nullField := range []string{`"calls": null`, `"called_by": null`, `"inherits": null`, `"composes": null`, `"includes": null`, `"imports": null`, `"tests": null`} {
+	for _, nullField := range []string{`"calls": null`, `"called_by": null`, `"inherits": null`, `"composes": null`, `"includes": null`, `"imports": null`, `"tests": null`, `"next_steps": null`} {
 		if strings.Contains(string(graphBytes), nullField) {
 			t.Errorf("GraphResponse zero-value slice field should be []: %s\ngot:\n%s", nullField, graphBytes)
 		}
@@ -114,12 +116,12 @@ func TestMarshalZeroValueEmptySlices(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MarshalBlast: %v", err)
 	}
-	for _, field := range []string{`"risk_factors": []`, `"direct_callers": []`, `"indirect_callers": []`, `"affected_tests": []`} {
+	for _, field := range []string{`"risk_factors": []`, `"direct_callers": []`, `"indirect_callers": []`, `"affected_tests": []`, `"next_steps": []`} {
 		if !strings.Contains(string(blastBytes), field) {
 			t.Errorf("BlastResponse zero-value missing %s\ngot:\n%s", field, blastBytes)
 		}
 	}
-	for _, nullField := range []string{`"risk_factors": null`, `"direct_callers": null`, `"indirect_callers": null`, `"affected_tests": null`} {
+	for _, nullField := range []string{`"risk_factors": null`, `"direct_callers": null`, `"indirect_callers": null`, `"affected_tests": null`, `"next_steps": null`} {
 		if strings.Contains(string(blastBytes), nullField) {
 			t.Errorf("BlastResponse zero-value slice field should be []: %s\ngot:\n%s", nullField, blastBytes)
 		}

--- a/internal/mcpio/testdata/blast_diff.json
+++ b/internal/mcpio/testdata/blast_diff.json
@@ -43,5 +43,6 @@
     "symbols_traversed": 9,
     "estimated_file_reads_avoided": 8,
     "estimated_tokens_saved": 6400
-  }
+  },
+  "next_steps": []
 }

--- a/internal/mcpio/testdata/blast_user_email_verified.json
+++ b/internal/mcpio/testdata/blast_user_email_verified.json
@@ -44,5 +44,6 @@
     "symbols_traversed": 47,
     "estimated_file_reads_avoided": 10,
     "estimated_tokens_saved": 8000
-  }
+  },
+  "next_steps": []
 }

--- a/internal/mcpio/testdata/graph_checkout_service.json
+++ b/internal/mcpio/testdata/graph_checkout_service.json
@@ -57,5 +57,6 @@
     "symbols_returned": 7,
     "estimated_file_reads_avoided": 6,
     "estimated_tokens_saved": 4800
-  }
+  },
+  "next_steps": []
 }

--- a/internal/mcpio/testdata/graph_empty.json
+++ b/internal/mcpio/testdata/graph_empty.json
@@ -20,5 +20,6 @@
     "symbols_returned": 0,
     "estimated_file_reads_avoided": 0,
     "estimated_tokens_saved": 0
-  }
+  },
+  "next_steps": []
 }

--- a/internal/mcpio/testdata/graph_with_freshness.json
+++ b/internal/mcpio/testdata/graph_with_freshness.json
@@ -61,5 +61,6 @@
   "freshness": {
     "index_age_seconds": 42,
     "stale_files_seen": 0
-  }
+  },
+  "next_steps": []
 }

--- a/internal/mcpio/testdata/status.json
+++ b/internal/mcpio/testdata/status.json
@@ -37,5 +37,6 @@
     "schema_current": true,
     "embedding_model": "all-MiniLM-L6-v2",
     "embedding_model_current": true
-  }
+  },
+  "next_steps": []
 }

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -49,6 +49,20 @@ func (c Confidence) MarshalJSON() ([]byte, error) {
 }
 
 // ---------------------------------------------------------------
+// Next-step hints (pitch 11-06)
+// ---------------------------------------------------------------
+
+// NextStep is a follow-up action hint appended to every MCP
+// response. Tool is the MCP tool name, Args are pre-filled
+// arguments the agent can pass directly, and Reason is a
+// one-sentence explanation of why this is the logical next call.
+type NextStep struct {
+	Tool   string         `json:"tool"`
+	Args   map[string]any `json:"args,omitempty"`
+	Reason string         `json:"reason"`
+}
+
+// ---------------------------------------------------------------
 // sense.graph response
 // ---------------------------------------------------------------
 
@@ -61,6 +75,7 @@ type GraphResponse struct {
 	Edges        GraphEdges   `json:"edges"`
 	SenseMetrics GraphMetrics `json:"sense_metrics"`
 	Freshness    *Freshness   `json:"freshness,omitempty"`
+	NextSteps    []NextStep   `json:"next_steps"`
 }
 
 // GraphSymbol is the focal symbol's identity block. File is always
@@ -169,6 +184,7 @@ type BlastResponse struct {
 	TotalAffected   int             `json:"total_affected"`
 	SenseMetrics    BlastMetrics    `json:"sense_metrics"`
 	Freshness       *Freshness      `json:"freshness,omitempty"`
+	NextSteps       []NextStep      `json:"next_steps"`
 }
 
 // BlastCaller is the shape of a direct_callers entry.
@@ -230,6 +246,7 @@ type StatusResponse struct {
 	Session           *StatusSession            `json:"session,omitempty"`
 	Lifetime          *StatusLifetime           `json:"lifetime,omitempty"`
 	Version           *StatusVersion            `json:"version,omitempty"`
+	NextSteps         []NextStep                `json:"next_steps"`
 }
 
 // EmbeddingProgress reports background embedding state. Present only
@@ -308,6 +325,7 @@ type SearchResponse struct {
 	Results      []SearchResultEntry `json:"results"`
 	SearchMode   string              `json:"search_mode"`
 	SenseMetrics SearchMetrics       `json:"sense_metrics"`
+	NextSteps    []NextStep          `json:"next_steps"`
 }
 
 // SearchResultEntry is a single search hit in the wire response.

--- a/internal/mcpserver/hints_test.go
+++ b/internal/mcpserver/hints_test.go
@@ -1,0 +1,520 @@
+package mcpserver
+
+import (
+	"testing"
+
+	"github.com/luuuc/sense/internal/mcpio"
+)
+
+func TestGraphHintsManyCallers(t *testing.T) {
+	resp := mcpio.GraphResponse{
+		Symbol: mcpio.GraphSymbol{
+			Name:      "HandleRequest",
+			Qualified: "server.HandleRequest",
+			File:      "internal/server/handler.go",
+		},
+		Edges: mcpio.GraphEdges{
+			CalledBy: make([]mcpio.CallEdgeRef, 7),
+		},
+	}
+	hints := graphHints(resp, "both")
+	if len(hints) != 1 {
+		t.Fatalf("want 1 hint, got %d", len(hints))
+	}
+	if hints[0].Tool != "sense.blast" {
+		t.Errorf("tool = %q, want sense.blast", hints[0].Tool)
+	}
+	if hints[0].Args["symbol"] != "server.HandleRequest" {
+		t.Errorf("args.symbol = %q, want server.HandleRequest", hints[0].Args["symbol"])
+	}
+}
+
+func TestGraphHintsNoCallers(t *testing.T) {
+	resp := mcpio.GraphResponse{
+		Symbol: mcpio.GraphSymbol{
+			Name:      "Orphan",
+			Qualified: "models.Orphan",
+			File:      "internal/models/orphan.go",
+		},
+		Edges: mcpio.GraphEdges{
+			CalledBy: []mcpio.CallEdgeRef{},
+		},
+	}
+	hints := graphHints(resp, "both")
+	if len(hints) != 1 {
+		t.Fatalf("want 1 hint, got %d", len(hints))
+	}
+	if hints[0].Tool != "sense.search" {
+		t.Errorf("tool = %q, want sense.search", hints[0].Tool)
+	}
+	if hints[0].Args["query"] != "Orphan" {
+		t.Errorf("args.query = %q, want Orphan", hints[0].Args["query"])
+	}
+}
+
+func TestGraphHintsNoCallersTestFile(t *testing.T) {
+	resp := mcpio.GraphResponse{
+		Symbol: mcpio.GraphSymbol{
+			Name:      "TestFoo",
+			Qualified: "pkg.TestFoo",
+			File:      "internal/pkg/handler_test.go",
+		},
+		Edges: mcpio.GraphEdges{
+			CalledBy: []mcpio.CallEdgeRef{},
+		},
+	}
+	hints := graphHints(resp, "both")
+	if len(hints) != 0 {
+		t.Fatalf("want 0 hints for test file with no callers, got %d", len(hints))
+	}
+}
+
+func TestGraphHintsCallersOnlyDirection(t *testing.T) {
+	resp := mcpio.GraphResponse{
+		Symbol: mcpio.GraphSymbol{
+			Name:      "Foo",
+			Qualified: "pkg.Foo",
+			File:      "internal/pkg/foo.go",
+		},
+		Edges: mcpio.GraphEdges{
+			CalledBy: []mcpio.CallEdgeRef{{Symbol: "Bar"}},
+		},
+	}
+	hints := graphHints(resp, "callers")
+	if len(hints) != 1 {
+		t.Fatalf("want 1 hint, got %d", len(hints))
+	}
+	if hints[0].Tool != "sense.graph" {
+		t.Errorf("tool = %q, want sense.graph", hints[0].Tool)
+	}
+	if hints[0].Args["direction"] != "callees" {
+		t.Errorf("args.direction = %q, want callees", hints[0].Args["direction"])
+	}
+}
+
+func TestGraphHintsManyCallersAndCallersDirection(t *testing.T) {
+	resp := mcpio.GraphResponse{
+		Symbol: mcpio.GraphSymbol{
+			Name:      "Hub",
+			Qualified: "pkg.Hub",
+			File:      "internal/pkg/hub.go",
+		},
+		Edges: mcpio.GraphEdges{
+			CalledBy: make([]mcpio.CallEdgeRef, 10),
+		},
+	}
+	hints := graphHints(resp, "callers")
+	if len(hints) != 2 {
+		t.Fatalf("want 2 hints (blast + callees), got %d", len(hints))
+	}
+	if hints[0].Tool != "sense.blast" {
+		t.Errorf("hints[0].tool = %q, want sense.blast", hints[0].Tool)
+	}
+	if hints[1].Tool != "sense.graph" {
+		t.Errorf("hints[1].tool = %q, want sense.graph", hints[1].Tool)
+	}
+}
+
+func TestGraphHintsEmpty(t *testing.T) {
+	resp := mcpio.GraphResponse{
+		Symbol: mcpio.GraphSymbol{
+			Name:      "Foo",
+			Qualified: "pkg.Foo",
+			File:      "internal/pkg/foo.go",
+		},
+		Edges: mcpio.GraphEdges{
+			CalledBy: []mcpio.CallEdgeRef{{Symbol: "Bar"}},
+		},
+	}
+	hints := graphHints(resp, "both")
+	if hints != nil {
+		t.Fatalf("want nil hints (1-4 callers, both direction), got %d", len(hints))
+	}
+}
+
+func TestSearchHintsStrongMatch(t *testing.T) {
+	resp := mcpio.SearchResponse{
+		Results: []mcpio.SearchResultEntry{
+			{Symbol: "auth.Verify", File: "internal/auth/verify.go", Score: 0.92},
+			{Symbol: "auth.Token", File: "internal/auth/token.go", Score: 0.71},
+		},
+	}
+	hints := searchHints(resp)
+	if len(hints) != 1 {
+		t.Fatalf("want 1 hint, got %d", len(hints))
+	}
+	if hints[0].Tool != "sense.graph" {
+		t.Errorf("tool = %q, want sense.graph", hints[0].Tool)
+	}
+	if hints[0].Args["symbol"] != "auth.Verify" {
+		t.Errorf("args.symbol = %q, want auth.Verify", hints[0].Args["symbol"])
+	}
+}
+
+func TestSearchHintsFileCluster(t *testing.T) {
+	resp := mcpio.SearchResponse{
+		Results: []mcpio.SearchResultEntry{
+			{Symbol: "Foo", File: "internal/models/user.go", Score: 0.5},
+			{Symbol: "Bar", File: "internal/models/user.go", Score: 0.4},
+			{Symbol: "Baz", File: "internal/models/user.go", Score: 0.3},
+		},
+	}
+	hints := searchHints(resp)
+	if len(hints) != 1 {
+		t.Fatalf("want 1 hint, got %d", len(hints))
+	}
+	if hints[0].Tool != "sense.conventions" {
+		t.Errorf("tool = %q, want sense.conventions", hints[0].Tool)
+	}
+	if hints[0].Args["domain"] != "internal/models" {
+		t.Errorf("args.domain = %q, want internal/models", hints[0].Args["domain"])
+	}
+}
+
+func TestSearchHintsStrongMatchAndCluster(t *testing.T) {
+	resp := mcpio.SearchResponse{
+		Results: []mcpio.SearchResultEntry{
+			{Symbol: "Foo", File: "internal/models/user.go", Score: 0.95},
+			{Symbol: "Bar", File: "internal/models/user.go", Score: 0.8},
+			{Symbol: "Baz", File: "internal/models/user.go", Score: 0.7},
+		},
+	}
+	hints := searchHints(resp)
+	if len(hints) != 2 {
+		t.Fatalf("want 2 hints (graph + conventions), got %d", len(hints))
+	}
+	if hints[0].Tool != "sense.graph" {
+		t.Errorf("hints[0].tool = %q, want sense.graph", hints[0].Tool)
+	}
+	if hints[1].Tool != "sense.conventions" {
+		t.Errorf("hints[1].tool = %q, want sense.conventions", hints[1].Tool)
+	}
+}
+
+func TestSearchHintsEmpty(t *testing.T) {
+	resp := mcpio.SearchResponse{
+		Results: []mcpio.SearchResultEntry{
+			{Symbol: "Foo", File: "a.go", Score: 0.3},
+			{Symbol: "Bar", File: "b.go", Score: 0.2},
+		},
+	}
+	hints := searchHints(resp)
+	if hints != nil {
+		t.Fatalf("want nil hints, got %d", len(hints))
+	}
+}
+
+func TestSearchHintsEmptyResults(t *testing.T) {
+	resp := mcpio.SearchResponse{Results: []mcpio.SearchResultEntry{}}
+	hints := searchHints(resp)
+	if hints != nil {
+		t.Fatalf("want nil hints for empty results, got %d", len(hints))
+	}
+}
+
+func TestSearchHintsClusterDeterminism(t *testing.T) {
+	resp := mcpio.SearchResponse{
+		Results: []mcpio.SearchResultEntry{
+			{Symbol: "A", File: "pkg/alpha.go", Score: 0.5},
+			{Symbol: "B", File: "pkg/beta.go", Score: 0.4},
+			{Symbol: "C", File: "pkg/beta.go", Score: 0.3},
+			{Symbol: "D", File: "pkg/beta.go", Score: 0.3},
+			{Symbol: "E", File: "pkg/alpha.go", Score: 0.2},
+			{Symbol: "F", File: "pkg/alpha.go", Score: 0.2},
+		},
+	}
+	first := searchHints(resp)
+	for i := 0; i < 20; i++ {
+		got := searchHints(resp)
+		if len(got) != len(first) {
+			t.Fatalf("iteration %d: length changed from %d to %d", i, len(first), len(got))
+		}
+		for j := range first {
+			if got[j].Tool != first[j].Tool || got[j].Reason != first[j].Reason {
+				t.Fatalf("iteration %d: hint[%d] changed", i, j)
+			}
+		}
+	}
+	if len(first) != 1 {
+		t.Fatalf("want 1 hint, got %d", len(first))
+	}
+	if first[0].Args["domain"] != "pkg" {
+		t.Errorf("expected first qualifying file's dir (pkg/beta.go → pkg), got %q", first[0].Args["domain"])
+	}
+}
+
+func TestBlastHintsHighRisk(t *testing.T) {
+	resp := mcpio.BlastResponse{
+		Symbol:        "User#destroy",
+		Risk:          "high",
+		TotalAffected: 15,
+		AffectedTests: []string{"test/user_test.rb"},
+	}
+	hints := blastHints(resp)
+	if len(hints) != 1 {
+		t.Fatalf("want 1 hint, got %d", len(hints))
+	}
+	if hints[0].Tool != "sense.conventions" {
+		t.Errorf("tool = %q, want sense.conventions", hints[0].Tool)
+	}
+}
+
+func TestBlastHintsNoTests(t *testing.T) {
+	resp := mcpio.BlastResponse{
+		Symbol:        "Order#finalize",
+		Risk:          "medium",
+		TotalAffected: 3,
+		AffectedTests: []string{},
+	}
+	hints := blastHints(resp)
+	if len(hints) != 1 {
+		t.Fatalf("want 1 hint, got %d", len(hints))
+	}
+	if hints[0].Tool != "sense.search" {
+		t.Errorf("tool = %q, want sense.search", hints[0].Tool)
+	}
+}
+
+func TestBlastHintsHighRiskNoTests(t *testing.T) {
+	resp := mcpio.BlastResponse{
+		Symbol:        "Critical#method",
+		Risk:          "high",
+		TotalAffected: 10,
+		AffectedTests: []string{},
+	}
+	hints := blastHints(resp)
+	if len(hints) != 2 {
+		t.Fatalf("want 2 hints, got %d", len(hints))
+	}
+	if hints[0].Tool != "sense.conventions" {
+		t.Errorf("hints[0].tool = %q, want sense.conventions", hints[0].Tool)
+	}
+	if hints[1].Tool != "sense.search" {
+		t.Errorf("hints[1].tool = %q, want sense.search", hints[1].Tool)
+	}
+}
+
+func TestBlastHintsEmpty(t *testing.T) {
+	resp := mcpio.BlastResponse{
+		Symbol:        "Leaf#method",
+		Risk:          "low",
+		TotalAffected: 1,
+		AffectedTests: []string{"test/leaf_test.rb"},
+	}
+	hints := blastHints(resp)
+	if hints != nil {
+		t.Fatalf("want nil hints, got %d", len(hints))
+	}
+}
+
+func TestBlastHintsNoTestsZeroAffected(t *testing.T) {
+	resp := mcpio.BlastResponse{
+		Symbol:        "Isolated",
+		Risk:          "low",
+		TotalAffected: 0,
+		AffectedTests: []string{},
+	}
+	hints := blastHints(resp)
+	if hints != nil {
+		t.Fatalf("want nil hints (no tests but 0 affected), got %d", len(hints))
+	}
+}
+
+func TestConventionsHintsStrongConvention(t *testing.T) {
+	resp := mcpio.ConventionsResponse{
+		Conventions: []mcpio.ConventionEntry{
+			{Description: "models inherit from Base", Strength: 0.5},
+			{Description: "controllers follow REST", Strength: 0.85},
+		},
+	}
+	hints := conventionsHints(resp, "")
+	if len(hints) != 1 {
+		t.Fatalf("want 1 hint, got %d", len(hints))
+	}
+	if hints[0].Tool != "sense.search" {
+		t.Errorf("tool = %q, want sense.search", hints[0].Tool)
+	}
+	if hints[0].Args["query"] != "controllers follow REST" {
+		t.Errorf("args.query = %q, want description of strong convention", hints[0].Args["query"])
+	}
+}
+
+func TestConventionsHintsDomainScoped(t *testing.T) {
+	resp := mcpio.ConventionsResponse{
+		Conventions: []mcpio.ConventionEntry{
+			{Description: "naming pattern", Strength: 0.4},
+		},
+	}
+	hints := conventionsHints(resp, "models")
+	if len(hints) != 1 {
+		t.Fatalf("want 1 hint, got %d", len(hints))
+	}
+	if hints[0].Tool != "sense.conventions" {
+		t.Errorf("tool = %q, want sense.conventions", hints[0].Tool)
+	}
+}
+
+func TestConventionsHintsStrongAndDomain(t *testing.T) {
+	resp := mcpio.ConventionsResponse{
+		Conventions: []mcpio.ConventionEntry{
+			{Description: "strong pattern", Strength: 0.9},
+		},
+	}
+	hints := conventionsHints(resp, "controllers")
+	if len(hints) != 2 {
+		t.Fatalf("want 2 hints, got %d", len(hints))
+	}
+	if hints[0].Tool != "sense.search" {
+		t.Errorf("hints[0].tool = %q, want sense.search", hints[0].Tool)
+	}
+	if hints[1].Tool != "sense.conventions" {
+		t.Errorf("hints[1].tool = %q, want sense.conventions", hints[1].Tool)
+	}
+}
+
+func TestConventionsHintsEmpty(t *testing.T) {
+	resp := mcpio.ConventionsResponse{
+		Conventions: []mcpio.ConventionEntry{
+			{Description: "weak pattern", Strength: 0.3},
+		},
+	}
+	hints := conventionsHints(resp, "")
+	if hints != nil {
+		t.Fatalf("want nil hints, got %d", len(hints))
+	}
+}
+
+func TestStatusHintsStaleFiles(t *testing.T) {
+	stale := 5
+	resp := mcpio.StatusResponse{
+		Freshness: mcpio.Freshness{
+			StaleFilesSeen: &stale,
+		},
+	}
+	hints := statusHints(resp, 3)
+	if len(hints) != 1 {
+		t.Fatalf("want 1 hint, got %d", len(hints))
+	}
+	if hints[0].Tool != "" {
+		t.Errorf("tool = %q, want empty (advisory)", hints[0].Tool)
+	}
+	if hints[0].Reason == "" {
+		t.Error("reason should not be empty")
+	}
+}
+
+func TestStatusHintsFirstQuery(t *testing.T) {
+	stale := 0
+	resp := mcpio.StatusResponse{
+		Freshness: mcpio.Freshness{
+			StaleFilesSeen: &stale,
+		},
+	}
+	hints := statusHints(resp, 0)
+	if len(hints) != 1 {
+		t.Fatalf("want 1 hint, got %d", len(hints))
+	}
+	if hints[0].Tool != "sense.conventions" {
+		t.Errorf("tool = %q, want sense.conventions", hints[0].Tool)
+	}
+}
+
+func TestStatusHintsStaleAndFirstQuery(t *testing.T) {
+	stale := 3
+	resp := mcpio.StatusResponse{
+		Freshness: mcpio.Freshness{
+			StaleFilesSeen: &stale,
+		},
+	}
+	hints := statusHints(resp, 0)
+	if len(hints) != 2 {
+		t.Fatalf("want 2 hints, got %d", len(hints))
+	}
+	if hints[0].Tool != "" {
+		t.Errorf("hints[0].tool = %q, want empty (advisory)", hints[0].Tool)
+	}
+	if hints[1].Tool != "sense.conventions" {
+		t.Errorf("hints[1].tool = %q, want sense.conventions", hints[1].Tool)
+	}
+}
+
+func TestStatusHintsEmpty(t *testing.T) {
+	stale := 0
+	resp := mcpio.StatusResponse{
+		Freshness: mcpio.Freshness{
+			StaleFilesSeen: &stale,
+		},
+	}
+	hints := statusHints(resp, 5)
+	if hints != nil {
+		t.Fatalf("want nil hints, got %d", len(hints))
+	}
+}
+
+func TestIsTestFile(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"internal/pkg/handler_test.go", true},
+		{"test/models/user_test.rb", true},
+		{"tests/integration/smoke.py", true},
+		{"spec/models/user_spec.rb", true},
+		{"internal/pkg/handler.go", false},
+		{"app/models/contest.rb", false},
+		{"internal/attestation/verify.go", false},
+		{"app/controllers/protest_controller.rb", false},
+	}
+	for _, tt := range tests {
+		got := isTestFile(tt.path)
+		if got != tt.want {
+			t.Errorf("isTestFile(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestHintDeterminism(t *testing.T) {
+	graphResp := mcpio.GraphResponse{
+		Symbol: mcpio.GraphSymbol{
+			Name: "Hub", Qualified: "pkg.Hub", File: "pkg/hub.go",
+		},
+		Edges: mcpio.GraphEdges{CalledBy: make([]mcpio.CallEdgeRef, 8)},
+	}
+	blastResp := mcpio.BlastResponse{
+		Symbol: "Critical", Risk: "high",
+		TotalAffected: 5, AffectedTests: []string{},
+	}
+	convResp := mcpio.ConventionsResponse{
+		Conventions: []mcpio.ConventionEntry{
+			{Description: "strong", Strength: 0.9},
+		},
+	}
+	stale := 2
+	statusResp := mcpio.StatusResponse{
+		Freshness: mcpio.Freshness{StaleFilesSeen: &stale},
+	}
+
+	firstGraph := graphHints(graphResp, "callers")
+	firstBlast := blastHints(blastResp)
+	firstConv := conventionsHints(convResp, "models")
+	firstStatus := statusHints(statusResp, 0)
+
+	for i := 0; i < 50; i++ {
+		assertSameHints(t, "graphHints", firstGraph, graphHints(graphResp, "callers"))
+		assertSameHints(t, "blastHints", firstBlast, blastHints(blastResp))
+		assertSameHints(t, "conventionsHints", firstConv, conventionsHints(convResp, "models"))
+		assertSameHints(t, "statusHints", firstStatus, statusHints(statusResp, 0))
+	}
+}
+
+func assertSameHints(t *testing.T, name string, want, got []mcpio.NextStep) {
+	t.Helper()
+	if len(want) != len(got) {
+		t.Fatalf("%s: length changed from %d to %d", name, len(want), len(got))
+	}
+	for i := range want {
+		if want[i].Tool != got[i].Tool || want[i].Reason != got[i].Reason {
+			t.Fatalf("%s: hint[%d] changed: %+v → %+v", name, i, want[i], got[i])
+		}
+	}
+}

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -357,12 +357,54 @@ func (h *handlers) handleGraph(ctx context.Context, req mcp.CallToolRequest) (*m
 
 	freshness := computeFreshness(ctx, h.db, h.dir, false, h.watchState)
 	resp.Freshness = freshness
+	resp.NextSteps = graphHints(resp, direction)
 
 	out, err := mcpio.MarshalGraph(resp)
 	if err != nil {
 		return nil, fmt.Errorf("sense.graph: marshal: %w", err)
 	}
 	return mcp.NewToolResultText(string(out)), nil
+}
+
+func graphHints(resp mcpio.GraphResponse, direction string) []mcpio.NextStep {
+	var hints []mcpio.NextStep
+
+	if len(resp.Edges.CalledBy) >= 5 {
+		hints = append(hints, mcpio.NextStep{
+			Tool:   "sense.blast",
+			Args:   map[string]any{"symbol": resp.Symbol.Qualified},
+			Reason: fmt.Sprintf("%d callers found — check blast radius before changing this symbol", len(resp.Edges.CalledBy)),
+		})
+	} else if len(resp.Edges.CalledBy) == 0 && !isTestFile(resp.Symbol.File) {
+		hints = append(hints, mcpio.NextStep{
+			Tool:   "sense.search",
+			Args:   map[string]any{"query": resp.Symbol.Name},
+			Reason: "no callers found in graph — search for dynamic references",
+		})
+	}
+
+	if direction == "callers" && len(hints) < 2 {
+		hints = append(hints, mcpio.NextStep{
+			Tool:   "sense.graph",
+			Args:   map[string]any{"symbol": resp.Symbol.Qualified, "direction": "callees"},
+			Reason: "see what this symbol depends on",
+		})
+	}
+
+	if len(hints) > 2 {
+		hints = hints[:2]
+	}
+	return hints
+}
+
+func isTestFile(path string) bool {
+	return strings.Contains(path, "_test.") ||
+		strings.Contains(path, "/test/") ||
+		strings.Contains(path, "/tests/") ||
+		strings.Contains(path, "/spec/") ||
+		strings.HasPrefix(path, "test/") ||
+		strings.HasPrefix(path, "tests/") ||
+		strings.HasPrefix(path, "spec/")
 }
 
 // ---------------------------------------------------------------
@@ -428,11 +470,49 @@ func (h *handlers) handleSearch(ctx context.Context, req mcp.CallToolRequest) (*
 	h.tracker.Record("sense.search", query,
 		resp.SenseMetrics.EstimatedFileReadsAvoided, resp.SenseMetrics.EstimatedTokensSaved)
 
+	resp.NextSteps = searchHints(resp)
+
 	out, err := mcpio.MarshalSearch(resp)
 	if err != nil {
 		return nil, fmt.Errorf("sense.search: marshal: %w", err)
 	}
 	return mcp.NewToolResultText(string(out)), nil
+}
+
+func searchHints(resp mcpio.SearchResponse) []mcpio.NextStep {
+	var hints []mcpio.NextStep
+
+	if len(resp.Results) > 0 && float64(resp.Results[0].Score) >= 0.8 {
+		hints = append(hints, mcpio.NextStep{
+			Tool:   "sense.graph",
+			Args:   map[string]any{"symbol": resp.Results[0].Symbol},
+			Reason: "strong match — explore its relationships",
+		})
+	}
+
+	if len(hints) < 2 {
+		fileCounts := map[string]int{}
+		for _, r := range resp.Results {
+			if r.File != "" {
+				fileCounts[r.File]++
+			}
+		}
+		for _, r := range resp.Results {
+			if r.File != "" && fileCounts[r.File] >= 3 {
+				hints = append(hints, mcpio.NextStep{
+					Tool:   "sense.conventions",
+					Args:   map[string]any{"domain": filepath.Dir(r.File)},
+					Reason: "cluster of related symbols — check conventions in this area",
+				})
+				break
+			}
+		}
+	}
+
+	if len(hints) > 2 {
+		hints = hints[:2]
+	}
+	return hints
 }
 
 // ---------------------------------------------------------------
@@ -488,12 +568,37 @@ func (h *handlers) handleBlast(ctx context.Context, req mcp.CallToolRequest) (*m
 
 	freshness := computeFreshness(ctx, h.db, h.dir, false, h.watchState)
 	resp.Freshness = freshness
+	resp.NextSteps = blastHints(resp)
 
 	out, err := mcpio.MarshalBlast(resp)
 	if err != nil {
 		return nil, fmt.Errorf("sense.blast: marshal: %w", err)
 	}
 	return mcp.NewToolResultText(string(out)), nil
+}
+
+func blastHints(resp mcpio.BlastResponse) []mcpio.NextStep {
+	var hints []mcpio.NextStep
+
+	if resp.Risk == "high" {
+		hints = append(hints, mcpio.NextStep{
+			Tool:   "sense.conventions",
+			Reason: "high blast radius — check conventions before changing",
+		})
+	}
+
+	if len(resp.AffectedTests) == 0 && resp.TotalAffected > 0 && len(hints) < 2 {
+		hints = append(hints, mcpio.NextStep{
+			Tool:   "sense.search",
+			Args:   map[string]any{"query": resp.Symbol + " test"},
+			Reason: "affected symbols have no test coverage — search for related tests",
+		})
+	}
+
+	if len(hints) > 2 {
+		hints = hints[:2]
+	}
+	return hints
 }
 
 type toolError struct{ msg string }
@@ -637,11 +742,40 @@ func (h *handlers) handleConventions(ctx context.Context, req mcp.CallToolReques
 	h.tracker.Record("sense.conventions", domain,
 		resp.SenseMetrics.EstimatedFileReadsAvoided, resp.SenseMetrics.EstimatedTokensSaved)
 
+	resp.NextSteps = conventionsHints(resp, domain)
+
 	out, err := mcpio.MarshalConventions(resp)
 	if err != nil {
 		return nil, fmt.Errorf("sense.conventions: marshal: %w", err)
 	}
 	return mcp.NewToolResultText(string(out)), nil
+}
+
+func conventionsHints(resp mcpio.ConventionsResponse, domain string) []mcpio.NextStep {
+	var hints []mcpio.NextStep
+
+	for _, c := range resp.Conventions {
+		if float64(c.Strength) >= 0.8 {
+			hints = append(hints, mcpio.NextStep{
+				Tool:   "sense.search",
+				Args:   map[string]any{"query": c.Description},
+				Reason: "strong convention — search for all instances",
+			})
+			break
+		}
+	}
+
+	if domain != "" && len(hints) < 2 {
+		hints = append(hints, mcpio.NextStep{
+			Tool:   "sense.conventions",
+			Reason: "scoped results — run without domain filter for project-wide patterns",
+		})
+	}
+
+	if len(hints) > 2 {
+		hints = hints[:2]
+	}
+	return hints
 }
 
 // ---------------------------------------------------------------
@@ -675,11 +809,35 @@ func (h *handlers) handleStatus(ctx context.Context, _ mcp.CallToolRequest) (*mc
 		EstimatedTokensSaved:      lt.TokensSaved,
 	}
 
+	resp.NextSteps = statusHints(resp, sess.Queries)
+
 	out, err := mcpio.MarshalStatus(resp)
 	if err != nil {
 		return nil, fmt.Errorf("sense.status: marshal: %w", err)
 	}
 	return mcp.NewToolResultText(string(out)), nil
+}
+
+func statusHints(resp mcpio.StatusResponse, sessionQueries int) []mcpio.NextStep {
+	var hints []mcpio.NextStep
+
+	if resp.Freshness.StaleFilesSeen != nil && *resp.Freshness.StaleFilesSeen > 0 {
+		hints = append(hints, mcpio.NextStep{
+			Reason: fmt.Sprintf("index has %d stale files — consider running `sense scan`", *resp.Freshness.StaleFilesSeen),
+		})
+	}
+
+	if sessionQueries == 0 && len(hints) < 2 {
+		hints = append(hints, mcpio.NextStep{
+			Tool:   "sense.conventions",
+			Reason: "start of session — check project conventions",
+		})
+	}
+
+	if len(hints) > 2 {
+		hints = hints[:2]
+	}
+	return hints
 }
 
 func buildStatusResponse(ctx context.Context, db *sql.DB, dir string, ws *mcpio.WatchState) (mcpio.StatusResponse, error) {

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -149,6 +149,11 @@ func TestMCPIntegration(t *testing.T) {
 				IndexAgeSeconds *int64 `json:"index_age_seconds"`
 				StaleFilesSeen  *int   `json:"stale_files_seen"`
 			} `json:"freshness"`
+			NextSteps []struct {
+				Tool   string         `json:"tool"`
+				Args   map[string]any `json:"args,omitempty"`
+				Reason string         `json:"reason"`
+			} `json:"next_steps"`
 		}
 		if err := json.Unmarshal([]byte(text), &graph); err != nil {
 			t.Fatalf("parse graph JSON: %v\n%s", err, text)
@@ -169,6 +174,12 @@ func TestMCPIntegration(t *testing.T) {
 			t.Error("freshness block missing")
 		} else if graph.Freshness.IndexAgeSeconds == nil {
 			t.Error("freshness.index_age_seconds missing")
+		}
+		if graph.NextSteps == nil {
+			t.Error("next_steps missing from graph response")
+		}
+		if len(graph.Edges.CalledBy) >= 5 && len(graph.NextSteps) == 0 {
+			t.Error("expected blast hint for symbol with ≥5 callers")
 		}
 	})
 
@@ -261,6 +272,10 @@ func TestMCPIntegration(t *testing.T) {
 				StaleFilesSeen        *int    `json:"stale_files_seen"`
 				MaxFileMtimeSinceScan *string `json:"max_file_mtime_since_scan"`
 			} `json:"freshness"`
+			NextSteps []struct {
+				Tool   string `json:"tool"`
+				Reason string `json:"reason"`
+			} `json:"next_steps"`
 		}
 		if err := json.Unmarshal([]byte(text), &status); err != nil {
 			t.Fatalf("parse status JSON: %v\n%s", err, text)
@@ -287,6 +302,9 @@ func TestMCPIntegration(t *testing.T) {
 		// the other freshness fields instead.
 		if status.Freshness.StaleFilesSeen == nil {
 			t.Error("freshness.stale_files_seen missing")
+		}
+		if status.NextSteps == nil {
+			t.Error("next_steps missing from status response")
 		}
 	})
 }


### PR DESCRIPTION
## Problem

When an agent calls a Sense tool, the response answers the question and goes silent. The agent has to decide — on its own — whether to check blast radius, search for related patterns, or read conventions. It re-derives the workflow from tool descriptions alone, sometimes wandering into grep and burning tokens rebuilding context Sense already has.

## Summary

Each MCP tool response now includes a `next_steps` array (0-2 entries) with pre-filled follow-up tool calls computed from the actual response data. Agents can read the hints and call the suggested tool directly.

## Changes

**Wire format (`internal/mcpio`)**
- `NextStep` struct with `tool`, `args` (omitempty), and `reason` fields
- `NextSteps []NextStep` field added to all 5 response types (Graph, Blast, Search, Conventions, Status)
- Normalize functions ensure `nil` → `[]` (consistent with existing empty-means-looked contract)
- Golden test data and round-trip tests updated

**Hint logic (`internal/mcpserver`)**
- `graphHints`: ≥5 callers → blast, 0 callers (non-test) → search, callers-only direction → callees
- `searchHints`: top result score ≥0.8 → graph, ≥3 results in same file → conventions (deterministic order)
- `blastHints`: high risk → conventions, no test coverage + affected > 0 → search
- `conventionsHints`: strong convention (≥0.8) → search, domain-scoped → unscoped
- `statusHints`: stale files → advisory, first session query → conventions
- `isTestFile` helper matches path segments (`_test.`, `/test/`, `/spec/`) to avoid false positives

**Tests**
- 27 unit tests covering all 5 hint functions: condition triggers, empty results, max-2 cap, determinism (50 iterations)
- Integration test assertions verify `next_steps` appears in graph and status JSON responses

## Test Plan

- [x] Each hint condition tested independently with correct tool/args
- [x] Empty `[]` returned when no conditions match
- [x] Max 2 hints enforced across all functions
- [x] Determinism verified: same input → same hints × 50 iterations
- [x] `isTestFile` correctly identifies test paths without false positives on "contest", "attestation"
- [x] Integration: `next_steps` field present in live MCP graph and status responses
- [x] `make ci` passes (build + test + lint)