### PR TITLE
feat(dead): add dead code detection to sense.graph and CLI

### DIFF
--- a/cmd/sense/main.go
+++ b/cmd/sense/main.go
@@ -29,6 +29,7 @@ Commands:
   search        Hybrid semantic + keyword search
   graph         Symbol relationships — callers, callees, inheritance, tests
   blast         Blast radius for a symbol or diff
+  dead          Find dead code (symbols with no incoming references)
   conventions   Detected project conventions
   status        Index health and embedding coverage
   doctor        Diagnose common index problems
@@ -134,6 +135,9 @@ func main() {
 
 	case "blast":
 		os.Exit(cli.RunBlast(os.Args[2:], cli.DefaultIO()))
+
+	case "dead":
+		os.Exit(cli.RunDead(os.Args[2:], cli.DefaultIO()))
 
 	case "conventions":
 		os.Exit(cli.RunConventions(os.Args[2:], cli.DefaultIO()))

--- a/internal/cli/dead.go
+++ b/internal/cli/dead.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/luuuc/sense/internal/dead"
+	"github.com/luuuc/sense/internal/mcpio"
+)
+
+const deadHelp = `usage: sense dead [flags]
+
+Find dead code: symbols with no incoming references.
+
+Flags:
+  --language LANG    Filter by language (e.g. "go", "ruby")
+  --domain PATH      Filter by path substring (e.g. "services", "models")
+  --limit N          Maximum symbols to report (default 100)
+  --json             Emit JSON matching the sense.graph dead_code MCP schema
+  -h, --help         Show this help
+
+Examples:
+  sense dead
+  sense dead --language go
+  sense dead --domain services --json
+  sense dead --limit 50
+
+Exit codes:
+  0  success
+  1  general error
+  3  index missing (run 'sense scan' first)
+  4  index corrupt
+`
+
+type deadOptions struct {
+	Language string
+	Domain   string
+	Limit    int
+	JSON     bool
+}
+
+func RunDead(args []string, cio IO) int {
+	opts, err := parseDeadArgs(args, cio.Stderr)
+	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return ExitSuccess
+		}
+		return ExitGeneralError
+	}
+
+	ctx := context.Background()
+
+	adapter, err := OpenIndex(ctx, cio.Dir)
+	if err != nil {
+		return handleIndexOpenError(cio.Stderr, err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	result, err := dead.FindDead(ctx, adapter.DB(), dead.Options{
+		Language: opts.Language,
+		Domain:   opts.Domain,
+		Limit:    opts.Limit,
+	})
+	if err != nil {
+		_, _ = fmt.Fprintln(cio.Stderr, "sense dead:", err)
+		return ExitGeneralError
+	}
+
+	rolled := dead.Rollup(result.Dead)
+
+	if opts.JSON {
+		resp := mcpio.BuildDeadCodeResponse(rolled, result.TotalSymbols)
+		out, merr := mcpio.MarshalDeadCode(resp)
+		if merr != nil {
+			_, _ = fmt.Fprintln(cio.Stderr, "sense dead:", merr)
+			return ExitGeneralError
+		}
+		_, _ = fmt.Fprintln(cio.Stdout, string(out))
+		return ExitSuccess
+	}
+
+	RenderDeadHuman(cio.Stdout, rolled, result.TotalSymbols)
+	return ExitSuccess
+}
+
+func RenderDeadHuman(w io.Writer, symbols []dead.Symbol, totalSymbols int) {
+	if len(symbols) == 0 {
+		_, _ = fmt.Fprintln(w, "No dead code found.")
+		return
+	}
+
+	_, _ = fmt.Fprintf(w, "Dead code: %d symbols with no incoming references\n\n", len(symbols))
+
+	var currentFile string
+	for _, s := range symbols {
+		if s.File != currentFile {
+			if currentFile != "" {
+				_, _ = fmt.Fprintln(w)
+			}
+			currentFile = s.File
+			_, _ = fmt.Fprintln(w, s.File)
+		}
+		_, _ = fmt.Fprintf(w, "  %s (%s, lines %d-%d)\n", s.Qualified, s.Kind, s.LineStart, s.LineEnd)
+	}
+
+	pct := float64(len(symbols)) * 100 / float64(totalSymbols)
+	_, _ = fmt.Fprintf(w, "\n%d dead symbols out of %d total (%.1f%%)\n", len(symbols), totalSymbols, pct)
+}
+
+func parseDeadArgs(args []string, stderr io.Writer) (deadOptions, error) {
+	fs := flag.NewFlagSet("sense dead", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Usage = func() { _, _ = fmt.Fprint(stderr, deadHelp) }
+
+	var opts deadOptions
+	fs.StringVar(&opts.Language, "language", "", "filter by language")
+	fs.StringVar(&opts.Domain, "domain", "", "filter by path substring")
+	fs.IntVar(&opts.Limit, "limit", 100, "maximum symbols to report")
+	fs.BoolVar(&opts.JSON, "json", false, "emit JSON")
+
+	if err := fs.Parse(args); err != nil {
+		return deadOptions{}, err
+	}
+
+	return opts, nil
+}

--- a/internal/dead/dead.go
+++ b/internal/dead/dead.go
@@ -1,0 +1,309 @@
+package dead
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+const defaultLimit = 100
+
+type Options struct {
+	Language string
+	Domain   string
+	Limit    int
+}
+
+type Symbol struct {
+	ID        int64
+	Name      string
+	Qualified string
+	Kind      string
+	File      string
+	FileID    int64
+	LineStart int
+	LineEnd   int
+	ParentID  *int64
+}
+
+type Result struct {
+	Dead         []Symbol
+	TotalSymbols int
+}
+
+func FindDead(ctx context.Context, db *sql.DB, opts Options) (Result, error) {
+	if opts.Limit <= 0 {
+		opts.Limit = defaultLimit
+	}
+
+	totalSymbols, err := countSymbols(ctx, db, opts)
+	if err != nil {
+		return Result{}, fmt.Errorf("dead: count symbols: %w", err)
+	}
+
+	candidates, err := queryCandidates(ctx, db, opts)
+	if err != nil {
+		return Result{}, fmt.Errorf("dead: query candidates: %w", err)
+	}
+
+	testsTargets, err := queryTestsTargets(ctx, db)
+	if err != nil {
+		return Result{}, fmt.Errorf("dead: query tests targets: %w", err)
+	}
+
+	candidates = excludeEntryPoints(candidates, testsTargets)
+
+	liveContainers, err := findLiveContainers(ctx, db, candidates)
+	if err != nil {
+		return Result{}, fmt.Errorf("dead: live containers: %w", err)
+	}
+	candidates = excludeIDs(candidates, liveContainers)
+
+	if len(candidates) > opts.Limit {
+		candidates = candidates[:opts.Limit]
+	}
+
+	return Result{
+		Dead:         candidates,
+		TotalSymbols: totalSymbols,
+	}, nil
+}
+
+func countSymbols(ctx context.Context, db *sql.DB, opts Options) (int, error) {
+	q := `SELECT COUNT(*) FROM sense_symbols s
+		JOIN sense_files f ON s.file_id = f.id
+		WHERE s.kind IN ('function', 'method', 'class', 'module', 'type', 'interface')`
+	var args []any
+
+	if opts.Language != "" {
+		q += " AND f.language = ?"
+		args = append(args, opts.Language)
+	}
+	if opts.Domain != "" {
+		q += " AND f.path LIKE ?"
+		args = append(args, "%"+opts.Domain+"%")
+	}
+
+	var count int
+	if err := db.QueryRowContext(ctx, q, args...).Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func queryCandidates(ctx context.Context, db *sql.DB, opts Options) ([]Symbol, error) {
+	q := `SELECT s.id, s.name, s.qualified, s.kind, f.path, s.file_id, s.line_start, s.line_end, s.parent_id
+		FROM sense_symbols s
+		JOIN sense_files f ON s.file_id = f.id
+		WHERE NOT EXISTS (
+			SELECT 1 FROM sense_edges e
+			WHERE e.target_id = s.id
+			AND e.kind IN ('calls', 'composes', 'includes', 'inherits')
+		)
+		AND s.kind IN ('function', 'method', 'class', 'module', 'type', 'interface')`
+	var args []any
+
+	if opts.Language != "" {
+		q += " AND f.language = ?"
+		args = append(args, opts.Language)
+	}
+	if opts.Domain != "" {
+		q += " AND f.path LIKE ?"
+		args = append(args, "%"+opts.Domain+"%")
+	}
+
+	q += " ORDER BY f.path, s.line_start"
+
+	rows, err := db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []Symbol
+	for rows.Next() {
+		var sym Symbol
+		var parentID sql.NullInt64
+		if err := rows.Scan(&sym.ID, &sym.Name, &sym.Qualified, &sym.Kind,
+			&sym.File, &sym.FileID, &sym.LineStart, &sym.LineEnd, &parentID); err != nil {
+			return nil, err
+		}
+		if parentID.Valid {
+			p := parentID.Int64
+			sym.ParentID = &p
+		}
+		out = append(out, sym)
+	}
+	return out, rows.Err()
+}
+
+func queryTestsTargets(ctx context.Context, db *sql.DB) (map[int64]struct{}, error) {
+	rows, err := db.QueryContext(ctx,
+		`SELECT DISTINCT target_id FROM sense_edges WHERE kind = 'tests'`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make(map[int64]struct{})
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out[id] = struct{}{}
+	}
+	return out, rows.Err()
+}
+
+func excludeEntryPoints(candidates []Symbol, testsTargets map[int64]struct{}) []Symbol {
+	var out []Symbol
+	for _, s := range candidates {
+		if isEntryPoint(s, testsTargets) {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// findLiveContainers returns IDs of class/module candidates that have
+// at least one child with incoming edges (i.e., child is NOT in the
+// dead candidate set). A container with live children is alive by
+// purpose — it's the namespace for referenced code.
+func findLiveContainers(ctx context.Context, db *sql.DB, candidates []Symbol) (map[int64]struct{}, error) {
+	deadIDs := make(map[int64]struct{}, len(candidates))
+	for _, s := range candidates {
+		deadIDs[s.ID] = struct{}{}
+	}
+
+	var containerIDs []int64
+	for _, s := range candidates {
+		if s.Kind == "class" || s.Kind == "module" {
+			containerIDs = append(containerIDs, s.ID)
+		}
+	}
+
+	if len(containerIDs) == 0 {
+		return nil, nil
+	}
+
+	// Bulk-load all children of candidate containers in one query,
+	// then partition in Go to find which containers have live children.
+	childrenByParent := map[int64][]int64{}
+	const chunk = 500
+	for start := 0; start < len(containerIDs); start += chunk {
+		end := start + chunk
+		if end > len(containerIDs) {
+			end = len(containerIDs)
+		}
+		batch := containerIDs[start:end]
+
+		placeholders := strings.Repeat("?,", len(batch))
+		placeholders = placeholders[:len(placeholders)-1]
+
+		q := `SELECT parent_id, id FROM sense_symbols
+			WHERE parent_id IN (` + placeholders + `)`
+
+		args := make([]any, len(batch))
+		for i, id := range batch {
+			args[i] = id
+		}
+
+		rows, err := db.QueryContext(ctx, q, args...)
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			var parentID, childID int64
+			if err := rows.Scan(&parentID, &childID); err != nil {
+				_ = rows.Close()
+				return nil, err
+			}
+			childrenByParent[parentID] = append(childrenByParent[parentID], childID)
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		_ = rows.Close()
+	}
+
+	result := make(map[int64]struct{})
+	for parentID, children := range childrenByParent {
+		for _, childID := range children {
+			if _, isDead := deadIDs[childID]; !isDead {
+				result[parentID] = struct{}{}
+				break
+			}
+		}
+	}
+
+	return result, nil
+}
+
+func excludeIDs(candidates []Symbol, exclude map[int64]struct{}) []Symbol {
+	if len(exclude) == 0 {
+		return candidates
+	}
+	var out []Symbol
+	for _, s := range candidates {
+		if _, excluded := exclude[s.ID]; !excluded {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func isEntryPoint(s Symbol, testsTargets map[int64]struct{}) bool {
+	if isMainFunction(s) {
+		return true
+	}
+	if isTestSymbol(s) {
+		return true
+	}
+	if isInTestFile(s) {
+		return true
+	}
+	if isConstructor(s) {
+		return true
+	}
+	if _, ok := testsTargets[s.ID]; ok {
+		return true
+	}
+	return false
+}
+
+func isMainFunction(s Symbol) bool {
+	return s.Name == "main" || s.Name == "Main"
+}
+
+func isTestSymbol(s Symbol) bool {
+	if strings.HasPrefix(s.Name, "Test") {
+		return true
+	}
+	if strings.HasPrefix(s.Name, "test_") {
+		return true
+	}
+	if strings.HasPrefix(s.Name, "Benchmark") {
+		return true
+	}
+	return s.Name == "it" || s.Name == "describe" || s.Name == "specify"
+}
+
+func isInTestFile(s Symbol) bool {
+	return strings.Contains(s.File, "_test.") ||
+		strings.Contains(s.File, "/test/") ||
+		strings.Contains(s.File, "/tests/") ||
+		strings.Contains(s.File, "/spec/") ||
+		strings.HasSuffix(s.File, ".spec.ts") ||
+		strings.HasSuffix(s.File, ".spec.js") ||
+		strings.HasSuffix(s.File, ".test.ts") ||
+		strings.HasSuffix(s.File, ".test.js")
+}
+
+func isConstructor(s Symbol) bool {
+	return s.Name == "initialize" || s.Name == "__init__" || s.Name == "constructor" ||
+		s.Name == "init" || s.Name == "Init"
+}

--- a/internal/dead/dead_test.go
+++ b/internal/dead/dead_test.go
@@ -1,0 +1,346 @@
+package dead_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/luuuc/sense/internal/dead"
+	"github.com/luuuc/sense/internal/scan"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+func setupFixture(t *testing.T) (*sql.DB, *sqlite.Adapter) {
+	t.Helper()
+	root := t.TempDir()
+
+	// LiveService: called by main.rb, so it's alive.
+	writeFile(t, filepath.Join(root, "live_service.rb"), `class LiveService
+  def process
+    42
+  end
+end
+`)
+	// DeadService: nothing calls it.
+	writeFile(t, filepath.Join(root, "dead_service.rb"), `class DeadService
+  def handle
+    1
+  end
+
+  def cleanup
+    2
+  end
+end
+`)
+	// Caller: calls LiveService#process via send.
+	writeFile(t, filepath.Join(root, "caller.rb"), `class Caller
+  def run
+    send(:process)
+  end
+end
+`)
+	// main.go: main function should be excluded as entry point.
+	writeFile(t, filepath.Join(root, "main.go"), `package main
+
+func main() {}
+
+func unusedGoFunc() {}
+`)
+	// widget_test.go: test functions should be excluded.
+	writeFile(t, filepath.Join(root, "widget_test.go"), `package main
+
+import "testing"
+
+func TestWidget(t *testing.T) {}
+`)
+	// Initializer: constructor should be excluded.
+	writeFile(t, filepath.Join(root, "initializer.rb"), `class Initializer
+  def initialize
+    @ready = true
+  end
+end
+`)
+
+	ctx := context.Background()
+	if _, err := scan.Run(ctx, scan.Options{
+		Root:     root,
+		Output:   &bytes.Buffer{},
+		Warnings: io.Discard,
+	}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+
+	dbPath := filepath.Join(root, ".sense", "index.db")
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	return db, adapter
+}
+
+func TestFindDeadBasic(t *testing.T) {
+	db, _ := setupFixture(t)
+	ctx := context.Background()
+
+	result, err := dead.FindDead(ctx, db, dead.Options{})
+	if err != nil {
+		t.Fatalf("FindDead: %v", err)
+	}
+
+	if result.TotalSymbols == 0 {
+		t.Fatal("TotalSymbols = 0, want > 0")
+	}
+
+	deadNames := map[string]bool{}
+	for _, s := range result.Dead {
+		deadNames[s.Qualified] = true
+	}
+
+	// DeadService and its methods should be flagged.
+	if !deadNames["DeadService"] || !deadNames["DeadService#handle"] {
+		t.Error("expected DeadService or DeadService#handle in dead symbols")
+	}
+
+	// LiveService#process is called by Caller#run via send(:process),
+	// so it should NOT be dead.
+	if deadNames["LiveService#process"] {
+		t.Error("LiveService#process should not be dead (called by Caller)")
+	}
+}
+
+func TestFindDeadExcludesMainFunction(t *testing.T) {
+	db, _ := setupFixture(t)
+	ctx := context.Background()
+
+	result, err := dead.FindDead(ctx, db, dead.Options{})
+	if err != nil {
+		t.Fatalf("FindDead: %v", err)
+	}
+
+	for _, s := range result.Dead {
+		if s.Name == "main" {
+			t.Error("main function should be excluded as entry point")
+		}
+	}
+}
+
+func TestFindDeadExcludesTestFunctions(t *testing.T) {
+	db, _ := setupFixture(t)
+	ctx := context.Background()
+
+	result, err := dead.FindDead(ctx, db, dead.Options{})
+	if err != nil {
+		t.Fatalf("FindDead: %v", err)
+	}
+
+	for _, s := range result.Dead {
+		if s.Name == "TestWidget" {
+			t.Error("TestWidget should be excluded as test entry point")
+		}
+	}
+}
+
+func TestFindDeadExcludesTestFiles(t *testing.T) {
+	db, _ := setupFixture(t)
+	ctx := context.Background()
+
+	result, err := dead.FindDead(ctx, db, dead.Options{})
+	if err != nil {
+		t.Fatalf("FindDead: %v", err)
+	}
+
+	for _, s := range result.Dead {
+		if s.File == "widget_test.go" {
+			t.Errorf("symbol %q in test file should be excluded", s.Qualified)
+		}
+	}
+}
+
+func TestFindDeadExcludesConstructors(t *testing.T) {
+	db, _ := setupFixture(t)
+	ctx := context.Background()
+
+	result, err := dead.FindDead(ctx, db, dead.Options{})
+	if err != nil {
+		t.Fatalf("FindDead: %v", err)
+	}
+
+	for _, s := range result.Dead {
+		if s.Name == "initialize" {
+			t.Error("initialize should be excluded as constructor entry point")
+		}
+	}
+}
+
+func TestFindDeadLanguageFilter(t *testing.T) {
+	db, _ := setupFixture(t)
+	ctx := context.Background()
+
+	result, err := dead.FindDead(ctx, db, dead.Options{Language: "ruby"})
+	if err != nil {
+		t.Fatalf("FindDead: %v", err)
+	}
+
+	for _, s := range result.Dead {
+		if filepath.Ext(s.File) != ".rb" {
+			t.Errorf("found non-ruby symbol %q in file %q with language=ruby filter", s.Qualified, s.File)
+		}
+	}
+}
+
+func TestFindDeadDomainFilter(t *testing.T) {
+	db, _ := setupFixture(t)
+	ctx := context.Background()
+
+	// Filter to a path substring that doesn't match any file.
+	result, err := dead.FindDead(ctx, db, dead.Options{Domain: "nonexistent_path"})
+	if err != nil {
+		t.Fatalf("FindDead: %v", err)
+	}
+
+	if len(result.Dead) != 0 {
+		t.Errorf("expected no results with nonexistent domain filter, got %d", len(result.Dead))
+	}
+}
+
+func TestFindDeadLimit(t *testing.T) {
+	db, _ := setupFixture(t)
+	ctx := context.Background()
+
+	result, err := dead.FindDead(ctx, db, dead.Options{Limit: 1})
+	if err != nil {
+		t.Fatalf("FindDead: %v", err)
+	}
+
+	if len(result.Dead) > 1 {
+		t.Errorf("expected at most 1 result with limit=1, got %d", len(result.Dead))
+	}
+}
+
+func TestRollupCollapsesDeadClassWithDeadMethods(t *testing.T) {
+	classID := int64(1)
+	symbols := []dead.Symbol{
+		{ID: classID, Name: "Klass", Qualified: "Klass", Kind: "class"},
+		{ID: 2, Name: "foo", Qualified: "Klass#foo", Kind: "method", ParentID: &classID},
+		{ID: 3, Name: "bar", Qualified: "Klass#bar", Kind: "method", ParentID: &classID},
+	}
+
+	rolled := dead.Rollup(symbols)
+
+	if len(rolled) != 1 {
+		t.Fatalf("Rollup returned %d symbols, want 1 (class only)", len(rolled))
+	}
+	if rolled[0].Qualified != "Klass" {
+		t.Errorf("Rollup[0] = %q, want Klass", rolled[0].Qualified)
+	}
+}
+
+func TestRollupKeepsDeadMethodsOfLiveClass(t *testing.T) {
+	// Class is alive (not in dead set), but method is dead.
+	aliveClassID := int64(99)
+	symbols := []dead.Symbol{
+		{ID: 2, Name: "orphan", Qualified: "AliveClass#orphan", Kind: "method", ParentID: &aliveClassID},
+	}
+
+	rolled := dead.Rollup(symbols)
+
+	if len(rolled) != 1 {
+		t.Fatalf("Rollup returned %d symbols, want 1", len(rolled))
+	}
+	if rolled[0].Qualified != "AliveClass#orphan" {
+		t.Errorf("Rollup[0] = %q, want AliveClass#orphan", rolled[0].Qualified)
+	}
+}
+
+func TestRollupPreservesStandaloneDeadFunctions(t *testing.T) {
+	symbols := []dead.Symbol{
+		{ID: 1, Name: "helper", Qualified: "helper", Kind: "function"},
+		{ID: 2, Name: "util", Qualified: "util", Kind: "function"},
+	}
+
+	rolled := dead.Rollup(symbols)
+
+	if len(rolled) != 2 {
+		t.Errorf("Rollup returned %d symbols, want 2", len(rolled))
+	}
+}
+
+func TestFindDeadExcludesContainersWithLiveChildren(t *testing.T) {
+	root := t.TempDir()
+
+	// MixedService: the class itself has no incoming calls, but one
+	// of its methods is called. The class should be excluded because
+	// its child (alive_method) has incoming edges.
+	writeFile(t, filepath.Join(root, "mixed.rb"), `class MixedService
+  def alive_method
+    42
+  end
+
+  def dead_method
+    0
+  end
+end
+`)
+	writeFile(t, filepath.Join(root, "consumer.rb"), `class Consumer
+  def use_it
+    send(:alive_method)
+  end
+end
+`)
+
+	ctx := context.Background()
+	if _, err := scan.Run(ctx, scan.Options{
+		Root:     root,
+		Output:   &bytes.Buffer{},
+		Warnings: io.Discard,
+	}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+
+	dbPath := filepath.Join(root, ".sense", "index.db")
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	result, err := dead.FindDead(ctx, db, dead.Options{})
+	if err != nil {
+		t.Fatalf("FindDead: %v", err)
+	}
+
+	for _, s := range result.Dead {
+		if s.Qualified == "MixedService" {
+			t.Error("MixedService should be excluded — it has a live child (alive_method)")
+		}
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}

--- a/internal/dead/golden_test.go
+++ b/internal/dead/golden_test.go
@@ -1,0 +1,170 @@
+package dead_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/luuuc/sense/internal/dead"
+	"github.com/luuuc/sense/internal/scan"
+)
+
+var updateGolden = flag.Bool("update-golden", false, "regenerate dead-golden.json")
+
+type goldenEntry struct {
+	Qualified string `json:"qualified"`
+	Kind      string `json:"kind"`
+	File      string `json:"file"`
+}
+
+type goldenFile struct {
+	Dead         []goldenEntry `json:"dead"`
+	TotalSymbols int           `json:"total_symbols"`
+	DeadCount    int           `json:"dead_count"`
+}
+
+func smokeRoot(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", "..", "testdata", "smoke"))
+	if err != nil {
+		t.Fatalf("resolve smoke root: %v", err)
+	}
+	return root
+}
+
+func goldenPath(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(smokeRoot(t), "dead-golden.json")
+}
+
+func scanSmoke(t *testing.T) *sql.DB {
+	t.Helper()
+	root := smokeRoot(t)
+	senseDir := t.TempDir()
+
+	ctx := context.Background()
+	if _, err := scan.Run(ctx, scan.Options{
+		Root:     root,
+		Sense:    senseDir,
+		Output:   &bytes.Buffer{},
+		Warnings: io.Discard,
+	}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+
+	dbPath := filepath.Join(senseDir, "index.db")
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestDeadCodeGolden(t *testing.T) {
+	db := scanSmoke(t)
+	ctx := context.Background()
+
+	result, err := dead.FindDead(ctx, db, dead.Options{Limit: 200})
+	if err != nil {
+		t.Fatalf("FindDead: %v", err)
+	}
+
+	rolled := dead.Rollup(result.Dead)
+
+	entries := make([]goldenEntry, len(rolled))
+	for i, s := range rolled {
+		entries[i] = goldenEntry{s.Qualified, s.Kind, s.File}
+	}
+
+	actual := goldenFile{
+		Dead:         entries,
+		TotalSymbols: result.TotalSymbols,
+		DeadCount:    len(rolled),
+	}
+
+	if *updateGolden {
+		data, err := json.MarshalIndent(actual, "", "  ")
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if err := os.WriteFile(goldenPath(t), append(data, '\n'), 0o644); err != nil {
+			t.Fatalf("write golden: %v", err)
+		}
+		t.Logf("updated %s: %d dead out of %d total", goldenPath(t), actual.DeadCount, actual.TotalSymbols)
+		return
+	}
+
+	data, err := os.ReadFile(goldenPath(t))
+	if err != nil {
+		t.Fatalf("read golden file (run with -update-golden to generate): %v", err)
+	}
+	var expected goldenFile
+	if err := json.Unmarshal(data, &expected); err != nil {
+		t.Fatalf("parse golden: %v", err)
+	}
+
+	actualJSON, _ := json.MarshalIndent(actual, "", "  ")
+	expectedJSON, _ := json.MarshalIndent(expected, "", "  ")
+
+	if !bytes.Equal(actualJSON, expectedJSON) {
+		t.Errorf("dead code output differs from golden file.\nGot:\n%s\nWant:\n%s\n\nRun with -update-golden to regenerate.",
+			string(actualJSON), string(expectedJSON))
+	}
+}
+
+func TestDeadCLIIntegration(t *testing.T) {
+	db := scanSmoke(t)
+	ctx := context.Background()
+
+	result, err := dead.FindDead(ctx, db, dead.Options{Limit: 200})
+	if err != nil {
+		t.Fatalf("FindDead: %v", err)
+	}
+
+	rolled := dead.Rollup(result.Dead)
+
+	if len(rolled) == 0 {
+		t.Fatal("expected dead symbols in smoke fixture, got none")
+	}
+
+	// Verify known-dead symbols are present.
+	deadSet := map[string]bool{}
+	for _, s := range rolled {
+		deadSet[s.Qualified] = true
+	}
+
+	// PaymentGateway.Refund is never called in the smoke fixture.
+	if !deadSet["smoke.PaymentGateway.Refund"] {
+		t.Error("expected smoke.PaymentGateway.Refund to be dead")
+	}
+
+	// Verify known-alive symbols are absent.
+	alive := []string{
+		"smoke.OrderService.Process",
+		"smoke.PaymentGateway.Charge",
+		"Order",
+		"ApplicationRecord",
+		"Trackable",
+	}
+	for _, name := range alive {
+		if deadSet[name] {
+			t.Errorf("%s should be alive, but appears in dead set", name)
+		}
+	}
+
+	// Test files should not appear.
+	for _, s := range rolled {
+		if s.File == "order_test.go" || s.File == "order_test.rb" {
+			t.Errorf("test file symbol %q should be excluded", s.Qualified)
+		}
+	}
+}

--- a/internal/dead/rollup.go
+++ b/internal/dead/rollup.go
@@ -1,0 +1,45 @@
+package dead
+
+// Rollup collapses parent-child dead symbols: when a class/module and
+// all its methods are dead, report only the class. When a class is
+// alive but some methods are dead, report the dead methods individually.
+func Rollup(symbols []Symbol) []Symbol {
+	deadIDs := make(map[int64]struct{}, len(symbols))
+	for _, s := range symbols {
+		deadIDs[s.ID] = struct{}{}
+	}
+
+	// Build parent → children index for dead symbols.
+	childrenOf := map[int64][]Symbol{}
+	for _, s := range symbols {
+		if s.ParentID != nil {
+			childrenOf[*s.ParentID] = append(childrenOf[*s.ParentID], s)
+		}
+	}
+
+	// Identify containers where ALL children in the dead set should be
+	// suppressed (the container subsumes them).
+	suppressChildren := map[int64]struct{}{}
+	for _, s := range symbols {
+		if s.Kind != "class" && s.Kind != "module" {
+			continue
+		}
+		children := childrenOf[s.ID]
+		if len(children) == 0 {
+			continue
+		}
+		// Container is dead and has dead children → collapse.
+		suppressChildren[s.ID] = struct{}{}
+	}
+
+	var out []Symbol
+	for _, s := range symbols {
+		if s.ParentID != nil {
+			if _, suppress := suppressChildren[*s.ParentID]; suppress {
+				continue
+			}
+		}
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/mcpio/dead.go
+++ b/internal/mcpio/dead.go
@@ -1,0 +1,35 @@
+package mcpio
+
+import "github.com/luuuc/sense/internal/dead"
+
+// BuildDeadCodeResponse assembles a wire DeadCodeResponse from the dead
+// package's result plus a rolled-up symbol list. Matches the
+// BuildBlastResponse / BuildGraphResponse pattern — one builder per
+// response shape, shared between CLI and MCP server.
+func BuildDeadCodeResponse(symbols []dead.Symbol, totalSymbols int) DeadCodeResponse {
+	entries := make([]DeadSymbolEntry, len(symbols))
+	uniqueFiles := map[string]struct{}{}
+	for i, s := range symbols {
+		entries[i] = DeadSymbolEntry{
+			Symbol:    s.Name,
+			Qualified: s.Qualified,
+			File:      s.File,
+			LineStart: s.LineStart,
+			LineEnd:   s.LineEnd,
+			Kind:      s.Kind,
+		}
+		uniqueFiles[s.File] = struct{}{}
+	}
+
+	filesAvoided := len(uniqueFiles)
+	return DeadCodeResponse{
+		DeadSymbols:  entries,
+		TotalSymbols: totalSymbols,
+		DeadCount:    len(symbols),
+		SenseMetrics: DeadCodeMetrics{
+			SymbolsAnalyzed:           totalSymbols,
+			EstimatedFileReadsAvoided: filesAvoided,
+			EstimatedTokensSaved:      filesAvoided * AvgTokensPerFile,
+		},
+	}
+}

--- a/internal/mcpio/marshal.go
+++ b/internal/mcpio/marshal.go
@@ -43,6 +43,18 @@ func MarshalSearch(r SearchResponse) ([]byte, error) {
 	return marshalPretty(r)
 }
 
+// MarshalDeadCode renders a DeadCodeResponse with the same
+// normalization + pretty-print contract as MarshalGraph.
+func MarshalDeadCode(r DeadCodeResponse) ([]byte, error) {
+	if r.DeadSymbols == nil {
+		r.DeadSymbols = []DeadSymbolEntry{}
+	}
+	if r.NextSteps == nil {
+		r.NextSteps = []NextStep{}
+	}
+	return marshalPretty(r)
+}
+
 // marshalPretty is the shared encoder: SetEscapeHTML(false) keeps
 // identifier characters like `<`, `>`, `&` literal so goldens in
 // card 3 pin the documented examples byte-for-byte. Two-space indent

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -354,3 +354,35 @@ type SearchMetrics struct {
 	EstimatedFileReadsAvoided int `json:"estimated_file_reads_avoided"`
 	EstimatedTokensSaved      int `json:"estimated_tokens_saved"`
 }
+
+// ---------------------------------------------------------------
+// Dead code response (sense.graph dead_code mode)
+// ---------------------------------------------------------------
+
+// DeadCodeResponse is the shape returned by sense.graph when dead_code
+// is true. It replaces the normal GraphResponse with project-wide dead
+// symbol analysis.
+type DeadCodeResponse struct {
+	DeadSymbols  []DeadSymbolEntry `json:"dead_symbols"`
+	TotalSymbols int               `json:"total_symbols"`
+	DeadCount    int               `json:"dead_count"`
+	SenseMetrics DeadCodeMetrics   `json:"sense_metrics"`
+	NextSteps    []NextStep        `json:"next_steps"`
+}
+
+// DeadSymbolEntry is a single dead symbol in the response.
+type DeadSymbolEntry struct {
+	Symbol    string `json:"symbol"`
+	Qualified string `json:"qualified"`
+	File      string `json:"file"`
+	LineStart int    `json:"line_start"`
+	LineEnd   int    `json:"line_end"`
+	Kind      string `json:"kind"`
+}
+
+// DeadCodeMetrics is the observability footer for dead code analysis.
+type DeadCodeMetrics struct {
+	SymbolsAnalyzed           int `json:"symbols_analyzed"`
+	EstimatedFileReadsAvoided int `json:"estimated_file_reads_avoided"`
+	EstimatedTokensSaved      int `json:"estimated_tokens_saved"`
+}

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/luuuc/sense/internal/blast"
 	"github.com/luuuc/sense/internal/cli"
 	"github.com/luuuc/sense/internal/conventions"
+	"github.com/luuuc/sense/internal/dead"
 	"github.com/luuuc/sense/internal/embed"
 	"github.com/luuuc/sense/internal/extract"
 	"github.com/luuuc/sense/internal/mcpio"
@@ -227,7 +228,9 @@ func graphTool() mcp.Tool {
 			"inheritance, composition, includes, imports, and test coverage. "+
 			"Use this instead of grep or file reading when the user asks about relationships, dependencies, "+
 			"callers, or how a symbol connects to the rest of the codebase. "+
-			"Returns a pre-computed graph from the Sense index with no context window cost for file contents."),
+			"Returns a pre-computed graph from the Sense index with no context window cost for file contents.\n\n"+
+			"When dead_code is true, returns project-wide dead symbols (zero incoming references) instead of "+
+			"per-symbol edges. The symbol, direction, and depth parameters are ignored in this mode."),
 		mcp.WithToolAnnotation(mcp.ToolAnnotation{
 			Title:           "Sense Graph",
 			ReadOnlyHint:    mcp.ToBoolPtr(true),
@@ -236,8 +239,7 @@ func graphTool() mcp.Tool {
 			OpenWorldHint:   mcp.ToBoolPtr(false),
 		}),
 		mcp.WithString("symbol",
-			mcp.Required(),
-			mcp.Description("Qualified or unqualified symbol name, e.g. 'User', 'Checkout::Order', 'HandleRequest'"),
+			mcp.Description("Qualified or unqualified symbol name, e.g. 'User', 'Checkout::Order', 'HandleRequest'. Ignored when dead_code is true."),
 		),
 		mcp.WithNumber("depth",
 			mcp.Description("How many hops to traverse from the symbol (default 1)"),
@@ -245,6 +247,15 @@ func graphTool() mcp.Tool {
 		mcp.WithString("direction",
 			mcp.Description("Which edges to follow: 'both' (default), 'callers' (who calls this), or 'callees' (what this calls)"),
 			mcp.Enum("both", "callers", "callees"),
+		),
+		mcp.WithBoolean("dead_code",
+			mcp.Description("When true, return project-wide dead symbols instead of per-symbol edges. Symbol, direction, and depth are ignored."),
+		),
+		mcp.WithString("language",
+			mcp.Description("Filter dead code results to a specific language, e.g. 'go', 'ruby'. Only used when dead_code is true."),
+		),
+		mcp.WithString("domain",
+			mcp.Description("Filter dead code results to a path substring, e.g. 'services', 'models'. Only used when dead_code is true."),
 		),
 	)
 }
@@ -303,8 +314,12 @@ func statusTool() mcp.Tool {
 // ---------------------------------------------------------------
 
 func (h *handlers) handleGraph(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	symbol, err := req.RequireString("symbol")
-	if err != nil {
+	if req.GetBool("dead_code", false) {
+		return h.handleDeadCode(ctx, req)
+	}
+
+	symbol := req.GetString("symbol", "")
+	if symbol == "" {
 		return mcp.NewToolResultError("sense.graph: missing required parameter 'symbol'"), nil
 	}
 
@@ -394,6 +409,47 @@ func graphHints(resp mcpio.GraphResponse, direction string) []mcpio.NextStep {
 	if len(hints) > 2 {
 		hints = hints[:2]
 	}
+	return hints
+}
+
+func (h *handlers) handleDeadCode(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	language := req.GetString("language", "")
+	domain := req.GetString("domain", "")
+
+	result, err := dead.FindDead(ctx, h.db, dead.Options{
+		Language: language,
+		Domain:   domain,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("sense.graph dead_code: %w", err)
+	}
+
+	rolled := dead.Rollup(result.Dead)
+	resp := mcpio.BuildDeadCodeResponse(rolled, result.TotalSymbols)
+
+	h.tracker.Record("sense.graph", "dead_code",
+		resp.SenseMetrics.EstimatedFileReadsAvoided, resp.SenseMetrics.EstimatedTokensSaved)
+
+	resp.NextSteps = deadCodeHints(resp)
+
+	out, err := mcpio.MarshalDeadCode(resp)
+	if err != nil {
+		return nil, fmt.Errorf("sense.graph dead_code: marshal: %w", err)
+	}
+	return mcp.NewToolResultText(string(out)), nil
+}
+
+func deadCodeHints(resp mcpio.DeadCodeResponse) []mcpio.NextStep {
+	var hints []mcpio.NextStep
+
+	if resp.DeadCount > 0 && len(resp.DeadSymbols) > 0 {
+		hints = append(hints, mcpio.NextStep{
+			Tool:   "sense.graph",
+			Args:   map[string]any{"symbol": resp.DeadSymbols[0].Qualified},
+			Reason: "inspect the top dead symbol's relationships to confirm it's truly unused",
+		})
+	}
+
 	return hints
 }
 

--- a/testdata/smoke/dead-golden.json
+++ b/testdata/smoke/dead-golden.json
@@ -1,0 +1,46 @@
+{
+  "dead": [
+    {
+      "qualified": "smoke.CheckoutService",
+      "kind": "class",
+      "file": "checkout.go"
+    },
+    {
+      "qualified": "smoke.ShippingService",
+      "kind": "class",
+      "file": "checkout.go"
+    },
+    {
+      "qualified": "LineItem#subtotal",
+      "kind": "method",
+      "file": "line_item.rb"
+    },
+    {
+      "qualified": "smoke.PaymentGateway.Refund",
+      "kind": "method",
+      "file": "payment.go"
+    },
+    {
+      "qualified": "smoke.BaseService.Log",
+      "kind": "method",
+      "file": "service.go"
+    },
+    {
+      "qualified": "smoke.Notifier.Notify",
+      "kind": "method",
+      "file": "service.go"
+    },
+    {
+      "qualified": "Trackable#track_change",
+      "kind": "method",
+      "file": "trackable.rb"
+    },
+    {
+      "qualified": "User#full_name",
+      "kind": "method",
+      "file": "user.rb"
+    }
+  ],
+  "total_symbols": 30,
+  "dead_count": 8
+}


### PR DESCRIPTION
## Problem

AI tools exploring a codebase via Sense encounter dead symbols — classes, methods, and functions with zero incoming references — alongside live ones. This wastes tokens reading code that doesn't matter and creates false leads when understanding architecture. Dead code detection is trivially derivable from the existing graph (symbols with no incoming edges), but Sense doesn't surface it.

## Summary

Add dead code detection as a query mode on `sense.graph` (`dead_code: true`) and a `sense dead` CLI command. No new MCP tool — dead code is a property of the graph, not a fifth capability.

## Changes

**Query engine (`internal/dead/`)**
- `FindDead` identifies symbols with zero incoming edges (calls, composes, includes, inherits) using a `NOT EXISTS` query for SQLite performance
- Entry-point heuristics exclude main functions, test symbols, test files, constructors, symbols with `tests` edges, and containers with live children
- Supports `language`, `domain` filtering and configurable `limit` (default 100)
- `Rollup` collapses dead class + dead methods into the class only; reports dead methods individually when the class is alive

**MCP surface (`internal/mcpserver/`)**
- `dead_code` boolean parameter on `sense.graph` switches to project-wide dead symbol analysis
- `symbol` parameter becomes optional (ignored when `dead_code` is true)
- `language` and `domain` filter parameters for dead code mode
- Next-step hint suggests inspecting the top dead symbol

**CLI surface (`internal/cli/`, `cmd/sense/`)**
- `sense dead` subcommand with human-readable output grouped by file
- `--json`, `--language`, `--domain`, `--limit` flags

**Shared response builder (`internal/mcpio/`)**
- `BuildDeadCodeResponse` and `MarshalDeadCode` shared between MCP handler and CLI
- `DeadCodeResponse`, `DeadSymbolEntry`, `DeadCodeMetrics` wire types

## Test Plan

- [x] 12 unit tests: basic dead/alive, all 5 entry-point exclusions, language/domain/limit filtering, 3 rollup scenarios, containers with live children
- [x] Golden-file test pins output against the smoke fixture (8 dead symbols out of 30); `-update-golden` flag for maintenance
- [x] Integration test verifies known-dead (`PaymentGateway.Refund`) and known-alive (`OrderService.Process`, `Order`) symbols by name
- [x] `go test ./...` passes (14 dead-code tests + full suite)
- [x] `make ci` clean (build + test + lint, 0 issues)
- [x] `sense dead` runs against Sense's own index (72 dead out of 1610, 4.5%)