### PR TITLE
feat: benchmark isolation, search ranking, and chunked embedding pipeline

### DIFF
--- a/bench/run.sh
+++ b/bench/run.sh
@@ -18,6 +18,7 @@ FILTER_TOOLS=""
 FILTER_REPOS=""
 FILTER_TASKS=""
 DRY_RUN=false
+VERIFY_ISOLATION=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -25,10 +26,11 @@ while [[ $# -gt 0 ]]; do
     --repo)  FILTER_REPOS="$2"; shift 2 ;;
     --task)  FILTER_TASKS="$2"; shift 2 ;;
     --dry-run) DRY_RUN=true; shift ;;
+    --verify-isolation) VERIFY_ISOLATION=true; shift ;;
     --budget) MAX_BUDGET_USD="$2"; shift 2 ;;
     --timeout) SESSION_TIMEOUT="$2"; shift 2 ;;
     -h|--help)
-      echo "Usage: run.sh [--tool t1,t2] [--repo r1,r2] [--task t1,t2] [--dry-run] [--budget USD] [--timeout SECS]"
+      echo "Usage: run.sh [--tool t1,t2] [--repo r1,r2] [--task t1,t2] [--dry-run] [--verify-isolation] [--budget USD] [--timeout SECS]"
       echo ""
       echo "Runs the competitive evaluation harness: tool × repo × task."
       echo ""
