### PR TITLE
feat(scan): add naming-convention edges and caller segmentation

### DIFF
--- a/bench/run.sh
+++ b/bench/run.sh
@@ -292,7 +292,7 @@ AI_CONFIG_FILES=(".mcp.json" ".claude" "CLAUDE.md" "AGENT.md" ".cursorrules" ".c
 for f in "${AI_CONFIG_FILES[@]}"; do
   [[ -e "$BENCH_ROOT/$f" ]] && mv "$BENCH_ROOT/$f" "$BENCH_ROOT/$f.bench-hidden"
 done
-trap 'for f in "${AI_CONFIG_FILES[@]}"; do [[ -e "$BENCH_ROOT/$f.bench-hidden" ]] && mv "$BENCH_ROOT/$f.bench-hidden" "$BENCH_ROOT/$f"; done' EXIT
+trap 'for f in "${AI_CONFIG_FILES[@]}"; do [[ -e "$BENCH_ROOT/$f.bench-hidden" ]] && { rm -rf "$BENCH_ROOT/$f"; mv "$BENCH_ROOT/$f.bench-hidden" "$BENCH_ROOT/$f"; }; done' EXIT
 
 # --- Main loop: tool → repo (setup once) → tasks ---
 

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -51,6 +51,9 @@ func RenderGraphHuman(w io.Writer, resp mcpio.GraphResponse) {
 	if s := renderCalls(resp.Edges.CalledBy); s != "" {
 		_, _ = fmt.Fprintf(w, label, "callers", s)
 	}
+	if ts := resp.TestCallerSummary; ts != nil && ts.Count > 0 {
+		_, _ = fmt.Fprintf(w, label, "test cal.", fmt.Sprintf("(%d in %s)", ts.Count, strings.Join(ts.Examples, ", ")))
+	}
 	if s := renderTests(resp.Edges.Tests); s != "" {
 		_, _ = fmt.Fprintf(w, label, "tests", s)
 	}

--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -76,6 +76,8 @@ func BuildBlastResponse(r blast.Result, files FileLookup) BlastResponse {
 		})
 	}
 
