### PR TITLE
feat(scan): add temporal coupling from git co-change history

### DIFF
--- a/internal/blast/engine.go
+++ b/internal/blast/engine.go
@@ -52,11 +52,13 @@ type Options struct {
 // one hop closer to the subject (predecessor on the BFS shortest
 // path), so a consumer can render "X calls Y which calls <subject>".
 // Hops is 1-indexed from the subject: Hops=2 means "callers of
-// direct callers".
+// direct callers". ViaTemporal is true when this hop traversed a
+// temporal coupling edge rather than a structural one.
 type CallerHop struct {
-	Symbol model.Symbol
-	Via    model.Symbol
-	Hops   int
+	Symbol      model.Symbol
+	Via         model.Symbol
+	Hops        int
+	ViaTemporal bool
 }
 
 // Result is the full blast-radius answer for one subject symbol. The
@@ -77,6 +79,9 @@ type Result struct {
 	IndirectCallers []CallerHop
 	AffectedTests   []string
 	TotalAffected   int
+	// DirectTemporalIDs tracks which direct callers were reached via
+	// a temporal edge. Keyed by symbol ID.
+	DirectTemporalIDs map[int64]bool
 }
 
 // Compute returns the blast radius of symbolIDs under the given
@@ -101,6 +106,7 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 
 	visited := map[int64]int{}
 	predecessor := map[int64]int64{}
+	viaTemporal := map[int64]bool{}
 	frontier := make([]int64, 0, len(symbolIDs))
 	for _, id := range symbolIDs {
 		visited[id] = 0
@@ -122,6 +128,9 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 			}
 			visited[pair.source] = hop
 			predecessor[pair.source] = pair.target
+			if pair.temporal {
+				viaTemporal[pair.source] = true
+			}
 			next = append(next, pair.source)
 		}
 		if len(next) == 0 {
@@ -171,9 +180,13 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 	symbolsByID[subject.ID] = subject
 
 	directCallers := make([]model.Symbol, 0, len(directIDs))
+	directTemporalIDs := map[int64]bool{}
 	for _, id := range directIDs {
 		if sym, ok := symbolsByID[id]; ok {
 			directCallers = append(directCallers, sym)
+			if viaTemporal[id] {
+				directTemporalIDs[id] = true
+			}
 		}
 	}
 	sortSymbolsByID(directCallers)
@@ -186,9 +199,10 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 		}
 		via := symbolsByID[predecessor[id]]
 		indirectCallers = append(indirectCallers, CallerHop{
-			Symbol: sym,
-			Via:    via,
-			Hops:   visited[id],
+			Symbol:      sym,
+			Via:         via,
+			Hops:        visited[id],
+			ViaTemporal: viaTemporal[id],
 		})
 	}
 	sortHopsByID(indirectCallers)
@@ -204,19 +218,26 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 		affectedTests = tests
 	}
 
-	// Card 11 replaces the placeholder risk. Filling the zero value
-	// now keeps the struct shape valid so callers written against the
-	// public API compile today.
-	risk, reasons := classifyRisk(len(directCallers))
+	hasTemporalEdge := len(directTemporalIDs) > 0
+	if !hasTemporalEdge {
+		for _, hop := range indirectCallers {
+			if hop.ViaTemporal {
+				hasTemporalEdge = true
+				break
+			}
+		}
+	}
+	risk, reasons := classifyRisk(len(directCallers), hasTemporalEdge)
 
 	return Result{
-		Symbol:          subject,
-		Risk:            risk,
-		RiskReasons:     reasons,
-		DirectCallers:   directCallers,
-		IndirectCallers: indirectCallers,
-		AffectedTests:   affectedTests,
-		TotalAffected:   len(directCallers) + len(indirectCallers),
+		Symbol:            subject,
+		Risk:              risk,
+		RiskReasons:       reasons,
+		DirectCallers:     directCallers,
+		IndirectCallers:   indirectCallers,
+		AffectedTests:     affectedTests,
+		TotalAffected:     len(directCallers) + len(indirectCallers),
+		DirectTemporalIDs: directTemporalIDs,
 	}, nil
 }
 
@@ -224,8 +245,9 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 // is the caller we're learning about; target is the node we already
 // visited and are expanding from.
 type edgePair struct {
-	source int64
-	target int64
+	source   int64
+	target   int64
+	temporal bool
 }
 
 // expandFrontier runs the BFS hop query: "which symbols reference
