### PR TITLE
feat(conventions): add key domain types detector and orient section

### DIFF
--- a/internal/conventions/conventions.go
+++ b/internal/conventions/conventions.go
@@ -7,6 +7,8 @@ import (
 	"path"
 	"sort"
 	"strings"
+
+	"github.com/luuuc/sense/internal/mcpio"
 )
 
 const minInstances = 3
@@ -26,11 +28,13 @@ const (
 	CategoryDesignPattern Category = "design_pattern"
 	CategoryFramework    Category = "framework"
 	CategoryArchitecture Category = "architecture"
+	CategoryKeyTypes     Category = "key_types"
 )
 
 type Example struct {
 	Name      string
 	Path      string
+	Kind      string
 	EdgeCount int
 }
 
@@ -88,6 +92,7 @@ func Detect(ctx context.Context, db *sql.DB, opts Options) ([]Convention, int, e
 	conventions = append(conventions, detectDesignPatterns(symbols, symbolByID, filePathByID)...)
 	conventions = append(conventions, detectFrameworkIdioms(symbols, edges, symbolByID, filePathByID)...)
 	conventions = append(conventions, detectArchitectureLayers(symbols, edges, symbolByID, filePathByID)...)
+	conventions = append(conventions, detectKeyTypes(symbols, edges, filePathByID, conventions)...)
 
 	enrichEdgeCounts(conventions, symbols, edges, filePathByID)
 
@@ -722,6 +727,8 @@ func categoryOrder(c Category) int {
 		return 6
 	case CategoryArchitecture:
 		return 7
+	case CategoryKeyTypes:
+		return 8
 	}
 	return 8
 }
@@ -1052,6 +1059,82 @@ func countParents(symbols []symbolRow) int {
 		}
 	}
 	return n
