### PR TITLE
feat(conventions): add Go type alias and middleware factory detectors

### DIFF
--- a/internal/conventions/conventions.go
+++ b/internal/conventions/conventions.go
@@ -969,6 +969,89 @@ func detectFrameworkIdioms(symbols []symbolRow, edges []edgeRow, symbolByID map[
 		})
 	}
 
+	// Go type aliases: named types wrapping another type (kind="type" in Go means alias/newtype)
+	var goAliases []Example
+	for _, s := range symbols {
+		if s.kind != "type" {
+			continue
+		}
+		fp := filePathByID[s.fileID]
+		if !strings.HasSuffix(fp, ".go") {
+			continue
+		}
+		goAliases = append(goAliases, Example{Name: s.name, Path: fp, Kind: s.kind})
+	}
+	if len(goAliases) >= minInstances {
+		sortExamples(goAliases)
+		totalTypes := countByKind(symbols, "type")
+		out = append(out, Convention{
+			Category:    CategoryStructure,
+			Description: fmt.Sprintf("Type aliases: %s — named domain types (%d aliases)", topNames(goAliases), len(goAliases)),
+			Instances:   len(goAliases),
+			Total:       totalTypes,
+			Strength:    safeStrength(len(goAliases), totalTypes),
+			Examples:    goAliases,
+		})
+	}
+
+	// Go middleware factory pattern: functions called by router methods (Use, GET, POST, etc.)
+	routerMethods := map[string]bool{
+		"Use": true, "GET": true, "POST": true, "PUT": true, "DELETE": true,
+		"PATCH": true, "Handle": true, "HandleFunc": true, "Group": true,
+		"Any": true, "HEAD": true, "OPTIONS": true,
+	}
+	routerSymbolIDs := map[int64]bool{}
+	for _, s := range symbols {
+		if routerMethods[s.name] && (s.kind == "method" || s.kind == "function") {
+			fp := filePathByID[s.fileID]
+			if strings.HasSuffix(fp, ".go") {
+				routerSymbolIDs[s.id] = true
+			}
+		}
+	}
+	if len(routerSymbolIDs) > 0 {
+		handlerCounts := map[int64]int{}
+		for _, e := range edges {
+			if e.kind != "calls" {
+				continue
+			}
+			if !routerSymbolIDs[e.sourceID] {
+				continue
+			}
+			handlerCounts[e.targetID]++
+		}
+		var factories []Example
+		seen := map[string]bool{}
+		for id, count := range handlerCounts {
+			s, ok := symbolByID[id]
+			if !ok || s.kind != "function" {
+				continue
+			}
+			if strings.HasPrefix(s.name, "Test") || strings.HasPrefix(s.name, "Benchmark") {
+				continue
+			}
+			if seen[s.name] {
+				continue
+			}
+			seen[s.name] = true
+			factories = append(factories, Example{Name: s.name, Path: filePathByID[s.fileID], EdgeCount: count})
+		}
+		if len(factories) >= minInstances {
+			sort.Slice(factories, func(i, j int) bool {
+				return factories[i].EdgeCount > factories[j].EdgeCount
+			})
+			totalFuncs := countByKind(symbols, "function")
+			out = append(out, Convention{
+				Category:    CategoryFramework,
+				Description: fmt.Sprintf("Middleware factories: %s return handler functions — composable request pipeline (%d factories)", topNames(factories), len(factories)),
+				Instances:   len(factories),
+				Total:       totalFuncs,
+				Strength:    safeStrength(len(factories), totalFuncs),
+				Examples:    factories,
+			})
+		}
+	}
+
 	return out
 }
 
@@ -1185,6 +1268,9 @@ func enrichEdgeCounts(conventions []Convention, symbols []symbolRow, edges []edg
 	for ci := range conventions {
 		for ei := range conventions[ci].Examples {
 			ex := &conventions[ci].Examples[ei]
+			if ex.EdgeCount != 0 {
+				continue
+			}
 			ex.EdgeCount = lookup[namePathKey{ex.Name, ex.Path}]
 		}
 	}

--- a/internal/conventions/conventions_test.go
+++ b/internal/conventions/conventions_test.go
@@ -794,3 +794,163 @@ func TestDetectDesignPatternsEmpty(t *testing.T) {
 	}
 }
 
