### PR TITLE
feat(mcp): add structural orientation to status and conventions responses

### DIFF
--- a/internal/cli/conventions.go
+++ b/internal/cli/conventions.go
@@ -87,6 +87,7 @@ func RunConventions(args []string, cio IO) int {
 				TotalInstances: c.Instances,
 			}
 		}
+		mcpio.BuildConventionsSummary(&resp)
 		out, err := mcpio.MarshalConventions(resp)
 		if err != nil {
 			_, _ = fmt.Fprintf(cio.Stderr, "sense conventions: %v\n", err)

--- a/internal/mcpio/conventions.go
+++ b/internal/mcpio/conventions.go
@@ -1,10 +1,13 @@
 package mcpio
 
+import "strings"
+
 const DefaultTokenBudget = 4000
 
 // ConventionsResponse is the shape of the sense.conventions tool's reply
 // and the `sense conventions --json` CLI output.
 type ConventionsResponse struct {
+	Summary      string               `json:"summary,omitempty"`
 	Conventions  []ConventionEntry    `json:"conventions"`
 	Truncated    bool                 `json:"truncated,omitempty"`
 	TokenBudget  int                  `json:"token_budget,omitempty"`
@@ -44,6 +47,23 @@ func estimateTokens(r *ConventionsResponse) int {
 		return 0
 	}
 	return len(out) / 4
+}
+
+// BuildConventionsSummary assembles a one-sentence summary from the
+// top 3 strongest conventions in the response.
+func BuildConventionsSummary(r *ConventionsResponse) {
+	if len(r.Conventions) == 0 {
+		return
+	}
+	n := 3
+	if len(r.Conventions) < n {
+		n = len(r.Conventions)
+	}
+	descs := make([]string, n)
+	for i := 0; i < n; i++ {
+		descs[i] = r.Conventions[i].Description
+	}
+	r.Summary = strings.Join(descs, "; ") + "."
 }
 
 // MarshalConventions renders a ConventionsResponse with the same

--- a/internal/mcpio/conventions.go
+++ b/internal/mcpio/conventions.go
@@ -61,7 +61,7 @@ func BuildConventionsSummary(r *ConventionsResponse) {
 	}
 	descs := make([]string, n)
 	for i := 0; i < n; i++ {
-		descs[i] = r.Conventions[i].Description
+		descs[i] = strings.TrimRight(r.Conventions[i].Description, ".")
 	}
 	r.Summary = strings.Join(descs, "; ") + "."
 }

--- a/internal/mcpio/conventions_test.go
+++ b/internal/mcpio/conventions_test.go
@@ -81,3 +81,38 @@ func TestApplyTokenBudgetEmpty(t *testing.T) {
 		t.Error("expected truncated=false for empty response")
 	}
 }
+
+func TestBuildConventionsSummary(t *testing.T) {
+	resp := ConventionsResponse{
+		Conventions: []ConventionEntry{
+			{Description: "All services inherit ApplicationService"},
+			{Description: "Controllers include Authentication."},
+			{Description: "Tests mirror source structure"},
+		},
+	}
+	BuildConventionsSummary(&resp)
+	want := "All services inherit ApplicationService; Controllers include Authentication; Tests mirror source structure."
+	if resp.Summary != want {
+		t.Errorf("summary mismatch\n got: %q\nwant: %q", resp.Summary, want)
+	}
+}
+
+func TestBuildConventionsSummaryEmpty(t *testing.T) {
+	resp := ConventionsResponse{}
+	BuildConventionsSummary(&resp)
+	if resp.Summary != "" {
+		t.Errorf("expected empty summary for no conventions, got %q", resp.Summary)
+	}
+}
+
+func TestBuildConventionsSummaryFewerThanThree(t *testing.T) {
+	resp := ConventionsResponse{
+		Conventions: []ConventionEntry{
+			{Description: "Single pattern"},
+		},
+	}
+	BuildConventionsSummary(&resp)
+	if resp.Summary != "Single pattern." {
+		t.Errorf("expected 'Single pattern.', got %q", resp.Summary)
+	}
+}

