### PR TITLE
feat(benchmark): add sense benchmark command and extended bench suite

### DIFF
--- a/cmd/sense/main.go
+++ b/cmd/sense/main.go
@@ -32,6 +32,7 @@ Commands:
   dead          Find dead code (symbols with no incoming references)
   conventions   Detected project conventions
   status        Index health and embedding coverage
+  benchmark     Run performance benchmarks on the index
   doctor        Diagnose common index problems
   hook          Claude Code lifecycle hooks (pre-tool-use, pre-compact, etc.)
   mcp           Start the MCP server (stdio transport)
@@ -144,6 +145,9 @@ func main() {
 
 	case "status":
 		os.Exit(cli.RunStatus(os.Args[2:], cli.DefaultIO()))
+
+	case "benchmark":
+		os.Exit(cli.RunBenchmark(os.Args[2:], cli.DefaultIO()))
 
 	case "doctor":
 		os.Exit(cli.RunDoctor(os.Args[2:], cli.DefaultIO()))

--- a/internal/benchmark/benchmark.go
+++ b/internal/benchmark/benchmark.go
@@ -1,0 +1,543 @@
+package benchmark
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math"
+	"os"
+	"os/exec"
+	"strings"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"time"
+
+	"github.com/luuuc/sense/internal/blast"
+	"github.com/luuuc/sense/internal/conventions"
+	"github.com/luuuc/sense/internal/embed"
+	"github.com/luuuc/sense/internal/mcpio"
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/scan"
+	"github.com/luuuc/sense/internal/search"
+	"github.com/luuuc/sense/internal/sqlite"
+
+	_ "modernc.org/sqlite"
+)
+
+type Options struct {
+	Iterations int
+	Dir        string
+	Binary     string // path to sense binary for cold start measurement
+	SkipScan   bool
+	SkipSearch bool
+}
+
+type Latency struct {
+	P50 time.Duration
+	P95 time.Duration
+	P99 time.Duration
+}
+
+type ScanMetrics struct {
+	FullScan          time.Duration
+	FilesPerSec       float64
+	SymbolsPerSec     float64
+	IncrementalClean  time.Duration
+	IncrementalDirty  time.Duration
+}
+
+type IndexMetrics struct {
+	DatabaseBytes  int64
+	EmbeddingBytes int64
+	SymbolCount    int
+	BytesPerSymbol float64
+}
+
+type MemoryMetrics struct {
+	QueryAllocBytes uint64
+}
+
+type Report struct {
+	Dir         string
+	SymbolCount int
+	EdgeCount   int
+	FileCount   int
+
+	Scan   ScanMetrics
+	Index  IndexMetrics
+	Memory MemoryMetrics
+
+	GraphLatency       Latency
+	SearchKeyword      Latency
+	SearchSemantic     Latency
+	SearchHybrid       Latency
+	BlastShallow       Latency
+	BlastDeep          Latency
+	ConventionsLatency Latency
+	StatusLatency      Latency
+
+	ColdStartLatency time.Duration
+
+	Iterations int
+}
+
+type symbolTier struct {
+	id    int64
+	name  string
+	fanIn int
+}
+
+func Run(ctx context.Context, dir string, opts Options) (*Report, error) {
+	if opts.Iterations <= 0 {
+		opts.Iterations = 100
+	}
+	if dir == "" {
+		dir = "."
+	}
+
+	dbPath := filepath.Join(dir, ".sense", "index.db")
+
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("open index: %w", err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	db, err := sql.Open("sqlite", "file:"+dbPath+"?mode=ro")
+	if err != nil {
+		return nil, fmt.Errorf("open read-only db: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	report := &Report{
+		Dir:        dir,
+		Iterations: opts.Iterations,
+	}
+
+	if err := queryIndexStats(ctx, db, report); err != nil {
+		return nil, err
+	}
+
+	hub, mid, leaf, err := selectSymbols(ctx, db)
+	if err != nil {
+		return nil, fmt.Errorf("select symbols: %w", err)
+	}
+
+	runtime.GC()
+	var memBefore runtime.MemStats
+	runtime.ReadMemStats(&memBefore)
+
+	report.GraphLatency = benchGraph(ctx, adapter, hub, mid, leaf, opts.Iterations)
+	report.BlastShallow = benchBlast(ctx, db, hub, mid, leaf, 1, opts.Iterations)
+	report.BlastDeep = benchBlast(ctx, db, hub, mid, leaf, 3, opts.Iterations)
+	report.ConventionsLatency = benchConventions(ctx, db, opts.Iterations)
+	report.StatusLatency = benchStatus(ctx, db, opts.Iterations)
+
+	if !opts.SkipSearch {
+		searchEngine, embedder, cleanup := buildSearchEngine(ctx, adapter, dir)
+		defer cleanup()
+		if searchEngine != nil {
+			report.SearchKeyword = benchSearch(ctx, searchEngine, hub, false, opts.Iterations)
+			if embedder != nil {
+				report.SearchSemantic = benchSearch(ctx, searchEngine, hub, true, opts.Iterations)
+				report.SearchHybrid = benchSearchHybrid(ctx, searchEngine, hub, opts.Iterations)
+			}
+		}
+	}
+
+	report.Index = measureIndex(dir, report.SymbolCount)
+
+	if opts.Binary != "" {
+		report.ColdStartLatency = measureColdStart(ctx, opts.Binary, dir)
+	}
+
+	if !opts.SkipScan {
+		report.Scan = measureScan(ctx, dir)
+	}
+
+	var memAfter runtime.MemStats
+	runtime.ReadMemStats(&memAfter)
+	report.Memory.QueryAllocBytes = memAfter.TotalAlloc - memBefore.TotalAlloc
+
+	return report, nil
+}
+
+func queryIndexStats(ctx context.Context, db *sql.DB, r *Report) error {
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM sense_files").Scan(&r.FileCount); err != nil {
+		return fmt.Errorf("count files: %w", err)
+	}
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM sense_symbols").Scan(&r.SymbolCount); err != nil {
+		return fmt.Errorf("count symbols: %w", err)
+	}
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM sense_edges").Scan(&r.EdgeCount); err != nil {
+		return fmt.Errorf("count edges: %w", err)
+	}
+	return nil
+}
+
+func selectSymbols(ctx context.Context, db *sql.DB) (hub, mid, leaf symbolTier, err error) {
+	var total int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM sense_symbols").Scan(&total); err != nil {
+		return hub, mid, leaf, fmt.Errorf("count symbols: %w", err)
+	}
+	if total == 0 {
+		return hub, mid, leaf, fmt.Errorf("no symbols in index")
+	}
+
+	const ranked = `
+		SELECT s.id, s.qualified,
+		       (SELECT COUNT(*) FROM sense_edges WHERE target_id = s.id) AS fan_in
+		FROM sense_symbols s
+		ORDER BY fan_in DESC
+		LIMIT 1 OFFSET ?`
+
+	scan := func(offset int) (symbolTier, error) {
+		var st symbolTier
+		if err := db.QueryRowContext(ctx, ranked, offset).Scan(&st.id, &st.name, &st.fanIn); err != nil {
+			return st, fmt.Errorf("select symbol at offset %d: %w", offset, err)
+		}
+		return st, nil
+	}
+
+	hub, err = scan(0)
+	if err != nil {
+		return hub, mid, leaf, err
+	}
+
+	if total == 1 {
+		return hub, hub, hub, nil
+	}
+	if total == 2 {
+		leaf, err = scan(1)
+		return hub, hub, leaf, err
+	}
+
+	mid, err = scan(total / 2)
+	if err != nil {
+		return hub, mid, leaf, err
+	}
+	leaf, err = scan(total - 1)
+	if err != nil {
+		return hub, mid, leaf, err
+	}
+
+	return hub, mid, leaf, nil
+}
+
+func benchGraph(ctx context.Context, adapter *sqlite.Adapter, hub, mid, leaf symbolTier, n int) Latency {
+	db := adapter.DB()
+	symbols := []symbolTier{hub, mid, leaf}
+	durations := make([]time.Duration, 0, n)
+	for i := 0; i < n; i++ {
+		sym := symbols[i%len(symbols)]
+		start := time.Now()
+		sc, err := adapter.ReadSymbol(ctx, sym.id)
+		if err == nil {
+			paths := loadEdgeFilePaths(ctx, db, sc)
+			lookup := func(id int64) (string, bool) {
+				p, ok := paths[id]
+				return p, ok
+			}
+			_ = mcpio.BuildGraphResponse(sc, lookup, mcpio.BuildGraphRequest{})
+		}
+		durations = append(durations, time.Since(start))
+	}
+	return percentiles(durations)
+}
+
+func loadEdgeFilePaths(ctx context.Context, db *sql.DB, sc *model.SymbolContext) map[int64]string {
+	seen := map[int64]struct{}{sc.File.ID: {}}
+	ids := []int64{sc.File.ID}
+	for _, e := range sc.Outbound {
+		if _, ok := seen[e.Target.FileID]; !ok {
+			seen[e.Target.FileID] = struct{}{}
+			ids = append(ids, e.Target.FileID)
+		}
+	}
+	for _, e := range sc.Inbound {
+		if _, ok := seen[e.Target.FileID]; !ok {
+			seen[e.Target.FileID] = struct{}{}
+			ids = append(ids, e.Target.FileID)
+		}
+	}
+	out := make(map[int64]string, len(ids))
+	for start := 0; start < len(ids); start += 500 {
+		end := start + 500
+		if end > len(ids) {
+			end = len(ids)
+		}
+		batch := ids[start:end]
+		placeholders := strings.Repeat("?,", len(batch))
+		placeholders = placeholders[:len(placeholders)-1]
+		q := `SELECT id, path FROM sense_files WHERE id IN (` + placeholders + `)`
+		args := make([]any, len(batch))
+		for i, id := range batch {
+			args[i] = id
+		}
+		rows, err := db.QueryContext(ctx, q, args...)
+		if err != nil {
+			continue
+		}
+		for rows.Next() {
+			var id int64
+			var path string
+			if err := rows.Scan(&id, &path); err != nil {
+				break
+			}
+			out[id] = path
+		}
+		_ = rows.Close()
+	}
+	return out
+}
+
+func benchBlast(ctx context.Context, db *sql.DB, hub, mid, leaf symbolTier, maxHops, n int) Latency {
+	symbols := []symbolTier{hub, mid, leaf}
+	durations := make([]time.Duration, 0, n)
+	for i := 0; i < n; i++ {
+		sym := symbols[i%len(symbols)]
+		start := time.Now()
+		_, _ = blast.Compute(ctx, db, []int64{sym.id}, blast.Options{
+			MaxHops:      maxHops,
+			IncludeTests: true,
+		})
+		durations = append(durations, time.Since(start))
+	}
+	return percentiles(durations)
+}
+
+func benchConventions(ctx context.Context, db *sql.DB, n int) Latency {
+	durations := make([]time.Duration, 0, n)
+	for i := 0; i < n; i++ {
+		start := time.Now()
+		_, _, _ = conventions.Detect(ctx, db, conventions.Options{})
+		durations = append(durations, time.Since(start))
+	}
+	return percentiles(durations)
+}
+
+func benchStatus(ctx context.Context, db *sql.DB, n int) Latency {
+	durations := make([]time.Duration, 0, n)
+	var dummy int
+	for i := 0; i < n; i++ {
+		start := time.Now()
+		_ = db.QueryRowContext(ctx, "SELECT COUNT(*) FROM sense_files").Scan(&dummy)
+		_ = db.QueryRowContext(ctx, "SELECT COUNT(*) FROM sense_symbols").Scan(&dummy)
+		_ = db.QueryRowContext(ctx, "SELECT COUNT(*) FROM sense_edges").Scan(&dummy)
+		durations = append(durations, time.Since(start))
+	}
+	return percentiles(durations)
+}
+
+func buildSearchEngine(ctx context.Context, adapter *sqlite.Adapter, dir string) (*search.Engine, embed.Embedder, func()) {
+	var vectorIdx search.VectorIndex
+	var embedder embed.Embedder
+
+	hnswPath := filepath.Join(dir, ".sense", "hnsw.bin")
+	idx, loadErr := search.LoadHNSWIndex(hnswPath)
+	if loadErr == nil && idx != nil {
+		vectorIdx = idx
+	} else {
+		embeddings, err := adapter.LoadEmbeddings(ctx)
+		if err == nil && len(embeddings) > 0 {
+			vectorIdx = search.BuildHNSWIndex(embeddings)
+		}
+	}
+
+	if vectorIdx != nil && vectorIdx.Len() > 0 {
+		e, err := embed.NewBundledEmbedder(0)
+		if err == nil {
+			embedder = e
+		}
+	}
+
+	engine := search.NewEngine(adapter, vectorIdx, embedder)
+	return engine, embedder, func() {
+		if embedder != nil {
+			_ = embedder.Close()
+		}
+	}
+}
+
+func benchSearch(ctx context.Context, engine *search.Engine, sym symbolTier, semantic bool, n int) Latency {
+	query := sym.name
+	if !semantic {
+		parts := splitQualified(sym.name)
+		if len(parts) > 0 {
+			query = parts[len(parts)-1]
+		}
+	}
+
+	durations := make([]time.Duration, 0, n)
+	for i := 0; i < n; i++ {
+		start := time.Now()
+		_, _, _, _ = engine.Search(ctx, search.Options{
+			Query: query,
+			Limit: 10,
+		})
+		durations = append(durations, time.Since(start))
+	}
+	return percentiles(durations)
+}
+
+func benchSearchHybrid(ctx context.Context, engine *search.Engine, sym symbolTier, n int) Latency {
+	query := "how does " + sym.name + " work"
+	durations := make([]time.Duration, 0, n)
+	for i := 0; i < n; i++ {
+		start := time.Now()
+		_, _, _, _ = engine.Search(ctx, search.Options{
+			Query: query,
+			Limit: 10,
+		})
+		durations = append(durations, time.Since(start))
+	}
+	return percentiles(durations)
+}
+
+func measureIndex(dir string, symbolCount int) IndexMetrics {
+	var m IndexMetrics
+	m.SymbolCount = symbolCount
+	dbPath := filepath.Join(dir, ".sense", "index.db")
+	if info, err := os.Stat(dbPath); err == nil {
+		m.DatabaseBytes = info.Size()
+	}
+	walPath := dbPath + "-wal"
+	if info, err := os.Stat(walPath); err == nil {
+		m.DatabaseBytes += info.Size()
+	}
+
+	embPath := filepath.Join(dir, ".sense", "hnsw.bin")
+	if info, err := os.Stat(embPath); err == nil {
+		m.EmbeddingBytes = info.Size()
+	}
+
+	if m.DatabaseBytes > 0 && m.SymbolCount > 0 {
+		m.BytesPerSymbol = float64(m.DatabaseBytes) / float64(m.SymbolCount)
+	}
+	return m
+}
+
+func measureColdStart(ctx context.Context, binary, dir string) time.Duration {
+	start := time.Now()
+	cmd := exec.CommandContext(ctx, binary, "status")
+	cmd.Dir = dir
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	if err := cmd.Run(); err != nil {
+		return 0
+	}
+	return time.Since(start)
+}
+
+func measureScan(ctx context.Context, dir string) ScanMetrics {
+	var m ScanMetrics
+
+	tmpDir, err := os.MkdirTemp("", "sense-bench-scan-*")
+	if err != nil {
+		return m
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	start := time.Now()
+	result, err := scan.Run(ctx, scan.Options{
+		Root:   dir,
+		Sense:  filepath.Join(tmpDir, ".sense"),
+		Output: nil,
+	})
+	m.FullScan = time.Since(start)
+
+	if err == nil && result != nil {
+		if m.FullScan > 0 {
+			m.FilesPerSec = float64(result.Indexed) / m.FullScan.Seconds()
+			m.SymbolsPerSec = float64(result.Symbols) / m.FullScan.Seconds()
+		}
+
+		start = time.Now()
+		_, _ = scan.Run(ctx, scan.Options{
+			Root:   dir,
+			Sense:  filepath.Join(tmpDir, ".sense"),
+			Output: nil,
+		})
+		m.IncrementalClean = time.Since(start)
+
+		restore := touchFiles(dir, 5)
+		start = time.Now()
+		_, _ = scan.Run(ctx, scan.Options{
+			Root:   dir,
+			Sense:  filepath.Join(tmpDir, ".sense"),
+			Output: nil,
+		})
+		m.IncrementalDirty = time.Since(start)
+		restore()
+	}
+
+	return m
+}
+
+func touchFiles(dir string, count int) func() {
+	type saved struct {
+		path  string
+		mtime time.Time
+	}
+	var originals []saved
+	now := time.Now()
+	_ = filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || len(originals) >= count {
+			if len(originals) >= count {
+				return filepath.SkipAll
+			}
+			return nil
+		}
+		ext := filepath.Ext(path)
+		switch ext {
+		case ".go", ".rb", ".py", ".ts", ".js":
+			info, infoErr := d.Info()
+			if infoErr == nil {
+				originals = append(originals, saved{path: path, mtime: info.ModTime()})
+				_ = os.Chtimes(path, now, now)
+			}
+		}
+		return nil
+	})
+	return func() {
+		for _, o := range originals {
+			_ = os.Chtimes(o.path, o.mtime, o.mtime)
+		}
+	}
+}
+
+func percentiles(durations []time.Duration) Latency {
+	if len(durations) == 0 {
+		return Latency{}
+	}
+	sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
+	return Latency{
+		P50: pct(durations, 50),
+		P95: pct(durations, 95),
+		P99: pct(durations, 99),
+	}
+}
+
+func pct(sorted []time.Duration, p float64) time.Duration {
+	if len(sorted) == 0 {
+		return 0
+	}
+	idx := int(math.Ceil(p/100*float64(len(sorted)))) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
+}
+
+func splitQualified(name string) []string {
+	for _, sep := range []string{"::", ".", "#"} {
+		if i := strings.LastIndex(name, sep); i >= 0 {
+			return []string{name[:i], name[i+len(sep):]}
+		}
+	}
+	return []string{name}
+}

