### PR TITLE
feat(conventions): rank representatives by edge count, lower interface threshold

### DIFF
--- a/internal/conventions/conventions.go
+++ b/internal/conventions/conventions.go
@@ -10,6 +10,7 @@ import (
 )
 
 const minInstances = 3
+const minInterfaceInstances = 2
 const maxDescriptionNames = 5
 const minPrevalence = 0.10
 const minPrevalenceInstances = 5
@@ -28,8 +29,9 @@ const (
 )
 
 type Example struct {
-	Name string
-	Path string
+	Name      string
+	Path      string
+	EdgeCount int
 }
 
 type Convention struct {
@@ -39,6 +41,7 @@ type Convention struct {
 	Total       int
 	Strength    float64
 	Examples    []Example
+	KeySymbol   string
 }
 
 type Options struct {
@@ -85,6 +88,8 @@ func Detect(ctx context.Context, db *sql.DB, opts Options) ([]Convention, int, e
 	conventions = append(conventions, detectDesignPatterns(symbols, symbolByID, filePathByID)...)
 	conventions = append(conventions, detectFrameworkIdioms(symbols, edges, symbolByID, filePathByID)...)
 	conventions = append(conventions, detectArchitectureLayers(symbols, edges, symbolByID, filePathByID)...)
+
+	enrichEdgeCounts(conventions, symbols, edges, filePathByID)
 
 	sort.Slice(conventions, func(i, j int) bool {
 		if conventions[i].Category != conventions[j].Category {
@@ -740,22 +745,18 @@ func PickRepresentatives(examples []Example, max int) []string {
 	if len(examples) == 0 {
 		return nil
 	}
-	if len(examples) <= max {
-		names := make([]string, len(examples))
-		for i, e := range examples {
-			names[i] = e.Name
-		}
-		return names
+	sorted := make([]Example, len(examples))
+	copy(sorted, examples)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return sorted[i].EdgeCount > sorted[j].EdgeCount
+	})
+	n := max
+	if n > len(sorted) {
+		n = len(sorted)
 	}
-	indices := []int{0, len(examples) / 2, len(examples) - 1}
-	seen := map[int]struct{}{}
-	var names []string
-	for _, idx := range indices {
-		if _, ok := seen[idx]; ok {
-			continue
-		}
-		seen[idx] = struct{}{}
-		names = append(names, examples[idx].Name)
+	names := make([]string, n)
+	for i := 0; i < n; i++ {
+		names[i] = sorted[i].Name
 	}
 	return names
 }
@@ -917,7 +918,7 @@ func detectFrameworkIdioms(symbols []symbolRow, edges []edgeRow, symbolByID map[
 		g.implementors = append(g.implementors, Example{Name: src.name, Path: filePathByID[src.fileID]})
 	}
 	for _, g := range ifaces {
-		if len(g.implementors) < minInstances {
+		if len(g.implementors) < minInterfaceInstances {
 			continue
 		}
 		sortExamples(g.implementors)
@@ -929,6 +930,7 @@ func detectFrameworkIdioms(symbols []symbolRow, edges []edgeRow, symbolByID map[
 			Total:       totalStructs,
 			Strength:    safeStrength(len(g.implementors), totalStructs),
 			Examples:    g.implementors,
+			KeySymbol:   g.iface.name,
 		})
 	}
 
@@ -1082,6 +1084,27 @@ func pluralize(kind string) string {
 		return kind + "es"
 	}
 	return kind + "s"
+}
+
+func enrichEdgeCounts(conventions []Convention, symbols []symbolRow, edges []edgeRow, filePathByID map[int64]string) {
+	type namePathKey struct{ name, path string }
+	inbound := make(map[int64]int, len(symbols))
+	for _, e := range edges {
+		inbound[e.targetID]++
+	}
+	lookup := make(map[namePathKey]int, len(symbols))
+	for _, s := range symbols {
+		key := namePathKey{s.name, filePathByID[s.fileID]}
+		if c := inbound[s.id]; c > lookup[key] {
+			lookup[key] = c
+		}
+	}
+	for ci := range conventions {
+		for ei := range conventions[ci].Examples {
+			ex := &conventions[ci].Examples[ei]
+			ex.EdgeCount = lookup[namePathKey{ex.Name, ex.Path}]
+		}
+	}
 }
 
 func dedupeExamples(examples []Example) []Example {

--- a/internal/conventions/conventions_test.go
+++ b/internal/conventions/conventions_test.go
@@ -401,13 +401,16 @@ func TestPickRepresentatives(t *testing.T) {
 		{"exactly three", []Example{
 			{Name: "A", Path: "a"}, {Name: "B", Path: "b"}, {Name: "C", Path: "c"},
 		}, 3, []string{"A", "B", "C"}},
-		{"four picks first/middle/last", []Example{
-			{Name: "A", Path: "a"}, {Name: "B", Path: "b"}, {Name: "C", Path: "c"}, {Name: "D", Path: "d"},
-		}, 3, []string{"A", "C", "D"}},
-		{"six picks first/middle/last", []Example{
+		{"picks by edge count descending", []Example{
+			{Name: "A", Path: "a", EdgeCount: 2},
+			{Name: "B", Path: "b", EdgeCount: 10},
+			{Name: "C", Path: "c", EdgeCount: 5},
+			{Name: "D", Path: "d", EdgeCount: 1},
+		}, 3, []string{"B", "C", "A"}},
+		{"zero edge counts preserves input order", []Example{
 			{Name: "A", Path: "a"}, {Name: "B", Path: "b"}, {Name: "C", Path: "c"},
 			{Name: "D", Path: "d"}, {Name: "E", Path: "e"}, {Name: "F", Path: "f"},
-		}, 3, []string{"A", "D", "F"}},
+		}, 3, []string{"A", "B", "C"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/mcpio/conventions.go
+++ b/internal/mcpio/conventions.go
@@ -25,6 +25,7 @@ type ConventionEntry struct {
 	Strength       Confidence `json:"strength"`
 	Instances      []string   `json:"instances"`
 	TotalInstances int        `json:"total_instances"`
+	KeySymbol      string     `json:"key_symbol,omitempty"`
 }
 
 // ConventionsMetrics is the observability footer.

--- a/internal/mcpserver/orient_test.go
+++ b/internal/mcpserver/orient_test.go
@@ -73,41 +73,53 @@ func TestExtractConcepts(t *testing.T) {
 
 func TestOrientHints(t *testing.T) {
 	tests := []struct {
-		name     string
-		resp     mcpio.OrientResponse
-		question string
-		wantLen  int
-		wantTool string
+		name      string
+		resp      mcpio.OrientResponse
+		wantLen   int
+		wantTool  string
+		wantTool2 string
 	}{
 		{
-			name: "with search hits suggests graph",
+			name: "hub symbol and search hit",
 			resp: mcpio.OrientResponse{
+				Structure: &mcpio.StatusStructure{
+					HubSymbols: []mcpio.StatusHub{{Name: "Run", Callers: 42, Kind: "function"}},
+				},
 				SearchHits: []mcpio.SearchResultEntry{
 					{Symbol: "Router", Kind: "struct"},
 				},
+			},
+			wantLen:   2,
+			wantTool:  "sense.graph",
+			wantTool2: "sense.blast",
+		},
+		{
+			name: "hub symbol and key symbol interface",
+			resp: mcpio.OrientResponse{
+				Structure: &mcpio.StatusStructure{
+					HubSymbols: []mcpio.StatusHub{{Name: "Close", Callers: 10, Kind: "method"}},
+				},
 				Conventions: []mcpio.ConventionEntry{
-					{Category: "naming"},
+					{Category: "framework", KeySymbol: "IRoutes"},
 				},
 			},
-			question: "routing",
-			wantLen:  2,
+			wantLen:   2,
+			wantTool:  "sense.graph",
+			wantTool2: "sense.graph",
+		},
+		{
+			name: "hub symbol only",
+			resp: mcpio.OrientResponse{
+				Structure: &mcpio.StatusStructure{
+					HubSymbols: []mcpio.StatusHub{{Name: "Open", Callers: 5, Kind: "function"}},
+				},
+			},
+			wantLen:  1,
 			wantTool: "sense.graph",
 		},
 		{
-			name: "no search hits with conventions",
-			resp: mcpio.OrientResponse{
-				Conventions: []mcpio.ConventionEntry{
-					{Category: "naming"},
-				},
-			},
-			question: "",
-			wantLen:  2,
-			wantTool: "sense.conventions",
-		},
-		{
-			name:     "empty response no question suggests search",
+			name:     "empty response suggests search",
 			resp:     mcpio.OrientResponse{},
-			question: "",
 			wantLen:  1,
 			wantTool: "sense.search",
 		},
@@ -115,12 +127,17 @@ func TestOrientHints(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			hints := orientHints(tt.resp, tt.question)
+			hints := orientHints(tt.resp)
 			if len(hints) != tt.wantLen {
 				t.Fatalf("orientHints: got %d hints, want %d: %+v", len(hints), tt.wantLen, hints)
 			}
 			if hints[0].Tool != tt.wantTool {
 				t.Errorf("orientHints[0].Tool = %q, want %q", hints[0].Tool, tt.wantTool)
+			}
+			if tt.wantTool2 != "" && len(hints) > 1 {
+				if hints[1].Tool != tt.wantTool2 {
+					t.Errorf("orientHints[1].Tool = %q, want %q", hints[1].Tool, tt.wantTool2)
+				}
 			}
 		})
 	}

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -992,6 +992,7 @@ func (h *handlers) handleConventions(ctx context.Context, req mcp.CallToolReques
 			Strength:       mcpio.Confidence(c.Strength),
 			Instances:      conventions.PickRepresentatives(c.Examples, instanceCap),
 			TotalInstances: c.Instances,
+			KeySymbol:      c.KeySymbol,
 		}
 	}
 
@@ -1069,6 +1070,7 @@ func (h *handlers) handleOrient(ctx context.Context, req mcp.CallToolRequest) (*
 			Strength:       mcpio.Confidence(c.Strength),
 			Instances:      conventions.PickRepresentatives(c.Examples, instanceCap),
 			TotalInstances: c.Instances,
+			KeySymbol:      c.KeySymbol,
 		})
 	}
 
@@ -1143,7 +1145,7 @@ func (h *handlers) handleOrient(ctx context.Context, req mcp.CallToolRequest) (*
 
 	mcpio.ApplyOrientTokenBudget(&resp, h.defaults.OrientTokenBudget)
 
-	resp.NextSteps = orientHints(resp, question)
+	resp.NextSteps = orientHints(resp)
 
 	h.tracker.Record("sense.orient", question,
 		resp.SenseMetrics.EstimatedFileReadsAvoided, resp.SenseMetrics.EstimatedTokensSaved)
@@ -1188,25 +1190,35 @@ func extractConcepts(question string) []string {
 	return concepts
 }
 
-func orientHints(resp mcpio.OrientResponse, question string) []mcpio.NextStep {
+func orientHints(resp mcpio.OrientResponse) []mcpio.NextStep {
 	var hints []mcpio.NextStep
 
-	if len(resp.SearchHits) > 0 {
+	if resp.Structure != nil && len(resp.Structure.HubSymbols) > 0 {
+		hub := resp.Structure.HubSymbols[0]
 		hints = append(hints, mcpio.NextStep{
 			Tool:   "sense.graph",
-			Args:   map[string]any{"symbol": resp.SearchHits[0].Symbol},
-			Reason: "explore relationships of the top search hit",
+			Args:   map[string]any{"symbol": hub.Name},
+			Reason: fmt.Sprintf("explore relationships of %s (%d callers)", hub.Name, hub.Callers),
 		})
 	}
 
-	if len(resp.Conventions) > 0 && len(hints) < 2 {
+	if iface := firstKeySymbol(resp.Conventions); iface != "" && len(hints) < 2 {
 		hints = append(hints, mcpio.NextStep{
-			Tool:   "sense.conventions",
-			Reason: "dive deeper into project conventions",
+			Tool:   "sense.graph",
+			Args:   map[string]any{"symbol": iface, "direction": "callers"},
+			Reason: fmt.Sprintf("see implementors and callers of interface %s", iface),
 		})
 	}
 
-	if question == "" && len(hints) < 2 {
+	if len(resp.SearchHits) > 0 && len(hints) < 2 {
+		hints = append(hints, mcpio.NextStep{
+			Tool:   "sense.blast",
+			Args:   map[string]any{"symbol": resp.SearchHits[0].Symbol},
+			Reason: fmt.Sprintf("assess change risk for %s", resp.SearchHits[0].Symbol),
+		})
+	}
+
+	if len(hints) == 0 {
 		hints = append(hints, mcpio.NextStep{
 			Tool:   "sense.search",
 			Args:   map[string]any{"query": "entry point main handler"},
@@ -1218,6 +1230,15 @@ func orientHints(resp mcpio.OrientResponse, question string) []mcpio.NextStep {
 		hints = hints[:2]
 	}
 	return hints
+}
+
+func firstKeySymbol(convs []mcpio.ConventionEntry) string {
+	for _, c := range convs {
+		if c.KeySymbol != "" {
+			return c.KeySymbol
+		}
+	}
+	return ""
 }
 
 // ---------------------------------------------------------------


### PR DESCRIPTION
## Problem

Orient output drops important symbols through three mechanisms: representatives picked by alphabetical position instead of importance, interfaces requiring 3+ implementations (missing 2-implementor frameworks like gin), and generic orient hints that don't reference the symbols just shown.

## Summary

- **Edge-count ranking**: `PickRepresentatives` now sorts by inbound edge count so the most-connected symbols surface first in convention descriptions
- **Interface threshold**: Separate `minInterfaceInstances = 2` for interface detection; other conventions stay at 3
- **Structured KeySymbol**: `Convention` and `ConventionEntry` carry a `KeySymbol` field for the subject symbol, replacing description string parsing
- **Context-aware orient hints**: `orientHints` references hub symbols and key interfaces from the response instead of generic suggestions

## Changes

- `internal/conventions/conventions.go`: `EdgeCount` field on `Example`, `enrichEdgeCounts` post-processing, edge-count-sorted `PickRepresentatives`, `minInterfaceInstances`, `KeySymbol` on `Convention`
- `internal/mcpio/conventions.go`: `KeySymbol` on `ConventionEntry` wire type
- `internal/mcpserver/server.go`: Rewritten `orientHints` using hub symbols and `KeySymbol`, propagate `KeySymbol` in both convention handlers
- Tests updated to match new behavior

## Test plan

- [x] `TestPickRepresentatives` — edge-count descending + zero-count stability
- [x] `TestOrientHints` — hub symbol, key symbol interface, blast, and fallback paths
- [x] `TestDetectThresholdEnforcement` — existing threshold test passes
- [x] Full `make ci` passes (build + test + lint)