### PR TITLE
feat(search): add confidence-gated fusion and identifier decomposition

### DIFF
--- a/internal/benchmark/benchmark.go
+++ b/internal/benchmark/benchmark.go
@@ -372,7 +372,7 @@ func benchSearch(ctx context.Context, engine *search.Engine, sym symbolTier, sem
 	durations := make([]time.Duration, 0, n)
 	for i := 0; i < n; i++ {
 		start := time.Now()
-		_, _, _, _ = engine.Search(ctx, search.Options{
+		_, _, _ = engine.Search(ctx, search.Options{
 			Query: query,
 			Limit: 10,
 		})
@@ -386,7 +386,7 @@ func benchSearchHybrid(ctx context.Context, engine *search.Engine, sym symbolTie
 	durations := make([]time.Duration, 0, n)
 	for i := 0; i < n; i++ {
 		start := time.Now()
-		_, _, _, _ = engine.Search(ctx, search.Options{
+		_, _, _ = engine.Search(ctx, search.Options{
 			Query: query,
 			Limit: 10,
 		})

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -92,7 +92,7 @@ func RunSearch(args []string, cio IO) int {
 	}
 
 	engine := search.NewEngine(adapter, vectorIdx, embedder)
-	results, symbolCount, _, err := engine.Search(ctx, search.Options{
+	results, meta, err := engine.Search(ctx, search.Options{
 		Query:    opts.Query,
 		Limit:    opts.Limit,
 		Language: opts.Language,
@@ -110,7 +110,7 @@ func RunSearch(args []string, cio IO) int {
 		return ExitGeneralError
 	}
 
-	resp := buildSearchResponse(results, pathByID, symbolCount)
+	resp := buildSearchResponse(results, pathByID, meta)
 
 	if opts.JSON {
 		out, merr := mcpio.MarshalSearch(resp)
@@ -137,7 +137,7 @@ func collectSearchFileIDs(results []search.Result) []int64 {
 	return ids
 }
 
-func buildSearchResponse(results []search.Result, pathByID map[int64]string, symbolCount int) mcpio.SearchResponse {
+func buildSearchResponse(results []search.Result, pathByID map[int64]string, meta search.SearchMeta) mcpio.SearchResponse {
 	entries := make([]mcpio.SearchResultEntry, len(results))
 	uniqueFiles := map[string]struct{}{}
 	for i, r := range results {
@@ -156,9 +156,14 @@ func buildSearchResponse(results []search.Result, pathByID map[int64]string, sym
 	}
 	filesAvoided := len(uniqueFiles)
 	return mcpio.SearchResponse{
-		Results: entries,
+		Results:    entries,
+		SearchMode: meta.Mode,
+		FusionWeights: mcpio.FusionWeights{
+			Keyword: meta.KeywordWeight,
+			Vector:  meta.VectorWeight,
+		},
 		SenseMetrics: mcpio.SearchMetrics{
-			SymbolsSearched:           symbolCount,
+			SymbolsSearched:           meta.SymbolCount,
 			EstimatedFileReadsAvoided: filesAvoided,
 			EstimatedTokensSaved:      filesAvoided * mcpio.AvgTokensPerFile,
 		},

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -363,10 +363,19 @@ type StatusLanguage struct {
 // `sense search --json` CLI output. Matches the documented example in
 // .doc/definition/06-mcp-and-cli.md exactly.
 type SearchResponse struct {
-	Results      []SearchResultEntry `json:"results"`
-	SearchMode   string              `json:"search_mode"`
-	SenseMetrics SearchMetrics       `json:"sense_metrics"`
-	NextSteps    []NextStep          `json:"next_steps"`
+	Results       []SearchResultEntry `json:"results"`
+	SearchMode    string              `json:"search_mode"`
+	FusionWeights FusionWeights       `json:"fusion_weights"`
+	SenseMetrics  SearchMetrics       `json:"sense_metrics"`
+	NextSteps     []NextStep          `json:"next_steps"`
+}
+
+// FusionWeights reports the keyword/vector weight pair used for
+// reciprocal rank fusion. Present in every search response for
+// diagnostics — helps debug why results changed across queries.
+type FusionWeights struct {
+	Keyword float64 `json:"keyword"`
+	Vector  float64 `json:"vector"`
 }
 
 // SearchResultEntry is a single search hit in the wire response.

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -471,7 +471,7 @@ func (h *handlers) handleSearch(ctx context.Context, req mcp.CallToolRequest) (*
 	language := req.GetString("language", "")
 	minScore := req.GetFloat("min_score", 0.0)
 
-	results, symbolCount, searchMode, err := h.search.Search(ctx, search.Options{
+	results, meta, err := h.search.Search(ctx, search.Options{
 		Query:    query,
 		Limit:    limit,
 		Language: language,
@@ -510,9 +510,13 @@ func (h *handlers) handleSearch(ctx context.Context, req mcp.CallToolRequest) (*
 	filesAvoided := len(uniqueFiles)
 	resp := mcpio.SearchResponse{
 		Results:    entries,
-		SearchMode: searchMode,
+		SearchMode: meta.Mode,
+		FusionWeights: mcpio.FusionWeights{
+			Keyword: meta.KeywordWeight,
+			Vector:  meta.VectorWeight,
+		},
 		SenseMetrics: mcpio.SearchMetrics{
-			SymbolsSearched:           symbolCount,
+			SymbolsSearched:           meta.SymbolCount,
 			EstimatedFileReadsAvoided: filesAvoided,
 			EstimatedTokensSaved:      filesAvoided * mcpio.AvgTokensPerFile,
 		},

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -67,9 +67,16 @@ const (
 	ModeKeyword = "keyword"
 )
 
+// SearchMeta carries non-result metadata from a search invocation.
+type SearchMeta struct {
+	SymbolCount   int
+	Mode          string
+	KeywordWeight float64
+	VectorWeight  float64
+}
+
 // Search runs hybrid search and returns fused, re-ranked results.
-// The mode string is "hybrid" when vector search was used, "keyword" otherwise.
-func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, int, string, error) {
+func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, SearchMeta, error) {
 	if opts.Limit <= 0 {
 		opts.Limit = 10
 	}
@@ -79,7 +86,7 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, int, strin
 
 	symbolCount, err := e.adapter.SymbolCount(ctx)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("search: %w", err)
+		return nil, SearchMeta{}, fmt.Errorf("search: %w", err)
 	}
 
 	// Fetch more candidates than requested so RRF has enough to fuse.
@@ -116,20 +123,23 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, int, strin
 		})
 
 		if err := g.Wait(); err != nil {
-			return nil, 0, "", fmt.Errorf("search: %w", err)
+			return nil, SearchMeta{}, fmt.Errorf("search: %w", err)
 		}
 	} else {
 		keywordResults, err = e.adapter.KeywordSearch(ctx, opts.Query, opts.Language, candidateLimit)
 		if err != nil {
-			return nil, 0, "", fmt.Errorf("search: %w", err)
+			return nil, SearchMeta{}, fmt.Errorf("search: %w", err)
 		}
 	}
 
-	fused := fuseRRF(keywordResults, vectorResults)
+	vecConfidence := vectorConfidence(vectorResults)
+	kwWeight, vecWeight := fusionWeights(vecConfidence)
+
+	fused := fuseRRF(keywordResults, vectorResults, kwWeight, vecWeight)
 
 	// Hydrate metadata for vector-only results that have no name/qualified.
 	if err := e.hydrateResults(ctx, fused); err != nil {
-		return nil, 0, "", fmt.Errorf("search: %w", err)
+		return nil, SearchMeta{}, fmt.Errorf("search: %w", err)
 	}
 
 	// Graph centrality re-ranking.
@@ -139,7 +149,7 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, int, strin
 	}
 	centrality, err := e.adapter.InboundEdgeCounts(ctx, symbolIDs)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("search centrality: %w", err)
+		return nil, SearchMeta{}, fmt.Errorf("search centrality: %w", err)
 	}
 	applyGraphCentrality(fused, centrality)
 	applyKindWeights(fused)
@@ -155,7 +165,7 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, int, strin
 	}
 	pathByID, err := e.adapter.FilePathsByIDs(ctx, fileIDs)
 	if err != nil {
-		return nil, 0, "", fmt.Errorf("search paths: %w", err)
+		return nil, SearchMeta{}, fmt.Errorf("search paths: %w", err)
 	}
 	applyPathWeights(fused, pathByID)
 
@@ -182,15 +192,39 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, int, strin
 	if canVector {
 		mode = ModeHybrid
 	}
-	return results, symbolCount, mode, nil
+	return results, SearchMeta{
+		SymbolCount:   symbolCount,
+		Mode:          mode,
+		KeywordWeight: kwWeight,
+		VectorWeight:  vecWeight,
+	}, nil
 }
 
 const rrfK = 60
 
+const (
+	confidenceHighThreshold = 0.6
+	confidenceLowThreshold  = 0.4
+)
+
+// fusionWeights returns keyword and vector weights for reciprocal rank
+// fusion based on vector confidence. High confidence → equal weight;
+// low confidence → keyword-biased; very low → keyword-only.
+func fusionWeights(vecConfidence float64) (keyword, vector float64) {
+	switch {
+	case vecConfidence >= confidenceHighThreshold:
+		return 0.5, 0.5
+	case vecConfidence >= confidenceLowThreshold:
+		return 0.7, 0.3
+	default:
+		return 1.0, 0.0
+	}
+}
+
 // fuseRRF merges keyword and vector result lists using reciprocal rank
-// fusion: score(symbol) = Σ 1/(k + rank_in_list). Symbols appearing
-// in both lists get contributions from both, naturally ranking higher.
-func fuseRRF(keyword []sqlite.SearchResult, vector []VectorResult) []Result {
+// fusion with configurable weights: score(symbol) = Σ weight/(k + rank).
+// Symbols appearing in both lists get contributions from both.
+func fuseRRF(keyword []sqlite.SearchResult, vector []VectorResult, kwWeight, vecWeight float64) []Result {
 	type entry struct {
 		result Result
 		score  float64
@@ -199,7 +233,7 @@ func fuseRRF(keyword []sqlite.SearchResult, vector []VectorResult) []Result {
 
 	for rank, kr := range keyword {
 		id := kr.SymbolID
-		rrfScore := 1.0 / float64(rrfK+rank+1)
+		rrfScore := kwWeight / float64(rrfK+rank+1)
 		if e, ok := merged[id]; ok {
 			e.score += rrfScore
 		} else {
@@ -218,17 +252,19 @@ func fuseRRF(keyword []sqlite.SearchResult, vector []VectorResult) []Result {
 		}
 	}
 
-	for rank, vr := range vector {
-		id := vr.SymbolID
-		rrfScore := 1.0 / float64(rrfK+rank+1)
-		if e, ok := merged[id]; ok {
-			e.score += rrfScore
-		} else {
-			merged[id] = &entry{
-				result: Result{
-					SymbolID: vr.SymbolID,
-				},
-				score: rrfScore,
+	if vecWeight > 0 {
+		for rank, vr := range vector {
+			id := vr.SymbolID
+			rrfScore := vecWeight / float64(rrfK+rank+1)
+			if e, ok := merged[id]; ok {
+				e.score += rrfScore
+			} else {
+				merged[id] = &entry{
+					result: Result{
+						SymbolID: vr.SymbolID,
+					},
+					score: rrfScore,
+				}
 			}
 		}
 	}
@@ -396,6 +432,25 @@ func applyPathWeights(results []Result, pathByID map[int64]string) {
 			}
 		}
 	}
+}
+
+const vectorConfidenceTopK = 3
+
+// vectorConfidence returns the mean cosine similarity of the top-K
+// vector results. Returns 0 when there are no vector results.
+func vectorConfidence(results []VectorResult) float64 {
+	if len(results) == 0 {
+		return 0
+	}
+	n := vectorConfidenceTopK
+	if n > len(results) {
+		n = len(results)
+	}
+	var sum float64
+	for i := range n {
+		sum += float64(results[i].Similarity)
+	}
+	return sum / float64(n)
 }
 
 // applyGraphCentrality boosts scores by graph importance. Symbols with

--- a/internal/search/search_bench_test.go
+++ b/internal/search/search_bench_test.go
@@ -37,7 +37,7 @@ func BenchmarkSearch(b *testing.B) {
 
 	b.Run("keyword", func(b *testing.B) {
 		for b.Loop() {
-			_, _, _, _ = engine.Search(ctx, search.Options{
+			_, _, _ = engine.Search(ctx, search.Options{
 				Query: "Symbol0",
 				Limit: 10,
 			})
@@ -46,7 +46,7 @@ func BenchmarkSearch(b *testing.B) {
 
 	b.Run("hybrid", func(b *testing.B) {
 		for b.Loop() {
-			_, _, _, _ = engine.Search(ctx, search.Options{
+			_, _, _ = engine.Search(ctx, search.Options{
 				Query: "how does Symbol0 work",
 				Limit: 10,
 			})

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -157,7 +157,7 @@ func TestFusionBothBackendsRankHigher(t *testing.T) {
 
 	engine := search.NewEngine(a, vectorIdx, &paymentQueryEmbedder{})
 
-	results, symbolCount, _, err := engine.Search(ctx, search.Options{
+	results, meta, err := engine.Search(ctx, search.Options{
 		Query: "payment",
 		Limit: 10,
 	})
@@ -165,8 +165,8 @@ func TestFusionBothBackendsRankHigher(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if symbolCount < 3 {
-		t.Errorf("expected at least 3 symbols searched, got %d", symbolCount)
+	if meta.SymbolCount < 3 {
+		t.Errorf("expected at least 3 symbols searched, got %d", meta.SymbolCount)
 	}
 
 	if len(results) == 0 {
@@ -199,7 +199,7 @@ func TestFusionKeywordOnly(t *testing.T) {
 	// No vector index, no embedder → keyword-only
 	engine := search.NewEngine(a, nil, nil)
 
-	results, _, _, err := engine.Search(ctx, search.Options{
+	results, _, err := engine.Search(ctx, search.Options{
 		Query: "payment",
 		Limit: 10,
 	})
@@ -280,7 +280,7 @@ func TestFusionCentralityBreaksTie(t *testing.T) {
 
 	engine := search.NewEngine(a, nil, nil)
 
-	results, _, _, err := engine.Search(ctx, search.Options{
+	results, _, err := engine.Search(ctx, search.Options{
 		Query: "handler",
 		Limit: 10,
 	})
@@ -316,7 +316,7 @@ func TestFusionMinScore(t *testing.T) {
 
 	engine := search.NewEngine(a, nil, nil)
 
-	results, _, _, err := engine.Search(ctx, search.Options{
+	results, _, err := engine.Search(ctx, search.Options{
 		Query:    "payment",
 		Limit:    10,
 		MinScore: 999, // absurdly high — should filter everything
@@ -347,7 +347,7 @@ func TestNormalizeScoresSpread(t *testing.T) {
 	vectorIdx := search.BuildHNSWIndex(embeddings)
 	engine := search.NewEngine(a, vectorIdx, &paymentQueryEmbedder{})
 
-	results, _, _, err := engine.Search(ctx, search.Options{
+	results, _, err := engine.Search(ctx, search.Options{
 		Query: "payment",
 		Limit: 10,
 	})
@@ -416,7 +416,7 @@ func TestKindWeightsDemotesModules(t *testing.T) {
 	}
 
 	engine := search.NewEngine(a, nil, nil)
-	results, _, _, err := engine.Search(ctx, search.Options{
+	results, _, err := engine.Search(ctx, search.Options{
 		Query: "payment",
 		Limit: 10,
 	})
@@ -456,12 +456,12 @@ func TestSearchModeKeyword(t *testing.T) {
 	seedFusionIndex(t, ctx, a)
 
 	engine := search.NewEngine(a, nil, nil)
-	_, _, mode, err := engine.Search(ctx, search.Options{Query: "payment", Limit: 10})
+	_, meta, err := engine.Search(ctx, search.Options{Query: "payment", Limit: 10})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if mode != search.ModeKeyword {
-		t.Errorf("mode = %q, want %q", mode, search.ModeKeyword)
+	if meta.Mode != search.ModeKeyword {
+		t.Errorf("mode = %q, want %q", meta.Mode, search.ModeKeyword)
 	}
 }
 
@@ -483,12 +483,12 @@ func TestSearchModeHybrid(t *testing.T) {
 	vectorIdx := search.BuildHNSWIndex(embeddings)
 	engine := search.NewEngine(a, vectorIdx, &paymentQueryEmbedder{})
 
-	_, _, mode, err := engine.Search(ctx, search.Options{Query: "payment", Limit: 10})
+	_, meta, err := engine.Search(ctx, search.Options{Query: "payment", Limit: 10})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if mode != search.ModeHybrid {
-		t.Errorf("mode = %q, want %q", mode, search.ModeHybrid)
+	if meta.Mode != search.ModeHybrid {
+		t.Errorf("mode = %q, want %q", meta.Mode, search.ModeHybrid)
 	}
 }
 
@@ -505,12 +505,12 @@ func TestSearchModeUpgradeViaSetVectors(t *testing.T) {
 
 	engine := search.NewEngine(a, nil, &paymentQueryEmbedder{})
 
-	_, _, mode1, err := engine.Search(ctx, search.Options{Query: "payment", Limit: 10})
+	_, meta1, err := engine.Search(ctx, search.Options{Query: "payment", Limit: 10})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if mode1 != search.ModeKeyword {
-		t.Errorf("before SetVectors: mode = %q, want %q", mode1, search.ModeKeyword)
+	if meta1.Mode != search.ModeKeyword {
+		t.Errorf("before SetVectors: mode = %q, want %q", meta1.Mode, search.ModeKeyword)
 	}
 
 	embeddings, err := a.LoadEmbeddings(ctx)
@@ -520,12 +520,12 @@ func TestSearchModeUpgradeViaSetVectors(t *testing.T) {
 	vectorIdx := search.BuildHNSWIndex(embeddings)
 	engine.SetVectors(vectorIdx)
 
-	_, _, mode2, err := engine.Search(ctx, search.Options{Query: "payment", Limit: 10})
+	_, meta2, err := engine.Search(ctx, search.Options{Query: "payment", Limit: 10})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if mode2 != search.ModeHybrid {
-		t.Errorf("after SetVectors: mode = %q, want %q", mode2, search.ModeHybrid)
+	if meta2.Mode != search.ModeHybrid {
+		t.Errorf("after SetVectors: mode = %q, want %q", meta2.Mode, search.ModeHybrid)
 	}
 }
 
@@ -583,7 +583,7 @@ func TestPathWeightsDemotesMigrationsAndScripts(t *testing.T) {
 	}
 
 	engine := search.NewEngine(a, nil, nil)
-	results, _, _, err := engine.Search(ctx, search.Options{
+	results, _, err := engine.Search(ctx, search.Options{
 		Query: "post moderation flagging",
 		Limit: 10,
 	})
@@ -608,5 +608,107 @@ func TestPathWeightsDemotesMigrationsAndScripts(t *testing.T) {
 		if !has[want] {
 			t.Errorf("demoted symbol %q missing from results — should be present but ranked lower", want)
 		}
+	}
+}
+
+func TestFusionWeightsKeywordOnly(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	a, err := sqlite.Open(ctx, filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	seedFusionIndex(t, ctx, a)
+
+	engine := search.NewEngine(a, nil, nil)
+	_, meta, err := engine.Search(ctx, search.Options{Query: "payment", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.KeywordWeight != 1.0 {
+		t.Errorf("keyword weight = %v, want 1.0", meta.KeywordWeight)
+	}
+	if meta.VectorWeight != 0.0 {
+		t.Errorf("vector weight = %v, want 0.0", meta.VectorWeight)
+	}
+}
+
+func TestFusionWeightsHybrid(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	a, err := sqlite.Open(ctx, filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	seedFusionIndex(t, ctx, a)
+	embeddings, err := a.LoadEmbeddings(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vectorIdx := search.BuildHNSWIndex(embeddings)
+	engine := search.NewEngine(a, vectorIdx, &paymentQueryEmbedder{})
+
+	_, meta, err := engine.Search(ctx, search.Options{Query: "payment", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.KeywordWeight+meta.VectorWeight == 0 {
+		t.Error("both weights are zero in hybrid mode")
+	}
+	if meta.KeywordWeight < meta.VectorWeight {
+		t.Logf("keyword=%.2f vector=%.2f — keyword-biased (low vector confidence)", meta.KeywordWeight, meta.VectorWeight)
+	} else {
+		t.Logf("keyword=%.2f vector=%.2f", meta.KeywordWeight, meta.VectorWeight)
+	}
+}
+
+func TestLowConfidenceExcludesVectorOnlySymbols(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	a, err := sqlite.Open(ctx, filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	seedFusionIndex(t, ctx, a)
+
+	// Build vector index with very weak embeddings (near-zero similarity).
+	// The default seedFusionIndex embeddings are simple byte patterns,
+	// and the paymentQueryEmbedder produces a different vector.
+	// With only 3 symbols, cosine similarities will be low.
+	embeddings, err := a.LoadEmbeddings(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vectorIdx := search.BuildHNSWIndex(embeddings)
+	engine := search.NewEngine(a, vectorIdx, &paymentQueryEmbedder{})
+
+	_, meta, err := engine.Search(ctx, search.Options{Query: "payment", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// When vector weight is 0, vector-only symbols should not appear.
+	if meta.VectorWeight == 0 {
+		t.Logf("vector confidence below threshold — keyword-only mode")
+		// In keyword-only mode, the "TransactionLog" symbol (which has no
+		// keyword match for "payment") should be absent.
+		results, _, err := engine.Search(ctx, search.Options{Query: "payment", Limit: 50})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, r := range results {
+			if r.Name == "TransactionLog" {
+				t.Errorf("TransactionLog (vector-only match) should not appear when vector weight is 0")
+			}
+		}
+	} else {
+		t.Logf("vector confidence above threshold (kw=%.2f vec=%.2f) — vector-only symbols may appear",
+			meta.KeywordWeight, meta.VectorWeight)
 	}
 }

--- a/internal/smoke/smoke_test.go
+++ b/internal/smoke/smoke_test.go
@@ -216,7 +216,7 @@ func TestSmoke(t *testing.T) {
 
 		for _, sq := range gt.Search {
 			queryStart := time.Now()
-			results, _, _, err := engine.Search(ctx, search.Options{
+			results, _, err := engine.Search(ctx, search.Options{
 				Query: sq.Query,
 				Limit: 10,
 			})
@@ -404,7 +404,7 @@ func generateGroundTruth(t *testing.T, ctx context.Context, adapter *sqlite.Adap
 
 	engine := search.NewEngine(adapter, nil, nil)
 	for _, sq := range gt.Search {
-		results, _, _, err := engine.Search(ctx, search.Options{Query: sq.Query, Limit: 5})
+		results, _, err := engine.Search(ctx, search.Options{Query: sq.Query, Limit: 5})
 		if err != nil {
 			t.Logf("REVIEW search %q: error: %v", sq.Query, err)
 			continue

--- a/internal/sqlite/adapter.go
+++ b/internal/sqlite/adapter.go
@@ -29,7 +29,7 @@ var schemaFTSSQL string
 // Bump when schema.sql changes incompatibly — a mismatch triggers
 // auto-rebuild (drop all tables, fresh schema, full scan). Never set
 // before a scan completes successfully; see StampSchemaVersion.
-const SchemaVersion = 3
+const SchemaVersion = 4
 
 // maxOpenConns is the connection-pool size Open applies. InTx relies on
 // this being 1 — its raw BEGIN/COMMIT approach shares a transaction
@@ -47,26 +47,26 @@ const maxOpenConns = 1
 var ftsTriggerStatements = []string{
 	`CREATE TRIGGER IF NOT EXISTS sense_symbols_fts_insert
 	 AFTER INSERT ON sense_symbols BEGIN
-	     INSERT INTO sense_symbols_fts(rowid, name, qualified, docstring, snippet)
-	     VALUES (new.id, new.name, new.qualified, new.docstring, new.snippet);
+	     INSERT INTO sense_symbols_fts(rowid, name, qualified, docstring, snippet, name_parts)
+	     VALUES (new.id, new.name, new.qualified, new.docstring, new.snippet, new.name_parts);
 	 END`,
 
 	`CREATE TRIGGER IF NOT EXISTS sense_symbols_fts_delete
 	 BEFORE DELETE ON sense_symbols BEGIN
-	     INSERT INTO sense_symbols_fts(sense_symbols_fts, rowid, name, qualified, docstring, snippet)
-	     VALUES ('delete', old.id, old.name, old.qualified, old.docstring, old.snippet);
+	     INSERT INTO sense_symbols_fts(sense_symbols_fts, rowid, name, qualified, docstring, snippet, name_parts)
+	     VALUES ('delete', old.id, old.name, old.qualified, old.docstring, old.snippet, old.name_parts);
 	 END`,
 
 	`CREATE TRIGGER IF NOT EXISTS sense_symbols_fts_update
 	 BEFORE UPDATE ON sense_symbols BEGIN
-	     INSERT INTO sense_symbols_fts(sense_symbols_fts, rowid, name, qualified, docstring, snippet)
-	     VALUES ('delete', old.id, old.name, old.qualified, old.docstring, old.snippet);
+	     INSERT INTO sense_symbols_fts(sense_symbols_fts, rowid, name, qualified, docstring, snippet, name_parts)
+	     VALUES ('delete', old.id, old.name, old.qualified, old.docstring, old.snippet, old.name_parts);
 	 END`,
 
 	`CREATE TRIGGER IF NOT EXISTS sense_symbols_fts_update_after
 	 AFTER UPDATE ON sense_symbols BEGIN
-	     INSERT INTO sense_symbols_fts(rowid, name, qualified, docstring, snippet)
-	     VALUES (new.id, new.name, new.qualified, new.docstring, new.snippet);
+	     INSERT INTO sense_symbols_fts(rowid, name, qualified, docstring, snippet, name_parts)
+	     VALUES (new.id, new.name, new.qualified, new.docstring, new.snippet, new.name_parts);
 	 END`,
 }
 
@@ -200,12 +200,11 @@ func ftsNeedsMigration(ctx context.Context, db *sql.DB) bool {
 	if err != nil {
 		return false
 	}
+	has := map[string]bool{}
 	for _, c := range cols {
-		if c == "snippet" {
-			return false
-		}
+		has[c] = true
 	}
-	return true
+	return !has["snippet"] || !has["name_parts"]
 }
 
 // StampSchemaVersion writes the current SchemaVersion into PRAGMA
@@ -373,8 +372,8 @@ func (a *Adapter) WriteSymbol(ctx context.Context, s *model.Symbol) (int64, erro
 	const q = `
 		INSERT INTO sense_symbols
 			(file_id, name, qualified, kind, visibility, parent_id,
-			 line_start, line_end, docstring, complexity, snippet)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			 line_start, line_end, docstring, complexity, snippet, name_parts)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(file_id, qualified) DO UPDATE SET
 			name       = excluded.name,
 			kind       = excluded.kind,
@@ -384,19 +383,30 @@ func (a *Adapter) WriteSymbol(ctx context.Context, s *model.Symbol) (int64, erro
 			line_end   = excluded.line_end,
 			docstring  = excluded.docstring,
 			complexity = excluded.complexity,
-			snippet    = excluded.snippet
+			snippet    = excluded.snippet,
+			name_parts = excluded.name_parts
 		RETURNING id`
 
+	nameParts := symbolNameParts(s.Name, s.Qualified)
 	var id int64
 	err := a.db.QueryRowContext(ctx, q,
 		s.FileID, s.Name, s.Qualified, string(s.Kind), s.Visibility,
 		nullableInt64(s.ParentID), s.LineStart, s.LineEnd,
-		s.Docstring, nullableInt(s.Complexity), s.Snippet,
+		s.Docstring, nullableInt(s.Complexity), s.Snippet, nameParts,
 	).Scan(&id)
 	if err != nil {
 		return 0, fmt.Errorf("sqlite WriteSymbol: %w", err)
 	}
 	return id, nil
+}
+
+func symbolNameParts(name, qualified string) string {
+	parts := Decompose(name)
+	qParts := Decompose(qualified)
+	if qParts != parts {
+		parts = parts + " " + qParts
+	}
+	return parts
 }
 
 func (a *Adapter) WriteEdge(ctx context.Context, e *model.Edge) (int64, error) {
@@ -443,8 +453,8 @@ func (a *Adapter) PrepareSymbolStmt(ctx context.Context) (*sql.Stmt, error) {
 	const q = `
 		INSERT INTO sense_symbols
 			(file_id, name, qualified, kind, visibility, parent_id,
-			 line_start, line_end, docstring, complexity, snippet)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			 line_start, line_end, docstring, complexity, snippet, name_parts)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(file_id, qualified) DO UPDATE SET
 			name       = excluded.name,
 			kind       = excluded.kind,
@@ -454,19 +464,20 @@ func (a *Adapter) PrepareSymbolStmt(ctx context.Context) (*sql.Stmt, error) {
 			line_end   = excluded.line_end,
 			docstring  = excluded.docstring,
 			complexity = excluded.complexity,
-			snippet    = excluded.snippet
+			snippet    = excluded.snippet,
+			name_parts = excluded.name_parts
 		RETURNING id`
 	return a.db.PrepareContext(ctx, q)
 }
 
-// ExecSymbolStmt writes a symbol using a prepared statement and returns
-// the row id. The statement must have been created by PrepareSymbolStmt.
+// ExecSymbolStmt writes a symbol using a prepared statement from PrepareSymbolStmt.
 func ExecSymbolStmt(ctx context.Context, stmt *sql.Stmt, s *model.Symbol) (int64, error) {
+	nameParts := symbolNameParts(s.Name, s.Qualified)
 	var id int64
 	err := stmt.QueryRowContext(ctx,
 		s.FileID, s.Name, s.Qualified, string(s.Kind), s.Visibility,
 		nullableInt64(s.ParentID), s.LineStart, s.LineEnd,
-		s.Docstring, nullableInt(s.Complexity), s.Snippet,
+		s.Docstring, nullableInt(s.Complexity), s.Snippet, nameParts,
 	).Scan(&id)
 	if err != nil {
 		return 0, fmt.Errorf("sqlite WriteSymbol (prepared): %w", err)

--- a/internal/sqlite/decompose.go
+++ b/internal/sqlite/decompose.go
@@ -1,0 +1,113 @@
+package sqlite
+
+import (
+	"strings"
+	"unicode"
+)
+
+var namespaceSplitter = strings.NewReplacer("::", " ", ".", " ", "/", " ")
+
+// Decompose splits an identifier into space-separated lowercase tokens.
+// It handles CamelCase (CopyPaymentLink → copy payment link),
+// snake_case (handle_payment_error → handle payment error), and
+// acronyms (HTTPSHandler → https handler). Namespace separators
+// (., ::, /) are treated as word boundaries.
+func Decompose(name string) string {
+	name = namespaceSplitter.Replace(name)
+
+	parts := strings.FieldsFunc(name, func(r rune) bool {
+		return r == '_' || r == ' ' || r == '-'
+	})
+
+	var tokens []string
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		split := splitCamelCase(part)
+		for _, s := range split {
+			if allUpper(s) && len(s) > 5 {
+				tokens = append(tokens, splitAcronymRun(s)...)
+			} else {
+				tokens = append(tokens, s)
+			}
+		}
+	}
+	if len(tokens) == 0 {
+		return strings.ToLower(name)
+	}
+	return strings.ToLower(strings.Join(tokens, " "))
+}
+
+// splitCamelCase splits a CamelCase identifier on case boundaries.
+// Runs of uppercase are kept as single tokens (acronyms):
+// HTTPSHandler → [HTTPS, Handler], getURL → [get, URL].
+func splitCamelCase(s string) []string {
+	runes := []rune(s)
+	if len(runes) <= 1 {
+		return []string{s}
+	}
+	var result []string
+	start := 0
+	for i := 1; i < len(runes); i++ {
+		prev := unicode.IsUpper(runes[i-1])
+		curr := unicode.IsUpper(runes[i])
+
+		if !prev && curr {
+			result = append(result, string(runes[start:i]))
+			start = i
+		} else if prev && !curr && i-start > 1 {
+			result = append(result, string(runes[start:i-1]))
+			start = i - 1
+		}
+	}
+	result = append(result, string(runes[start:]))
+	return result
+}
+
+var knownAcronyms = map[string]bool{
+	"ID": true, "IO": true, "IP": true, "OS": true, "UI": true, "DB": true,
+	"API": true, "CLI": true, "CSS": true, "CSV": true, "CDN": true,
+	"DNS": true, "EOF": true, "FTP": true, "GUI": true, "JWT": true,
+	"RPC": true, "SDK": true, "SQL": true, "SSH": true, "SSL": true,
+	"TCP": true, "TLS": true, "UDP": true, "URI": true, "URL": true,
+	"XML": true, "AWS": true, "GCP": true,
+	"GRPC": true, "HTML": true, "HTTP": true, "JSON": true,
+	"REST": true, "SMTP": true, "TOML": true, "UUID": true, "YAML": true,
+	"HTTPS": true,
+}
+
+// splitAcronymRun splits a fully-uppercase string into known acronyms.
+// Greedy from left, longest match first. Unknown remainders stay as one token.
+func splitAcronymRun(s string) []string {
+	var result []string
+	for len(s) > 0 {
+		matched := false
+		maxLen := len(s)
+		if maxLen > 5 {
+			maxLen = 5
+		}
+		for l := maxLen; l >= 2; l-- {
+			if knownAcronyms[s[:l]] {
+				result = append(result, s[:l])
+				s = s[l:]
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			result = append(result, s)
+			break
+		}
+	}
+	return result
+}
+
+func allUpper(s string) bool {
+	for _, r := range s {
+		if unicode.IsLetter(r) && !unicode.IsUpper(r) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/sqlite/decompose_test.go
+++ b/internal/sqlite/decompose_test.go
@@ -1,0 +1,88 @@
+package sqlite
+
+import "testing"
+
+func TestDecompose(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"CopyPaymentLink", "copy payment link"},
+		{"handle_payment_error", "handle payment error"},
+		{"HTTPSHandler", "https handler"},
+		{"getHTTPSURL", "get https url"},
+		{"XMLParser", "xml parser"},
+		{"getURL", "get url"},
+		{"parseJSON", "parse json"},
+		{"simple", "simple"},
+		{"A", "a"},
+		{"", ""},
+		{"already_lower", "already lower"},
+		{"MixedSnake_CamelCase", "mixed snake camel case"},
+		{"search.Engine", "search engine"},
+		{"Checkout::Order", "checkout order"},
+		{"io_timeout_handler", "io timeout handler"},
+		{"APIClient", "api client"},
+		{"newHTTPClient", "new http client"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := Decompose(tt.input)
+			if got != tt.want {
+				t.Errorf("Decompose(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSplitCamelCase(t *testing.T) {
+	tests := []struct {
+		input string
+		want  []string
+	}{
+		{"HTTPSHandler", []string{"HTTPS", "Handler"}},
+		{"CopyPaymentLink", []string{"Copy", "Payment", "Link"}},
+		{"getURL", []string{"get", "URL"}},
+		{"simple", []string{"simple"}},
+		{"X", []string{"X"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := splitCamelCase(tt.input)
+			if len(got) != len(tt.want) {
+				t.Fatalf("splitCamelCase(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("splitCamelCase(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestSplitAcronymRun(t *testing.T) {
+	tests := []struct {
+		input string
+		want  []string
+	}{
+		{"HTTPSURL", []string{"HTTPS", "URL"}},
+		{"APIDB", []string{"API", "DB"}},
+		{"JSONAPI", []string{"JSON", "API"}},
+		{"UNKNOWNXYZ", []string{"UNKNOWNXYZ"}},
+		{"HTTPID", []string{"HTTP", "ID"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := splitAcronymRun(tt.input)
+			if len(got) != len(tt.want) {
+				t.Fatalf("splitAcronymRun(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("splitAcronymRun(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/sqlite/schema.sql
+++ b/internal/sqlite/schema.sql
@@ -28,6 +28,7 @@ CREATE TABLE IF NOT EXISTS sense_symbols (
     docstring   TEXT,
     complexity  INTEGER,
     snippet     TEXT,
+    name_parts  TEXT,
     -- (file_id, qualified) is the Index contract's natural key for Symbol
     -- upserts. Not in the definition doc but required for ON CONFLICT.
     UNIQUE (file_id, qualified)

--- a/internal/sqlite/schema_fts.sql
+++ b/internal/sqlite/schema_fts.sql
@@ -9,6 +9,7 @@ CREATE VIRTUAL TABLE IF NOT EXISTS sense_symbols_fts USING fts5(
     qualified,
     docstring,
     snippet,
+    name_parts,
     content='sense_symbols',
     content_rowid='id'
 );

--- a/internal/sqlite/search.go
+++ b/internal/sqlite/search.go
@@ -376,6 +376,6 @@ func sanitizeFTS5Query(q string) string {
 		tok = strings.ReplaceAll(tok, `"`, `""`)
 		quoted = append(quoted, `"`+tok+`"`)
 	}
-	return strings.Join(quoted, " ")
+	return strings.Join(quoted, " OR ")
 }
 

--- a/internal/sqlite/search.go
+++ b/internal/sqlite/search.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"slices"
 	"strings"
 )
 
@@ -35,7 +36,7 @@ func (a *Adapter) KeywordSearch(ctx context.Context, query string, language stri
 		limit = 10
 	}
 
-	query = sanitizeFTS5Query(query)
+	ftsQuery := buildFTSQuery(query)
 
 	var q string
 	var args []any
@@ -50,7 +51,7 @@ func (a *Adapter) KeywordSearch(ctx context.Context, query string, language stri
 		       AND f.language = ?
 		     ORDER BY rank
 		     LIMIT ?`
-		args = []any{query, language, limit}
+		args = []any{ftsQuery, language, limit}
 	} else {
 		q = `SELECT s.id, s.name, s.qualified, s.kind, s.file_id, s.line_start,
 		            s.snippet, -rank AS score
@@ -59,7 +60,7 @@ func (a *Adapter) KeywordSearch(ctx context.Context, query string, language stri
 		     WHERE sense_symbols_fts MATCH ?
 		     ORDER BY rank
 		     LIMIT ?`
-		args = []any{query, limit}
+		args = []any{ftsQuery, limit}
 	}
 
 	rows, err := a.db.QueryContext(ctx, q, args...)
@@ -80,6 +81,29 @@ func (a *Adapter) KeywordSearch(ctx context.Context, query string, language stri
 		results = append(results, r)
 	}
 	return results, rows.Err()
+}
+
+// buildFTSQuery constructs an FTS5 MATCH expression that searches the
+// original tokens plus decomposed tokens in name_parts. For a query
+// like "PaymentLink", the result is:
+//
+//	("PaymentLink") OR (name_parts:"payment" name_parts:"link")
+func buildFTSQuery(raw string) string {
+	sanitized := sanitizeFTS5Query(raw)
+	decomposed := Decompose(raw)
+	decompTokens := strings.Fields(decomposed)
+	origTokens := strings.Fields(strings.ToLower(raw))
+
+	if len(decompTokens) <= 1 || slices.Equal(decompTokens, origTokens) {
+		return sanitized
+	}
+
+	var parts []string
+	for _, tok := range decompTokens {
+		tok = strings.ReplaceAll(tok, `"`, `""`)
+		parts = append(parts, `name_parts:"`+tok+`"`)
+	}
+	return "(" + sanitized + ") OR (" + strings.Join(parts, " ") + ")"
 }
 
 // SymbolCount returns the total number of symbols in the index.

--- a/internal/sqlite/search_test.go
+++ b/internal/sqlite/search_test.go
@@ -480,3 +480,53 @@ func TestFTSMigrationAddsSnippet(t *testing.T) {
 		t.Fatalf("expected 1 result for 'belongs_to' after migration, got %d", len(results))
 	}
 }
+
+func TestNamePartsMatchesDecomposed(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	a, err := sqlite.Open(ctx, filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	fid, err := a.WriteFile(ctx, &model.File{
+		Path: "components/payment.tsx", Language: "typescript",
+		Hash: "np1", Symbols: 2, IndexedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := a.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid, Name: "CopyPaymentLink", Qualified: "CopyPaymentLink",
+		Kind: "function", LineStart: 1, LineEnd: 20,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid, Name: "handleHTTPSError", Qualified: "handleHTTPSError",
+		Kind: "function", LineStart: 25, LineEnd: 40,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := a.KeywordSearch(ctx, "PaymentLink", "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected PaymentLink to match CopyPaymentLink via name_parts, got 0 results")
+	}
+	if results[0].Name != "CopyPaymentLink" {
+		t.Errorf("top result = %q, want CopyPaymentLink", results[0].Name)
+	}
+
+	results, err = a.KeywordSearch(ctx, "HTTPS", "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected HTTPS to match handleHTTPSError via name_parts, got 0 results")
+	}
+}

--- a/internal/sqlite/search_test.go
+++ b/internal/sqlite/search_test.go
@@ -481,6 +481,39 @@ func TestFTSMigrationAddsSnippet(t *testing.T) {
 	}
 }
 
+func TestMultiWordQueryUsesOR(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	a, err := sqlite.Open(ctx, filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	seedSearchIndex(t, ctx, a)
+
+	// "credit" appears only in ProcessPayment's docstring, "user" only in
+	// the User symbol. No single document contains both. With OR, both
+	// should be found; with AND, zero results.
+	results, err := a.KeywordSearch(ctx, "credit user", "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) < 2 {
+		t.Fatalf("multi-word OR query: got %d results, want at least 2 (ProcessPayment + User)", len(results))
+	}
+	names := map[string]bool{}
+	for _, r := range results {
+		names[r.Name] = true
+	}
+	if !names["ProcessPayment"] {
+		t.Error("expected ProcessPayment (matches 'credit') in results")
+	}
+	if !names["User"] {
+		t.Error("expected User (matches 'user') in results")
+	}
+}
+
 func TestNamePartsMatchesDecomposed(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()


### PR DESCRIPTION
## Problem

Sense's hybrid search loses to the baseline on 3 of 5 benchmark repos. Equal-weight reciprocal rank fusion lets weak vector matches dilute correct keyword hits on large repos with noisy embedding spaces. Separately, FTS5 treats CamelCase and snake_case identifiers as single tokens, so a search for `PaymentLink` can't find `CopyPaymentLink` — strictly worse than grep for partial name queries.

## Summary

Add confidence-gated fusion weights that bias toward keyword search when vector results are weak, and add CamelCase/snake_case decomposition to the FTS5 index so partial identifier matches work.

## Changes

**Confidence-gated fusion** (`internal/search/search.go`)
- Compute vector confidence as mean cosine similarity of top-3 results
- Gate fusion weights: >=0.6 → equal (0.5/0.5), 0.4-0.6 → keyword-biased (0.7/0.3), <0.4 → keyword-only
- Replace `([]Result, int, string, error)` return with `SearchMeta` struct carrying mode and weights

**CamelCase/snake_case decomposition** (`internal/sqlite/decompose.go`)
- `Decompose()` splits identifiers into lowercase tokens with acronym handling (e.g., `HTTPSHandler` → `https handler`)
- New `name_parts` column in `sense_symbols` and `sense_symbols_fts`
- FTS5 queries search both original name (exact) and `name_parts` (decomposed)

**FTS5 query fix** (`internal/sqlite/search.go`)
- Multi-word queries now use OR between tokens (was implicit AND, which returned zero results for natural language queries like "HTTP request routing")

**Response diagnostics** (`internal/mcpio/types.go`, `internal/mcpserver/server.go`, `internal/cli/search.go`)
- `fusion_weights` field added to search responses for debugging

**Schema** (`internal/sqlite/schema.sql`, `schema_fts.sql`, `adapter.go`)
- Schema version 3→4 (auto-rebuild on mismatch)
- FTS triggers updated for `name_parts` column
- FTS migration detects missing columns

## Test Plan
- [x] `TestDecompose` — CopyPaymentLink, HTTPSHandler, getHTTPSURL, snake_case, namespaces
- [x] `TestNamePartsMatchesDecomposed` — FTS5 finds CopyPaymentLink via query "PaymentLink"
- [x] `TestMultiWordQueryUsesOR` — "credit user" matches documents containing either term
- [x] `TestFusionWeightsKeywordOnly` / `TestFusionWeightsHybrid` — weight gating
- [x] `TestLowConfidenceExcludesVectorOnlySymbols` — vector-only symbols absent in keyword-only mode
- [x] Smoke tests pass with updated `SearchMeta` return type
- [x] `go test ./...` passes
- [x] `make build && make smoke` pass