### PR TITLE
feat(scan): add progress display and grouped warning output

### DIFF
--- a/cmd/sense/main.go
+++ b/cmd/sense/main.go
@@ -105,6 +105,7 @@ func main() {
 			if _, err := scan.Run(ctx, scan.Options{
 				Root:              *dir,
 				Warnings:          warnSink,
+				Quiet:             *quietFlag,
 				EmbeddingsEnabled: cli.EmbeddingsEnabled(*dir),
 				Embed:             *embedFlag,
 			}); err != nil {

--- a/internal/scan/embed.go
+++ b/internal/scan/embed.go
@@ -285,6 +285,8 @@ func (h *harness) embedSymbols() error {
 	}
 	defer func() { _ = pool.Close() }()
 
+	h.progress.setPhase("Embedding...", int64(len(inputs)))
+
 	for i := 0; i < len(inputs); i += embedChunkSize {
 		end := i + embedChunkSize
 		if end > len(inputs) {
@@ -315,6 +317,7 @@ func (h *harness) embedSymbols() error {
 			return fmt.Errorf("write embeddings: %w", err)
 		}
 		h.embedded += len(vecs)
+		h.progress.current.Add(int64(len(vecs)))
 	}
 
 	if h.embedded > 0 {

--- a/internal/scan/incremental.go
+++ b/internal/scan/incremental.go
@@ -45,11 +45,15 @@ func RunIncremental(ctx context.Context, opts IncrementalOptions) (*Result, erro
 		parsers = NewParserCache()
 	}
 
+	wc := newWarningCollector()
+
 	h := &harness{
 		ctx:           ctx,
 		idx:           opts.Idx,
 		out:           out,
 		warn:          warn,
+		progress:      newProgress(out, true),
+		collector:     wc,
 		parsers:       parsers.parsers,
 		matcher:       opts.Matcher,
 		maxFileSizeKB: opts.MaxFileSizeKB,
@@ -132,7 +136,7 @@ func RunIncremental(ctx context.Context, opts IncrementalOptions) (*Result, erro
 		Edges:      h.edges,
 		Embedded:   h.embedded,
 		Unresolved: h.unresolved,
-		Warnings:   h.warnings,
+		Warnings:   wc.count(),
 		Duration:   elapsed,
 		Phases:     phases,
 	}

--- a/internal/scan/progress.go
+++ b/internal/scan/progress.go
@@ -1,0 +1,119 @@
+package scan
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/mattn/go-isatty"
+)
+
+// progress owns the single-line \r-overwriting status display during
+// a scan. One goroutine (the ticker in start) writes to the terminal;
+// parse workers feed it via atomic counter bumps.
+type progress struct {
+	out     io.Writer
+	enabled bool
+
+	phase    atomic.Value // string
+	current  atomic.Int64
+	total    atomic.Int64
+	warnings atomic.Int64
+
+	once sync.Once
+	done chan struct{}
+}
+
+func newProgress(out io.Writer, quiet bool) *progress {
+	p := &progress{
+		out:  out,
+		done: make(chan struct{}),
+	}
+	p.phase.Store("")
+	if !quiet {
+		if f, ok := out.(*os.File); ok {
+			p.enabled = isatty.IsTerminal(f.Fd()) || isatty.IsCygwinTerminal(f.Fd())
+		}
+	}
+	return p
+}
+
+func (p *progress) start() {
+	if !p.enabled {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				p.render()
+			case <-p.done:
+				p.clear()
+				return
+			}
+		}
+	}()
+}
+
+func (p *progress) stop() {
+	if !p.enabled {
+		return
+	}
+	p.once.Do(func() { close(p.done) })
+}
+
+// setPhase updates the display phase. Pass total > 0 to show a counter.
+func (p *progress) setPhase(name string, total int64) {
+	p.phase.Store(name)
+	p.current.Store(0)
+	p.total.Store(total)
+	if p.enabled {
+		p.render()
+	}
+}
+
+func (p *progress) inc() {
+	p.current.Add(1)
+}
+
+func (p *progress) incWarnings() {
+	p.warnings.Add(1)
+}
+
+func (p *progress) render() {
+	phase := p.phase.Load().(string)
+	if phase == "" {
+		return
+	}
+	cur := p.current.Load()
+	tot := p.total.Load()
+	warns := p.warnings.Load()
+
+	var b strings.Builder
+	b.WriteString("\r")
+	b.WriteString(phase)
+	if tot > 0 {
+		fmt.Fprintf(&b, " %d/%d", cur, tot)
+	}
+	if warns > 0 {
+		fmt.Fprintf(&b, "  [%d warnings]", warns)
+	}
+
+	line := b.String()
+	// Pad with spaces to overwrite any remnant from a longer previous line.
+	const minWidth = 60
+	if pad := minWidth - len(line) + 1; pad > 0 {
+		line += strings.Repeat(" ", pad)
+	}
+	_, _ = fmt.Fprint(p.out, line)
+}
+
+func (p *progress) clear() {
+	_, _ = fmt.Fprintf(p.out, "\r%s\r", strings.Repeat(" ", 60))
+}

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -56,6 +56,7 @@ type Options struct {
 	Sense             string    // sense dir (default: "<Root>/.sense")
 	Output            io.Writer // summary-line sink (default: os.Stderr)
 	Warnings          io.Writer // per-file warning sink (default: os.Stderr)
+	Quiet             bool      // suppress progress display and warning hints; forces non-TTY behavior
 	EmbeddingsEnabled bool      // when true, embeddings are part of the index pipeline
 	Embed             bool      // block until embeddings complete; requires EmbeddingsEnabled. When false, embeddings are deferred and a watermark is written for the MCP server to pick up.
 }
@@ -173,12 +174,15 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 		_, _ = fmt.Fprintf(out, "migrated fts index — keyword search will repopulate during this scan\n")
 	}
 
+	prog := newProgress(out, opts.Quiet)
+
 	h := &harness{
 		ctx:            ctx,
 		idx:            idx,
 		out:            out,
 		warn:           warn,
 		root:           root,
+		progress:       prog,
 		parsers:        map[string]*sitter.Parser{},
 		matcher:        matcher,
 		defaultMatcher: ignore.New(ignore.DefaultPatterns()...),
@@ -186,6 +190,9 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 		seenPaths:      map[string]bool{},
 	}
 	defer h.closeParsers()
+
+	prog.start()
+	defer prog.stop()
 
 	start := time.Now()
 	var phases PhaseTiming
@@ -210,6 +217,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	}
 	phases.RemoveStale = time.Since(t0)
 
