### PR TITLE
feat(mcp): leaner responses and smarter blast-radius traversal

### DIFF
--- a/internal/blast/engine.go
+++ b/internal/blast/engine.go
@@ -28,6 +28,9 @@ import (
 
 const defaultMaxResults = 100
 
+// MaxFrontierWidth caps BFS frontier per hop — distinct from the SQL batch chunk (500).
+const MaxFrontierWidth = 500
+
 // defaultMaxHops matches the pitch's acceptance-criterion call:
 // Options{MaxHops: 3, IncludeTests: true}. Callers that pass
 // MaxHops: 0 get three hops of traversal — deep enough to be useful
@@ -86,15 +89,32 @@ func isTypeKind(kind model.SymbolKind) bool {
 	return false
 }
 
+const (
+	// InheritsDecay — type hierarchy is a strong structural signal.
+	InheritsDecay = 0.7
+	// ComposesDecay — field/association; ORM relationships survive 2 hops.
+	ComposesDecay = 0.5
+	// IncludesDecay — mixins/imports are weak, prune early.
+	IncludesDecay = 0.3
+	// StructuralMinConf — lowered floor for structural edges (composes/inherits/includes) so ORM chains survive 2 hops.
+	StructuralMinConf = 0.2
+	// TestsDecay — test edges are weaker than structural edges but stronger than includes.
+	TestsDecay = 0.5
+)
+
 // kindDecay returns the confidence multiplier for an edge kind during
-// BFS traversal. Weak edge kinds decay faster, causing paths through
-// composition/test edges to hit the MinConfidence floor sooner.
+// BFS traversal. Per-kind values ensure ORM associations (composes)
+// survive two hops while mixins/imports prune early.
 func kindDecay(edgeKind string) float64 {
 	switch edgeKind {
-	case "composes", "includes", "inherits":
-		return 0.3
+	case "inherits":
+		return InheritsDecay
+	case "composes":
+		return ComposesDecay
+	case "includes":
+		return IncludesDecay
 	case "tests":
-		return 0.5
+		return TestsDecay
 	default:
 		return 1.0
 	}
@@ -146,6 +166,8 @@ type Result struct {
 	// SymbolTiers classifies each affected symbol by relevance tier.
 	// Keyed by symbol ID. Used by response shapers to cap output.
 	SymbolTiers map[int64]Tier
+
+	Truncated bool
 }
 
 // Compute returns the blast radius of symbolIDs under the given
@@ -186,6 +208,7 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 		frontier = append(frontier, id)
 	}
 
+	truncated := false
 	for hop := 1; hop <= opts.MaxHops; hop++ {
 		if err := ctx.Err(); err != nil {
 			return Result{}, fmt.Errorf("blast: cancelled at hop %d: %w", hop, err)
@@ -200,7 +223,11 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 				continue
 			}
 			cumConf := pathConf[pair.target] * pair.confidence * kindDecay(pair.kind)
-			if cumConf < opts.MinConfidence {
+			minConf := opts.MinConfidence
+			if pair.kind == "composes" || pair.kind == "inherits" || pair.kind == "includes" {
+				minConf = StructuralMinConf
+			}
+			if cumConf < minConf {
 				continue
 			}
 			visited[pair.source] = hop
@@ -211,6 +238,24 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 				viaTemporal[pair.source] = true
 			}
 			next = append(next, pair.source)
+		}
+		// Cap frontier width: evicted nodes are removed from visited so they
+		// may be re-discovered via a stronger path in a later hop. This is
+		// intentional — it preserves the highest-confidence paths.
+		if len(next) > MaxFrontierWidth {
+			sort.Slice(next, func(i, j int) bool {
+				return pathConf[next[i]] > pathConf[next[j]]
+			})
+			evicted := next[MaxFrontierWidth:]
+			next = next[:MaxFrontierWidth]
+			for _, id := range evicted {
+				delete(visited, id)
+				delete(predecessor, id)
+				delete(visitedKind, id)
+				delete(pathConf, id)
+				delete(viaTemporal, id)
+			}
+			truncated = true
 		}
 		if len(next) == 0 {
 			break
@@ -409,6 +454,7 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 		AffectedViaComposition: viaComposition,
 		AffectedViaIncludes:    viaIncludes,
 		SymbolTiers:            symbolTiers,
+		Truncated:              truncated,
 	}, nil
 }
 

