### PR TITLE
feat(graph): add multi-hop BFS traversal (depth 1-3)

### DIFF
--- a/internal/cli/graph.go
+++ b/internal/cli/graph.go
@@ -8,6 +8,7 @@ import (
 	"io"
 
 	"github.com/luuuc/sense/internal/mcpio"
+	"github.com/luuuc/sense/internal/model"
 )
 
 // graphHelp mirrors the `sense graph` example block in
@@ -43,15 +44,14 @@ Exit codes:
      'sense scan --force' lands in pitch 01-06)
 `
 
-// GraphDirection names the traversal direction flag values. Exported
-// so the MCP wrapper in 01-05 can reuse the same vocabulary on the
-// wire.
-type GraphDirection string
+// GraphDirection aliases model.Direction so existing callers and tests
+// in the cli package keep compiling without an import change.
+type GraphDirection = model.Direction
 
 const (
-	DirectionBoth    GraphDirection = "both"
-	DirectionCallers GraphDirection = "callers"
-	DirectionCallees GraphDirection = "callees"
+	DirectionBoth    = model.DirectionBoth
+	DirectionCallers = model.DirectionCallers
+	DirectionCallees = model.DirectionCallees
 )
 
 // graphOptions is the parsed flag shape for the graph subcommand.
@@ -82,8 +82,11 @@ func RunGraph(args []string, cio IO) int {
 		}
 		return ExitGeneralError
 	}
-	if opts.Depth != 1 {
-		_, _ = fmt.Fprintln(cio.Stderr, "sense graph: --depth > 1 is not yet supported")
+	if opts.Depth < 1 {
+		opts.Depth = 1
+	}
+	if opts.Depth > mcpio.MaxGraphDepth {
+		_, _ = fmt.Fprintf(cio.Stderr, "sense graph: --depth %d exceeds maximum of %d\n", opts.Depth, mcpio.MaxGraphDepth)
 		return ExitGeneralError
 	}
 
@@ -113,13 +116,13 @@ func RunGraph(args []string, cio IO) int {
 		return ExitSymbolIssue
 	}
 
-	sc, err := adapter.ReadSymbol(ctx, matches[0].ID)
+	gr, err := adapter.ReadSymbolGraph(ctx, matches[0].ID, opts.Depth, opts.Direction, mcpio.MaxPerHop)
 	if err != nil {
 		_, _ = fmt.Fprintln(cio.Stderr, "sense graph:", err)
 		return ExitGeneralError
 	}
 
-	fileIDs := CollectFileIDs(sc)
+	fileIDs := CollectGraphFileIDs(gr)
 	pathByID, err := LoadFilePaths(ctx, adapter.DB(), fileIDs)
 	if err != nil {
 		_, _ = fmt.Fprintln(cio.Stderr, "sense graph:", err)
@@ -130,9 +133,10 @@ func RunGraph(args []string, cio IO) int {
 		return p, ok
 	}
 
-	resp := mcpio.BuildGraphResponse(sc, lookup, mcpio.BuildGraphRequest{
-		Direction: string(opts.Direction),
-	})
+	buildReq := mcpio.BuildGraphRequest{
+		Direction: opts.Direction,
+	}
+	resp := mcpio.BuildFullGraphResponse(gr, lookup, buildReq)
 
 	if opts.JSON {
 		out, merr := mcpio.MarshalGraph(resp)

--- a/internal/cli/graph_test.go
+++ b/internal/cli/graph_test.go
@@ -352,16 +352,16 @@ func TestRunGraphDirectionCallees(t *testing.T) {
 	}
 }
 
-func TestRunGraphDepthTwoRejected(t *testing.T) {
+func TestRunGraphDepthExceedsMax(t *testing.T) {
 	dir := seedGraphProject(t)
 	var stdout, stderr bytes.Buffer
-	code := RunGraph([]string{"--depth", "2", "App::Services::CheckoutService"},
+	code := RunGraph([]string{"--depth", "4", "App::Services::CheckoutService"},
 		IO{Stdout: &stdout, Stderr: &stderr, Dir: dir})
 	if code != ExitGeneralError {
 		t.Errorf("exit=%d, want %d", code, ExitGeneralError)
 	}
-	if !strings.Contains(stderr.String(), "--depth > 1") {
-		t.Errorf("expected --depth > 1 message, got: %s", stderr.String())
+	if !strings.Contains(stderr.String(), "exceeds maximum") {
+		t.Errorf("expected max depth message, got: %s", stderr.String())
 	}
 }
 
@@ -442,4 +442,194 @@ func TestRunGraphUnreadableIndexExit1(t *testing.T) {
 	if strings.Contains(stderr.String(), "corrupt") {
 		t.Errorf("permission error should not be labeled corrupt, got: %s", stderr.String())
 	}
+}
+
+// seedGraphProjectDeep builds a 3-hop call chain:
+//
+//	D → C → B → A
+//
+// where → means "calls". Querying A with direction=callers at depth 1
+// returns B, depth 2 returns B+C, depth 3 returns B+C+D.
+func seedGraphProjectDeep(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	files := []model.File{
+		{Path: "a.rb", Language: "ruby", Hash: "a", IndexedAt: time.Now()},
+		{Path: "b.rb", Language: "ruby", Hash: "b", IndexedAt: time.Now()},
+		{Path: "c.rb", Language: "ruby", Hash: "c", IndexedAt: time.Now()},
+		{Path: "d.rb", Language: "ruby", Hash: "d", IndexedAt: time.Now()},
+	}
+	fids := make([]int64, len(files))
+	for i := range files {
+		id, werr := adapter.WriteFile(ctx, &files[i])
+		if werr != nil {
+			t.Fatalf("WriteFile: %v", werr)
+		}
+		fids[i] = id
+	}
+
+	syms := []model.Symbol{
+		{FileID: fids[0], Name: "A", Qualified: "A", Kind: "method", LineStart: 1, LineEnd: 5},
+		{FileID: fids[1], Name: "B", Qualified: "B", Kind: "method", LineStart: 1, LineEnd: 5},
+		{FileID: fids[2], Name: "C", Qualified: "C", Kind: "method", LineStart: 1, LineEnd: 5},
+		{FileID: fids[3], Name: "D", Qualified: "D", Kind: "method", LineStart: 1, LineEnd: 5},
+	}
+	sids := make([]int64, len(syms))
+	for i := range syms {
+		id, werr := adapter.WriteSymbol(ctx, &syms[i])
+		if werr != nil {
+			t.Fatalf("WriteSymbol: %v", werr)
+		}
+		sids[i] = id
+	}
+
+	// D→C→B→A call chain
+	edges := []model.Edge{
+		{SourceID: &sids[1], TargetID: sids[0], Kind: model.EdgeCalls, FileID: fids[1], Confidence: 1.0},
+		{SourceID: &sids[2], TargetID: sids[1], Kind: model.EdgeCalls, FileID: fids[2], Confidence: 1.0},
+		{SourceID: &sids[3], TargetID: sids[2], Kind: model.EdgeCalls, FileID: fids[3], Confidence: 1.0},
+	}
+	for i := range edges {
+		if _, werr := adapter.WriteEdge(ctx, &edges[i]); werr != nil {
+			t.Fatalf("WriteEdge: %v", werr)
+		}
+	}
+	return dir
+}
+
+func TestRunGraphDepthCallers(t *testing.T) {
+	dir := seedGraphProjectDeep(t)
+
+	t.Run("depth=1 returns direct caller only", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		code := RunGraph([]string{"--depth", "1", "--direction", "callers", "--json", "A"},
+			IO{Stdout: &stdout, Stderr: &stderr, Dir: dir})
+		if code != ExitSuccess {
+			t.Fatalf("exit=%d stderr=%s", code, stderr.String())
+		}
+		var resp mcpio.GraphResponse
+		if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &resp); err != nil {
+			t.Fatalf("json: %v", err)
+		}
+		if len(resp.Edges.CalledBy) != 1 || resp.Edges.CalledBy[0].Symbol != "B" {
+			t.Errorf("depth=1 called_by = %v, want [B]", resp.Edges.CalledBy)
+		}
+		if len(resp.Layers) != 0 {
+			t.Errorf("depth=1 layers = %d, want 0", len(resp.Layers))
+		}
+	})
+
+	t.Run("depth=2 returns direct + transitive callers", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		code := RunGraph([]string{"--depth", "2", "--direction", "callers", "--json", "A"},
+			IO{Stdout: &stdout, Stderr: &stderr, Dir: dir})
+		if code != ExitSuccess {
+			t.Fatalf("exit=%d stderr=%s", code, stderr.String())
+		}
+		var resp mcpio.GraphResponse
+		if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &resp); err != nil {
+			t.Fatalf("json: %v", err)
+		}
+		if len(resp.Edges.CalledBy) != 1 || resp.Edges.CalledBy[0].Symbol != "B" {
+			t.Errorf("depth=2 edges.called_by = %v, want [B]", resp.Edges.CalledBy)
+		}
+		if len(resp.Layers) != 1 {
+			t.Fatalf("depth=2 layers = %d, want 1", len(resp.Layers))
+		}
+		if resp.Layers[0].Depth != 2 {
+			t.Errorf("layer depth = %d, want 2", resp.Layers[0].Depth)
+		}
+		if len(resp.Layers[0].Edges.CalledBy) != 1 || resp.Layers[0].Edges.CalledBy[0].Symbol != "C" {
+			t.Errorf("depth=2 layer called_by = %v, want [C]", resp.Layers[0].Edges.CalledBy)
+		}
+	})
+
+	t.Run("depth=3 returns full 3-hop chain", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		code := RunGraph([]string{"--depth", "3", "--direction", "callers", "--json", "A"},
+			IO{Stdout: &stdout, Stderr: &stderr, Dir: dir})
+		if code != ExitSuccess {
+			t.Fatalf("exit=%d stderr=%s", code, stderr.String())
+		}
+		var resp mcpio.GraphResponse
+		if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &resp); err != nil {
+			t.Fatalf("json: %v", err)
+		}
+		if len(resp.Edges.CalledBy) != 1 || resp.Edges.CalledBy[0].Symbol != "B" {
+			t.Errorf("depth=3 edges.called_by = %v, want [B]", resp.Edges.CalledBy)
+		}
+		if len(resp.Layers) != 2 {
+			t.Fatalf("depth=3 layers = %d, want 2", len(resp.Layers))
+		}
+		if resp.Layers[0].Edges.CalledBy[0].Symbol != "C" {
+			t.Errorf("depth=3 layer[0] = %v, want C", resp.Layers[0].Edges.CalledBy)
+		}
+		if resp.Layers[1].Depth != 3 {
+			t.Errorf("layer[1] depth = %d, want 3", resp.Layers[1].Depth)
+		}
+		if len(resp.Layers[1].Edges.CalledBy) != 1 || resp.Layers[1].Edges.CalledBy[0].Symbol != "D" {
+			t.Errorf("depth=3 layer[1] = %v, want [D]", resp.Layers[1].Edges.CalledBy)
+		}
+	})
+
+	t.Run("depth=2 callees direction", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		code := RunGraph([]string{"--depth", "2", "--direction", "callees", "--json", "D"},
+			IO{Stdout: &stdout, Stderr: &stderr, Dir: dir})
+		if code != ExitSuccess {
+			t.Fatalf("exit=%d stderr=%s", code, stderr.String())
+		}
+		var resp mcpio.GraphResponse
+		if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &resp); err != nil {
+			t.Fatalf("json: %v", err)
+		}
+		if len(resp.Edges.Calls) != 1 || resp.Edges.Calls[0].Symbol != "C" {
+			t.Errorf("depth=2 callees calls = %v, want [C]", resp.Edges.Calls)
+		}
+		if len(resp.Layers) != 1 {
+			t.Fatalf("depth=2 callees layers = %d, want 1", len(resp.Layers))
+		}
+		if len(resp.Layers[0].Edges.Calls) != 1 || resp.Layers[0].Edges.Calls[0].Symbol != "B" {
+			t.Errorf("depth=2 callees layer = %v, want [B]", resp.Layers[0].Edges.Calls)
+		}
+	})
+
+	t.Run("deduplication across hops", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		code := RunGraph([]string{"--depth", "3", "--direction", "callees", "--json", "D"},
+			IO{Stdout: &stdout, Stderr: &stderr, Dir: dir})
+		if code != ExitSuccess {
+			t.Fatalf("exit=%d stderr=%s", code, stderr.String())
+		}
+		var resp mcpio.GraphResponse
+		if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &resp); err != nil {
+			t.Fatalf("json: %v", err)
+		}
+		seen := map[string]bool{}
+		for _, e := range resp.Edges.Calls {
+			if seen[e.Symbol] {
+				t.Errorf("duplicate in edges: %s", e.Symbol)
+			}
+			seen[e.Symbol] = true
+		}
+		for _, layer := range resp.Layers {
+			for _, e := range layer.Edges.Calls {
+				if seen[e.Symbol] {
+					t.Errorf("duplicate across layers: %s", e.Symbol)
+				}
+				seen[e.Symbol] = true
+			}
+		}
+	})
 }

--- a/internal/cli/index.go
+++ b/internal/cli/index.go
@@ -82,6 +82,31 @@ func CollectFileIDs(sc *model.SymbolContext) []int64 {
 	return ids
 }
 
+// CollectGraphFileIDs returns unique file IDs from a GraphResult,
+// including both the root symbol context and all multi-hop layers.
+func CollectGraphFileIDs(gr *model.GraphResult) []int64 {
+	ids := CollectFileIDs(&gr.Root)
+	seen := make(map[int64]struct{}, len(ids))
+	for _, id := range ids {
+		seen[id] = struct{}{}
+	}
+	for _, layer := range gr.Layers {
+		for _, e := range layer.Outbound {
+			if _, ok := seen[e.Target.FileID]; !ok {
+				seen[e.Target.FileID] = struct{}{}
+				ids = append(ids, e.Target.FileID)
+			}
+		}
+		for _, e := range layer.Inbound {
+			if _, ok := seen[e.Target.FileID]; !ok {
+				seen[e.Target.FileID] = struct{}{}
+				ids = append(ids, e.Target.FileID)
+			}
+		}
+	}
+	return ids
+}
+
 // loadFilePaths bulk-fetches path strings for the given file ids,
 // keyed for O(1) lookup in the mcpio builders. Chunked on
 // SQLITE_MAX_VARIABLE_NUMBER (999) to stay safe on wide graph

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -28,33 +28,42 @@ func RenderGraphHuman(w io.Writer, resp mcpio.GraphResponse) {
 	_, _ = fmt.Fprintf(w, "%s  (%s)\n", resp.Symbol.Name, resp.Symbol.Kind)
 	_, _ = fmt.Fprintf(w, "  %s:%d-%d\n", resp.Symbol.File, resp.Symbol.LineStart, resp.Symbol.LineEnd)
 
-	// Group order matches the pitch example: inherits → calls →
-	// callers → tests. Labels are padded to a shared width so the
-	// edge lists line up on a common left edge.
 	const label = "  %-9s %s\n"
 
-	if s := renderInherits(resp.Edges.Inherits); s != "" {
-		_, _ = fmt.Fprintf(w, label, "inherits", s)
-	}
-	if s := renderComposes(resp.Edges.Composes); s != "" {
-		_, _ = fmt.Fprintf(w, label, "composes", s)
-	}
-	if s := renderIncludes(resp.Edges.Includes); s != "" {
-		_, _ = fmt.Fprintf(w, label, "includes", s)
-	}
-	if s := renderImports(resp.Edges.Imports); s != "" {
-		_, _ = fmt.Fprintf(w, label, "imports", s)
-	}
-	if s := renderCalls(resp.Edges.Calls); s != "" {
-		_, _ = fmt.Fprintf(w, label, "calls", s)
-	}
-	if s := renderCalls(resp.Edges.CalledBy); s != "" {
-		_, _ = fmt.Fprintf(w, label, "callers", s)
-	}
+	renderEdgeGroup(w, label, resp.Edges)
 	if ts := resp.TestCallerSummary; ts != nil && ts.Count > 0 {
 		_, _ = fmt.Fprintf(w, label, "test cal.", fmt.Sprintf("(%d in %s)", ts.Count, strings.Join(ts.Examples, ", ")))
 	}
-	if s := renderTests(resp.Edges.Tests); s != "" {
+
+	for _, layer := range resp.Layers {
+		_, _ = fmt.Fprintf(w, "\n  ── depth %d ──\n", layer.Depth)
+		renderEdgeGroup(w, label, layer.Edges)
+	}
+	if resp.Truncated {
+		_, _ = fmt.Fprintf(w, "\n  (results truncated — per-hop limit reached)\n")
+	}
+}
+
+func renderEdgeGroup(w io.Writer, label string, edges mcpio.GraphEdges) {
+	if s := renderInherits(edges.Inherits); s != "" {
+		_, _ = fmt.Fprintf(w, label, "inherits", s)
+	}
+	if s := renderComposes(edges.Composes); s != "" {
+		_, _ = fmt.Fprintf(w, label, "composes", s)
+	}
+	if s := renderIncludes(edges.Includes); s != "" {
+		_, _ = fmt.Fprintf(w, label, "includes", s)
+	}
+	if s := renderImports(edges.Imports); s != "" {
+		_, _ = fmt.Fprintf(w, label, "imports", s)
+	}
+	if s := renderCalls(edges.Calls); s != "" {
+		_, _ = fmt.Fprintf(w, label, "calls", s)
+	}
+	if s := renderCalls(edges.CalledBy); s != "" {
+		_, _ = fmt.Fprintf(w, label, "callers", s)
+	}
+	if s := renderTests(edges.Tests); s != "" {
 		_, _ = fmt.Fprintf(w, label, "tests", s)
 	}
 }

--- a/internal/mcpio/graph.go
+++ b/internal/mcpio/graph.go
@@ -8,6 +8,11 @@ import (
 
 const testCallerCollapseThreshold = 20
 
+const (
+	MaxGraphDepth = 3
+	MaxPerHop     = 200
+)
+
 // FileLookup resolves a sense_files row id to its path. Used by
 // BuildGraphResponse / BuildBlastResponse to hydrate edge endpoints.
 // A miss returns ("", false); the builder then renders `File` as
@@ -20,7 +25,7 @@ type FileLookup func(fileID int64) (path string, ok bool)
 // caller has already loaded the SymbolContext at the right depth
 // from the DB layer.
 type BuildGraphRequest struct {
-	Direction       string // "both", "callers", "callees"; "" == "both"
+	Direction       model.Direction // DirectionBoth, DirectionCallers, DirectionCallees; "" == both
 	SegmentCallers  bool   // split callers into production vs test
 }
 
@@ -50,80 +55,20 @@ func BuildGraphResponse(sc *model.SymbolContext, files FileLookup, req BuildGrap
 		},
 	}
 
-	wantOutbound := req.Direction != "callers"
-	wantInbound := req.Direction != "callees"
+	resp.Edges = categorizeEdges(sc.Outbound, sc.Inbound, files, req.Direction)
 
-	if wantOutbound {
-		for _, e := range sc.Outbound {
-			switch e.Edge.Kind {
-			case model.EdgeCalls:
-				resp.Edges.Calls = append(resp.Edges.Calls, CallEdgeRef{
-					Symbol:     qualifiedOrName(e.Target),
-					File:       fileRefOrNil(e.Target.FileID, files),
-					Confidence: Confidence(e.Edge.Confidence),
-				})
-			case model.EdgeInherits:
-				resp.Edges.Inherits = append(resp.Edges.Inherits, InheritEdgeRef{
-					Symbol: qualifiedOrName(e.Target),
-					File:   fileRefOrNil(e.Target.FileID, files),
-				})
-			case model.EdgeComposes:
-				resp.Edges.Composes = append(resp.Edges.Composes, ComposeEdgeRef{
-					Symbol: qualifiedOrName(e.Target),
-					File:   fileRefOrNil(e.Target.FileID, files),
-				})
-			case model.EdgeIncludes:
-				resp.Edges.Includes = append(resp.Edges.Includes, IncludeEdgeRef{
-					Symbol: qualifiedOrName(e.Target),
-					File:   fileRefOrNil(e.Target.FileID, files),
-				})
-			case model.EdgeImports:
-				resp.Edges.Imports = append(resp.Edges.Imports, ImportEdgeRef{
-					Symbol: qualifiedOrName(e.Target),
-					File:   fileRefOrNil(e.Target.FileID, files),
-				})
-			}
-		}
-	}
+	// Test-caller segmentation: split test callers out of CalledBy.
 	var testCallers []CallEdgeRef
-	if wantInbound {
-		for _, e := range sc.Inbound {
-			switch e.Edge.Kind {
-			case model.EdgeCalls:
-				ref := CallEdgeRef{
-					Symbol:     qualifiedOrName(e.Target),
-					File:       fileRefOrNil(e.Target.FileID, files),
-					Confidence: Confidence(e.Edge.Confidence),
-				}
-				if req.SegmentCallers && ref.File != nil && IsTestPath(*ref.File) {
-					testCallers = append(testCallers, ref)
-				} else {
-					resp.Edges.CalledBy = append(resp.Edges.CalledBy, ref)
-				}
-			case model.EdgeComposes:
-				resp.Edges.Composes = append(resp.Edges.Composes, ComposeEdgeRef{
-					Symbol: qualifiedOrName(e.Target),
-					File:   fileRefOrNil(e.Target.FileID, files),
-				})
-			case model.EdgeIncludes:
-				resp.Edges.Includes = append(resp.Edges.Includes, IncludeEdgeRef{
-					Symbol: qualifiedOrName(e.Target),
-					File:   fileRefOrNil(e.Target.FileID, files),
-				})
-			case model.EdgeImports:
-				resp.Edges.Imports = append(resp.Edges.Imports, ImportEdgeRef{
-					Symbol: qualifiedOrName(e.Target),
-					File:   fileRefOrNil(e.Target.FileID, files),
-				})
-			case model.EdgeTests:
-				if path, ok := files(e.Target.FileID); ok {
-					resp.Edges.Tests = append(resp.Edges.Tests, TestEdgeRef{
-						File:       path,
-						Confidence: Confidence(e.Edge.Confidence),
-					})
-				}
+	if req.SegmentCallers && len(resp.Edges.CalledBy) > 0 {
+		prod := resp.Edges.CalledBy[:0]
+		for _, ref := range resp.Edges.CalledBy {
+			if ref.File != nil && IsTestPath(*ref.File) {
+				testCallers = append(testCallers, ref)
+			} else {
+				prod = append(prod, ref)
 			}
 		}
+		resp.Edges.CalledBy = prod
 	}
 
 	// Temporal edges are bidirectional — collect from outbound to get one
@@ -186,6 +131,115 @@ func BuildGraphResponse(sc *model.SymbolContext, files FileLookup, req BuildGrap
 	return resp
 }
 
+// BuildFullGraphResponse builds the complete response for a multi-hop
+// graph result, including root edges and any transitive layers.
+// Metrics are recomputed after layers are added so they account for
+// the full traversal, not just depth-1 edges.
+func BuildFullGraphResponse(gr *model.GraphResult, files FileLookup, req BuildGraphRequest) GraphResponse {
+	resp := BuildGraphResponse(&gr.Root, files, req)
+	for i, layer := range gr.Layers {
+		resp.Layers = append(resp.Layers, BuildGraphLayer(layer, i+2, files, req))
+	}
+	resp.Truncated = gr.Truncated
+
+	if len(resp.Layers) > 0 {
+		for _, l := range resp.Layers {
+			resp.SenseMetrics.SymbolsReturned += countEdgeSymbols(l.Edges)
+		}
+		uniqueFiles := countUniqueEdgeFiles(resp, nil)
+		resp.SenseMetrics.EstimatedFileReadsAvoided = uniqueFiles
+		resp.SenseMetrics.EstimatedTokensSaved = uniqueFiles * AvgTokensPerFile
+	}
+	return resp
+}
+
+// BuildGraphLayer converts a model.HopEdges into a wire-format
+// GraphLayer for the given hop depth.
+func BuildGraphLayer(hop model.HopEdges, depth int, files FileLookup, req BuildGraphRequest) GraphLayer {
+	return GraphLayer{
+		Depth: depth,
+		Edges: categorizeEdges(hop.Outbound, hop.Inbound, files, req.Direction),
+	}
+}
+
+// categorizeEdges maps model edge refs into the wire-format GraphEdges
+// shape, dispatching each edge kind to the right bucket. Temporal edges
+// and test-caller segmentation are root-only concerns handled by
+// BuildGraphResponse on top of this.
+func categorizeEdges(outbound, inbound []model.EdgeRef, files FileLookup, direction model.Direction) GraphEdges {
+	var edges GraphEdges
+
+	if direction != model.DirectionCallers {
+		for _, e := range outbound {
+			switch e.Edge.Kind {
+			case model.EdgeCalls:
+				edges.Calls = append(edges.Calls, CallEdgeRef{
+					Symbol:     qualifiedOrName(e.Target),
+					File:       fileRefOrNil(e.Target.FileID, files),
+					Confidence: Confidence(e.Edge.Confidence),
+				})
+			case model.EdgeInherits:
+				edges.Inherits = append(edges.Inherits, InheritEdgeRef{
+					Symbol: qualifiedOrName(e.Target),
+					File:   fileRefOrNil(e.Target.FileID, files),
+				})
+			case model.EdgeComposes:
+				edges.Composes = append(edges.Composes, ComposeEdgeRef{
+					Symbol: qualifiedOrName(e.Target),
+					File:   fileRefOrNil(e.Target.FileID, files),
+				})
+			case model.EdgeIncludes:
+				edges.Includes = append(edges.Includes, IncludeEdgeRef{
+					Symbol: qualifiedOrName(e.Target),
+					File:   fileRefOrNil(e.Target.FileID, files),
+				})
+			case model.EdgeImports:
+				edges.Imports = append(edges.Imports, ImportEdgeRef{
+					Symbol: qualifiedOrName(e.Target),
+					File:   fileRefOrNil(e.Target.FileID, files),
+				})
+			}
+		}
+	}
+
+	if direction != model.DirectionCallees {
+		for _, e := range inbound {
+			switch e.Edge.Kind {
+			case model.EdgeCalls:
+				edges.CalledBy = append(edges.CalledBy, CallEdgeRef{
+					Symbol:     qualifiedOrName(e.Target),
+					File:       fileRefOrNil(e.Target.FileID, files),
+					Confidence: Confidence(e.Edge.Confidence),
+				})
+			case model.EdgeComposes:
+				edges.Composes = append(edges.Composes, ComposeEdgeRef{
+					Symbol: qualifiedOrName(e.Target),
+					File:   fileRefOrNil(e.Target.FileID, files),
+				})
+			case model.EdgeIncludes:
+				edges.Includes = append(edges.Includes, IncludeEdgeRef{
+					Symbol: qualifiedOrName(e.Target),
+					File:   fileRefOrNil(e.Target.FileID, files),
+				})
+			case model.EdgeImports:
+				edges.Imports = append(edges.Imports, ImportEdgeRef{
+					Symbol: qualifiedOrName(e.Target),
+					File:   fileRefOrNil(e.Target.FileID, files),
+				})
+			case model.EdgeTests:
+				if path, ok := files(e.Target.FileID); ok {
+					edges.Tests = append(edges.Tests, TestEdgeRef{
+						File:       path,
+						Confidence: Confidence(e.Edge.Confidence),
+					})
+				}
+			}
+		}
+	}
+
+	return edges
+}
+
 // qualifiedOrName prefers the qualified name but falls back to the
 // bare name when qualified is empty — defensive against extractors
 // that only emit unqualified identifiers for some kinds.
@@ -196,52 +250,66 @@ func qualifiedOrName(s model.Symbol) string {
 	return s.Name
 }
 
+func countEdgeSymbols(edges GraphEdges) int {
+	return len(edges.Calls) + len(edges.CalledBy) +
+		len(edges.Inherits) + len(edges.Composes) +
+		len(edges.Includes) + len(edges.Imports) +
+		len(edges.Tests) + len(edges.Temporal)
+}
+
 func countUniqueEdgeFiles(resp GraphResponse, testCallers []CallEdgeRef) int {
 	seen := map[string]struct{}{}
-	for _, e := range resp.Edges.Calls {
-		if e.File != nil {
-			seen[*e.File] = struct{}{}
-		}
-	}
-	for _, e := range resp.Edges.CalledBy {
-		if e.File != nil {
-			seen[*e.File] = struct{}{}
-		}
+	collectEdgeFiles(resp.Edges, seen)
+	for _, l := range resp.Layers {
+		collectEdgeFiles(l.Edges, seen)
 	}
 	for _, e := range testCallers {
 		if e.File != nil {
 			seen[*e.File] = struct{}{}
 		}
 	}
-	for _, e := range resp.Edges.Inherits {
+	return len(seen)
+}
+
+func collectEdgeFiles(edges GraphEdges, seen map[string]struct{}) {
+	for _, e := range edges.Calls {
 		if e.File != nil {
 			seen[*e.File] = struct{}{}
 		}
 	}
-	for _, e := range resp.Edges.Composes {
+	for _, e := range edges.CalledBy {
 		if e.File != nil {
 			seen[*e.File] = struct{}{}
 		}
 	}
-	for _, e := range resp.Edges.Includes {
+	for _, e := range edges.Inherits {
 		if e.File != nil {
 			seen[*e.File] = struct{}{}
 		}
 	}
-	for _, e := range resp.Edges.Imports {
+	for _, e := range edges.Composes {
 		if e.File != nil {
 			seen[*e.File] = struct{}{}
 		}
 	}
-	for _, e := range resp.Edges.Tests {
+	for _, e := range edges.Includes {
+		if e.File != nil {
+			seen[*e.File] = struct{}{}
+		}
+	}
+	for _, e := range edges.Imports {
+		if e.File != nil {
+			seen[*e.File] = struct{}{}
+		}
+	}
+	for _, e := range edges.Tests {
 		seen[e.File] = struct{}{}
 	}
-	for _, e := range resp.Edges.Temporal {
+	for _, e := range edges.Temporal {
 		if e.File != nil {
 			seen[*e.File] = struct{}{}
 		}
 	}
-	return len(seen)
 }
 
 // fileRefOrNil turns a FileID into a *string via FileLookup.

--- a/internal/mcpio/graph_test.go
+++ b/internal/mcpio/graph_test.go
@@ -73,12 +73,12 @@ func TestBuildGraphResponseComposesDirection(t *testing.T) {
 	}
 	files := func(int64) (string, bool) { return "", false }
 
-	resp := BuildGraphResponse(sc, files, BuildGraphRequest{Direction: "callees"})
+	resp := BuildGraphResponse(sc, files, BuildGraphRequest{Direction: model.DirectionCallees})
 	if len(resp.Edges.Composes) != 1 || resp.Edges.Composes[0].Symbol != "Order" {
 		t.Errorf("callees direction: want only outbound Order, got %v", resp.Edges.Composes)
 	}
 
-	resp = BuildGraphResponse(sc, files, BuildGraphRequest{Direction: "callers"})
+	resp = BuildGraphResponse(sc, files, BuildGraphRequest{Direction: model.DirectionCallers})
 	if len(resp.Edges.Composes) != 1 || resp.Edges.Composes[0].Symbol != "Profile" {
 		t.Errorf("callers direction: want only inbound Profile, got %v", resp.Edges.Composes)
 	}
@@ -210,7 +210,7 @@ func TestBuildGraphResponseTemporalDirectionIndependent(t *testing.T) {
 	files := func(int64) (string, bool) { return "", false }
 
 	// Temporal should appear regardless of direction filter.
-	for _, dir := range []string{"both", "callers", "callees"} {
+	for _, dir := range []model.Direction{model.DirectionBoth, model.DirectionCallers, model.DirectionCallees} {
 		resp := BuildGraphResponse(sc, files, BuildGraphRequest{Direction: dir})
 		if len(resp.Edges.Temporal) != 1 {
 			t.Errorf("direction=%q: Temporal = %d, want 1", dir, len(resp.Edges.Temporal))
@@ -247,7 +247,7 @@ func TestCallerSegmentation(t *testing.T) {
 		},
 	}
 
-	resp := BuildGraphResponse(sc, files, BuildGraphRequest{Direction: "callers", SegmentCallers: true})
+	resp := BuildGraphResponse(sc, files, BuildGraphRequest{Direction: model.DirectionCallers, SegmentCallers: true})
 
 	if len(resp.Edges.CalledBy) != 2 {
 		t.Fatalf("CalledBy (production) = %d, want 2", len(resp.Edges.CalledBy))
@@ -263,7 +263,7 @@ func TestCallerSegmentation(t *testing.T) {
 	}
 
 	// Without SegmentCallers, all callers stay in CalledBy.
-	resp = BuildGraphResponse(sc, files, BuildGraphRequest{Direction: "callers", SegmentCallers: false})
+	resp = BuildGraphResponse(sc, files, BuildGraphRequest{Direction: model.DirectionCallers, SegmentCallers: false})
 	if len(resp.Edges.CalledBy) != 5 {
 		t.Fatalf("CalledBy (unsegmented) = %d, want 5", len(resp.Edges.CalledBy))
 	}
@@ -311,7 +311,7 @@ func TestCallerSegmentationCollapseOver20(t *testing.T) {
 		Inbound: inbound,
 	}
 
-	resp := BuildGraphResponse(sc, files, BuildGraphRequest{Direction: "callers", SegmentCallers: true})
+	resp := BuildGraphResponse(sc, files, BuildGraphRequest{Direction: model.DirectionCallers, SegmentCallers: true})
 
 	if len(resp.Edges.CalledBy) != 1 {
 		t.Fatalf("CalledBy (production) = %d, want 1", len(resp.Edges.CalledBy))

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -73,10 +73,20 @@ type NextStep struct {
 type GraphResponse struct {
 	Symbol             GraphSymbol        `json:"symbol"`
 	Edges              GraphEdges         `json:"edges"`
+	Layers             []GraphLayer       `json:"layers,omitempty"`
+	Truncated          bool               `json:"truncated,omitempty"`
 	TestCallerSummary  *TestCallerSummary `json:"test_caller_summary,omitempty"`
 	SenseMetrics       GraphMetrics       `json:"sense_metrics"`
 	Freshness          *Freshness         `json:"freshness,omitempty"`
 	NextSteps          []NextStep         `json:"next_steps"`
+}
+
+// GraphLayer holds edges discovered at one BFS hop beyond the root.
+// Depth is the hop number (2, 3, …). Edges use the same shape as the
+// root's edges so the LLM can process them uniformly.
+type GraphLayer struct {
+	Depth int        `json:"depth"`
+	Edges GraphEdges `json:"edges"`
 }
 
 // TestCallerSummary segments test callers out of the main called_by

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/luuuc/sense/internal/embed"
 	"github.com/luuuc/sense/internal/extract"
 	"github.com/luuuc/sense/internal/mcpio"
+	"github.com/luuuc/sense/internal/model"
 	"github.com/luuuc/sense/internal/metrics"
 	"github.com/luuuc/sense/internal/profile"
 	"github.com/luuuc/sense/internal/scan"
@@ -349,11 +350,19 @@ func (h *handlers) handleGraph(ctx context.Context, req mcp.CallToolRequest) (*m
 	}
 
 	depth := req.GetInt("depth", 1)
-	if depth != 1 {
-		return mcp.NewToolResultError("sense.graph: --depth > 1 is not yet supported"), nil
+	if depth < 1 {
+		depth = 1
+	}
+	if depth > mcpio.MaxGraphDepth {
+		return mcp.NewToolResultError(fmt.Sprintf("sense.graph: depth %d exceeds maximum of %d", depth, mcpio.MaxGraphDepth)), nil
 	}
 
-	direction := req.GetString("direction", "both")
+	direction := model.Direction(req.GetString("direction", "both"))
+	switch direction {
+	case model.DirectionBoth, model.DirectionCallers, model.DirectionCallees:
+	default:
+		return mcp.NewToolResultError(fmt.Sprintf("sense.graph: direction must be both, callers, or callees (got %q)", direction)), nil
+	}
 
 	match, err := h.resolveSymbol(ctx, "sense.graph", symbol)
 	if err != nil {
@@ -363,12 +372,12 @@ func (h *handlers) handleGraph(ctx context.Context, req mcp.CallToolRequest) (*m
 		return nil, err
 	}
 
-	sc, err := h.adapter.ReadSymbol(ctx, match.ID)
+	gr, err := h.adapter.ReadSymbolGraph(ctx, match.ID, depth, direction, mcpio.MaxPerHop)
 	if err != nil {
 		return nil, fmt.Errorf("sense.graph: read symbol: %w", err)
 	}
 
-	fileIDs := cli.CollectFileIDs(sc)
+	fileIDs := cli.CollectGraphFileIDs(gr)
 	pathByID, err := cli.LoadFilePaths(ctx, h.db, fileIDs)
 	if err != nil {
 		return nil, fmt.Errorf("sense.graph: load file paths: %w", err)
@@ -378,10 +387,11 @@ func (h *handlers) handleGraph(ctx context.Context, req mcp.CallToolRequest) (*m
 		return p, ok
 	}
 
-	resp := mcpio.BuildGraphResponse(sc, lookup, mcpio.BuildGraphRequest{
+	buildReq := mcpio.BuildGraphRequest{
 		Direction:      direction,
 		SegmentCallers: h.defaults.GraphSegmentCallers,
-	})
+	}
+	resp := mcpio.BuildFullGraphResponse(gr, lookup, buildReq)
 	h.tracker.Record("sense.graph", symbol,
 		resp.SenseMetrics.EstimatedFileReadsAvoided, resp.SenseMetrics.EstimatedTokensSaved)
 
@@ -396,7 +406,7 @@ func (h *handlers) handleGraph(ctx context.Context, req mcp.CallToolRequest) (*m
 	return mcp.NewToolResultText(string(out)), nil
 }
 
-func graphHints(resp mcpio.GraphResponse, direction string) []mcpio.NextStep {
+func graphHints(resp mcpio.GraphResponse, direction model.Direction) []mcpio.NextStep {
 	var hints []mcpio.NextStep
 
 	totalCallers := len(resp.Edges.CalledBy)
@@ -417,7 +427,7 @@ func graphHints(resp mcpio.GraphResponse, direction string) []mcpio.NextStep {
 		})
 	}
 
-	if direction == "callers" && len(hints) < 2 {
+	if direction == model.DirectionCallers && len(hints) < 2 {
 		hints = append(hints, mcpio.NextStep{
 			Tool:   "sense.graph",
 			Args:   map[string]any{"symbol": resp.Symbol.Qualified, "direction": "callees"},

--- a/internal/model/context.go
+++ b/internal/model/context.go
@@ -17,3 +17,28 @@ type SymbolContext struct {
 	Outbound []EdgeRef
 	Inbound  []EdgeRef
 }
+
+// Direction enumerates the traversal direction values accepted by
+// ReadSymbolGraph and the MCP/CLI layers.
+type Direction string
+
+const (
+	DirectionBoth    Direction = "both"
+	DirectionCallers Direction = "callers"
+	DirectionCallees Direction = "callees"
+)
+
+// GraphResult holds multi-hop graph traversal results. Root contains
+// the depth-1 edges (same as ReadSymbol). Layers holds one HopEdges
+// per additional hop (index 0 = depth 2, index 1 = depth 3).
+type GraphResult struct {
+	Root      SymbolContext
+	Layers    []HopEdges
+	Truncated bool
+}
+
+// HopEdges holds edges discovered at one BFS hop beyond the root.
+type HopEdges struct {
+	Outbound []EdgeRef
+	Inbound  []EdgeRef
+}

--- a/internal/sqlite/adapter.go
+++ b/internal/sqlite/adapter.go
@@ -571,6 +571,127 @@ func (a *Adapter) ReadSymbol(ctx context.Context, id int64) (*model.SymbolContex
 	}, nil
 }
 
+// ReadSymbolGraph performs a multi-hop BFS from the given symbol.
+// Depth 1 behaves identically to ReadSymbol. At depth 2+, the BFS
+// expands the frontier in the requested direction, deduplicating
+// against already-visited nodes. MaxPerHop caps new symbols per hop;
+// zero means unlimited.
+func (a *Adapter) ReadSymbolGraph(ctx context.Context, id int64, depth int, direction model.Direction, maxPerHop int) (*model.GraphResult, error) {
+	root, err := a.ReadSymbol(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	result := &model.GraphResult{Root: *root}
+	if depth <= 1 {
+		return result, nil
+	}
+
+	visited := map[int64]struct{}{id: {}}
+	frontier := graphFrontier(&result.Root, direction, visited)
+
+	for hop := 2; hop <= depth; hop++ {
+		if len(frontier) == 0 {
+			break
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("graph depth: cancelled at hop %d: %w", hop, err)
+		}
+
+		var layer model.HopEdges
+		var nextFrontier []int64
+		hopSymbols := 0
+
+		expand := func(symID int64, outbound bool, dest *[]model.EdgeRef) error {
+			refs, err := a.loadEdges(ctx, symID, outbound)
+			if err != nil {
+				return fmt.Errorf("graph depth hop %d: %w", hop, err)
+			}
+			for _, e := range refs {
+				if !expandableEdge(e, visited) {
+					continue
+				}
+				visited[e.Target.ID] = struct{}{}
+				*dest = append(*dest, e)
+				nextFrontier = append(nextFrontier, e.Target.ID)
+				hopSymbols++
+				if maxPerHop > 0 && hopSymbols >= maxPerHop {
+					result.Truncated = true
+					return nil
+				}
+			}
+			return nil
+		}
+
+		for _, symID := range frontier {
+			if err := ctx.Err(); err != nil {
+				return nil, fmt.Errorf("graph depth: cancelled at hop %d: %w", hop, err)
+			}
+			if maxPerHop > 0 && hopSymbols >= maxPerHop {
+				result.Truncated = true
+				break
+			}
+			if direction != model.DirectionCallees {
+				if err := expand(symID, false, &layer.Inbound); err != nil {
+					return nil, err
+				}
+				if result.Truncated {
+					break
+				}
+			}
+			if direction != model.DirectionCallers {
+				if err := expand(symID, true, &layer.Outbound); err != nil {
+					return nil, err
+				}
+				if result.Truncated {
+					break
+				}
+			}
+		}
+		if len(layer.Inbound) > 0 || len(layer.Outbound) > 0 {
+			result.Layers = append(result.Layers, layer)
+		}
+		if result.Truncated {
+			break
+		}
+		frontier = nextFrontier
+	}
+	return result, nil
+}
+
+// expandableEdge returns true if the edge should be followed during
+// BFS — filters out zero-ID targets, temporal (co-change) edges, and
+// already-visited nodes.
+func expandableEdge(e model.EdgeRef, visited map[int64]struct{}) bool {
+	if e.Target.ID == 0 || e.Edge.Kind == model.EdgeTemporal {
+		return false
+	}
+	_, seen := visited[e.Target.ID]
+	return !seen
+}
+
+// graphFrontier extracts the initial BFS frontier from the root's
+// edges, filtered by direction. Discovered IDs are added to visited.
+func graphFrontier(sc *model.SymbolContext, direction model.Direction, visited map[int64]struct{}) []int64 {
+	var frontier []int64
+	if direction != model.DirectionCallees {
+		for _, e := range sc.Inbound {
+			if expandableEdge(e, visited) {
+				visited[e.Target.ID] = struct{}{}
+				frontier = append(frontier, e.Target.ID)
+			}
+		}
+	}
+	if direction != model.DirectionCallers {
+		for _, e := range sc.Outbound {
+			if expandableEdge(e, visited) {
+				visited[e.Target.ID] = struct{}{}
+				frontier = append(frontier, e.Target.ID)
+			}
+		}
+	}
+	return frontier
+}
+
 func (a *Adapter) Query(ctx context.Context, f index.Filter) ([]model.Symbol, error) {
 	limit := int64(f.Limit)
 	if limit <= 0 {

--- a/internal/sqlite/context_test.go
+++ b/internal/sqlite/context_test.go
@@ -303,3 +303,237 @@ func TestContextForFileEmpty(t *testing.T) {
 		t.Errorf("expected nil for file with no symbols, got %d entries", len(result))
 	}
 }
+
+// seedChain builds a linear call chain of length n:
+//
+//	sym[n-1] → sym[n-2] → … → sym[1] → sym[0]
+//
+// Returns the symbol IDs in order sym[0]…sym[n-1].
+func seedChain(t *testing.T, ctx context.Context, a *sqlite.Adapter, n int) []int64 {
+	t.Helper()
+	ids := make([]int64, n)
+	for i := range n {
+		fid, err := a.WriteFile(ctx, &model.File{
+			Path: fmt.Sprintf("chain_%d.rb", i), Language: "ruby",
+			Hash: fmt.Sprintf("ch%d", i), IndexedAt: time.Now(),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		sid, err := a.WriteSymbol(ctx, &model.Symbol{
+			FileID: fid, Name: fmt.Sprintf("S%d", i),
+			Qualified: fmt.Sprintf("S%d", i),
+			Kind: model.KindMethod, LineStart: 1, LineEnd: 5,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		ids[i] = sid
+	}
+	for i := 1; i < n; i++ {
+		if _, err := a.WriteEdge(ctx, &model.Edge{
+			SourceID: model.Int64Ptr(ids[i]), TargetID: ids[i-1],
+			Kind: model.EdgeCalls, FileID: 1, Confidence: 1.0,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return ids
+}
+
+func TestReadSymbolGraphDepth(t *testing.T) {
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	// Chain: S3 → S2 → S1 → S0
+	ids := seedChain(t, ctx, a, 4)
+
+	t.Run("depth=1 returns root only", func(t *testing.T) {
+		gr, err := a.ReadSymbolGraph(ctx, ids[0], 1, "both", 200)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(gr.Layers) != 0 {
+			t.Errorf("layers = %d, want 0", len(gr.Layers))
+		}
+		if len(gr.Root.Inbound) != 1 {
+			t.Errorf("root inbound = %d, want 1 (S1)", len(gr.Root.Inbound))
+		}
+	})
+
+	t.Run("depth=2 adds one layer", func(t *testing.T) {
+		gr, err := a.ReadSymbolGraph(ctx, ids[0], 2, "callers", 200)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(gr.Layers) != 1 {
+			t.Fatalf("layers = %d, want 1", len(gr.Layers))
+		}
+		if len(gr.Layers[0].Inbound) != 1 {
+			t.Errorf("layer[0] inbound = %d, want 1 (S2)", len(gr.Layers[0].Inbound))
+		}
+	})
+
+	t.Run("depth=3 adds two layers", func(t *testing.T) {
+		gr, err := a.ReadSymbolGraph(ctx, ids[0], 3, "callers", 200)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(gr.Layers) != 2 {
+			t.Fatalf("layers = %d, want 2", len(gr.Layers))
+		}
+		if gr.Root.Inbound[0].Target.Qualified != "S1" {
+			t.Errorf("root caller = %s, want S1", gr.Root.Inbound[0].Target.Qualified)
+		}
+		if gr.Layers[0].Inbound[0].Target.Qualified != "S2" {
+			t.Errorf("layer[0] caller = %s, want S2", gr.Layers[0].Inbound[0].Target.Qualified)
+		}
+		if gr.Layers[1].Inbound[0].Target.Qualified != "S3" {
+			t.Errorf("layer[1] caller = %s, want S3", gr.Layers[1].Inbound[0].Target.Qualified)
+		}
+	})
+
+	t.Run("callees direction", func(t *testing.T) {
+		gr, err := a.ReadSymbolGraph(ctx, ids[3], 2, "callees", 200)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(gr.Root.Outbound) != 1 || gr.Root.Outbound[0].Target.Qualified != "S2" {
+			t.Errorf("root callee = %v, want [S2]", gr.Root.Outbound)
+		}
+		if len(gr.Layers) != 1 {
+			t.Fatalf("layers = %d, want 1", len(gr.Layers))
+		}
+		if len(gr.Layers[0].Outbound) != 1 || gr.Layers[0].Outbound[0].Target.Qualified != "S1" {
+			t.Errorf("layer callee = %v, want [S1]", gr.Layers[0].Outbound)
+		}
+	})
+
+	t.Run("dedup prevents cycles", func(t *testing.T) {
+		gr, err := a.ReadSymbolGraph(ctx, ids[0], 3, "both", 200)
+		if err != nil {
+			t.Fatal(err)
+		}
+		seen := map[string]bool{}
+		for _, e := range gr.Root.Inbound {
+			seen[e.Target.Qualified] = true
+		}
+		for _, e := range gr.Root.Outbound {
+			seen[e.Target.Qualified] = true
+		}
+		for _, layer := range gr.Layers {
+			for _, e := range layer.Inbound {
+				if seen[e.Target.Qualified] {
+					t.Errorf("duplicate across layers: %s", e.Target.Qualified)
+				}
+				seen[e.Target.Qualified] = true
+			}
+			for _, e := range layer.Outbound {
+				if seen[e.Target.Qualified] {
+					t.Errorf("duplicate across layers: %s", e.Target.Qualified)
+				}
+				seen[e.Target.Qualified] = true
+			}
+		}
+	})
+}
+
+func TestReadSymbolGraphTruncation(t *testing.T) {
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	// Star topology: hub has 10 callers, each caller has its own caller.
+	hubFile, err := a.WriteFile(ctx, &model.File{
+		Path: "hub.rb", Language: "ruby",
+		Hash: "hub", IndexedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	hubID, err := a.WriteSymbol(ctx, &model.Symbol{
+		FileID: hubFile, Name: "Hub", Qualified: "Hub",
+		Kind: model.KindMethod, LineStart: 1, LineEnd: 5,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := range 10 {
+		fid, _ := a.WriteFile(ctx, &model.File{
+			Path: fmt.Sprintf("caller_%d.rb", i), Language: "ruby",
+			Hash: fmt.Sprintf("c%d", i), IndexedAt: time.Now(),
+		})
+		callerID, _ := a.WriteSymbol(ctx, &model.Symbol{
+			FileID: fid, Name: fmt.Sprintf("Caller%d", i),
+			Qualified: fmt.Sprintf("Caller%d", i),
+			Kind: model.KindMethod, LineStart: 1, LineEnd: 5,
+		})
+		if _, err := a.WriteEdge(ctx, &model.Edge{
+			SourceID: model.Int64Ptr(callerID), TargetID: hubID,
+			Kind: model.EdgeCalls, FileID: fid, Confidence: 1.0,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		// Each caller has its own grandparent caller
+		gfid, _ := a.WriteFile(ctx, &model.File{
+			Path: fmt.Sprintf("grand_%d.rb", i), Language: "ruby",
+			Hash: fmt.Sprintf("g%d", i), IndexedAt: time.Now(),
+		})
+		grandID, _ := a.WriteSymbol(ctx, &model.Symbol{
+			FileID: gfid, Name: fmt.Sprintf("Grand%d", i),
+			Qualified: fmt.Sprintf("Grand%d", i),
+			Kind: model.KindMethod, LineStart: 1, LineEnd: 5,
+		})
+		if _, err := a.WriteEdge(ctx, &model.Edge{
+			SourceID: model.Int64Ptr(grandID), TargetID: callerID,
+			Kind: model.EdgeCalls, FileID: gfid, Confidence: 1.0,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("maxPerHop=3 truncates at hop 2", func(t *testing.T) {
+		gr, err := a.ReadSymbolGraph(ctx, hubID, 2, "callers", 3)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !gr.Truncated {
+			t.Error("expected Truncated=true")
+		}
+		// Root should have all 10 callers (depth-1 is not capped by maxPerHop)
+		if len(gr.Root.Inbound) != 10 {
+			t.Errorf("root inbound = %d, want 10", len(gr.Root.Inbound))
+		}
+		// Layer should exist with partial results
+		if len(gr.Layers) != 1 {
+			t.Fatalf("layers = %d, want 1", len(gr.Layers))
+		}
+		if len(gr.Layers[0].Inbound) != 3 {
+			t.Errorf("layer inbound = %d, want 3 (maxPerHop)", len(gr.Layers[0].Inbound))
+		}
+	})
+
+	t.Run("maxPerHop=0 means unlimited", func(t *testing.T) {
+		gr, err := a.ReadSymbolGraph(ctx, hubID, 2, "callers", 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if gr.Truncated {
+			t.Error("expected Truncated=false with unlimited cap")
+		}
+		if len(gr.Layers) != 1 {
+			t.Fatalf("layers = %d, want 1", len(gr.Layers))
+		}
+		if len(gr.Layers[0].Inbound) != 10 {
+			t.Errorf("layer inbound = %d, want 10", len(gr.Layers[0].Inbound))
+		}
+	})
+}


### PR DESCRIPTION
## Problem

`sense graph` only supports `depth: 1`. When an LLM requests `depth: 2` callers, it gets an error: "depth > 1 is not yet supported." This blocks refactor tasks that need to discover indirect dependencies — e.g. tracing `PostCreator#create` → `TopicCreator#create` → validators requires multiple hops that graph couldn't provide in one call.