@@ -37,6 +39,7 @@ while [[ $# -gt 0 ]]; do
       echo "  --repo    Comma-separated repo filter (e.g. sense,discourse)"
       echo "  --task    Comma-separated task filter (e.g. callers,blast-radius)"
       echo "  --dry-run Show what would run without executing Claude sessions"
+      echo "  --verify-isolation Scan existing transcripts for Sense MCP contamination"
       echo "  --budget  Max USD per Claude session (default: $MAX_BUDGET_USD)"
       echo "  --timeout Max seconds per Claude session (default: $SESSION_TIMEOUT)"
       exit 0
@@ -222,6 +225,60 @@ if $DRY_RUN; then
   exit 0
 fi
 
+# --- Verify isolation: scan existing transcripts for Sense MCP contamination ---
+
+if $VERIFY_ISOLATION; then
+  echo ""
+  echo "=== ISOLATION VERIFICATION ==="
+  echo ""
+  contaminated=0
+  checked=0
+  for tool in "${tools[@]}"; do
+    [[ "$tool" == "sense" ]] && continue
+    # Find all transcripts for this tool
+    transcripts=()
+    while IFS= read -r f; do transcripts+=("$f"); done < <(find "$RESULTS_DIR/$tool" -name 'transcript.json' -size +0c 2>/dev/null)
+    if [[ ${#transcripts[@]} -eq 0 ]]; then
+      echo "  $tool: SKIP (no transcripts found)"
+      continue
+    fi
+    checked=$((checked + 1))
+    # Check all transcripts for Sense MCP tool calls and server connections
+    sense_calls=0
+    sense_server=0
+    for transcript in "${transcripts[@]}"; do
+      c=$(grep -c '"mcp__sense__' "$transcript" 2>/dev/null || true)
+      s=$(grep -c '"name":"sense","status"' "$transcript" 2>/dev/null || true)
+      sense_calls=$((sense_calls + c))
+      sense_server=$((sense_server + s))
+    done
+    if [[ "$sense_calls" -gt 0 || "$sense_server" -gt 0 ]]; then
+      detail=""
+      [[ "$sense_calls" -gt 0 ]] && detail="$sense_calls tool calls"
+      [[ "$sense_server" -gt 0 ]] && detail="${detail:+$detail, }sense server in ${#transcripts[@]} transcripts"
+      echo "  $tool: CONTAMINATED ($detail)"
+      contaminated=$((contaminated + 1))
+    else
+      echo "  $tool: CLEAN"
+    fi
+  done
+  echo ""
+  if [[ $checked -eq 0 ]]; then
+    echo "No transcripts found. Run the benchmark first, then verify."
+    exit 1
+  elif [[ $contaminated -gt 0 ]]; then
+    echo "FAIL: $contaminated/$checked non-sense tools have Sense MCP contamination."
+    echo "Re-run the benchmark with isolation fixes applied."
+    exit 1
+  else
+    echo "PASS: $checked non-sense tools verified clean."
+    exit 0
+  fi
+fi
+
+# --- Suppress Sense hook injection for all tools (each tool gets MCP via --mcp-config) ---
+export SENSE_BENCH=1
+
 # --- Main loop: tool → repo (setup once) → tasks ---
 
 run_num=0
@@ -313,6 +370,10 @@ for tool in "${tools[@]}"; do
     index_meta=$(cat "$setup_result_dir/index_meta.json")
     log "  index ready: $index_meta"
 
+    # Hide repo-level config so only workspace config is active during Claude sessions
+    [[ -f "$rp/.mcp.json" ]] && mv "$rp/.mcp.json" "$rp/.mcp.json.bench-hidden"
+    [[ -d "$rp/.claude" ]] && mv "$rp/.claude" "$rp/.claude.bench-hidden"
+
     # Run all tasks for this tool+repo
     claude_md=$(cat "$workspace/CLAUDE.md")
     for task in $(tasks_for_repo "$repo"); do
@@ -403,6 +464,10 @@ print()
         failed=$((failed + 1))
       fi
     done
+
+    # Restore repo-level config
+    [[ -f "$rp/.mcp.json.bench-hidden" ]] && mv "$rp/.mcp.json.bench-hidden" "$rp/.mcp.json"
+    [[ -d "$rp/.claude.bench-hidden" ]] && mv "$rp/.claude.bench-hidden" "$rp/.claude"
 
     # Workspace persists at $RESULTS_DIR/$tool/$repo/.workspace for reuse
   done

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -247,7 +247,7 @@ if $VERIFY_ISOLATION; then
     sense_calls=0
     sense_server=0
     for transcript in "${transcripts[@]}"; do
-      c=$(grep -c '"mcp__sense__' "$transcript" 2>/dev/null || true)
+      c=$(grep -c '"name":"mcp__sense__' "$transcript" 2>/dev/null || true)
       s=$(grep -c '"name":"sense","status"' "$transcript" 2>/dev/null || true)
       sense_calls=$((sense_calls + c))
       sense_server=$((sense_server + s))
@@ -278,6 +278,14 @@ fi
 
 # --- Suppress Sense hook injection for all tools (each tool gets MCP via --mcp-config) ---
 export SENSE_BENCH=1
+
+# Hide bench-root (sense repo) AI config — Claude walks parent dirs and would find it
+BENCH_ROOT="$(cd "$BENCH_DIR/.." && pwd)"
+AI_CONFIG_FILES=(".mcp.json" ".claude" "CLAUDE.md" "AGENT.md" ".cursorrules" ".cursorignore" ".windsurfrules")
+for f in "${AI_CONFIG_FILES[@]}"; do
+  [[ -e "$BENCH_ROOT/$f" ]] && mv "$BENCH_ROOT/$f" "$BENCH_ROOT/$f.bench-hidden"
+done
+trap 'for f in "${AI_CONFIG_FILES[@]}"; do [[ -e "$BENCH_ROOT/$f.bench-hidden" ]] && mv "$BENCH_ROOT/$f.bench-hidden" "$BENCH_ROOT/$f"; done' EXIT
 
 # --- Main loop: tool → repo (setup once) → tasks ---
 
@@ -370,9 +378,10 @@ for tool in "${tools[@]}"; do
     index_meta=$(cat "$setup_result_dir/index_meta.json")
     log "  index ready: $index_meta"
 
-    # Hide repo-level config so only workspace config is active during Claude sessions
-    [[ -f "$rp/.mcp.json" ]] && mv "$rp/.mcp.json" "$rp/.mcp.json.bench-hidden"
-    [[ -d "$rp/.claude" ]] && mv "$rp/.claude" "$rp/.claude.bench-hidden"
+    # Hide repo-level AI config so only workspace config is active during Claude sessions
+    for f in "${AI_CONFIG_FILES[@]}"; do
+      [[ -e "$rp/$f" ]] && mv "$rp/$f" "$rp/$f.bench-hidden"
+    done
 
     # Run all tasks for this tool+repo
     claude_md=$(cat "$workspace/CLAUDE.md")
@@ -465,9 +474,10 @@ print()
       fi
     done
 
-    # Restore repo-level config
-    [[ -f "$rp/.mcp.json.bench-hidden" ]] && mv "$rp/.mcp.json.bench-hidden" "$rp/.mcp.json"
-    [[ -d "$rp/.claude.bench-hidden" ]] && mv "$rp/.claude.bench-hidden" "$rp/.claude"
+    # Restore repo-level AI config
+    for f in "${AI_CONFIG_FILES[@]}"; do
+      [[ -e "$rp/$f.bench-hidden" ]] && mv "$rp/$f.bench-hidden" "$rp/$f"
+    done
 
     # Workspace persists at $RESULTS_DIR/$tool/$repo/.workspace for reuse
   done

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -119,12 +119,19 @@ log() {
 # --- Discover tools and tasks ---
 
 tools=()
-for script in "$TOOLS_DIR"/*.sh; do
-  [[ -f "$script" ]] || continue
-  name="$(basename "$script" .sh)"
-  [[ "$name" == "protocol" ]] && continue
-  matches_filter "$name" "$FILTER_TOOLS" && tools+=("$name")
-done
+if [[ -n "$FILTER_TOOLS" ]]; then
+  # Preserve user-specified order from --tool argument.
+  while IFS= read -r name; do
+    [[ -f "$TOOLS_DIR/$name.sh" ]] && tools+=("$name")
+  done < <(echo "$FILTER_TOOLS" | tr ',' '\n')
+else
+  for script in "$TOOLS_DIR"/*.sh; do
+    [[ -f "$script" ]] || continue
+    name="$(basename "$script" .sh)"
+    [[ "$name" == "protocol" ]] && continue
+    tools+=("$name")
+  done
+fi
 
 tasks=()
 for taskfile in "$TASKS_DIR"/*.yaml; do

--- a/bench/tools/baseline.sh
+++ b/bench/tools/baseline.sh
@@ -16,12 +16,20 @@ check_ready() {
 write_config() {
   local workspace="$2"
 
+  # Clean-room: wipe prior config, write empty hooks to prevent ambient injection
+  rm -rf "$workspace/.claude" "$workspace/CLAUDE.md" "$workspace/.mcp.json"
+  mkdir -p "$workspace/.claude"
+  echo '{"hooks":[]}' > "$workspace/.claude/settings.json"
+
   cat > "$workspace/CLAUDE.md" << 'EOF'
 Use the available MCP tools for codebase understanding when they would help answer the question.
 Do not spawn Explore agents or sub-agents.
 
 No additional tools are configured. Use grep, find, Read, and Bash as needed.
 EOF
+
+  # Empty MCP config — no servers
+  echo '{}' > "$workspace/.mcp.json"
 }
 
 setup() {

--- a/bench/tools/baseline.sh
+++ b/bench/tools/baseline.sh
@@ -29,7 +29,7 @@ No additional tools are configured. Use grep, find, Read, and Bash as needed.
 EOF
 
   # Empty MCP config — no servers
-  echo '{}' > "$workspace/.mcp.json"
+  echo '{"mcpServers":{}}' > "$workspace/.mcp.json"
 }
 
 setup() {

--- a/bench/tools/crg.sh
+++ b/bench/tools/crg.sh
@@ -43,6 +43,11 @@ write_config() {
   local repo_abs
   repo_abs=$(cd "$repo" && pwd)
 
+  # Clean-room: wipe prior config, write empty hooks to prevent ambient injection
+  rm -rf "$workspace/.claude" "$workspace/CLAUDE.md" "$workspace/.mcp.json"
+  mkdir -p "$workspace/.claude"
+  echo '{"hooks":[]}' > "$workspace/.claude/settings.json"
+
   cat > "$workspace/.mcp.json" << EOF
 {
   "mcpServers": {

--- a/bench/tools/grepai.sh
+++ b/bench/tools/grepai.sh
@@ -47,6 +47,11 @@ write_config() {
   local repo_abs
   repo_abs=$(cd "$repo" && pwd)
 
+  # Clean-room: wipe prior config, write empty hooks to prevent ambient injection
+  rm -rf "$workspace/.claude" "$workspace/CLAUDE.md" "$workspace/.mcp.json"
+  mkdir -p "$workspace/.claude"
+  echo '{"hooks":[]}' > "$workspace/.claude/settings.json"
+
   cat > "$workspace/.mcp.json" << EOF
 {
   "mcpServers": {

--- a/bench/tools/roam.sh
+++ b/bench/tools/roam.sh
@@ -41,6 +41,11 @@ write_config() {
   local workspace="$2"
   local venv="$workspace/$VENV_NAME"
 
+  # Clean-room: wipe prior config, write empty hooks to prevent ambient injection
+  rm -rf "$workspace/.claude" "$workspace/CLAUDE.md" "$workspace/.mcp.json"
+  mkdir -p "$workspace/.claude"
+  echo '{"hooks":[]}' > "$workspace/.claude/settings.json"
+
   cat > "$workspace/.mcp.json" << EOF
 {
   "mcpServers": {

--- a/bench/tools/sense.sh
+++ b/bench/tools/sense.sh
@@ -56,6 +56,11 @@ write_config() {
   local repo_abs
   repo_abs=$(cd "$repo" && pwd)
 
+  # Clean-room: wipe prior config, write empty hooks to prevent ambient injection
+  rm -rf "$workspace/.claude" "$workspace/CLAUDE.md" "$workspace/.mcp.json"
+  mkdir -p "$workspace/.claude"
+  echo '{"hooks":[]}' > "$workspace/.claude/settings.json"
+
   cat > "$workspace/.mcp.json" << EOF
 {
   "mcpServers": {

--- a/bench/tools/tokensave.sh
+++ b/bench/tools/tokensave.sh
@@ -34,7 +34,13 @@ check_ready() {
 }
 
 write_config() {
+  local repo="$1"
   local workspace="$2"
+
+  # Clean-room: wipe prior config, write empty hooks to prevent ambient injection
+  rm -rf "$workspace/.claude" "$workspace/CLAUDE.md" "$workspace/.mcp.json"
+  mkdir -p "$workspace/.claude"
+  echo '{"hooks":[]}' > "$workspace/.claude/settings.json"
 
   cat > "$workspace/.mcp.json" << EOF
 {

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -143,12 +143,13 @@ func buildSearchResponse(results []search.Result, pathByID map[int64]string, met
 	for i, r := range results {
 		path := pathByID[r.FileID]
 		entries[i] = mcpio.SearchResultEntry{
-			Symbol:  r.Qualified,
-			File:    path,
-			Line:    r.LineStart,
-			Kind:    r.Kind,
-			Score:   mcpio.SearchScore(r.Score),
-			Snippet: r.Snippet,
+			Symbol:     r.Qualified,
+			File:       path,
+			Line:       r.LineStart,
+			Kind:       r.Kind,
+			Score:      mcpio.SearchScore(r.Score),
+			Snippet:    r.Snippet,
+			References: r.References,
 		}
 		if path != "" {
 			uniqueFiles[path] = struct{}{}

--- a/internal/embed/embedder.go
+++ b/internal/embed/embedder.go
@@ -13,6 +13,7 @@ type EmbedInput struct {
 	Kind          string
 	Snippet       string
 	Context       string
+	FilePath      string
 }
 
 // ModelID identifies the bundled embedding model and format version.
@@ -34,8 +35,8 @@ type Embedder interface {
 // graph-derived Context is available, it forms the primary content
 // with the code Snippet appended. When Context is absent but
 // structural fields exist (Kind, QualifiedName), they provide a
-// minimal identity header. For queries (no Context, no Kind), the
-// raw Snippet is returned as-is.
+// minimal identity header with file path for directory-level signal.
+// For queries (no Context, no Kind), the raw Snippet is returned as-is.
 func FormatContext(in EmbedInput) string {
 	if in.Context != "" {
 		if in.Snippet != "" {
@@ -44,7 +45,11 @@ func FormatContext(in EmbedInput) string {
 		return in.Context
 	}
 	if in.Kind != "" {
-		s := in.Kind + " " + in.QualifiedName
+		var s string
+		if in.FilePath != "" {
+			s = "File: " + in.FilePath + "\n"
+		}
+		s += in.Kind + " " + in.QualifiedName
 		if in.Snippet != "" {
 			s += "\n" + in.Snippet
 		}

--- a/internal/embed/onnx.go
+++ b/internal/embed/onnx.go
@@ -19,11 +19,14 @@ const BatchSize = 50
 // MaxSequenceLength is the maximum token sequence length the model accepts.
 const MaxSequenceLength = 256
 
-// ONNXEmbedder wraps an ONNX Runtime session for all-MiniLM-L6-v2 inference.
+// ONNXEmbedder wraps an ONNX Runtime session for transformer model inference.
 // Not safe for concurrent use.
 type ONNXEmbedder struct {
 	session   *ort.DynamicAdvancedSession
 	tokenizer *tokenizer
+
+	dims   int
+	seqLen int
 
 	// Pre-allocated buffers reused across embedBatch calls.
 	inputIDs      []int64
@@ -31,11 +34,15 @@ type ONNXEmbedder struct {
 	tokenTypeIDs  []int64
 }
 
-// NewONNXEmbedder creates an embedder from model and vocabulary bytes.
-// The caller must have previously called InitORTLibrary.
-// intraOpThreads controls per-session thread parallelism; use 0 for the
-// ONNX Runtime default (all cores).
+// NewONNXEmbedder creates an embedder from model and vocabulary bytes
+// using the bundled model's default dimensions and sequence length.
 func NewONNXEmbedder(modelBytes []byte, vocabBytes []byte, intraOpThreads int) (*ONNXEmbedder, error) {
+	return NewONNXEmbedderWithConfig(modelBytes, vocabBytes, intraOpThreads, Dimensions, MaxSequenceLength)
+}
+
+// NewONNXEmbedderWithConfig creates an embedder with configurable output
+// dimensions and max sequence length.
+func NewONNXEmbedderWithConfig(modelBytes []byte, vocabBytes []byte, intraOpThreads, dims, maxSeqLen int) (*ONNXEmbedder, error) {
 	inputNames := []string{"input_ids", "attention_mask", "token_type_ids"}
 	outputNames := []string{"last_hidden_state"}
 
@@ -63,12 +70,14 @@ func NewONNXEmbedder(modelBytes []byte, vocabBytes []byte, intraOpThreads int) (
 		return nil, fmt.Errorf("create ONNX session: %w", err)
 	}
 
-	tok := newTokenizer(vocabBytes, MaxSequenceLength)
+	tok := newTokenizer(vocabBytes, maxSeqLen)
 
-	bufSize := int64(BatchSize) * int64(MaxSequenceLength)
+	bufSize := int64(BatchSize) * int64(maxSeqLen)
 	return &ONNXEmbedder{
 		session:       session,
 		tokenizer:     tok,
+		dims:          dims,
+		seqLen:        maxSeqLen,
 		inputIDs:      make([]int64, bufSize),
 		attentionMask: make([]int64, bufSize),
 		tokenTypeIDs:  make([]int64, bufSize),
@@ -112,7 +121,8 @@ func (e *ONNXEmbedder) Embed(ctx context.Context, inputs []EmbedInput) ([][]floa
 
 func (e *ONNXEmbedder) embedBatch(batch []EmbedInput) ([][]float32, error) {
 	batchSize := int64(len(batch))
-	seqLen := int64(MaxSequenceLength)
+	seqLen := int64(e.seqLen)
+	dims := e.dims
 	needed := batchSize * seqLen
 
 	// Use pre-allocated buffers, sliced to actual batch size.
@@ -155,7 +165,7 @@ func (e *ONNXEmbedder) embedBatch(batch []EmbedInput) ([][]float32, error) {
 	}
 	defer func() { _ = tokenTypeIDsTensor.Destroy() }()
 
-	outputTensor, err := ort.NewEmptyTensor[float32](ort.Shape{batchSize, seqLen, int64(Dimensions)})
+	outputTensor, err := ort.NewEmptyTensor[float32](ort.Shape{batchSize, seqLen, int64(dims)})
 	if err != nil {
 		return nil, fmt.Errorf("create output tensor: %w", err)
 	}
@@ -174,7 +184,7 @@ func (e *ONNXEmbedder) embedBatch(batch []EmbedInput) ([][]float32, error) {
 	results := make([][]float32, batchSize)
 
 	for i := int64(0); i < batchSize; i++ {
-		vec := make([]float32, Dimensions)
+		vec := make([]float32, dims)
 		var tokenCount float32
 
 		for j := int64(0); j < seqLen; j++ {
@@ -182,8 +192,8 @@ func (e *ONNXEmbedder) embedBatch(batch []EmbedInput) ([][]float32, error) {
 				continue
 			}
 			tokenCount++
-			baseIdx := i*seqLen*int64(Dimensions) + j*int64(Dimensions)
-			for k := 0; k < Dimensions; k++ {
+			baseIdx := i*seqLen*int64(dims) + j*int64(dims)
+			for k := 0; k < dims; k++ {
 				vec[k] += output[baseIdx+int64(k)]
 			}
 		}

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -24,6 +24,11 @@ const staleThreshold = 24 * time.Hour
 // Run dispatches to the named hook handler. It returns an exit code
 // (always 0 — hooks must not fail the host tool).
 func Run(name string, dir string, stdin io.Reader, stdout io.Writer) int {
+	if os.Getenv("SENSE_BENCH") != "" {
+		writeEmpty(stdout)
+		return 0
+	}
+
 	switch name {
 	case "pre-tool-use":
 		silentRun(dir, stdin, stdout, handlePreToolUse)

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -53,6 +53,23 @@ func staleDir(t *testing.T) string {
 	return dir
 }
 
+func TestRunSenseBenchSuppressesAllHooks(t *testing.T) {
+	dir := indexedDir(t)
+	t.Setenv("SENSE_BENCH", "1")
+
+	hooks := []string{"session-start", "pre-tool-use", "subagent-start", "pre-compact", "post-tool-use"}
+	for _, hook := range hooks {
+		var buf bytes.Buffer
+		code := Run(hook, dir, strings.NewReader(`{"tool_name":"Grep","tool_input":{"pattern":"UserService"}}`), &buf)
+		if code != 0 {
+			t.Errorf("%s: exit code = %d, want 0", hook, code)
+		}
+		if buf.String() != "{}\n" {
+			t.Errorf("%s: output = %q, want {} (SENSE_BENCH should suppress)", hook, buf.String())
+		}
+	}
+}
+
 func TestRunUnknownHook(t *testing.T) {
 	var buf bytes.Buffer
 	code := Run("nonexistent", ".", strings.NewReader("{}"), &buf)

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -393,12 +393,13 @@ type FusionWeights struct {
 
 // SearchResultEntry is a single search hit in the wire response.
 type SearchResultEntry struct {
-	Symbol  string      `json:"symbol"`
-	File    string      `json:"file"`
-	Line    int         `json:"line"`
-	Kind    string      `json:"kind"`
-	Score   SearchScore `json:"score"`
-	Snippet string      `json:"snippet"`
+	Symbol     string      `json:"symbol"`
+	File       string      `json:"file"`
+	Line       int         `json:"line"`
+	Kind       string      `json:"kind"`
+	Score      SearchScore `json:"score"`
+	Snippet    string      `json:"snippet"`
+	References int         `json:"references,omitempty"`
 }
 
 // SearchScore is a fused relevance score. It renders with two decimal

--- a/internal/scan/embed.go
+++ b/internal/scan/embed.go
@@ -18,7 +18,134 @@ import (
 	"github.com/luuuc/sense/internal/sqlite"
 )
 
-const maxEmbedWorkers = 8
+const maxEmbedWorkers = 4
+
+const embedChunkSize = 512
+
+type embedPool struct {
+	embedders []*embed.ONNXEmbedder
+	workers   int
+}
+
+func newEmbedPool() (*embedPool, error) {
+	ncpu := runtime.NumCPU()
+	workers := ncpu / 2
+	if workers < 2 {
+		workers = 2
+	}
+	if workers > maxEmbedWorkers {
+		workers = maxEmbedWorkers
+	}
+
+	threadsPerWorker := ncpu / workers
+	if threadsPerWorker < 1 {
+		threadsPerWorker = 1
+	}
+
+	embedders := make([]*embed.ONNXEmbedder, workers)
+	for i := range embedders {
+		emb, err := embed.NewBundledEmbedder(threadsPerWorker)
+		if err != nil {
+			for j := 0; j < i; j++ {
+				_ = embedders[j].Close()
+			}
+			return nil, fmt.Errorf("create embedder %d: %w", i, err)
+		}
+		embedders[i] = emb
+	}
+	return &embedPool{embedders: embedders, workers: workers}, nil
+}
+
+func (p *embedPool) embed(ctx context.Context, inputs []embed.EmbedInput) ([][]float32, error) {
+	if len(inputs) == 0 {
+		return nil, nil
+	}
+
+	batches := (len(inputs) + embed.BatchSize - 1) / embed.BatchSize
+	workers := p.workers
+	if workers > batches {
+		workers = batches
+	}
+	if workers <= 1 {
+		return p.embedders[0].Embed(ctx, inputs)
+	}
+
+	chunkSize := (len(inputs) + workers - 1) / workers
+	type result struct {
+		vecs [][]float32
+		err  error
+	}
+	results := make([]result, workers)
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		start := w * chunkSize
+		if start >= len(inputs) {
+			break
+		}
+		end := start + chunkSize
+		if end > len(inputs) {
+			end = len(inputs)
+		}
+		wg.Add(1)
+		go func(idx int, chunk []embed.EmbedInput) {
+			defer wg.Done()
+			vecs, err := p.embedders[idx].Embed(ctx, chunk)
+			if err != nil {
+				results[idx] = result{err: err}
+				cancel()
+				return
+			}
+			results[idx] = result{vecs: vecs}
+		}(w, inputs[start:end])
+	}
+	wg.Wait()
+
+	all := make([][]float32, 0, len(inputs))
+	for _, r := range results {
+		if r.err != nil {
+			return nil, r.err
+		}
+		all = append(all, r.vecs...)
+	}
+	return all, nil
+}
+
+func (p *embedPool) Close() error {
+	var first error
+	for _, emb := range p.embedders {
+		if err := emb.Close(); err != nil && first == nil {
+			first = err
+		}
+	}
+	return first
+}
+
+// migrateEmbeddingModel checks whether the stored embedding model
+// matches the current binary's model. If they differ, it clears all
+// embeddings and removes the HNSW index so everything gets
+// re-embedded with the new model. Returns true if a migration occurred.
+func (h *harness) migrateEmbeddingModel(senseDir string) (bool, error) {
+	stored, err := h.idx.ReadMeta(h.ctx, "embedding_model")
+	if err != nil {
+		return false, fmt.Errorf("read embedding model: %w", err)
+	}
+	if stored == "" || stored == embed.ModelID {
+		return false, nil
+	}
+
+	if err := h.idx.ClearEmbeddings(h.ctx); err != nil {
+		return false, fmt.Errorf("clear embeddings: %w", err)
+	}
+	if err := h.idx.DeleteMeta(h.ctx, "embedding_model"); err != nil {
+		return false, fmt.Errorf("delete embedding model meta: %w", err)
+	}
+	_ = os.Remove(filepath.Join(senseDir, "hnsw.bin"))
+	return true, nil
+}
 
 // EmbedPending generates embeddings for all symbols that lack them and
 // rebuilds the HNSW index. Designed for the MCP server's background
@@ -37,6 +164,12 @@ func EmbedPending(ctx context.Context, idx *sqlite.Adapter, root, senseDir strin
 	h.extendMethodSnippets(syms)
 	contextMap := h.buildContextMap(syms)
 
+	fileIDs := uniqueFileIDs(syms)
+	paths, pathErr := idx.FilePathsByIDs(ctx, fileIDs)
+	if pathErr != nil {
+		_, _ = fmt.Fprintf(h.warn, "warn: resolve file paths for embeddings: %v\n", pathErr)
+	}
+
 	inputs := make([]embed.EmbedInput, len(syms))
 	for i, s := range syms {
 		inputs[i] = embed.EmbedInput{
@@ -44,50 +177,70 @@ func EmbedPending(ctx context.Context, idx *sqlite.Adapter, root, senseDir strin
 			Kind:          s.Kind,
 			Snippet:       s.Snippet,
 			Context:       contextMap[s.ID],
+			FilePath:      paths[s.FileID],
 		}
 	}
 
-	vecs, err := parallelEmbed(ctx, inputs)
+	pool, err := newEmbedPool()
 	if err != nil {
-		return 0, fmt.Errorf("generate embeddings: %w", err)
+		return 0, fmt.Errorf("create embed pool: %w", err)
 	}
+	defer func() { _ = pool.Close() }()
 
-	err = idx.InTx(ctx, func() error {
-		stmt, err := idx.PrepareEmbeddingStmt(ctx)
+	var total int
+	for i := 0; i < len(inputs); i += embedChunkSize {
+		end := i + embedChunkSize
+		if end > len(inputs) {
+			end = len(inputs)
+		}
+
+		vecs, err := pool.embed(ctx, inputs[i:end])
 		if err != nil {
-			return err
+			return total, fmt.Errorf("generate embeddings: %w", err)
 		}
-		defer func() { _ = stmt.Close() }()
-		for i, vec := range vecs {
-			blob := vectorToBlob(vec)
-			if _, err := stmt.ExecContext(ctx, syms[i].ID, blob); err != nil {
-				return fmt.Errorf("write embedding symbol=%d: %w", syms[i].ID, err)
+
+		chunkSyms := syms[i:end]
+		err = idx.InTx(ctx, func() error {
+			stmt, err := idx.PrepareEmbeddingStmt(ctx)
+			if err != nil {
+				return err
 			}
+			defer func() { _ = stmt.Close() }()
+			for j, vec := range vecs {
+				blob := vectorToBlob(vec)
+				if _, err := stmt.ExecContext(ctx, chunkSyms[j].ID, blob); err != nil {
+					return fmt.Errorf("write embedding symbol=%d: %w", chunkSyms[j].ID, err)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return total, fmt.Errorf("write embeddings: %w", err)
 		}
+		total += len(vecs)
+	}
+
+	if total > 0 {
 		if err := idx.WriteMeta(ctx, "embedding_model", embed.ModelID); err != nil {
-			return fmt.Errorf("write embedding model meta: %w", err)
+			return total, fmt.Errorf("write embedding model meta: %w", err)
 		}
-		return nil
-	})
-	if err != nil {
-		return 0, fmt.Errorf("write embeddings: %w", err)
 	}
 
 	hnswPath := filepath.Join(senseDir, "hnsw.bin")
 	embeddings, err := idx.LoadEmbeddings(ctx)
 	if err != nil {
-		return len(vecs), fmt.Errorf("load embeddings for hnsw: %w", err)
+		return total, fmt.Errorf("load embeddings for hnsw: %w", err)
 	}
 	if len(embeddings) > 0 {
 		if err := search.SaveHNSWIndex(hnswPath, embeddings); err != nil {
-			return len(vecs), fmt.Errorf("save hnsw index: %w", err)
+			return total, fmt.Errorf("save hnsw index: %w", err)
 		}
 	}
 
 	if err := idx.DeleteMeta(ctx, "embedding_watermark"); err != nil {
-		return len(vecs), fmt.Errorf("clear embedding watermark: %w", err)
+		return total, fmt.Errorf("clear embedding watermark: %w", err)
 	}
-	return len(vecs), nil
+	return total, nil
 }
 
 // embedSymbols is pass 3: generate embeddings for symbols in changed files.
@@ -109,6 +262,12 @@ func (h *harness) embedSymbols() error {
 	h.extendMethodSnippets(syms)
 	contextMap := h.buildContextMap(syms)
 
+	fileIDs := uniqueFileIDs(syms)
+	paths, pathErr := h.idx.FilePathsByIDs(h.ctx, fileIDs)
+	if pathErr != nil {
+		_, _ = fmt.Fprintf(h.warn, "warn: resolve file paths for embeddings: %v\n", pathErr)
+	}
+
 	inputs := make([]embed.EmbedInput, len(syms))
 	for i, s := range syms {
 		inputs[i] = embed.EmbedInput{
@@ -116,36 +275,54 @@ func (h *harness) embedSymbols() error {
 			Kind:          s.Kind,
 			Snippet:       s.Snippet,
 			Context:       contextMap[s.ID],
+			FilePath:      paths[s.FileID],
 		}
 	}
 
-	vecs, err := parallelEmbed(h.ctx, inputs)
+	pool, err := newEmbedPool()
 	if err != nil {
-		return fmt.Errorf("generate embeddings: %w", err)
+		return fmt.Errorf("create embed pool: %w", err)
+	}
+	defer func() { _ = pool.Close() }()
+
+	for i := 0; i < len(inputs); i += embedChunkSize {
+		end := i + embedChunkSize
+		if end > len(inputs) {
+			end = len(inputs)
+		}
+
+		vecs, err := pool.embed(h.ctx, inputs[i:end])
+		if err != nil {
+			return fmt.Errorf("generate embeddings: %w", err)
+		}
+
+		chunkSyms := syms[i:end]
+		err = h.idx.InTx(h.ctx, func() error {
+			stmt, err := h.idx.PrepareEmbeddingStmt(h.ctx)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = stmt.Close() }()
+			for j, vec := range vecs {
+				blob := vectorToBlob(vec)
+				if _, err := stmt.ExecContext(h.ctx, chunkSyms[j].ID, blob); err != nil {
+					return fmt.Errorf("write embedding symbol=%d: %w", chunkSyms[j].ID, err)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("write embeddings: %w", err)
+		}
+		h.embedded += len(vecs)
 	}
 
-	err = h.idx.InTx(h.ctx, func() error {
-		stmt, err := h.idx.PrepareEmbeddingStmt(h.ctx)
-		if err != nil {
-			return err
-		}
-		defer func() { _ = stmt.Close() }()
-		for i, vec := range vecs {
-			blob := vectorToBlob(vec)
-			if _, err := stmt.ExecContext(h.ctx, syms[i].ID, blob); err != nil {
-				return fmt.Errorf("write embedding symbol=%d: %w", syms[i].ID, err)
-			}
-		}
+	if h.embedded > 0 {
 		if err := h.idx.WriteMeta(h.ctx, "embedding_model", embed.ModelID); err != nil {
 			return fmt.Errorf("write embedding model meta: %w", err)
 		}
-		return nil
-	})
-	if err != nil {
-		return fmt.Errorf("write embeddings: %w", err)
 	}
 
-	h.embedded = len(vecs)
 	return nil
 }
 
@@ -207,92 +384,16 @@ func (h *harness) tryIncrementalHNSW(path string) (bool, error) {
 	return true, nil
 }
 
-// parallelEmbed fans inputs across multiple ONNXEmbedder instances to
-// saturate available CPU cores. Each embedder owns an independent ONNX
-// session and pre-allocated buffers — no shared mutable state.
-func parallelEmbed(ctx context.Context, inputs []embed.EmbedInput) ([][]float32, error) {
-	batches := (len(inputs) + embed.BatchSize - 1) / embed.BatchSize
-	ncpu := runtime.NumCPU()
-	workers := ncpu
-	if workers > batches {
-		workers = batches
-	}
-	if workers > maxEmbedWorkers {
-		workers = maxEmbedWorkers
-	}
-	if workers <= 1 {
-		emb, err := embed.NewBundledEmbedder(0)
-		if err != nil {
-			return nil, err
+func uniqueFileIDs(syms []sqlite.EmbedSymbol) []int64 {
+	seen := make(map[int64]bool, len(syms))
+	ids := make([]int64, 0, len(syms))
+	for _, s := range syms {
+		if !seen[s.FileID] {
+			seen[s.FileID] = true
+			ids = append(ids, s.FileID)
 		}
-		defer func() { _ = emb.Close() }()
-		return emb.Embed(ctx, inputs)
 	}
-
-	threadsPerWorker := ncpu / workers
-	if threadsPerWorker < 1 {
-		threadsPerWorker = 1
-	}
-
-	embedders := make([]*embed.ONNXEmbedder, workers)
-	for i := range embedders {
-		emb, err := embed.NewBundledEmbedder(threadsPerWorker)
-		if err != nil {
-			for j := 0; j < i; j++ {
-				_ = embedders[j].Close()
-			}
-			return nil, fmt.Errorf("create embedder %d: %w", i, err)
-		}
-		embedders[i] = emb
-	}
-	defer func() {
-		for _, emb := range embedders {
-			_ = emb.Close()
-		}
-	}()
-
-	chunkSize := (len(inputs) + workers - 1) / workers
-	type result struct {
-		vecs [][]float32
-		err  error
-	}
-	results := make([]result, workers)
-
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	var wg sync.WaitGroup
-	for w := 0; w < workers; w++ {
-		start := w * chunkSize
-		if start >= len(inputs) {
-			break
-		}
-		end := start + chunkSize
-		if end > len(inputs) {
-			end = len(inputs)
-		}
-		wg.Add(1)
-		go func(idx int, chunk []embed.EmbedInput) {
-			defer wg.Done()
-			vecs, err := embedders[idx].Embed(ctx, chunk)
-			if err != nil {
-				results[idx] = result{err: err}
-				cancel()
-				return
-			}
-			results[idx] = result{vecs: vecs}
-		}(w, inputs[start:end])
-	}
-	wg.Wait()
-
-	all := make([][]float32, 0, len(inputs))
-	for _, r := range results {
-		if r.err != nil {
-			return nil, r.err
-		}
-		all = append(all, r.vecs...)
-	}
-	return all, nil
+	return ids
 }
 
 // buildContextMap calls ContextForFile for each unique file among the

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -31,6 +31,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/luuuc/sense/internal/config"
+	"github.com/luuuc/sense/internal/embed"
 	"github.com/luuuc/sense/internal/extract"
 	_ "github.com/luuuc/sense/internal/extract/languages" // register every extractor
 	"github.com/luuuc/sense/internal/ignore"
@@ -217,6 +218,16 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	}
 	phases.Temporal = time.Since(t0)
 
+	var modelMigrated bool
+	if opts.EmbeddingsEnabled {
+		if changed, merr := h.migrateEmbeddingModel(senseDir); merr != nil {
+			_, _ = fmt.Fprintf(warn, "warn: embedding model migration: %v\n", merr)
+		} else if changed {
+			modelMigrated = true
+			_, _ = fmt.Fprintf(out, "embedding model changed to %s — re-embedding all symbols\n", embed.ModelID)
+		}
+	}
+
 	if opts.EmbeddingsEnabled && opts.Embed {
 		t0 = time.Now()
 		if err := h.embedSymbols(); err != nil {
@@ -246,7 +257,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	}
 
 	var embeddingDebt int
-	if opts.EmbeddingsEnabled && !opts.Embed && h.changed > 0 {
+	if opts.EmbeddingsEnabled && !opts.Embed && (h.changed > 0 || modelMigrated) {
 		ts := time.Now().UTC().Format(time.RFC3339)
 		if err := idx.WriteMeta(ctx, "embedding_watermark", ts); err != nil {
 			_, _ = fmt.Fprintf(warn, "warn: write embedding watermark: %v\n", err)

--- a/internal/search/expand.go
+++ b/internal/search/expand.go
@@ -1,0 +1,125 @@
+package search
+
+import (
+	"strings"
+	"unicode"
+)
+
+const maxSubQueries = 3
+
+// expandQuery decomposes a query into up to 3 sub-queries for multi-angle
+// search. Returns at least the original query.
+func expandQuery(query string) []string {
+	queries := []string{query}
+
+	// Sub-query 2: split identifiers into constituent words.
+	// "HandleHTTPRequest" → "handle http request"
+	// "user_auth_token" → "user auth token"
+	identTokens := splitIdentifiers(query)
+	if identTokens != "" && identTokens != strings.ToLower(query) {
+		queries = append(queries, identTokens)
+	}
+
+	// Sub-query 3: for long queries (4+ words), take first 3 words.
+	words := strings.Fields(query)
+	if len(words) >= 4 {
+		short := strings.Join(words[:3], " ")
+		if short != query && short != identTokens {
+			queries = append(queries, short)
+		}
+	}
+
+	if len(queries) > maxSubQueries {
+		queries = queries[:maxSubQueries]
+	}
+	return queries
+}
+
+// splitIdentifiers extracts words from camelCase, PascalCase, and
+// snake_case tokens in the query, returning them as a lowercase
+// space-separated string.
+func splitIdentifiers(query string) string {
+	var words []string
+	for _, token := range strings.Fields(query) {
+		words = append(words, splitToken(token)...)
+	}
+	if len(words) == 0 {
+		return ""
+	}
+	return strings.Join(words, " ")
+}
+
+// splitToken breaks a single token by camelCase boundaries and underscores.
+func splitToken(s string) []string {
+	// First split on underscores/hyphens.
+	parts := strings.FieldsFunc(s, func(r rune) bool {
+		return r == '_' || r == '-' || r == '.'
+	})
+
+	var words []string
+	for _, part := range parts {
+		words = append(words, splitCamelCase(part)...)
+	}
+	return words
+}
+
+// splitCamelCase splits "HandleHTTPRequest" → ["handle", "http", "request"].
+func splitCamelCase(s string) []string {
+	if s == "" {
+		return nil
+	}
+
+	var words []string
+	runes := []rune(s)
+	start := 0
+
+	for i := 1; i < len(runes); i++ {
+		// Split before an uppercase letter following a lowercase letter:
+		// "handleRequest" → split before 'R'
+		if unicode.IsUpper(runes[i]) && unicode.IsLower(runes[i-1]) {
+			words = append(words, strings.ToLower(string(runes[start:i])))
+			start = i
+			continue
+		}
+		// Split before the last uppercase in an acronym run:
+		// "HTTPRequest" → split before 'R' (keeping "HTTP" together then "Request")
+		if i+1 < len(runes) && unicode.IsUpper(runes[i]) && unicode.IsUpper(runes[i-1]) && unicode.IsLower(runes[i+1]) {
+			words = append(words, strings.ToLower(string(runes[start:i])))
+			start = i
+			continue
+		}
+	}
+
+	if start < len(runes) {
+		words = append(words, strings.ToLower(string(runes[start:])))
+	}
+	return words
+}
+
+// mergeMultiQuery merges per-query result lists using RRF. Symbols that
+// appear in multiple sub-query results get boosted.
+func mergeMultiQuery(queryResults [][]Result) []Result {
+	type entry struct {
+		result Result
+		score  float64
+	}
+	merged := make(map[int64]*entry)
+
+	for _, results := range queryResults {
+		for rank, r := range results {
+			rrfScore := 1.0 / float64(rrfK+rank+1)
+			if e, ok := merged[r.SymbolID]; ok {
+				e.score += rrfScore
+			} else {
+				merged[r.SymbolID] = &entry{result: r, score: rrfScore}
+			}
+		}
+	}
+
+	out := make([]Result, 0, len(merged))
+	for _, e := range merged {
+		e.result.Score = e.score
+		out = append(out, e.result)
+	}
+	return out
+}

--- a/internal/search/expand_test.go
+++ b/internal/search/expand_test.go
@@ -1,0 +1,94 @@
+package search
+
+import (
+	"testing"
+)
+
+func TestExpandQuerySingleWord(t *testing.T) {
+	got := expandQuery("payment")
+	if len(got) != 1 || got[0] != "payment" {
+		t.Errorf("expandQuery(\"payment\") = %v, want [\"payment\"]", got)
+	}
+}
+
+func TestExpandQueryCamelCase(t *testing.T) {
+	got := expandQuery("HandleHTTPRequest")
+	if len(got) < 2 {
+		t.Fatalf("expandQuery(\"HandleHTTPRequest\") = %v, want at least 2 sub-queries", got)
+	}
+	if got[0] != "HandleHTTPRequest" {
+		t.Errorf("first sub-query = %q, want original", got[0])
+	}
+	if got[1] != "handle http request" {
+		t.Errorf("second sub-query = %q, want \"handle http request\"", got[1])
+	}
+}
+
+func TestExpandQuerySnakeCase(t *testing.T) {
+	got := expandQuery("user_auth_token")
+	if len(got) < 2 {
+		t.Fatalf("expandQuery(\"user_auth_token\") = %v, want at least 2 sub-queries", got)
+	}
+	if got[1] != "user auth token" {
+		t.Errorf("second sub-query = %q, want \"user auth token\"", got[1])
+	}
+}
+
+func TestExpandQueryLongPhrase(t *testing.T) {
+	got := expandQuery("HTTP request routing middleware handler")
+	if len(got) < 2 {
+		t.Fatalf("got %v, want at least 2", got)
+	}
+	// Should have short variant (first 3 words)
+	found := false
+	for _, q := range got {
+		if q == "HTTP request routing" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected short variant \"HTTP request routing\" in %v", got)
+	}
+}
+
+func TestExpandQueryCapsAt3(t *testing.T) {
+	// A query that could produce 4+ expansions should be capped.
+	got := expandQuery("ProcessHTTPPaymentRequest handler code logic")
+	if len(got) > 3 {
+		t.Errorf("expandQuery produced %d sub-queries, want <= 3", len(got))
+	}
+}
+
+func TestExpandQueryAlreadyLowercase(t *testing.T) {
+	// If splitting produces the same string, don't duplicate.
+	got := expandQuery("payment")
+	if len(got) != 1 {
+		t.Errorf("expandQuery(\"payment\") = %v, want 1 sub-query (no duplicate)", got)
+	}
+}
+
+func TestSplitCamelCase(t *testing.T) {
+	tests := []struct {
+		input string
+		want  []string
+	}{
+		{"ServeHTTP", []string{"serve", "http"}},
+		{"HandleRequest", []string{"handle", "request"}},
+		{"HTTPRequest", []string{"http", "request"}},
+		{"simple", []string{"simple"}},
+		{"URL", []string{"url"}},
+		{"getURLParser", []string{"get", "url", "parser"}},
+	}
+	for _, tt := range tests {
+		got := splitCamelCase(tt.input)
+		if len(got) != len(tt.want) {
+			t.Errorf("splitCamelCase(%q) = %v, want %v", tt.input, got, tt.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tt.want[i] {
+				t.Errorf("splitCamelCase(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
+			}
+		}
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -15,14 +15,15 @@ import (
 
 // Result is a single fused search hit with metadata from both backends.
 type Result struct {
-	SymbolID  int64
-	Name      string
-	Qualified string
-	Kind      string
-	FileID    int64
-	LineStart int
-	Snippet   string
-	Score     float64
+	SymbolID   int64
+	Name       string
+	Qualified  string
+	Kind       string
+	FileID     int64
+	LineStart  int
+	Snippet    string
+	Score      float64
+	References int
 }
 
 // Options controls search behavior.
@@ -96,52 +97,82 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, SearchMeta
 		candidateLimit = 50
 	}
 
-	var keywordResults []sqlite.SearchResult
-	var vectorResults []VectorResult
-
 	e.mu.RLock()
 	vectors := e.vectors
 	e.mu.RUnlock()
 
 	canVector := vectors != nil && vectors.Len() > 0 && e.embedder != nil
 
+	queries := expandQuery(opts.Query)
+
+	// Batch-embed all sub-queries in one call when in hybrid mode.
+	var queryVecs [][]float32
 	if canVector {
-		g, gctx := errgroup.WithContext(ctx)
-
-		g.Go(func() error {
-			var err error
-			keywordResults, err = e.adapter.KeywordSearch(gctx, opts.Query, opts.Language, candidateLimit)
-			return err
-		})
-
-		g.Go(func() error {
-			queryVec, err := EmbedQuery(gctx, e.embedder, opts.Query)
-			if err != nil {
-				return err
-			}
-			vectorResults = vectors.Search(queryVec, candidateLimit)
-			return nil
-		})
-
-		if err := g.Wait(); err != nil {
-			return nil, SearchMeta{}, fmt.Errorf("search: %w", err)
+		inputs := make([]embed.EmbedInput, len(queries))
+		for i, q := range queries {
+			inputs[i] = embed.EmbedInput{Snippet: q}
 		}
-	} else {
-		keywordResults, err = e.adapter.KeywordSearch(ctx, opts.Query, opts.Language, candidateLimit)
+		queryVecs, err = e.embedder.Embed(ctx, inputs)
 		if err != nil {
-			return nil, SearchMeta{}, fmt.Errorf("search: %w", err)
+			return nil, SearchMeta{}, fmt.Errorf("search embed: %w", err)
 		}
 	}
 
-	vecConfidence := vectorConfidence(vectorResults)
-	kwWeight, vecWeight := fusionWeights(vecConfidence)
+	// Run each sub-query through keyword+vector pipeline and fuse per-query.
+	var kwWeight, vecWeight float64
+	queryResults := make([][]Result, len(queries))
+	for i, q := range queries {
+		var kwResults []sqlite.SearchResult
+		var vecResults []VectorResult
 
-	if opts.KeywordBias > 0 && vecWeight > 0 {
-		kwWeight = math.Min(1.0, kwWeight+opts.KeywordBias)
-		vecWeight = math.Max(0.0, 1.0-kwWeight)
+		if canVector {
+			g, gctx := errgroup.WithContext(ctx)
+			g.Go(func() error {
+				var err error
+				kwResults, err = e.adapter.KeywordSearch(gctx, q, opts.Language, candidateLimit)
+				return err
+			})
+			qVec := queryVecs[i]
+			g.Go(func() error {
+				vecResults = vectors.Search(qVec, candidateLimit)
+				return nil
+			})
+			if err := g.Wait(); err != nil {
+				return nil, SearchMeta{}, fmt.Errorf("search: %w", err)
+			}
+		} else {
+			kwResults, err = e.adapter.KeywordSearch(ctx, q, opts.Language, candidateLimit)
+			if err != nil {
+				return nil, SearchMeta{}, fmt.Errorf("search: %w", err)
+			}
+		}
+
+		qKwWeight, qVecWeight := 1.0, 0.0
+		if canVector {
+			vecConf := vectorConfidence(vecResults)
+			qKwWeight, qVecWeight = fusionWeights(vecConf)
+		}
+
+		// Report primary query's weights in metadata.
+		if i == 0 {
+			kwWeight, vecWeight = qKwWeight, qVecWeight
+			if opts.KeywordBias > 0 && vecWeight > 0 {
+				kwWeight = math.Min(1.0, kwWeight+opts.KeywordBias)
+				vecWeight = math.Max(0.0, 1.0-kwWeight)
+				qKwWeight, qVecWeight = kwWeight, vecWeight
+			}
+		}
+
+		queryResults[i] = fuseRRF(kwResults, vecResults, qKwWeight, qVecWeight)
 	}
 
-	fused := fuseRRF(keywordResults, vectorResults, kwWeight, vecWeight)
+	// Merge multi-query results with RRF.
+	var fused []Result
+	if len(queryResults) == 1 {
+		fused = queryResults[0]
+	} else {
+		fused = mergeMultiQuery(queryResults)
+	}
 
 	// Hydrate metadata for vector-only results that have no name/qualified.
 	if err := e.hydrateResults(ctx, fused); err != nil {
@@ -182,6 +213,12 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, SearchMeta
 		return fused[i].Score > fused[j].Score
 	})
 
+	// Graph-augmented enrichment: boost callees of top results.
+	fused, err = e.enrichFromGraph(ctx, fused)
+	if err != nil {
+		return nil, SearchMeta{}, fmt.Errorf("search enrich: %w", err)
+	}
+
 	// Apply min_score filter and limit.
 	var results []Result
 	for _, r := range fused {
@@ -215,7 +252,8 @@ const (
 
 // fusionWeights returns keyword and vector weights for reciprocal rank
 // fusion based on vector confidence. High confidence → equal weight;
-// low confidence → keyword-biased; very low → keyword-only.
+// low confidence → keyword-biased; very low → keyword-heavy but vectors
+// still contribute (floor of 0.2).
 func fusionWeights(vecConfidence float64) (keyword, vector float64) {
 	switch {
 	case vecConfidence >= confidenceHighThreshold:
@@ -223,7 +261,7 @@ func fusionWeights(vecConfidence float64) (keyword, vector float64) {
 	case vecConfidence >= confidenceLowThreshold:
 		return 0.7, 0.3
 	default:
-		return 1.0, 0.0
+		return 0.8, 0.2
 	}
 }
 
@@ -461,15 +499,101 @@ func vectorConfidence(results []VectorResult) float64 {
 
 // applyGraphCentrality boosts scores by graph importance. Symbols with
 // more inbound edges (callers, inheritors, testers) are hub nodes and
-// rank higher. The boost is additive and scaled to not overwhelm the
-// RRF scores: boost = log2(1 + inbound_count) * 0.001.
+// rank higher. The boost is additive and log-scaled:
+// boost = log2(1 + inbound_count) * 0.01.
 func applyGraphCentrality(results []Result, centrality map[int64]int) {
 	if len(centrality) == 0 {
 		return
 	}
 	for i := range results {
 		if count, ok := centrality[results[i].SymbolID]; ok && count > 0 {
-			results[i].Score += math.Log2(1+float64(count)) * 0.001
+			results[i].Score += math.Log2(1+float64(count)) * 0.01
+			results[i].References = count
 		}
 	}
+}
+
+const (
+	enrichTopN     = 3
+	enrichBoost    = 0.15
+	enrichBaseScore = 0.05
+)
+
+// enrichFromGraph boosts callees of the top-N results that appear in the
+// candidate set, and injects missing callees as low-score suggestions.
+// Results must be sorted by score descending before calling.
+func (e *Engine) enrichFromGraph(ctx context.Context, results []Result) ([]Result, error) {
+	if len(results) == 0 {
+		return results, nil
+	}
+
+	// Take top-N symbol IDs.
+	n := enrichTopN
+	if n > len(results) {
+		n = len(results)
+	}
+	topIDs := make([]int64, n)
+	for i := range n {
+		topIDs[i] = results[i].SymbolID
+	}
+
+	// Fetch 1-hop callees.
+	calleeMap, err := e.adapter.CalleeIDs(ctx, topIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Collect all callee IDs.
+	calleeSet := map[int64]struct{}{}
+	for _, targets := range calleeMap {
+		for _, id := range targets {
+			calleeSet[id] = struct{}{}
+		}
+	}
+	if len(calleeSet) == 0 {
+		return results, nil
+	}
+
+	// Build index of existing results for fast lookup.
+	existing := make(map[int64]int, len(results))
+	for i, r := range results {
+		existing[r.SymbolID] = i
+	}
+
+	// Boost existing candidates that are callees of top results.
+	var missingIDs []int64
+	for id := range calleeSet {
+		if idx, ok := existing[id]; ok {
+			results[idx].Score += enrichBoost
+		} else {
+			missingIDs = append(missingIDs, id)
+		}
+	}
+
+	// Inject missing callees as graph-suggested results.
+	if len(missingIDs) > 0 {
+		syms, err := e.adapter.SymbolsByIDs(ctx, missingIDs)
+		if err != nil {
+			return nil, err
+		}
+		for _, sym := range syms {
+			results = append(results, Result{
+				SymbolID:  sym.SymbolID,
+				Name:      sym.Name,
+				Qualified: sym.Qualified,
+				Kind:      sym.Kind,
+				FileID:    sym.FileID,
+				LineStart:  sym.LineStart,
+				Snippet:   sym.Snippet,
+				Score:     enrichBaseScore,
+			})
+		}
+	}
+
+	// Re-sort after boosting and injection.
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Score > results[j].Score
+	})
+
+	return results, nil
 }

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -666,7 +666,24 @@ func TestFusionWeightsHybrid(t *testing.T) {
 	}
 }
 
-func TestLowConfidenceExcludesVectorOnlySymbols(t *testing.T) {
+// lowConfidenceEmbedder returns vectors orthogonal to all indexed symbols,
+// ensuring cosine similarity is near zero and triggering the weight floor.
+type lowConfidenceEmbedder struct{}
+
+func (l *lowConfidenceEmbedder) Embed(_ context.Context, inputs []embed.EmbedInput) ([][]float32, error) {
+	vecs := make([][]float32, len(inputs))
+	for i := range inputs {
+		vec := make([]float32, 384)
+		vec[200] = 0.9
+		vec[201] = 0.1
+		vecs[i] = vec
+	}
+	return vecs, nil
+}
+
+func (l *lowConfidenceEmbedder) Close() error { return nil }
+
+func TestLowConfidenceVectorFloor(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
 	a, err := sqlite.Open(ctx, filepath.Join(dir, "test.db"))
@@ -677,38 +694,114 @@ func TestLowConfidenceExcludesVectorOnlySymbols(t *testing.T) {
 
 	seedFusionIndex(t, ctx, a)
 
-	// Build vector index with very weak embeddings (near-zero similarity).
-	// The default seedFusionIndex embeddings are simple byte patterns,
-	// and the paymentQueryEmbedder produces a different vector.
-	// With only 3 symbols, cosine similarities will be low.
 	embeddings, err := a.LoadEmbeddings(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
 	vectorIdx := search.BuildHNSWIndex(embeddings)
-	engine := search.NewEngine(a, vectorIdx, &paymentQueryEmbedder{})
+	// Use an embedder that produces vectors orthogonal to the index,
+	// guaranteeing low vector confidence (< 0.4).
+	engine := search.NewEngine(a, vectorIdx, &lowConfidenceEmbedder{})
 
 	_, meta, err := engine.Search(ctx, search.Options{Query: "payment", Limit: 10})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// When vector weight is 0, vector-only symbols should not appear.
-	if meta.VectorWeight == 0 {
-		t.Logf("vector confidence below threshold — keyword-only mode")
-		// In keyword-only mode, the "TransactionLog" symbol (which has no
-		// keyword match for "payment") should be absent.
-		results, _, err := engine.Search(ctx, search.Options{Query: "payment", Limit: 50})
-		if err != nil {
-			t.Fatal(err)
+	// With the weight floor, vector weight should be exactly 0.2 when
+	// confidence is below the low threshold.
+	if meta.VectorWeight != 0.2 {
+		t.Errorf("vector weight = %v, want 0.2 (floor)", meta.VectorWeight)
+	}
+	if meta.KeywordWeight != 0.8 {
+		t.Errorf("keyword weight = %v, want 0.8", meta.KeywordWeight)
+	}
+	t.Logf("low confidence floor active: kw=%.2f vec=%.2f", meta.KeywordWeight, meta.VectorWeight)
+}
+
+func TestGraphEnrichmentBoostsCallees(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	a, err := sqlite.Open(ctx, filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	// Create a hub function that calls a leaf function.
+	fid, err := a.WriteFile(ctx, &model.File{
+		Path: "handler.go", Language: "go",
+		Hash: "h1", Symbols: 3, IndexedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hub, err := a.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid, Name: "ServeHTTP", Qualified: "pkg.ServeHTTP",
+		Kind: "function", LineStart: 1, LineEnd: 20,
+		Docstring: "serves HTTP requests",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Callee that also matches keyword but with lower rank.
+	callee, err := a.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid, Name: "HandleRoute", Qualified: "pkg.HandleRoute",
+		Kind: "function", LineStart: 25, LineEnd: 40,
+		Docstring: "handles a route",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Unrelated symbol that matches keyword.
+	_, err = a.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid, Name: "HTTPConfig", Qualified: "pkg.HTTPConfig",
+		Kind: "type", LineStart: 45, LineEnd: 50,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Edge: ServeHTTP calls HandleRoute.
+	if _, err := a.WriteEdge(ctx, &model.Edge{
+		SourceID: &hub, TargetID: callee,
+		Kind: model.EdgeCalls, FileID: fid, Confidence: 1.0,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	engine := search.NewEngine(a, nil, nil)
+	results, _, err := engine.Search(ctx, search.Options{Query: "HTTP", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// HandleRoute should be boosted because it's a callee of ServeHTTP (top result).
+	if len(results) < 2 {
+		t.Fatalf("expected at least 2 results, got %d", len(results))
+	}
+
+	// Find HandleRoute's position.
+	var handleRouteScore float64
+	var httpConfigScore float64
+	for _, r := range results {
+		switch r.Name {
+		case "HandleRoute":
+			handleRouteScore = r.Score
+		case "HTTPConfig":
+			httpConfigScore = r.Score
 		}
-		for _, r := range results {
-			if r.Name == "TransactionLog" {
-				t.Errorf("TransactionLog (vector-only match) should not appear when vector weight is 0")
-			}
-		}
-	} else {
-		t.Logf("vector confidence above threshold (kw=%.2f vec=%.2f) — vector-only symbols may appear",
-			meta.KeywordWeight, meta.VectorWeight)
+	}
+
+	if handleRouteScore <= httpConfigScore {
+		t.Errorf("HandleRoute (callee of top result) score=%.4f should be > HTTPConfig score=%.4f",
+			handleRouteScore, httpConfigScore)
+	}
+	t.Logf("enrichment result:")
+	for i, r := range results {
+		t.Logf("  %d. %s (score=%.4f)", i+1, r.Qualified, r.Score)
 	}
 }

--- a/internal/sqlite/adapter.go
+++ b/internal/sqlite/adapter.go
@@ -878,6 +878,15 @@ func (a *Adapter) EmbeddingDebtCount(ctx context.Context) (int, error) {
 	return count, nil
 }
 
+// ClearEmbeddings deletes all rows from sense_embeddings.
+func (a *Adapter) ClearEmbeddings(ctx context.Context) error {
+	_, err := a.db.ExecContext(ctx, "DELETE FROM sense_embeddings")
+	if err != nil {
+		return fmt.Errorf("sqlite ClearEmbeddings: %w", err)
+	}
+	return nil
+}
+
 // DeleteMeta removes a key from sense_meta.
 func (a *Adapter) DeleteMeta(ctx context.Context, key string) error {
 	_, err := a.db.ExecContext(ctx, "DELETE FROM sense_meta WHERE key = ?", key)

--- a/internal/sqlite/search.go
+++ b/internal/sqlite/search.go
@@ -316,6 +316,39 @@ func (a *Adapter) InboundEdgeCounts(ctx context.Context, symbolIDs []int64) (map
 	return out, nil
 }
 
+// CalleeIDs returns outbound "calls" edge targets for each source symbol.
+// Used by graph-augmented search enrichment to find 1-hop callees.
+func (a *Adapter) CalleeIDs(ctx context.Context, symbolIDs []int64) (map[int64][]int64, error) {
+	if len(symbolIDs) == 0 {
+		return nil, nil
+	}
+	out := make(map[int64][]int64, len(symbolIDs))
+	placeholders := make([]byte, 0, len(symbolIDs)*2-1)
+	args := make([]any, len(symbolIDs))
+	for i, id := range symbolIDs {
+		if i > 0 {
+			placeholders = append(placeholders, ',')
+		}
+		placeholders = append(placeholders, '?')
+		args[i] = id
+	}
+	q := `SELECT source_id, target_id FROM sense_edges
+	      WHERE source_id IN (` + string(placeholders) + `) AND kind = 'calls'`
+	rows, err := a.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite CalleeIDs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var src, tgt int64
+		if err := rows.Scan(&src, &tgt); err != nil {
+			return nil, fmt.Errorf("sqlite CalleeIDs scan: %w", err)
+		}
+		out[src] = append(out[src], tgt)
+	}
+	return out, rows.Err()
+}
+
 // FilePathsByIDs returns the file path for each of the given file IDs.
 // Used by search re-ranking to apply path-based score weights.
 func (a *Adapter) FilePathsByIDs(ctx context.Context, fileIDs []int64) (map[int64]string, error) {


### PR DESCRIPTION
## Problem

The competitive benchmark (`bench/run.sh`) produced misleading results because Sense MCP tools leaked into every non-Sense tool session via ambient hooks and repo-level config files. Baseline sessions made 200+ Sense MCP calls — rendering all tool comparisons meaningless. Separately, search ranking suffered from discarding vector results at low confidence, single-query evaluation, and flat result lists with no graph context. The embedding pipeline also wrote all vectors in a single transaction, risking OOM on large repos, and lacked model migration support.

## Summary

Three interrelated improvements: (1) fully isolate benchmark tool sessions from ambient Sense config, (2) improve search ranking with multi-query expansion, weight floor, and graph enrichment, and (3) harden the embedding pipeline with chunked writes, model migration, and file path context.

## Changes

### Benchmark isolation
- Add `SENSE_BENCH=1` env var to suppress all hooks during benchmark runs
- Clean-room workspace setup in each tool script: wipe prior config, write empty hooks, write tool-specific `.mcp.json`
- Hide AI config files (`.mcp.json`, `.claude`, `CLAUDE.md`, etc.) from bench root and target repos during sessions
- Add `--verify-isolation` flag to scan transcripts for Sense MCP contamination
- Preserve user-specified tool ordering from `--tool` argument

### Search ranking
- Weight floor: low-confidence vectors get 0.2 weight instead of 0.0 — vectors always participate
- Multi-query expansion: decompose identifiers (camelCase/snake_case splitting) and long phrases into up to 3 sub-queries, merged with RRF
- Graph enrichment: boost callees of top-3 results, inject missing callees as low-score suggestions
- Increase graph centrality multiplier 10x (0.001 → 0.01) so hub symbols actually rank higher
- Surface `references` count in search result entries

### Embedding pipeline
- Chunked writes: embed and commit 512 symbols at a time instead of all-at-once
- Embedding model migration: auto-detect model change, clear stale embeddings, re-embed
- Configurable dims and sequence length via `NewONNXEmbedderWithConfig`
- File path context in embedding input for directory-level signal
- Refactor parallel embedding into reusable `embedPool` struct

## Test Plan
- [x] `go test ./internal/hook/...` — SENSE_BENCH suppresses all hooks
- [x] `go test ./internal/search/...` — multi-query expansion, low-confidence floor, graph enrichment boost
- [x] `go test ./...` passes
- [x] sense binary builds cleanly
- [x] `bench/run.sh --verify-isolation` confirms no contamination after a benchmark run