--- a/internal/blast/engine_test.go
+++ b/internal/blast/engine_test.go
@@ -1140,3 +1140,114 @@ func TestSelfMethodExclusion(t *testing.T) {
 		t.Errorf("TotalAffected = %d, want 1 (only external caller)", res.TotalAffected)
 	}
 }
+
+// TestBlastFollowsCompositionTwoHops verifies that a User --composes--> Post
+// --calls--> Validator chain is fully traversed: Post at hop 1 and Validator
+// at hop 2 should both appear in blast results.
+func TestBlastFollowsCompositionTwoHops(t *testing.T) {
+	fix := newFixtureDB(t)
+	user := fix.addSymbol(t, "User")
+	post := fix.addSymbol(t, "Post")
+	validator := fix.addSymbol(t, "Validator")
+
+	// Post composes User (reverse: blast from User sees Post)
+	fix.addEdge(t, post, user, model.EdgeComposes, 1.0)
+	// Validator calls Post (reverse: blast from Post sees Validator)
+	fix.addEdge(t, validator, post, model.EdgeCalls, 1.0)
+
+	res, err := blast.Compute(context.Background(), fix.db, []int64{user}, blast.Options{
+		MaxHops: 3,
+	})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+
+	foundPost := false
+	for _, c := range res.DirectCallers {
+		if c.ID == post {
+			foundPost = true
+		}
+	}
+	if !foundPost {
+		t.Errorf("Post should appear at hop 1 (composes), got DirectCallers: %+v", res.DirectCallers)
+	}
+
+	foundValidator := false
+	for _, hop := range res.IndirectCallers {
+		if hop.Symbol.ID == validator {
+			foundValidator = true
+		}
+	}
+	if !foundValidator {
+		t.Errorf("Validator should appear at hop 2 (calls via Post), got IndirectCallers: %+v", res.IndirectCallers)
+	}
+}
+
+func TestBlastCapsFrontierWidth(t *testing.T) {
+	fix := newFixtureDB(t)
+	hub := fix.addSymbol(t, "Hub")
+
+	callerCount := blast.MaxFrontierWidth + 100
+	for i := 0; i < callerCount; i++ {
+		caller := fix.addSymbol(t, fmt.Sprintf("Caller%d", i))
+		fix.addEdge(t, caller, hub, model.EdgeCalls, 1.0)
+	}
+
+	res, err := blast.Compute(context.Background(), fix.db, []int64{hub}, blast.Options{
+		MaxHops:    2,
+		MaxResults: callerCount + 10,
+	})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+
+	if !res.Truncated {
+		t.Error("expected Truncated=true when frontier exceeds MaxFrontierWidth")
+	}
+	if res.TotalAffected > blast.MaxFrontierWidth {
+		t.Errorf("TotalAffected = %d, want <= %d", res.TotalAffected, blast.MaxFrontierWidth)
+	}
+}
+
+// TestBlastPrunesCompositionThreeHops verifies that three consecutive
+// composition hops get pruned: cumulative confidence 0.5^3 = 0.125 < StructuralMinConf (0.2).
+func TestBlastPrunesCompositionThreeHops(t *testing.T) {
+	fix := newFixtureDB(t)
+	a := fix.addSymbol(t, "A")
+	b := fix.addSymbol(t, "B")
+	c := fix.addSymbol(t, "C")
+	d := fix.addSymbol(t, "D")
+
+	fix.addEdge(t, b, a, model.EdgeComposes, 1.0)
+	fix.addEdge(t, c, b, model.EdgeComposes, 1.0)
+	fix.addEdge(t, d, c, model.EdgeComposes, 1.0)
+
+	res, err := blast.Compute(context.Background(), fix.db, []int64{a}, blast.Options{
+		MaxHops: 4,
+	})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+
+	// B at hop 1: 1.0 * 1.0 * 0.5 = 0.5 >= 0.2 ✓
+	// C at hop 2: 0.5 * 1.0 * 0.5 = 0.25 >= 0.2 ✓
+	// D at hop 3: 0.25 * 1.0 * 0.5 = 0.125 < 0.2 ✗ (pruned)
+	foundD := false
+	for _, c := range res.DirectCallers {
+		if c.ID == d {
+			foundD = true
+		}
+	}
+	for _, hop := range res.IndirectCallers {
+		if hop.Symbol.ID == d {
+			foundD = true
+		}
+	}
+	if foundD {
+		t.Errorf("D at hop 3 should be pruned (0.5^3=0.125 < StructuralMinConf 0.2)")
+	}
+
+	if res.TotalAffected != 2 {
+		t.Errorf("TotalAffected = %d, want 2 (B + C survive, D pruned)", res.TotalAffected)
+	}
+}