## Summary

Extend graph traversal to support depth 1–3 via iterative BFS in the SQLite adapter, with layered results in the wire format.

## Changes

**Model layer**
- Add `model.Direction` type with `DirectionBoth`/`DirectionCallers`/`DirectionCallees` constants — replaces raw string comparisons across adapter, mcpio, and MCP server
- Add `GraphResult` and `HopEdges` types to carry multi-hop BFS results

**SQLite adapter**
- `ReadSymbolGraph`: BFS engine that expands frontiers per direction with a visited set, per-hop cap (`MaxPerHop=200`), and `Truncated` flag
- `expandableEdge` predicate filters zero-ID targets, temporal edges, and already-visited nodes (single source of truth for BFS filtering)
- Temporal (co-change) edges excluded from BFS propagation — they're statistical signals, not structural relationships

**Response builders (mcpio)**
- Extract `categorizeEdges` shared edge-kind dispatch (~70 lines of duplication removed)
- `BuildFullGraphResponse` assembles root + layers + truncated in one call (used by both CLI and MCP handler)
- `SenseMetrics` now accounts for layer symbols and files, not just depth-1
- `collectEdgeFiles` / `countEdgeSymbols` helpers for accurate metrics across layers

**CLI and MCP server**
- Remove "depth > 1 not yet supported" guard; enforce `MaxGraphDepth=3` cap
- MCP handler validates direction with a user-facing error for invalid values
- `CollectGraphFileIDs` walks root + all layers for file path hydration
- `renderEdgeGroup` extracted — root and layers share the same renderer
- Layer output with `── depth N ──` headers and truncation notice

**Wire format**
- Backward-compatible: `layers` and `truncated` use `omitempty` — depth=1 responses are byte-identical to before

## Test Plan

- [x] `TestRunGraphDepthCallers` — 5 subtests: depth=1 (direct only), depth=2 (transitive), depth=3 (full chain), callees direction, cross-hop deduplication
- [x] `TestRunGraphDepthExceedsMax` — depth=4 rejected with cap message
- [x] `TestReadSymbolGraphDepth` — adapter-level: depth 1/2/3, callees direction, cycle dedup
- [x] `TestReadSymbolGraphTruncation` — star topology with maxPerHop=3 verifies truncation flag and partial results; maxPerHop=0 verifies unlimited mode
- [x] `make ci` passes (all tests + lint)