### PR TITLE
fix(hook): stop blocking Grep/Bash fallbacks, pass Glob through

### DIFF
--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -14,12 +14,9 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/luuuc/sense/internal/sqlite"
 )
-
-const staleThreshold = 24 * time.Hour
 
 // Run dispatches to the named hook handler. It returns an exit code
 // (always 0 — hooks must not fail the host tool).
@@ -94,19 +91,6 @@ func silentRun(dir string, stdin io.Reader, stdout io.Writer, fn handlerFunc) {
 
 func writeEmpty(w io.Writer) {
 	_, _ = io.WriteString(w, "{}\n")
-}
-
-func indexAge(ctx context.Context, adapter *sqlite.Adapter) time.Duration {
-	var raw string
-	err := adapter.DB().QueryRowContext(ctx, `SELECT MAX(indexed_at) FROM sense_files`).Scan(&raw)
-	if err != nil || raw == "" {
-		return 0
-	}
-	t, err := time.Parse(time.RFC3339Nano, raw)
-	if err != nil {
-		return 0
-	}
-	return time.Since(t)
 }
 
 func indexPath(dir string) string {

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/luuuc/sense/internal/scan"
 	_ "modernc.org/sqlite"
@@ -37,21 +36,6 @@ func indexedDir(t *testing.T) string {
 	return root
 }
 
-func staleDir(t *testing.T) string {
-	t.Helper()
-	dir := indexedDir(t)
-	dbPath := filepath.Join(dir, ".sense", "index.db")
-	db, err := sql.Open("sqlite", dbPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = db.Close() }()
-	old := time.Now().Add(-48 * time.Hour).Format(time.RFC3339Nano)
-	if _, err := db.Exec(`UPDATE sense_files SET indexed_at = ?`, old); err != nil {
-		t.Fatal(err)
-	}
-	return dir
-}
 
 func TestRunSenseBenchSuppressesAllHooks(t *testing.T) {
 	dir := indexedDir(t)
@@ -147,21 +131,36 @@ func TestSubagentStartReturnsGuidance(t *testing.T) {
 	}
 }
 
-func TestPreToolUseSymbolMatch(t *testing.T) {
+func TestPreToolUseSymbolMatchAdvises(t *testing.T) {
 	dir := indexedDir(t)
 	input := `{"tool_name":"Grep","tool_input":{"pattern":"UserService"}}`
 	var buf bytes.Buffer
 	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
 
-	var resp denyResponse
+	var resp hookResponse
 	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
 		t.Fatalf("parse response: %v", err)
 	}
-	if resp.Output.Decision != "deny" {
-		t.Fatalf("expected deny decision, got %q", resp.Output.Decision)
+	if resp.AdditionalContext == "" {
+		t.Fatal("expected advisory context for known symbol")
 	}
-	if !strings.Contains(resp.Output.Reason, "sense_graph") {
-		t.Error("expected sense_graph suggestion in deny reason")
+	if !strings.Contains(resp.AdditionalContext, "sense_graph") {
+		t.Error("expected sense_graph suggestion in advisory")
+	}
+}
+
+func TestPreToolUseFilePathNoOp(t *testing.T) {
+	dir := indexedDir(t)
+	cases := []string{
+		`{"tool_name":"Grep","tool_input":{"pattern":"internal/hook/pre_tool_use.go"}}`,
+		`{"tool_name":"Grep","tool_input":{"pattern":"main.go"}}`,
+	}
+	for _, input := range cases {
+		var buf bytes.Buffer
+		Run("pre-tool-use", dir, strings.NewReader(input), &buf)
+		if buf.String() != "{}\n" {
+			t.Errorf("file-path pattern should be no-op, got %q for input %s", buf.String(), input)
+		}
 	}
 }
 
@@ -216,18 +215,37 @@ func TestPreToolUseAgentAllowNonExplore(t *testing.T) {
 	}
 }
 
-func TestPreToolUseBashGrepDeny(t *testing.T) {
+func TestPreToolUseGlobPassthrough(t *testing.T) {
+	dir := indexedDir(t)
+	cases := []string{
+		`{"tool_name":"Glob","tool_input":{"pattern":"src/controllers/**/*.rb"}}`,
+		`{"tool_name":"Glob","tool_input":{"pattern":"internal/hook/*.go"}}`,
+		`{"tool_name":"Glob","tool_input":{"pattern":"UserService"}}`,
+	}
+	for _, input := range cases {
+		var buf bytes.Buffer
+		Run("pre-tool-use", dir, strings.NewReader(input), &buf)
+		if buf.String() != "{}\n" {
+			t.Errorf("Glob should always pass through, got %q for input %s", buf.String(), input)
+		}
+	}
+}
+
+func TestPreToolUseBashGrepAdvises(t *testing.T) {
 	dir := indexedDir(t)
 	input := `{"tool_name":"Bash","tool_input":{"command":"grep -rn UserService ."}}`
 	var buf bytes.Buffer
 	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
 
-	var resp denyResponse
+	var resp hookResponse
 	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
 		t.Fatalf("parse response: %v", err)
 	}
-	if resp.Output.Decision != "deny" {
-		t.Fatalf("expected deny for bash grep of known symbol, got %q", resp.Output.Decision)
+	if resp.AdditionalContext == "" {
+		t.Fatal("expected advisory for bash grep of known symbol")
+	}
+	if !strings.Contains(resp.AdditionalContext, "sense_graph") {
+		t.Error("expected sense_graph suggestion in advisory")
 	}
 }
 
@@ -257,48 +275,6 @@ func TestPreToolUseExploreAgentDeny(t *testing.T) {
 	}
 }
 
-func TestPreToolUseStaleIndexAdvisesInsteadOfDeny(t *testing.T) {
-	dir := staleDir(t)
-	input := `{"tool_name":"Grep","tool_input":{"pattern":"UserService"}}`
-	var buf bytes.Buffer
-	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
-
-	var deny denyResponse
-	if err := json.Unmarshal(buf.Bytes(), &deny); err == nil && deny.Output.Decision == "deny" {
-		t.Fatal("stale index should advise, not deny")
-	}
-
-	var resp hookResponse
-	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
-		t.Fatalf("parse response: %v", err)
-	}
-	if resp.AdditionalContext == "" {
-		t.Fatal("expected additionalContext for stale index")
-	}
-	if !strings.Contains(resp.AdditionalContext, "sense_graph") {
-		t.Error("expected sense_graph suggestion in advisory")
-	}
-}
-
-func TestPreToolUseBashStaleIndexAdvises(t *testing.T) {
-	dir := staleDir(t)
-	input := `{"tool_name":"Bash","tool_input":{"command":"grep -rn UserService ."}}`
-	var buf bytes.Buffer
-	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
-
-	var deny denyResponse
-	if err := json.Unmarshal(buf.Bytes(), &deny); err == nil && deny.Output.Decision == "deny" {
-		t.Fatal("stale index should advise, not deny")
-	}
-
-	var resp hookResponse
-	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
-		t.Fatalf("parse response: %v", err)
-	}
-	if resp.AdditionalContext == "" {
-		t.Fatal("expected additionalContext for stale bash grep")
-	}
-}
 
 func TestExtractBashPattern(t *testing.T) {
 	cases := []struct {
@@ -343,6 +319,11 @@ func TestIsSymbolShaped(t *testing.T) {
 		{"[a-z]+", false},
 		{"a", false},
 		{"", false},
+		{"src/controllers/user.rb", false},
+		{"internal/hook/pre_tool_use.go", false},
+		{"main.go", false},
+		{"app.py", false},
+		{"models/**/*.rb", false},
 	}
 	for _, tc := range cases {
 		if got := isSymbolShaped(tc.pattern); got != tc.want {

--- a/internal/hook/pre_tool_use.go
+++ b/internal/hook/pre_tool_use.go
@@ -72,12 +72,14 @@ func handlePreToolUse(ctx context.Context, input json.RawMessage, adapter *sqlit
 		return handleAgent(ctx, req, adapter)
 	case "Bash":
 		return handleBash(ctx, req, adapter)
+	case "Glob":
+		return nil, nil
 	default:
-		return handleGrepGlob(ctx, req, adapter)
+		return handleGrep(ctx, req, adapter)
 	}
 }
 
-func handleGrepGlob(ctx context.Context, req preToolUseInput, adapter *sqlite.Adapter) (any, error) {
+func handleGrep(ctx context.Context, req preToolUseInput, adapter *sqlite.Adapter) (any, error) {
 	pattern := extractPattern(req)
 	if pattern == "" {
 		return nil, nil
@@ -97,7 +99,7 @@ func handleGrepGlob(ctx context.Context, req preToolUseInput, adapter *sqlite.Ad
 		return nil, nil
 	}
 
-	return denyOrAdvise(ctx, adapter, len(symbols), pattern, "grep"), nil
+	return buildAdvice(len(symbols), pattern, "grep"), nil
 }
 
 func handleAgent(ctx context.Context, req preToolUseInput, adapter *sqlite.Adapter) (any, error) {
@@ -141,7 +143,7 @@ func handleBash(ctx context.Context, req preToolUseInput, adapter *sqlite.Adapte
 	if pattern != "" && isSymbolShaped(pattern) {
 		symbols, err := adapter.Query(ctx, index.Filter{Name: pattern, Limit: 5})
 		if err == nil && len(symbols) > 0 {
-			return denyOrAdvise(ctx, adapter, len(symbols), pattern, "bash grep"), nil
+			return buildAdvice(len(symbols), pattern, "bash grep"), nil
 		}
 		if isMultiWordPattern(pattern) {
 			return advise(fmt.Sprintf(
@@ -159,19 +161,13 @@ func handleBash(ctx context.Context, req preToolUseInput, adapter *sqlite.Adapte
 	return nil, nil
 }
 
-// denyOrAdvise blocks the tool call when the index is fresh, or adds
-// advisory context when it is stale (> 24h since last scan).
-func denyOrAdvise(ctx context.Context, adapter *sqlite.Adapter, count int, pattern, source string) any {
+func buildAdvice(count int, pattern, source string) *hookResponse {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "Sense has %d indexed symbol(s) matching %q. Use Sense MCP tools instead of %s:\n", count, pattern, source)
+	fmt.Fprintf(&sb, "Sense has %d indexed symbol(s) matching %q. Consider Sense MCP tools instead of %s:\n", count, pattern, source)
 	fmt.Fprintf(&sb, "- sense_graph symbol=%q for callers/callees\n", pattern)
 	fmt.Fprintf(&sb, "- sense_search query=%q for semantic matches\n", pattern)
 	fmt.Fprintf(&sb, "Load tools first: %s", toolSearchCmd)
-
-	if age := indexAge(ctx, adapter); age > staleThreshold {
-		return &hookResponse{AdditionalContext: sb.String()}
-	}
-	return deny(sb.String())
+	return &hookResponse{AdditionalContext: sb.String()}
 }
 
 func extractPattern(req preToolUseInput) string {
@@ -228,17 +224,20 @@ func needsValue(flag string) bool {
 	return false
 }
 
-// isSymbolShaped returns true if the pattern looks like a symbol name
-// rather than a regex. Symbol-shaped: word chars, dots, colons, #.
-// Regex-shaped: contains *, +, |, (, [, {, ?, ^, $.
 func isSymbolShaped(pattern string) bool {
+	if len(pattern) < 2 {
+		return false
+	}
+	if strings.Contains(pattern, "/") {
+		return false
+	}
 	for _, c := range pattern {
 		switch c {
 		case '*', '+', '|', '(', ')', '[', ']', '{', '}', '?', '^', '$', '\\':
 			return false
 		}
 	}
-	return len(pattern) >= 2
+	return !hasCodeExtension(pattern)
 }
 
 func hasExplorationKeyword(prompt string) bool {


### PR DESCRIPTION
## Problem

The PreToolUse hook denied Grep and Bash tool calls when the Sense index was fresh and had matching symbols. Benchmark data across 50 runs showed 54 blocked calls that were legitimate fallbacks — grep after sense_search returned incomplete results, Glob for file-path listings, and bash grep for exact strings. Blocking these caused the agent to give up or produce worse answers.

## Summary

Downgrade the hook from deny to advise for Grep/Bash, pass Glob through unconditionally, and tighten `isSymbolShaped` to stop matching file paths.

## Changes

- **Glob passthrough** — `case "Glob": return nil, nil` skips all hook logic (Glob patterns are always file paths)
- **Deny → advise** — replace `denyOrAdvise` with `buildAdvice` (pure function, always advisory)
- **Path exclusion** — `isSymbolShaped` now rejects patterns containing `/` or file extensions (`.go`, `.py`, etc.)
- **Dead code removal** — `indexAge`, `staleThreshold`, stale-index tests removed (fresh/stale distinction no longer applies)
- **Rename** — `handleGrepGlob` → `handleGrep` for accuracy
- Agent spawns (deep-explore, Explore) remain denied

## Test Plan

- [x] `TestPreToolUseGlobPassthrough` — Glob always passes, even with symbol-like patterns
- [x] `TestPreToolUseSymbolMatchAdvises` — Grep for known symbol gets advisory, not deny
- [x] `TestPreToolUseBashGrepAdvises` — bash grep for known symbol gets advisory
- [x] `TestPreToolUseFilePathNoOp` — file paths like `main.go` skip the hook entirely
- [x] `TestPreToolUseAgentDeny` / `TestPreToolUseExploreAgentDeny` — Agent spawns still denied
- [x] `TestIsSymbolShaped` — new cases for path patterns
- [x] `make ci` passes (build + all tests + lint)