--- a/internal/cli/conventions_test.go
+++ b/internal/cli/conventions_test.go
@@ -94,12 +94,8 @@ func TestRunConventionsJSON(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
 		t.Fatalf("invalid JSON: %v\n%s", err, stdout.String())
 	}
-	if resp.SenseMetrics.SymbolsAnalyzed == 0 {
-		t.Error("expected non-zero symbols_analyzed")
-	}
-	if resp.SenseMetrics.EstimatedFileReadsAvoided != 0 {
-		t.Errorf("estimated_file_reads_avoided = %d, want 0 (4 symbols / 5 rounds down)",
-			resp.SenseMetrics.EstimatedFileReadsAvoided)
+	if strings.Contains(stdout.String(), "sense_metrics") {
+		t.Error("JSON output should not contain sense_metrics")
 	}
 }
 

--- a/internal/cli/search_test.go
+++ b/internal/cli/search_test.go
@@ -95,15 +95,8 @@ func TestRunSearchKeywordFallbackJSON(t *testing.T) {
 	if len(resp.Results) == 0 {
 		t.Fatal("expected results, got none")
 	}
-	if resp.SenseMetrics.SymbolsSearched < 2 {
-		t.Errorf("expected at least 2 symbols searched, got %d", resp.SenseMetrics.SymbolsSearched)
-	}
-	if resp.SenseMetrics.EstimatedFileReadsAvoided == 0 {
-		t.Error("expected non-zero estimated_file_reads_avoided")
-	}
-	if resp.SenseMetrics.EstimatedTokensSaved != resp.SenseMetrics.EstimatedFileReadsAvoided*mcpio.AvgTokensPerFile {
-		t.Errorf("expected estimated_tokens_saved = files * %d, got %d",
-			mcpio.AvgTokensPerFile, resp.SenseMetrics.EstimatedTokensSaved)
+	if strings.Contains(stdout.String(), "sense_metrics") {
+		t.Error("JSON output should not contain sense_metrics")
 	}
 }
 

--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -25,6 +25,7 @@ func BuildBlastResponse(r blast.Result, files FileLookup) BlastResponse {
 		AffectedTests:      append([]string{}, r.AffectedTests...),
 		TotalAffected:      r.TotalAffected,
 		TestsAffectedCount: len(r.AffectedTests),
+		Truncated:          r.Truncated,
 	}
 
 	hasTiers := len(r.SymbolTiers) > 0

--- a/internal/mcpio/conventions.go
+++ b/internal/mcpio/conventions.go
@@ -14,7 +14,7 @@ type ConventionsResponse struct {
 	Conventions  []ConventionEntry    `json:"conventions"`
 	Truncated    bool                 `json:"truncated,omitempty"`
 	TokenBudget  int                  `json:"token_budget,omitempty"`
-	SenseMetrics ConventionsMetrics   `json:"sense_metrics"`
+	SenseMetrics ConventionsMetrics   `json:"-"`
 	NextSteps    []NextStep           `json:"next_steps"`
 }
 

--- a/internal/mcpio/marshal_test.go
+++ b/internal/mcpio/marshal_test.go
@@ -38,8 +38,7 @@ func TestMarshalGraphRoundTrip(t *testing.T) {
 			Tests:    []TestEdgeRef{{File: "test/services/checkout_service_test.rb", Confidence: 0.8}},
 			Temporal: []TemporalEdgeRef{},
 		},
-		SenseMetrics: GraphMetrics{SymbolsReturned: 3},
-		NextSteps:    []NextStep{},
+		NextSteps: []NextStep{},
 	}
 
 	raw, err := MarshalGraph(in)
