### PR TITLE
fix(bench): correct scorer normalization for Symbol:filepath format and class-level matching

### DIFF
--- a/bench/lib/scorer.py
+++ b/bench/lib/scorer.py
@@ -225,6 +225,22 @@ def _strip_bare_go_package(symbol):
     return symbol
 
 
+_FILE_EXT_RE = re.compile(
+    r"\.(ts|tsx|js|jsx|rb|py|go|rs|java|kt|scala|php|c|cpp|cs|h|hpp|swift|vue|svelte|ex|exs)$",
+    re.IGNORECASE,
+)
+
+
+def _looks_like_path(s):
+    return "/" in s or bool(_FILE_EXT_RE.search(s))
+
+
+def _extract_class_prefix(normalized):
+    symbol = normalized.rsplit(":", 1)[-1] if ":" in normalized else normalized
+    m = re.match(r"^([^.#]+)[.#]", symbol)
+    return m.group(1) if m else None
+
+
 def normalize_caller(entry):
     """Normalize a caller/affected entry for comparison.
 
@@ -248,6 +264,8 @@ def normalize_caller(entry):
         symbol_part = segments[-1]
         if len(segments) >= 2 and segments[1].isdigit():
             symbol_part = segments[-1] if len(segments) > 2 else ""
+        elif not _looks_like_path(segments[0]) and _looks_like_path(":".join(segments[1:])):
+            return _strip_bare_go_package(segments[0])
     else:
         return _strip_bare_go_package(entry)
 
@@ -279,8 +297,27 @@ def score_set_match(response_json, ground_truth, match_key):
     fp = found - expected
     fn = expected - found
 
-    precision = len(tp) / len(found) if found else 0.0
-    recall = len(tp) / len(expected) if expected else 0.0
+    partial_matches = []
+    remaining_fp = set(fp)
+    remaining_fn = set(fn)
+
+    for fp_entry in sorted(fp):
+        cls = _extract_class_prefix(fp_entry)
+        if not cls:
+            continue
+        for fn_entry in sorted(remaining_fn):
+            fn_symbol = fn_entry.rsplit(":", 1)[-1] if ":" in fn_entry else fn_entry
+            if cls == fn_entry or cls == fn_symbol:
+                partial_matches.append({"found": fp_entry, "expected": fn_entry})
+                remaining_fp.discard(fp_entry)
+                remaining_fn.discard(fn_entry)
+                break
+
+    partial_count = len(partial_matches)
+    weighted_tp = len(tp) + 0.5 * partial_count
+
+    precision = weighted_tp / len(found) if found else 0.0
+    recall = weighted_tp / len(expected) if expected else 0.0
     f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) > 0 else 0.0
 
     return {
@@ -291,8 +328,9 @@ def score_set_match(response_json, ground_truth, match_key):
         "found_count": len(found),
         "expected_count": len(expected),
         "true_positives": sorted(tp),
-        "false_positives": sorted(fp),
-        "false_negatives": sorted(fn),
+        "false_positives": sorted(remaining_fp),
+        "false_negatives": sorted(remaining_fn),
+        "partial_matches": partial_matches,
     }
 
 

--- a/bench/lib/test_scorer.py
+++ b/bench/lib/test_scorer.py
@@ -10,6 +10,7 @@ import unittest
 sys.path.insert(0, os.path.dirname(__file__))
 
 from scorer import (
+    _extract_class_prefix,
     classify_tool_calls,
     detect_misses,
     extract_json_from_text,
@@ -101,6 +102,134 @@ class TestNormalizeCaller(unittest.TestCase):
 
     def test_bare_symbol_keeps_scan_lowercase(self):
         self.assertEqual(normalize_caller("scan.indexedFile"), "scan.indexedFile")
+
+    # --- Symbol:filepath format (card 1 fix) ---
+
+    def test_symbol_filepath_ts(self):
+        self.assertEqual(
+            normalize_caller("renderToHTMLOrFlight:packages/next/src/server/app-render/app-render.tsx"),
+            "renderToHTMLOrFlight",
+        )
+
+    def test_symbol_filepath_rb(self):
+        self.assertEqual(
+            normalize_caller("PostCreator:app/models/post_creator.rb"),
+            "PostCreator",
+        )
+
+    def test_symbol_filepath_bare_go(self):
+        self.assertEqual(normalize_caller("HandleRequest:main.go"), "HandleRequest")
+
+    def test_symbol_filepath_uppercase(self):
+        self.assertEqual(normalize_caller("Flask:src/flask/app.py"), "Flask")
+
+    def test_symbol_filepath_go_package_stripped(self):
+        self.assertEqual(normalize_caller("gin.Engine:gin.go"), "Engine")
+
+    def test_filepath_symbol_preserved(self):
+        self.assertEqual(
+            normalize_caller("packages/next/src/module.ts:AppPageRouteModule.render"),
+            "packages/next/src/module.ts:AppPageRouteModule.render",
+        )
+
+    def test_filepath_symbol_rb_preserved(self):
+        self.assertEqual(
+            normalize_caller("app/models/post_creator.rb:PostCreator"),
+            "app/models/post_creator.rb:PostCreator",
+        )
+
+    def test_symbol_filepath_method_dot(self):
+        self.assertEqual(
+            normalize_caller("PostCreator.create:app/models/post_creator.rb"),
+            "PostCreator.create",
+        )
+
+    def test_symbol_filepath_method_hash(self):
+        self.assertEqual(
+            normalize_caller("PostCreator#new_topic?:lib/post_creator.rb"),
+            "PostCreator#new_topic?",
+        )
+
+
+class TestExtractClassPrefix(unittest.TestCase):
+    def test_dot_method(self):
+        self.assertEqual(_extract_class_prefix("PostCreator.create"), "PostCreator")
+
+    def test_hash_method(self):
+        self.assertEqual(_extract_class_prefix("PostCreator#new_topic?"), "PostCreator")
+
+    def test_bare_class_no_prefix(self):
+        self.assertIsNone(_extract_class_prefix("PostCreator"))
+
+    def test_file_colon_class_method(self):
+        self.assertEqual(
+            _extract_class_prefix("lib/post_creator.rb:PostCreator#create_topic"),
+            "PostCreator",
+        )
+
+    def test_go_type_method(self):
+        self.assertEqual(_extract_class_prefix("Engine.ServeHTTP"), "Engine")
+
+    def test_no_separator(self):
+        self.assertIsNone(_extract_class_prefix("renderToHTMLOrFlight"))
+
+    def test_over_broad_guard(self):
+        self.assertEqual(
+            _extract_class_prefix("PostGuardian#can_create_post?"),
+            "PostGuardian",
+        )
+
+
+class TestScoreSetMatchPartialCredit(unittest.TestCase):
+    def test_class_method_matches_class(self):
+        response = {"symbols": ["PostCreator.create"]}
+        gt = {"symbols": ["PostCreator"]}
+        result = score_set_match(response, gt, "symbols")
+        self.assertEqual(len(result["partial_matches"]), 1)
+        self.assertEqual(result["partial_matches"][0]["found"], "PostCreator.create")
+        self.assertEqual(result["partial_matches"][0]["expected"], "PostCreator")
+        self.assertAlmostEqual(result["precision"], 0.5)
+        self.assertAlmostEqual(result["recall"], 0.5)
+
+    def test_hash_method_matches_class(self):
+        response = {"symbols": ["TopicCreator#create"]}
+        gt = {"symbols": ["TopicCreator"]}
+        result = score_set_match(response, gt, "symbols")
+        self.assertEqual(len(result["partial_matches"]), 1)
+        self.assertAlmostEqual(result["f1"], 0.5)
+
+    def test_over_broad_no_match(self):
+        response = {"symbols": ["PostGuardian#can_create_post?"]}
+        gt = {"symbols": ["Post"]}
+        result = score_set_match(response, gt, "symbols")
+        self.assertEqual(len(result["partial_matches"]), 0)
+        self.assertEqual(result["f1"], 0.0)
+
+    def test_one_to_one_pairing(self):
+        response = {"symbols": ["PostCreator.create", "PostCreator#new_topic?"]}
+        gt = {"symbols": ["PostCreator"]}
+        result = score_set_match(response, gt, "symbols")
+        self.assertEqual(len(result["partial_matches"]), 1)
+        self.assertEqual(len(result["false_positives"]), 1)
+
+    def test_exact_match_preferred_over_partial(self):
+        response = {"symbols": ["PostCreator", "PostCreator.create"]}
+        gt = {"symbols": ["PostCreator"]}
+        result = score_set_match(response, gt, "symbols")
+        self.assertEqual(result["true_positives"], ["PostCreator"])
+        self.assertEqual(len(result["partial_matches"]), 0)
+
+    def test_no_partial_when_no_separator(self):
+        response = {"symbols": ["Foo", "Bar"]}
+        gt = {"symbols": ["Baz"]}
+        result = score_set_match(response, gt, "symbols")
+        self.assertEqual(len(result["partial_matches"]), 0)
+
+    def test_file_symbol_partial_with_bare_gt(self):
+        response = {"callers": ["lib/post_creator.rb:PostCreator#create_topic"]}
+        gt = {"callers": ["PostCreator"]}
+        result = score_set_match(response, gt, "callers")
+        self.assertEqual(len(result["partial_matches"]), 1)
 
 
 class TestScoreSetMatch(unittest.TestCase):


### PR DESCRIPTION
## Problem

The benchmark scorer produces false zeros. When Claude formats output as `Symbol:filepath` (e.g. `renderToHTMLOrFlight:packages/next/src/server/app-render/app-render.tsx`), `normalize_caller` treats the first segment as a file path and the remainder as a symbol — they never match ground truth. Additionally, when Sense returns `PostCreator.create` but ground truth expects `PostCreator`, the scorer treats it as completely wrong despite finding the right entity.

These bugs affected every `set_match` scored task across all tools. 14 scores were reported as 0.00 when they should have been non-zero.

## Summary

Fix two normalization bugs in `bench/lib/scorer.py` and add class-level partial credit matching, correcting 14 false zeros across all benchmark tools.

## Changes

- **Symbol:filepath detection** — `normalize_caller` now detects when the first colon-segment is a symbol (no slashes, no file extension) and the remainder is a file path (contains `/` or ends with a known extension). Returns the bare symbol instead of the broken `symbol:filepath` concatenation.
- **Class-level partial credit** — `score_set_match` runs a second pass after standard TP/FP/FN: extracts class/module prefix from false positives (split on `.` or `#`), checks for exact match against false negatives, and reclassifies as a 0.5-weight partial match. Prevents over-broad matching (`PostGuardian` ≠ `Post`) and enforces 1:1 pairing.
- **23 new tests** — covers `Symbol:filepath` and `filepath:Symbol` formats, class extraction for `.` and `#` separators, over-broad guard, 1:1 pairing constraint, and exact-match-before-partial priority.

## Key score corrections after re-scoring

| Task | Old F1 | New F1 |
|------|-------:|-------:|
| sense/nextjs/semantic-search | 0.00 | 0.50 |
| grepai/nextjs/semantic-search | 0.00 | 0.30 |
| roam/nextjs/semantic-search | 0.00 | 0.30 |
| sense/discourse/semantic-search | 0.00 | 0.27 |
| crg/openproject/callers | 0.00 | 0.14 |

## Test Plan

- [x] `python3 -m unittest bench.lib.test_scorer` — 79 tests pass
- [x] `make ci` — full green (Go tests + lint)
- [x] Re-scored 210 transcripts with 0 errors, no score regressions