@@ -251,10 +273,10 @@ func expandFrontier(ctx context.Context, db *sql.DB, frontier []int64, minConfid
 		placeholders := strings.Repeat("?,", len(batch))
 		placeholders = placeholders[:len(placeholders)-1]
 
-		q := `SELECT source_id, target_id FROM sense_edges
+		q := `SELECT source_id, target_id, kind FROM sense_edges
 		      WHERE target_id IN (` + placeholders + `)
 		        AND source_id IS NOT NULL
-		        AND kind IN ('calls', 'composes', 'includes', 'inherits')
+		        AND kind IN ('calls', 'composes', 'includes', 'inherits', 'temporal')
 		        AND confidence >= ?`
 
 		args := make([]any, 0, len(batch)+1)
@@ -269,10 +291,12 @@ func expandFrontier(ctx context.Context, db *sql.DB, frontier []int64, minConfid
 		}
 		for rows.Next() {
 			var p edgePair
-			if err := rows.Scan(&p.source, &p.target); err != nil {
+			var kind string
+			if err := rows.Scan(&p.source, &p.target, &kind); err != nil {
 				_ = rows.Close()
 				return nil, err
 			}
+			p.temporal = kind == "temporal"
 			out = append(out, p)
 		}
 		if err := rows.Err(); err != nil {
@@ -311,22 +335,25 @@ const (
 //	direct_callers >= 3   → medium
 //	otherwise             → low
 //
-// RiskReasons carries one human-readable line per factor. Today the
-// only factor is the direct-caller count; the pitch's "crosses
-// module boundary" example is reserved for when a real case argues
-// for it, so the slice is always a single element. Consumers that
-// want to check risk programmatically should branch on the Risk
-// string (or the Risk* constants) rather than parsing Reasons.
-func classifyRisk(directCallers int) (string, []string) {
+// When temporal coupling edges are present, risk is bumped to at
+// least medium — a symbol with 0 structural callers but temporal
+// coupling has hidden dependencies.
+func classifyRisk(directCallers int, hasTemporal bool) (string, []string) {
 	reasons := []string{directCallersReason(directCallers)}
+	if hasTemporal {
+		reasons = append(reasons, "temporal coupling detected (git co-change history)")
+	}
+	risk := RiskLow
 	switch {
 	case directCallers >= riskHighThreshold:
-		return RiskHigh, reasons
+		risk = RiskHigh
 	case directCallers >= riskMediumThreshold:
-		return RiskMedium, reasons
-	default:
-		return RiskLow, reasons
+		risk = RiskMedium
 	}
+	if hasTemporal && risk == RiskLow {
+		risk = RiskMedium
+	}
+	return risk, reasons
 }
 
 // directCallersReason formats the direct-caller count as a human

--- a/internal/blast/engine_test.go
+++ b/internal/blast/engine_test.go
@@ -603,6 +603,119 @@ func TestComputeMultiSeedAggregatesReopenings(t *testing.T) {
 	}
 }
 
+// TestComputeTemporalEdgeBumpsRisk verifies that a temporal edge in
+// the blast radius bumps risk to at least medium and appears in callers.
+func TestComputeTemporalEdgeBumpsRisk(t *testing.T) {
+	db, adapter := setupGraph(t)
+	ctx := context.Background()
+
+	// C#leaf has 1 structural caller (B#middle), so risk is normally low.
+	// Insert a temporal edge from a new "phantom" symbol to C#leaf.
+	leafID := idOf(t, adapter, "C#leaf")
+
+	// First create a symbol in a different file to serve as temporal partner.
+	// We'll reuse C's file for the edge's file_id.
+	cFileID := fileIDOf(t, adapter, "c.rb")
+	aFileID := fileIDOf(t, adapter, "a.rb")
+
+	phantomID, err := adapter.WriteSymbol(ctx, &model.Symbol{
+		FileID:    aFileID,
+		Name:      "PhantomCron",
+		Qualified: "PhantomCron",
+		Kind:      "class",
+		LineStart: 1,
+		LineEnd:   5,
+	})
+	if err != nil {
+		t.Fatalf("WriteSymbol: %v", err)
+	}
+
+	coChanges := 8
+	_, err = adapter.WriteEdge(ctx, &model.Edge{
+		SourceID:   model.Int64Ptr(phantomID),
+		TargetID:   leafID,
+		Kind:       model.EdgeTemporal,
+		FileID:     cFileID,
+		Line:       &coChanges,
+		Confidence: 0.7,
+	})
+	if err != nil {
+		t.Fatalf("WriteEdge temporal: %v", err)
+	}
+
+	res, err := blast.Compute(ctx, db, []int64{leafID}, blast.Options{MaxHops: 1})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+
+	// Should have 2 direct callers: B#middle (structural) + PhantomCron (temporal).
+	if len(res.DirectCallers) != 2 {
+		t.Fatalf("DirectCallers = %d, want 2", len(res.DirectCallers))
+	}
+
+	// Risk should be at least medium because of temporal edge.
+	if res.Risk == blast.RiskLow {
+		t.Errorf("Risk = %q, want at least medium (temporal coupling present)", res.Risk)
+	}
+
+	foundTemporal := false
+	for _, reason := range res.RiskReasons {
+		if reason == "temporal coupling detected (git co-change history)" {
+			foundTemporal = true
+		}
+	}
+	if !foundTemporal {
+		t.Errorf("RiskReasons missing temporal: %v", res.RiskReasons)
+	}
+
+	// Verify DirectTemporalIDs contains the phantom.
+	if !res.DirectTemporalIDs[phantomID] {
+		t.Errorf("DirectTemporalIDs should contain phantom %d", phantomID)
+	}
+}
+
+// TestComputeNoTemporalEdgesStaysLow confirms that without temporal
+// edges, the risk classification is unchanged.
+func TestComputeNoTemporalEdgesStaysLow(t *testing.T) {
+	db, adapter := setupGraph(t)
+	leafID := idOf(t, adapter, "C#leaf")
+
+	res, err := blast.Compute(context.Background(), db, []int64{leafID}, blast.Options{MaxHops: 1})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	if res.Risk != blast.RiskLow {
+		t.Errorf("Risk = %q, want low (no temporal edges)", res.Risk)
+	}
+	if len(res.DirectTemporalIDs) != 0 {
+		t.Errorf("DirectTemporalIDs should be empty, got %v", res.DirectTemporalIDs)
+	}
+}
+
+func fileIDOf(t *testing.T, a *sqlite.Adapter, filename string) int64 {
+	t.Helper()
+	all, err := a.Query(context.Background(), index.Filter{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	seen := map[int64]bool{}
+	for _, s := range all {
+		if seen[s.FileID] {
+			continue
+		}
+		seen[s.FileID] = true
+		sc, rerr := a.ReadSymbol(context.Background(), s.ID)
+		if rerr != nil {
+			continue
+		}
+		if sc.File.Path == filename {
+			return sc.File.ID
+		}
+	}
+	t.Fatalf("file %q not found in index", filename)
+	return 0
+}
+
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/blast/risk_test.go
+++ b/internal/blast/risk_test.go
@@ -5,33 +5,55 @@ import (
 	"testing"
 )
 
-// TestClassifyRiskThresholds pins every boundary of the pitch's
-// three-tier formula: low ends at 2, medium starts at 3 and ends at
-// 9, high starts at 10. One reason line always lands regardless of
-// tier so consumers can format Reasons unconditionally.
 func TestClassifyRiskThresholds(t *testing.T) {
 	cases := []struct {
 		directCallers int
+		hasTemporal   bool
 		wantRisk      string
 		wantReasons   []string
 	}{
-		{0, RiskLow, []string{"0 direct callers"}},
-		{1, RiskLow, []string{"1 direct caller"}},
-		{2, RiskLow, []string{"2 direct callers"}},
-		{3, RiskMedium, []string{"3 direct callers"}},
-		{5, RiskMedium, []string{"5 direct callers"}},
-		{9, RiskMedium, []string{"9 direct callers"}},
-		{10, RiskHigh, []string{"10 direct callers"}},
-		{11, RiskHigh, []string{"11 direct callers"}},
-		{100, RiskHigh, []string{"100 direct callers"}},
+		{0, false, RiskLow, []string{"0 direct callers"}},
+		{1, false, RiskLow, []string{"1 direct caller"}},
+		{2, false, RiskLow, []string{"2 direct callers"}},
+		{3, false, RiskMedium, []string{"3 direct callers"}},
+		{5, false, RiskMedium, []string{"5 direct callers"}},
+		{9, false, RiskMedium, []string{"9 direct callers"}},
+		{10, false, RiskHigh, []string{"10 direct callers"}},
+		{11, false, RiskHigh, []string{"11 direct callers"}},
+		{100, false, RiskHigh, []string{"100 direct callers"}},
 	}
 	for _, c := range cases {
-		gotRisk, gotReasons := classifyRisk(c.directCallers)
+		gotRisk, gotReasons := classifyRisk(c.directCallers, c.hasTemporal)
 		if gotRisk != c.wantRisk {
-			t.Errorf("classifyRisk(%d) risk = %q, want %q", c.directCallers, gotRisk, c.wantRisk)
+			t.Errorf("classifyRisk(%d, %v) risk = %q, want %q", c.directCallers, c.hasTemporal, gotRisk, c.wantRisk)
 		}
 		if !reflect.DeepEqual(gotReasons, c.wantReasons) {
-			t.Errorf("classifyRisk(%d) reasons = %v, want %v", c.directCallers, gotReasons, c.wantReasons)
+			t.Errorf("classifyRisk(%d, %v) reasons = %v, want %v", c.directCallers, c.hasTemporal, gotReasons, c.wantReasons)
 		}
+	}
+}
+
+func TestClassifyRiskTemporalBump(t *testing.T) {
+	risk, reasons := classifyRisk(0, true)
+	if risk != RiskMedium {
+		t.Errorf("expected medium with 0 callers + temporal, got %q", risk)
+	}
+	if len(reasons) != 2 {
+		t.Fatalf("expected 2 reasons, got %d: %v", len(reasons), reasons)
+	}
+	if reasons[0] != "0 direct callers" {
+		t.Errorf("reasons[0] = %q, want %q", reasons[0], "0 direct callers")
+	}
+
+	// Temporal + already medium stays medium.
+	risk, _ = classifyRisk(3, true)
+	if risk != RiskMedium {
+		t.Errorf("expected medium with 3 callers + temporal, got %q", risk)
+	}
+
+	// Temporal + already high stays high.
+	risk, _ = classifyRisk(10, true)
+	if risk != RiskHigh {
+		t.Errorf("expected high with 10 callers + temporal, got %q", risk)
 	}
 }

--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -26,24 +26,22 @@ func BuildBlastResponse(r blast.Result, files FileLookup) BlastResponse {
 	}
 
 	for _, c := range r.DirectCallers {
-		// Empty File indicates a FileLookup miss — a data-integrity
-		// race between the blast read and the file-path read, not an
-		// intentional empty path. Direct callers are indexed symbols
-		// by construction, so a miss here is rare.
 		var file string
 		if path, ok := files(c.FileID); ok {
 			file = path
 		}
 		resp.DirectCallers = append(resp.DirectCallers, BlastCaller{
-			Symbol: qualifiedOrName(c),
-			File:   file,
+			Symbol:      qualifiedOrName(c),
+			File:        file,
+			ViaTemporal: r.DirectTemporalIDs[c.ID],
 		})
 	}
 	for _, hop := range r.IndirectCallers {
 		resp.IndirectCallers = append(resp.IndirectCallers, BlastIndirect{
-			Symbol: qualifiedOrName(hop.Symbol),
-			Via:    qualifiedOrName(hop.Via),
-			Hops:   hop.Hops,
+			Symbol:      qualifiedOrName(hop.Symbol),
+			Via:         qualifiedOrName(hop.Via),
+			Hops:        hop.Hops,
+			ViaTemporal: hop.ViaTemporal,
 		})
 	}
 

--- a/internal/mcpio/blast_test.go
+++ b/internal/mcpio/blast_test.go
@@ -92,3 +92,54 @@ func TestBuildDiffBlastResponseDedupCallers(t *testing.T) {
 		t.Errorf("TotalAffected = %d, want 2 (1 direct + 1 indirect)", resp.TotalAffected)
 	}
 }
+
+func TestBuildBlastResponseViaTemporal(t *testing.T) {
+	r := blast.Result{
+		Symbol: model.Symbol{ID: 1, Qualified: "Subject"},
+		Risk:   blast.RiskMedium,
+		RiskReasons: []string{
+			"0 direct callers",
+			"temporal coupling detected (git co-change history)",
+		},
+		DirectCallers: []model.Symbol{
+			{ID: 10, Qualified: "TemporalPartner", FileID: 2},
+		},
+		IndirectCallers: []blast.CallerHop{
+			{
+				Symbol:      model.Symbol{ID: 20, Qualified: "Indirect"},
+				Via:         model.Symbol{ID: 10, Qualified: "TemporalPartner"},
+				Hops:        2,
+				ViaTemporal: true,
+			},
+		},
+		AffectedTests:     []string{},
+		TotalAffected:     2,
+		DirectTemporalIDs: map[int64]bool{10: true},
+	}
+
+	filePaths := map[int64]string{2: "partner.rb"}
+	files := func(id int64) (string, bool) {
+		p, ok := filePaths[id]
+		return p, ok
+	}
+
+	resp := BuildBlastResponse(r, files)
+
+	if len(resp.DirectCallers) != 1 {
+		t.Fatalf("DirectCallers = %d, want 1", len(resp.DirectCallers))
+	}
+	if !resp.DirectCallers[0].ViaTemporal {
+		t.Error("DirectCallers[0].ViaTemporal should be true")
+	}
+
+	if len(resp.IndirectCallers) != 1 {
+		t.Fatalf("IndirectCallers = %d, want 1", len(resp.IndirectCallers))
+	}
+	if !resp.IndirectCallers[0].ViaTemporal {
+		t.Error("IndirectCallers[0].ViaTemporal should be true")
+	}
+
+	if resp.Risk != blast.RiskMedium {
+		t.Errorf("Risk = %q, want medium", resp.Risk)
+	}
+}

--- a/internal/mcpio/graph.go
+++ b/internal/mcpio/graph.go
@@ -115,9 +115,52 @@ func BuildGraphResponse(sc *model.SymbolContext, files FileLookup, req BuildGrap
 		}
 	}
 
+	// Temporal edges are bidirectional — collect from outbound to get one
+	// entry per partner, regardless of direction filter.
+	temporalSeen := map[int64]struct{}{}
+	for _, e := range sc.Outbound {
+		if e.Edge.Kind != model.EdgeTemporal {
+			continue
+		}
+		if _, dup := temporalSeen[e.Target.ID]; dup {
+			continue
+		}
+		temporalSeen[e.Target.ID] = struct{}{}
+		coChanges := 0
+		if e.Edge.Line != nil {
+			coChanges = *e.Edge.Line
+		}
+		resp.Edges.Temporal = append(resp.Edges.Temporal, TemporalEdgeRef{
+			Symbol:    qualifiedOrName(e.Target),
+			File:      fileRefOrNil(e.Target.FileID, files),
+			CoChanges: coChanges,
+			Strength:  Confidence(e.Edge.Confidence),
+		})
+	}
+	for _, e := range sc.Inbound {
+		if e.Edge.Kind != model.EdgeTemporal {
+			continue
+		}
+		if _, dup := temporalSeen[e.Target.ID]; dup {
+			continue
+		}
+		temporalSeen[e.Target.ID] = struct{}{}
+		coChanges := 0
+		if e.Edge.Line != nil {
+			coChanges = *e.Edge.Line
+		}
+		resp.Edges.Temporal = append(resp.Edges.Temporal, TemporalEdgeRef{
+			Symbol:    qualifiedOrName(e.Target),
+			File:      fileRefOrNil(e.Target.FileID, files),
+			CoChanges: coChanges,
+			Strength:  Confidence(e.Edge.Confidence),
+		})
+	}
+
 	symbolsReturned := len(resp.Edges.Calls) + len(resp.Edges.CalledBy) +
 		len(resp.Edges.Inherits) + len(resp.Edges.Composes) +
-		len(resp.Edges.Includes) + len(resp.Edges.Imports) + len(resp.Edges.Tests)
+		len(resp.Edges.Includes) + len(resp.Edges.Imports) + len(resp.Edges.Tests) +
+		len(resp.Edges.Temporal)
 
 	uniqueFiles := countUniqueEdgeFiles(resp)
 	resp.SenseMetrics = GraphMetrics{
@@ -172,6 +215,11 @@ func countUniqueEdgeFiles(resp GraphResponse) int {
 	}
 	for _, e := range resp.Edges.Tests {
 		seen[e.File] = struct{}{}
+	}
+	for _, e := range resp.Edges.Temporal {
+		if e.File != nil {
+			seen[*e.File] = struct{}{}
+		}
 	}
 	return len(seen)
 }

--- a/internal/mcpio/graph_test.go
+++ b/internal/mcpio/graph_test.go
@@ -129,3 +129,117 @@ func TestBuildGraphResponseIncludesImports(t *testing.T) {
 		t.Errorf("Imports[0].Symbol = %q, want %q", resp.Edges.Imports[0].Symbol, "utils")
 	}
 }
+
+func TestBuildGraphResponseTemporalEdges(t *testing.T) {
+	filePaths := map[int64]string{
+		1: "app/services/checkout.rb",
+		2: "app/jobs/export_cron.rb",
+	}
+	files := func(id int64) (string, bool) {
+		p, ok := filePaths[id]
+		return p, ok
+	}
+
+	coChanges := 14
+	sc := &model.SymbolContext{
+		Symbol: model.Symbol{
+			ID: 1, Name: "Checkout", Qualified: "Checkout",
+			Kind: "class", FileID: 1, LineStart: 1, LineEnd: 50,
+		},
+		File: model.File{Path: "app/services/checkout.rb"},
+		Outbound: []model.EdgeRef{
+			{
+				Edge:   model.Edge{Kind: model.EdgeTemporal, Confidence: 0.7, Line: &coChanges},
+				Target: model.Symbol{ID: 2, Qualified: "ExportCron", FileID: 2},
+			},
+		},
+		Inbound: []model.EdgeRef{
+			{
+				Edge:   model.Edge{Kind: model.EdgeTemporal, Confidence: 0.7, Line: &coChanges},
+				Target: model.Symbol{ID: 2, Qualified: "ExportCron", FileID: 2},
+			},
+		},
+	}
+
+	resp := BuildGraphResponse(sc, files, BuildGraphRequest{})
+
+	// Temporal edges are deduplicated — even though the same symbol appears
+	// in both inbound and outbound, only one entry should appear.
+	if len(resp.Edges.Temporal) != 1 {
+		t.Fatalf("Temporal = %d, want 1 (deduplicated)", len(resp.Edges.Temporal))
+	}
+	te := resp.Edges.Temporal[0]
+	if te.Symbol != "ExportCron" {
+		t.Errorf("Symbol = %q, want %q", te.Symbol, "ExportCron")
+	}
+	if te.CoChanges != 14 {
+		t.Errorf("CoChanges = %d, want 14", te.CoChanges)
+	}
+	if float64(te.Strength) != 0.7 {
+		t.Errorf("Strength = %v, want 0.7", te.Strength)
+	}
+	if te.File == nil || *te.File != "app/jobs/export_cron.rb" {
+		t.Errorf("File = %v, want app/jobs/export_cron.rb", te.File)
+	}
+}
+
+func TestBuildGraphResponseTemporalEmptyWhenNoEdges(t *testing.T) {
+	sc := &model.SymbolContext{
+		Symbol: model.Symbol{Name: "Foo", Qualified: "Foo", Kind: "class"},
+		File:   model.File{Path: "foo.rb"},
+	}
+	files := func(int64) (string, bool) { return "", false }
+	resp := BuildGraphResponse(sc, files, BuildGraphRequest{})
+	if resp.Edges.Temporal != nil {
+		t.Errorf("Temporal should be nil (not empty slice) before normalization, got %v", resp.Edges.Temporal)
+	}
+}
+
+func TestBuildGraphResponseTemporalDirectionIndependent(t *testing.T) {
+	coChanges := 5
+	sc := &model.SymbolContext{
+		Symbol: model.Symbol{Name: "A", Qualified: "A", Kind: "class"},
+		File:   model.File{Path: "a.rb"},
+		Outbound: []model.EdgeRef{
+			{
+				Edge:   model.Edge{Kind: model.EdgeTemporal, Confidence: 0.5, Line: &coChanges},
+				Target: model.Symbol{ID: 2, Qualified: "B", FileID: 2},
+			},
+		},
+	}
+	files := func(int64) (string, bool) { return "", false }
+
+	// Temporal should appear regardless of direction filter.
+	for _, dir := range []string{"both", "callers", "callees"} {
+		resp := BuildGraphResponse(sc, files, BuildGraphRequest{Direction: dir})
+		if len(resp.Edges.Temporal) != 1 {
+			t.Errorf("direction=%q: Temporal = %d, want 1", dir, len(resp.Edges.Temporal))
+		}
+	}
+}
+
+func TestBuildGraphResponseTemporalCountsInMetrics(t *testing.T) {
+	coChanges := 3
+	sc := &model.SymbolContext{
+		Symbol: model.Symbol{Name: "A", Qualified: "A", Kind: "class", FileID: 1},
+		File:   model.File{Path: "a.rb"},
+		Outbound: []model.EdgeRef{
+			{
+				Edge:   model.Edge{Kind: model.EdgeTemporal, Confidence: 0.5, Line: &coChanges},
+				Target: model.Symbol{ID: 2, Qualified: "B", FileID: 2},
+			},
+		},
+	}
+	filePaths := map[int64]string{2: "b.rb"}
+	files := func(id int64) (string, bool) {
+		p, ok := filePaths[id]
+		return p, ok
+	}
+	resp := BuildGraphResponse(sc, files, BuildGraphRequest{})
+	if resp.SenseMetrics.SymbolsReturned != 1 {
+		t.Errorf("SymbolsReturned = %d, want 1", resp.SenseMetrics.SymbolsReturned)
+	}
+	if resp.SenseMetrics.EstimatedFileReadsAvoided != 1 {
+		t.Errorf("EstimatedFileReadsAvoided = %d, want 1", resp.SenseMetrics.EstimatedFileReadsAvoided)
+	}
+}

--- a/internal/mcpio/marshal.go
+++ b/internal/mcpio/marshal.go
@@ -85,6 +85,9 @@ func normalizeGraphResponse(r *GraphResponse) {
 	if r.Edges.Tests == nil {
 		r.Edges.Tests = []TestEdgeRef{}
 	}
+	if r.Edges.Temporal == nil {
+		r.Edges.Temporal = []TemporalEdgeRef{}
+	}
 	if r.NextSteps == nil {
 		r.NextSteps = []NextStep{}
 	}

--- a/internal/mcpio/marshal_test.go
+++ b/internal/mcpio/marshal_test.go
@@ -36,6 +36,7 @@ func TestMarshalGraphRoundTrip(t *testing.T) {
 			Includes: []IncludeEdgeRef{},
 			Imports:  []ImportEdgeRef{},
 			Tests:    []TestEdgeRef{{File: "test/services/checkout_service_test.rb", Confidence: 0.8}},
+			Temporal: []TemporalEdgeRef{},
 		},
 		SenseMetrics: GraphMetrics{SymbolsReturned: 3},
 		NextSteps:    []NextStep{},
@@ -101,12 +102,12 @@ func TestMarshalZeroValueEmptySlices(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MarshalGraph: %v", err)
 	}
-	for _, field := range []string{`"calls": []`, `"called_by": []`, `"inherits": []`, `"composes": []`, `"includes": []`, `"imports": []`, `"tests": []`, `"next_steps": []`} {
+	for _, field := range []string{`"calls": []`, `"called_by": []`, `"inherits": []`, `"composes": []`, `"includes": []`, `"imports": []`, `"tests": []`, `"temporal": []`, `"next_steps": []`} {
 		if !strings.Contains(string(graphBytes), field) {
 			t.Errorf("GraphResponse zero-value missing %s\ngot:\n%s", field, graphBytes)
 		}
 	}
-	for _, nullField := range []string{`"calls": null`, `"called_by": null`, `"inherits": null`, `"composes": null`, `"includes": null`, `"imports": null`, `"tests": null`, `"next_steps": null`} {
+	for _, nullField := range []string{`"calls": null`, `"called_by": null`, `"inherits": null`, `"composes": null`, `"includes": null`, `"imports": null`, `"tests": null`, `"temporal": null`, `"next_steps": null`} {
 		if strings.Contains(string(graphBytes), nullField) {
 			t.Errorf("GraphResponse zero-value slice field should be []: %s\ngot:\n%s", nullField, graphBytes)
 		}
@@ -151,6 +152,7 @@ func TestMarshalNoHTMLEscape(t *testing.T) {
 			Includes: []IncludeEdgeRef{},
 			Imports:  []ImportEdgeRef{},
 			Tests:    []TestEdgeRef{},
+			Temporal: []TemporalEdgeRef{},
 		},
 	}
 	raw, err := MarshalGraph(in)

--- a/internal/mcpio/testdata/graph_checkout_service.json
+++ b/internal/mcpio/testdata/graph_checkout_service.json
@@ -51,7 +51,8 @@
         "file": "test/services/checkout_service_test.rb",
         "confidence": 0.8
       }
-    ]
+    ],
+    "temporal": []
   },
   "sense_metrics": {
     "symbols_returned": 7,

--- a/internal/mcpio/testdata/graph_empty.json
+++ b/internal/mcpio/testdata/graph_empty.json
@@ -14,7 +14,8 @@
     "composes": [],
     "includes": [],
     "imports": [],
-    "tests": []
+    "tests": [],
+    "temporal": []
   },
   "sense_metrics": {
     "symbols_returned": 0,

--- a/internal/mcpio/testdata/graph_with_freshness.json
+++ b/internal/mcpio/testdata/graph_with_freshness.json
@@ -51,7 +51,8 @@
         "file": "test/services/checkout_service_test.rb",
         "confidence": 0.8
       }
-    ]
+    ],
+    "temporal": []
   },
   "sense_metrics": {
     "symbols_returned": 7,

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -96,13 +96,14 @@ type GraphSymbol struct {
 // leave unrequested kinds as empty slices and callers must treat
 // `[]` as "none found" rather than "not provided."
 type GraphEdges struct {
-	Calls    []CallEdgeRef    `json:"calls"`
-	CalledBy []CallEdgeRef    `json:"called_by"`
-	Inherits []InheritEdgeRef `json:"inherits"`
-	Composes []ComposeEdgeRef `json:"composes"`
-	Includes []IncludeEdgeRef `json:"includes"`
-	Imports  []ImportEdgeRef  `json:"imports"`
-	Tests    []TestEdgeRef    `json:"tests"`
+	Calls    []CallEdgeRef      `json:"calls"`
+	CalledBy []CallEdgeRef      `json:"called_by"`
+	Inherits []InheritEdgeRef   `json:"inherits"`
+	Composes []ComposeEdgeRef   `json:"composes"`
+	Includes []IncludeEdgeRef   `json:"includes"`
+	Imports  []ImportEdgeRef    `json:"imports"`
+	Tests    []TestEdgeRef      `json:"tests"`
+	Temporal []TemporalEdgeRef  `json:"temporal"`
 }
 
 // CallEdgeRef is the shape of a calls / called_by edge entry. File
@@ -157,6 +158,16 @@ type TestEdgeRef struct {
 	Confidence Confidence `json:"confidence"`
 }
 
+// TemporalEdgeRef is the shape of a temporal coupling edge entry.
+// Co-change data is derived from git history; strength is the
+// normalized co-change frequency (co_changes / max(changes_A, changes_B)).
+type TemporalEdgeRef struct {
+	Symbol    string     `json:"symbol"`
+	File      *string    `json:"file"`
+	CoChanges int        `json:"co_changes"`
+	Strength  Confidence `json:"strength"`
+}
+
 // GraphMetrics is the observability footer on a graph response.
 type GraphMetrics struct {
 	SymbolsReturned           int `json:"symbols_returned"`
@@ -189,8 +200,9 @@ type BlastResponse struct {
 
 // BlastCaller is the shape of a direct_callers entry.
 type BlastCaller struct {
-	Symbol string `json:"symbol"`
-	File   string `json:"file"`
+	Symbol      string `json:"symbol"`
+	File        string `json:"file"`
+	ViaTemporal bool   `json:"via_temporal,omitempty"`
 }
 
 // BlastIndirect is the shape of an indirect_callers entry. Via names
@@ -198,9 +210,10 @@ type BlastCaller struct {
 // closer" to the subject — so a consumer can render
 // "X (via Y, hops=N)".
 type BlastIndirect struct {
-	Symbol string `json:"symbol"`
-	Via    string `json:"via"`
-	Hops   int    `json:"hops"`
+	Symbol      string `json:"symbol"`
+	Via         string `json:"via"`
+	Hops        int    `json:"hops"`
+	ViaTemporal bool   `json:"via_temporal,omitempty"`
 }
 
 // BlastMetrics mirrors GraphMetrics' footer shape but with the

--- a/internal/model/edge.go
+++ b/internal/model/edge.go
@@ -28,4 +28,5 @@ const (
 	EdgeIncludes EdgeKind = "includes"
 	EdgeTests    EdgeKind = "tests"
 	EdgeComposes EdgeKind = "composes"
+	EdgeTemporal EdgeKind = "temporal"
 )

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -65,6 +65,7 @@ type PhaseTiming struct {
 	ResolveEdges      time.Duration
 	SatisfyInterfaces time.Duration
 	AssociateTests    time.Duration
+	Temporal          time.Duration
 	Embed             time.Duration
 	BuildHNSW         time.Duration
 }
@@ -209,6 +210,12 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	}
 	phases.AssociateTests = time.Since(t0)
 
+	t0 = time.Now()
+	if err := h.extractTemporalCoupling(); err != nil {
+		return nil, err
+	}
+	phases.Temporal = time.Since(t0)
+
 	if opts.EmbeddingsEnabled && opts.Embed {
 		t0 = time.Now()
 		if err := h.embedSymbols(); err != nil {
@@ -294,12 +301,13 @@ func printPhaseBreakdown(out io.Writer, total time.Duration, p PhaseTiming) {
 		}
 		return int(100 * d / total)
 	}
-	_, _ = fmt.Fprintf(out, "phases: walk %s (%d%%), stale %s (%d%%), edges %s (%d%%), interfaces %s (%d%%), tests %s (%d%%)",
+	_, _ = fmt.Fprintf(out, "phases: walk %s (%d%%), stale %s (%d%%), edges %s (%d%%), interfaces %s (%d%%), tests %s (%d%%), temporal %s (%d%%)",
 		p.Walk, pct(p.Walk),
 		p.RemoveStale, pct(p.RemoveStale),
 		p.ResolveEdges, pct(p.ResolveEdges),
 		p.SatisfyInterfaces, pct(p.SatisfyInterfaces),
-		p.AssociateTests, pct(p.AssociateTests))
+		p.AssociateTests, pct(p.AssociateTests),
+		p.Temporal, pct(p.Temporal))
 	if p.Embed > 0 || p.BuildHNSW > 0 {
 		_, _ = fmt.Fprintf(out, ", embed %s (%d%%), hnsw %s (%d%%)",
 			p.Embed, pct(p.Embed),

--- a/internal/scan/scan_test.go
+++ b/internal/scan/scan_test.go
@@ -1163,6 +1163,36 @@ func TestScan_AddSenseToGitignore(t *testing.T) {
 	})
 }
 
+func TestTemporalCouplingNoOpWithoutGit(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "a.rb"), "class A; end\n")
+	writeFile(t, filepath.Join(root, "sub", "b.rb"), "class B; end\n")
+
+	ctx := context.Background()
+	res, err := scan.Run(ctx, quietOpts(root))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Indexed < 2 {
+		t.Fatalf("Indexed = %d, want >= 2", res.Indexed)
+	}
+
+	dbPath := filepath.Join(root, ".sense", "index.db")
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	edges, err := adapter.EdgesOfKind(ctx, model.EdgeTemporal)
+	if err != nil {
+		t.Fatalf("EdgesOfKind: %v", err)
+	}
+	if len(edges) != 0 {
+		t.Errorf("expected 0 temporal edges without git, got %d", len(edges))
+	}
+}
+
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/scan/temporal.go
+++ b/internal/scan/temporal.go
@@ -1,0 +1,372 @@
+package scan
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/luuuc/sense/internal/index"
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+const (
+	gitTimeout   = 2 * time.Second
+	minCoChanges = 3
+	maxCommits   = 1000
+	historySince = "6 months ago"
+)
+
+// extractTemporalCoupling derives temporal edges from git co-change history.
+// No-op if git is absent or the git log exceeds gitTimeout.
+func (h *harness) extractTemporalCoupling() error {
+	ctx, cancel := context.WithTimeout(h.ctx, gitTimeout)
+	defer cancel()
+
+	if !gitPresent(ctx, h.root) {
+		return nil
+	}
+
+	commits, err := parseGitLog(ctx, h.root)
+	if err != nil {
+		if ctx.Err() != nil {
+			_, _ = fmt.Fprintf(h.warn, "warn: git log timed out, skipping temporal coupling\n")
+		}
+		return nil
+	}
+
+	indexedFiles, err := h.indexedFilePaths()
+	if err != nil {
+		return err
+	}
+	if len(indexedFiles) == 0 {
+		return nil
+	}
+
+	pairs, fileCounts := countCoChanges(commits, indexedFiles)
+
+	var significant []pairKey
+	for pair, count := range pairs {
+		if count < minCoChanges {
+			continue
+		}
+		significant = append(significant, pair)
+	}
+	if len(significant) == 0 {
+		return nil
+	}
+	sort.Slice(significant, func(i, j int) bool {
+		if significant[i].a != significant[j].a {
+			return significant[i].a < significant[j].a
+		}
+		return significant[i].b < significant[j].b
+	})
+
+	repSymbols, err := h.representativeSymbols(indexedFiles)
+	if err != nil {
+		return err
+	}
+
+	if err := h.clearTemporalEdges(); err != nil {
+		return err
+	}
+
+	var written int
+	err = h.idx.InTx(h.ctx, func() error {
+		edgeStmt, serr := h.idx.PrepareEdgeStmt(h.ctx)
+		if serr != nil {
+			return serr
+		}
+		defer func() { _ = edgeStmt.Close() }()
+
+		for _, pk := range significant {
+			symA, okA := repSymbols[pk.a]
+			symB, okB := repSymbols[pk.b]
+			if !okA || !okB {
+				continue
+			}
+
+			coCount := pairs[pk]
+			maxChanges := fileCounts[pk.a]
+			if fileCounts[pk.b] > maxChanges {
+				maxChanges = fileCounts[pk.b]
+			}
+			strength := float64(coCount) / float64(maxChanges)
+
+			for _, dir := range []struct{ src, tgt model.Symbol }{
+				{symA, symB},
+				{symB, symA},
+			} {
+				srcID := dir.src.ID
+				coChanges := coCount
+				// Line stores co-change count for temporal edges (not a source line number).
+				edge := &model.Edge{
+					SourceID:   &srcID,
+					TargetID:   dir.tgt.ID,
+					Kind:       model.EdgeTemporal,
+					FileID:     dir.src.FileID,
+					Line:       &coChanges,
+					Confidence: strength,
+				}
+				if _, werr := sqlite.ExecEdgeStmt(h.ctx, edgeStmt, edge); werr != nil {
+					return fmt.Errorf("write temporal edge: %w", werr)
+				}
+				written++
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("temporal coupling: %w", err)
+	}
+
+	if written > 0 {
+		h.edges += written
+	}
+	return nil
+}
+
+// gitPresent checks whether the root is inside a git repository.
+func gitPresent(ctx context.Context, root string) bool {
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--git-dir")
+	cmd.Dir = root
+	return cmd.Run() == nil
+}
+
+// parseGitLog runs git log and returns a list of commits, each with its
+// set of changed file paths (relative to the repo root).
+func parseGitLog(ctx context.Context, root string) ([][]string, error) {
+	cmd := exec.CommandContext(ctx, "git", "log",
+		"--name-only",
+		"--no-merges",
+		"--pretty=format:%H",
+		"--since="+historySince,
+		fmt.Sprintf("--max-count=%d", maxCommits),
+	)
+	cmd.Dir = root
+
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	return parseGitLogOutput(out), nil
+}
+
+// parseGitLogOutput parses the raw output of git log --name-only into
+// a slice of commits, each being a slice of file paths.
+func parseGitLogOutput(data []byte) [][]string {
+	var commits [][]string
+	var current []string
+	inCommit := false
+
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if len(line) == 40 && isHexString(line) {
+			if inCommit && len(current) > 0 {
+				commits = append(commits, current)
+			}
+			current = nil
+			inCommit = true
+			continue
+		}
+		if inCommit {
+			current = append(current, line)
+		}
+	}
+	if inCommit && len(current) > 0 {
+		commits = append(commits, current)
+	}
+	return commits
+}
+
+func isHexString(s string) bool {
+	for _, c := range s {
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+type pairKey struct {
+	a, b string
+}
+
+func makePairKey(a, b string) pairKey {
+	if a > b {
+		a, b = b, a
+	}
+	return pairKey{a, b}
+}
+
+// countCoChanges counts how many commits each file pair co-appeared in.
+// Only counts pairs where both files are indexed and in different directories.
+// Also returns per-file total change counts.
+func countCoChanges(commits [][]string, indexed map[string]bool) (map[pairKey]int, map[string]int) {
+	pairs := map[pairKey]int{}
+	fileCounts := map[string]int{}
+
+	for _, files := range commits {
+		var relevant []string
+		for _, f := range files {
+			if indexed[f] {
+				relevant = append(relevant, f)
+				fileCounts[f]++
+			}
+		}
+		for i := 0; i < len(relevant); i++ {
+			for j := i + 1; j < len(relevant); j++ {
+				if filepath.Dir(relevant[i]) == filepath.Dir(relevant[j]) {
+					continue
+				}
+				pairs[makePairKey(relevant[i], relevant[j])]++
+			}
+		}
+	}
+	return pairs, fileCounts
+}
+
+// indexedFilePaths returns the set of file paths currently in the index.
+func (h *harness) indexedFilePaths() (map[string]bool, error) {
+	paths, err := h.idx.FilePaths(h.ctx)
+	if err != nil {
+		return nil, fmt.Errorf("temporal coupling: list files: %w", err)
+	}
+	m := make(map[string]bool, len(paths))
+	for _, p := range paths {
+		m[p] = true
+	}
+	return m, nil
+}
+
+// representativeSymbols maps each file path to its "most important" symbol.
+// Preference: first class/module-level symbol, then highest connectivity.
+func (h *harness) representativeSymbols(indexed map[string]bool) (map[string]model.Symbol, error) {
+	db := h.idx.DB()
+	ctx := h.ctx
+
+	connectivity := map[int64]int{}
+	rows, err := db.QueryContext(ctx, `
+		SELECT source_id, COUNT(*) FROM sense_edges
+		WHERE source_id IS NOT NULL AND kind != 'temporal'
+		GROUP BY source_id`)
+	if err != nil {
+		return nil, fmt.Errorf("temporal coupling: load outbound connectivity: %w", err)
+	}
+	for rows.Next() {
+		var id int64
+		var cnt int
+		if err := rows.Scan(&id, &cnt); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		connectivity[id] += cnt
+	}
+	_ = rows.Close()
+
+	rows, err = db.QueryContext(ctx, `
+		SELECT target_id, COUNT(*) FROM sense_edges
+		WHERE kind != 'temporal'
+		GROUP BY target_id`)
+	if err != nil {
+		return nil, fmt.Errorf("temporal coupling: load inbound connectivity: %w", err)
+	}
+	for rows.Next() {
+		var id int64
+		var cnt int
+		if err := rows.Scan(&id, &cnt); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		connectivity[id] += cnt
+	}
+	_ = rows.Close()
+
+	result := map[string]model.Symbol{}
+
+	fileIDs := map[string]int64{}
+	frows, err := db.QueryContext(ctx, `SELECT id, path FROM sense_files`)
+	if err != nil {
+		return nil, fmt.Errorf("temporal coupling: load file IDs: %w", err)
+	}
+	for frows.Next() {
+		var id int64
+		var path string
+		if err := frows.Scan(&id, &path); err != nil {
+			_ = frows.Close()
+			return nil, err
+		}
+		if indexed[path] {
+			fileIDs[path] = id
+		}
+	}
+	_ = frows.Close()
+
+	for path, fid := range fileIDs {
+		symbols, err := h.idx.Query(h.ctx, index.Filter{FileID: fid})
+		if err != nil {
+			return nil, fmt.Errorf("temporal coupling: query symbols for %s: %w", path, err)
+		}
+		if len(symbols) == 0 {
+			continue
+		}
+		rep := pickRepresentative(symbols, connectivity)
+		result[path] = rep
+	}
+	return result, nil
+}
+
+var classLevelKinds = map[model.SymbolKind]bool{
+	"class": true, "module": true, "interface": true, "trait": true,
+}
+
+// pickRepresentative selects the best symbol to represent a file in
+// temporal coupling edges. Prefers class/module-level symbols, then
+// falls back to highest connectivity.
+func pickRepresentative(symbols []model.Symbol, connectivity map[int64]int) model.Symbol {
+	var bestClass *model.Symbol
+	var bestClassConn int
+	var bestAny *model.Symbol
+	var bestAnyConn int
+
+	for i := range symbols {
+		s := &symbols[i]
+		conn := connectivity[s.ID]
+		if classLevelKinds[s.Kind] {
+			if bestClass == nil || conn > bestClassConn || (conn == bestClassConn && s.ID < bestClass.ID) {
+				bestClass = s
+				bestClassConn = conn
+			}
+		}
+		if bestAny == nil || conn > bestAnyConn || (conn == bestAnyConn && s.ID < bestAny.ID) {
+			bestAny = s
+			bestAnyConn = conn
+		}
+	}
+
+	if bestClass != nil {
+		return *bestClass
+	}
+	return *bestAny
+}
+
+// clearTemporalEdges removes all existing temporal edges before re-computing.
+func (h *harness) clearTemporalEdges() error {
+	_, err := h.idx.DB().ExecContext(h.ctx,
+		`DELETE FROM sense_edges WHERE kind = 'temporal'`)
+	if err != nil {
+		return fmt.Errorf("temporal coupling: clear old edges: %w", err)
+	}
+	return nil
+}

--- a/internal/scan/temporal_test.go
+++ b/internal/scan/temporal_test.go
@@ -1,0 +1,279 @@
+package scan
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/luuuc/sense/internal/model"
+)
+
+func TestParseGitLogOutput(t *testing.T) {
+	raw := []byte(`abc123def456abc123def456abc123def456abcd
+internal/scan/scan.go
+internal/model/edge.go
+
+def456abc123def456abc123def456abc123abcd
+internal/scan/scan.go
+internal/blast/engine.go
+internal/model/edge.go
+
+eee456abc123def456abc123def456abc123abcd
+internal/scan/scan.go
+internal/blast/engine.go
+`)
+
+	commits := parseGitLogOutput(raw)
+	if len(commits) != 3 {
+		t.Fatalf("expected 3 commits, got %d", len(commits))
+	}
+	want := [][]string{
+		{"internal/scan/scan.go", "internal/model/edge.go"},
+		{"internal/scan/scan.go", "internal/blast/engine.go", "internal/model/edge.go"},
+		{"internal/scan/scan.go", "internal/blast/engine.go"},
+	}
+	if !reflect.DeepEqual(commits, want) {
+		t.Errorf("commits mismatch:\ngot:  %v\nwant: %v", commits, want)
+	}
+}
+
+func TestParseGitLogOutputEmpty(t *testing.T) {
+	commits := parseGitLogOutput([]byte{})
+	if len(commits) != 0 {
+		t.Errorf("expected 0 commits from empty input, got %d", len(commits))
+	}
+}
+
+func TestParseGitLogOutputNoFiles(t *testing.T) {
+	raw := []byte("abc123def456abc123def456abc123def456abcd\n\n")
+	commits := parseGitLogOutput(raw)
+	if len(commits) != 0 {
+		t.Errorf("expected 0 commits (no files), got %d", len(commits))
+	}
+}
+
+func TestIsHexString(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"abc123", true},
+		{"0000000000000000000000000000000000000000", true},
+		{"xyz", false},
+		{"ABC", false},
+		{"", true},
+	}
+	for _, c := range cases {
+		if got := isHexString(c.in); got != c.want {
+			t.Errorf("isHexString(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestMakePairKey(t *testing.T) {
+	k1 := makePairKey("b.rb", "a.rb")
+	k2 := makePairKey("a.rb", "b.rb")
+	if k1 != k2 {
+		t.Errorf("expected symmetric pair keys, got %v and %v", k1, k2)
+	}
+	if k1.a != "a.rb" || k1.b != "b.rb" {
+		t.Errorf("expected sorted keys (a.rb, b.rb), got (%s, %s)", k1.a, k1.b)
+	}
+}
+
+func TestCountCoChanges(t *testing.T) {
+	indexed := map[string]bool{
+		"pkg/a/file.go":  true,
+		"pkg/b/file.go":  true,
+		"pkg/a/other.go": true,
+		"pkg/c/file.go":  true,
+	}
+
+	commits := [][]string{
+		{"pkg/a/file.go", "pkg/b/file.go"},
+		{"pkg/a/file.go", "pkg/b/file.go", "pkg/c/file.go"},
+		{"pkg/a/file.go", "pkg/b/file.go"},
+		{"pkg/a/file.go", "pkg/a/other.go"}, // same directory — should not count
+		{"pkg/c/file.go", "untracked.go"},    // untracked not in indexed
+	}
+
+	pairs, fileCounts := countCoChanges(commits, indexed)
+
+	// pkg/a/file.go ↔ pkg/b/file.go: 3 co-changes
+	abKey := makePairKey("pkg/a/file.go", "pkg/b/file.go")
+	if pairs[abKey] != 3 {
+		t.Errorf("a↔b co-changes = %d, want 3", pairs[abKey])
+	}
+
+	// pkg/a/file.go ↔ pkg/c/file.go: 1 co-change
+	acKey := makePairKey("pkg/a/file.go", "pkg/c/file.go")
+	if pairs[acKey] != 1 {
+		t.Errorf("a↔c co-changes = %d, want 1", pairs[acKey])
+	}
+
+	// pkg/b/file.go ↔ pkg/c/file.go: 1 co-change
+	bcKey := makePairKey("pkg/b/file.go", "pkg/c/file.go")
+	if pairs[bcKey] != 1 {
+		t.Errorf("b↔c co-changes = %d, want 1", pairs[bcKey])
+	}
+
+	// Same-directory pair should not appear.
+	sameDir := makePairKey("pkg/a/file.go", "pkg/a/other.go")
+	if pairs[sameDir] != 0 {
+		t.Errorf("same-directory pair should be 0, got %d", pairs[sameDir])
+	}
+
+	if fileCounts["pkg/a/file.go"] != 4 {
+		t.Errorf("file count for pkg/a/file.go = %d, want 4", fileCounts["pkg/a/file.go"])
+	}
+	if fileCounts["pkg/b/file.go"] != 3 {
+		t.Errorf("file count for pkg/b/file.go = %d, want 3", fileCounts["pkg/b/file.go"])
+	}
+}
+
+func TestCountCoChangesUnindexedFilesIgnored(t *testing.T) {
+	indexed := map[string]bool{"a/x.go": true}
+	commits := [][]string{
+		{"a/x.go", "b/untracked.go"},
+	}
+	pairs, fileCounts := countCoChanges(commits, indexed)
+	if len(pairs) != 0 {
+		t.Errorf("expected no pairs with unindexed files, got %d", len(pairs))
+	}
+	if fileCounts["a/x.go"] != 1 {
+		t.Errorf("file count for a/x.go = %d, want 1", fileCounts["a/x.go"])
+	}
+}
+
+func TestPickRepresentative(t *testing.T) {
+	t.Run("prefers class over function", func(t *testing.T) {
+		symbols := []model.Symbol{
+			{ID: 1, Name: "helper", Kind: "function"},
+			{ID: 2, Name: "Widget", Kind: "class"},
+			{ID: 3, Name: "doThing", Kind: "method"},
+		}
+		conn := map[int64]int{1: 5, 2: 1, 3: 3}
+		rep := pickRepresentative(symbols, conn)
+		if rep.Name != "Widget" {
+			t.Errorf("expected Widget (class), got %s (%s)", rep.Name, rep.Kind)
+		}
+	})
+
+	t.Run("highest connectivity class wins", func(t *testing.T) {
+		symbols := []model.Symbol{
+			{ID: 1, Name: "ClassA", Kind: "class"},
+			{ID: 2, Name: "ClassB", Kind: "class"},
+		}
+		conn := map[int64]int{1: 3, 2: 7}
+		rep := pickRepresentative(symbols, conn)
+		if rep.Name != "ClassB" {
+			t.Errorf("expected ClassB (higher connectivity), got %s", rep.Name)
+		}
+	})
+
+	t.Run("falls back to highest connectivity function", func(t *testing.T) {
+		symbols := []model.Symbol{
+			{ID: 1, Name: "helper", Kind: "function"},
+			{ID: 2, Name: "main", Kind: "function"},
+			{ID: 3, Name: "init", Kind: "function"},
+		}
+		conn := map[int64]int{1: 1, 2: 5, 3: 2}
+		rep := pickRepresentative(symbols, conn)
+		if rep.Name != "main" {
+			t.Errorf("expected main (highest connectivity), got %s", rep.Name)
+		}
+	})
+
+	t.Run("tie-breaks by lowest ID", func(t *testing.T) {
+		symbols := []model.Symbol{
+			{ID: 5, Name: "B", Kind: "function"},
+			{ID: 3, Name: "A", Kind: "function"},
+		}
+		conn := map[int64]int{5: 2, 3: 2}
+		rep := pickRepresentative(symbols, conn)
+		if rep.ID != 3 {
+			t.Errorf("expected ID 3 (lower), got %d", rep.ID)
+		}
+	})
+
+	t.Run("module kind treated as class-level", func(t *testing.T) {
+		symbols := []model.Symbol{
+			{ID: 1, Name: "BigFunc", Kind: "function"},
+			{ID: 2, Name: "MyModule", Kind: "module"},
+		}
+		conn := map[int64]int{1: 10, 2: 1}
+		rep := pickRepresentative(symbols, conn)
+		if rep.Name != "MyModule" {
+			t.Errorf("expected MyModule (module kind), got %s", rep.Name)
+		}
+	})
+}
+
+func TestCountCoChangesStrength(t *testing.T) {
+	indexed := map[string]bool{
+		"a/x.go": true,
+		"b/y.go": true,
+	}
+
+	// 5 co-changes out of 5 changes each → strength 1.0
+	commits := make([][]string, 5)
+	for i := range commits {
+		commits[i] = []string{"a/x.go", "b/y.go"}
+	}
+
+	pairs, fileCounts := countCoChanges(commits, indexed)
+	key := makePairKey("a/x.go", "b/y.go")
+
+	coChanges := pairs[key]
+	if coChanges != 5 {
+		t.Errorf("co-changes = %d, want 5", coChanges)
+	}
+
+	maxChanges := fileCounts["a/x.go"]
+	if fileCounts["b/y.go"] > maxChanges {
+		maxChanges = fileCounts["b/y.go"]
+	}
+	strength := float64(coChanges) / float64(maxChanges)
+	if strength != 1.0 {
+		t.Errorf("strength = %f, want 1.0", strength)
+	}
+}
+
+func TestCountCoChangesMinThresholdFiltering(t *testing.T) {
+	indexed := map[string]bool{
+		"a/x.go": true,
+		"b/y.go": true,
+		"c/z.go": true,
+	}
+
+	// a↔b: 3 co-changes (meets threshold)
+	// a↔c: 2 co-changes (below threshold)
+	commits := [][]string{
+		{"a/x.go", "b/y.go", "c/z.go"},
+		{"a/x.go", "b/y.go", "c/z.go"},
+		{"a/x.go", "b/y.go"},
+	}
+
+	pairs, _ := countCoChanges(commits, indexed)
+
+	type countedPair struct {
+		key   pairKey
+		count int
+	}
+	var significant []countedPair
+	for k, v := range pairs {
+		if v >= minCoChanges {
+			significant = append(significant, countedPair{k, v})
+		}
+	}
+	sort.Slice(significant, func(i, j int) bool {
+		return significant[i].key.a < significant[j].key.a
+	})
+
+	if len(significant) != 1 {
+		t.Fatalf("expected 1 significant pair, got %d: %v", len(significant), significant)
+	}
+	if significant[0].key != makePairKey("a/x.go", "b/y.go") {
+		t.Errorf("expected a/x.go↔b/y.go, got %v", significant[0].key)
+	}
+}


### PR DESCRIPTION
## Problem

Sense's blast radius only traces structural edges — calls, composes, includes, inherits. Dependencies that are invisible to static analysis (e.g., a service and a legacy cron job that reads its output) get a "risk: low, 0 direct callers" verdict even when they co-change in 14 of the last 20 commits. Developers modifying one side without checking the other break production.

## Summary

Add temporal coupling detection: a new scan phase mines `git log` for file pairs that co-change frequently, writes bidirectional `temporal` edges into the graph, and surfaces them through both blast radius and graph responses.

## Changes

**Scan pipeline** (`internal/scan/`)
- New `extractTemporalCoupling` phase runs after test association
- Parses `git log --name-only` (6-month window, 1000-commit cap) into co-change pairs
- Filters to indexed files in different directories, ≥3 co-changes
- Maps each file to a representative symbol (prefers class/module kinds, then highest connectivity)
- Writes bidirectional temporal edges in a single transaction
- Graceful no-op when git is absent; warns and skips on 2-second timeout

**Model & types** (`internal/model/`, `internal/mcpio/types.go`)
- `EdgeTemporal` edge kind
- `TemporalEdgeRef` struct (symbol, file, co_changes, strength) in graph response
- `ViaTemporal` flag on blast caller and indirect types

**Blast radius** (`internal/blast/engine.go`)
- BFS frontier expansion includes `'temporal'` edges
- Temporal coupling bumps risk to at least `medium`
- Risk reasons include "temporal coupling detected (git co-change history)"

**Graph & blast responses** (`internal/mcpio/`)
- Graph response populates `temporal` array with deduplication (bidirectional edges → one entry)
- Temporal edges shown regardless of direction filter
- Blast response sets `via_temporal` on callers reached through temporal edges

## Test Plan

- [x] `TestParseGitLogOutput` — git log parsing (normal, empty, no-files)
- [x] `TestCountCoChanges` — same-dir exclusion, unindexed filtering, strength computation
- [x] `TestPickRepresentative` — class preference, connectivity fallback, tie-breaking
- [x] `TestComputeTemporalEdgeBumpsRisk` — integration test with real DB, verifies risk bump
- [x] `TestComputeNoTemporalEdgesStaysLow` — no false positives
- [x] `TestClassifyRiskTemporalBump` — unit test for risk classification with temporal flag
- [x] `TestBuildGraphResponseTemporalEdges` — deduplication, fields, direction independence
- [x] `TestBuildBlastResponseViaTemporal` — via_temporal on direct and indirect callers
- [x] `TestTemporalCouplingNoOpWithoutGit` — scans non-git temp dir, asserts zero temporal edges
- [x] `go test ./...` passes
- [x] `make ci` passes (build + test + lint)