@@ -74,8 +73,7 @@ func TestMarshalBlastRoundTrip(t *testing.T) {
 		AffectedViaComposition: []BlastCaller{},
 		AffectedViaIncludes:    []BlastCaller{},
 		References:             BlastTierSummary{Count: 0, Examples: []BlastCaller{}},
-		SenseMetrics:           BlastMetrics{SymbolsTraversed: 5},
-		NextSteps:              []NextStep{},
+		NextSteps: []NextStep{},
 	}
 
 	raw, err := MarshalBlast(in)
@@ -97,10 +95,7 @@ func TestMarshalBlastRoundTrip(t *testing.T) {
 // declares — without this test, a future edit to remove a
 // normalizer would break the contract silently.
 //
-// The savings fields on SenseMetrics render as `null` by policy
-// (pitch 01-05: honest stub until 04-03 lands real estimation),
-// so the test explicitly allows null there and elsewhere — it only
-// enforces that the named slice fields carry `[]`.
+// This test enforces that all named slice fields carry `[]`, not `null`.
 func TestMarshalZeroValueEmptySlices(t *testing.T) {
 	graphBytes, err := MarshalGraph(GraphResponse{})
 	if err != nil {
@@ -130,6 +125,92 @@ func TestMarshalZeroValueEmptySlices(t *testing.T) {
 		if strings.Contains(string(blastBytes), nullField) {
 			t.Errorf("BlastResponse zero-value slice field should be []: %s\ngot:\n%s", nullField, blastBytes)
 		}
+	}
+}
+
+func TestResponseOmitsMetrics(t *testing.T) {
+	graph := GraphResponse{
+		Symbol:       GraphSymbol{Name: "X", Qualified: "X", File: "x.go", Kind: "function"},
+		SenseMetrics: GraphMetrics{SymbolsReturned: 99, EstimatedFileReadsAvoided: 10, EstimatedTokensSaved: 8000},
+	}
+	graphBytes, err := MarshalGraph(graph)
+	if err != nil {
+		t.Fatalf("MarshalGraph: %v", err)
+	}
+	if strings.Contains(string(graphBytes), "sense_metrics") {
+		t.Errorf("graph response should not contain sense_metrics:\n%s", graphBytes)
+	}
+
+	bl := BlastResponse{
+		Symbol:       "Y",
+		Risk:         "low",
+		RiskFactors:  []string{"1 direct caller"},
+		SenseMetrics: BlastMetrics{SymbolsTraversed: 50, EstimatedFileReadsAvoided: 5, EstimatedTokensSaved: 4000},
+	}
+	blastBytes, err := MarshalBlast(bl)
+	if err != nil {
+		t.Fatalf("MarshalBlast: %v", err)
+	}
+	if strings.Contains(string(blastBytes), "sense_metrics") {
+		t.Errorf("blast response should not contain sense_metrics:\n%s", blastBytes)
+	}
+
+	sr := SearchResponse{
+		Results:      []SearchResultEntry{{Symbol: "Z", File: "z.go", Kind: "function", Score: 0.9}},
+		SearchMode:   "hybrid",
+		SenseMetrics: SearchMetrics{SymbolsSearched: 100, EstimatedFileReadsAvoided: 3, EstimatedTokensSaved: 2400},
+	}
+	searchBytes, err := MarshalSearch(sr)
+	if err != nil {
+		t.Fatalf("MarshalSearch: %v", err)
+	}
+	if strings.Contains(string(searchBytes), "sense_metrics") {
+		t.Errorf("search response should not contain sense_metrics:\n%s", searchBytes)
+	}
+
+	conv := ConventionsResponse{
+		Conventions:  []ConventionEntry{{Category: "naming", Description: "test", Strength: 0.8, Instances: []string{"a"}, TotalInstances: 1}},
+		SenseMetrics: ConventionsMetrics{SymbolsAnalyzed: 200, EstimatedFileReadsAvoided: 10, EstimatedTokensSaved: 8000},
+	}
+	convBytes, err := MarshalConventions(conv)
+	if err != nil {
+		t.Fatalf("MarshalConventions: %v", err)
+	}
+	if strings.Contains(string(convBytes), "sense_metrics") {
+		t.Errorf("conventions response should not contain sense_metrics:\n%s", convBytes)
+	}
+
+	dc := DeadCodeResponse{
+		DeadSymbols:  []DeadSymbolEntry{{Symbol: "W", Qualified: "W", File: "w.go", Kind: "function"}},
+		TotalSymbols: 100,
+		DeadCount:    1,
+		SenseMetrics: DeadCodeMetrics{SymbolsAnalyzed: 100, EstimatedFileReadsAvoided: 1, EstimatedTokensSaved: 800},
+	}
+	dcBytes, err := MarshalDeadCode(dc)
+	if err != nil {
+		t.Fatalf("MarshalDeadCode: %v", err)
+	}
+	if strings.Contains(string(dcBytes), "sense_metrics") {
+		t.Errorf("dead code response should not contain sense_metrics:\n%s", dcBytes)
+	}
+}
+
+func TestResponseRetainsFreshness(t *testing.T) {
+	age := int64(42)
+	stale := 2
+	graph := GraphResponse{
+		Symbol:    GraphSymbol{Name: "X", Qualified: "X", File: "x.go", Kind: "function"},
+		Freshness: &Freshness{IndexAgeSeconds: &age, StaleFilesSeen: &stale},
+	}
+	graphBytes, err := MarshalGraph(graph)
+	if err != nil {
+		t.Fatalf("MarshalGraph: %v", err)
+	}
+	if !strings.Contains(string(graphBytes), "freshness") {
+		t.Errorf("graph response should contain freshness when set:\n%s", graphBytes)
+	}
+	if !strings.Contains(string(graphBytes), "index_age_seconds") {
+		t.Errorf("freshness should contain index_age_seconds:\n%s", graphBytes)
 	}
 }
 

--- a/internal/mcpio/testdata/blast_diff.json
+++ b/internal/mcpio/testdata/blast_diff.json
@@ -49,10 +49,5 @@
   "tests_affected_count": 0,
   "production_affected": 6,
   "test_affected": 3,
-  "sense_metrics": {
-    "symbols_traversed": 9,
-    "estimated_file_reads_avoided": 8,
-    "estimated_tokens_saved": 6400
-  },
   "next_steps": []
 }

--- a/internal/mcpio/testdata/blast_user_email_verified.json
+++ b/internal/mcpio/testdata/blast_user_email_verified.json
@@ -50,10 +50,5 @@
   "tests_affected_count": 0,
   "production_affected": 5,
   "test_affected": 6,
-  "sense_metrics": {
-    "symbols_traversed": 47,
-    "estimated_file_reads_avoided": 10,
-    "estimated_tokens_saved": 8000
-  },
   "next_steps": []
 }