--- a/internal/benchmark/benchmark_test.go
+++ b/internal/benchmark/benchmark_test.go
@@ -1,0 +1,187 @@
+package benchmark
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+func TestSelectSymbolsDistinctTiers(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "select.db")
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	fix, err := BuildFixture(ctx, adapter, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fix.SymbolIDs) < 3 {
+		t.Fatalf("fixture has %d symbols, need at least 3", len(fix.SymbolIDs))
+	}
+
+	hub, mid, leaf, err := selectSymbols(ctx, adapter.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if hub.id == mid.id || hub.id == leaf.id || mid.id == leaf.id {
+		t.Errorf("expected 3 distinct symbols, got hub=%d mid=%d leaf=%d", hub.id, mid.id, leaf.id)
+	}
+
+	if hub.fanIn < mid.fanIn {
+		t.Errorf("hub (%d fans) should have >= fan-in than mid (%d fans)", hub.fanIn, mid.fanIn)
+	}
+	if mid.fanIn < leaf.fanIn {
+		t.Errorf("mid (%d fans) should have >= fan-in than leaf (%d fans)", mid.fanIn, leaf.fanIn)
+	}
+}
+
+func TestReportFieldsPopulated(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	sensePath := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(sensePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dbPath := filepath.Join(sensePath, "index.db")
+
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := BuildFixture(ctx, adapter, 50); err != nil {
+		t.Fatal(err)
+	}
+	_ = adapter.Close()
+
+	report, err := Run(ctx, dir, Options{Iterations: 3, SkipScan: true, SkipSearch: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if report.SymbolCount == 0 {
+		t.Error("SymbolCount should be > 0")
+	}
+	if report.EdgeCount == 0 {
+		t.Error("EdgeCount should be > 0")
+	}
+	if report.FileCount == 0 {
+		t.Error("FileCount should be > 0")
+	}
+	if report.Iterations != 3 {
+		t.Errorf("Iterations = %d, want 3", report.Iterations)
+	}
+	if report.GraphLatency.P50 == 0 {
+		t.Error("GraphLatency.P50 should be > 0")
+	}
+	if report.BlastShallow.P50 == 0 {
+		t.Error("BlastShallow.P50 should be > 0")
+	}
+	if report.BlastDeep.P50 == 0 {
+		t.Error("BlastDeep.P50 should be > 0")
+	}
+	if report.ConventionsLatency.P50 == 0 {
+		t.Error("ConventionsLatency.P50 should be > 0")
+	}
+	if report.StatusLatency.P50 == 0 {
+		t.Error("StatusLatency.P50 should be > 0")
+	}
+	if report.Index.DatabaseBytes == 0 {
+		t.Error("Index.DatabaseBytes should be > 0")
+	}
+}
+
+func TestMarshalJSONValid(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	sensePath := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(sensePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dbPath := filepath.Join(sensePath, "index.db")
+
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := BuildFixture(ctx, adapter, 50); err != nil {
+		t.Fatal(err)
+	}
+	_ = adapter.Close()
+
+	report, err := Run(ctx, dir, Options{Iterations: 3, SkipScan: true, SkipSearch: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := MarshalJSON(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var parsed JSONReport
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("invalid JSON: %v\n%s", err, data)
+	}
+
+	if parsed.Project.Symbols == 0 {
+		t.Error("JSON project.symbols should be > 0")
+	}
+	if parsed.Iterations != 3 {
+		t.Errorf("JSON iterations = %d, want 3", parsed.Iterations)
+	}
+	if parsed.Query.Graph.P50Ms == 0 {
+		t.Error("JSON query.graph.p50_ms should be > 0")
+	}
+	if parsed.Query.BlastShort.P50Ms == 0 {
+		t.Error("JSON query.blast_1hop.p50_ms should be > 0")
+	}
+}
+
+func TestPercentiles(t *testing.T) {
+	tests := []struct {
+		name string
+		n    int
+		wP50 int
+		wP95 int
+		wP99 int
+	}{
+		{"10 items", 10, 5, 10, 10},
+		{"100 items", 100, 50, 95, 99},
+		{"1 item", 1, 1, 1, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var durations []time.Duration
+			for i := 1; i <= tt.n; i++ {
+				durations = append(durations, time.Duration(i)*time.Millisecond)
+			}
+			l := percentiles(durations)
+			p50ms := int(l.P50.Milliseconds())
+			p95ms := int(l.P95.Milliseconds())
+			p99ms := int(l.P99.Milliseconds())
+
+			if p50ms != tt.wP50 {
+				t.Errorf("P50 = %dms, want %dms", p50ms, tt.wP50)
+			}
+			if p95ms != tt.wP95 {
+				t.Errorf("P95 = %dms, want %dms", p95ms, tt.wP95)
+			}
+			if p99ms != tt.wP99 {
+				t.Errorf("P99 = %dms, want %dms", p99ms, tt.wP99)
+			}
+		})
+	}
+}

--- a/internal/benchmark/fixture.go
+++ b/internal/benchmark/fixture.go
@@ -1,0 +1,151 @@
+package benchmark
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"math/rand"
+	"time"
+
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+type Fixture struct {
+	Adapter   *sqlite.Adapter
+	SymbolIDs []int64
+	FileIDs   []int64
+}
+
+func BuildFixture(ctx context.Context, adapter *sqlite.Adapter, symbolCount int) (*Fixture, error) {
+	rng := rand.New(rand.NewSource(42))
+	fix := &Fixture{Adapter: adapter}
+
+	langs := []struct {
+		lang string
+		ext  string
+		dir  string
+	}{
+		{"go", ".go", "internal/"},
+		{"ruby", ".rb", "app/"},
+		{"python", ".py", "lib/"},
+		{"typescript", ".ts", "src/"},
+	}
+
+	kinds := []model.SymbolKind{
+		model.KindClass, model.KindFunction, model.KindMethod,
+		model.KindConstant, model.KindInterface,
+	}
+
+	filesPerLang := max(symbolCount/20, 1)
+	now := time.Now().UTC()
+
+	err := adapter.InTx(ctx, func() error {
+		for _, l := range langs {
+			for f := 0; f < filesPerLang; f++ {
+				fid, err := adapter.WriteFile(ctx, &model.File{
+					Path:      fmt.Sprintf("%s%s_%d%s", l.dir, l.lang, f, l.ext),
+					Language:  l.lang,
+					Hash:      fmt.Sprintf("hash_%s_%d", l.lang, f),
+					Symbols:   symbolCount / (len(langs) * filesPerLang),
+					IndexedAt: now,
+				})
+				if err != nil {
+					return fmt.Errorf("write file: %w", err)
+				}
+				fix.FileIDs = append(fix.FileIDs, fid)
+			}
+		}
+
+		symsPerFile := symbolCount / len(fix.FileIDs)
+		if symsPerFile < 1 {
+			symsPerFile = 1
+		}
+
+		for i, fid := range fix.FileIDs {
+			langIdx := i / filesPerLang
+			if langIdx >= len(langs) {
+				langIdx = len(langs) - 1
+			}
+
+			for s := 0; s < symsPerFile && len(fix.SymbolIDs) < symbolCount; s++ {
+				kind := kinds[rng.Intn(len(kinds))]
+				name := fmt.Sprintf("Symbol%d", len(fix.SymbolIDs))
+				qualified := fmt.Sprintf("%s.%s", langs[langIdx].dir, name)
+
+				sid, err := adapter.WriteSymbol(ctx, &model.Symbol{
+					FileID:    fid,
+					Name:      name,
+					Qualified: qualified,
+					Kind:      kind,
+					LineStart: s*10 + 1,
+					LineEnd:   s*10 + 9,
+					Snippet:   fmt.Sprintf("func %s() {}", name),
+				})
+				if err != nil {
+					return fmt.Errorf("write symbol: %w", err)
+				}
+				fix.SymbolIDs = append(fix.SymbolIDs, sid)
+			}
+		}
+
+		for i := 1; i < len(fix.SymbolIDs); i++ {
+			targetIdx := rng.Intn(i)
+			src := fix.SymbolIDs[i]
+			if _, err := adapter.WriteEdge(ctx, &model.Edge{
+				SourceID:   &src,
+				TargetID:   fix.SymbolIDs[targetIdx],
+				Kind:       model.EdgeCalls,
+				FileID:     fix.FileIDs[i%len(fix.FileIDs)],
+				Confidence: 0.8 + rng.Float64()*0.2,
+			}); err != nil {
+				return fmt.Errorf("write edge: %w", err)
+			}
+		}
+
+		hubIdx := 0
+		for i := 0; i < min(50, len(fix.SymbolIDs)-1); i++ {
+			src := fix.SymbolIDs[rng.Intn(len(fix.SymbolIDs)-1)+1]
+			if _, err := adapter.WriteEdge(ctx, &model.Edge{
+				SourceID:   &src,
+				TargetID:   fix.SymbolIDs[hubIdx],
+				Kind:       model.EdgeCalls,
+				FileID:     fix.FileIDs[0],
+				Confidence: 1.0,
+			}); err != nil {
+				return fmt.Errorf("write hub edge: %w", err)
+			}
+		}
+
+		for i := 0; i < len(fix.SymbolIDs); i++ {
+			vec := make([]float32, 384)
+			for j := range vec {
+				vec[j] = rng.Float32()*2 - 1
+			}
+			norm := float32(0)
+			for _, v := range vec {
+				norm += v * v
+			}
+			norm = float32(math.Sqrt(float64(norm)))
+			for j := range vec {
+				vec[j] /= norm
+			}
+
+			blob := make([]byte, len(vec)*4)
+			for j, v := range vec {
+				binary.LittleEndian.PutUint32(blob[j*4:], math.Float32bits(v))
+			}
+			if err := adapter.WriteEmbedding(ctx, fix.SymbolIDs[i], blob); err != nil {
+				return fmt.Errorf("write embedding: %w", err)
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return fix, nil
+}

--- a/internal/benchmark/format.go
+++ b/internal/benchmark/format.go
@@ -1,0 +1,213 @@
+package benchmark
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+type JSONReport struct {
+	Project    JSONProject     `json:"project"`
+	Scan       JSONScan        `json:"scan"`
+	Query      JSONQueryReport `json:"query"`
+	ColdStart  *JSONColdStart  `json:"cold_start,omitempty"`
+	Index      JSONIndex       `json:"index"`
+	Memory     JSONMemory      `json:"memory"`
+	Iterations int             `json:"iterations"`
+}
+
+type JSONProject struct {
+	Dir     string `json:"dir"`
+	Files   int    `json:"files"`
+	Symbols int    `json:"symbols"`
+	Edges   int    `json:"edges"`
+}
+
+type JSONScan struct {
+	FullMs             float64 `json:"full_ms"`
+	FilesPerSec        float64 `json:"files_per_sec"`
+	SymbolsPerSec      float64 `json:"symbols_per_sec"`
+	IncrementalCleanMs float64 `json:"incremental_clean_ms"`
+	IncrementalDirtyMs float64 `json:"incremental_dirty_ms"`
+}
+
+type JSONLatency struct {
+	P50Ms float64 `json:"p50_ms"`
+	P95Ms float64 `json:"p95_ms"`
+	P99Ms float64 `json:"p99_ms"`
+}
+
+type JSONQueryReport struct {
+	Graph       JSONLatency  `json:"graph"`
+	Keyword     JSONLatency  `json:"search_keyword"`
+	Semantic    *JSONLatency `json:"search_semantic,omitempty"`
+	Hybrid      *JSONLatency `json:"search_hybrid,omitempty"`
+	BlastShort  JSONLatency  `json:"blast_1hop"`
+	BlastDeep   JSONLatency  `json:"blast_3hop"`
+	Conventions JSONLatency  `json:"conventions"`
+	Status      JSONLatency  `json:"status"`
+}
+
+type JSONColdStart struct {
+	Ms float64 `json:"ms"`
+}
+
+type JSONIndex struct {
+	DatabaseBytes  int64   `json:"database_bytes"`
+	EmbeddingBytes int64   `json:"embedding_bytes"`
+	BytesPerSymbol float64 `json:"bytes_per_symbol"`
+}
+
+type JSONMemory struct {
+	QueryAllocBytes uint64 `json:"query_alloc_bytes"`
+}
+
+func MarshalJSON(r *Report) ([]byte, error) {
+	jr := JSONReport{
+		Project: JSONProject{
+			Dir:     r.Dir,
+			Files:   r.FileCount,
+			Symbols: r.SymbolCount,
+			Edges:   r.EdgeCount,
+		},
+		Scan: JSONScan{
+			FullMs:             msFromDuration(r.Scan.FullScan),
+			FilesPerSec:        r.Scan.FilesPerSec,
+			SymbolsPerSec:      r.Scan.SymbolsPerSec,
+			IncrementalCleanMs: msFromDuration(r.Scan.IncrementalClean),
+			IncrementalDirtyMs: msFromDuration(r.Scan.IncrementalDirty),
+		},
+		Query: JSONQueryReport{
+			Graph:       latencyToJSON(r.GraphLatency),
+			Keyword:     latencyToJSON(r.SearchKeyword),
+			BlastShort:  latencyToJSON(r.BlastShallow),
+			BlastDeep:   latencyToJSON(r.BlastDeep),
+			Conventions: latencyToJSON(r.ConventionsLatency),
+			Status:      latencyToJSON(r.StatusLatency),
+		},
+		Index: JSONIndex{
+			DatabaseBytes:  r.Index.DatabaseBytes,
+			EmbeddingBytes: r.Index.EmbeddingBytes,
+			BytesPerSymbol: r.Index.BytesPerSymbol,
+		},
+		Memory: JSONMemory{
+			QueryAllocBytes: r.Memory.QueryAllocBytes,
+		},
+		Iterations: r.Iterations,
+	}
+
+	if r.SearchSemantic.P50 > 0 {
+		l := latencyToJSON(r.SearchSemantic)
+		jr.Query.Semantic = &l
+	}
+	if r.SearchHybrid.P50 > 0 {
+		l := latencyToJSON(r.SearchHybrid)
+		jr.Query.Hybrid = &l
+	}
+	if r.ColdStartLatency > 0 {
+		jr.ColdStart = &JSONColdStart{Ms: msFromDuration(r.ColdStartLatency)}
+	}
+
+	return json.MarshalIndent(jr, "", "  ")
+}
+
+func WriteHuman(w io.Writer, r *Report) {
+	_, _ = fmt.Fprintf(w, "Benchmark: %s (%d symbols, %d edges, %d files)\n\n",
+		r.Dir, r.SymbolCount, r.EdgeCount, r.FileCount)
+
+	_, _ = fmt.Fprintf(w, "Scan\n")
+	_, _ = fmt.Fprintf(w, "  full scan .............. %s (%.1f files/sec, %.0f symbols/sec)\n",
+		fmtDuration(r.Scan.FullScan), r.Scan.FilesPerSec, r.Scan.SymbolsPerSec)
+	_, _ = fmt.Fprintf(w, "  incremental (0 changed)  %s\n", fmtDuration(r.Scan.IncrementalClean))
+	_, _ = fmt.Fprintf(w, "  incremental (5 changed)  %s\n", fmtDuration(r.Scan.IncrementalDirty))
+
+	_, _ = fmt.Fprintf(w, "\nQuery latency (%d iterations, p50 / p95 / p99)\n", r.Iterations)
+	printLatency(w, "graph", r.GraphLatency)
+	printLatency(w, "search (keyword)", r.SearchKeyword)
+	if r.SearchSemantic.P50 > 0 {
+		printLatency(w, "search (semantic)", r.SearchSemantic)
+	}
+	if r.SearchHybrid.P50 > 0 {
+		printLatency(w, "search (hybrid)", r.SearchHybrid)
+	}
+	printLatency(w, "blast (1 hop)", r.BlastShallow)
+	printLatency(w, "blast (3 hops)", r.BlastDeep)
+	printLatency(w, "conventions", r.ConventionsLatency)
+	printLatency(w, "status", r.StatusLatency)
+
+	if r.ColdStartLatency > 0 {
+		_, _ = fmt.Fprintf(w, "\nCold start\n")
+		_, _ = fmt.Fprintf(w, "  mcp launch to ready .... %s\n", fmtDuration(r.ColdStartLatency))
+	}
+
+	_, _ = fmt.Fprintf(w, "\nIndex\n")
+	_, _ = fmt.Fprintf(w, "  database size .......... %s", fmtBytes(r.Index.DatabaseBytes))
+	if r.Index.BytesPerSymbol > 0 {
+		_, _ = fmt.Fprintf(w, " (%.1f KB/symbol)", r.Index.BytesPerSymbol/1024)
+	}
+	_, _ = fmt.Fprintln(w)
+	if r.Index.EmbeddingBytes > 0 {
+		_, _ = fmt.Fprintf(w, "  embeddings ............. %s\n", fmtBytes(r.Index.EmbeddingBytes))
+	}
+
+	_, _ = fmt.Fprintf(w, "\nMemory\n")
+	_, _ = fmt.Fprintf(w, "  RSS (query serving) .... %s\n", fmtBytes(int64(r.Memory.QueryAllocBytes)))
+}
+
+func printLatency(w io.Writer, label string, l Latency) {
+	padding := 25 - len(label)
+	if padding < 1 {
+		padding = 1
+	}
+	_, _ = fmt.Fprintf(w, "  %s %s %s / %s / %s\n",
+		label, strings.Repeat(".", padding),
+		fmtMs(l.P50), fmtMs(l.P95), fmtMs(l.P99))
+}
+
+func latencyToJSON(l Latency) JSONLatency {
+	return JSONLatency{
+		P50Ms: msFromDuration(l.P50),
+		P95Ms: msFromDuration(l.P95),
+		P99Ms: msFromDuration(l.P99),
+	}
+}
+
+func msFromDuration(d time.Duration) float64 {
+	return float64(d.Microseconds()) / 1000.0
+}
+
+func fmtMs(d time.Duration) string {
+	ms := msFromDuration(d)
+	if ms < 1 {
+		return fmt.Sprintf("%.2fms", ms)
+	}
+	if ms < 100 {
+		return fmt.Sprintf("%.1fms", ms)
+	}
+	return fmt.Sprintf("%.0fms", ms)
+}
+
+func fmtDuration(d time.Duration) string {
+	if d < time.Millisecond {
+		return fmt.Sprintf("%.2fms", float64(d.Microseconds())/1000.0)
+	}
+	if d < time.Second {
+		return fmt.Sprintf("%.0fms", float64(d.Milliseconds()))
+	}
+	return fmt.Sprintf("%.1fs", d.Seconds())
+}
+
+func fmtBytes(b int64) string {
+	switch {
+	case b >= 1<<30:
+		return fmt.Sprintf("%.1f GB", float64(b)/float64(1<<30))
+	case b >= 1<<20:
+		return fmt.Sprintf("%.1f MB", float64(b)/float64(1<<20))
+	case b >= 1<<10:
+		return fmt.Sprintf("%.1f KB", float64(b)/float64(1<<10))
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}

--- a/internal/blast/blast_bench_test.go
+++ b/internal/blast/blast_bench_test.go
@@ -10,6 +10,7 @@ import (
 
 	_ "modernc.org/sqlite"
 
+	"github.com/luuuc/sense/internal/benchmark"
 	"github.com/luuuc/sense/internal/blast"
 	"github.com/luuuc/sense/internal/model"
 	"github.com/luuuc/sense/internal/sqlite"
@@ -37,6 +38,41 @@ import (
 func BenchmarkBlast(b *testing.B) {
 	b.Run("small_graph", func(b *testing.B) { runBlastBench(b, 1024, 8) })
 	b.Run("large_graph", func(b *testing.B) { runBlastBench(b, 30000, 30) })
+}
+
+func BenchmarkBlastHops(b *testing.B) {
+	b.ReportAllocs()
+	ctx := context.Background()
+	dbPath := filepath.Join(b.TempDir(), "hops-bench.db")
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		b.Fatalf("sqlite.Open: %v", err)
+	}
+	b.Cleanup(func() { _ = adapter.Close() })
+
+	fix, err := benchmark.BuildFixture(ctx, adapter, 500)
+	if err != nil {
+		b.Fatalf("BuildFixture: %v", err)
+	}
+
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		b.Fatalf("sql.Open: %v", err)
+	}
+	b.Cleanup(func() { _ = db.Close() })
+
+	subjectID := fix.SymbolIDs[0]
+
+	for _, hops := range []int{1, 2, 3} {
+		b.Run(fmt.Sprintf("hops_%d", hops), func(b *testing.B) {
+			for b.Loop() {
+				_, err := blast.Compute(ctx, db, []int64{subjectID}, blast.Options{MaxHops: hops})
+				if err != nil {
+					b.Fatalf("Compute: %v", err)
+				}
+			}
+		})
+	}
 }
 
 func runBlastBench(b *testing.B, n, branching int) {

--- a/internal/cli/benchmark.go
+++ b/internal/cli/benchmark.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/luuuc/sense/internal/benchmark"
+)
+
+const benchmarkHelp = `usage: sense benchmark [flags]
+
+Run performance benchmarks against the current project's index.
+
+Measures query latency (graph, search, blast, conventions, status),
+scan throughput, index size, and memory usage.
+
+Flags:
+  --iterations N            Number of query iterations (default 100)
+  --json                    Emit machine-readable JSON report
+  -h, --help                Show this help
+
+Examples:
+  sense benchmark
+  sense benchmark --iterations 50
+  sense benchmark --json
+
+Exit codes:
+  0  success
+  1  general error
+  3  index missing (run 'sense scan' first)
+`
+
+func RunBenchmark(args []string, cio IO) int {
+	fs := flag.NewFlagSet("sense benchmark", flag.ContinueOnError)
+	fs.SetOutput(cio.Stderr)
+	fs.Usage = func() { _, _ = fmt.Fprint(cio.Stderr, benchmarkHelp) }
+
+	iterations := fs.Int("iterations", 100, "number of query iterations")
+	jsonFlag := fs.Bool("json", false, "emit machine-readable JSON report")
+
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return ExitSuccess
+		}
+		return ExitGeneralError
+	}
+
+	ctx := context.Background()
+
+	dbPath := filepath.Join(cio.Dir, ".sense", "index.db")
+	if _, err := os.Stat(dbPath); err != nil {
+		_, _ = fmt.Fprintln(cio.Stderr, "sense: no index found. Run 'sense scan' to build one.")
+		return ExitIndexMissing
+	}
+
+	binPath, _ := exec.LookPath("sense")
+
+	report, err := benchmark.Run(ctx, cio.Dir, benchmark.Options{
+		Iterations: *iterations,
+		Dir:        cio.Dir,
+		Binary:     binPath,
+	})
+	if err != nil {
+		_, _ = fmt.Fprintf(cio.Stderr, "sense benchmark: %v\n", err)
+		return ExitGeneralError
+	}
+
+	if *jsonFlag {
+		out, err := benchmark.MarshalJSON(report)
+		if err != nil {
+			_, _ = fmt.Fprintf(cio.Stderr, "sense benchmark: %v\n", err)
+			return ExitGeneralError
+		}
+		_, _ = fmt.Fprintln(cio.Stdout, string(out))
+	} else {
+		benchmark.WriteHuman(cio.Stdout, report)
+	}
+
+	return ExitSuccess
+}

--- a/internal/conventions/conventions_bench_test.go
+++ b/internal/conventions/conventions_bench_test.go
@@ -1,0 +1,47 @@
+package conventions_test
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/luuuc/sense/internal/benchmark"
+	"github.com/luuuc/sense/internal/conventions"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+func BenchmarkConventionsDetect(b *testing.B) {
+	b.ReportAllocs()
+	ctx := context.Background()
+	dbPath := filepath.Join(b.TempDir(), "conv-bench.db")
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		b.Fatalf("sqlite.Open: %v", err)
+	}
+	b.Cleanup(func() { _ = adapter.Close() })
+
+	if _, err := benchmark.BuildFixture(ctx, adapter, 500); err != nil {
+		b.Fatalf("BuildFixture: %v", err)
+	}
+
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		b.Fatalf("sql.Open: %v", err)
+	}
+	b.Cleanup(func() { _ = db.Close() })
+
+	b.Run("no_filter", func(b *testing.B) {
+		for b.Loop() {
+			_, _, _ = conventions.Detect(ctx, db, conventions.Options{})
+		}
+	})
+
+	b.Run("domain_filter", func(b *testing.B) {
+		for b.Loop() {
+			_, _, _ = conventions.Detect(ctx, db, conventions.Options{Domain: "internal"})
+		}
+	})
+}

--- a/internal/search/search_bench_test.go
+++ b/internal/search/search_bench_test.go
@@ -1,0 +1,70 @@
+package search_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/luuuc/sense/internal/benchmark"
+	"github.com/luuuc/sense/internal/embed"
+	"github.com/luuuc/sense/internal/search"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+func BenchmarkSearch(b *testing.B) {
+	b.ReportAllocs()
+	ctx := context.Background()
+	dbPath := filepath.Join(b.TempDir(), "search-bench.db")
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		b.Fatalf("sqlite.Open: %v", err)
+	}
+	b.Cleanup(func() { _ = adapter.Close() })
+
+	fix, err := benchmark.BuildFixture(ctx, adapter, 500)
+	if err != nil {
+		b.Fatalf("BuildFixture: %v", err)
+	}
+
+	embeddings, err := adapter.LoadEmbeddings(ctx)
+	if err != nil {
+		b.Fatalf("LoadEmbeddings: %v", err)
+	}
+
+	vectorIdx := search.BuildHNSWIndex(embeddings)
+	engine := search.NewEngine(adapter, vectorIdx, &fixedEmbedder{})
+	_ = fix.SymbolIDs
+
+	b.Run("keyword", func(b *testing.B) {
+		for b.Loop() {
+			_, _, _, _ = engine.Search(ctx, search.Options{
+				Query: "Symbol0",
+				Limit: 10,
+			})
+		}
+	})
+
+	b.Run("hybrid", func(b *testing.B) {
+		for b.Loop() {
+			_, _, _, _ = engine.Search(ctx, search.Options{
+				Query: "how does Symbol0 work",
+				Limit: 10,
+			})
+		}
+	})
+}
+
+type fixedEmbedder struct{}
+
+func (f *fixedEmbedder) Embed(_ context.Context, inputs []embed.EmbedInput) ([][]float32, error) {
+	vecs := make([][]float32, len(inputs))
+	for i := range inputs {
+		vec := make([]float32, 384)
+		vec[0] = 0.5
+		vec[1] = 0.3
+		vecs[i] = vec
+	}
+	return vecs, nil
+}
+
+func (f *fixedEmbedder) Close() error { return nil }


### PR DESCRIPTION
## Problem

Sense claims specific performance targets (< 10ms graph queries, < 50ms semantic search) but has no way to verify them end-to-end. Existing micro-benchmarks in `blast_bench_test.go` cover individual functions but don't measure what users experience: full query latency from call to response, scan throughput, cold start, or index size.

## Summary

Adds a `sense benchmark` CLI command that runs end-to-end performance measurements against a project's index, and extends the `go test -bench` suite with realistic 500-symbol fixtures across blast, search, and conventions.

## Changes

**Benchmark runner (`internal/benchmark/`)**
- `Run(ctx, dir, opts)` measures graph, blast, search, conventions, and status query latency (p50/p95/p99 over N iterations)
- Automatically selects representative symbols by connectivity tier (hub/mid/leaf fan-in)
- Measures scan throughput (full + incremental) in a temp directory — never destroys the user's index
- Measures cold start by spawning a child process; returns 0 on failure instead of reporting error-exit latency
- Reports memory via `TotalAlloc` delta (actual allocations during benchmarks, not a point-in-time heap snapshot)
- `touchFiles` saves and restores original mtimes — no permanent side effects on the source tree
- `BuildFixture` generates a deterministic 500-symbol graph with hub node, normalized embeddings, and multi-language files

**CLI (`sense benchmark`)**
- Human-readable output by default, `--json` for machine consumption
- `--iterations N` to control run count (default 100)
- Checks for index existence before running

**Extended `go test -bench` suite**
- `BenchmarkBlastHops` — blast at 1/2/3 hops with 500-symbol fixture
- `BenchmarkSearch` — keyword and hybrid search
- `BenchmarkConventionsDetect` — unfiltered and domain-filtered
- All report allocations via `b.ReportAllocs()`

**Graph benchmark fidelity**
- `benchGraph` exercises the full `sense graph` data path: `ReadSymbol` (symbol + edge traversal) → file path resolution → `BuildGraphResponse` assembly

## Test Plan

- [x] `TestSelectSymbolsDistinctTiers` — verifies hub/mid/leaf are distinct with correct fan-in ordering
- [x] `TestReportFieldsPopulated` — runner produces non-zero counts for all fields
- [x] `TestMarshalJSONValid` — JSON output parses back into expected structure
- [x] `TestPercentiles` — edge cases (1, 10, 100 items)
- [x] `make ci` passes (build + test + lint)
- [x] Bench tests compile and run: `go test -bench=. ./internal/blast/ ./internal/search/ ./internal/conventions/`