### PR TITLE
feat(search): parent symbol promotion and scorer class-qualifier matching

### DIFF
--- a/bench/lib/scorer.py
+++ b/bench/lib/scorer.py
@@ -225,6 +225,24 @@ def _strip_bare_go_package(symbol):
     return symbol
 
 
+def _strip_class_qualifier(symbol):
+    """Strip PascalCase class qualifier from a symbol.
+
+    Handles TypeScript/Ruby/Python patterns where the class name
+    prefixes the method: 'Server.renderToHTML' -> 'renderToHTML',
+    'Flask.wsgi_app' -> 'wsgi_app'. Only strips when the prefix
+    starts with uppercase (to distinguish from Go package prefixes
+    which are handled by _strip_bare_go_package).
+    """
+    m = re.match(r"^([A-Z][A-Za-z0-9_]*)\.(.+)$", symbol)
+    if m:
+        return m.group(2)
+    m = re.match(r"^([A-Z][A-Za-z0-9_]*)#(.+)$", symbol)
+    if m:
+        return m.group(2)
+    return symbol
+
+
 _PYTHON_MODULE_RE = re.compile(r"^(?:[a-z][a-z0-9_]*\.){2,}(.+)$")
 
 
@@ -320,11 +338,16 @@ def score_set_match(response_json, ground_truth, match_key):
 
     for fp_entry in sorted(fp):
         cls = _extract_class_prefix(fp_entry)
-        if not cls:
-            continue
+        fp_bare = fp_entry.rsplit(":", 1)[-1] if ":" in fp_entry else fp_entry
+        fp_stripped = _strip_class_qualifier(fp_bare)
         for fn_entry in sorted(remaining_fn):
             fn_symbol = fn_entry.rsplit(":", 1)[-1] if ":" in fn_entry else fn_entry
-            if cls == fn_entry or cls == fn_symbol:
+            matched = False
+            if cls and (cls == fn_entry or cls == fn_symbol):
+                matched = True
+            elif fp_stripped != fp_bare and (fp_stripped == fn_entry or fp_stripped == fn_symbol):
+                matched = True
+            if matched:
                 partial_matches.append({"found": fp_entry, "expected": fn_entry})
                 remaining_fp.discard(fp_entry)
                 remaining_fn.discard(fn_entry)
@@ -332,11 +355,16 @@ def score_set_match(response_json, ground_truth, match_key):
 
     for fn_entry in sorted(set(remaining_fn)):
         cls = _extract_class_prefix(fn_entry)
-        if not cls:
-            continue
+        fn_bare = fn_entry.rsplit(":", 1)[-1] if ":" in fn_entry else fn_entry
+        fn_stripped = _strip_class_qualifier(fn_bare)
         for fp_entry in sorted(remaining_fp):
             fp_symbol = fp_entry.rsplit(":", 1)[-1] if ":" in fp_entry else fp_entry
-            if cls == fp_entry or cls == fp_symbol:
+            matched = False
+            if cls and (cls == fp_entry or cls == fp_symbol):
+                matched = True
+            elif fn_stripped != fn_bare and (fn_stripped == fp_entry or fn_stripped == fp_symbol):
+                matched = True
+            if matched:
                 partial_matches.append({"found": fp_entry, "expected": fn_entry})
                 remaining_fp.discard(fp_entry)
                 remaining_fn.discard(fn_entry)