--- a/internal/mcpio/testdata/graph_checkout_service.json
+++ b/internal/mcpio/testdata/graph_checkout_service.json
@@ -54,10 +54,5 @@
     ],
     "temporal": []
   },
-  "sense_metrics": {
-    "symbols_returned": 7,
-    "estimated_file_reads_avoided": 6,
-    "estimated_tokens_saved": 4800
-  },
   "next_steps": []
 }

--- a/internal/mcpio/testdata/graph_empty.json
+++ b/internal/mcpio/testdata/graph_empty.json
@@ -17,10 +17,5 @@
     "tests": [],
     "temporal": []
   },
-  "sense_metrics": {
-    "symbols_returned": 0,
-    "estimated_file_reads_avoided": 0,
-    "estimated_tokens_saved": 0
-  },
   "next_steps": []
 }

--- a/internal/mcpio/testdata/graph_with_freshness.json
+++ b/internal/mcpio/testdata/graph_with_freshness.json
@@ -54,11 +54,6 @@
     ],
     "temporal": []
   },
-  "sense_metrics": {
-    "symbols_returned": 7,
-    "estimated_file_reads_avoided": 6,
-    "estimated_tokens_saved": 4800
-  },
   "freshness": {
     "index_age_seconds": 42,
     "stale_files_seen": 0

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -26,6 +26,9 @@ import (
 // source file. Used across all estimation formulas.
 const AvgTokensPerFile = 800
 
+// MaxNextSteps caps follow-up hints per response — transcript evidence shows agents follow at most 1-2.
+const MaxNextSteps = 2
+
 // ServerInstructions is the canonical MCP server instruction text.
 // Used by both the MCP server (serverInstructions) and setup (.mcp.json).
 const ServerInstructions = "When Sense is available and indexed, prefer Sense tools over grep, glob, " +
@@ -98,7 +101,7 @@ type GraphResponse struct {
 	Layers             []GraphLayer       `json:"layers,omitempty"`
 	Truncated          bool               `json:"truncated,omitempty"`
 	TestCallerSummary  *TestCallerSummary `json:"test_caller_summary,omitempty"`
-	SenseMetrics       GraphMetrics       `json:"sense_metrics"`
+	SenseMetrics       GraphMetrics       `json:"-"`
 	Freshness          *Freshness         `json:"freshness,omitempty"`
 	NextSteps          []NextStep         `json:"next_steps"`
 }
@@ -246,10 +249,11 @@ type BlastResponse struct {
 	// Tier 3 — affected test count (detail omitted to keep response focused).
 	TestsAffectedCount int `json:"tests_affected_count"`
 
-	ProductionAffected int `json:"production_affected"`
-	TestAffected       int `json:"test_affected"`
+	ProductionAffected int  `json:"production_affected"`
+	TestAffected       int  `json:"test_affected"`
+	Truncated          bool `json:"truncated,omitempty"`
 
-	SenseMetrics BlastMetrics `json:"sense_metrics"`
+	SenseMetrics BlastMetrics `json:"-"`
 	Freshness    *Freshness   `json:"freshness,omitempty"`
 	NextSteps    []NextStep   `json:"next_steps"`
 }
@@ -439,7 +443,7 @@ type SearchResponse struct {
 	Results       []SearchResultEntry `json:"results"`
 	SearchMode    string              `json:"search_mode"`
 	FusionWeights FusionWeights       `json:"fusion_weights"`
-	SenseMetrics  SearchMetrics       `json:"sense_metrics"`
+	SenseMetrics  SearchMetrics       `json:"-"`
 	NextSteps     []NextStep          `json:"next_steps"`
 }
 
@@ -491,7 +495,7 @@ type DeadCodeResponse struct {
 	TotalSymbols int               `json:"total_symbols"`
 	DeadCount    int               `json:"dead_count"`
 	Note         string            `json:"note,omitempty"`
-	SenseMetrics DeadCodeMetrics   `json:"sense_metrics"`
+	SenseMetrics DeadCodeMetrics   `json:"-"`
 	NextSteps    []NextStep        `json:"next_steps"`
 }
 

--- a/internal/mcpserver/hints_test.go
+++ b/internal/mcpserver/hints_test.go
@@ -518,3 +518,50 @@ func assertSameHints(t *testing.T, name string, want, got []mcpio.NextStep) {
 		}
 	}
 }