+func setupGoFrameworkFixture(t *testing.T) *sqlite.Adapter {
+	t.Helper()
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	now := time.Now()
+	files := []model.File{
+		{Path: "gin.go", Language: "go", Hash: "g1", Symbols: 1, IndexedAt: now},
+		{Path: "routergroup.go", Language: "go", Hash: "g2", Symbols: 1, IndexedAt: now},
+		{Path: "auth.go", Language: "go", Hash: "g3", Symbols: 1, IndexedAt: now},
+		{Path: "logger.go", Language: "go", Hash: "g4", Symbols: 1, IndexedAt: now},
+		{Path: "recovery.go", Language: "go", Hash: "g5", Symbols: 1, IndexedAt: now},
+		{Path: "cors.go", Language: "go", Hash: "g6", Symbols: 1, IndexedAt: now},
+	}
+	fileIDs := make(map[string]int64)
+	for i := range files {
+		id, err := adapter.WriteFile(ctx, &files[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		fileIDs[files[i].Path] = id
+	}
+
+	type symDef struct {
+		fileKey   string
+		name      string
+		qualified string
+		kind      string
+	}
+	symDefs := []symDef{
+		// Type aliases (kind="type" in Go = alias/newtype)
+		{"gin.go", "HandlerFunc", "gin.HandlerFunc", "type"},
+		{"gin.go", "HandlersChain", "gin.HandlersChain", "type"},
+		{"gin.go", "Params", "gin.Params", "type"},
+		{"gin.go", "H", "gin.H", "type"},
+		// Structs
+		{"gin.go", "Engine", "gin.Engine", "class"},
+		{"routergroup.go", "RouterGroup", "gin.RouterGroup", "class"},
+		// Router method
+		{"routergroup.go", "Use", "gin.RouterGroup.Use", "method"},
+		// Middleware factories (functions)
+		{"logger.go", "Logger", "gin.Logger", "function"},
+		{"recovery.go", "Recovery", "gin.Recovery", "function"},
+		{"auth.go", "BasicAuth", "gin.BasicAuth", "function"},
+		{"cors.go", "CORS", "gin.CORS", "function"},
+	}
+
+	symIDs := make(map[string]int64)
+	for _, sd := range symDefs {
+		fid := fileIDs[sd.fileKey]
+		s := &model.Symbol{
+			FileID:    fid,
+			Name:      sd.name,
+			Qualified: sd.qualified,
+			Kind:      model.SymbolKind(sd.kind),
+			LineStart: 1,
+			LineEnd:   10,
+		}
+		id, err := adapter.WriteSymbol(ctx, s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		symIDs[sd.qualified] = id
+	}
+
+	type edgeDef struct {
+		source string
+		target string
+		kind   string
+		file   string
+	}
+	edgeDefs := []edgeDef{
+		// Router method calls middleware factories
+		{"gin.RouterGroup.Use", "gin.Logger", "calls", "routergroup.go"},
+		{"gin.RouterGroup.Use", "gin.Recovery", "calls", "routergroup.go"},
+		{"gin.RouterGroup.Use", "gin.BasicAuth", "calls", "routergroup.go"},
+		{"gin.RouterGroup.Use", "gin.CORS", "calls", "routergroup.go"},
+	}
+	for _, ed := range edgeDefs {
+		srcID := symIDs[ed.source]
+		tgtID := symIDs[ed.target]
+		fid := fileIDs[ed.file]
+		e := &model.Edge{
+			SourceID:   &srcID,
+			TargetID:   tgtID,
+			Kind:       model.EdgeKind(ed.kind),
+			FileID:     fid,
+			Confidence: 1.0,
+		}
+		if _, err := adapter.WriteEdge(ctx, e); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return adapter
+}
+
+func TestDetectGoTypeAliases(t *testing.T) {
+	adapter := setupGoFrameworkFixture(t)
+	ctx := context.Background()
+
+	conventions, _, err := Detect(ctx, adapter.DB(), Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	for _, c := range conventions {
+		if strings.Contains(c.Description, "Type aliases") {
+			found = true
+			if c.Instances < 2 {
+				t.Errorf("type alias convention should have at least 2 instances, got %d", c.Instances)
+			}
+			if c.Category != CategoryStructure {
+				t.Errorf("type alias convention category = %q, want %q", c.Category, CategoryStructure)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("expected Type aliases convention to be detected")
+	}
+}
+
+func TestDetectGoMiddlewareFactories(t *testing.T) {
+	adapter := setupGoFrameworkFixture(t)
+	ctx := context.Background()
+
+	conventions, _, err := Detect(ctx, adapter.DB(), Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	for _, c := range conventions {
+		if strings.Contains(c.Description, "Middleware factories") {
+			found = true
+			if c.Instances < 3 {
+				t.Errorf("middleware factory convention should have at least 3 instances, got %d", c.Instances)
+			}
+			if c.Category != CategoryFramework {
+				t.Errorf("middleware factory convention category = %q, want %q", c.Category, CategoryFramework)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("expected Middleware factories convention to be detected")
+	}
+}
+


### PR DESCRIPTION
## Summary
- Add Go type alias detector that identifies named domain types (kind="type" in Go) with ≥3 instances
- Add Go middleware factory detector that finds functions called by router methods (Use, GET, POST, etc.)
- Fix `enrichEdgeCounts` to preserve detector-set EdgeCount values instead of overwriting them

## Test plan
- [x] `TestDetectGoTypeAliases` — gin-like fixture with 4 type aliases detected as structure convention
- [x] `TestDetectGoMiddlewareFactories` — 4 middleware factories (Logger, Recovery, BasicAuth, CORS) called by Use method
- [x] `make ci` passes (all tests, lint, build)