--- a/bench/lib/test_scorer.py
+++ b/bench/lib/test_scorer.py
@@ -12,6 +12,7 @@ sys.path.insert(0, os.path.dirname(__file__))
 from scorer import (
     _extract_class_prefix,
     _keyword_matches,
+    _strip_class_qualifier,
     _strip_python_module_prefix,
     classify_tool_calls,
     detect_misses,
@@ -104,6 +105,17 @@ class TestNormalizeCaller(unittest.TestCase):
 
     def test_bare_symbol_keeps_scan_lowercase(self):
         self.assertEqual(normalize_caller("scan.indexedFile"), "scan.indexedFile")
+
+    # --- PascalCase class qualifier preserved in normalize ---
+
+    def test_bare_preserves_class_method_dot(self):
+        self.assertEqual(normalize_caller("Server.renderToHTML"), "Server.renderToHTML")
+
+    def test_bare_preserves_class_method_hash(self):
+        self.assertEqual(normalize_caller("Flask#wsgi_app"), "Flask#wsgi_app")
+
+    def test_bare_go_then_class_preserved(self):
+        self.assertEqual(normalize_caller("gin.Engine.ServeHTTP"), "Engine.ServeHTTP")
 
     # --- Symbol:filepath format (card 1 fix) ---
 
@@ -350,6 +362,20 @@ class TestScoreSetMatchPartialCredit(unittest.TestCase):
         self.assertEqual(len(result["partial_matches"]), 2)
         self.assertEqual(len(result["false_positives"]), 0)
         self.assertEqual(len(result["false_negatives"]), 0)
+
+    def test_class_method_matches_bare_method(self):
+        response = {"symbols": ["Server.renderToHTML"]}
+        gt = {"symbols": ["renderToHTML"]}
+        result = score_set_match(response, gt, "symbols")
+        self.assertEqual(len(result["partial_matches"]), 1)
+        self.assertAlmostEqual(result["f1"], 0.5)
+
+    def test_bare_method_matches_class_method(self):
+        response = {"symbols": ["wsgi_app"]}
+        gt = {"symbols": ["Flask.wsgi_app"]}
+        result = score_set_match(response, gt, "symbols")
+        self.assertEqual(len(result["partial_matches"]), 1)
+        self.assertAlmostEqual(result["f1"], 0.5)
 
 
 class TestIntegrationNormalization(unittest.TestCase):

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -256,6 +256,13 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, SearchMeta
 		return nil, SearchMeta{}, fmt.Errorf("search enrich: %w", err)
 	}
 
+	// Parent promotion: when 2+ methods of the same class appear in top
+	// results, replace them with the parent class at the highest score.
+	fused, err = e.promoteParents(ctx, fused, opts.Limit)
+	if err != nil {
+		return nil, SearchMeta{}, fmt.Errorf("search promote: %w", err)
+	}
+
 	// Apply min_score filter and limit.
 	var results []Result
 	for _, r := range fused {
@@ -634,4 +641,102 @@ func (e *Engine) enrichFromGraph(ctx context.Context, results []Result) ([]Resul
 	})
 
 	return results, nil
+}
+
+const parentPromotionThreshold = 2
+
+// promoteParents replaces multiple child methods from the same parent
+// class/struct with the parent symbol when 2+ children appear in the
+// top-K results. The parent inherits the highest child score.
+func (e *Engine) promoteParents(ctx context.Context, results []Result, limit int) ([]Result, error) {
+	if len(results) == 0 {
+		return results, nil
+	}
+
+	topK := limit
+	if topK > len(results) {
+		topK = len(results)
+	}
+
+	topIDs := make([]int64, topK)
+	for i := range topK {
+		topIDs[i] = results[i].SymbolID
+	}
+
+	parents, err := e.adapter.ParentSymbols(ctx, topIDs)
+	if err != nil {
+		return nil, err
+	}
+	if len(parents) == 0 {
+		return results, nil
+	}
+
+	type parentGroup struct {
+		info     sqlite.ParentInfo
+		children []int
+		maxScore float64
+	}
+	groups := map[int64]*parentGroup{}
+	for i := range topK {
+		pi, ok := parents[results[i].SymbolID]
+		if !ok {
+			continue
+		}
+		g, exists := groups[pi.ParentID]
+		if !exists {
+			g = &parentGroup{info: pi}
+			groups[pi.ParentID] = g
+		}
+		g.children = append(g.children, i)
+		if results[i].Score > g.maxScore {
+			g.maxScore = results[i].Score
+		}
+	}
+
+	existing := map[int64]bool{}
+	for _, r := range results {
+		existing[r.SymbolID] = true
+	}
+
+	remove := map[int]bool{}
+	var promoted []Result
+	for _, g := range groups {
+		if len(g.children) < parentPromotionThreshold {
+			continue
+		}
+		if existing[g.info.ParentID] {
+			continue
+		}
+		for _, idx := range g.children {
+			remove[idx] = true
+		}
+		promoted = append(promoted, Result{
+			SymbolID:  g.info.ParentID,
+			Name:      g.info.Name,
+			Qualified: g.info.Qualified,
+			Kind:      g.info.Kind,
+			FileID:    g.info.FileID,
+			LineStart: g.info.LineStart,
+			Snippet:   g.info.Snippet,
+			Score:     g.maxScore,
+		})
+	}
+
+	if len(promoted) == 0 {
+		return results, nil
+	}
+
+	var out []Result
+	for i, r := range results {
+		if !remove[i] {
+			out = append(out, r)
+		}
+	}
+	out = append(out, promoted...)
+
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Score > out[j].Score
+	})
+
+	return out, nil
 }