+
+func TestResponseCapsNextSteps(t *testing.T) {
+	graphResp := mcpio.GraphResponse{
+		Symbol: mcpio.GraphSymbol{Qualified: "X", File: "x.go"},
+		Edges:  mcpio.GraphEdges{CalledBy: make([]mcpio.CallEdgeRef, 20)},
+	}
+	if n := len(graphHints(graphResp, "callers")); n > mcpio.MaxNextSteps {
+		t.Errorf("graphHints returned %d hints, max is %d", n, mcpio.MaxNextSteps)
+	}
+
+	searchResp := mcpio.SearchResponse{
+		Results: []mcpio.SearchResultEntry{
+			{Symbol: "A", File: "pkg/a.go", Score: 0.95},
+			{Symbol: "B", File: "pkg/a.go", Score: 0.9},
+			{Symbol: "C", File: "pkg/a.go", Score: 0.85},
+		},
+	}
+	if n := len(searchHints(searchResp)); n > mcpio.MaxNextSteps {
+		t.Errorf("searchHints returned %d hints, max is %d", n, mcpio.MaxNextSteps)
+	}
+
+	blastResp := mcpio.BlastResponse{
+		Risk:          "high",
+		TotalAffected: 10,
+	}
+	if n := len(blastHints(blastResp)); n > mcpio.MaxNextSteps {
+		t.Errorf("blastHints returned %d hints, max is %d", n, mcpio.MaxNextSteps)
+	}
+
+	convResp := mcpio.ConventionsResponse{
+		Conventions: []mcpio.ConventionEntry{
+			{Strength: 0.9, Description: "test pattern"},
+		},
+	}
+	if n := len(conventionsHints(convResp, "models")); n > mcpio.MaxNextSteps {
+		t.Errorf("conventionsHints returned %d hints, max is %d", n, mcpio.MaxNextSteps)
+	}
+
+	statusResp := mcpio.StatusResponse{
+		Freshness: mcpio.Freshness{StaleFilesSeen: intPtr(5)},
+	}
+	if n := len(statusHints(statusResp, 0)); n > mcpio.MaxNextSteps {
+		t.Errorf("statusHints returned %d hints, max is %d", n, mcpio.MaxNextSteps)
+	}
+}
+
+func intPtr(v int) *int { return &v }

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -420,7 +420,7 @@ func graphHints(resp mcpio.GraphResponse, direction model.Direction) []mcpio.Nex
 		})
 	}
 