+}
+
+func detectKeyTypes(symbols []symbolRow, edges []edgeRow, filePathByID map[int64]string, existing []Convention) []Convention {
+	typeKinds := map[string]bool{"struct": true, "class": true, "interface": true, "type": true}
+	inbound := make(map[int64]int)
+	for _, e := range edges {
+		inbound[e.targetID]++
+	}
+
+	surfaced := map[string]bool{}
+	for _, c := range existing {
+		for _, ex := range c.Examples {
+			surfaced[ex.Name] = true
+		}
+	}
+
+	type candidate struct {
+		sym   symbolRow
+		path  string
+		count int
+	}
+	var candidates []candidate
+	for _, s := range symbols {
+		if !typeKinds[s.kind] {
+			continue
+		}
+		fp := filePathByID[s.fileID]
+		if mcpio.IsTestPath(fp) {
+			continue
+		}
+		c := inbound[s.id]
+		if c == 0 {
+			continue
+		}
+		candidates = append(candidates, candidate{sym: s, path: fp, count: c})
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].count > candidates[j].count
+	})
+
+	const maxKeyTypes = 8
+	var examples []Example
+	for _, c := range candidates {
+		if surfaced[c.sym.name] {
+			continue
+		}
+		if len(examples) >= maxKeyTypes {
+			break
+		}
+		examples = append(examples, Example{
+			Name:      c.sym.name,
+			Path:      c.path,
+			Kind:      c.sym.kind,
+			EdgeCount: c.count,
+		})
+		surfaced[c.sym.name] = true
+	}
+
+	if len(examples) == 0 {
+		return nil
+	}
+
+	var parts []string
+	for _, e := range examples {
+		parts = append(parts, fmt.Sprintf("%s (%d refs)", e.Name, e.EdgeCount))
+	}
+	totalTypes := countByKind(symbols, "struct", "class", "interface", "type")
+	return []Convention{{
+		Category:    CategoryKeyTypes,
+		Description: fmt.Sprintf("Key domain types: %s — most-referenced types in the codebase", strings.Join(parts, ", ")),
+		Instances:   len(examples),
+		Total:       totalTypes,
+		Strength:    1.0,
+		Examples:    examples,
+	}}
 }
 
 func countByKind(symbols []symbolRow, kinds ...string) int {

--- a/internal/mcpio/graph.go
+++ b/internal/mcpio/graph.go
@@ -355,6 +355,7 @@ func IsTestPath(path string) bool {
 	return strings.Contains(path, "_test.") ||
 		strings.Contains(path, "/test/") ||
 		strings.Contains(path, "/tests/") ||
+		strings.Contains(path, "/testdata/") ||
 		strings.Contains(path, "/spec/") ||
 		strings.HasPrefix(path, "test/") ||
 		strings.HasPrefix(path, "tests/") ||

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -524,12 +524,20 @@ type DeadCodeMetrics struct {
 type OrientResponse struct {
 	Fingerprint  string               `json:"fingerprint"`
 	Structure    *StatusStructure     `json:"structure"`
+	KeyTypes     []KeyTypeEntry       `json:"key_types,omitempty"`
 	Conventions  []ConventionEntry    `json:"conventions"`
 	SearchHits   []SearchResultEntry  `json:"search_hits"`
 	Truncated    bool                 `json:"truncated,omitempty"`
 	TokenBudget  int                  `json:"token_budget,omitempty"`
 	SenseMetrics OrientMetrics        `json:"sense_metrics"`
 	NextSteps    []NextStep           `json:"next_steps"`
+}
+
+type KeyTypeEntry struct {
+	Name      string `json:"name"`
+	Kind      string `json:"kind"`
+	File      string `json:"file"`
+	Refs      int    `json:"refs"`
 }
 
 // OrientMetrics is the observability footer for orient responses.

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -1060,9 +1060,21 @@ func (h *handlers) handleOrient(ctx context.Context, req mcp.CallToolRequest) (*
 	instanceCap := h.defaults.ConventionsInstanceCap
 	convCap := h.defaults.OrientConventionsCap
 	convEntries := make([]mcpio.ConventionEntry, 0, min(len(convResults), convCap))
-	for i, c := range convResults {
-		if i >= convCap {
-			break
+	var keyTypes []mcpio.KeyTypeEntry
+	for _, c := range convResults {
+		if c.Category == conventions.CategoryKeyTypes {
+			for _, ex := range c.Examples {
+				keyTypes = append(keyTypes, mcpio.KeyTypeEntry{
+					Name: ex.Name,
+					Kind: ex.Kind,
+					File: ex.Path,
+					Refs: ex.EdgeCount,
+				})
+			}
+			continue
+		}
+		if len(convEntries) >= convCap {
+			continue
 		}
 		convEntries = append(convEntries, mcpio.ConventionEntry{
 			Category:       string(c.Category),
@@ -1134,6 +1146,7 @@ func (h *handlers) handleOrient(ctx context.Context, req mcp.CallToolRequest) (*
 	resp := mcpio.OrientResponse{
 		Fingerprint: statusResp.Structure.Fingerprint,
 		Structure:   statusResp.Structure,
+		KeyTypes:    keyTypes,
 		Conventions: convEntries,
 		SearchHits:  searchHits,
 		SenseMetrics: mcpio.OrientMetrics{


### PR DESCRIPTION
## Problem

Convention detection surfaces types only when they match a pattern. If a type is central to the codebase but doesn't participate in a detected convention, it's invisible to orient output. On gin, `Engine` is the most important type but only appears if it happens to match some convention. On flask, `Flask` and `Blueprint` are the framework core but have no pattern to trigger detection.

## Summary

- **Key types detector**: New `detectKeyTypes` in conventions.go ranks types/structs/classes/interfaces by inbound edge count, deduplicates against already-surfaced conventions, caps at 8
- **Orient section**: New `key_types` field in OrientResponse renders between structure and conventions with name, kind, file, and reference count
- **CategoryKeyTypes**: Typed category constant for dispatch instead of string matching
- **Canonical IsTestPath**: Reuses `mcpio.IsTestPath` (extended with `/testdata/`) instead of a local copy
- **Real symbol kind**: Propagates actual kind (struct/class/interface) through Example to KeyTypeEntry

## Changes

- `internal/conventions/conventions.go`: `detectKeyTypes`, `CategoryKeyTypes`, `Kind` on `Example`
- `internal/mcpio/types.go`: `KeyTypeEntry`, `KeyTypes` field on `OrientResponse`
- `internal/mcpio/graph.go`: Added `/testdata/` to `IsTestPath`
- `internal/mcpserver/server.go`: Extract key types by category, populate orient section

## Test plan

- [x] Full `make ci` passes (build + test + lint)
- [x] Existing convention tests pass with new detector in chain
- [x] Key types excluded from convention cap (separate section)