--- a/internal/sqlite/search.go
+++ b/internal/sqlite/search.go
@@ -395,6 +395,71 @@ func (a *Adapter) FilePathsByIDs(ctx context.Context, fileIDs []int64) (map[int6
 	return out, nil
 }
 
+// ParentInfo holds metadata about a parent symbol, returned by ParentSymbols.
+type ParentInfo struct {
+	ParentID  int64
+	Name      string
+	Qualified string
+	Kind      string
+	FileID    int64
+	LineStart int
+	Snippet   string
+}
+
+// ParentSymbols returns parent symbol info for each child symbol ID.
+// The result map is keyed by child symbol ID. Only symbols that have
+// a non-null parent_id are included.
+func (a *Adapter) ParentSymbols(ctx context.Context, childIDs []int64) (map[int64]ParentInfo, error) {
+	if len(childIDs) == 0 {
+		return nil, nil
+	}
+	out := make(map[int64]ParentInfo, len(childIDs))
+	const chunk = 500
+	for start := 0; start < len(childIDs); start += chunk {
+		end := start + chunk
+		if end > len(childIDs) {
+			end = len(childIDs)
+		}
+		if err := a.parentSymbolsBatch(ctx, childIDs[start:end], out); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+func (a *Adapter) parentSymbolsBatch(ctx context.Context, batch []int64, out map[int64]ParentInfo) error {
+	placeholders := make([]byte, 0, len(batch)*2-1)
+	args := make([]any, len(batch))
+	for i, id := range batch {
+		if i > 0 {
+			placeholders = append(placeholders, ',')
+		}
+		placeholders = append(placeholders, '?')
+		args[i] = id
+	}
+	q := `SELECT s.id, p.id, p.name, p.qualified, p.kind, p.file_id, p.line_start, p.snippet
+	      FROM sense_symbols s
+	      JOIN sense_symbols p ON s.parent_id = p.id
+	      WHERE s.id IN (` + string(placeholders) + `)`
+	rows, err := a.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return fmt.Errorf("sqlite ParentSymbols: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var childID int64
+		var pi ParentInfo
+		var snippet sql.NullString
+		if err := rows.Scan(&childID, &pi.ParentID, &pi.Name, &pi.Qualified,
+			&pi.Kind, &pi.FileID, &pi.LineStart, &snippet); err != nil {
+			return fmt.Errorf("sqlite ParentSymbols scan: %w", err)
+		}
+		pi.Snippet = snippet.String
+		out[childID] = pi
+	}
+	return rows.Err()
+}
+
 // sanitizeFTS5Query quotes each whitespace-delimited token so that
 // FTS5 operator characters (*, ", OR, AND, NOT, NEAR, ^, :) in user
 // input are treated as literals. Embedded double-quotes are escaped

--- a/testdata/smoke/ground-truth.json
+++ b/testdata/smoke/ground-truth.json
@@ -63,7 +63,7 @@
     },
     {
       "query": "validate_total",
-      "expected_in_top3": "validate_total"
+      "expected_in_top3": "Order"
     }
   ],
   "blast": [


### PR DESCRIPTION
## Summary

- When 2+ methods of the same class appear in top-K search results, collapse them into the parent class at the highest child score. Adds `ParentSymbols` SQLite query and `promoteParents` pipeline step.
- Add PascalCase class qualifier stripping in the benchmark scorer for bidirectional partial matching (`Server.renderToHTML` ↔ `renderToHTML`).
- Dedup guard prevents promotion when the parent is already in results.

## Test plan

- [x] Go tests pass: `internal/search/`, `internal/sqlite/`, `internal/smoke/`, `internal/mcpserver/`
- [x] Python scorer tests pass: 121 tests OK
- [x] Smoke test ground truth updated — `validate_total` query now expects promoted parent `Order`
- [x] Lint clean (`make lint` — 0 issues)