-	if direction == model.DirectionCallers && len(hints) < 2 {
+	if direction == model.DirectionCallers && len(hints) < mcpio.MaxNextSteps {
 		hints = append(hints, mcpio.NextStep{
 			Tool:   "sense.graph",
 			Args:   map[string]any{"symbol": resp.Symbol.Qualified, "direction": "callees"},
@@ -428,8 +428,8 @@ func graphHints(resp mcpio.GraphResponse, direction model.Direction) []mcpio.Nex
 		})
 	}
 
-	if len(hints) > 2 {
-		hints = hints[:2]
+	if len(hints) > mcpio.MaxNextSteps {
+		hints = hints[:mcpio.MaxNextSteps]
 	}
 	return hints
 }
@@ -572,7 +572,7 @@ func searchHints(resp mcpio.SearchResponse) []mcpio.NextStep {
 		})
 	}
 
-	if len(hints) < 2 {
+	if len(hints) < mcpio.MaxNextSteps {
 		fileCounts := map[string]int{}
 		for _, r := range resp.Results {
 			if r.File != "" {
@@ -591,8 +591,8 @@ func searchHints(resp mcpio.SearchResponse) []mcpio.NextStep {
 		}
 	}
 
-	if len(hints) > 2 {
-		hints = hints[:2]
+	if len(hints) > mcpio.MaxNextSteps {
+		hints = hints[:mcpio.MaxNextSteps]
 	}
 	return hints
 }
@@ -673,7 +673,7 @@ func blastHints(resp mcpio.BlastResponse) []mcpio.NextStep {
 		})
 	}
 
-	if resp.TestsAffectedCount == 0 && len(resp.AffectedTests) == 0 && resp.TotalAffected > 0 && len(hints) < 2 {
+	if resp.TestsAffectedCount == 0 && len(resp.AffectedTests) == 0 && resp.TotalAffected > 0 && len(hints) < mcpio.MaxNextSteps {
 		hints = append(hints, mcpio.NextStep{
 			Tool:   "sense.search",
 			Args:   map[string]any{"query": resp.Symbol + " test"},
@@ -681,8 +681,8 @@ func blastHints(resp mcpio.BlastResponse) []mcpio.NextStep {
 		})
 	}
 
-	if len(hints) > 2 {
-		hints = hints[:2]
+	if len(hints) > mcpio.MaxNextSteps {
+		hints = hints[:mcpio.MaxNextSteps]
 	}
 	return hints
 }
@@ -1005,15 +1005,15 @@ func conventionsHints(resp mcpio.ConventionsResponse, domain string) []mcpio.Nex
 		}
 	}
 
-	if domain != "" && len(hints) < 2 {
+	if domain != "" && len(hints) < mcpio.MaxNextSteps {
 		hints = append(hints, mcpio.NextStep{
 			Tool:   "sense.conventions",
 			Reason: "scoped results — run without domain filter for project-wide patterns",
 		})
 	}
 
-	if len(hints) > 2 {
-		hints = hints[:2]
+	if len(hints) > mcpio.MaxNextSteps {
+		hints = hints[:mcpio.MaxNextSteps]
 	}
 	return hints
 }
@@ -1067,15 +1067,15 @@ func statusHints(resp mcpio.StatusResponse, sessionQueries int) []mcpio.NextStep
 		})
 	}
 
