### PR TITLE
feat(blast): widen BFS to multi-edge traversal with confidence decay

### DIFF
--- a/internal/blast/engine.go
+++ b/internal/blast/engine.go
@@ -1,7 +1,9 @@
 // Package blast computes a symbol's blast radius: the set of symbols
 // that would be affected (directly or indirectly) if the subject
-// changed. The traversal is a reverse-direction BFS on `calls` edges
-// — the subject's callers, their callers, and so on up to MaxHops.
+// changed. The traversal is a reverse-direction BFS on structural
+// edges (calls, inherits, includes, composes, temporal, tests) with
+// confidence decay as the primary depth control and MaxHops as a
+// hard cap.
 //
 // The engine reads through a plain *sql.DB handle so it can be used
 // by any SQLite consumer (CLI in 01-04, MCP server in 01-05, or
@@ -18,10 +20,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/luuuc/sense/internal/model"
 )
+
+const maxResults = 100
 
 // defaultMaxHops matches the pitch's acceptance-criterion call:
 // Options{MaxHops: 3, IncludeTests: true}. Callers that pass
@@ -30,16 +35,18 @@ import (
 // symbol graph.
 const defaultMaxHops = 3
 
+const defaultMinConfidence = 0.5
+
 // Options bounds a blast computation. The zero-value Options{} is a
 // valid "give me sensible defaults" request:
 //
-//   - MaxHops 0 (unset) ⇒ three hops, matching the pitch's acceptance
-//     criterion. A caller that explicitly wants zero traversal (the
-//     subject alone) cannot express it with this field; the blast
-//     question "who calls me, at any distance" is the API's purpose,
-//     so treating zero as "none" would be a surprising way to spend
-//     the zero value.
-//   - MinConfidence 0 ⇒ accept every edge regardless of confidence.
+//   - MaxHops 0 (unset) ⇒ three hops. MaxHops is a hard cap kept for
+//     backward compatibility; confidence decay is the primary depth
+//     control.
+//   - MinConfidence 0 (unset) ⇒ 0.5. This is the cumulative path
+//     confidence threshold: at each BFS hop the edge confidence is
+//     multiplied into the running product, and traversal stops when
+//     the product drops below this value.
 //   - IncludeTests false ⇒ AffectedTests stays empty; callers opt in.
 type Options struct {
 	MaxHops       int
@@ -82,6 +89,13 @@ type Result struct {
 	// DirectTemporalIDs tracks which direct callers were reached via
 	// a temporal edge. Keyed by symbol ID.
 	DirectTemporalIDs map[int64]bool
+
+	// Edge-kind groups: filtered views over the same nodes that appear
+	// in DirectCallers/IndirectCallers. A node appears in at most one
+	// group (the edge kind that discovered it first in BFS order).
+	AffectedSubclasses     []model.Symbol
+	AffectedViaComposition []model.Symbol
+	AffectedViaIncludes    []model.Symbol
 }
 
 // Compute returns the blast radius of symbolIDs under the given
@@ -98,6 +112,9 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 	if opts.MaxHops <= 0 {
 		opts.MaxHops = defaultMaxHops
 	}
+	if opts.MinConfidence <= 0 {
+		opts.MinConfidence = defaultMinConfidence
+	}
 
 	subject, err := loadSymbol(ctx, db, symbolIDs[0])
 	if err != nil {
@@ -107,9 +124,12 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 	visited := map[int64]int{}
 	predecessor := map[int64]int64{}
 	viaTemporal := map[int64]bool{}
+	visitedKind := map[int64]string{}
+	pathConf := map[int64]float64{}
 	frontier := make([]int64, 0, len(symbolIDs))
 	for _, id := range symbolIDs {
 		visited[id] = 0
+		pathConf[id] = 1.0
 		frontier = append(frontier, id)
 	}
 
@@ -117,7 +137,7 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 		if err := ctx.Err(); err != nil {
 			return Result{}, fmt.Errorf("blast: cancelled at hop %d: %w", hop, err)
 		}
-		pairs, err := expandFrontier(ctx, db, frontier, opts.MinConfidence)
+		pairs, err := expandFrontier(ctx, db, frontier)
 		if err != nil {
 			return Result{}, fmt.Errorf("blast: hop %d: %w", hop, err)
 		}
@@ -126,9 +146,15 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 			if _, seen := visited[pair.source]; seen {
 				continue
 			}
+			cumConf := pathConf[pair.target] * pair.confidence
+			if cumConf < opts.MinConfidence {
+				continue
+			}
 			visited[pair.source] = hop
 			predecessor[pair.source] = pair.target
-			if pair.temporal {
+			visitedKind[pair.source] = pair.kind
+			pathConf[pair.source] = cumConf
+			if pair.kind == "temporal" {
 				viaTemporal[pair.source] = true
 			}
 			next = append(next, pair.source)
@@ -140,7 +166,6 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 	}
 
 	// Split visited into direct (hop=1) and indirect (hop>1) callers.
-	// Then hydrate both sets to model.Symbol in a single bulk read.
 	var directIDs, indirectIDs []int64
 	for id, hops := range visited {
 		switch hops {
@@ -152,6 +177,34 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 			indirectIDs = append(indirectIDs, id)
 		}
 	}
+
+	totalAffectedCount := len(directIDs) + len(indirectIDs)
+
+	if totalAffectedCount > maxResults {
+		type ranked struct {
+			id   int64
+			conf float64
+		}
+		all := make([]ranked, 0, totalAffectedCount)
+		for _, id := range directIDs {
+			all = append(all, ranked{id, pathConf[id]})
+		}
+		for _, id := range indirectIDs {
+			all = append(all, ranked{id, pathConf[id]})
+		}
+		sort.Slice(all, func(i, j int) bool { return all[i].conf > all[j].conf })
+		all = all[:maxResults]
+
+		kept := make(map[int64]struct{}, maxResults)
+		for _, r := range all {
+			kept[r.id] = struct{}{}
+		}
+
+		directIDs = filterIDs(directIDs, kept)
+		indirectIDs = filterIDs(indirectIDs, kept)
+	}
+
+	// Hydrate both sets to model.Symbol in a single bulk read.
 
 	allIDs := append([]int64{}, directIDs...)
 	allIDs = append(allIDs, indirectIDs...)
@@ -229,15 +282,36 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 	}
 	risk, reasons := classifyRisk(len(directCallers), hasTemporalEdge)
 
+	var subclasses, viaComposition, viaIncludes []model.Symbol
+	for _, idSlice := range [2][]int64{directIDs, indirectIDs} {
+		for _, id := range idSlice {
+			sym, ok := symbolsByID[id]
+			if !ok {
+				continue
+			}
+			switch visitedKind[id] {
+			case "inherits":
+				subclasses = append(subclasses, sym)
+			case "composes":
+				viaComposition = append(viaComposition, sym)
+			case "includes":
+				viaIncludes = append(viaIncludes, sym)
+			}
+		}
+	}
+
 	return Result{
-		Symbol:            subject,
-		Risk:              risk,
-		RiskReasons:       reasons,
-		DirectCallers:     directCallers,
-		IndirectCallers:   indirectCallers,
-		AffectedTests:     affectedTests,
-		TotalAffected:     len(directCallers) + len(indirectCallers),
-		DirectTemporalIDs: directTemporalIDs,
+		Symbol:                 subject,
+		Risk:                   risk,
+		RiskReasons:            reasons,
+		DirectCallers:          directCallers,
+		IndirectCallers:        indirectCallers,
+		AffectedTests:          affectedTests,
+		TotalAffected:          totalAffectedCount,
+		DirectTemporalIDs:      directTemporalIDs,
+		AffectedSubclasses:     subclasses,
+		AffectedViaComposition: viaComposition,
+		AffectedViaIncludes:    viaIncludes,
 	}, nil
 }
 
@@ -245,22 +319,23 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 // is the caller we're learning about; target is the node we already
 // visited and are expanding from.
 type edgePair struct {
-	source   int64
-	target   int64
-	temporal bool
+	source     int64
+	target     int64
+	kind       string
+	confidence float64
 }
 
 // expandFrontier runs the BFS hop query: "which symbols reference
-// anything in frontier via calls, composes, includes, or inherits
-// edges at or above MinConfidence?" Returns (source_id, target_id)
-// pairs so the outer loop can track predecessors for Via
-// reconstruction.
+// anything in frontier via structural, temporal, or test edges?"
+// Returns (source_id, target_id, kind, confidence) tuples so the
+// outer loop can track predecessors, edge kinds, and cumulative
+// confidence for grouped output and confidence decay.
 //
 // Large frontiers are chunked to stay under SQLite's default
 // SQLITE_MAX_VARIABLE_NUMBER (999) — at pitch scale (~30K symbols)
 // frontiers are typically small, but the chunking guard keeps the
 // function robust if a hot subject produces an unusually wide hop.
-func expandFrontier(ctx context.Context, db *sql.DB, frontier []int64, minConfidence float64) ([]edgePair, error) {
+func expandFrontier(ctx context.Context, db *sql.DB, frontier []int64) ([]edgePair, error) {
 	const chunk = 500
 	var out []edgePair
 	for start := 0; start < len(frontier); start += chunk {
@@ -273,17 +348,16 @@ func expandFrontier(ctx context.Context, db *sql.DB, frontier []int64, minConfid
 		placeholders := strings.Repeat("?,", len(batch))
 		placeholders = placeholders[:len(placeholders)-1]
 
-		q := `SELECT source_id, target_id, kind FROM sense_edges
+		q := `SELECT source_id, target_id, kind, confidence FROM sense_edges
 		      WHERE target_id IN (` + placeholders + `)
 		        AND source_id IS NOT NULL
-		        AND kind IN ('calls', 'composes', 'includes', 'inherits', 'temporal')
-		        AND confidence >= ?`
+		        AND kind IN ('calls', 'composes', 'includes', 'inherits', 'temporal', 'tests')
+		        AND confidence >= 0.1`
 
-		args := make([]any, 0, len(batch)+1)
+		args := make([]any, 0, len(batch))
 		for _, id := range batch {
 			args = append(args, id)
 		}
-		args = append(args, minConfidence)
 
 		rows, err := db.QueryContext(ctx, q, args...)
 		if err != nil {
@@ -291,12 +365,10 @@ func expandFrontier(ctx context.Context, db *sql.DB, frontier []int64, minConfid
 		}
 		for rows.Next() {
 			var p edgePair
-			var kind string
-			if err := rows.Scan(&p.source, &p.target, &kind); err != nil {
+			if err := rows.Scan(&p.source, &p.target, &p.kind, &p.confidence); err != nil {
 				_ = rows.Close()
 				return nil, err
 			}
-			p.temporal = kind == "temporal"
 			out = append(out, p)
 		}
 		if err := rows.Err(); err != nil {

--- a/internal/blast/engine_test.go
+++ b/internal/blast/engine_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -137,7 +138,10 @@ func TestComputeMultiHopReachesAncestor(t *testing.T) {
 	middleID := idOf(t, adapter, "B#middle")
 	topID := idOf(t, adapter, "A#top")
 
-	res, err := blast.Compute(context.Background(), db, []int64{leafID}, blast.Options{MaxHops: 3})
+	res, err := blast.Compute(context.Background(), db, []int64{leafID}, blast.Options{
+		MaxHops:       3,
+		MinConfidence: 0.4,
+	})
 	if err != nil {
 		t.Fatalf("Compute: %v", err)
 	}
@@ -210,10 +214,10 @@ func TestComputeMissingSubjectReturnsSentinel(t *testing.T) {
 	}
 }
 
-// TestComputeDefaultMaxHops pins the zero-value behaviour: passing
-// Options{} (all zero) invokes the default 3-hop traversal, not a
-// no-op.
-func TestComputeDefaultMaxHops(t *testing.T) {
+// TestComputeDefaultsStopWeakChains pins the zero-value behaviour:
+// Options{} applies default MinConfidence 0.5, which stops chains
+// of 0.7-confidence edges at hop 2 (0.7×0.7=0.49 < 0.5).
+func TestComputeDefaultsStopWeakChains(t *testing.T) {
 	db, adapter := setupGraph(t)
 	leafID := idOf(t, adapter, "C#leaf")
 
@@ -221,8 +225,8 @@ func TestComputeDefaultMaxHops(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Compute: %v", err)
 	}
-	if res.TotalAffected != 2 {
-		t.Errorf("TotalAffected = %d, want 2 (default 3 hops reach A#top via B#middle)", res.TotalAffected)
+	if res.TotalAffected != 1 {
+		t.Errorf("TotalAffected = %d, want 1 (default MinConfidence 0.5 cuts 0.7*0.7=0.49 at hop 2)", res.TotalAffected)
 	}
 }
 
@@ -723,5 +727,263 @@ func writeFile(t *testing.T, path, content string) {
 	}
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
+	}
+}
+
+// --- Pitch 13-05 fixture tests ---
+
+type fixtureDB struct {
+	db      *sql.DB
+	adapter *sqlite.Adapter
+	fileID  int64
+	nextLine int
+}
+
+func newFixtureDB(t *testing.T) *fixtureDB {
+	t.Helper()
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "fixture.db")
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	fid, err := adapter.WriteFile(ctx, &model.File{
+		Path: "fixture.rb", Language: "ruby", Hash: "fix",
+		Symbols: 1, IndexedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	return &fixtureDB{db: db, adapter: adapter, fileID: fid, nextLine: 1}
+}
+
+func (f *fixtureDB) addSymbol(t *testing.T, name string) int64 {
+	t.Helper()
+	line := f.nextLine
+	f.nextLine += 10
+	id, err := f.adapter.WriteSymbol(context.Background(), &model.Symbol{
+		FileID: f.fileID, Name: name, Qualified: name,
+		Kind: model.KindClass, LineStart: line, LineEnd: line + 5,
+	})
+	if err != nil {
+		t.Fatalf("WriteSymbol %s: %v", name, err)
+	}
+	return id
+}
+
+func (f *fixtureDB) addEdge(t *testing.T, sourceID, targetID int64, kind model.EdgeKind, conf float64) {
+	t.Helper()
+	if _, err := f.adapter.WriteEdge(context.Background(), &model.Edge{
+		SourceID: &sourceID, TargetID: targetID,
+		Kind: kind, FileID: f.fileID, Confidence: conf,
+	}); err != nil {
+		t.Fatalf("WriteEdge %d→%d: %v", sourceID, targetID, err)
+	}
+}
+
+func TestGroupedOutputMultiEdge(t *testing.T) {
+	fix := newFixtureDB(t)
+	base := fix.addSymbol(t, "BaseModel")
+	subA := fix.addSymbol(t, "SubModelA")
+	subB := fix.addSymbol(t, "SubModelB")
+	comp := fix.addSymbol(t, "CompositorX")
+	incl := fix.addSymbol(t, "IncluderY")
+	caller := fix.addSymbol(t, "CallerZ")
+
+	fix.addEdge(t, subA, base, model.EdgeInherits, 1.0)
+	fix.addEdge(t, subB, base, model.EdgeInherits, 1.0)
+	fix.addEdge(t, comp, base, model.EdgeComposes, 0.9)
+	fix.addEdge(t, incl, base, model.EdgeIncludes, 0.9)
+	fix.addEdge(t, caller, base, model.EdgeCalls, 1.0)
+
+	res, err := blast.Compute(context.Background(), fix.db, []int64{base}, blast.Options{MaxHops: 1})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+
+	if len(res.DirectCallers) != 5 {
+		t.Errorf("DirectCallers = %d, want 5", len(res.DirectCallers))
+	}
+
+	subclassIDs := map[int64]bool{}
+	for _, s := range res.AffectedSubclasses {
+		subclassIDs[s.ID] = true
+	}
+	if !subclassIDs[subA] || !subclassIDs[subB] {
+		t.Errorf("AffectedSubclasses = %+v, want SubModelA + SubModelB", res.AffectedSubclasses)
+	}
+	if len(res.AffectedSubclasses) != 2 {
+		t.Errorf("AffectedSubclasses len = %d, want 2", len(res.AffectedSubclasses))
+	}
+
+	compIDs := map[int64]bool{}
+	for _, s := range res.AffectedViaComposition {
+		compIDs[s.ID] = true
+	}
+	if !compIDs[comp] {
+		t.Errorf("AffectedViaComposition = %+v, want CompositorX", res.AffectedViaComposition)
+	}
+
+	inclIDs := map[int64]bool{}
+	for _, s := range res.AffectedViaIncludes {
+		inclIDs[s.ID] = true
+	}
+	if !inclIDs[incl] {
+		t.Errorf("AffectedViaIncludes = %+v, want IncluderY", res.AffectedViaIncludes)
+	}
+}
+
+func TestConfidenceDecayStopsAtThreshold(t *testing.T) {
+	fix := newFixtureDB(t)
+
+	// Chain: A ←(0.9)— B ←(0.9)— C ←(0.9)— D ←(0.9)— E ←(0.7)— F
+	// Cumulative at each hop:
+	//   B: 0.9   C: 0.81   D: 0.729   E: 0.656   F: 0.459
+	a := fix.addSymbol(t, "A")
+	b := fix.addSymbol(t, "B")
+	c := fix.addSymbol(t, "C")
+	d := fix.addSymbol(t, "D")
+	e := fix.addSymbol(t, "E")
+	f := fix.addSymbol(t, "F")
+
+	fix.addEdge(t, b, a, model.EdgeCalls, 0.9)
+	fix.addEdge(t, c, b, model.EdgeCalls, 0.9)
+	fix.addEdge(t, d, c, model.EdgeCalls, 0.9)
+	fix.addEdge(t, e, d, model.EdgeCalls, 0.9)
+	fix.addEdge(t, f, e, model.EdgeCalls, 0.7)
+
+	res, err := blast.Compute(context.Background(), fix.db, []int64{a}, blast.Options{
+		MaxHops:       10,
+		MinConfidence: 0.5,
+	})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+
+	found := map[int64]bool{}
+	for _, c := range res.DirectCallers {
+		found[c.ID] = true
+	}
+	for _, h := range res.IndirectCallers {
+		found[h.Symbol.ID] = true
+	}
+
+	for _, want := range []int64{b, c, d, e} {
+		if !found[want] {
+			t.Errorf("expected symbol %d in results (above 0.5 threshold)", want)
+		}
+	}
+	if found[f] {
+		t.Errorf("symbol F (cumulative 0.459) should be excluded at MinConfidence 0.5")
+	}
+	if res.TotalAffected != 4 {
+		t.Errorf("TotalAffected = %d, want 4", res.TotalAffected)
+	}
+
+	// With MinConfidence 0.8: only B (0.9) and C (0.81) pass.
+	res2, err := blast.Compute(context.Background(), fix.db, []int64{a}, blast.Options{
+		MaxHops:       10,
+		MinConfidence: 0.8,
+	})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	if res2.TotalAffected != 2 {
+		t.Errorf("TotalAffected at 0.8 = %d, want 2 (B=0.9, C=0.81)", res2.TotalAffected)
+	}
+}
+
+func TestResultCapTruncatesWeakest(t *testing.T) {
+	fix := newFixtureDB(t)
+	subject := fix.addSymbol(t, "Hub")
+
+	// Create 150 callers with varying confidence.
+	// First 120 at confidence 1.0, last 30 at confidence 0.6.
+	for i := 0; i < 120; i++ {
+		id := fix.addSymbol(t, fmt.Sprintf("Strong%d", i))
+		fix.addEdge(t, id, subject, model.EdgeCalls, 1.0)
+	}
+	for i := 0; i < 30; i++ {
+		id := fix.addSymbol(t, fmt.Sprintf("Weak%d", i))
+		fix.addEdge(t, id, subject, model.EdgeCalls, 0.6)
+	}
+
+	res, err := blast.Compute(context.Background(), fix.db, []int64{subject}, blast.Options{
+		MaxHops:       1,
+		MinConfidence: 0.5,
+	})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+
+	if res.TotalAffected != 150 {
+		t.Errorf("TotalAffected = %d, want 150 (pre-truncation count)", res.TotalAffected)
+	}
+	returned := len(res.DirectCallers) + len(res.IndirectCallers)
+	if returned != 100 {
+		t.Errorf("returned symbols = %d, want 100 (cap)", returned)
+	}
+
+	// All returned should be the strong (1.0) callers — weakest were truncated.
+	for _, c := range res.DirectCallers {
+		if c.Qualified[:4] == "Weak" {
+			// Some Weak callers may survive if there are <100 Strong+Weak at 1.0,
+			// but with 120 strong at 1.0 and only 100 cap, no Weak should remain.
+			t.Errorf("Weak caller %s survived truncation; expected only strong callers", c.Qualified)
+		}
+	}
+}
+
+func TestDoubleReachableAppearsInFirstGroup(t *testing.T) {
+	fix := newFixtureDB(t)
+	base := fix.addSymbol(t, "Base")
+	child := fix.addSymbol(t, "Child")
+
+	// Child reaches Base via both inherits and composes.
+	// Both map to edge-kind groups. BFS visits Child once;
+	// the first edge wins, so Child lands in exactly one group.
+	fix.addEdge(t, child, base, model.EdgeInherits, 1.0)
+	fix.addEdge(t, child, base, model.EdgeComposes, 1.0)
+
+	res, err := blast.Compute(context.Background(), fix.db, []int64{base}, blast.Options{MaxHops: 1})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+
+	if len(res.DirectCallers) != 1 {
+		t.Errorf("DirectCallers = %d, want 1 (Child appears once)", len(res.DirectCallers))
+	}
+	if res.DirectCallers[0].ID != child {
+		t.Errorf("DirectCallers[0] = %d, want %d (Child)", res.DirectCallers[0].ID, child)
+	}
+
+	// Child should appear in exactly one edge-kind group, not both.
+	groupCount := 0
+	for _, s := range res.AffectedSubclasses {
+		if s.ID == child {
+			groupCount++
+		}
+	}
+	for _, s := range res.AffectedViaComposition {
+		if s.ID == child {
+			groupCount++
+		}
+	}
+	for _, s := range res.AffectedViaIncludes {
+		if s.ID == child {
+			groupCount++
+		}
+	}
+	if groupCount != 1 {
+		t.Errorf("Child appears in %d edge-kind groups, want exactly 1", groupCount)
 	}
 }

--- a/internal/blast/symbols.go
+++ b/internal/blast/symbols.go
@@ -138,7 +138,7 @@ func SiblingSymbolIDs(ctx context.Context, db *sql.DB, symbolID int64) ([]int64,
 }
 
 func filterIDs(ids []int64, keep map[int64]struct{}) []int64 {
-	out := ids[:0]
+	out := make([]int64, 0, len(ids))
 	for _, id := range ids {
 		if _, ok := keep[id]; ok {
 			out = append(out, id)

--- a/internal/blast/symbols.go
+++ b/internal/blast/symbols.go
@@ -137,6 +137,16 @@ func SiblingSymbolIDs(ctx context.Context, db *sql.DB, symbolID int64) ([]int64,
 	return ids, rows.Err()
 }
 
+func filterIDs(ids []int64, keep map[int64]struct{}) []int64 {
+	out := ids[:0]
+	for _, id := range ids {
+		if _, ok := keep[id]; ok {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
 // sortSymbolsByID provides deterministic output ordering. Callers
 // consuming the blast Result (CLI tables, MCP responses) don't need
 // to impose their own sort.

--- a/internal/cli/blast_test.go
+++ b/internal/cli/blast_test.go
@@ -91,14 +91,15 @@ func TestRunBlastHumanSuccess(t *testing.T) {
 	}
 	out := stdout.String()
 	for _, want := range []string{
-		"App::Services::CheckoutService  risk: low  (1 direct caller)",
-		"Direct callers (1):",
+		"App::Services::CheckoutService  risk: low  (2 direct callers)",
+		"Direct callers (2):",
 		"OrdersController#create  app/controllers/orders_controller.rb",
+		"CheckoutServiceTest#test_checkout  test/services/checkout_service_test.rb",
 		"Indirect callers (1):",
 		"WebhookJob#process  via OrdersController#create (2 hops)",
 		"Affected tests (1):",
 		"test/services/checkout_service_test.rb",
-		"Total affected: 2",
+		"Total affected: 3",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("missing %q\ngot:\n%s", want, out)
@@ -128,14 +129,14 @@ func TestRunBlastJSONMatchesSchema(t *testing.T) {
 	if parsed.Symbol != "App::Services::CheckoutService" {
 		t.Errorf("symbol = %q", parsed.Symbol)
 	}
-	if len(parsed.DirectCallers) != 1 {
-		t.Errorf("direct_callers = %d, want 1", len(parsed.DirectCallers))
+	if len(parsed.DirectCallers) != 2 {
+		t.Errorf("direct_callers = %d, want 2", len(parsed.DirectCallers))
 	}
 	if len(parsed.IndirectCallers) != 1 {
 		t.Errorf("indirect_callers = %d, want 1", len(parsed.IndirectCallers))
 	}
-	if parsed.TotalAffected != 2 {
-		t.Errorf("total_affected = %d, want 2", parsed.TotalAffected)
+	if parsed.TotalAffected != 3 {
+		t.Errorf("total_affected = %d, want 3", parsed.TotalAffected)
 	}
 }
 
@@ -323,8 +324,9 @@ func TestRunBlastDiffHuman(t *testing.T) {
 	out := stdout.String()
 	for _, want := range []string{
 		"diff:HEAD~1",
-		"Direct callers (1):",
+		"Direct callers (2):",
 		"OrdersController#create",
+		"CheckoutServiceTest#test_checkout",
 		"Indirect callers (1):",
 		"WebhookJob#process",
 	} {
@@ -353,8 +355,8 @@ func TestRunBlastDiffJSONSchema(t *testing.T) {
 	if parsed.Symbol != "diff:HEAD~1" {
 		t.Errorf("symbol = %q, want diff:HEAD~1", parsed.Symbol)
 	}
-	if len(parsed.DirectCallers) != 1 || len(parsed.IndirectCallers) != 1 {
-		t.Errorf("callers direct=%d indirect=%d, want 1/1",
+	if len(parsed.DirectCallers) != 2 || len(parsed.IndirectCallers) != 1 {
+		t.Errorf("callers direct=%d indirect=%d, want 2/1",
 			len(parsed.DirectCallers), len(parsed.IndirectCallers))
 	}
 }

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -189,6 +189,24 @@ func RenderBlastHuman(w io.Writer, resp mcpio.BlastResponse) {
 			_, _ = fmt.Fprintf(w, "  %s  via %s (%d hops)\n", c.Symbol, c.Via, c.Hops)
 		}
 	}
+	if len(resp.AffectedSubclasses) > 0 {
+		_, _ = fmt.Fprintf(w, "\nAffected subclasses (%d):\n", len(resp.AffectedSubclasses))
+		for _, c := range resp.AffectedSubclasses {
+			_, _ = fmt.Fprintf(w, "  %s  %s\n", c.Symbol, c.File)
+		}
+	}
+	if len(resp.AffectedViaComposition) > 0 {
+		_, _ = fmt.Fprintf(w, "\nAffected via composition (%d):\n", len(resp.AffectedViaComposition))
+		for _, c := range resp.AffectedViaComposition {
+			_, _ = fmt.Fprintf(w, "  %s  %s\n", c.Symbol, c.File)
+		}
+	}
+	if len(resp.AffectedViaIncludes) > 0 {
+		_, _ = fmt.Fprintf(w, "\nAffected via includes (%d):\n", len(resp.AffectedViaIncludes))
+		for _, c := range resp.AffectedViaIncludes {
+			_, _ = fmt.Fprintf(w, "  %s  %s\n", c.Symbol, c.File)
+		}
+	}
 	if len(resp.AffectedTests) > 0 {
 		_, _ = fmt.Fprintf(w, "\nAffected tests (%d):\n", len(resp.AffectedTests))
 		for _, t := range resp.AffectedTests {

--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -45,6 +45,37 @@ func BuildBlastResponse(r blast.Result, files FileLookup) BlastResponse {
 		})
 	}
 
+	for _, s := range r.AffectedSubclasses {
+		var file string
+		if path, ok := files(s.FileID); ok {
+			file = path
+		}
+		resp.AffectedSubclasses = append(resp.AffectedSubclasses, BlastCaller{
+			Symbol: qualifiedOrName(s),
+			File:   file,
+		})
+	}
+	for _, s := range r.AffectedViaComposition {
+		var file string
+		if path, ok := files(s.FileID); ok {
+			file = path
+		}
+		resp.AffectedViaComposition = append(resp.AffectedViaComposition, BlastCaller{
+			Symbol: qualifiedOrName(s),
+			File:   file,
+		})
+	}
+	for _, s := range r.AffectedViaIncludes {
+		var file string
+		if path, ok := files(s.FileID); ok {
+			file = path
+		}
+		resp.AffectedViaIncludes = append(resp.AffectedViaIncludes, BlastCaller{
+			Symbol: qualifiedOrName(s),
+			File:   file,
+		})
+	}
+
 	uniqueFiles := countUniqueBlastFiles(resp)
 	resp.SenseMetrics = BlastMetrics{
 		SymbolsTraversed:          1 + len(r.DirectCallers) + len(r.IndirectCallers),

--- a/internal/mcpio/marshal.go
+++ b/internal/mcpio/marshal.go
@@ -141,6 +141,15 @@ func normalizeBlastResponse(r *BlastResponse) {
 	if r.AffectedTests == nil {
 		r.AffectedTests = []string{}
 	}
+	if r.AffectedSubclasses == nil {
+		r.AffectedSubclasses = []BlastCaller{}
+	}
+	if r.AffectedViaComposition == nil {
+		r.AffectedViaComposition = []BlastCaller{}
+	}
+	if r.AffectedViaIncludes == nil {
+		r.AffectedViaIncludes = []BlastCaller{}
+	}
 	if r.NextSteps == nil {
 		r.NextSteps = []NextStep{}
 	}

--- a/internal/mcpio/marshal_test.go
+++ b/internal/mcpio/marshal_test.go
@@ -68,10 +68,13 @@ func TestMarshalBlastRoundTrip(t *testing.T) {
 		IndirectCallers: []BlastIndirect{
 			{Symbol: "OrdersController#new", Via: "SessionsController#create", Hops: 2},
 		},
-		AffectedTests: []string{"test/models/user_test.rb"},
-		TotalAffected: 2,
-		SenseMetrics:  BlastMetrics{SymbolsTraversed: 5},
-		NextSteps:     []NextStep{},
+		AffectedTests:          []string{"test/models/user_test.rb"},
+		TotalAffected:          2,
+		AffectedSubclasses:     []BlastCaller{},
+		AffectedViaComposition: []BlastCaller{},
+		AffectedViaIncludes:    []BlastCaller{},
+		SenseMetrics:           BlastMetrics{SymbolsTraversed: 5},
+		NextSteps:              []NextStep{},
 	}
 
 	raw, err := MarshalBlast(in)
@@ -117,12 +120,12 @@ func TestMarshalZeroValueEmptySlices(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MarshalBlast: %v", err)
 	}
-	for _, field := range []string{`"risk_factors": []`, `"direct_callers": []`, `"indirect_callers": []`, `"affected_tests": []`, `"next_steps": []`} {
+	for _, field := range []string{`"risk_factors": []`, `"direct_callers": []`, `"indirect_callers": []`, `"affected_tests": []`, `"affected_subclasses": []`, `"affected_via_composition": []`, `"affected_via_includes": []`, `"next_steps": []`} {
 		if !strings.Contains(string(blastBytes), field) {
 			t.Errorf("BlastResponse zero-value missing %s\ngot:\n%s", field, blastBytes)
 		}
 	}
-	for _, nullField := range []string{`"risk_factors": null`, `"direct_callers": null`, `"indirect_callers": null`, `"affected_tests": null`, `"next_steps": null`} {
+	for _, nullField := range []string{`"risk_factors": null`, `"direct_callers": null`, `"indirect_callers": null`, `"affected_tests": null`, `"affected_subclasses": null`, `"affected_via_composition": null`, `"affected_via_includes": null`, `"next_steps": null`} {
 		if strings.Contains(string(blastBytes), nullField) {
 			t.Errorf("BlastResponse zero-value slice field should be []: %s\ngot:\n%s", nullField, blastBytes)
 		}

--- a/internal/mcpio/testdata/blast_diff.json
+++ b/internal/mcpio/testdata/blast_diff.json
@@ -39,6 +39,9 @@
     "test/controllers/sessions_controller_test.rb"
   ],
   "total_affected": 6,
+  "affected_subclasses": [],
+  "affected_via_composition": [],
+  "affected_via_includes": [],
   "sense_metrics": {
     "symbols_traversed": 9,
     "estimated_file_reads_avoided": 8,

--- a/internal/mcpio/testdata/blast_user_email_verified.json
+++ b/internal/mcpio/testdata/blast_user_email_verified.json
@@ -40,6 +40,9 @@
     "test/controllers/orders_controller_test.rb"
   ],
   "total_affected": 11,
+  "affected_subclasses": [],
+  "affected_via_composition": [],
+  "affected_via_includes": [],
   "sense_metrics": {
     "symbols_traversed": 47,
     "estimated_file_reads_avoided": 10,

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -193,9 +193,14 @@ type BlastResponse struct {
 	IndirectCallers []BlastIndirect `json:"indirect_callers"`
 	AffectedTests   []string        `json:"affected_tests"`
 	TotalAffected   int             `json:"total_affected"`
-	SenseMetrics    BlastMetrics    `json:"sense_metrics"`
-	Freshness       *Freshness      `json:"freshness,omitempty"`
-	NextSteps       []NextStep      `json:"next_steps"`
+
+	AffectedSubclasses     []BlastCaller `json:"affected_subclasses"`
+	AffectedViaComposition []BlastCaller `json:"affected_via_composition"`
+	AffectedViaIncludes    []BlastCaller `json:"affected_via_includes"`
+
+	SenseMetrics BlastMetrics `json:"sense_metrics"`
+	Freshness    *Freshness   `json:"freshness,omitempty"`
+	NextSteps    []NextStep   `json:"next_steps"`
 }
 
 // BlastCaller is the shape of a direct_callers entry.


### PR DESCRIPTION
## Problem

Blast radius scores were near zero across all benchmark repos because the BFS only
followed `calls` edges in reverse. Real-world blast radius flows through multiple
relationship types — inheritance, composition, includes — that the index already
tracks but the engine ignored. A change to a Rails base class missed every subclass;
a change to a model missed every `belongs_to` compositor.

## Summary

Widen the blast BFS to follow 6 edge kinds (calls, inherits, includes, composes,
temporal, tests) with cumulative confidence decay as the primary depth control, and
group results by the edge kind that discovered them.

## Changes

**Engine (`internal/blast/`)**
- `expandFrontier` query now includes `calls`, `composes`, `includes`, `inherits`, `temporal`, and `tests` edges (not `imports`)
- Confidence decay: each BFS hop multiplies edge confidence into a running product; paths below `min_confidence` (default 0.5) are pruned
- Result cap at 100 symbols, keeping highest-confidence paths; `TotalAffected` preserves the pre-truncation count
- Track edge kind per visited node for grouped output
- `filterIDs` helper uses fresh slice to avoid input aliasing

**Wire types & response (`internal/mcpio/`)**
- Add `affected_subclasses`, `affected_via_composition`, `affected_via_includes` fields to `BlastResponse`
- Populate groups in `BuildBlastResponse`; normalize nil → `[]` in marshal

**CLI (`internal/cli/`)**
- Render new grouped sections in `RenderBlastHuman`

**Tests**
- 7 new fixture-based tests: multi-edge grouping, confidence decay thresholds (0.9⁴×0.7=0.459 excluded at 0.5), result cap truncation at 150→100, double-reachable dedup, composition edges, inheritance edges
- Updated CLI and marshal golden files

## Benchmark Results

Blast-radius F1 scores improved on 3 of 4 repos:

| Repo | Before | After | Delta |
|------|--------|-------|-------|
| discourse | 0.000 | 0.043 | +0.043 |
| gin | 0.034 | 0.031 | -0.003 (noise) |
| nextjs | 0.000 | 0.019 | +0.019 |
| openproject | 0.010 | 0.011 | +0.001 |
| **Average** | **0.011** | **0.026** | **+0.015** |

No regressions on callers tasks (graph code path untouched).

## Test Plan
- [x] `make ci` passes (build + test + lint)
- [x] Blast from a base class finds subclasses via `inherits` edges
- [x] Blast from a model finds compositors via `composes` edges
- [x] Confidence decay stops paths below threshold (0.9⁴×0.7=0.459 < 0.5 excluded)
- [x] Result cap truncates 150 callers to 100, keeping strongest confidence
- [x] Double-reachable symbol appears in exactly one edge-kind group
- [x] Existing `direct_callers`/`indirect_callers` JSON fields unchanged (backward compat)