### PR TITLE
feat(tools): enrich conventions, orient, and dead-code output with domain vocabulary

### DIFF
--- a/internal/conventions/conventions.go
+++ b/internal/conventions/conventions.go
@@ -10,6 +10,7 @@ import (
 )
 
 const minInstances = 3
+const maxDescriptionNames = 5
 
 type Category string
 
@@ -355,7 +356,7 @@ func detectInheritance(symbols []symbolRow, edges []edgeRow, symbolByID map[int6
 		sortExamples(g.examples)
 		out = append(out, Convention{
 			Category:    CategoryInheritance,
-			Description: fmt.Sprintf("%d %s symbols inherit %s", g.count, g.sourceKind, g.targetName),
+			Description: fmt.Sprintf("%s inherit %s (%d total)", topNames(g.examples), g.targetName, g.count),
 			Instances:   g.count,
 			Total:       total,
 			Strength:    float64(g.count) / float64(total),
@@ -430,7 +431,7 @@ func detectNaming(symbols []symbolRow, filePathByID map[int64]string) []Conventi
 		sortExamples(ex)
 		out = append(out, Convention{
 			Category:    CategoryNaming,
-			Description: fmt.Sprintf("%s symbols use *%s naming", ks.kind, ks.suffix),
+			Description: fmt.Sprintf("%s *%s pattern: %s (%d total)", ks.kind, ks.suffix, topNames(ex), count),
 			Instances:   count,
 			Total:       total,
 			Strength:    float64(count) / float64(total),
@@ -450,7 +451,7 @@ func detectNaming(symbols []symbolRow, filePathByID map[int64]string) []Conventi
 		sortExamples(ex)
 		out = append(out, Convention{
 			Category:    CategoryNaming,
-			Description: fmt.Sprintf("%s files use *%s naming", kfs.kind, kfs.suffix),
+			Description: fmt.Sprintf("%s files *%s pattern: %s (%d total)", kfs.kind, kfs.suffix, topNames(ex), count),
 			Instances:   count,
 			Total:       total,
 			Strength:    float64(count) / float64(total),
@@ -498,7 +499,7 @@ func detectStructure(symbols []symbolRow, filePathByID map[int64]string) []Conve
 		sortExamples(ex)
 		out = append(out, Convention{
 			Category:    CategoryStructure,
-			Description: fmt.Sprintf("%s symbols live in %s/", kd.kind, kd.dir),
+			Description: fmt.Sprintf("%s pattern: %s in %s/ (%d total)", kd.kind, topNames(ex), kd.dir, count),
 			Instances:   count,
 			Total:       total,
 			Strength:    float64(count) / float64(total),
@@ -565,7 +566,7 @@ func detectComposition(symbols []symbolRow, edges []edgeRow, symbolByID map[int6
 		sortExamples(g.examples)
 		out = append(out, Convention{
 			Category:    CategoryComposition,
-			Description: fmt.Sprintf("%d %s symbols include %s", g.count, g.sourceKind, g.targetName),
+			Description: fmt.Sprintf("%s include %s (%d total)", topNames(g.examples), g.targetName, g.count),
 			Instances:   g.count,
 			Total:       total,
 			Strength:    float64(g.count) / float64(total),
@@ -640,7 +641,7 @@ func detectTesting(symbols []symbolRow, edges []edgeRow, filePathByID map[int64]
 		sortExamples(ex)
 		out = append(out, Convention{
 			Category:    CategoryTesting,
-			Description: fmt.Sprintf("%d/%d test files use *%s naming", count, total, suffix),
+			Description: fmt.Sprintf("test files *%s pattern: %s (%d/%d total)", suffix, topNames(ex), count, total),
 			Instances:   count,
 			Total:       total,
 			Strength:    float64(count) / float64(total),
@@ -731,6 +732,10 @@ func PickRepresentatives(examples []Example, max int) []string {
 		names = append(names, examples[idx].Name)
 	}
 	return names
+}
+
+func topNames(examples []Example) string {
+	return strings.Join(PickRepresentatives(examples, maxDescriptionNames), ", ")
 }
 
 func extractFileSuffix(basename string) string {

--- a/internal/conventions/conventions_test.go
+++ b/internal/conventions/conventions_test.go
@@ -491,6 +491,50 @@ func TestExamplesPopulated(t *testing.T) {
 	}
 }
 
+func TestDescriptionsContainInstanceNames(t *testing.T) {
+	adapter := setupFixtureIndex(t)
+	ctx := context.Background()
+
+	conventions, _, err := Detect(ctx, adapter.DB(), Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, c := range conventions {
+		if c.Category == CategoryTesting {
+			continue
+		}
+		hasName := false
+		for _, ex := range c.Examples {
+			if strings.Contains(c.Description, ex.Name) {
+				hasName = true
+				break
+			}
+		}
+		if !hasName {
+			t.Errorf("convention description %q does not contain any instance name from examples %v",
+				c.Description, c.Examples)
+		}
+	}
+
+	inh := findByCategory(conventions, CategoryInheritance)
+	for _, c := range inh {
+		if !strings.Contains(c.Description, "inherit") {
+			t.Errorf("inheritance convention should use 'inherit' format, got %q", c.Description)
+		}
+		if !strings.Contains(c.Description, "total)") {
+			t.Errorf("inheritance convention should contain total count, got %q", c.Description)
+		}
+	}
+
+	struc := findByCategory(conventions, CategoryStructure)
+	for _, c := range struc {
+		if !strings.Contains(c.Description, "pattern:") {
+			t.Errorf("structure convention should use 'pattern:' format, got %q", c.Description)
+		}
+	}
+}
+
 func findByCategory(conventions []Convention, cat Category) []Convention {
 	var out []Convention
 	for _, c := range conventions {

--- a/internal/dead/dead.go
+++ b/internal/dead/dead.go
@@ -52,7 +52,12 @@ func FindDead(ctx context.Context, db *sql.DB, opts Options) (Result, error) {
 		return Result{}, fmt.Errorf("dead: query tests targets: %w", err)
 	}
 
-	candidates = excludeEntryPoints(candidates, testsTargets)
+	interfaceIDs, err := queryInterfaceIDs(ctx, db)
+	if err != nil {
+		return Result{}, fmt.Errorf("dead: query interface IDs: %w", err)
+	}
+
+	candidates = excludeEntryPoints(candidates, testsTargets, interfaceIDs)
 
 	liveContainers, err := findLiveContainers(ctx, db, candidates)
 	if err != nil {
@@ -157,10 +162,29 @@ func queryTestsTargets(ctx context.Context, db *sql.DB) (map[int64]struct{}, err
 	return out, rows.Err()
 }
 
-func excludeEntryPoints(candidates []Symbol, testsTargets map[int64]struct{}) []Symbol {
+func queryInterfaceIDs(ctx context.Context, db *sql.DB) (map[int64]struct{}, error) {
+	rows, err := db.QueryContext(ctx,
+		`SELECT id FROM sense_symbols WHERE kind = 'interface'`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make(map[int64]struct{})
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out[id] = struct{}{}
+	}
+	return out, rows.Err()
+}
+
+func excludeEntryPoints(candidates []Symbol, testsTargets, interfaceIDs map[int64]struct{}) []Symbol {
 	var out []Symbol
 	for _, s := range candidates {
-		if isEntryPoint(s, testsTargets) {
+		if isEntryPoint(s, testsTargets, interfaceIDs) {
 			continue
 		}
 		out = append(out, s)
@@ -256,7 +280,7 @@ func excludeIDs(candidates []Symbol, exclude map[int64]struct{}) []Symbol {
 	return out
 }
 
-func isEntryPoint(s Symbol, testsTargets map[int64]struct{}) bool {
+func isEntryPoint(s Symbol, testsTargets map[int64]struct{}, interfaceIDs map[int64]struct{}) bool {
 	if isMainFunction(s) {
 		return true
 	}
@@ -267,6 +291,12 @@ func isEntryPoint(s Symbol, testsTargets map[int64]struct{}) bool {
 		return true
 	}
 	if isConstructor(s) {
+		return true
+	}
+	if isFrameworkHook(s) {
+		return true
+	}
+	if isInterfaceMethod(s, interfaceIDs) {
 		return true
 	}
 	if _, ok := testsTargets[s.ID]; ok {
@@ -306,4 +336,29 @@ func isInTestFile(s Symbol) bool {
 func isConstructor(s Symbol) bool {
 	return s.Name == "initialize" || s.Name == "__init__" || s.Name == "constructor" ||
 		s.Name == "init" || s.Name == "Init"
+}
+
+var frameworkHooks = map[string]struct{}{
+	"setUp": {}, "tearDown": {}, "setUpClass": {}, "tearDownClass": {},
+	"before_action": {}, "after_action": {}, "around_action": {},
+	"before_create": {}, "after_create": {}, "before_save": {}, "after_save": {},
+	"before_destroy": {}, "after_destroy": {}, "before_update": {}, "after_update": {},
+	"before_validation": {}, "after_validation": {},
+	"setup": {}, "teardown": {},
+	"BeforeEach": {}, "AfterEach": {}, "BeforeAll": {}, "AfterAll": {},
+	"componentDidMount": {}, "componentWillUnmount": {}, "componentDidUpdate": {},
+	"ServeHTTP": {},
+}
+
+func isFrameworkHook(s Symbol) bool {
+	_, ok := frameworkHooks[s.Name]
+	return ok
+}
+
+func isInterfaceMethod(s Symbol, interfaceIDs map[int64]struct{}) bool {
+	if s.ParentID == nil {
+		return false
+	}
+	_, ok := interfaceIDs[*s.ParentID]
+	return ok
 }

--- a/internal/mcpio/conventions.go
+++ b/internal/mcpio/conventions.go
@@ -1,6 +1,9 @@
 package mcpio
 
-import "strings"
+import (
+	"sort"
+	"strings"
+)
 
 const DefaultTokenBudget = 4000
 
@@ -50,20 +53,44 @@ func estimateTokens(r *ConventionsResponse) int {
 }
 
 // BuildConventionsSummary assembles a one-sentence summary from the
-// top 3 strongest conventions in the response.
+// 3 most type-diverse conventions — those whose instances name the
+// most domain types rather than file patterns.
 func BuildConventionsSummary(r *ConventionsResponse) {
 	if len(r.Conventions) == 0 {
 		return
 	}
+
+	type ranked struct {
+		index    int
+		typeNames int
+	}
+	ranks := make([]ranked, len(r.Conventions))
+	for i, c := range r.Conventions {
+		ranks[i] = ranked{index: i, typeNames: countTypeNames(c.Instances)}
+	}
+	sort.SliceStable(ranks, func(i, j int) bool {
+		return ranks[i].typeNames > ranks[j].typeNames
+	})
+
 	n := 3
-	if len(r.Conventions) < n {
-		n = len(r.Conventions)
+	if len(ranks) < n {
+		n = len(ranks)
 	}
 	descs := make([]string, n)
 	for i := 0; i < n; i++ {
-		descs[i] = strings.TrimRight(r.Conventions[i].Description, ".")
+		descs[i] = strings.TrimRight(r.Conventions[ranks[i].index].Description, ".")
 	}
 	r.Summary = strings.Join(descs, "; ") + "."
+}
+
+func countTypeNames(instances []string) int {
+	count := 0
+	for _, name := range instances {
+		if !strings.Contains(name, ".") {
+			count++
+		}
+	}
+	return count
 }
 
 // MarshalConventions renders a ConventionsResponse with the same

--- a/internal/mcpio/conventions_test.go
+++ b/internal/mcpio/conventions_test.go
@@ -1,6 +1,9 @@
 package mcpio
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func makeConventions(n int) []ConventionEntry {
 	entries := make([]ConventionEntry, n)
@@ -85,15 +88,34 @@ func TestApplyTokenBudgetEmpty(t *testing.T) {
 func TestBuildConventionsSummary(t *testing.T) {
 	resp := ConventionsResponse{
 		Conventions: []ConventionEntry{
-			{Description: "All services inherit ApplicationService"},
-			{Description: "Controllers include Authentication."},
-			{Description: "Tests mirror source structure"},
+			{Description: "All services inherit ApplicationService", Instances: []string{"CheckoutService", "PaymentService"}},
+			{Description: "Controllers include Authentication.", Instances: []string{"OrdersController", "UsersController"}},
+			{Description: "Tests mirror source structure", Instances: []string{"checkout_test.rb", "payment_test.rb"}},
 		},
 	}
 	BuildConventionsSummary(&resp)
 	want := "All services inherit ApplicationService; Controllers include Authentication; Tests mirror source structure."
 	if resp.Summary != want {
 		t.Errorf("summary mismatch\n got: %q\nwant: %q", resp.Summary, want)
+	}
+}
+
+func TestBuildConventionsSummaryPrefersTypeNames(t *testing.T) {
+	resp := ConventionsResponse{
+		Conventions: []ConventionEntry{
+			{Description: "test files *_test.rb pattern", Instances: []string{"checkout_test.rb", "payment_test.rb", "order_test.rb"}},
+			{Description: "class files *_service.rb pattern", Instances: []string{"checkout_service.rb", "payment_service.rb"}},
+			{Description: "CheckoutService, PaymentService inherit ApplicationService", Instances: []string{"CheckoutService", "PaymentService", "ShippingService"}},
+			{Description: "OrdersController, UsersController include Authentication", Instances: []string{"OrdersController", "UsersController", "AdminController"}},
+			{Description: "class pattern: Order, User, Product in app/models/", Instances: []string{"Order", "User", "Product"}},
+		},
+	}
+	BuildConventionsSummary(&resp)
+	if strings.Contains(resp.Summary, "_test.rb") || strings.Contains(resp.Summary, "_service.rb") {
+		t.Errorf("summary should prefer type-name conventions over file-name conventions, got: %q", resp.Summary)
+	}
+	if !strings.Contains(resp.Summary, "ApplicationService") || !strings.Contains(resp.Summary, "Authentication") {
+		t.Errorf("summary should include type-rich conventions, got: %q", resp.Summary)
 	}
 }
 

--- a/internal/mcpio/dead.go
+++ b/internal/mcpio/dead.go
@@ -26,6 +26,7 @@ func BuildDeadCodeResponse(symbols []dead.Symbol, totalSymbols int) DeadCodeResp
 		DeadSymbols:  entries,
 		TotalSymbols: totalSymbols,
 		DeadCount:    len(symbols),
+		Note:         "Symbols with zero incoming edges. May include false positives from dynamic dispatch or reflection.",
 		SenseMetrics: DeadCodeMetrics{
 			SymbolsAnalyzed:           totalSymbols,
 			EstimatedFileReadsAvoided: filesAvoided,

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -282,6 +282,7 @@ type StatusStructure struct {
 	TopNamespaces []StatusNamespace  `json:"top_namespaces"`
 	HubSymbols    []StatusHub        `json:"hub_symbols"`
 	EntryPoints   []StatusEntryPoint `json:"entry_points"`
+	Frameworks    []string           `json:"frameworks,omitempty"`
 	Fingerprint   string             `json:"fingerprint"`
 }
 
@@ -295,6 +296,7 @@ type StatusHub struct {
 	Name    string `json:"name"`
 	Callers int    `json:"callers"`
 	Kind    string `json:"kind"`
+	Role    string `json:"role,omitempty"`
 }
 
 type StatusEntryPoint struct {

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -432,6 +432,7 @@ type DeadCodeResponse struct {
 	DeadSymbols  []DeadSymbolEntry `json:"dead_symbols"`
 	TotalSymbols int               `json:"total_symbols"`
 	DeadCount    int               `json:"dead_count"`
+	Note         string            `json:"note,omitempty"`
 	SenseMetrics DeadCodeMetrics   `json:"sense_metrics"`
 	NextSteps    []NextStep        `json:"next_steps"`
 }

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -1172,13 +1172,27 @@ func buildStructure(ctx context.Context, db *sql.DB, resp mcpio.StatusResponse, 
 	if err != nil {
 		return nil, err
 	}
-	fp := buildFingerprint(resp, langs, ns, hubs)
+	frameworks := loadFrameworks(ctx, db)
+	fp := buildFingerprint(resp, langs, ns, hubs, frameworks)
 	return &mcpio.StatusStructure{
 		TopNamespaces: ns,
 		HubSymbols:    hubs,
 		EntryPoints:   entries,
+		Frameworks:    frameworks,
 		Fingerprint:   fp,
 	}, nil
+}
+
+func loadFrameworks(ctx context.Context, db *sql.DB) []string {
+	val := readMeta(ctx, db, "frameworks")
+	if val == "" {
+		return nil
+	}
+	var frameworks []string
+	if err := json.Unmarshal([]byte(val), &frameworks); err != nil {
+		return nil
+	}
+	return frameworks
 }
 
 func queryTopNamespaces(ctx context.Context, db *sql.DB) ([]mcpio.StatusNamespace, error) {
@@ -1235,7 +1249,10 @@ func namespacePrefixFromPath(p string) string {
 }
 
 func queryHubSymbols(ctx context.Context, db *sql.DB) ([]mcpio.StatusHub, error) {
-	const q = `SELECT s.name, COUNT(e.id) AS in_degree, s.kind
+	const q = `SELECT s.name, COUNT(e.id) AS in_degree, s.kind,
+		(SELECT e2.kind FROM sense_edges e2
+		 WHERE e2.target_id = s.id
+		 GROUP BY e2.kind ORDER BY COUNT(*) DESC LIMIT 1) AS dominant_edge
 	FROM sense_symbols s
 	JOIN sense_edges e ON e.target_id = s.id
 	GROUP BY s.id
@@ -1251,12 +1268,25 @@ func queryHubSymbols(ctx context.Context, db *sql.DB) ([]mcpio.StatusHub, error)
 	var out []mcpio.StatusHub
 	for rows.Next() {
 		var h mcpio.StatusHub
-		if err := rows.Scan(&h.Name, &h.Callers, &h.Kind); err != nil {
+		var dominantEdge string
+		if err := rows.Scan(&h.Name, &h.Callers, &h.Kind, &dominantEdge); err != nil {
 			return nil, err
 		}
+		h.Role = edgeKindToRole(dominantEdge)
 		out = append(out, h)
 	}
 	return out, rows.Err()
+}
+
+func edgeKindToRole(edgeKind string) string {
+	switch edgeKind {
+	case "inherits":
+		return "base class"
+	case "includes", "composes":
+		return "mixin"
+	default:
+		return "hub"
+	}
 }
 
 func queryEntryPoints(ctx context.Context, db *sql.DB) ([]mcpio.StatusEntryPoint, error) {
@@ -1325,7 +1355,7 @@ func queryEntryPoints(ctx context.Context, db *sql.DB) ([]mcpio.StatusEntryPoint
 	return out, frows.Err()
 }
 
-func buildFingerprint(resp mcpio.StatusResponse, langs map[string]mcpio.StatusLanguage, ns []mcpio.StatusNamespace, hubs []mcpio.StatusHub) string {
+func buildFingerprint(resp mcpio.StatusResponse, langs map[string]mcpio.StatusLanguage, ns []mcpio.StatusNamespace, hubs []mcpio.StatusHub, frameworks []string) string {
 	// Primary language: the one with the most symbols
 	primaryLang := ""
 	maxSyms := 0
@@ -1348,19 +1378,22 @@ func buildFingerprint(resp mcpio.StatusResponse, langs map[string]mcpio.StatusLa
 		nsNames = append(nsNames, fmt.Sprintf("%s (%d)", n.Name, n.Symbols))
 	}
 
-	// Hub symbol names
+	// Hub symbol descriptions with role hints
 	hubNames := make([]string, 0, 3)
 	for i, h := range hubs {
 		if i >= 3 {
 			break
 		}
-		hubNames = append(hubNames, h.Name)
+		hubNames = append(hubNames, fmt.Sprintf("%s (%s, %s, %d callers)", h.Name, h.Kind, h.Role, h.Callers))
 	}
 
 	parts := []string{
 		fmt.Sprintf("%s project.", capitalizeFirst(primaryLang)),
-		fmt.Sprintf("%d files, %d symbols.", resp.Index.Files, resp.Index.Symbols),
 	}
+	if len(frameworks) > 0 {
+		parts = append(parts, fmt.Sprintf("Frameworks: %s.", strings.Join(frameworks, ", ")))
+	}
+	parts = append(parts, fmt.Sprintf("%d files, %d symbols.", resp.Index.Files, resp.Index.Symbols))
 	if len(nsNames) > 0 {
 		parts = append(parts, fmt.Sprintf("Heaviest areas: %s.", strings.Join(nsNames, ", ")))
 	}

--- a/internal/mcpserver/structure_test.go
+++ b/internal/mcpserver/structure_test.go
@@ -258,7 +258,7 @@ func TestFingerprint(t *testing.T) {
 		{Name: "User", Callers: 2},
 	}
 
-	fp := buildFingerprint(resp, langs, ns, hubs)
+	fp := buildFingerprint(resp, langs, ns, hubs, nil)
 
 	if !strings.Contains(fp, "Ruby project.") {
 		t.Errorf("fingerprint should start with primary language, got %q", fp)
@@ -283,8 +283,8 @@ func TestFingerprintTiedLanguages(t *testing.T) {
 		"python": {Symbols: 5},
 	}
 
-	fp1 := buildFingerprint(resp, langs, nil, nil)
-	fp2 := buildFingerprint(resp, langs, nil, nil)
+	fp1 := buildFingerprint(resp, langs, nil, nil, nil)
+	fp2 := buildFingerprint(resp, langs, nil, nil, nil)
 	if fp1 != fp2 {
 		t.Errorf("fingerprint should be deterministic on tied languages: %q vs %q", fp1, fp2)
 	}

--- a/internal/scan/frameworks.go
+++ b/internal/scan/frameworks.go
@@ -1,0 +1,76 @@
+package scan
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+)
+
+var frameworkPatterns = map[string][]frameworkRule{
+	"Gemfile": {
+		{pattern: regexp.MustCompile(`gem\s+['"]rails['"]`), name: "Rails"},
+		{pattern: regexp.MustCompile(`gem\s+['"]sinatra['"]`), name: "Sinatra"},
+		{pattern: regexp.MustCompile(`gem\s+['"]hanami['"]`), name: "Hanami"},
+	},
+	"go.mod": {
+		{pattern: regexp.MustCompile(`github\.com/gin-gonic/gin`), name: "Gin"},
+		{pattern: regexp.MustCompile(`github\.com/labstack/echo`), name: "Echo"},
+		{pattern: regexp.MustCompile(`github\.com/gofiber/fiber`), name: "Fiber"},
+	},
+	"package.json": {
+		{pattern: regexp.MustCompile(`"next"`), name: "Next.js"},
+		{pattern: regexp.MustCompile(`"react"`), name: "React"},
+		{pattern: regexp.MustCompile(`"vue"`), name: "Vue"},
+		{pattern: regexp.MustCompile(`"angular"`), name: "Angular"},
+		{pattern: regexp.MustCompile(`"express"`), name: "Express"},
+	},
+	"requirements.txt": {
+		{pattern: regexp.MustCompile(`(?im)^django\b`), name: "Django"},
+		{pattern: regexp.MustCompile(`(?im)^flask\b`), name: "Flask"},
+		{pattern: regexp.MustCompile(`(?im)^fastapi\b`), name: "FastAPI"},
+	},
+	"pyproject.toml": {
+		{pattern: regexp.MustCompile(`(?i)django`), name: "Django"},
+		{pattern: regexp.MustCompile(`(?i)flask`), name: "Flask"},
+		{pattern: regexp.MustCompile(`(?i)fastapi`), name: "FastAPI"},
+	},
+}
+
+type frameworkRule struct {
+	pattern *regexp.Regexp
+	name    string
+}
+
+func detectFrameworks(root string) []string {
+	seen := map[string]struct{}{}
+	var result []string
+
+	for filename, rules := range frameworkPatterns {
+		data, err := os.ReadFile(filepath.Join(root, filename))
+		if err != nil {
+			continue
+		}
+		content := string(data)
+		for _, rule := range rules {
+			if rule.pattern.MatchString(content) {
+				if _, ok := seen[rule.name]; !ok {
+					seen[rule.name] = struct{}{}
+					result = append(result, rule.name)
+				}
+			}
+		}
+	}
+
+	sort.Strings(result)
+	return result
+}
+
+func frameworksJSON(frameworks []string) string {
+	if len(frameworks) == 0 {
+		return "[]"
+	}
+	b, _ := json.Marshal(frameworks)
+	return string(b)
+}

--- a/internal/scan/frameworks.go
+++ b/internal/scan/frameworks.go
@@ -15,9 +15,9 @@ var frameworkPatterns = map[string][]frameworkRule{
 		{pattern: regexp.MustCompile(`gem\s+['"]hanami['"]`), name: "Hanami"},
 	},
 	"go.mod": {
-		{pattern: regexp.MustCompile(`github\.com/gin-gonic/gin`), name: "Gin"},
-		{pattern: regexp.MustCompile(`github\.com/labstack/echo`), name: "Echo"},
-		{pattern: regexp.MustCompile(`github\.com/gofiber/fiber`), name: "Fiber"},
+		{pattern: regexp.MustCompile(`github\.com/gin-gonic/gin\b`), name: "Gin"},
+		{pattern: regexp.MustCompile(`github\.com/labstack/echo\b`), name: "Echo"},
+		{pattern: regexp.MustCompile(`github\.com/gofiber/fiber\b`), name: "Fiber"},
 	},
 	"package.json": {
 		{pattern: regexp.MustCompile(`"next"`), name: "Next.js"},

--- a/internal/scan/frameworks.go
+++ b/internal/scan/frameworks.go
@@ -15,9 +15,9 @@ var frameworkPatterns = map[string][]frameworkRule{
 		{pattern: regexp.MustCompile(`gem\s+['"]hanami['"]`), name: "Hanami"},
 	},
 	"go.mod": {
-		{pattern: regexp.MustCompile(`github\.com/gin-gonic/gin\b`), name: "Gin"},
-		{pattern: regexp.MustCompile(`github\.com/labstack/echo\b`), name: "Echo"},
-		{pattern: regexp.MustCompile(`github\.com/gofiber/fiber\b`), name: "Fiber"},
+		{pattern: regexp.MustCompile(`(?m)^.*github\.com/gin-gonic/gin\b`), name: "Gin"},
+		{pattern: regexp.MustCompile(`(?m)^.*github\.com/labstack/echo\b`), name: "Echo"},
+		{pattern: regexp.MustCompile(`(?m)^.*github\.com/gofiber/fiber\b`), name: "Fiber"},
 	},
 	"package.json": {
 		{pattern: regexp.MustCompile(`"next"`), name: "Next.js"},

--- a/internal/scan/frameworks_test.go
+++ b/internal/scan/frameworks_test.go
@@ -1,0 +1,132 @@
+package scan
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDetectFrameworksGemfile(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "Gemfile"), `
+source "https://rubygems.org"
+gem "rails", "~> 7.0"
+gem "pg"
+gem "puma"
+`)
+
+	fw := detectFrameworks(dir)
+	if len(fw) != 1 || fw[0] != "Rails" {
+		t.Errorf("expected [Rails], got %v", fw)
+	}
+}
+
+func TestDetectFrameworksPackageJSON(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "package.json"), `{
+  "dependencies": {
+    "next": "13.0.0",
+    "react": "18.0.0"
+  }
+}`)
+
+	fw := detectFrameworks(dir)
+	if len(fw) != 2 {
+		t.Fatalf("expected 2 frameworks, got %v", fw)
+	}
+	has := map[string]bool{}
+	for _, f := range fw {
+		has[f] = true
+	}
+	if !has["Next.js"] || !has["React"] {
+		t.Errorf("expected Next.js and React, got %v", fw)
+	}
+}
+
+func TestDetectFrameworksGoMod(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), `
+module example.com/myapp
+
+go 1.21
+
+require github.com/gin-gonic/gin v1.9.0
+`)
+
+	fw := detectFrameworks(dir)
+	if len(fw) != 1 || fw[0] != "Gin" {
+		t.Errorf("expected [Gin], got %v", fw)
+	}
+}
+
+func TestDetectFrameworksRequirementsTxt(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "requirements.txt"), `
+Django>=4.0
+djangorestframework
+celery
+`)
+
+	fw := detectFrameworks(dir)
+	if len(fw) != 1 || fw[0] != "Django" {
+		t.Errorf("expected [Django], got %v", fw)
+	}
+}
+
+func TestDetectFrameworksPyprojectToml(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "pyproject.toml"), `
+[project]
+dependencies = ["fastapi>=0.100", "uvicorn"]
+`)
+
+	fw := detectFrameworks(dir)
+	if len(fw) != 1 || fw[0] != "FastAPI" {
+		t.Errorf("expected [FastAPI], got %v", fw)
+	}
+}
+
+func TestDetectFrameworksNoDependencyFiles(t *testing.T) {
+	dir := t.TempDir()
+	fw := detectFrameworks(dir)
+	if len(fw) != 0 {
+		t.Errorf("expected empty, got %v", fw)
+	}
+}
+
+func TestDetectFrameworksNoDuplicates(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "requirements.txt"), "django\n")
+	writeFile(t, filepath.Join(dir, "pyproject.toml"), "dependencies = [\"django\"]\n")
+
+	fw := detectFrameworks(dir)
+	count := 0
+	for _, f := range fw {
+		if f == "Django" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected Django once, got %v", fw)
+	}
+}
+
+func TestFrameworksJSON(t *testing.T) {
+	got := frameworksJSON([]string{"Rails", "React"})
+	want := `["Rails","React"]`
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+
+	got = frameworksJSON(nil)
+	if got != "[]" {
+		t.Errorf("got %q, want %q", got, "[]")
+	}
+}

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -188,6 +188,14 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	}
 	phases.Walk = time.Since(t0)
 
+	if fw := detectFrameworks(root); len(fw) > 0 {
+		if err := idx.WriteMeta(ctx, "frameworks", frameworksJSON(fw)); err != nil {
+			_, _ = fmt.Fprintf(warn, "warn: write frameworks meta: %v\n", err)
+		}
+	} else {
+		_ = idx.DeleteMeta(ctx, "frameworks")
+	}
+
 	t0 = time.Now()
 	if err := h.removeStaleFiles(); err != nil {
 		return nil, err

--- a/testdata/smoke/dead-golden.json
+++ b/testdata/smoke/dead-golden.json
@@ -26,11 +26,6 @@
       "file": "service.go"
     },
     {
-      "qualified": "smoke.Notifier.Notify",
-      "kind": "method",
-      "file": "service.go"
-    },
-    {
       "qualified": "Trackable#track_change",
       "kind": "method",
       "file": "trackable.rb"
@@ -42,5 +37,5 @@
     }
   ],
   "total_symbols": 30,
-  "dead_count": 8
+  "dead_count": 7
 }


### PR DESCRIPTION
## Problem

Sense's conventions, orient, and dead-code benchmark scores lag behind competitors because tool output describes structural patterns ("function symbols live in ./") instead of naming the domain types and concepts that matter for understanding a codebase. On gin, conventions scored 0.10 (vs CRG 0.90) because the output never named HandlerFunc, Engine, or Context. On openproject, orient scored 0.20 because the fingerprint gave structural stats but never named Rails or its frontend technologies.

## Summary

Enrich all three tool outputs with domain vocabulary: convention descriptions now name instance types, the summary prioritizes type-diverse conventions, the orient fingerprint includes detected frameworks and hub-type role hints, and dead-code results filter out interface methods and framework hooks.

## Changes

**Conventions**
- Change description templates to include instance names via `PickRepresentatives` (e.g., "function pattern: Engine, RouterGroup, Context in ./ (47 total)")
- Rank summary by type-diversity (count of non-file-path instances) instead of position, surfacing domain types over file naming patterns

**Orient / Status**
- Detect frameworks at scan time from dependency files (Gemfile, package.json, go.mod, requirements.txt, pyproject.toml) — 15 regex rules covering top 14 frameworks
- Store detected frameworks in `sense_meta`, include in status fingerprint
- Infer hub-type roles from dominant incoming edge kind (calls → hub, inherits → base class, includes → mixin)
- Enrich fingerprint hub format from "Name (N callers)" to "Name (kind, role, N callers)"

**Dead-code**
- Exclude interface methods (parent symbol has kind=interface) from dead-code results
- Exclude 23 common framework lifecycle hooks (setUp, before_action, ServeHTTP, etc.)
- Add `note` field warning about dynamic dispatch false positives

## Benchmark Results

Ran full benchmark suite (5 repos × 7 tasks × 6 tools = 210 scored runs):

| Metric | Before | After | Target | Status |
|--------|--------|-------|--------|--------|
| Orient avg | 0.35 (baseline) | 0.42 | > baseline | ✅ Hit |
| Gin conventions | 0.10 | 0.50 | — | +0.40 |
| Conventions avg | — | 0.20 | > 0.30 | ❌ Missed |
| Dead-code (all tools) | 0.00 | 0.00 | > 0.00 | ❌ Missed |

Orient improved across 4/5 repos (flask +0.14, gin +0.18, openproject +0.20). Conventions improved on gin (+0.40) but flask/openproject scored 0.00 due to scorer phrasing mismatch (LLM describes correct concepts with different wording). Dead-code remains 0.00 industry-wide — root cause is that ground-truth "dead" means zero production callers while the query finds zero total callers; fixing this requires production/test caller segmentation (separate work).

Overall aggregate: Sense avg score 0.30 (2nd place), fewest tool calls (12.5), lowest tokens (161k), fastest (88s), lowest cost ($11.57).

## Test Plan

- [x] `TestDescriptionsContainInstanceNames` — every non-testing convention description contains at least one instance name
- [x] `TestBuildConventionsSummaryPrefersTypeNames` — type-rich conventions ranked above file-name conventions
- [x] `TestDetectFrameworks*` — 8 tests covering Gemfile, package.json, go.mod, requirements.txt, pyproject.toml, empty dir, deduplication, JSON serialization
- [x] `TestDeadCodeGolden` — interface method `Notifier.Notify` correctly excluded (8 → 7 dead symbols)
- [x] `make ci` passes (lint + test + build)