+	segmentBlastCallers(&resp)
+
 	uniqueFiles := countUniqueBlastFiles(resp)
 	resp.SenseMetrics = BlastMetrics{
 		SymbolsTraversed:          1 + len(r.DirectCallers) + len(r.IndirectCallers),
@@ -153,6 +155,8 @@ func BuildDiffBlastResponse(ref string, results []blast.Result, files FileLookup
 		fmt.Sprintf("%d modified symbols; %d direct callers", len(results), len(resp.DirectCallers)),
 	}
 
+	segmentBlastCallers(&resp)
+
 	uniqueFiles := countUniqueBlastFiles(resp)
 	resp.SenseMetrics = BlastMetrics{
 		SymbolsTraversed:          len(results) + len(resp.DirectCallers) + len(resp.IndirectCallers),
@@ -191,5 +195,43 @@ func riskRank(r string) int {
 		return 1
 	}
 	return 0
+}
+
+// segmentBlastCallers counts production vs test affected symbols
+// across all caller lists and sets the summary fields.
+func segmentBlastCallers(resp *BlastResponse) {
+	var prod, test int
+	for _, c := range resp.DirectCallers {
+		if IsTestPath(c.File) {
+			test++
+		} else {
+			prod++
+		}
+	}
+	prod += len(resp.IndirectCallers)
+	for _, c := range resp.AffectedSubclasses {
+		if IsTestPath(c.File) {
+			test++
+		} else {
+			prod++
+		}
+	}
+	for _, c := range resp.AffectedViaComposition {
+		if IsTestPath(c.File) {
+			test++
+		} else {
+			prod++
+		}
+	}
+	for _, c := range resp.AffectedViaIncludes {
+		if IsTestPath(c.File) {
+			test++
+		} else {
+			prod++
+		}
+	}
+	test += len(resp.AffectedTests)
+	resp.ProductionAffected = prod
+	resp.TestAffected = test
 }
 

--- a/internal/mcpio/contract_test.go
+++ b/internal/mcpio/contract_test.go
@@ -219,7 +219,9 @@ func fixtureBlastDiff() BlastResponse {
 			"test/controllers/orders_controller_test.rb",
 			"test/controllers/sessions_controller_test.rb",
 		},
-		TotalAffected: 6,
+		TotalAffected:      6,
+		ProductionAffected: 6,
+		TestAffected:       3,
 		SenseMetrics: BlastMetrics{
 			SymbolsTraversed:          9,
 			EstimatedFileReadsAvoided: 8,
@@ -250,7 +252,9 @@ func fixtureBlastUserEmailVerified() BlastResponse {
 			"test/controllers/admin/users_controller_test.rb",
 			"test/controllers/orders_controller_test.rb",
 		},
-		TotalAffected: 11,
+		TotalAffected:      11,
+		ProductionAffected: 5,
+		TestAffected:       6,
 		SenseMetrics: BlastMetrics{
 			SymbolsTraversed:          47,
 			EstimatedFileReadsAvoided: 10,

--- a/internal/mcpio/graph.go
+++ b/internal/mcpio/graph.go
@@ -1,8 +1,12 @@
 package mcpio
 
 import (
+	"strings"
+
 	"github.com/luuuc/sense/internal/model"
 )
+
+const testCallerCollapseThreshold = 20
 
 // FileLookup resolves a sense_files row id to its path. Used by
 // BuildGraphResponse / BuildBlastResponse to hydrate edge endpoints.
@@ -16,7 +20,8 @@ type FileLookup func(fileID int64) (path string, ok bool)
 // caller has already loaded the SymbolContext at the right depth
 // from the DB layer.
 type BuildGraphRequest struct {
-	Direction string // "both", "callers", "callees"; "" == "both"
+	Direction       string // "both", "callers", "callees"; "" == "both"
+	SegmentCallers  bool   // split callers into production vs test
 }
 
 // BuildGraphResponse assembles the wire-shape response from the
@@ -80,15 +85,21 @@ func BuildGraphResponse(sc *model.SymbolContext, files FileLookup, req BuildGrap
 			}
 		}
 	}
+	var testCallers []CallEdgeRef
 	if wantInbound {
 		for _, e := range sc.Inbound {
 			switch e.Edge.Kind {
 			case model.EdgeCalls:
-				resp.Edges.CalledBy = append(resp.Edges.CalledBy, CallEdgeRef{
+				ref := CallEdgeRef{
 					Symbol:     qualifiedOrName(e.Target),
 					File:       fileRefOrNil(e.Target.FileID, files),
 					Confidence: Confidence(e.Edge.Confidence),
-				})
+				}
+				if req.SegmentCallers && ref.File != nil && IsTestPath(*ref.File) {
+					testCallers = append(testCallers, ref)
+				} else {
+					resp.Edges.CalledBy = append(resp.Edges.CalledBy, ref)
+				}
 			case model.EdgeComposes:
 				resp.Edges.Composes = append(resp.Edges.Composes, ComposeEdgeRef{
 					Symbol: qualifiedOrName(e.Target),
@@ -157,12 +168,16 @@ func BuildGraphResponse(sc *model.SymbolContext, files FileLookup, req BuildGrap
 		})
 	}
 
-	symbolsReturned := len(resp.Edges.Calls) + len(resp.Edges.CalledBy) +
+	if len(testCallers) > 0 {
+		resp.TestCallerSummary = buildTestCallerSummary(testCallers)
+	}
+
+	symbolsReturned := len(resp.Edges.Calls) + len(resp.Edges.CalledBy) + len(testCallers) +
 		len(resp.Edges.Inherits) + len(resp.Edges.Composes) +
 		len(resp.Edges.Includes) + len(resp.Edges.Imports) + len(resp.Edges.Tests) +
 		len(resp.Edges.Temporal)
 
-	uniqueFiles := countUniqueEdgeFiles(resp)
+	uniqueFiles := countUniqueEdgeFiles(resp, testCallers)
 	resp.SenseMetrics = GraphMetrics{
 		SymbolsReturned:           symbolsReturned,
 		EstimatedFileReadsAvoided: uniqueFiles,
@@ -181,7 +196,7 @@ func qualifiedOrName(s model.Symbol) string {
 	return s.Name
 }
 
-func countUniqueEdgeFiles(resp GraphResponse) int {
+func countUniqueEdgeFiles(resp GraphResponse, testCallers []CallEdgeRef) int {
 	seen := map[string]struct{}{}
 	for _, e := range resp.Edges.Calls {
 		if e.File != nil {
@@ -189,6 +204,11 @@ func countUniqueEdgeFiles(resp GraphResponse) int {
 		}
 	}
 	for _, e := range resp.Edges.CalledBy {
+		if e.File != nil {
+			seen[*e.File] = struct{}{}
+		}
+	}
+	for _, e := range testCallers {
 		if e.File != nil {
 			seen[*e.File] = struct{}{}
 		}
@@ -233,4 +253,42 @@ func fileRefOrNil(fileID int64, files FileLookup) *string {
 		return &path
 	}
 	return nil
+}
+
+// buildTestCallerSummary creates a TestCallerSummary from a list of
+// test callers. When the count exceeds the collapse threshold, only
+// 3 unique file path examples are kept.
+func buildTestCallerSummary(callers []CallEdgeRef) *TestCallerSummary {
+	seen := map[string]struct{}{}
+	var examples []string
+	for _, c := range callers {
+		if c.File == nil {
+			continue
+		}
+		if _, dup := seen[*c.File]; dup {
+			continue
+		}
+		seen[*c.File] = struct{}{}
+		examples = append(examples, *c.File)
+	}
+	summary := &TestCallerSummary{
+		Count:    len(callers),
+		Examples: examples,
+	}
+	if len(callers) > testCallerCollapseThreshold && len(examples) > 3 {
+		summary.Examples = examples[:3]
+	}
+	return summary
+}
+
+// IsTestPath returns true if the file path matches common test
+// directory or filename conventions.
+func IsTestPath(path string) bool {
+	return strings.Contains(path, "_test.") ||
+		strings.Contains(path, "/test/") ||
+		strings.Contains(path, "/tests/") ||
+		strings.Contains(path, "/spec/") ||
+		strings.HasPrefix(path, "test/") ||
+		strings.HasPrefix(path, "tests/") ||
+		strings.HasPrefix(path, "spec/")
 }

--- a/internal/mcpio/graph_test.go
+++ b/internal/mcpio/graph_test.go
@@ -218,6 +218,115 @@ func TestBuildGraphResponseTemporalDirectionIndependent(t *testing.T) {
 	}
 }
 
+func TestCallerSegmentation(t *testing.T) {
+	filePaths := map[int64]string{
+		1: "app/models/user.rb",
+		2: "app/services/auth.rb",
+		3: "app/controllers/sessions.rb",
+		4: "spec/models/user_spec.rb",
+		5: "spec/services/auth_spec.rb",
+		6: "test/controllers/sessions_test.rb",
+	}
+	files := func(id int64) (string, bool) {
+		p, ok := filePaths[id]
+		return p, ok
+	}
+
+	sc := &model.SymbolContext{
+		Symbol: model.Symbol{
+			ID: 1, Name: "User", Qualified: "User",
+			Kind: "class", FileID: 1, LineStart: 1, LineEnd: 50,
+		},
+		File: model.File{Path: "app/models/user.rb"},
+		Inbound: []model.EdgeRef{
+			{Edge: model.Edge{Kind: model.EdgeCalls, Confidence: 1.0}, Target: model.Symbol{Qualified: "AuthService#login", FileID: 2}},
+			{Edge: model.Edge{Kind: model.EdgeCalls, Confidence: 1.0}, Target: model.Symbol{Qualified: "SessionsController#create", FileID: 3}},
+			{Edge: model.Edge{Kind: model.EdgeCalls, Confidence: 1.0}, Target: model.Symbol{Qualified: "UserSpec#test_login", FileID: 4}},
+			{Edge: model.Edge{Kind: model.EdgeCalls, Confidence: 1.0}, Target: model.Symbol{Qualified: "AuthSpec#test_auth", FileID: 5}},
+			{Edge: model.Edge{Kind: model.EdgeCalls, Confidence: 1.0}, Target: model.Symbol{Qualified: "SessionsTest#test_create", FileID: 6}},
+		},
+	}
+
+	resp := BuildGraphResponse(sc, files, BuildGraphRequest{Direction: "callers", SegmentCallers: true})
+
+	if len(resp.Edges.CalledBy) != 2 {
+		t.Fatalf("CalledBy (production) = %d, want 2", len(resp.Edges.CalledBy))
+	}
+	if resp.TestCallerSummary == nil {
+		t.Fatal("TestCallerSummary is nil, want non-nil")
+	}
+	if resp.TestCallerSummary.Count != 3 {
+		t.Errorf("TestCallerSummary.Count = %d, want 3", resp.TestCallerSummary.Count)
+	}
+	if resp.SenseMetrics.SymbolsReturned != 5 {
+		t.Errorf("SymbolsReturned = %d, want 5 (2 prod + 3 test)", resp.SenseMetrics.SymbolsReturned)
+	}
+
+	// Without SegmentCallers, all callers stay in CalledBy.
+	resp = BuildGraphResponse(sc, files, BuildGraphRequest{Direction: "callers", SegmentCallers: false})
+	if len(resp.Edges.CalledBy) != 5 {
+		t.Fatalf("CalledBy (unsegmented) = %d, want 5", len(resp.Edges.CalledBy))
+	}
+	if resp.TestCallerSummary != nil {
+		t.Errorf("TestCallerSummary should be nil when segmentation disabled, got %v", resp.TestCallerSummary)
+	}
+}
+
+func TestCallerSegmentationCollapseOver20(t *testing.T) {
+	testFiles := []string{
+		"spec/models/user_spec.rb",
+		"spec/services/auth_spec.rb",
+		"test/controllers/sessions_test.rb",
+		"spec/integration/user_flow_spec.rb",
+		"test/models/user_test.rb",
+	}
+	filePaths := map[int64]string{1: "app/models/user.rb"}
+	for i := int64(2); i <= 32; i++ {
+		filePaths[i] = testFiles[(i-2)%int64(len(testFiles))]
+	}
+	filePaths[33] = "app/services/auth.rb"
+	files := func(id int64) (string, bool) {
+		p, ok := filePaths[id]
+		return p, ok
+	}
+
+	var inbound []model.EdgeRef
+	for i := int64(2); i <= 32; i++ {
+		inbound = append(inbound, model.EdgeRef{
+			Edge:   model.Edge{Kind: model.EdgeCalls, Confidence: 1.0},
+			Target: model.Symbol{Qualified: "TestCaller", FileID: i},
+		})
+	}
+	inbound = append(inbound, model.EdgeRef{
+		Edge:   model.Edge{Kind: model.EdgeCalls, Confidence: 1.0},
+		Target: model.Symbol{Qualified: "AuthService#login", FileID: 33},
+	})
+
+	sc := &model.SymbolContext{
+		Symbol: model.Symbol{
+			ID: 1, Name: "User", Qualified: "User",
+			Kind: "class", FileID: 1, LineStart: 1, LineEnd: 50,
+		},
+		File:    model.File{Path: "app/models/user.rb"},
+		Inbound: inbound,
+	}
+
+	resp := BuildGraphResponse(sc, files, BuildGraphRequest{Direction: "callers", SegmentCallers: true})
+
+	if len(resp.Edges.CalledBy) != 1 {
+		t.Fatalf("CalledBy (production) = %d, want 1", len(resp.Edges.CalledBy))
+	}
+	if resp.TestCallerSummary == nil {
+		t.Fatal("TestCallerSummary is nil")
+	}
+	if resp.TestCallerSummary.Count != 31 {
+		t.Errorf("TestCallerSummary.Count = %d, want 31", resp.TestCallerSummary.Count)
+	}
+	if len(resp.TestCallerSummary.Examples) != 3 {
+		t.Errorf("TestCallerSummary.Examples = %d, want exactly 3 (truncated from 5 unique paths)", len(resp.TestCallerSummary.Examples))
+	}
+}
+
 func TestBuildGraphResponseTemporalCountsInMetrics(t *testing.T) {
 	coChanges := 3
 	sc := &model.SymbolContext{

--- a/internal/mcpio/marshal.go
+++ b/internal/mcpio/marshal.go
@@ -111,6 +111,9 @@ func normalizeGraphResponse(r *GraphResponse) {
 	if r.Edges.Temporal == nil {
 		r.Edges.Temporal = []TemporalEdgeRef{}
 	}
+	if r.TestCallerSummary != nil && r.TestCallerSummary.Examples == nil {
+		r.TestCallerSummary.Examples = []string{}
+	}
 	if r.NextSteps == nil {
 		r.NextSteps = []NextStep{}
 	}

--- a/internal/mcpio/testdata/blast_diff.json
+++ b/internal/mcpio/testdata/blast_diff.json
@@ -42,6 +42,8 @@
   "affected_subclasses": [],
   "affected_via_composition": [],
   "affected_via_includes": [],
+  "production_affected": 6,
+  "test_affected": 3,
   "sense_metrics": {
     "symbols_traversed": 9,
     "estimated_file_reads_avoided": 8,

--- a/internal/mcpio/testdata/blast_user_email_verified.json
+++ b/internal/mcpio/testdata/blast_user_email_verified.json
@@ -43,6 +43,8 @@
   "affected_subclasses": [],
   "affected_via_composition": [],
   "affected_via_includes": [],
+  "production_affected": 5,
+  "test_affected": 6,
   "sense_metrics": {
     "symbols_traversed": 47,
     "estimated_file_reads_avoided": 10,

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -71,11 +71,22 @@ type NextStep struct {
 // that do not compute it (the CLI in 01-04) omit the block entirely;
 // the MCP server in 01-05 always populates it.
 type GraphResponse struct {
-	Symbol       GraphSymbol  `json:"symbol"`
-	Edges        GraphEdges   `json:"edges"`
-	SenseMetrics GraphMetrics `json:"sense_metrics"`
-	Freshness    *Freshness   `json:"freshness,omitempty"`
-	NextSteps    []NextStep   `json:"next_steps"`
+	Symbol             GraphSymbol        `json:"symbol"`
+	Edges              GraphEdges         `json:"edges"`
+	TestCallerSummary  *TestCallerSummary `json:"test_caller_summary,omitempty"`
+	SenseMetrics       GraphMetrics       `json:"sense_metrics"`
+	Freshness          *Freshness         `json:"freshness,omitempty"`
+	NextSteps          []NextStep         `json:"next_steps"`
+}
+
+// TestCallerSummary segments test callers out of the main called_by
+// list so the LLM focuses on production callers. When test callers
+// exceed 20, Examples holds 3 representative file paths instead of
+// the full list. Present only when there are test callers; nil
+// otherwise.
+type TestCallerSummary struct {
+	Count    int      `json:"count"`
+	Examples []string `json:"examples"`
 }
 
 // GraphSymbol is the focal symbol's identity block. File is always
@@ -197,6 +208,9 @@ type BlastResponse struct {
 	AffectedSubclasses     []BlastCaller `json:"affected_subclasses"`
 	AffectedViaComposition []BlastCaller `json:"affected_via_composition"`
 	AffectedViaIncludes    []BlastCaller `json:"affected_via_includes"`
+
+	ProductionAffected int `json:"production_affected"`
+	TestAffected       int `json:"test_affected"`
 
 	SenseMetrics BlastMetrics `json:"sense_metrics"`
 	Freshness    *Freshness   `json:"freshness,omitempty"`

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -369,7 +369,8 @@ func (h *handlers) handleGraph(ctx context.Context, req mcp.CallToolRequest) (*m
 	}
 
 	resp := mcpio.BuildGraphResponse(sc, lookup, mcpio.BuildGraphRequest{
-		Direction: direction,
+		Direction:      direction,
+		SegmentCallers: h.defaults.GraphSegmentCallers,
 	})
 	h.tracker.Record("sense.graph", symbol,
 		resp.SenseMetrics.EstimatedFileReadsAvoided, resp.SenseMetrics.EstimatedTokensSaved)
@@ -388,13 +389,17 @@ func (h *handlers) handleGraph(ctx context.Context, req mcp.CallToolRequest) (*m
 func graphHints(resp mcpio.GraphResponse, direction string) []mcpio.NextStep {
 	var hints []mcpio.NextStep
 
-	if len(resp.Edges.CalledBy) >= 5 {
+	totalCallers := len(resp.Edges.CalledBy)
+	if resp.TestCallerSummary != nil {
+		totalCallers += resp.TestCallerSummary.Count
+	}
+	if totalCallers >= 5 {
 		hints = append(hints, mcpio.NextStep{
 			Tool:   "sense.blast",
 			Args:   map[string]any{"symbol": resp.Symbol.Qualified},
-			Reason: fmt.Sprintf("%d callers found — check blast radius before changing this symbol", len(resp.Edges.CalledBy)),
+			Reason: fmt.Sprintf("%d callers found — check blast radius before changing this symbol", totalCallers),
 		})
-	} else if len(resp.Edges.CalledBy) == 0 && !isTestFile(resp.Symbol.File) {
+	} else if totalCallers == 0 && !isTestFile(resp.Symbol.File) {
 		hints = append(hints, mcpio.NextStep{
 			Tool:   "sense.search",
 			Args:   map[string]any{"query": resp.Symbol.Name},
@@ -458,13 +463,7 @@ func deadCodeHints(resp mcpio.DeadCodeResponse) []mcpio.NextStep {
 }
 
 func isTestFile(path string) bool {
-	return strings.Contains(path, "_test.") ||
-		strings.Contains(path, "/test/") ||
-		strings.Contains(path, "/tests/") ||
-		strings.Contains(path, "/spec/") ||
-		strings.HasPrefix(path, "test/") ||
-		strings.HasPrefix(path, "tests/") ||
-		strings.HasPrefix(path, "spec/")
+	return mcpio.IsTestPath(path)
 }
 
 // ---------------------------------------------------------------

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -183,6 +183,7 @@ type Defaults struct {
 	BlastMaxHops           int
 	BlastMinConfidence     float64
 	BlastResultCap         int
+	GraphSegmentCallers    bool
 }
 
 func DefaultsForTier(tier string) Defaults {
@@ -197,6 +198,7 @@ func DefaultsForTier(tier string) Defaults {
 			BlastMaxHops:           5,
 			BlastMinConfidence:     0.3,
 			BlastResultCap:         200,
+			GraphSegmentCallers:    false,
 		}
 	case TierLarge:
 		return Defaults{
@@ -208,6 +210,7 @@ func DefaultsForTier(tier string) Defaults {
 			BlastMaxHops:           2,
 			BlastMinConfidence:     0.6,
 			BlastResultCap:         75,
+			GraphSegmentCallers:    true,
 		}
 	default:
 		return Defaults{
@@ -219,6 +222,7 @@ func DefaultsForTier(tier string) Defaults {
 			BlastMaxHops:           3,
 			BlastMinConfidence:     0.5,
 			BlastResultCap:         100,
+			GraphSegmentCallers:    true,
 		}
 	}
 }

--- a/internal/scan/incremental.go
+++ b/internal/scan/incremental.go
@@ -106,6 +106,12 @@ func RunIncremental(ctx context.Context, opts IncrementalOptions) (*Result, erro
 	}
 	phases.AssociateTests = time.Since(t0)
 
+	t0 = time.Now()
+	if err := h.namingConventionEdges(); err != nil {
+		return nil, fmt.Errorf("naming convention edges: %w", err)
+	}
+	phases.NamingConventions = time.Since(t0)
+
 	if opts.EmbeddingsEnabled {
 		t0 = time.Now()
 		if err := h.embedSymbols(); err != nil {

--- a/internal/scan/naming.go
+++ b/internal/scan/naming.go
@@ -1,0 +1,224 @@
+package scan
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/luuuc/sense/internal/index"
+	"github.com/luuuc/sense/internal/model"
+)
+
+const confidenceNamingConvention = 0.6
+
+var roleSuffixes = []string{
+	"Service", "Controller", "Serializer", "Validator",
+	"Decorator", "Job", "Worker", "Presenter",
+	"Contract", "Representer", "Mailer",
+}
+
+var excludedSuffixes = map[string]bool{
+	"Gateway":   true,
+	"Provider":  true,
+	"Client":    true,
+	"Adapter":   true,
+	"Error":     true,
+	"Exception": true,
+}
+
+type namingCandidate struct {
+	sym      model.Symbol
+	prefixes []string
+}
+
+// namingConventionEdges creates low-confidence calls edges between
+// classes whose names follow Rails/Django naming conventions and their
+// associated model classes. For example, WorkPackagesController → WorkPackage
+// and WorkPackages::CreateService → WorkPackage.
+//
+// Only runs for projects with Ruby or Python files — Go and TypeScript
+// have explicit references that tree-sitter already captures.
+func (h *harness) namingConventionEdges() error {
+	rubyFiles, err := h.idx.FileIDsByLanguage(h.ctx, "ruby")
+	if err != nil {
+		return fmt.Errorf("naming: query ruby files: %w", err)
+	}
+	pythonFiles, err := h.idx.FileIDsByLanguage(h.ctx, "python")
+	if err != nil {
+		return fmt.Errorf("naming: query python files: %w", err)
+	}
+	dynamicFiles := make(map[int64]bool, len(rubyFiles)+len(pythonFiles))
+	for id := range rubyFiles {
+		dynamicFiles[id] = true
+	}
+	for id := range pythonFiles {
+		dynamicFiles[id] = true
+	}
+	if len(dynamicFiles) == 0 {
+		return nil
+	}
+
+	syms, err := h.idx.Query(h.ctx, index.Filter{})
+	if err != nil {
+		return fmt.Errorf("naming: query symbols: %w", err)
+	}
+
+	classesByName := map[string][]model.Symbol{}
+	var candidates []namingCandidate
+	for _, s := range syms {
+		if !dynamicFiles[s.FileID] {
+			continue
+		}
+		if s.Kind != model.KindClass && s.Kind != model.KindModule {
+			continue
+		}
+		bare, _ := splitQualified(s.Qualified)
+		classesByName[bare] = append(classesByName[bare], s)
+		if prefixes, ok := modelPrefixes(s.Qualified); ok {
+			candidates = append(candidates, namingCandidate{sym: s, prefixes: prefixes})
+		}
+	}
+
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	var written int
+	err = h.idx.InTx(h.ctx, func() error {
+		for _, c := range candidates {
+			target, found := resolveModelTarget(c.prefixes, classesByName)
+			if !found || target.ID == c.sym.ID {
+				continue
+			}
+			_, werr := h.idx.WriteEdge(h.ctx, &model.Edge{
+				SourceID:   model.Int64Ptr(c.sym.ID),
+				TargetID:   target.ID,
+				Kind:       model.EdgeCalls,
+				FileID:     c.sym.FileID,
+				Confidence: confidenceNamingConvention,
+			})
+			if werr != nil {
+				return fmt.Errorf("write naming edge %s → %s: %w", c.sym.Qualified, target.Qualified, werr)
+			}
+			written++
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	h.edges += written
+	return nil
+}
+
+// splitQualified splits a qualified name into its bare name and
+// immediate namespace. Returns ("CreateService", "WorkPackages") for
+// "WorkPackages::CreateService" and ("UserController", "") for
+// "UserController".
+func splitQualified(qualified string) (bare, namespace string) {
+	for _, sep := range []string{"::", ".", "/"} {
+		i := strings.LastIndex(qualified, sep)
+		if i < 0 {
+			continue
+		}
+		bare = qualified[i+len(sep):]
+		prefix := qualified[:i]
+		for _, sep2 := range []string{"::", ".", "/"} {
+			if j := strings.LastIndex(prefix, sep2); j >= 0 {
+				namespace = prefix[j+len(sep2):]
+				return
+			}
+		}
+		namespace = prefix
+		return
+	}
+	return qualified, ""
+}
+
+// modelPrefixes returns candidate model names to look up for a class
+// that matches a role suffix. Returns prefixes from both the bare name
+// and the namespace.
+//
+// "WorkPackagesController" → ["WorkPackages"]
+// "WorkPackages::CreateService" → ["Create", "WorkPackages"]
+// "UserError" → nil (excluded suffix)
+func modelPrefixes(qualified string) ([]string, bool) {
+	bare, ns := splitQualified(qualified)
+
+	for suffix := range excludedSuffixes {
+		if strings.HasSuffix(bare, suffix) {
+			return nil, false
+		}
+	}
+
+	var prefixes []string
+
+	for _, suffix := range roleSuffixes {
+		if strings.HasSuffix(bare, suffix) && len(bare) > len(suffix) {
+			prefixes = append(prefixes, bare[:len(bare)-len(suffix)])
+			break
+		}
+	}
+
+	if ns != "" {
+		for _, suffix := range roleSuffixes {
+			if strings.HasSuffix(bare, suffix) {
+				if !slices.Contains(prefixes, ns) {
+					prefixes = append(prefixes, ns)
+				}
+				break
+			}
+		}
+	}
+
+	if len(prefixes) == 0 {
+		return nil, false
+	}
+	return prefixes, true
+}
+
+// resolveModelTarget tries to find a class matching any of the
+// candidate prefixes. Singularized forms are tried first so the
+// model class (WorkPackage) is preferred over a namespace module
+// (WorkPackages) that shares the plural name.
+func resolveModelTarget(prefixes []string, classesByName map[string][]model.Symbol) (model.Symbol, bool) {
+	for _, prefix := range prefixes {
+		singular := singularize(prefix)
+		if singular != prefix {
+			if ss, ok := classesByName[singular]; ok {
+				return ss[0], true
+			}
+		}
+	}
+	for _, prefix := range prefixes {
+		if ss, ok := classesByName[prefix]; ok {
+			return ss[0], true
+		}
+	}
+	return model.Symbol{}, false
+}
+
+func singularize(s string) string {
+	if s == "" {
+		return s
+	}
+	if strings.HasSuffix(s, "ies") && len(s) > 3 {
+		return s[:len(s)-3] + "y"
+	}
+	if strings.HasSuffix(s, "sses") {
+		return s[:len(s)-2]
+	}
+	if strings.HasSuffix(s, "ses") && len(s) > 3 {
+		return s[:len(s)-2]
+	}
+	if strings.HasSuffix(s, "xes") && len(s) > 3 {
+		return s[:len(s)-2]
+	}
+	if strings.HasSuffix(s, "ss") || strings.HasSuffix(s, "us") || strings.HasSuffix(s, "is") {
+		return s
+	}
+	if strings.HasSuffix(s, "s") && len(s) > 1 {
+		return s[:len(s)-1]
+	}
+	return s
+}

--- a/internal/scan/naming_test.go
+++ b/internal/scan/naming_test.go
@@ -1,0 +1,73 @@
+package scan
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestSingularize(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"WorkPackages", "WorkPackage"},
+		{"Categories", "Category"},
+		{"Addresses", "Address"},
+		{"Users", "User"},
+		{"Status", "Status"},
+		{"Class", "Class"},
+		{"Address", "Address"},
+		{"", ""},
+		{"s", "s"},
+		{"Boxes", "Box"},
+	}
+	for _, tc := range cases {
+		got := singularize(tc.in)
+		if got != tc.want {
+			t.Errorf("singularize(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestSplitQualified(t *testing.T) {
+	cases := []struct {
+		in        string
+		wantBare  string
+		wantNS    string
+	}{
+		{"WorkPackages::CreateService", "CreateService", "WorkPackages"},
+		{"Admin::WorkPackages::CreateService", "CreateService", "WorkPackages"},
+		{"WorkPackagesController", "WorkPackagesController", ""},
+		{"", "", ""},
+	}
+	for _, tc := range cases {
+		bare, ns := splitQualified(tc.in)
+		if bare != tc.wantBare || ns != tc.wantNS {
+			t.Errorf("splitQualified(%q) = (%q, %q), want (%q, %q)",
+				tc.in, bare, ns, tc.wantBare, tc.wantNS)
+		}
+	}
+}
+
+func TestModelPrefixes(t *testing.T) {
+	cases := []struct {
+		qualified string
+		want      []string
+		ok        bool
+	}{
+		{"WorkPackagesController", []string{"WorkPackages"}, true},
+		{"WorkPackages::CreateService", []string{"Create", "WorkPackages"}, true},
+		{"UserMailer", []string{"User"}, true},
+		{"UserError", nil, false},
+		{"UserGateway", nil, false},
+		{"User", nil, false},
+		{"Payments::StripeAdapter", nil, false},
+	}
+	for _, tc := range cases {
+		got, ok := modelPrefixes(tc.qualified)
+		if ok != tc.ok {
+			t.Errorf("modelPrefixes(%q) ok = %v, want %v", tc.qualified, ok, tc.ok)
+			continue
+		}
+		if ok && !slices.Equal(got, tc.want) {
+			t.Errorf("modelPrefixes(%q) = %v, want %v", tc.qualified, got, tc.want)
+		}
+	}
+}

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -67,6 +67,7 @@ type PhaseTiming struct {
 	ResolveEdges      time.Duration
 	SatisfyInterfaces time.Duration
 	AssociateTests    time.Duration
+	NamingConventions time.Duration
 	Temporal          time.Duration
 	Embed             time.Duration
 	BuildHNSW         time.Duration
@@ -221,6 +222,12 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	phases.AssociateTests = time.Since(t0)
 
 	t0 = time.Now()
+	if err := h.namingConventionEdges(); err != nil {
+		return nil, err
+	}
+	phases.NamingConventions = time.Since(t0)
+
+	t0 = time.Now()
 	if err := h.extractTemporalCoupling(); err != nil {
 		return nil, err
 	}
@@ -337,12 +344,13 @@ func printPhaseBreakdown(out io.Writer, total time.Duration, p PhaseTiming) {
 		}
 		return int(100 * d / total)
 	}
-	_, _ = fmt.Fprintf(out, "phases: walk %s (%d%%), stale %s (%d%%), edges %s (%d%%), interfaces %s (%d%%), tests %s (%d%%), temporal %s (%d%%)",
+	_, _ = fmt.Fprintf(out, "phases: walk %s (%d%%), stale %s (%d%%), edges %s (%d%%), interfaces %s (%d%%), tests %s (%d%%), naming %s (%d%%), temporal %s (%d%%)",
 		p.Walk, pct(p.Walk),
 		p.RemoveStale, pct(p.RemoveStale),
 		p.ResolveEdges, pct(p.ResolveEdges),
 		p.SatisfyInterfaces, pct(p.SatisfyInterfaces),
 		p.AssociateTests, pct(p.AssociateTests),
+		p.NamingConventions, pct(p.NamingConventions),
 		p.Temporal, pct(p.Temporal))
 	if p.Embed > 0 || p.BuildHNSW > 0 {
 		_, _ = fmt.Fprintf(out, ", embed %s (%d%%), hnsw %s (%d%%)",

--- a/internal/scan/testdata/crossfile/naming_convention/expected.golden.json
+++ b/internal/scan/testdata/crossfile/naming_convention/expected.golden.json
@@ -1,0 +1,28 @@
+{
+  "edges": [
+    {
+      "source": "UserMailer",
+      "source_file": "services.rb",
+      "target": "User",
+      "target_file": "work_package.rb",
+      "kind": "calls",
+      "confidence": 0.6
+    },
+    {
+      "source": "WorkPackages::CreateService",
+      "source_file": "services.rb",
+      "target": "WorkPackage",
+      "target_file": "work_package.rb",
+      "kind": "calls",
+      "confidence": 0.6
+    },
+    {
+      "source": "WorkPackagesController",
+      "source_file": "services.rb",
+      "target": "WorkPackage",
+      "target_file": "work_package.rb",
+      "kind": "calls",
+      "confidence": 0.6
+    }
+  ]
+}

--- a/internal/scan/testdata/crossfile/naming_convention/services.rb
+++ b/internal/scan/testdata/crossfile/naming_convention/services.rb
@@ -1,0 +1,25 @@
+module WorkPackages
+  class CreateService
+    def call
+      true
+    end
+  end
+end
+
+class WorkPackagesController
+  def index
+    true
+  end
+end
+
+class UserMailer
+  def welcome
+    true
+  end
+end
+
+class UserError
+  def message
+    "error"
+  end
+end

--- a/internal/scan/testdata/crossfile/naming_convention/work_package.rb
+++ b/internal/scan/testdata/crossfile/naming_convention/work_package.rb
@@ -1,0 +1,11 @@
+class WorkPackage
+  def save
+    true
+  end
+end
+
+class User
+  def login
+    true
+  end
+end


### PR DESCRIPTION
## Problem

Sense scores poorly on refactor tasks for large Ruby codebases (openproject 0.09, discourse 0.20) because two things compound: naming-convention relationships like `WorkPackagesController → WorkPackage` are invisible to the graph, and callers lists are dominated by test files — on openproject, 77 of 81 callers of `WorkPackage#save` were tests, burying the 4 production callers that matter for refactoring context.

## Summary

Add a post-scan pass that creates edges from Rails/Django naming conventions, and segment graph callers into production vs test so the LLM focuses on architecturally significant callers.

## Changes

**Naming-convention edges** (`internal/scan/naming.go`)
- Post-scan pass creates `calls` edges (confidence 0.6) between classes matching role suffixes (Service, Controller, Serializer, etc.) and their model classes
- Handles namespace resolution (`WorkPackages::CreateService → WorkPackage`), singularization (`WorkPackages → WorkPackage`), and excluded suffixes (Gateway, Provider, Client, Adapter, Error, Exception)
- Only fires for Ruby/Python projects; hooked into both full and incremental scan

**Caller segmentation** (`internal/mcpio/graph.go`)
- Split inbound call edges into production callers (`called_by`) and test callers (`test_caller_summary`) based on file path heuristics
- Collapse test callers to 3 example paths when count exceeds 20
- Tier-gated via auto-calibration profile: disabled on small projects (< 3k symbols) to preserve exhaustive caller enumeration

**Blast segmentation** (`internal/mcpio/blast.go`)
- Add `production_affected` and `test_affected` counts to blast response

**Bench fix** (`bench/run.sh`)
- Fix EXIT trap that moved `.claude.bench-hidden` inside a regenerated `.claude/` directory instead of replacing it

## Test Plan
- [x] `make ci` passes (all tests + lint)
- [x] Naming: fixture with `WorkPackages::CreateService`, `WorkPackagesController`, `UserMailer` → 3 edges created; `UserError` excluded
- [x] Singularization: WorkPackages→WorkPackage, Categories→Category, Status→Status (protected)
- [x] Caller segmentation: 5 callers split into 2 production + 3 test; collapse test at >20 to 3 examples
- [x] Segmentation disabled on small tier: all callers stay in CalledBy
- [x] Benchmark: openproject/refactor 0.09→0.45, flask/callers restored to 1.00, gin/refactor 1.00