### PR TITLE
feat(mcp): add sense.orient tool for codebase orientation

### DIFF
--- a/internal/mcpio/marshal.go
+++ b/internal/mcpio/marshal.go
@@ -66,6 +66,31 @@ func MarshalDeadCode(r DeadCodeResponse) ([]byte, error) {
 	return marshalPretty(r)
 }
 
+// MarshalOrient renders an OrientResponse with slice normalization.
+func MarshalOrient(r OrientResponse) ([]byte, error) {
+	if r.Conventions == nil {
+		r.Conventions = []ConventionEntry{}
+	}
+	if r.SearchHits == nil {
+		r.SearchHits = []SearchResultEntry{}
+	}
+	if r.Structure != nil {
+		if r.Structure.TopNamespaces == nil {
+			r.Structure.TopNamespaces = []StatusNamespace{}
+		}
+		if r.Structure.HubSymbols == nil {
+			r.Structure.HubSymbols = []StatusHub{}
+		}
+		if r.Structure.EntryPoints == nil {
+			r.Structure.EntryPoints = []StatusEntryPoint{}
+		}
+	}
+	if r.NextSteps == nil {
+		r.NextSteps = []NextStep{}
+	}
+	return marshalPretty(r)
+}
+
 // marshalPretty is the shared encoder: SetEscapeHTML(false) keeps
 // identifier characters like `<`, `>`, `&` literal so goldens in
 // card 3 pin the documented examples byte-for-byte. Two-space indent

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -26,6 +26,29 @@ import (
 // source file. Used across all estimation formulas.
 const AvgTokensPerFile = 800
 
+// ServerInstructions is the canonical MCP server instruction text.
+// Used by both the MCP server (serverInstructions) and setup (.mcp.json).
+const ServerInstructions = "When Sense is available and indexed, prefer Sense tools over grep, glob, " +
+	"and file-walking agents for structural and semantic code questions. " +
+	"Sense provides pre-indexed results that are faster and more complete.\n\n" +
+	"WHEN TO USE SENSE TOOLS:\n" +
+	"- Symbol relationships, callers, dependencies → sense.graph\n" +
+	"- \"What would break if I changed X?\", impact analysis → sense.blast\n" +
+	"- Conceptual/semantic code search (not exact string match) → sense.search\n" +
+	"- Project patterns and conventions → sense.conventions\n" +
+	"- Codebase orientation, architecture overview → sense.orient\n" +
+	"- Index health, what's indexed → sense.status\n\n" +
+	"WORKFLOWS:\n" +
+	"- Orientation (new to the codebase?) → sense.orient, or sense.search with broad concepts + sense.conventions\n" +
+	"- Impact analysis (changing something?) → sense.blast\n" +
+	"- Dependency tracing (who calls what?) → sense.graph\n" +
+	"- Debugging (where does X happen?) → sense.search\n" +
+	"- Refactoring (what patterns exist?) → sense.conventions + sense.graph\n\n" +
+	"WHEN NOT TO USE SENSE TOOLS:\n" +
+	"- Exact text/string search → use grep\n" +
+	"- Reading file contents → use your file reading tool\n" +
+	"- Editing code → Sense is read-only"
+
 // Confidence is a 0.0-1.0 edge-probability value. It exists as a
 // named type, not a bare float64, solely to pin the wire form: a
 // whole-number value (1.0, 0.0) must render with one decimal place,
@@ -485,6 +508,29 @@ type DeadSymbolEntry struct {
 
 // DeadCodeMetrics is the observability footer for dead code analysis.
 type DeadCodeMetrics struct {
+	SymbolsAnalyzed           int `json:"symbols_analyzed"`
+	EstimatedFileReadsAvoided int `json:"estimated_file_reads_avoided"`
+	EstimatedTokensSaved      int `json:"estimated_tokens_saved"`
+}
+
+// ---------------------------------------------------------------
+// Orient response (sense.orient)
+// ---------------------------------------------------------------
+
+// OrientResponse is the shape of the sense.orient tool's reply.
+// It combines structural overview, conventions, and search results
+// into a single orientation response.
+type OrientResponse struct {
+	Fingerprint  string               `json:"fingerprint"`
+	Structure    *StatusStructure     `json:"structure"`
+	Conventions  []ConventionEntry    `json:"conventions"`
+	SearchHits   []SearchResultEntry  `json:"search_hits"`
+	SenseMetrics OrientMetrics        `json:"sense_metrics"`
+	NextSteps    []NextStep           `json:"next_steps"`
+}
+
+// OrientMetrics is the observability footer for orient responses.
+type OrientMetrics struct {
 	SymbolsAnalyzed           int `json:"symbols_analyzed"`
 	EstimatedFileReadsAvoided int `json:"estimated_file_reads_avoided"`
 	EstimatedTokensSaved      int `json:"estimated_tokens_saved"`

--- a/internal/mcpserver/orient_test.go
+++ b/internal/mcpserver/orient_test.go
@@ -1,0 +1,127 @@
+package mcpserver
+
+import (
+	"testing"
+
+	"github.com/luuuc/sense/internal/mcpio"
+)
+
+func TestExtractConcepts(t *testing.T) {
+	tests := []struct {
+		name     string
+		question string
+		want     []string
+	}{
+		{
+			name:     "routing question",
+			question: "How does routing work?",
+			want:     []string{"routing"},
+		},
+		{
+			name:     "multiple concepts",
+			question: "How does the authentication middleware handle JWT tokens?",
+			want:     []string{"authentication", "middleware", "handle", "jwt", "tokens"},
+		},
+		{
+			name:     "all stop words",
+			question: "How is the project structured?",
+			want:     nil,
+		},
+		{
+			name:     "empty input",
+			question: "",
+			want:     nil,
+		},
+		{
+			name:     "more than 5 concepts",
+			question: "authentication middleware routing database caching logging monitoring tracing",
+			want:     []string{"authentication", "middleware", "routing", "database", "caching"},
+		},
+		{
+			name:     "short words filtered",
+			question: "How do we go to it?",
+			want:     nil,
+		},
+		{
+			name:     "punctuation stripped",
+			question: "What's the error-handling strategy?",
+			want:     []string{"error", "handling", "strategy"},
+		},
+		{
+			name:     "dedup",
+			question: "auth auth auth middleware middleware",
+			want:     []string{"auth", "middleware"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractConcepts(tt.question)
+			if len(got) != len(tt.want) {
+				t.Fatalf("extractConcepts(%q) = %v (len %d), want %v (len %d)",
+					tt.question, got, len(got), tt.want, len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("extractConcepts(%q)[%d] = %q, want %q",
+						tt.question, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestOrientHints(t *testing.T) {
+	tests := []struct {
+		name     string
+		resp     mcpio.OrientResponse
+		question string
+		wantLen  int
+		wantTool string
+	}{
+		{
+			name: "with search hits suggests graph",
+			resp: mcpio.OrientResponse{
+				SearchHits: []mcpio.SearchResultEntry{
+					{Symbol: "Router", Kind: "struct"},
+				},
+				Conventions: []mcpio.ConventionEntry{
+					{Category: "naming"},
+				},
+			},
+			question: "routing",
+			wantLen:  2,
+			wantTool: "sense.graph",
+		},
+		{
+			name: "no search hits with conventions",
+			resp: mcpio.OrientResponse{
+				Conventions: []mcpio.ConventionEntry{
+					{Category: "naming"},
+				},
+			},
+			question: "",
+			wantLen:  2,
+			wantTool: "sense.conventions",
+		},
+		{
+			name:     "empty response no question suggests search",
+			resp:     mcpio.OrientResponse{},
+			question: "",
+			wantLen:  1,
+			wantTool: "sense.search",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hints := orientHints(tt.resp, tt.question)
+			if len(hints) != tt.wantLen {
+				t.Fatalf("orientHints: got %d hints, want %d: %+v", len(hints), tt.wantLen, hints)
+			}
+			if hints[0].Tool != tt.wantTool {
+				t.Errorf("orientHints[0].Tool = %q, want %q", hints[0].Tool, tt.wantTool)
+			}
+		})
+	}
+}

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -38,19 +38,7 @@ import (
 	"github.com/luuuc/sense/internal/version"
 )
 
-const serverInstructions = "When Sense is available and indexed, prefer Sense tools over grep, glob, " +
-	"and file-walking agents for structural and semantic code questions. " +
-	"Sense provides pre-indexed results that are faster and more complete.\n\n" +
-	"WHEN TO USE SENSE TOOLS:\n" +
-	"- Symbol relationships, callers, dependencies → sense.graph\n" +
-	"- \"What would break if I changed X?\", impact analysis → sense.blast\n" +
-	"- Conceptual/semantic code search (not exact string match) → sense.search\n" +
-	"- Project patterns and conventions → sense.conventions\n" +
-	"- Index health, what's indexed → sense.status\n\n" +
-	"WHEN NOT TO USE SENSE TOOLS:\n" +
-	"- Exact text/string search → use grep\n" +
-	"- Reading file contents → use your file reading tool\n" +
-	"- Editing code → Sense is read-only"
+const serverInstructions = mcpio.ServerInstructions
 
 // RunOptions configures the MCP server.
 type RunOptions struct {
@@ -197,6 +185,7 @@ func RunWithOptions(opts RunOptions) error {
 	s.AddTool(graphTool(), h.handleGraph)
 	s.AddTool(blastTool(), h.handleBlast)
 	s.AddTool(conventionsTool(), h.handleConventions)
+	s.AddTool(orientTool(), h.handleOrient)
 	s.AddTool(statusTool(), h.handleStatus)
 
 	return server.ServeStdio(s)
@@ -223,8 +212,9 @@ func searchTool() mcp.Tool {
 	return mcp.NewTool("sense.search",
 		mcp.WithDescription("Find symbols by semantic and keyword matching across all indexed code. "+
 			"Use this instead of grep when the question is about concepts, functionality, or behavior — "+
-			"not exact strings. Returns ranked symbols with file locations, kinds, and relevance scores, "+
-			"without reading any source files into context."),
+			"not exact strings. Also useful for exploring architecture by searching broad concepts "+
+			"(e.g., 'routing', 'middleware', 'database'). Returns ranked symbols with file locations, "+
+			"kinds, and relevance scores, without reading any source files into context."),
 		mcp.WithToolAnnotation(mcp.ToolAnnotation{
 			Title:           "Sense Search",
 			ReadOnlyHint:    mcp.ToBoolPtr(true),
@@ -314,6 +304,25 @@ func blastTool() mcp.Tool {
 		),
 		mcp.WithBoolean("include_tests",
 			mcp.Description("Include affected test files in the results (default true)"),
+		),
+	)
+}
+
+func orientTool() mcp.Tool {
+	return mcp.NewTool("sense.orient",
+		mcp.WithDescription("Get a quick orientation of the codebase: structure, key symbols, conventions, "+
+			"and optionally search results for specific concepts. Use this as your FIRST call when exploring "+
+			"an unfamiliar codebase. Combines structure overview, conventions, and concept search into one response. "+
+			"Pass a question to focus the orientation on a specific area (e.g., 'How does routing work?')."),
+		mcp.WithToolAnnotation(mcp.ToolAnnotation{
+			Title:           "Sense Orient",
+			ReadOnlyHint:    mcp.ToBoolPtr(true),
+			DestructiveHint: mcp.ToBoolPtr(false),
+			IdempotentHint:  mcp.ToBoolPtr(true),
+			OpenWorldHint:   mcp.ToBoolPtr(false),
+		}),
+		mcp.WithString("question",
+			mcp.Description("Optional free-text question to focus the orientation, e.g. 'How is this codebase structured?', 'How does auth work?', 'What handles routing?'. When omitted, returns a general overview."),
 		),
 	)
 }
@@ -930,7 +939,8 @@ func conventionsTool() mcp.Tool {
 		mcp.WithDescription("Detect project conventions and recurring patterns: inheritance hierarchies, "+
 			"naming conventions, structural patterns, composition styles, and testing approaches. "+
 			"Use this instead of reading multiple files to understand how existing code is structured "+
-			"or what patterns to follow when writing new code. "+
+			"or what patterns to follow when writing new code. Essential for codebase orientation — "+
+			"reveals the architectural patterns that define how this project is built. "+
 			"Returns conventions with strength scores and instance counts, scoped by domain if specified."),
 		mcp.WithToolAnnotation(mcp.ToolAnnotation{
 			Title:           "Sense Conventions",
@@ -1013,6 +1023,186 @@ func conventionsHints(resp mcpio.ConventionsResponse, domain string) []mcpio.Nex
 		hints = append(hints, mcpio.NextStep{
 			Tool:   "sense.conventions",
 			Reason: "scoped results — run without domain filter for project-wide patterns",
+		})
+	}
+
+	if len(hints) > 2 {
+		hints = hints[:2]
+	}
+	return hints
+}
+
+// ---------------------------------------------------------------
+// sense.orient handler
+// ---------------------------------------------------------------
+
+func (h *handlers) handleOrient(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	question := req.GetString("question", "")
+
+	statusResp, err := buildStatusResponse(ctx, h.db, h.dir, h.watchState)
+	if err != nil {
+		return nil, fmt.Errorf("sense.orient: %w", err)
+	}
+
+	convResults, symbolCount, err := conventions.Detect(ctx, h.db, conventions.Options{
+		MinStrength: 0.5,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("sense.orient: conventions: %w", err)
+	}
+
+	instanceCap := h.defaults.ConventionsInstanceCap
+	convEntries := make([]mcpio.ConventionEntry, 0, min(len(convResults), 5))
+	for i, c := range convResults {
+		if i >= 5 {
+			break
+		}
+		convEntries = append(convEntries, mcpio.ConventionEntry{
+			Category:       string(c.Category),
+			Description:    c.Description,
+			Strength:       mcpio.Confidence(c.Strength),
+			Instances:      conventions.PickRepresentatives(c.Examples, instanceCap),
+			TotalInstances: c.Instances,
+		})
+	}
+
+	var searchHits []mcpio.SearchResultEntry
+	filesAvoided := 0
+
+	if question != "" {
+		concepts := extractConcepts(question)
+		if len(concepts) == 0 {
+			concepts = []string{question}
+		}
+		seen := map[string]bool{}
+		for _, concept := range concepts {
+			keywordBias := h.defaults.SearchKeywordWeight - 0.5
+			if keywordBias < 0 {
+				keywordBias = 0
+			}
+			results, _, searchErr := h.search.Search(ctx, search.Options{
+				Query:       concept,
+				Limit:       5,
+				KeywordBias: keywordBias,
+			})
+			if searchErr != nil {
+				continue
+			}
+
+			fileIDs := make([]int64, len(results))
+			for i, r := range results {
+				fileIDs[i] = r.FileID
+			}
+			pathByID, pathErr := cli.LoadFilePaths(ctx, h.db, fileIDs)
+			if pathErr != nil {
+				continue
+			}
+
+			for _, r := range results {
+				if seen[r.Qualified] {
+					continue
+				}
+				seen[r.Qualified] = true
+				searchHits = append(searchHits, mcpio.SearchResultEntry{
+					Symbol:  r.Qualified,
+					File:    pathByID[r.FileID],
+					Line:    r.LineStart,
+					Kind:    r.Kind,
+					Score:   mcpio.SearchScore(r.Score),
+					Snippet: r.Snippet,
+				})
+				filesAvoided++
+			}
+		}
+		if len(searchHits) > 15 {
+			searchHits = searchHits[:15]
+		}
+	}
+
+	structureAvoided := 5
+	convAvoided := min(symbolCount/5, 10)
+	totalAvoided := structureAvoided + convAvoided + filesAvoided
+
+	resp := mcpio.OrientResponse{
+		Fingerprint: statusResp.Structure.Fingerprint,
+		Structure:   statusResp.Structure,
+		Conventions: convEntries,
+		SearchHits:  searchHits,
+		SenseMetrics: mcpio.OrientMetrics{
+			SymbolsAnalyzed:           symbolCount,
+			EstimatedFileReadsAvoided: totalAvoided,
+			EstimatedTokensSaved:      totalAvoided * mcpio.AvgTokensPerFile,
+		},
+	}
+
+	resp.NextSteps = orientHints(resp, question)
+
+	h.tracker.Record("sense.orient", question,
+		resp.SenseMetrics.EstimatedFileReadsAvoided, resp.SenseMetrics.EstimatedTokensSaved)
+
+	out, err := mcpio.MarshalOrient(resp)
+	if err != nil {
+		return nil, fmt.Errorf("sense.orient: marshal: %w", err)
+	}
+	return mcp.NewToolResultText(string(out)), nil
+}
+
+func extractConcepts(question string) []string {
+	stop := map[string]bool{
+		"how": true, "does": true, "the": true, "this": true, "what": true,
+		"is": true, "are": true, "where": true, "which": true, "can": true,
+		"do": true, "it": true, "its": true, "a": true, "an": true,
+		"in": true, "of": true, "for": true, "to": true, "and": true,
+		"or": true, "with": true, "from": true, "by": true, "on": true,
+		"about": true, "work": true, "works": true, "structured": true,
+		"codebase": true, "project": true, "code": true, "i": true,
+		"me": true, "tell": true, "show": true, "explain": true,
+		"understand": true, "overview": true, "get": true, "give": true,
+	}
+
+	words := strings.FieldsFunc(strings.ToLower(question), func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+
+	var concepts []string
+	seen := map[string]bool{}
+	for _, w := range words {
+		if len(w) < 3 || stop[w] || seen[w] {
+			continue
+		}
+		seen[w] = true
+		concepts = append(concepts, w)
+	}
+
+	if len(concepts) > 5 {
+		concepts = concepts[:5]
+	}
+	return concepts
+}
+
+func orientHints(resp mcpio.OrientResponse, question string) []mcpio.NextStep {
+	var hints []mcpio.NextStep
+
+	if len(resp.SearchHits) > 0 {
+		hints = append(hints, mcpio.NextStep{
+			Tool:   "sense.graph",
+			Args:   map[string]any{"symbol": resp.SearchHits[0].Symbol},
+			Reason: "explore relationships of the top search hit",
+		})
+	}
+
+	if len(resp.Conventions) > 0 && len(hints) < 2 {
+		hints = append(hints, mcpio.NextStep{
+			Tool:   "sense.conventions",
+			Reason: "dive deeper into project conventions",
+		})
+	}
+
+	if question == "" && len(hints) < 2 {
+		hints = append(hints, mcpio.NextStep{
+			Tool:   "sense.search",
+			Args:   map[string]any{"query": "entry point main handler"},
+			Reason: "search for entry points and request handlers",
 		})
 	}
 

--- a/internal/setup/marker.go
+++ b/internal/setup/marker.go
@@ -35,10 +35,19 @@ Sense gives you structural understanding of the codebase — symbols, relationsh
 
 | Question | Tool |
 |---|---|
+| New to the codebase? Need an overview? | ` + "`sense_orient question=\"How is this codebase structured?\"`" + ` |
 | Who calls X? What does X call? | ` + "`sense_graph symbol=\"X\"`" + ` |
 | Find code related to a concept | ` + "`sense_search query=\"description\"`" + ` |
 | What breaks if I change X? | ` + "`sense_blast symbol=\"X\"`" + ` |
 | What patterns does this project follow? | ` + "`sense_conventions`" + ` |
+
+**Workflows:**
+
+- **Orientation** → ` + "`sense_orient`" + `, or ` + "`sense_search`" + ` with broad concepts + ` + "`sense_conventions`" + `
+- **Impact analysis** → ` + "`sense_blast`" + `
+- **Dependency tracing** → ` + "`sense_graph`" + `
+- **Debugging** → ` + "`sense_search`" + `
+- **Refactoring** → ` + "`sense_conventions`" + ` + ` + "`sense_graph`" + `
 
 **When NOT to use Sense** (use grep instead):
 

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -14,6 +14,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/luuuc/sense/internal/mcpio"
 )
 
 // Options controls which tools setup configures.
@@ -195,22 +197,9 @@ func writeMCPJSON(root string) (bool, error) {
 	path := filepath.Join(root, ".mcp.json")
 
 	senseCfg := map[string]any{
-		"command": "sense",
-		"args":    []any{"mcp"},
-		"serverInstructions": "When Sense is available and indexed, you MUST use Sense tools " +
-			"instead of grep, glob, or exploration agents for codebase understanding, " +
-			"exploration, and research. Sense provides pre-indexed results that are faster and more complete.\n\n" +
-			"WHEN TO USE SENSE TOOLS:\n" +
-			"- Symbol relationships, callers, dependencies → sense.graph\n" +
-			"- \"What would break if I changed X?\", impact analysis → sense.blast\n" +
-			"- Conceptual/semantic code search (not exact string match) → sense.search\n" +
-			"- Project patterns and conventions → sense.conventions\n" +
-			"- Index health, what's indexed → sense.status\n" +
-			"- ANY question about how the codebase works or is structured → start with Sense\n\n" +
-			"WHEN NOT TO USE SENSE TOOLS:\n" +
-			"- Exact text/string search → use grep\n" +
-			"- Reading file contents → use your file reading tool\n" +
-			"- Editing code → Sense is read-only",
+		"command":            "sense",
+		"args":               []any{"mcp"},
+		"serverInstructions": mcpio.ServerInstructions,
 	}
 
 	existing, err := readJSONFile(path)


### PR DESCRIPTION
## Problem

In 3/6 orient benchmark runs, the LLM made zero MCP calls — falling back entirely to Bash/Read/Glob. The existing Sense tools work well for orientation but their names don't map to "orientation" as a concept. When the LLM did use `sense_search` for orientation (nextjs), it scored 0.82 — the highest orient score.

## Summary

- Add `sense.orient` MCP tool that combines structure overview, conventions, and concept-based search into one response
- Update `serverInstructions` with a WORKFLOWS section mapping tasks to tools
- Consolidate instruction text into `mcpio.ServerInstructions` constant (single source of truth for server.go and setup.go)
- Update search and conventions tool descriptions to hint at orientation use
- Update CLAUDE.md and .mcp.json templates with orient tool and workflow mappings

## Changes

- `internal/mcpio/types.go` — `OrientResponse`, `OrientMetrics` types, shared `ServerInstructions` constant
- `internal/mcpio/marshal.go` — `MarshalOrient` with slice normalization
- `internal/mcpserver/server.go` — `orientTool()`, `handleOrient`, `extractConcepts`, `orientHints`, updated tool descriptions
- `internal/mcpserver/orient_test.go` — unit tests for `extractConcepts` and `orientHints`
- `internal/setup/marker.go` — CLAUDE.md template with orient + workflows
- `internal/setup/setup.go` — .mcp.json references shared `ServerInstructions`

## Test plan

- [x] `TestExtractConcepts` — 8 cases: routing, multi-concept, all stop words, empty, >5 truncation, short words, punctuation, dedup
- [x] `TestOrientHints` — 3 cases: search hits → graph, conventions only, empty → search
- [x] `make ci` passes (build + test + lint)