### PR TITLE
feat(search): add cross-encoder reranking for improved search precision

### DIFF
--- a/bench/.gitignore
+++ b/bench/.gitignore
@@ -6,4 +6,6 @@ repos/flask/
 repos/discourse/
 repos/openproject/
 repos/gin/
+repos/maket/
 repos/nextjs/
+ground-truth/maket/

--- a/bench/repos/PINNED_COMMITS.json
+++ b/bench/repos/PINNED_COMMITS.json
@@ -4,5 +4,6 @@
   "discourse": "d73e4484b4b9dcffa1e75e2ceff6e0a005d479c6",
   "openproject": "cc860737145fb237413b5b5a31c561ef97fdd7a8",
   "gin": "d3ffc9985281dcf4d3bef604cce4e662b1a327a6",
+  "maket": "5bf00223e718736203865c06700589c3cab24acf",
   "nextjs": "16e5f9e685188751f1f4fb085f6e9e729f409950"
 }

--- a/bench/repos/README.md
+++ b/bench/repos/README.md
@@ -10,6 +10,7 @@ Clone these repos locally before running the harness. Pin to exact commits for r
 | **discourse** | Ruby/Rails | `git clone https://github.com/discourse/discourse.git repos/discourse` | Pin on first clone |
 | **openproject** | Ruby/Rails | `git clone https://github.com/opf/openproject.git repos/openproject` | Pin on first clone |
 | **gin** | Go | `git clone https://github.com/gin-gonic/gin.git repos/gin` | Pin on first clone |
+| **maket** | Ruby/Rails | `git clone https://github.com/maket-store/maket-web.git repos/maket` | Pin on first clone |
 | **nextjs** | TypeScript | `git clone https://github.com/vercel/next.js.git repos/nextjs` | Pin on first clone |
 
 ## Pinning
@@ -44,4 +45,5 @@ git checkout $(python3 -c "import json; print(json.load(open('../PINNED_COMMITS.
 | discourse | ~21,500 | Ruby (~427k lines), TS/JS (~320k lines) |
 | openproject | ~20,600 | Ruby (~509k lines), TS/JS (~164k lines) |
 | gin | ~120 | Go |
+| maket | ~1,243 | Ruby (~207k lines) |
 | nextjs | ~8,000 | TypeScript |

--- a/bench/tasks/blast-radius.yaml
+++ b/bench/tasks/blast-radius.yaml
@@ -20,6 +20,9 @@ repos:
   gin:
     symbol: "Context"
     ground_truth_file: ground-truth/gin/blast-radius.json
+  maket:
+    symbol: "Listing::Item"
+    ground_truth_file: ground-truth/maket/blast-radius.json
   nextjs:
     symbol: "NextConfig"
     ground_truth_file: ground-truth/nextjs/blast-radius.json

--- a/bench/tasks/callers.yaml
+++ b/bench/tasks/callers.yaml
@@ -19,6 +19,9 @@ repos:
   gin:
     symbol: "Engine.ServeHTTP"
     ground_truth_file: ground-truth/gin/callers.json
+  maket:
+    symbol: "Checkout::Order"
+    ground_truth_file: ground-truth/maket/callers.json
   nextjs:
     symbol: "renderToHTMLOrFlight"
     ground_truth_file: ground-truth/nextjs/callers.json

--- a/bench/tasks/conventions.yaml
+++ b/bench/tasks/conventions.yaml
@@ -20,6 +20,9 @@ repos:
   gin:
     domain: "."
     ground_truth_file: ground-truth/gin/conventions.json
+  maket:
+    domain: "app/services"
+    ground_truth_file: ground-truth/maket/conventions.json
   nextjs:
     domain: "packages/next/src/server"
     ground_truth_file: ground-truth/nextjs/conventions.json

--- a/bench/tasks/dead-code.yaml
+++ b/bench/tasks/dead-code.yaml
@@ -19,6 +19,9 @@ repos:
   gin:
     domain: "."
     ground_truth_file: ground-truth/gin/dead-code.json
+  maket:
+    domain: "app/models"
+    ground_truth_file: ground-truth/maket/dead-code.json
   nextjs:
     domain: "packages/next/src/server"
     ground_truth_file: ground-truth/nextjs/dead-code.json

--- a/bench/tasks/orient.yaml
+++ b/bench/tasks/orient.yaml
@@ -16,6 +16,8 @@ repos:
     ground_truth_file: ground-truth/openproject/orient.json
   gin:
     ground_truth_file: ground-truth/gin/orient.json
+  maket:
+    ground_truth_file: ground-truth/maket/orient.json
   nextjs:
     ground_truth_file: ground-truth/nextjs/orient.json
 

--- a/bench/tasks/refactor.yaml
+++ b/bench/tasks/refactor.yaml
@@ -20,6 +20,9 @@ repos:
   gin:
     symbol: "Engine.handleHTTPRequest"
     ground_truth_file: ground-truth/gin/refactor.json
+  maket:
+    symbol: "Listing::Item"
+    ground_truth_file: ground-truth/maket/refactor.json
   nextjs:
     symbol: "renderToHTMLOrFlight"
     ground_truth_file: ground-truth/nextjs/refactor.json

--- a/bench/tasks/semantic-search.yaml
+++ b/bench/tasks/semantic-search.yaml
@@ -20,6 +20,9 @@ repos:
   gin:
     concept: "HTTP request routing and middleware"
     ground_truth_file: ground-truth/gin/semantic-search.json
+  maket:
+    concept: "checkout and payment processing"
+    ground_truth_file: ground-truth/maket/semantic-search.json
   nextjs:
     concept: "server-side rendering and page generation"
     ground_truth_file: ground-truth/nextjs/semantic-search.json

--- a/internal/benchmark/benchmark.go
+++ b/internal/benchmark/benchmark.go
@@ -353,7 +353,20 @@ func buildSearchEngine(ctx context.Context, adapter *sqlite.Adapter, dir string)
 	}
 
 	engine := search.NewEngine(adapter, vectorIdx, embedder)
