### PR TITLE
fix(dead): filter NULL source_id in interface alive query

### DIFF
--- a/internal/dead/dead.go
+++ b/internal/dead/dead.go
@@ -433,7 +433,7 @@ func queryInterfaceAliveMethods(ctx context.Context, db *sql.DB) (map[ifaceMetho
 		FROM sense_symbols im
 		JOIN sense_edges ie ON ie.target_id = im.id AND ie.kind = 'calls'
 		JOIN sense_symbols iface ON im.parent_id = iface.id AND iface.kind = 'interface'
-		JOIN sense_edges impl ON impl.target_id = iface.id AND impl.kind = 'inherits'
+		JOIN sense_edges impl ON impl.target_id = iface.id AND impl.kind = 'inherits' AND impl.source_id IS NOT NULL
 		GROUP BY impl.source_id, im.name`
 
 	rows, err := db.QueryContext(ctx, q)

--- a/internal/dead/dead_test.go
+++ b/internal/dead/dead_test.go
@@ -553,6 +553,35 @@ func standaloneUnused() {}
 	}
 }
 
+func TestFindDeadNullSourceID(t *testing.T) {
+	db, _ := setupFixture(t)
+	ctx := context.Background()
+
+	// Insert an 'inherits' edge with NULL source_id — legal per schema,
+	// but previously crashed queryInterfaceAliveMethods via rows.Scan.
+	var targetID, fileID int64
+	err := db.QueryRowContext(ctx,
+		`SELECT s.id, s.file_id FROM sense_symbols s WHERE s.kind = 'class' ORDER BY s.id LIMIT 1`,
+	).Scan(&targetID, &fileID)
+	if err != nil {
+		t.Fatalf("finding a target symbol: %v", err)
+	}
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO sense_edges (source_id, target_id, kind, file_id) VALUES (NULL, ?, 'inherits', ?)`,
+		targetID, fileID)
+	if err != nil {
+		t.Fatalf("inserting NULL source_id edge: %v", err)
+	}
+
+	result, err := dead.FindDead(ctx, db, dead.Options{})
+	if err != nil {
+		t.Fatalf("FindDead should not error with NULL source_id edges: %v", err)
+	}
+	if result.TotalSymbols == 0 {
+		t.Fatal("TotalSymbols = 0, want > 0")
+	}
+}
+
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {


### PR DESCRIPTION
## Problem

`queryInterfaceAliveMethods` in `internal/dead/dead.go` crashes when
`sense_edges.source_id` is NULL — a legal value per the schema. The
`rows.Scan` into a plain `int64` returns an error on NULL, which propagates
up through `FindDead` and kills the dead code tool on ~40% of benchmark
repos. Dead code detection is Sense's #1 ranked competitive feature.

## Summary

Add `AND impl.source_id IS NOT NULL` to the inherits JOIN, matching the
existing guard in the sibling function `queryInterfaceImplementors`.

## Changes

- Filter NULL `source_id` rows at the SQL level in `queryInterfaceAliveMethods`
- Add `TestFindDeadNullSourceID` regression test that injects a NULL edge and
  confirms `FindDead` succeeds

## Test Plan

- [x] `TestFindDeadNullSourceID` — injects NULL `source_id` edge, asserts no error
- [x] All existing dead code tests pass
- [x] `make ci` full green (build, test, lint)