+	prog.setPhase("Resolving edges...", 0)
 	t0 = time.Now()
 	if err := h.resolveAndWriteEdges(); err != nil {
 		return nil, err
@@ -222,6 +230,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	}
 	phases.SatisfyInterfaces = time.Since(t0)
 
+	prog.setPhase("Associating tests...", 0)
 	t0 = time.Now()
 	if err := h.associateTests(); err != nil {
 		return nil, err
@@ -298,6 +307,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	if err := idx.StampSchemaVersion(ctx); err != nil {
 		return nil, err
 	}
+	prog.stop()
 	elapsed := time.Since(start)
 
 	res := &Result{
@@ -424,12 +434,13 @@ func addSenseToGitignore(root string) bool {
 // file's transaction because most of them point at targets in other
 // files. The consequence is called out on resolveAndWriteEdges.
 type harness struct {
-	ctx     context.Context
-	idx     *sqlite.Adapter
-	out     io.Writer // summary-line sink
-	warn    io.Writer // per-file warning sink
-	root    string    // repository root directory
-	parsers map[string]*sitter.Parser
+	ctx      context.Context
+	idx      *sqlite.Adapter
+	out      io.Writer // summary-line sink
+	warn     io.Writer // per-file warning sink
+	root     string    // repository root directory
+	progress *progress
+	parsers  map[string]*sitter.Parser
 
 	matcher        *ignore.Matcher
 	defaultMatcher *ignore.Matcher
@@ -526,6 +537,7 @@ func int64Ptr(v int64) *int64 {
 func (h *harness) warnf(format string, args ...any) {
 	h.warnings++
 	_, _ = fmt.Fprintf(h.warn, "warn: "+format+"\n", args...)
+	h.progress.incWarnings()
 }
 
 type walkEntry struct {
@@ -597,6 +609,8 @@ func (h *harness) walkTree(root string) error {
 		return nil
 	}
 
+	h.progress.setPhase("Scanning...", int64(len(entries)))
+
 	// Phase 2: pre-load file hashes for incremental skip.
 	hashMap, err := h.idx.FileHashMap(h.ctx)
 	if err != nil {
@@ -611,8 +625,9 @@ func (h *harness) walkTree(root string) error {
 
 	for i, entry := range entries {
 		g.Go(func() error {
-			fr := parseFileStandalone(gctx, entry.path, entry.rel, hashMap, h.maxFileSizeKB, &mu, h.warn, &h.warnings)
+			fr := parseFileStandalone(gctx, entry.path, entry.rel, hashMap, h.maxFileSizeKB, &mu, h.warn, &h.warnings, h.progress)
 			results[i] = fr
+			h.progress.inc()
 			return nil
 		})
 	}
@@ -841,12 +856,14 @@ func parseFileStandalone(
 	warnMu *sync.Mutex,
 	warnOut io.Writer,
 	warnCount *int,
+	prog *progress,
 ) *fileResult {
 	wf := func(format string, args ...any) {
 		warnMu.Lock()
 		*warnCount++
 		_, _ = fmt.Fprintf(warnOut, "warn: "+format+"\n", args...)
 		warnMu.Unlock()
+		prog.incWarnings()
 	}
 	po := parseOpts{
 		ctx:           ctx,

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -344,6 +344,9 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 		_, _ = fmt.Fprintf(out, "skipped %d directories (default ignores: %s)\n",
 			res.DefaultIgnored, strings.Join(ignore.DefaultPatterns(), ", "))
 	}
+	if res.Warnings > 0 && !opts.Quiet {
+		_, _ = fmt.Fprintf(out, "%d warnings — see .sense/warnings.log\n", res.Warnings)
+	}
 	if embeddingDebt > 0 {
 		_, _ = fmt.Fprintf(out, "graph, blast, and conventions ready — embeddings deferred (%d symbols)\n", embeddingDebt)
 	}

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -24,7 +24,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	sitter "github.com/tree-sitter/go-tree-sitter"
@@ -175,6 +174,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	}
 
 	prog := newProgress(out, opts.Quiet)
+	wc := newWarningCollector()
 
 	h := &harness{
 		ctx:            ctx,
@@ -183,6 +183,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 		warn:           warn,
 		root:           root,
 		progress:       prog,
+		collector:      wc,
 		parsers:        map[string]*sitter.Parser{},
 		matcher:        matcher,
 		defaultMatcher: ignore.New(ignore.DefaultPatterns()...),
@@ -308,6 +309,11 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 		return nil, err
 	}
 	prog.stop()
+
+	if err := wc.writeLog(senseDir); err != nil {
+		_, _ = fmt.Fprintf(warn, "warn: write warnings log: %v\n", err)
+	}
+
 	elapsed := time.Since(start)
 
 	res := &Result{
@@ -322,7 +328,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 		EmbeddingDebt:  embeddingDebt,
 		Unresolved:     h.unresolved,
 		Ambiguous:      h.ambiguous,
-		Warnings:       h.warnings,
+		Warnings:       wc.count(),
 		DefaultIgnored: h.defaultIgnored,
 		Duration:       elapsed,
 		Phases:         phases,
@@ -434,13 +440,14 @@ func addSenseToGitignore(root string) bool {
 // file's transaction because most of them point at targets in other
 // files. The consequence is called out on resolveAndWriteEdges.
 type harness struct {
-	ctx      context.Context
-	idx      *sqlite.Adapter
-	out      io.Writer // summary-line sink
-	warn     io.Writer // per-file warning sink
-	root     string    // repository root directory
-	progress *progress
-	parsers  map[string]*sitter.Parser
+	ctx       context.Context
+	idx       *sqlite.Adapter
+	out       io.Writer // summary-line sink
+	warn      io.Writer // infrastructure warning sink (not per-file)
+	root      string    // repository root directory
+	progress  *progress
+	collector *warningCollector
+	parsers   map[string]*sitter.Parser
 
 	matcher        *ignore.Matcher
 	defaultMatcher *ignore.Matcher
@@ -484,7 +491,6 @@ type harness struct {
 	embedded       int
 	unresolved     int
 	ambiguous      int
-	warnings       int
 	defaultIgnored int
 }
 
@@ -532,11 +538,8 @@ func int64Ptr(v int64) *int64 {
 	return &v
 }
 
-// warnf logs a per-file warning to h.warn and increments the counter.
-// Warnings are non-fatal: scan continues past them.
-func (h *harness) warnf(format string, args ...any) {
-	h.warnings++
-	_, _ = fmt.Fprintf(h.warn, "warn: "+format+"\n", args...)
+func (h *harness) addWarning(kind warningKind, format string, args ...any) {
+	h.collector.add(kind, fmt.Sprintf(format, args...))
 	h.progress.incWarnings()
 }
 
@@ -619,13 +622,12 @@ func (h *harness) walkTree(root string) error {
 
 	// Phase 3: parallel parse+extract.
 	results := make([]*fileResult, len(entries))
-	var mu sync.Mutex
 	g, gctx := errgroup.WithContext(h.ctx)
 	g.SetLimit(runtime.NumCPU())
 
 	for i, entry := range entries {
 		g.Go(func() error {
-			fr := parseFileStandalone(gctx, entry.path, entry.rel, hashMap, h.maxFileSizeKB, &mu, h.warn, &h.warnings, h.progress)
+			fr := parseFileStandalone(gctx, entry.path, entry.rel, hashMap, h.maxFileSizeKB, h.collector, h.progress)
 			results[i] = fr
 			h.progress.inc()
 			return nil
@@ -698,7 +700,7 @@ func (h *harness) flushBatch(batch []*fileResult) error {
 		h.indexedFiles = h.indexedFiles[:snapIndexed]
 		h.changedFileIDs = h.changedFileIDs[:snapChanged]
 
-		h.warnf("%s: write failed, retrying batch without it: %v", batch[failedIdx].Rel, err)
+		h.addWarning(warnWriteFailed, "%s (%v)", batch[failedIdx].Rel, err)
 		retry := make([]*fileResult, 0, len(batch)-1)
 		for i, fr := range batch {
 			if i != failedIdx {
@@ -745,7 +747,7 @@ func (h *harness) processFile(path, rel string) {
 		return
 	}
 	if err := h.writeFileResult(fr); err != nil {
-		h.warnf("%s: write failed: %v", rel, err)
+		h.addWarning(warnWriteFailed, "%s (%v)", rel, err)
 		return
 	}
 	h.indexed++
@@ -758,7 +760,7 @@ func (h *harness) processFile(path, rel string) {
 type parseOpts struct {
 	ctx           context.Context
 	maxFileSizeKB int
-	warnf         func(string, ...any)
+	warnf         func(warningKind, string, ...any)
 	parserFor     func(extract.Extractor) (*sitter.Parser, bool)
 }
 
@@ -775,11 +777,11 @@ func parseFileCore(po parseOpts, path, rel string, skip func(hash string) bool) 
 	if po.maxFileSizeKB > 0 {
 		info, err := os.Stat(path)
 		if err != nil {
-			po.warnf("%s: stat failed: %v", rel, err)
+			po.warnf(warnMetaError, "%s (%v)", rel, err)
 			return nil
 		}
 		if info.Size() > int64(po.maxFileSizeKB)*1024 {
-			po.warnf("%s: skipped (%d KB > %d KB max)", rel, info.Size()/1024, po.maxFileSizeKB)
+			po.warnf(warnFileTooLarge, "%s (%d KB > %d KB max)", rel, info.Size()/1024, po.maxFileSizeKB)
 			return nil
 		}
 	}
@@ -790,7 +792,7 @@ func parseFileCore(po parseOpts, path, rel string, skip func(hash string) bool) 
 
 	source, err := os.ReadFile(path)
 	if err != nil {
-		po.warnf("%s: read failed: %v", rel, err)
+		po.warnf(warnMetaError, "%s (%v)", rel, err)
 		return nil
 	}
 
@@ -803,7 +805,7 @@ func parseFileCore(po parseOpts, path, rel string, skip func(hash string) bool) 
 
 	if raw, ok := ex.(extract.RawExtractor); ok {
 		if err := safeExtractRaw(raw, source, rel, collected); err != nil {
-			po.warnf("%s: extract failed: %v", rel, err)
+			po.warnf(warnParseFailed, "%s (%v)", rel, err)
 			return nil
 		}
 	} else {
@@ -817,17 +819,17 @@ func parseFileCore(po parseOpts, path, rel string, skip func(hash string) bool) 
 
 		tree := parser.Parse(source, nil)
 		if tree == nil {
-			po.warnf("%s: parse returned nil tree", rel)
+			po.warnf(warnParseFailed, "%s (nil parse tree)", rel)
 			return nil
 		}
 		defer tree.Close()
 
 		if tree.RootNode().HasError() {
-			po.warnf("%s: parse errors present, extracting best-effort", rel)
+			po.warnf(warnParseFailed, "%s (parse errors, best-effort extraction)", rel)
 		}
 
 		if err := safeExtract(ex, tree, source, rel, collected); err != nil {
-			po.warnf("%s: extract failed: %v", rel, err)
+			po.warnf(warnParseFailed, "%s (%v)", rel, err)
 			return nil
 		}
 	}
@@ -853,16 +855,11 @@ func parseFileStandalone(
 	path, rel string,
 	hashMap map[string]sqlite.CachedFile,
 	maxFileSizeKB int,
-	warnMu *sync.Mutex,
-	warnOut io.Writer,
-	warnCount *int,
+	wc *warningCollector,
 	prog *progress,
 ) *fileResult {
-	wf := func(format string, args ...any) {
-		warnMu.Lock()
-		*warnCount++
-		_, _ = fmt.Fprintf(warnOut, "warn: "+format+"\n", args...)
-		warnMu.Unlock()
+	wf := func(kind warningKind, format string, args ...any) {
+		wc.add(kind, fmt.Sprintf(format, args...))
 		prog.incWarnings()
 	}
 	po := parseOpts{
@@ -873,7 +870,7 @@ func parseFileStandalone(
 			p := sitter.NewParser()
 			if err := p.SetLanguage(ex.Grammar()); err != nil {
 				p.Close()
-				wf("%s: parser setup failed: %v", rel, err)
+				wf(warnParseFailed, "%s (%v)", rel, err)
 				return nil, false
 			}
 			return p, true // caller owns — parseFileCore will defer Close
@@ -891,11 +888,11 @@ func (h *harness) parseFile(path, rel string) *fileResult {
 	po := parseOpts{
 		ctx:           h.ctx,
 		maxFileSizeKB: h.maxFileSizeKB,
-		warnf:         h.warnf,
+		warnf:         h.addWarning,
 		parserFor: func(ex extract.Extractor) (*sitter.Parser, bool) {
 			p, err := h.parserFor(ex)
 			if err != nil {
-				h.warnf("%s: parser setup failed: %v", rel, err)
+				h.addWarning(warnParseFailed, "%s (%v)", rel, err)
 				return nil, false
 			}
 			return p, false // harness owns — do not close
@@ -908,7 +905,7 @@ func (h *harness) parseFile(path, rel string) *fileResult {
 	return parseFileCore(po, path, rel, func(hash string) bool {
 		fileID, oldHash, metaErr := h.idx.FileMeta(h.ctx, rel)
 		if metaErr != nil {
-			h.warnf("%s: file meta lookup failed: %v", rel, metaErr)
+			h.addWarning(warnMetaError, "%s (%v)", rel, metaErr)
 			return false
 		}
 		if oldHash != hash {

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -125,6 +125,13 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 		warn = os.Stderr
 	}
 
+	absRoot, _ := filepath.Abs(root)
+	if opts.Embed {
+		_, _ = fmt.Fprintf(out, "Indexing %s (with embeddings)...\n", absRoot)
+	} else {
+		_, _ = fmt.Fprintf(out, "Indexing %s...\n", absRoot)
+	}
+
 	cfg, err := config.Load(root)
 	if err != nil {
 		return nil, fmt.Errorf("load config: %w", err)

--- a/internal/scan/scan_test.go
+++ b/internal/scan/scan_test.go
@@ -757,7 +757,11 @@ func TestScanTolerantOfInvalidSource(t *testing.T) {
 	if res.Warnings == 0 {
 		t.Error("expected at least one warning for broken.go parse errors")
 	}
-	// Summary writer must be clean — warnings must not leak here.
+	// Summary should contain the hint line pointing to warnings.log.
+	if !strings.Contains(summary.String(), "warnings — see .sense/warnings.log") {
+		t.Errorf("summary missing warning hint line, got: %q", summary.String())
+	}
+	// But individual warning details must not leak into the summary.
 	if strings.Contains(summary.String(), "parse errors") {
 		t.Errorf("summary writer leaked warning text: %q", summary.String())
 	}

--- a/internal/scan/scan_test.go
+++ b/internal/scan/scan_test.go
@@ -742,11 +742,11 @@ func TestScanTolerantOfInvalidSource(t *testing.T) {
 	// and the extractor emits what it can. The scan should carry on.
 	writeFile(t, filepath.Join(root, "broken.go"), "package broken\n\nfunc incompl")
 
-	var summary, warnings bytes.Buffer
+	var summary bytes.Buffer
 	res, err := scan.Run(context.Background(), scan.Options{
 		Root:     root,
 		Output:   &summary,
-		Warnings: &warnings,
+		Warnings: io.Discard,
 	})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
@@ -754,12 +754,21 @@ func TestScanTolerantOfInvalidSource(t *testing.T) {
 	if res.Files != 2 {
 		t.Errorf("Files = %d, want 2", res.Files)
 	}
-	if !strings.Contains(warnings.String(), "parse errors present") {
-		t.Errorf("expected parse-errors warning on Warnings writer, got: %q", warnings.String())
+	if res.Warnings == 0 {
+		t.Error("expected at least one warning for broken.go parse errors")
 	}
 	// Summary writer must be clean — warnings must not leak here.
 	if strings.Contains(summary.String(), "parse errors") {
 		t.Errorf("summary writer leaked warning text: %q", summary.String())
+	}
+	// Warnings log file should exist with grouped content.
+	logPath := filepath.Join(root, ".sense", "warnings.log")
+	logContent, lerr := os.ReadFile(logPath)
+	if lerr != nil {
+		t.Fatalf("expected warnings.log, got error: %v", lerr)
+	}
+	if !strings.Contains(string(logContent), "parse failed") {
+		t.Errorf("warnings.log missing 'parse failed' group, got:\n%s", logContent)
 	}
 }
 
@@ -942,11 +951,10 @@ func TestScan_SizeCapSkipsLargeFiles(t *testing.T) {
 	writeFile(t, filepath.Join(root, "big.rb"), big)
 
 	ctx := context.Background()
-	var warnings bytes.Buffer
 	res, err := scan.Run(ctx, scan.Options{
 		Root:     root,
 		Output:   &bytes.Buffer{},
-		Warnings: &warnings,
+		Warnings: io.Discard,
 	})
 	if err != nil {
 		t.Fatalf("Run: %v", err)
@@ -954,8 +962,16 @@ func TestScan_SizeCapSkipsLargeFiles(t *testing.T) {
 	if res.Indexed != 1 {
 		t.Errorf("Indexed = %d, want 1 (only small.rb)", res.Indexed)
 	}
-	if !strings.Contains(warnings.String(), "big.rb: skipped") {
-		t.Errorf("expected size-cap skip warning, got: %q", warnings.String())
+	if res.Warnings == 0 {
+		t.Error("expected at least one warning for big.rb size skip")
+	}
+	logPath := filepath.Join(root, ".sense", "warnings.log")
+	logContent, lerr := os.ReadFile(logPath)
+	if lerr != nil {
+		t.Fatalf("expected warnings.log, got error: %v", lerr)
+	}
+	if !strings.Contains(string(logContent), "file too large") {
+		t.Errorf("warnings.log missing 'file too large' group, got:\n%s", logContent)
 	}
 }
 

--- a/internal/scan/scan_test.go
+++ b/internal/scan/scan_test.go
@@ -179,9 +179,9 @@ func TestScanOutputFormat(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	// Summary line: "scanned N files (...) in Xms" optionally followed
-	// by edges, then the first-run AI tool integration summary.
-	pattern := regexp.MustCompile(`^scanned 2 files \(\d+ indexed, \d+ changed, \d+ skipped\) in \S+\n(edges: \d+ resolved, \d+ unresolved, \d+ ambiguous\n)?`)
+	// Banner line "Indexing <root>..." followed by summary "scanned N files (...) in Xms"
+	// optionally followed by edges, then the first-run AI tool integration summary.
+	pattern := regexp.MustCompile(`^Indexing .+\.\.\.\nscanned 2 files \(\d+ indexed, \d+ changed, \d+ skipped\) in \S+\n(edges: \d+ resolved, \d+ unresolved, \d+ ambiguous\n)?`)
 	if !pattern.MatchString(buf.String()) {
 		t.Fatalf("output does not match summary pattern\nhave: %q",
 			buf.String())

--- a/internal/scan/warnings.go
+++ b/internal/scan/warnings.go
@@ -1,0 +1,106 @@
+package scan
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+)
+
+type warningKind int
+
+const (
+	warnParseFailed  warningKind = iota
+	warnFileTooLarge
+	warnWriteFailed
+	warnMetaError
+)
+
+func (k warningKind) label() string {
+	switch k {
+	case warnParseFailed:
+		return "parse failed"
+	case warnFileTooLarge:
+		return "file too large"
+	case warnWriteFailed:
+		return "write failed"
+	case warnMetaError:
+		return "meta error"
+	default:
+		return "unknown"
+	}
+}
+
+// warningCollector accumulates per-file warnings during a scan,
+// grouped by category. Thread-safe for use from parallel parse workers.
+type warningCollector struct {
+	mu      sync.Mutex
+	entries map[warningKind][]string
+}
+
+func newWarningCollector() *warningCollector {
+	return &warningCollector{entries: make(map[warningKind][]string)}
+}
+
+func (wc *warningCollector) add(kind warningKind, detail string) {
+	wc.mu.Lock()
+	wc.entries[kind] = append(wc.entries[kind], detail)
+	wc.mu.Unlock()
+}
+
+func (wc *warningCollector) count() int {
+	wc.mu.Lock()
+	defer wc.mu.Unlock()
+	n := 0
+	for _, v := range wc.entries {
+		n += len(v)
+	}
+	return n
+}
+
+// format returns the grouped warning output for the log file.
+func (wc *warningCollector) format() string {
+	wc.mu.Lock()
+	defer wc.mu.Unlock()
+
+	total := 0
+	for _, v := range wc.entries {
+		total += len(v)
+	}
+	if total == 0 {
+		return ""
+	}
+
+	// Stable ordering by kind value.
+	kinds := make([]warningKind, 0, len(wc.entries))
+	for k := range wc.entries {
+		kinds = append(kinds, k)
+	}
+	sort.Slice(kinds, func(i, j int) bool { return kinds[i] < kinds[j] })
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Warnings (%d):\n", total)
+	for _, k := range kinds {
+		details := wc.entries[k]
+		fmt.Fprintf(&b, "  %dx %s\n", len(details), k.label())
+		for _, d := range details {
+			fmt.Fprintf(&b, "     %s\n", d)
+		}
+	}
+	return b.String()
+}
+
+// writeLog writes the grouped warning output to .sense/warnings.log.
+// Overwrites the file each scan. Returns nil if there are no warnings
+// (and removes a stale log file if one exists).
+func (wc *warningCollector) writeLog(senseDir string) error {
+	path := filepath.Join(senseDir, "warnings.log")
+	content := wc.format()
+	if content == "" {
+		_ = os.Remove(path)
+		return nil
+	}
+	return os.WriteFile(path, []byte(content), 0o644)
+}

--- a/internal/scan/warnings_test.go
+++ b/internal/scan/warnings_test.go
@@ -1,0 +1,106 @@
+package scan
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWarningCollector_GroupedFormat(t *testing.T) {
+	wc := newWarningCollector()
+
+	wc.add(warnParseFailed, "vendor/legacy.js (syntax error at line 42)")
+	wc.add(warnParseFailed, "assets/generated.min.js (syntax error at line 1)")
+	wc.add(warnParseFailed, "lib/old.js (nil parse tree)")
+	wc.add(warnFileTooLarge, "assets/bundle.min.js (1024 KB > 512 KB max)")
+	wc.add(warnFileTooLarge, "dist/vendor.js (2048 KB > 512 KB max)")
+	wc.add(warnWriteFailed, "tmp/broken.go (disk full)")
+	wc.add(warnMetaError, "config.rb (stat failed)")
+	wc.add(warnMetaError, "lib/util.py (read failed)")
+	wc.add(warnParseFailed, "test/bad.ts (extract failed)")
+	wc.add(warnWriteFailed, "src/flaky.go (transaction rolled back)")
+
+	if wc.count() != 10 {
+		t.Fatalf("count = %d, want 10", wc.count())
+	}
+
+	out := wc.format()
+
+	if !strings.HasPrefix(out, "Warnings (10):\n") {
+		t.Errorf("missing header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "4x parse failed") {
+		t.Errorf("missing '4x parse failed' group, got:\n%s", out)
+	}
+	if !strings.Contains(out, "2x file too large") {
+		t.Errorf("missing '2x file too large' group, got:\n%s", out)
+	}
+	if !strings.Contains(out, "2x write failed") {
+		t.Errorf("missing '2x write failed' group, got:\n%s", out)
+	}
+	if !strings.Contains(out, "2x meta error") {
+		t.Errorf("missing '2x meta error' group, got:\n%s", out)
+	}
+	if !strings.Contains(out, "     vendor/legacy.js (syntax error at line 42)") {
+		t.Errorf("missing detail line, got:\n%s", out)
+	}
+}
+
+func TestWarningCollector_WriteLog(t *testing.T) {
+	dir := t.TempDir()
+	wc := newWarningCollector()
+
+	wc.add(warnParseFailed, "bad.go (syntax error)")
+	wc.add(warnFileTooLarge, "huge.js (4096 KB > 512 KB max)")
+
+	if err := wc.writeLog(dir); err != nil {
+		t.Fatalf("writeLog: %v", err)
+	}
+
+	path := filepath.Join(dir, "warnings.log")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read warnings.log: %v", err)
+	}
+	if !strings.Contains(string(content), "Warnings (2):") {
+		t.Errorf("log file missing header, got:\n%s", content)
+	}
+	if !strings.Contains(string(content), "parse failed") {
+		t.Errorf("log file missing parse failed group, got:\n%s", content)
+	}
+	if !strings.Contains(string(content), "file too large") {
+		t.Errorf("log file missing file too large group, got:\n%s", content)
+	}
+}
+
+func TestWarningCollector_ZeroWarnings_NoLogFile(t *testing.T) {
+	dir := t.TempDir()
+	wc := newWarningCollector()
+
+	if err := wc.writeLog(dir); err != nil {
+		t.Fatalf("writeLog: %v", err)
+	}
+
+	path := filepath.Join(dir, "warnings.log")
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("expected no warnings.log for zero warnings, but file exists")
+	}
+}
+
+func TestWarningCollector_OverwritesStaleLog(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "warnings.log")
+	if err := os.WriteFile(path, []byte("stale content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	wc := newWarningCollector()
+	if err := wc.writeLog(dir); err != nil {
+		t.Fatalf("writeLog: %v", err)
+	}
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("expected stale warnings.log to be removed when zero warnings")
+	}
+}


### PR DESCRIPTION
## Problem

`sense scan` is silent while working and noisy when it finishes. On large repos, the user sees nothing for 10–30 seconds — no sign it started or is progressing. When it completes, individual `warn:` lines scroll past the summary, burying the useful output.

## Summary

Add a live progress display during scan and replace per-file warning prints with grouped collection to `.sense/warnings.log`.

## Changes

**Instant banner**
- Print `Indexing <root>...` (with absolute path) immediately on scan start, before any file I/O

**Live progress**
- `\r`-overwriting progress line showing current phase, file counter (`142/380 files`), and warning tally
- Background goroutine renders at 100ms intervals; parse workers feed it via atomic counters
- TTY detection via go-isatty: non-TTY (pipe, CI) and `--quiet` skip progress entirely
- `defer prog.stop()` + `sync.Once` ensures cleanup on all exit paths

**Grouped warnings**
- `warningCollector` with 4 categories: parse failed, file too large, write failed, meta error
- Warnings accumulate silently during scan, written to `.sense/warnings.log` at end
- Zero-warning scans produce no log file; stale log files are cleaned up
- `parseFileStandalone` simplified from 9 to 7 parameters

**Summary output**
- `N warnings — see .sense/warnings.log` hint line when warnings present, omitted when clean
- `--quiet` suppresses hint line for programmatic callers

## Test Plan

- [x] `TestScanOutputFormat` — banner + summary pattern match
- [x] `TestScanTolerantOfInvalidSource` — warnings collected, hint line present, log file written with `parse failed` group
- [x] `TestScan_SizeCapSkipsLargeFiles` — `file too large` category in log file
- [x] `TestWarningCollector_GroupedFormat` — 10 warnings across 4 categories, correct grouped output
- [x] `TestWarningCollector_WriteLog` — log file written with correct content
- [x] `TestWarningCollector_ZeroWarnings_NoLogFile` — no file created on clean scan
- [x] `TestWarningCollector_OverwritesStaleLog` — stale log removed on clean rescan
- [x] `go test ./...` passes
- [x] `make ci` passes (tests + lint)
- [x] Manual smoke test: `sense scan` shows banner and summary, no per-file warnings