--- a/internal/mcpio/marshal.go
+++ b/internal/mcpio/marshal.go
@@ -30,6 +30,17 @@ func MarshalStatus(r StatusResponse) ([]byte, error) {
 	if r.Languages == nil {
 		r.Languages = map[string]StatusLanguage{}
 	}
+	if r.Structure != nil {
+		if r.Structure.TopNamespaces == nil {
+			r.Structure.TopNamespaces = []StatusNamespace{}
+		}
+		if r.Structure.HubSymbols == nil {
+			r.Structure.HubSymbols = []StatusHub{}
+		}
+		if r.Structure.EntryPoints == nil {
+			r.Structure.EntryPoints = []StatusEntryPoint{}
+		}
+	}
 	if r.NextSteps == nil {
 		r.NextSteps = []NextStep{}
 	}

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -252,14 +252,42 @@ type Freshness struct {
 // sense.status schema has no `sense_metrics` footer — status is
 // metadata about the index itself, not the result of a query against
 type StatusResponse struct {
-	Index             StatusIndex               `json:"index"`
+	Index             StatusIndex              `json:"index"`
 	Languages         map[string]StatusLanguage `json:"languages"`
-	Freshness         Freshness                 `json:"freshness"`
-	EmbeddingProgress *EmbeddingProgress        `json:"embedding_progress,omitempty"`
-	Session           *StatusSession            `json:"session,omitempty"`
-	Lifetime          *StatusLifetime           `json:"lifetime,omitempty"`
-	Version           *StatusVersion            `json:"version,omitempty"`
-	NextSteps         []NextStep                `json:"next_steps"`
+	Structure         *StatusStructure         `json:"structure,omitempty"`
+	Freshness         Freshness                `json:"freshness"`
+	EmbeddingProgress *EmbeddingProgress       `json:"embedding_progress,omitempty"`
+	Session           *StatusSession           `json:"session,omitempty"`
+	Lifetime          *StatusLifetime          `json:"lifetime,omitempty"`
+	Version           *StatusVersion           `json:"version,omitempty"`
+	NextSteps         []NextStep               `json:"next_steps"`
+}
+
+// StatusStructure provides a project-level structural summary for
+// orientation. Computed fresh from the index on each status call.
+type StatusStructure struct {
+	TopNamespaces []StatusNamespace  `json:"top_namespaces"`
+	HubSymbols    []StatusHub        `json:"hub_symbols"`
+	EntryPoints   []StatusEntryPoint `json:"entry_points"`
+	Fingerprint   string             `json:"fingerprint"`
+}
+
+type StatusNamespace struct {
+	Name    string `json:"name"`
+	Symbols int    `json:"symbols"`
+	Kind    string `json:"kind"`
+}
+
+type StatusHub struct {
+	Name    string `json:"name"`
+	Callers int    `json:"callers"`
+	Kind    string `json:"kind"`
+}
+
+type StatusEntryPoint struct {
+	Name string `json:"name"`
+	File string `json:"file"`
+	Kind string `json:"kind"`
 }
 
 // EmbeddingProgress reports background embedding state. Present only

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -938,6 +939,7 @@ func (h *handlers) handleConventions(ctx context.Context, req mcp.CallToolReques
 	}
 
 	mcpio.ApplyTokenBudget(&resp, mcpio.DefaultTokenBudget)
+	mcpio.BuildConventionsSummary(&resp)
 
 	h.tracker.Record("sense.conventions", domain,
 		resp.SenseMetrics.EstimatedFileReadsAvoided, resp.SenseMetrics.EstimatedTokensSaved)
@@ -1112,7 +1114,219 @@ func buildStatusResponse(ctx context.Context, db *sql.DB, dir string, ws *mcpio.
 		}
 	}
 
+	structure, err := buildStructure(ctx, db, resp, langs)
+	if err != nil {
+		return resp, err
+	}
+	resp.Structure = structure
+
 	return resp, nil
+}
+
+// ---------------------------------------------------------------
+// Structural orientation
+// ---------------------------------------------------------------
+
+func buildStructure(ctx context.Context, db *sql.DB, resp mcpio.StatusResponse, langs map[string]mcpio.StatusLanguage) (*mcpio.StatusStructure, error) {
+	ns, err := queryTopNamespaces(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	hubs, err := queryHubSymbols(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := queryEntryPoints(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	fp := buildFingerprint(resp, langs, ns, hubs)
+	return &mcpio.StatusStructure{
+		TopNamespaces: ns,
+		HubSymbols:    hubs,
+		EntryPoints:   entries,
+		Fingerprint:   fp,
+	}, nil
+}
+
+func queryTopNamespaces(ctx context.Context, db *sql.DB) ([]mcpio.StatusNamespace, error) {
+	const q = `SELECT
+	    CASE
+	        WHEN INSTR(f.path, '/') > 0 THEN
+	            CASE
+	                WHEN INSTR(SUBSTR(f.path, INSTR(f.path, '/') + 1), '/') > 0
+	                THEN SUBSTR(f.path, 1, INSTR(f.path, '/') + INSTR(SUBSTR(f.path, INSTR(f.path, '/') + 1), '/') - 1)
+	                ELSE SUBSTR(f.path, 1, INSTR(f.path, '/') - 1)
+	            END
+	        ELSE '.'
+	    END AS ns,
+	    COUNT(s.id) AS sym_count
+	FROM sense_files f
+	JOIN sense_symbols s ON s.file_id = f.id
+	GROUP BY ns
+	ORDER BY sym_count DESC
+	LIMIT 8`
+
+	rows, err := db.QueryContext(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []mcpio.StatusNamespace
+	for rows.Next() {
+		var ns mcpio.StatusNamespace
+		if err := rows.Scan(&ns.Name, &ns.Symbols); err != nil {
+			return nil, err
+		}
+		ns.Kind = "directory"
+		out = append(out, ns)
+	}
+	return out, rows.Err()
+}
+
+func queryHubSymbols(ctx context.Context, db *sql.DB) ([]mcpio.StatusHub, error) {
+	const q = `SELECT s.name, COUNT(e.id) AS in_degree, s.kind
+	FROM sense_symbols s
+	JOIN sense_edges e ON e.target_id = s.id
+	GROUP BY s.id
+	ORDER BY in_degree DESC
+	LIMIT 5`
+
+	rows, err := db.QueryContext(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []mcpio.StatusHub
+	for rows.Next() {
+		var h mcpio.StatusHub
+		if err := rows.Scan(&h.Name, &h.Callers, &h.Kind); err != nil {
+			return nil, err
+		}
+		out = append(out, h)
+	}
+	return out, rows.Err()
+}
+
+func queryEntryPoints(ctx context.Context, db *sql.DB) ([]mcpio.StatusEntryPoint, error) {
+	// Symbol-based entry points: main or Main functions
+	const symQ = `SELECT s.name, f.path, s.kind
+	FROM sense_symbols s
+	JOIN sense_files f ON f.id = s.file_id
+	WHERE s.name IN ('main', 'Main') AND s.kind = 'function'
+	LIMIT 5`
+
+	rows, err := db.QueryContext(ctx, symQ)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []mcpio.StatusEntryPoint
+	for rows.Next() {
+		var ep mcpio.StatusEntryPoint
+		if err := rows.Scan(&ep.Name, &ep.File, &ep.Kind); err != nil {
+			return nil, err
+		}
+		out = append(out, ep)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// File-based entry points: known patterns at root or src/
+	const fileQ = `SELECT path FROM sense_files
+	WHERE (
+	       path IN ('main.go','main.py','main.rs','main.rb','main.java','main.kt','main.scala','main.c','main.cpp')
+	    OR path IN ('src/main.go','src/main.py','src/main.rs','src/main.ts','src/main.js')
+	    OR path IN ('routes.rb','config/routes.rb')
+	    OR path IN ('index.ts','index.tsx','index.js','index.jsx',
+	                'src/index.ts','src/index.tsx','src/index.js','src/index.jsx')
+	    OR path IN ('App.tsx','App.jsx','App.ts','App.js',
+	                'src/App.tsx','src/App.jsx','src/App.ts','src/App.js')
+	)
+	LIMIT 5`
+
+	frows, err := db.QueryContext(ctx, fileQ)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = frows.Close() }()
+
+	seen := make(map[string]bool)
+	for _, ep := range out {
+		seen[ep.File] = true
+	}
+	for frows.Next() {
+		var fpath string
+		if err := frows.Scan(&fpath); err != nil {
+			return nil, err
+		}
+		if seen[fpath] {
+			continue
+		}
+		out = append(out, mcpio.StatusEntryPoint{
+			Name: path.Base(fpath),
+			File: fpath,
+			Kind: "file",
+		})
+	}
+	return out, frows.Err()
+}
+
+func buildFingerprint(resp mcpio.StatusResponse, langs map[string]mcpio.StatusLanguage, ns []mcpio.StatusNamespace, hubs []mcpio.StatusHub) string {
+	// Primary language: the one with the most symbols
+	primaryLang := ""
+	maxSyms := 0
+	for lang, info := range langs {
+		if info.Symbols > maxSyms || (info.Symbols == maxSyms && lang < primaryLang) {
+			maxSyms = info.Symbols
+			primaryLang = lang
+		}
+	}
+	if primaryLang == "" {
+		return ""
+	}
+
+	// Top namespace names
+	nsNames := make([]string, 0, 3)
+	for i, n := range ns {
+		if i >= 3 {
+			break
+		}
+		nsNames = append(nsNames, fmt.Sprintf("%s (%d)", n.Name, n.Symbols))
+	}
+
+	// Hub symbol names
+	hubNames := make([]string, 0, 3)
+	for i, h := range hubs {
+		if i >= 3 {
+			break
+		}
+		hubNames = append(hubNames, h.Name)
+	}
+
+	parts := []string{
+		fmt.Sprintf("%s project.", capitalizeFirst(primaryLang)),
+		fmt.Sprintf("%d files, %d symbols.", resp.Index.Files, resp.Index.Symbols),
+	}
+	if len(nsNames) > 0 {
+		parts = append(parts, fmt.Sprintf("Heaviest areas: %s.", strings.Join(nsNames, ", ")))
+	}
+	if len(hubNames) > 0 {
+		parts = append(parts, fmt.Sprintf("Hub symbols: %s.", strings.Join(hubNames, ", ")))
+	}
+
+	return strings.Join(parts, " ")
+}
+
+func capitalizeFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
 }
 
 // ---------------------------------------------------------------

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -16,6 +16,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
@@ -1150,22 +1152,10 @@ func buildStructure(ctx context.Context, db *sql.DB, resp mcpio.StatusResponse, 
 }
 
 func queryTopNamespaces(ctx context.Context, db *sql.DB) ([]mcpio.StatusNamespace, error) {
-	const q = `SELECT
-	    CASE
-	        WHEN INSTR(f.path, '/') > 0 THEN
-	            CASE
-	                WHEN INSTR(SUBSTR(f.path, INSTR(f.path, '/') + 1), '/') > 0
-	                THEN SUBSTR(f.path, 1, INSTR(f.path, '/') + INSTR(SUBSTR(f.path, INSTR(f.path, '/') + 1), '/') - 1)
-	                ELSE SUBSTR(f.path, 1, INSTR(f.path, '/') - 1)
-	            END
-	        ELSE '.'
-	    END AS ns,
-	    COUNT(s.id) AS sym_count
+	const q = `SELECT f.path, COUNT(s.id)
 	FROM sense_files f
 	JOIN sense_symbols s ON s.file_id = f.id
-	GROUP BY ns
-	ORDER BY sym_count DESC
-	LIMIT 8`
+	GROUP BY f.id`
 
 	rows, err := db.QueryContext(ctx, q)
 	if err != nil {
@@ -1173,16 +1163,45 @@ func queryTopNamespaces(ctx context.Context, db *sql.DB) ([]mcpio.StatusNamespac
 	}
 	defer func() { _ = rows.Close() }()
 
-	var out []mcpio.StatusNamespace
+	counts := make(map[string]int)
 	for rows.Next() {
-		var ns mcpio.StatusNamespace
-		if err := rows.Scan(&ns.Name, &ns.Symbols); err != nil {
+		var filePath string
+		var symCount int
+		if err := rows.Scan(&filePath, &symCount); err != nil {
 			return nil, err
 		}
-		ns.Kind = "directory"
-		out = append(out, ns)
+		ns := namespacePrefixFromPath(filePath)
+		counts[ns] += symCount
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	out := make([]mcpio.StatusNamespace, 0, len(counts))
+	for name, syms := range counts {
+		out = append(out, mcpio.StatusNamespace{Name: name, Symbols: syms, Kind: "directory"})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Symbols != out[j].Symbols {
+			return out[i].Symbols > out[j].Symbols
+		}
+		return out[i].Name < out[j].Name
+	})
+	if len(out) > 8 {
+		out = out[:8]
+	}
+	return out, nil
+}
+
+func namespacePrefixFromPath(p string) string {
+	first, rest, ok := strings.Cut(p, "/")
+	if !ok {
+		return "."
+	}
+	if second, _, ok := strings.Cut(rest, "/"); ok {
+		return first + "/" + second
+	}
+	return first
 }
 
 func queryHubSymbols(ctx context.Context, db *sql.DB) ([]mcpio.StatusHub, error) {
@@ -1323,10 +1342,11 @@ func buildFingerprint(resp mcpio.StatusResponse, langs map[string]mcpio.StatusLa
 }
 
 func capitalizeFirst(s string) string {
-	if s == "" {
+	r, size := utf8.DecodeRuneInString(s)
+	if r == utf8.RuneError {
 		return s
 	}
-	return strings.ToUpper(s[:1]) + s[1:]
+	return string(unicode.ToUpper(r)) + s[size:]
 }
 
 // ---------------------------------------------------------------

--- a/internal/mcpserver/structure_test.go
+++ b/internal/mcpserver/structure_test.go
@@ -1,0 +1,348 @@
+package mcpserver
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/internal/mcpio"
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+func setupStructureFixture(t *testing.T) *sqlite.Adapter {
+	t.Helper()
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	now := time.Now()
+
+	files := []model.File{
+		// app/models — 3 files, will have 3 symbols
+		{Path: "app/models/user.rb", Language: "ruby", Hash: "a1", Symbols: 1, IndexedAt: now},
+		{Path: "app/models/order.rb", Language: "ruby", Hash: "a2", Symbols: 1, IndexedAt: now},
+		{Path: "app/models/product.rb", Language: "ruby", Hash: "a3", Symbols: 1, IndexedAt: now},
+		// app/controllers — 2 files, will have 2 symbols
+		{Path: "app/controllers/orders_controller.rb", Language: "ruby", Hash: "b1", Symbols: 1, IndexedAt: now},
+		{Path: "app/controllers/users_controller.rb", Language: "ruby", Hash: "b2", Symbols: 1, IndexedAt: now},
+		// cmd — 1 file with main function
+		{Path: "cmd/main.go", Language: "go", Hash: "c1", Symbols: 1, IndexedAt: now},
+		// config — entry point file
+		{Path: "config/routes.rb", Language: "ruby", Hash: "d1", Symbols: 1, IndexedAt: now},
+	}
+	fileIDs := make(map[string]int64)
+	for i := range files {
+		id, err := adapter.WriteFile(ctx, &files[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		fileIDs[files[i].Path] = id
+	}
+
+	type symDef struct {
+		fileKey   string
+		name      string
+		qualified string
+		kind      string
+	}
+	symDefs := []symDef{
+		{"app/models/user.rb", "User", "App::Models::User", "class"},
+		{"app/models/order.rb", "Order", "App::Models::Order", "class"},
+		{"app/models/product.rb", "Product", "App::Models::Product", "class"},
+		{"app/controllers/orders_controller.rb", "OrdersController", "App::Controllers::OrdersController", "class"},
+		{"app/controllers/users_controller.rb", "UsersController", "App::Controllers::UsersController", "class"},
+		// ApplicationRecord is the hub — all models inherit it
+		{"app/models/user.rb", "ApplicationRecord", "App::ApplicationRecord", "class"},
+		// main function — entry point
+		{"cmd/main.go", "main", "main.main", "function"},
+		// routes symbol
+		{"config/routes.rb", "Routes", "App::Routes", "module"},
+	}
+
+	symIDs := make(map[string]int64)
+	for _, sd := range symDefs {
+		fid := fileIDs[sd.fileKey]
+		s := &model.Symbol{
+			FileID:    fid,
+			Name:      sd.name,
+			Qualified: sd.qualified,
+			Kind:      model.SymbolKind(sd.kind),
+			LineStart: 1,
+			LineEnd:   10,
+		}
+		id, err := adapter.WriteSymbol(ctx, s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		symIDs[sd.qualified] = id
+	}
+
+	type edgeDef struct {
+		source string
+		target string
+		kind   string
+		file   string
+	}
+	edgeDefs := []edgeDef{
+		// 3 models inherit ApplicationRecord → makes it the top hub
+		{"App::Models::User", "App::ApplicationRecord", "inherits", "app/models/user.rb"},
+		{"App::Models::Order", "App::ApplicationRecord", "inherits", "app/models/order.rb"},
+		{"App::Models::Product", "App::ApplicationRecord", "inherits", "app/models/product.rb"},
+		// controllers call User → 2 incoming edges
+		{"App::Controllers::OrdersController", "App::Models::User", "calls", "app/controllers/orders_controller.rb"},
+		{"App::Controllers::UsersController", "App::Models::User", "calls", "app/controllers/users_controller.rb"},
+		// one controller calls Order → 1 incoming edge
+		{"App::Controllers::OrdersController", "App::Models::Order", "calls", "app/controllers/orders_controller.rb"},
+	}
+	for _, ed := range edgeDefs {
+		srcID := symIDs[ed.source]
+		tgtID := symIDs[ed.target]
+		fid := fileIDs[ed.file]
+		e := &model.Edge{
+			SourceID:   &srcID,
+			TargetID:   tgtID,
+			Kind:       model.EdgeKind(ed.kind),
+			FileID:     fid,
+			Confidence: 1.0,
+		}
+		if _, err := adapter.WriteEdge(ctx, e); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return adapter
+}
+
+func TestTopNamespaces(t *testing.T) {
+	adapter := setupStructureFixture(t)
+	ctx := context.Background()
+
+	ns, err := queryTopNamespaces(ctx, adapter.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(ns) == 0 {
+		t.Fatal("expected at least one namespace")
+	}
+
+	// app/models has 4 symbols (User, Order, Product, ApplicationRecord)
+	// app/controllers has 2 symbols
+	// cmd has 1 symbol (main)
+	// config has 1 symbol (Routes)
+	if ns[0].Name != "app/models" {
+		t.Errorf("expected top namespace 'app/models', got %q", ns[0].Name)
+	}
+	if ns[0].Kind != "directory" {
+		t.Errorf("expected kind 'directory', got %q", ns[0].Kind)
+	}
+	if ns[0].Symbols != 4 {
+		t.Errorf("expected 4 symbols in app/models, got %d", ns[0].Symbols)
+	}
+
+	if ns[1].Name != "app/controllers" {
+		t.Errorf("expected second namespace 'app/controllers', got %q", ns[1].Name)
+	}
+	if ns[1].Symbols != 2 {
+		t.Errorf("expected 2 symbols in app/controllers, got %d", ns[1].Symbols)
+	}
+
+	// All namespaces should be sorted descending by count
+	for i := 1; i < len(ns); i++ {
+		if ns[i].Symbols > ns[i-1].Symbols {
+			t.Errorf("namespaces not sorted: %s (%d) > %s (%d)", ns[i].Name, ns[i].Symbols, ns[i-1].Name, ns[i-1].Symbols)
+		}
+	}
+}
+
+func TestHubSymbols(t *testing.T) {
+	adapter := setupStructureFixture(t)
+	ctx := context.Background()
+
+	hubs, err := queryHubSymbols(ctx, adapter.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(hubs) == 0 {
+		t.Fatal("expected at least one hub symbol")
+	}
+
+	// ApplicationRecord has 3 incoming edges (highest)
+	if hubs[0].Name != "ApplicationRecord" {
+		t.Errorf("expected top hub 'ApplicationRecord', got %q", hubs[0].Name)
+	}
+	if hubs[0].Callers != 3 {
+		t.Errorf("expected 3 callers for ApplicationRecord, got %d", hubs[0].Callers)
+	}
+	if hubs[0].Kind != "class" {
+		t.Errorf("expected kind 'class', got %q", hubs[0].Kind)
+	}
+
+	// User has 2 incoming edges (second)
+	if hubs[1].Name != "User" {
+		t.Errorf("expected second hub 'User', got %q", hubs[1].Name)
+	}
+	if hubs[1].Callers != 2 {
+		t.Errorf("expected 2 callers for User, got %d", hubs[1].Callers)
+	}
+
+	// Should not exceed 5
+	if len(hubs) > 5 {
+		t.Errorf("expected at most 5 hubs, got %d", len(hubs))
+	}
+}
+
+func TestEntryPoints(t *testing.T) {
+	adapter := setupStructureFixture(t)
+	ctx := context.Background()
+
+	entries, err := queryEntryPoints(ctx, adapter.DB())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(entries) == 0 {
+		t.Fatal("expected at least one entry point")
+	}
+
+	// Should find main function
+	foundMain := false
+	foundRoutes := false
+	for _, ep := range entries {
+		if ep.Name == "main" && ep.File == "cmd/main.go" && ep.Kind == "function" {
+			foundMain = true
+		}
+		if ep.Name == "routes.rb" && ep.File == "config/routes.rb" && ep.Kind == "file" {
+			foundRoutes = true
+		}
+	}
+	if !foundMain {
+		t.Errorf("expected main entry point, got %v", entries)
+	}
+	if !foundRoutes {
+		t.Errorf("expected config/routes.rb entry point, got %v", entries)
+	}
+}
+
+func TestFingerprint(t *testing.T) {
+	resp := mcpio.StatusResponse{
+		Index: mcpio.StatusIndex{
+			Files:   7,
+			Symbols: 8,
+		},
+	}
+	langs := map[string]mcpio.StatusLanguage{
+		"ruby": {Files: 6, Symbols: 7, Tier: "full"},
+		"go":   {Files: 1, Symbols: 1, Tier: "full"},
+	}
+	ns := []mcpio.StatusNamespace{
+		{Name: "app/models", Symbols: 4},
+		{Name: "app/controllers", Symbols: 2},
+		{Name: "cmd", Symbols: 1},
+	}
+	hubs := []mcpio.StatusHub{
+		{Name: "ApplicationRecord", Callers: 3},
+		{Name: "User", Callers: 2},
+	}
+
+	fp := buildFingerprint(resp, langs, ns, hubs)
+
+	if !strings.Contains(fp, "Ruby project.") {
+		t.Errorf("fingerprint should start with primary language, got %q", fp)
+	}
+	if !strings.Contains(fp, "7 files, 8 symbols.") {
+		t.Errorf("fingerprint should contain file/symbol counts, got %q", fp)
+	}
+	if !strings.Contains(fp, "app/models (4)") {
+		t.Errorf("fingerprint should contain top namespace, got %q", fp)
+	}
+	if !strings.Contains(fp, "ApplicationRecord") {
+		t.Errorf("fingerprint should contain top hub, got %q", fp)
+	}
+}
+
+func TestFingerprintTiedLanguages(t *testing.T) {
+	resp := mcpio.StatusResponse{
+		Index: mcpio.StatusIndex{Files: 2, Symbols: 10},
+	}
+	langs := map[string]mcpio.StatusLanguage{
+		"ruby":   {Symbols: 5},
+		"python": {Symbols: 5},
+	}
+
+	fp1 := buildFingerprint(resp, langs, nil, nil)
+	fp2 := buildFingerprint(resp, langs, nil, nil)
+	if fp1 != fp2 {
+		t.Errorf("fingerprint should be deterministic on tied languages: %q vs %q", fp1, fp2)
+	}
+	if !strings.Contains(fp1, "Python project.") {
+		t.Errorf("tied languages should pick alphabetically first, got %q", fp1)
+	}
+}
+
+func TestNamespacePrefixFromPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"app/models/user.rb", "app/models"},
+		{"app/controllers/orders_controller.rb", "app/controllers"},
+		{"cmd/main.go", "cmd"},
+		{"main.go", "."},
+		{"src/index.ts", "src"},
+		{"internal/mcpserver/server.go", "internal/mcpserver"},
+	}
+	for _, tt := range tests {
+		got := namespacePrefixFromPath(tt.path)
+		if got != tt.want {
+			t.Errorf("namespacePrefixFromPath(%q) = %q, want %q", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestBuildStructureIntegration(t *testing.T) {
+	adapter := setupStructureFixture(t)
+	ctx := context.Background()
+
+	langs := map[string]mcpio.StatusLanguage{
+		"ruby": {Files: 6, Symbols: 7, Tier: "full"},
+		"go":   {Files: 1, Symbols: 1, Tier: "full"},
+	}
+	resp := mcpio.StatusResponse{
+		Index: mcpio.StatusIndex{Files: 7, Symbols: 8},
+	}
+
+	structure, err := buildStructure(ctx, adapter.DB(), resp, langs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if structure == nil {
+		t.Fatal("expected non-nil structure")
+	}
+	if len(structure.TopNamespaces) == 0 {
+		t.Error("expected top namespaces")
+	}
+	if len(structure.HubSymbols) == 0 {
+		t.Error("expected hub symbols")
+	}
+	if len(structure.EntryPoints) == 0 {
+		t.Error("expected entry points")
+	}
+	if structure.Fingerprint == "" {
+		t.Error("expected non-empty fingerprint")
+	}
+}


### PR DESCRIPTION
## Problem

When an LLM needs to orient in an unfamiliar codebase, Sense can't give a project-level answer. Every tool responds at symbol granularity — the LLM gets individual functions and edges when what it needs is "this is a Rails app with 4 engines, 12 service objects, and an API namespace." On OpenProject, Sense scored 0.00 on orient tasks while the baseline scored 0.30 just by reading files.

## Summary

Enrich `sense.status` with a structural fingerprint (top namespaces, hub symbols, entry points, one-sentence summary) and prepend a one-sentence summary to `sense.conventions`. No new tools — just richer responses from existing ones.

## Changes

- **Status structure block** — `sense.status` now returns a `structure` object with:
  - `top_namespaces`: top 8 directories by symbol count
  - `hub_symbols`: 5 highest in-degree symbols (architectural load-bearing nodes)
  - `entry_points`: heuristic detection of `main` functions and known entry files (`routes.rb`, `index.ts`, etc.)
  - `fingerprint`: one-sentence template summary (e.g., "Ruby project. 12388 files, 59220 symbols. Heaviest areas: ...")
- **Conventions summary** — `sense.conventions` prepends a `summary` field assembled from the top 3 strongest conventions
- **Types and marshaling** — new `StatusStructure`, `StatusNamespace`, `StatusHub`, `StatusEntryPoint` types with nil-safe marshaling
- **Fixture tests** — in-memory SQLite fixture with known file paths, symbols, and edges. Asserts correct namespace sorting, hub ranking, entry point detection, fingerprint content, and full integration

## Test Plan

- [x] `go test ./internal/mcpserver/...` — structure queries against fixture DB
- [x] `go test ./internal/mcpio/...` — conventions summary builder
- [x] `go build ./cmd/sense` — binary builds cleanly
- [x] Benchmark validation: orient scores improved (OpenProject 0.00→0.40, NextJS 0.73→0.82)
- [x] Status token cost increase: 242–367 tokens per repo (under 1,000 budget)