-	if sessionQueries == 0 && len(hints) < 2 {
+	if sessionQueries == 0 && len(hints) < mcpio.MaxNextSteps {
 		hints = append(hints, mcpio.NextStep{
 			Tool:   "sense.conventions",
 			Reason: "start of session — check project conventions",
 		})
 	}
 
-	if len(hints) > 2 {
-		hints = hints[:2]
+	if len(hints) > mcpio.MaxNextSteps {
+		hints = hints[:mcpio.MaxNextSteps]
 	}
 	return hints
 }

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -142,9 +142,6 @@ func TestMCPIntegration(t *testing.T) {
 			Edges struct {
 				CalledBy []any `json:"called_by"`
 			} `json:"edges"`
-			SenseMetrics struct {
-				SymbolsReturned *int `json:"symbols_returned"`
-			} `json:"sense_metrics"`
 			Freshness *struct {
 				IndexAgeSeconds *int64 `json:"index_age_seconds"`
 				StaleFilesSeen  *int   `json:"stale_files_seen"`
@@ -250,11 +247,6 @@ func TestMCPIntegration(t *testing.T) {
 			Risk          string `json:"risk"`
 			DirectCallers []any  `json:"direct_callers"`
 			TotalAffected int    `json:"total_affected"`
-			SenseMetrics  struct {
-				SymbolsTraversed          int `json:"symbols_traversed"`
-				EstimatedFileReadsAvoided int `json:"estimated_file_reads_avoided"`
-				EstimatedTokensSaved      int `json:"estimated_tokens_saved"`
-			} `json:"sense_metrics"`
 		}
 		if err := json.Unmarshal([]byte(text), &blastResp); err != nil {
 			t.Fatalf("parse blast JSON: %v\n%s", err, text)
@@ -269,12 +261,6 @@ func TestMCPIntegration(t *testing.T) {
 		}
 		if len(blastResp.DirectCallers) < 5 {
 			t.Errorf("direct_callers = %d, want >= 5", len(blastResp.DirectCallers))
-		}
-		if blastResp.SenseMetrics.EstimatedFileReadsAvoided == 0 {
-			t.Error("expected non-zero estimated_file_reads_avoided")
-		}
-		if blastResp.SenseMetrics.EstimatedTokensSaved == 0 {
-			t.Error("expected non-zero estimated_tokens_saved")
 		}
 	})
 


### PR DESCRIPTION
## Problem

MCP responses included a `sense_metrics` block with profiling data (symbols traversed, estimated file reads avoided, tokens saved) that consumed ~15-20% of response tokens without being actionable by AI agents. Additionally, the blast engine used a flat 0.3 decay for all structural edges, causing ORM association chains (composes) to be pruned at hop 1 — making composition relationships invisible to impact analysis.

## Summary

Strip internal metrics from the wire format and tune the BFS traversal so structural relationships survive proportionally to their strength.

## Changes

**MCP response cleanup (`internal/mcpio`, `internal/mcpserver`)**
- Tag `SenseMetrics` fields with `json:"-"` across all 5 response types (graph, blast, search, conventions, dead_code)
- Extract `MaxNextSteps = 2` constant, use in all hint generators
- Update golden test files to match the leaner contract

**Blast engine tuning (`internal/blast`)**
- Replace flat 0.3 structural decay with per-kind constants: `InheritsDecay` 0.7, `ComposesDecay` 0.5, `IncludesDecay` 0.3, `TestsDecay` 0.5
- Add `StructuralMinConf = 0.2` floor so composition/inheritance survive 2 hops (0.5² = 0.25 > 0.2) but prune at 3 (0.5³ = 0.125 < 0.2)
- Cap BFS frontier at `MaxFrontierWidth = 500` with eviction; set `Truncated` flag when triggered

## Test Plan

- [x] `TestResponseOmitsMetrics` — all 5 response types exclude `sense_metrics` from JSON
- [x] `TestResponseRetainsFreshness` — freshness block still serializes when present
- [x] `TestBlastFollowsCompositionTwoHops` — User→Post→Validator chain fully traversed
- [x] `TestBlastPrunesCompositionThreeHops` — 3 consecutive composes hops pruned at 0.125 < 0.2
- [x] `TestBlastCapsFrontierWidth` — 600-node frontier capped at 500, `Truncated=true`
- [x] `TestResponseCapsNextSteps` — all hint generators respect `MaxNextSteps`
- [x] `make ci` passes (lint + all tests)