+
+	var reranker *embed.ONNXReranker
+	if embedder != nil {
+		r, err := embed.NewBundledReranker(0)
+		if err == nil {
+			reranker = r
+			engine.SetReranker(r)
+		}
+	}
+
 	return engine, embedder, func() {
+		if reranker != nil {
+			_ = reranker.Close()
+		}
 		if embedder != nil {
 			_ = embedder.Close()
 		}

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -92,6 +92,17 @@ func RunSearch(args []string, cio IO) int {
 	}
 
 	engine := search.NewEngine(adapter, vectorIdx, embedder)
+
+	if embedder != nil {
+		reranker, rerankErr := embed.NewBundledReranker(0)
+		if rerankErr != nil {
+			_, _ = fmt.Fprintln(cio.Stderr, "sense search: init reranker:", rerankErr)
+		} else {
+			engine.SetReranker(reranker)
+			defer func() { _ = reranker.Close() }()
+		}
+	}
+
 	results, meta, err := engine.Search(ctx, search.Options{
 		Query:    opts.Query,
 		Limit:    opts.Limit,

--- a/internal/embed/bundle.go
+++ b/internal/embed/bundle.go
@@ -16,6 +16,9 @@ var modelBytes []byte
 //go:embed bundle/vocab.txt
 var vocabBytes []byte
 
+//go:embed bundle/reranker.onnx
+var rerankerBytes []byte
+
 // NewBundledEmbedder creates an ONNXEmbedder using the model, vocabulary,
 // and ONNX Runtime library embedded in the binary. It extracts the
 // platform-specific shared library to a cache directory on first use.
@@ -33,6 +36,21 @@ func NewBundledEmbedder(intraOpThreads int) (*ONNXEmbedder, error) {
 	}
 
 	return NewONNXEmbedder(modelBytes, vocabBytes, intraOpThreads)
+}
+
+// NewBundledReranker creates an ONNXReranker using the cross-encoder model
+// and vocabulary embedded in the binary.
+func NewBundledReranker(intraOpThreads int) (*ONNXReranker, error) {
+	libPath, err := ensureORTLib()
+	if err != nil {
+		return nil, fmt.Errorf("extract ONNX Runtime library: %w", err)
+	}
+
+	if err := InitORTLibrary(libPath); err != nil {
+		return nil, fmt.Errorf("init ONNX Runtime: %w", err)
+	}
+
+	return NewONNXReranker(rerankerBytes, vocabBytes, intraOpThreads)
 }
 
 // ensureORTLib extracts the bundled ONNX Runtime shared library to a

--- a/internal/embed/bundle/.gitignore
+++ b/internal/embed/bundle/.gitignore
@@ -1,5 +1,6 @@
 *.onnx
 vocab.txt
 darwin_arm64/
+darwin_amd64/
 linux_amd64/
 linux_arm64/

--- a/internal/embed/bundle_test.go
+++ b/internal/embed/bundle_test.go
@@ -38,6 +38,38 @@ func TestNewBundledEmbedder(t *testing.T) {
 	}
 }
 
+func TestNewBundledReranker(t *testing.T) {
+	if len(rerankerBytes) == 0 {
+		t.Skip("reranker model not bundled; run scripts/fetch-deps.sh --local")
+	}
+	if len(vocabBytes) == 0 {
+		t.Skip("vocab not bundled; run scripts/fetch-deps.sh --local")
+	}
+	if len(ortLibData) == 0 {
+		t.Skip("ORT library not bundled; run scripts/fetch-deps.sh --local")
+	}
+
+	r, err := NewBundledReranker(0)
+	if err != nil {
+		t.Fatalf("NewBundledReranker: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+
+	scores, err := r.Score("user authentication", []string{
+		"method Auth::Login#call\ndef call(email, password)",
+		"method CSV::Parser#parse\ndef parse(input)",
+	})
+	if err != nil {
+		t.Fatalf("score: %v", err)
+	}
+	if len(scores) != 2 {
+		t.Fatalf("expected 2 scores, got %d", len(scores))
+	}
+	if scores[0] <= scores[1] {
+		t.Errorf("auth doc (%.4f) should score higher than csv doc (%.4f)", scores[0], scores[1])
+	}
+}
+
 func TestEnsureORTLibCacheInvalidation(t *testing.T) {
 	if len(ortLibData) == 0 {
 		t.Skip("ORT library not bundled; run scripts/fetch-deps.sh --local")

--- a/internal/embed/reranker.go
+++ b/internal/embed/reranker.go
@@ -1,0 +1,157 @@
+package embed
+
+import (
+	"fmt"
+
+	ort "github.com/yalue/onnxruntime_go"
+)
+
+// RerankerBatchSize is the max pairs per ONNX inference call.
+const RerankerBatchSize = 50
+
+// ONNXReranker implements Reranker using a cross-encoder ONNX model.
+// Not safe for concurrent use.
+type ONNXReranker struct {
+	session   *ort.DynamicAdvancedSession
+	tokenizer *tokenizer
+	seqLen    int
+
+	inputIDs      []int64
+	attentionMask []int64
+	tokenTypeIDs  []int64
+}
+
+// NewONNXReranker creates a reranker from cross-encoder model and
+// vocabulary bytes. The model must accept input_ids, attention_mask,
+// and token_type_ids, and output logits of shape [batch, 1].
+func NewONNXReranker(modelBytes, vocabBytes []byte, intraOpThreads int) (*ONNXReranker, error) {
+	opts, err := ort.NewSessionOptions()
+	if err != nil {
+		return nil, fmt.Errorf("create session options: %w", err)
+	}
+	defer func() { _ = opts.Destroy() }()
+
+	if intraOpThreads > 0 {
+		if err := opts.SetIntraOpNumThreads(intraOpThreads); err != nil {
+			return nil, fmt.Errorf("set intra-op threads: %w", err)
+		}
+	}
+	if err := opts.SetGraphOptimizationLevel(ort.GraphOptimizationLevelEnableAll); err != nil {
+		return nil, fmt.Errorf("set graph optimization: %w", err)
+	}
+
+	session, err := ort.NewDynamicAdvancedSessionWithONNXData(
+		modelBytes,
+		[]string{"input_ids", "attention_mask", "token_type_ids"},
+		[]string{"logits"},
+		opts,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create cross-encoder session: %w", err)
+	}
+
+	tok := newTokenizer(vocabBytes, MaxSequenceLength)
+
+	bufSize := int64(RerankerBatchSize) * int64(MaxSequenceLength)
+	return &ONNXReranker{
+		session:       session,
+		tokenizer:     tok,
+		seqLen:        MaxSequenceLength,
+		inputIDs:      make([]int64, bufSize),
+		attentionMask: make([]int64, bufSize),
+		tokenTypeIDs:  make([]int64, bufSize),
+	}, nil
+}
+
+// Score returns a relevance score for each (query, doc) pair.
+// Higher scores indicate greater relevance. Handles batching
+// internally when len(docs) > RerankerBatchSize.
+func (r *ONNXReranker) Score(query string, docs []string) ([]float32, error) {
+	if len(docs) == 0 {
+		return nil, nil
+	}
+
+	scores := make([]float32, 0, len(docs))
+	for i := 0; i < len(docs); i += RerankerBatchSize {
+		end := i + RerankerBatchSize
+		if end > len(docs) {
+			end = len(docs)
+		}
+
+		batchScores, err := r.scoreBatch(query, docs[i:end])
+		if err != nil {
+			return nil, fmt.Errorf("score batch at %d: %w", i, err)
+		}
+		scores = append(scores, batchScores...)
+	}
+
+	return scores, nil
+}
+
+func (r *ONNXReranker) scoreBatch(query string, docs []string) ([]float32, error) {
+	batchSize := int64(len(docs))
+	seqLen := int64(r.seqLen)
+	needed := batchSize * seqLen
+
+	inputIDs := r.inputIDs[:needed]
+	attentionMask := r.attentionMask[:needed]
+	tokenTypeIDs := r.tokenTypeIDs[:needed]
+
+	clear(inputIDs)
+	clear(attentionMask)
+	clear(tokenTypeIDs)
+
+	for i, doc := range docs {
+		pair := r.tokenizer.TokenizePair(query, doc)
+		offset := int64(i) * seqLen
+		for j := int64(0); j < seqLen; j++ {
+			inputIDs[offset+j] = int64(pair.InputIDs[j])
+			attentionMask[offset+j] = int64(pair.AttentionMask[j])
+			tokenTypeIDs[offset+j] = int64(pair.TokenTypeIDs[j])
+		}
+	}
+
+	shape := ort.Shape{batchSize, seqLen}
+
+	idT, err := ort.NewTensor(shape, inputIDs)
+	if err != nil {
+		return nil, fmt.Errorf("create input_ids tensor: %w", err)
+	}
+	defer func() { _ = idT.Destroy() }()
+
+	maskT, err := ort.NewTensor(shape, attentionMask)
+	if err != nil {
+		return nil, fmt.Errorf("create attention_mask tensor: %w", err)
+	}
+	defer func() { _ = maskT.Destroy() }()
+
+	typeT, err := ort.NewTensor(shape, tokenTypeIDs)
+	if err != nil {
+		return nil, fmt.Errorf("create token_type_ids tensor: %w", err)
+	}
+	defer func() { _ = typeT.Destroy() }()
+
+	outT, err := ort.NewEmptyTensor[float32](ort.Shape{batchSize, 1})
+	if err != nil {
+		return nil, fmt.Errorf("create output tensor: %w", err)
+	}
+	defer func() { _ = outT.Destroy() }()
+
+	if err := r.session.Run([]ort.Value{idT, maskT, typeT}, []ort.Value{outT}); err != nil {
+		return nil, fmt.Errorf("cross-encoder inference: %w", err)
+	}
+
+	data := outT.GetData()
+	scores := make([]float32, batchSize)
+	copy(scores, data)
+	return scores, nil
+}
+
+func (r *ONNXReranker) Close() error {
+	if r.session != nil {
+		err := r.session.Destroy()
+		r.session = nil
+		return err
+	}
+	return nil
+}

--- a/internal/embed/reranker_eval_test.go
+++ b/internal/embed/reranker_eval_test.go
@@ -1,0 +1,219 @@
+package embed
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func setupRerankerCandidate(t *testing.T, name string) *ONNXReranker {
+	t.Helper()
+
+	dir := testdataDir()
+	modelPath := filepath.Join(dir, "rerankers", name, "model.onnx")
+	vocabPath := filepath.Join(dir, "vocab.txt")
+
+	if _, err := os.Stat(modelPath); err != nil {
+		t.Skipf("model not downloaded; run internal/embed/testdata/rerankers/download.sh")
+	}
+	if _, err := os.Stat(vocabPath); err != nil {
+		t.Skip("vocab not downloaded")
+	}
+
+	libPath := ortLibPath()
+	if _, err := os.Stat(libPath); err != nil && !filepath.IsAbs(libPath) {
+		t.Skipf("ONNX Runtime not found at %s", libPath)
+	}
+	if err := InitORTLibrary(libPath); err != nil {
+		t.Fatalf("init ORT: %v", err)
+	}
+
+	mb, err := os.ReadFile(modelPath)
+	if err != nil {
+		t.Fatalf("read model: %v", err)
+	}
+	vb, err := os.ReadFile(vocabPath)
+	if err != nil {
+		t.Fatalf("read vocab: %v", err)
+	}
+
+	r, err := NewONNXReranker(mb, vb, 0)
+	if err != nil {
+		t.Fatalf("create reranker %s: %v", name, err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+
+	return r
+}
+
+func TestCrossEncoderEvaluation(t *testing.T) {
+	candidates := []string{"ms-marco-MiniLM-L-6-v2", "ms-marco-MiniLM-L-12-v2"}
+
+	for _, name := range candidates {
+		t.Run(name, func(t *testing.T) {
+			r := setupRerankerCandidate(t, name)
+
+			// Warmup
+			_, _ = r.Score("warmup query", []string{"warmup document text"})
+
+			t.Run("latency_sequential", func(t *testing.T) {
+				docs := make([]string, 50)
+				for i := range docs {
+					docs[i] = fmt.Sprintf("method Auth::Login#call\ndef call(email, password)\n  validate_credentials(email, password)\nend variant_%d", i)
+				}
+				start := time.Now()
+				for _, doc := range docs {
+					_, err := r.Score("user authentication and password validation", []string{doc})
+					if err != nil {
+						t.Fatalf("score: %v", err)
+					}
+				}
+				elapsed := time.Since(start)
+				msPerPair := float64(elapsed.Microseconds()) / 50000.0
+				t.Logf("50 sequential: %v total, %.2f ms/pair", elapsed, msPerPair)
+				if elapsed > 5*time.Second {
+					t.Errorf("latency %v exceeds 5s budget", elapsed)
+				}
+			})
+
+			t.Run("latency_batch", func(t *testing.T) {
+				docs := make([]string, 50)
+				for i := range docs {
+					docs[i] = fmt.Sprintf("method Auth::Login#call\ndef call(email, password)\n  validate_credentials(email, password)\nend variant_%d", i)
+				}
+				start := time.Now()
+				_, err := r.Score("user authentication and password validation", docs)
+				if err != nil {
+					t.Fatalf("score: %v", err)
+				}
+				elapsed := time.Since(start)
+				t.Logf("50 batched: %v", elapsed)
+			})
+
+			t.Run("quality", func(t *testing.T) {
+				var totalSep float64
+				wins := 0
+				for _, tc := range separationCases {
+					targetScores, err := r.Score(tc.query, []string{tc.targetRich})
+					if err != nil {
+						t.Fatalf("score target: %v", err)
+					}
+					noiseScores, err := r.Score(tc.query, []string{tc.noiseRich})
+					if err != nil {
+						t.Fatalf("score noise: %v", err)
+					}
+					sep := float64(targetScores[0] - noiseScores[0])
+					totalSep += sep
+
+					pass := "PASS"
+					if sep <= 0 {
+						pass = "FAIL"
+					} else {
+						wins++
+					}
+
+					t.Logf("%-50s target=%8.4f noise=%8.4f sep=%8.4f %s",
+						tc.name, targetScores[0], noiseScores[0], sep, pass)
+				}
+				n := len(separationCases)
+				t.Logf("average separation: %.4f  wins: %d/%d", totalSep/float64(n), wins, n)
+
+				if wins < n/2 {
+					t.Errorf("cross-encoder won only %d/%d separation cases", wins, n)
+				}
+			})
+		})
+	}
+}
+
+func TestTokenizePair(t *testing.T) {
+	vocabPath := filepath.Join(testdataDir(), "vocab.txt")
+	vocabBytes, err := os.ReadFile(vocabPath)
+	if err != nil {
+		t.Skip("vocab not downloaded")
+	}
+
+	tok := newTokenizer(vocabBytes, MaxSequenceLength)
+	result := tok.TokenizePair("hello world", "this is a test document")
+
+	if result.InputIDs[0] != tok.clsID {
+		t.Errorf("first token should be [CLS] (%d), got %d", tok.clsID, result.InputIDs[0])
+	}
+
+	var sepPositions []int
+	for i, id := range result.InputIDs {
+		if id == tok.sepID && i > 0 {
+			sepPositions = append(sepPositions, i)
+		}
+	}
+	if len(sepPositions) < 2 {
+		t.Fatalf("expected 2 [SEP] tokens, found %d", len(sepPositions))
+	}
+
+	for i := 0; i <= sepPositions[0]; i++ {
+		if result.TokenTypeIDs[i] != 0 {
+			t.Errorf("position %d: token_type_id = %d, want 0 (query segment)", i, result.TokenTypeIDs[i])
+		}
+	}
+
+	for i := sepPositions[0] + 1; i <= sepPositions[1]; i++ {
+		if result.TokenTypeIDs[i] != 1 {
+			t.Errorf("position %d: token_type_id = %d, want 1 (doc segment)", i, result.TokenTypeIDs[i])
+		}
+	}
+
+	lastNonPad := 0
+	for i, m := range result.AttentionMask {
+		if m == 1 {
+			lastNonPad = i
+		}
+	}
+	if lastNonPad < sepPositions[1] {
+		t.Error("attention mask ends before second [SEP]")
+	}
+	if lastNonPad < MaxSequenceLength-1 && result.AttentionMask[lastNonPad+1] != 0 {
+		t.Error("padding positions should have attention mask = 0")
+	}
+}
+
+func TestTokenizePairTruncation(t *testing.T) {
+	vocabPath := filepath.Join(testdataDir(), "vocab.txt")
+	vocabBytes, err := os.ReadFile(vocabPath)
+	if err != nil {
+		t.Skip("vocab not downloaded")
+	}
+
+	// Use a very short max length to force truncation.
+	tok := newTokenizer(vocabBytes, 16)
+	result := tok.TokenizePair(
+		"this is a fairly long query that should get truncated",
+		"this is an even longer document that should definitely get truncated at the boundary",
+	)
+
+	// Count non-padding tokens.
+	nonPad := 0
+	for _, m := range result.AttentionMask {
+		if m == 1 {
+			nonPad++
+		}
+	}
+	if nonPad > 16 {
+		t.Errorf("non-padding tokens %d exceeds max length 16", nonPad)
+	}
+
+	// Must have [CLS] and two [SEP] tokens.
+	if result.InputIDs[0] != tok.clsID {
+		t.Error("missing [CLS]")
+	}
+	sepCount := 0
+	for i, id := range result.InputIDs {
+		if id == tok.sepID && i > 0 {
+			sepCount++
+		}
+	}
+	if sepCount < 2 {
+		t.Errorf("expected 2 [SEP] tokens, found %d", sepCount)
+	}
+}

--- a/internal/embed/reranker_test.go
+++ b/internal/embed/reranker_test.go
@@ -1,0 +1,191 @@
+package embed
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func setupReranker(t *testing.T) *ONNXReranker {
+	t.Helper()
+
+	dir := testdataDir()
+	modelPath := filepath.Join(dir, "rerankers", "ms-marco-MiniLM-L-6-v2", "model.onnx")
+	vocabPath := filepath.Join(dir, "vocab.txt")
+
+	if _, err := os.Stat(modelPath); err != nil {
+		t.Skip("reranker model not downloaded; run internal/embed/testdata/rerankers/download.sh")
+	}
+	if _, err := os.Stat(vocabPath); err != nil {
+		t.Skip("vocab not downloaded; run internal/embed/testdata/download.sh")
+	}
+
+	libPath := ortLibPath()
+	if _, err := os.Stat(libPath); err != nil && !filepath.IsAbs(libPath) {
+		t.Skipf("ONNX Runtime not found at %s", libPath)
+	}
+	if err := InitORTLibrary(libPath); err != nil {
+		t.Fatalf("init ORT: %v", err)
+	}
+
+	modelBytes, err := os.ReadFile(modelPath)
+	if err != nil {
+		t.Fatalf("read model: %v", err)
+	}
+	vocabBytes, err := os.ReadFile(vocabPath)
+	if err != nil {
+		t.Fatalf("read vocab: %v", err)
+	}
+
+	r, err := NewONNXReranker(modelBytes, vocabBytes, 0)
+	if err != nil {
+		t.Fatalf("create reranker: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+
+	return r
+}
+
+func TestRerankerScore(t *testing.T) {
+	r := setupReranker(t)
+
+	scores, err := r.Score("user authentication", []string{
+		"method Auth::Login#call\ndef call(email, password)",
+		"method CSV::Parser#parse\ndef parse(input_stream)",
+	})
+	if err != nil {
+		t.Fatalf("score: %v", err)
+	}
+	if len(scores) != 2 {
+		t.Fatalf("expected 2 scores, got %d", len(scores))
+	}
+
+	t.Logf("auth query → auth doc: %.4f", scores[0])
+	t.Logf("auth query → csv doc:  %.4f", scores[1])
+}
+
+func TestRerankerOrdering(t *testing.T) {
+	r := setupReranker(t)
+
+	scores, err := r.Score("user authentication and password validation", []string{
+		"method Users::AuthenticateService#execute\ndef execute\n  user = User.find_by(email: params[:login])\n  return error unless user&.valid_password?(params[:password])",
+		"method Users::UpdateService#execute\ndef execute\n  user.name = params[:name]\n  user.email = params[:email]\n  user.save",
+		"method CSV::Parser#parse\ndef parse(input_stream, delimiter)",
+	})
+	if err != nil {
+		t.Fatalf("score: %v", err)
+	}
+
+	if scores[0] <= scores[1] {
+		t.Errorf("auth doc (%.4f) should score higher than update doc (%.4f)", scores[0], scores[1])
+	}
+	if scores[0] <= scores[2] {
+		t.Errorf("auth doc (%.4f) should score higher than csv doc (%.4f)", scores[0], scores[2])
+	}
+
+	t.Logf("auth:   %.4f", scores[0])
+	t.Logf("update: %.4f", scores[1])
+	t.Logf("csv:    %.4f", scores[2])
+}
+
+func TestRerankerEmptyDocs(t *testing.T) {
+	r := &ONNXReranker{}
+
+	scores, err := r.Score("anything", nil)
+	if err != nil {
+		t.Fatalf("score nil: %v", err)
+	}
+	if scores != nil {
+		t.Errorf("expected nil scores for nil docs, got %v", scores)
+	}
+
+	scores, err = r.Score("anything", []string{})
+	if err != nil {
+		t.Fatalf("score empty: %v", err)
+	}
+	if scores != nil {
+		t.Errorf("expected nil scores for empty docs, got %v", scores)
+	}
+}
+
+func TestRerankerBatching(t *testing.T) {
+	r := setupReranker(t)
+
+	// More docs than RerankerBatchSize to exercise multi-batch path.
+	n := RerankerBatchSize + 3
+	docs := make([]string, n)
+	for i := range docs {
+		docs[i] = "method Foo#bar\ndef bar(x)"
+	}
+
+	scores, err := r.Score("test query", docs)
+	if err != nil {
+		t.Fatalf("score: %v", err)
+	}
+	if len(scores) != n {
+		t.Fatalf("expected %d scores, got %d", n, len(scores))
+	}
+}
+
+func TestRerankerDeterminism(t *testing.T) {
+	r := setupReranker(t)
+
+	docs := []string{
+		"method Auth::Login#call\ndef call(email, password)",
+		"method HTTP::Router#dispatch\ndef dispatch(req, res)",
+	}
+
+	scores1, err := r.Score("authentication", docs)
+	if err != nil {
+		t.Fatalf("first score: %v", err)
+	}
+
+	scores2, err := r.Score("authentication", docs)
+	if err != nil {
+		t.Fatalf("second score: %v", err)
+	}
+
+	for i := range scores1 {
+		if scores1[i] != scores2[i] {
+			t.Fatalf("non-deterministic: score[%d] = %.6f then %.6f", i, scores1[i], scores2[i])
+		}
+	}
+}
+
+func BenchmarkRerankerScore(b *testing.B) {
+	dir := testdataDir()
+	modelPath := filepath.Join(dir, "rerankers", "ms-marco-MiniLM-L-6-v2", "model.onnx")
+	vocabPath := filepath.Join(dir, "vocab.txt")
+
+	if _, err := os.Stat(modelPath); err != nil {
+		b.Skip("reranker model not downloaded")
+	}
+
+	libPath := ortLibPath()
+	if _, err := os.Stat(libPath); err != nil && !filepath.IsAbs(libPath) {
+		b.Skipf("ONNX Runtime not found at %s", libPath)
+	}
+	if err := InitORTLibrary(libPath); err != nil {
+		b.Fatalf("init ORT: %v", err)
+	}
+
+	mb, _ := os.ReadFile(modelPath)
+	vb, _ := os.ReadFile(vocabPath)
+	r, err := NewONNXReranker(mb, vb, 0)
+	if err != nil {
+		b.Fatalf("create reranker: %v", err)
+	}
+	defer func() { _ = r.Close() }()
+
+	docs := make([]string, RerankerBatchSize)
+	for i := range docs {
+		docs[i] = "method Pkg::Method#call\ndef call(arg1, arg2)\n  process(arg1)\n  validate(arg2)"
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		if _, err := r.Score("user authentication", docs); err != nil {
+			b.Fatalf("score: %v", err)
+		}
+	}
+}

--- a/internal/embed/testdata/rerankers/.gitignore
+++ b/internal/embed/testdata/rerankers/.gitignore
@@ -1,0 +1,1 @@
+*/model.onnx

--- a/internal/embed/testdata/rerankers/download.sh
+++ b/internal/embed/testdata/rerankers/download.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Downloads cross-encoder ONNX models for reranker evaluation.
+# Run from the repo root:
+#   bash internal/embed/testdata/rerankers/download.sh
+#
+# Requires: curl
+# Models share vocab.txt with the embedding model (same BERT-base-uncased vocabulary).
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
+download_model() {
+    local name="$1"
+    local hf_repo="$2"
+    local dest="$DIR/$name"
+
+    if [ -f "$dest/model.onnx" ]; then
+        echo "$name: already downloaded ($(du -h "$dest/model.onnx" | cut -f1))"
+        return
+    fi
+
+    mkdir -p "$dest"
+
+    # Try quantized (INT8 ARM64) first, then unquantized.
+    local urls=(
+        "https://huggingface.co/$hf_repo/resolve/main/onnx/model_qint8_arm64.onnx"
+        "https://huggingface.co/$hf_repo/resolve/main/onnx/model_quantized.onnx"
+        "https://huggingface.co/$hf_repo/resolve/main/onnx/model.onnx"
+    )
+
+    for url in "${urls[@]}"; do
+        echo "$name: trying $url ..."
+        if curl -fSL "$url" -o "$dest/model.onnx" 2>/dev/null; then
+            echo "$name: downloaded ($(du -h "$dest/model.onnx" | cut -f1))"
+            return
+        fi
+    done
+
+    echo "$name: all URLs failed. Export manually:"
+    echo "  pip install optimum[exporters] onnxruntime"
+    echo "  optimum-cli export onnx --model $hf_repo $dest/"
+    rm -rf "$dest"
+    return 1
+}
+
+# Candidate 1: ms-marco-MiniLM-L-6-v2 (6 layers, ~22MB quantized / ~80MB FP32)
+download_model "ms-marco-MiniLM-L-6-v2" "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+# Candidate 2: ms-marco-MiniLM-L-12-v2 (12 layers, ~33MB quantized / ~130MB FP32)
+download_model "ms-marco-MiniLM-L-12-v2" "cross-encoder/ms-marco-MiniLM-L-12-v2"
+
+echo ""
+echo "Model sizes:"
+du -h "$DIR"/*/model.onnx 2>/dev/null || echo "(no models downloaded)"

--- a/internal/embed/tokenizer.go
+++ b/internal/embed/tokenizer.go
@@ -163,6 +163,71 @@ func basicTokenize(text string) []string {
 	return tokens
 }
 
+// TokenizePair encodes a (query, document) pair for cross-encoder scoring.
+// Format: [CLS] query_tokens [SEP] doc_tokens [SEP] [PAD]...
+// token_type_ids: 0 for query segment (A), 1 for document segment (B).
+func (t *tokenizer) TokenizePair(query, document string) tokenizeResult {
+	qTokens := t.wordpiece(query)
+	dTokens := t.wordpiece(document)
+
+	// Budget: maxLen - 3 ([CLS], [SEP], [SEP])
+	budget := t.maxLen - 3
+	if budget < 0 {
+		budget = 0
+	}
+
+	// Truncate document first, then query if still over budget.
+	if len(qTokens)+len(dTokens) > budget {
+		dBudget := budget - len(qTokens)
+		if dBudget < 0 {
+			qTokens = qTokens[:budget/2]
+			dBudget = budget - len(qTokens)
+		}
+		if dBudget < len(dTokens) {
+			dTokens = dTokens[:dBudget]
+		}
+	}
+
+	ids := make([]int32, t.maxLen)
+	mask := make([]int32, t.maxLen)
+	typeIDs := make([]int32, t.maxLen)
+
+	pos := 0
+
+	// Segment A: [CLS] query [SEP]
+	ids[pos] = t.clsID
+	mask[pos] = 1
+	pos++
+
+	for _, tok := range qTokens {
+		ids[pos] = tok
+		mask[pos] = 1
+		pos++
+	}
+
+	ids[pos] = t.sepID
+	mask[pos] = 1
+	pos++
+
+	// Segment B: document [SEP]
+	for _, tok := range dTokens {
+		ids[pos] = tok
+		mask[pos] = 1
+		typeIDs[pos] = 1
+		pos++
+	}
+
+	ids[pos] = t.sepID
+	mask[pos] = 1
+	typeIDs[pos] = 1
+
+	return tokenizeResult{
+		InputIDs:      ids,
+		AttentionMask: mask,
+		TokenTypeIDs:  typeIDs,
+	}
+}
+
 func isPunct(r rune) bool {
 	return unicode.IsPunct(r) || unicode.IsSymbol(r)
 }

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -137,6 +137,16 @@ func RunWithOptions(opts RunOptions) error {
 
 	engine := search.NewEngine(adapter, vectorIdx, embedder)
 
+	if embedder != nil {
+		reranker, rerankErr := embed.NewBundledReranker(0)
+		if rerankErr != nil {
+			fmt.Fprintf(os.Stderr, "sense mcp: init reranker: %v\n", rerankErr)
+		} else {
+			engine.SetReranker(reranker)
+			defer func() { _ = reranker.Close() }()
+		}
+	}
+
 	embedCtx, cancelEmbed := context.WithCancel(ctx)
 	defer cancelEmbed()
 

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -13,6 +13,12 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// Reranker scores (query, document) pairs for relevance using a
+// cross-encoder that sees both inputs jointly.
+type Reranker interface {
+	Score(query string, docs []string) ([]float32, error)
+}
+
 // Result is a single fused search hit with metadata from both backends.
 type Result struct {
 	SymbolID   int64
@@ -44,6 +50,7 @@ type Engine struct {
 	adapter  *sqlite.Adapter
 	vectors  VectorIndex
 	embedder embed.Embedder
+	reranker Reranker
 }
 
 // NewEngine creates a search engine. When vectors is nil or embedder
@@ -64,6 +71,14 @@ func (e *Engine) SetVectors(v VectorIndex) {
 	e.mu.Unlock()
 }
 
+// SetReranker sets the cross-encoder reranker. When non-nil, search
+// results are reranked after RRF fusion for improved precision.
+func (e *Engine) SetReranker(r Reranker) {
+	e.mu.Lock()
+	e.reranker = r
+	e.mu.Unlock()
+}
+
 const (
 	ModeHybrid  = "hybrid"
 	ModeKeyword = "keyword"
@@ -75,6 +90,7 @@ type SearchMeta struct {
 	Mode          string
 	KeywordWeight float64
 	VectorWeight  float64
+	Reranked      bool
 }
 
 // Search runs hybrid search and returns fused, re-ranked results.
@@ -99,6 +115,7 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, SearchMeta
 
 	e.mu.RLock()
 	vectors := e.vectors
+	reranker := e.reranker
 	e.mu.RUnlock()
 
 	canVector := vectors != nil && vectors.Len() > 0 && e.embedder != nil
@@ -179,6 +196,26 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, SearchMeta
 		return nil, SearchMeta{}, fmt.Errorf("search: %w", err)
 	}
 
+	// Cross-encoder reranking: replace RRF scores with joint relevance scores.
+	reranked := false
+	if reranker != nil && len(fused) > 0 {
+		docs := make([]string, len(fused))
+		for i, r := range fused {
+			docs[i] = r.Kind + " " + r.Qualified
+			if r.Snippet != "" {
+				docs[i] += "\n" + r.Snippet
+			}
+		}
+		scores, rerankErr := reranker.Score(opts.Query, docs)
+		if rerankErr != nil {
+			return nil, SearchMeta{}, fmt.Errorf("search rerank: %w", rerankErr)
+		}
+		for i := range fused {
+			fused[i].Score = float64(scores[i])
+		}
+		reranked = true
+	}
+
 	// Graph centrality re-ranking.
 	symbolIDs := make([]int64, len(fused))
 	for i, r := range fused {
@@ -240,6 +277,7 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, SearchMeta
 		Mode:          mode,
 		KeywordWeight: kwWeight,
 		VectorWeight:  vecWeight,
+		Reranked:      reranked,
 	}, nil
 }
 

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"strings"
+
 	"github.com/luuuc/sense/internal/embed"
 	"github.com/luuuc/sense/internal/model"
 	"github.com/luuuc/sense/internal/search"
@@ -803,5 +805,136 @@ func TestGraphEnrichmentBoostsCallees(t *testing.T) {
 	t.Logf("enrichment result:")
 	for i, r := range results {
 		t.Logf("  %d. %s (score=%.4f)", i+1, r.Qualified, r.Score)
+	}
+}
+
+// boostReranker boosts documents containing the target substring.
+type boostReranker struct {
+	target string
+}
+
+func (b *boostReranker) Score(_ string, docs []string) ([]float32, error) {
+	scores := make([]float32, len(docs))
+	for i, doc := range docs {
+		if strings.Contains(doc, b.target) {
+			scores[i] = 10.0
+		} else {
+			scores[i] = -10.0
+		}
+	}
+	return scores, nil
+}
+
+func TestRerankerChangesOrdering(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	a, err := sqlite.Open(ctx, filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	seedFusionIndex(t, ctx, a)
+
+	engine := search.NewEngine(a, nil, nil)
+
+	// Without reranker: "ProcessPayment" ranks first for "payment".
+	results1, meta1, err := engine.Search(ctx, search.Options{Query: "payment", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta1.Reranked {
+		t.Error("expected Reranked=false without reranker")
+	}
+	if len(results1) == 0 || results1[0].Qualified != "pkg.ProcessPayment" {
+		t.Fatalf("expected ProcessPayment first without reranker, got %v", results1)
+	}
+
+	// With reranker that boosts "PaymentConfig": it should flip to rank first,
+	// despite ProcessPayment having higher centrality (2 callers).
+	engine.SetReranker(&boostReranker{target: "PaymentConfig"})
+
+	results2, meta2, err := engine.Search(ctx, search.Options{Query: "payment", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !meta2.Reranked {
+		t.Error("expected Reranked=true with reranker")
+	}
+
+	for i, r := range results2 {
+		t.Logf("  %d. %s (score=%.4f)", i+1, r.Qualified, r.Score)
+	}
+	if len(results2) == 0 || results2[0].Qualified != "pkg.PaymentConfig" {
+		t.Errorf("reranker should have promoted PaymentConfig to first, got %q", results2[0].Qualified)
+	}
+}
+
+func TestRerankerMetaFlag(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	a, err := sqlite.Open(ctx, filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	seedFusionIndex(t, ctx, a)
+
+	engine := search.NewEngine(a, nil, nil)
+
+	_, meta, err := engine.Search(ctx, search.Options{Query: "payment", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.Reranked {
+		t.Error("Reranked should be false when no reranker is set")
+	}
+
+	engine.SetReranker(&boostReranker{target: "anything"})
+	_, meta, err = engine.Search(ctx, search.Options{Query: "payment", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !meta.Reranked {
+		t.Error("Reranked should be true when reranker is set")
+	}
+}
+
+func TestRerankerGracefulDegradation(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	a, err := sqlite.Open(ctx, filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	seedFusionIndex(t, ctx, a)
+
+	engine := search.NewEngine(a, nil, nil)
+
+	// Search with no reranker works normally.
+	results, _, err := engine.Search(ctx, search.Options{Query: "payment", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected results without reranker")
+	}
+
+	// Set reranker, then clear it — should degrade back gracefully.
+	engine.SetReranker(&boostReranker{target: "ChargeCard"})
+	engine.SetReranker(nil)
+
+	results2, meta, err := engine.Search(ctx, search.Options{Query: "payment", Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.Reranked {
+		t.Error("Reranked should be false after clearing reranker")
+	}
+	if len(results2) == 0 {
+		t.Fatal("expected results after clearing reranker")
 	}
 }

--- a/scripts/fetch-deps.sh
+++ b/scripts/fetch-deps.sh
@@ -50,6 +50,17 @@ if [ ! -f "$BUNDLE/vocab.txt" ]; then
     curl -fSL "https://huggingface.co/$MODEL_REPO/resolve/main/vocab.txt" -o "$BUNDLE/vocab.txt"
 fi
 
+RERANKER_REPO="cross-encoder/ms-marco-MiniLM-L-6-v2"
+if [ ! -f "$BUNDLE/reranker.onnx" ]; then
+    echo "Downloading reranker model..."
+    # Try quantized INT8 first, then unquantized.
+    if ! curl -fSL "https://huggingface.co/$RERANKER_REPO/resolve/main/onnx/model_qint8_arm64.onnx" -o "$BUNDLE/reranker.onnx" 2>/dev/null; then
+        if ! curl -fSL "https://huggingface.co/$RERANKER_REPO/resolve/main/onnx/model_quantized.onnx" -o "$BUNDLE/reranker.onnx" 2>/dev/null; then
+            curl -fSL "https://huggingface.co/$RERANKER_REPO/resolve/main/onnx/model.onnx" -o "$BUNDLE/reranker.onnx"
+        fi
+    fi
+fi
+
 # ── ONNX Runtime shared libraries ───────────────────────────────────
 
 fetch_ort() {


### PR DESCRIPTION
## Problem

Sense's search pipeline uses bi-encoder embeddings for vector similarity, comparing query and document independently via cosine similarity. This is fast but coarse — the model never sees query and document together, missing fine-grained relevance signals. Every production code search system that achieves high precision uses a two-stage pipeline: fast retrieval followed by cross-encoder reranking.

## Summary

Add a cross-encoder reranking step to the search pipeline using ms-marco-MiniLM-L-6-v2 (23MB INT8 quantized). The reranker scores the top 50 candidates jointly after RRF fusion, replacing coarse similarity scores with precise relevance scores before graph centrality and path weighting.

## Changes

**Tokenizer**
- Add `TokenizePair` for BERT pair encoding: `[CLS] query [SEP] document [SEP]` with segment-aware `token_type_ids`

**ONNX Reranker (`internal/embed/reranker.go`)**
- `ONNXReranker` wrapping cross-encoder ONNX session with `Score(query, docs)` API
- Pre-allocated buffers, automatic batching at 50 pairs, double-close safe
- Model evaluation framework comparing L-6-v2 (23MB, 9.5ms/pair) vs L-12-v2 (33MB, 20ms/pair)

**Search Pipeline (`internal/search/search.go`)**
- `Reranker` interface defined at consumer (Go convention)
- `SetReranker` setter following `SetVectors` pattern
- Reranking inserted after hydration, before graph centrality — pure score replacement
- `SearchMeta.Reranked` flag for observability

**Binary Bundling**
- `NewBundledReranker` mirroring `NewBundledEmbedder`
- Wired into mcpserver, CLI, and benchmark via `engine.SetReranker()`
- `fetch-deps.sh` updated with quantized-first download fallback
- Binary size: 126MB (under 250MB threshold)
- Init errors logged to stderr (non-fatal — search degrades gracefully)

## Benchmark Results

42 runs across 6 repos × 7 tasks:

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Avg Score | 0.3003 | 0.3146 | +5% |
| Avg Tokens | 161K | 139K | -14% |
| Avg Time | 88.3s | 73.4s | -17% |
| Avg Misses | 3.6 | 2.9 | -19% |

Semantic-search highlight: gin improved from 0.20 → 0.40.

## Test Plan

- [x] `TestRerankerScore` — basic scoring produces 2 scores
- [x] `TestRerankerOrdering` — auth doc scores higher than unrelated docs
- [x] `TestRerankerEmptyDocs` — nil/empty input returns nil (no model load)
- [x] `TestRerankerBatching` — 53 docs exercises multi-batch path
- [x] `TestRerankerDeterminism` — same input produces identical scores
- [x] `TestRerankerChangesOrdering` — reranker flips ordering despite centrality
- [x] `TestRerankerMetaFlag` — `SearchMeta.Reranked` reflects reranker state
- [x] `TestRerankerGracefulDegradation` — set/clear/nil lifecycle works
- [x] `TestNewBundledReranker` — bundled model loads and scores correctly
- [x] `make ci` passes (build + test + lint)