### PR TITLE
feat(graph): infer callers through interface dispatch

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,65 @@ linters:
   enable:
     - errcheck
     - staticcheck
+    - govet
+    - gosec
+    - ineffassign
+    - unconvert
+    - gocritic
+    - exhaustive
+    - unused
+    - misspell
+    - dupword
+    - revive
+    - nolintlint
+  settings:
+    exhaustive:
+      default-signifies-exhaustive: true
+    nolintlint:
+      require-explanation: true
+      require-specific: true
   exclusions:
     paths:
       - bench/lib/test_fixtures
+    rules:
+      # dupword: SQL NULL repetitions and embedded Ruby/test fixtures are fine
+      - linters: [dupword]
+        path: _test\.go
+      - linters: [dupword]
+        path: cmd/sense/main\.go
+      # gosec: test files legitimately use weak RNG, broad perms, variable paths
+      - linters: [gosec]
+        path: _test\.go
+      # gosec: benchmark fixtures use weak RNG and broad file ops
+      - linters: [gosec]
+        path: internal/benchmark/
+      # gosec: suppress rules that are false positives for a CLI tool
+      - linters: [gosec]
+        text: "G118:"
+      - linters: [gosec]
+        text: "G202:"
+      - linters: [gosec]
+        text: "G204:"
+      - linters: [gosec]
+        text: "G301:"
+      - linters: [gosec]
+        text: "G302:"
+      - linters: [gosec]
+        text: "G304:"
+      - linters: [gosec]
+        text: "G306:"
+      - linters: [gosec]
+        text: "G602:"
+      - linters: [gosec]
+        text: "G703:"
+      # revive: don't require doc comments on every export — CLI tool, not a library
+      - linters: [revive]
+        text: "exported: "
+      - linters: [revive]
+        text: "package-comments: "
+      # revive: blank imports are used for side-effect registration (SQLite driver, extractors)
+      - linters: [revive]
+        text: "blank-imports: "
+      # revive: indent-error-flow is noisy in CLI command handlers
+      - linters: [revive]
+        text: "indent-error-flow: "

--- a/cmd/sense/main.go
+++ b/cmd/sense/main.go
@@ -99,7 +99,7 @@ func main() {
 				EmbeddingsEnabled: cli.EmbeddingsEnabled(*dir),
 			}); err != nil {
 				fmt.Fprintln(os.Stderr, "sense scan --watch:", err)
-				os.Exit(1)
+				os.Exit(1) //nolint:gocritic // exitAfterDefer: pprof defer only matters on success path
 			}
 		} else {
 			if _, err := scan.Run(ctx, scan.Options{

--- a/internal/blast/engine.go
+++ b/internal/blast/engine.go
@@ -85,8 +85,9 @@ func isTypeKind(kind model.SymbolKind) bool {
 	switch kind {
 	case model.KindClass, model.KindModule, model.KindInterface, model.KindType:
 		return true
+	default:
+		return false
 	}
-	return false
 }
 
 const (

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -212,19 +212,20 @@ func runDoctorChecks(ctx context.Context, cio IO) doctorResponse {
 	_ = db.QueryRowContext(ctx, "SELECT COUNT(*) FROM sense_embeddings").Scan(&embeddings)
 
 	enabled := EmbeddingsEnabled(cio.Dir)
-	if !enabled {
+	switch {
+	case !enabled:
 		checks = append(checks, checkResult{
 			Name:    "embedding_completeness",
 			Status:  "pass",
 			Message: "Embeddings disabled (skipped)",
 		})
-	} else if symbols == 0 {
+	case symbols == 0:
 		checks = append(checks, checkResult{
 			Name:    "embedding_completeness",
 			Status:  "pass",
 			Message: "No symbols to embed",
 		})
-	} else {
+	default:
 		pct := embeddings * 100 / symbols
 		switch {
 		case pct == 100:

--- a/internal/conventions/conventions.go
+++ b/internal/conventions/conventions.go
@@ -606,7 +606,7 @@ func detectComposition(symbols []symbolRow, edges []edgeRow, symbolByID map[int6
 	return out
 }
 
-func detectTesting(symbols []symbolRow, edges []edgeRow, filePathByID map[int64]string, symbolByID map[int64]symbolRow) []Convention {
+func detectTesting(_ []symbolRow, edges []edgeRow, filePathByID map[int64]string, symbolByID map[int64]symbolRow) []Convention {
 	// Detect test file naming conventions from files with "tests" edges
 	testFileIDs := map[int64]struct{}{}
 	for _, e := range edges {
@@ -748,7 +748,7 @@ func sortExamples(examples []Example) {
 	})
 }
 
-func PickRepresentatives(examples []Example, max int) []string {
+func PickRepresentatives(examples []Example, limit int) []string {
 	if len(examples) == 0 {
 		return nil
 	}
@@ -757,7 +757,7 @@ func PickRepresentatives(examples []Example, max int) []string {
 	sort.SliceStable(sorted, func(i, j int) bool {
 		return sorted[i].EdgeCount > sorted[j].EdgeCount
 	})
-	n := max
+	n := limit
 	if n > len(sorted) {
 		n = len(sorted)
 	}

--- a/internal/conventions/conventions_test.go
+++ b/internal/conventions/conventions_test.go
@@ -228,8 +228,8 @@ func TestDetectAllCategories(t *testing.T) {
 	}
 
 	// Check testing category
-	testing_ := findByCategory(conventions, CategoryTesting)
-	if len(testing_) == 0 {
+	testingConvs := findByCategory(conventions, CategoryTesting)
+	if len(testingConvs) == 0 {
 		t.Error("expected testing conventions")
 	}
 

--- a/internal/dead/dead.go
+++ b/internal/dead/dead.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+
+	"github.com/luuuc/sense/internal/sqlite"
 )
 
 const defaultLimit = 100
@@ -49,9 +51,7 @@ func FindDead(ctx context.Context, db *sql.DB, opts Options) (Result, error) {
 		return Result{}, fmt.Errorf("dead: query candidates: %w", err)
 	}
 
-	// Interface implementation check: exclude methods whose parent type
-	// implements an interface with callers on the matching method.
-	ifaceAlive, err := queryInterfaceAliveMethods(ctx, db)
+	ifaceAlive, err := sqlite.InterfaceAliveMethods(ctx, db)
 	if err != nil {
 		return Result{}, fmt.Errorf("dead: interface alive methods: %w", err)
 	}
@@ -417,51 +417,14 @@ func isInterfaceMethod(s Symbol, interfaceIDs map[int64]struct{}) bool {
 	return ok
 }
 
-type ifaceMethodKey struct {
-	parentID   int64
-	methodName string
-}
-
-// queryInterfaceAliveMethods finds method names on interfaces that have
-// callers, then maps those to all types that implement those interfaces.
-// Returns a set of (implementor_parent_id, method_name) pairs that
-// should be excluded from dead code results.
-func queryInterfaceAliveMethods(ctx context.Context, db *sql.DB) (map[ifaceMethodKey]struct{}, error) {
-	// Find interface methods that have callers (alive via dynamic dispatch).
-	// Then find all types that inherit those interfaces.
-	q := `SELECT impl.source_id, im.name
-		FROM sense_symbols im
-		JOIN sense_edges ie ON ie.target_id = im.id AND ie.kind = 'calls'
-		JOIN sense_symbols iface ON im.parent_id = iface.id AND iface.kind = 'interface'
-		JOIN sense_edges impl ON impl.target_id = iface.id AND impl.kind = 'inherits' AND impl.source_id IS NOT NULL
-		GROUP BY impl.source_id, im.name`
-
-	rows, err := db.QueryContext(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = rows.Close() }()
-
-	out := make(map[ifaceMethodKey]struct{})
-	for rows.Next() {
-		var parentID int64
-		var methodName string
-		if err := rows.Scan(&parentID, &methodName); err != nil {
-			return nil, err
-		}
-		out[ifaceMethodKey{parentID: parentID, methodName: methodName}] = struct{}{}
-	}
-	return out, rows.Err()
-}
-
-func excludeInterfaceImplementors(candidates []Symbol, alive map[ifaceMethodKey]struct{}) []Symbol {
+func excludeInterfaceImplementors(candidates []Symbol, alive map[sqlite.InterfaceMethodKey]struct{}) []Symbol {
 	if len(alive) == 0 {
 		return candidates
 	}
 	var out []Symbol
 	for _, s := range candidates {
 		if s.ParentID != nil {
-			if _, ok := alive[ifaceMethodKey{parentID: *s.ParentID, methodName: s.Name}]; ok {
+			if _, ok := alive[sqlite.InterfaceMethodKey{ParentID: *s.ParentID, MethodName: s.Name}]; ok {
 				continue
 			}
 		}

--- a/internal/extract/extractor.go
+++ b/internal/extract/extractor.go
@@ -111,7 +111,7 @@ func StimulusControllerQualified(name string) string {
 		parts[i] = kebabToPascal(part)
 	}
 	last := len(parts) - 1
-	parts[last] = parts[last] + "Controller"
+	parts[last] += "Controller"
 	return strings.Join(parts, "::")
 }
 

--- a/internal/extract/langspec/langspec.go
+++ b/internal/extract/langspec/langspec.go
@@ -129,11 +129,12 @@ func (w *walker) handleClass(n *sitter.Node, scope []string) error {
 
 	symKind := model.KindClass
 	nk := n.Kind()
-	if strings.Contains(nk, "interface") {
+	switch {
+	case strings.Contains(nk, "interface"):
 		symKind = model.KindInterface
-	} else if strings.Contains(nk, "namespace") || strings.Contains(nk, "module") {
+	case strings.Contains(nk, "namespace") || strings.Contains(nk, "module"):
 		symKind = model.KindModule
-	} else if strings.Contains(nk, "enum") {
+	case strings.Contains(nk, "enum"):
 		symKind = model.KindType
 	}
 

--- a/internal/extract/tsjs/tsjs.go
+++ b/internal/extract/tsjs/tsjs.go
@@ -917,7 +917,7 @@ func (w *walker) walkClassBody(n *sitter.Node, methodScope []string, classQualif
 
 // handleStimulusClass handles anonymous (or oddly-named) default-export classes
 // in Stimulus controller files. Uses the convention-derived name from the file path.
-func (w *walker) handleStimulusClass(n *sitter.Node, scope []string) error {
+func (w *walker) handleStimulusClass(n *sitter.Node, _ []string) error {
 	qualified := w.stimulusName
 
 	if err := w.emit.Symbol(extract.EmittedSymbol{
@@ -1067,7 +1067,7 @@ func inferStimulusController(filePath string) string {
 		segments[i] = snakeToPascal(seg)
 	}
 	last := len(segments) - 1
-	segments[last] = segments[last] + "Controller"
+	segments[last] += "Controller"
 	return strings.Join(segments, "::")
 }
 

--- a/internal/index/indextest/conformance.go
+++ b/internal/index/indextest/conformance.go
@@ -64,7 +64,7 @@ func open(t *testing.T, newIdx Factory) index.Index {
 	return idx
 }
 
-func mustWriteFile(t *testing.T, ctx context.Context, idx index.Index, f *model.File) int64 {
+func mustWriteFile(ctx context.Context, t *testing.T, idx index.Index, f *model.File) int64 {
 	t.Helper()
 	id, err := idx.WriteFile(ctx, f)
 	if err != nil {
@@ -73,7 +73,7 @@ func mustWriteFile(t *testing.T, ctx context.Context, idx index.Index, f *model.
 	return id
 }
 
-func mustWriteSymbol(t *testing.T, ctx context.Context, idx index.Index, s *model.Symbol) int64 {
+func mustWriteSymbol(ctx context.Context, t *testing.T, idx index.Index, s *model.Symbol) int64 {
 	t.Helper()
 	id, err := idx.WriteSymbol(ctx, s)
 	if err != nil {
@@ -82,7 +82,7 @@ func mustWriteSymbol(t *testing.T, ctx context.Context, idx index.Index, s *mode
 	return id
 }
 
-func mustWriteEdge(t *testing.T, ctx context.Context, idx index.Index, e *model.Edge) int64 {
+func mustWriteEdge(ctx context.Context, t *testing.T, idx index.Index, e *model.Edge) int64 {
 	t.Helper()
 	id, err := idx.WriteEdge(ctx, e)
 	if err != nil {
@@ -133,13 +133,13 @@ func testFileRoundTrip(t *testing.T, newIdx Factory) {
 	idx := open(t, newIdx)
 
 	f := sampleFile("app/services/checkout_service.rb")
-	fileID := mustWriteFile(t, ctx, idx, f)
+	fileID := mustWriteFile(ctx, t, idx, f)
 	if fileID == 0 {
 		t.Fatal("WriteFile returned zero id")
 	}
 
 	s := sampleSymbol(fileID, "CheckoutService", "App::Services::CheckoutService", model.KindClass)
-	symID := mustWriteSymbol(t, ctx, idx, s)
+	symID := mustWriteSymbol(ctx, t, idx, s)
 
 	got, err := idx.ReadSymbol(ctx, symID)
 	if err != nil {
@@ -164,11 +164,11 @@ func testFileUpsertIdempotent(t *testing.T, newIdx Factory) {
 	idx := open(t, newIdx)
 
 	f := sampleFile("app/models/user.rb")
-	id1 := mustWriteFile(t, ctx, idx, f)
+	id1 := mustWriteFile(ctx, t, idx, f)
 
 	f2 := sampleFile("app/models/user.rb")
 	f2.Hash = "cafef00d" // non-key field change
-	id2 := mustWriteFile(t, ctx, idx, f2)
+	id2 := mustWriteFile(ctx, t, idx, f2)
 
 	if id1 != id2 {
 		t.Errorf("upsert returned new id: first=%d second=%d", id1, id2)
@@ -179,13 +179,13 @@ func testSymbolRoundTrip(t *testing.T, newIdx Factory) {
 	ctx := context.Background()
 	idx := open(t, newIdx)
 
-	fileID := mustWriteFile(t, ctx, idx, sampleFile("app/models/user.rb"))
+	fileID := mustWriteFile(ctx, t, idx, sampleFile("app/models/user.rb"))
 	s := sampleSymbol(fileID, "email_verified?", "User#email_verified?", model.KindMethod)
 	s.LineStart = 12
 	s.LineEnd = 18
 	s.Docstring = "Whether the user's email has been confirmed."
 
-	symID := mustWriteSymbol(t, ctx, idx, s)
+	symID := mustWriteSymbol(ctx, t, idx, s)
 
 	got, err := idx.ReadSymbol(ctx, symID)
 	if err != nil {
@@ -213,13 +213,13 @@ func testSymbolUpsertIdempotent(t *testing.T, newIdx Factory) {
 	ctx := context.Background()
 	idx := open(t, newIdx)
 
-	fileID := mustWriteFile(t, ctx, idx, sampleFile("app/services/billing.rb"))
+	fileID := mustWriteFile(ctx, t, idx, sampleFile("app/services/billing.rb"))
 	s := sampleSymbol(fileID, "charge", "BillingService#charge", model.KindMethod)
-	id1 := mustWriteSymbol(t, ctx, idx, s)
+	id1 := mustWriteSymbol(ctx, t, idx, s)
 
 	s2 := sampleSymbol(fileID, "charge", "BillingService#charge", model.KindMethod)
 	s2.LineStart = 42
-	id2 := mustWriteSymbol(t, ctx, idx, s2)
+	id2 := mustWriteSymbol(ctx, t, idx, s2)
 
 	if id1 != id2 {
 		t.Errorf("upsert returned new id: first=%d second=%d", id1, id2)
@@ -230,11 +230,11 @@ func testSymbolSameQualifiedDifferentFile(t *testing.T, newIdx Factory) {
 	ctx := context.Background()
 	idx := open(t, newIdx)
 
-	fileA := mustWriteFile(t, ctx, idx, sampleFile("app/legacy/user.rb"))
-	fileB := mustWriteFile(t, ctx, idx, sampleFile("app/models/user.rb"))
+	fileA := mustWriteFile(ctx, t, idx, sampleFile("app/legacy/user.rb"))
+	fileB := mustWriteFile(ctx, t, idx, sampleFile("app/models/user.rb"))
 
-	idA := mustWriteSymbol(t, ctx, idx, sampleSymbol(fileA, "User", "User", model.KindClass))
-	idB := mustWriteSymbol(t, ctx, idx, sampleSymbol(fileB, "User", "User", model.KindClass))
+	idA := mustWriteSymbol(ctx, t, idx, sampleSymbol(fileA, "User", "User", model.KindClass))
+	idB := mustWriteSymbol(ctx, t, idx, sampleSymbol(fileB, "User", "User", model.KindClass))
 
 	if idA == idB {
 		t.Fatalf("two files with the same qualified name collapsed: id=%d", idA)
@@ -245,20 +245,20 @@ func testSymbolNullablesRoundTrip(t *testing.T, newIdx Factory) {
 	ctx := context.Background()
 	idx := open(t, newIdx)
 
-	fileID := mustWriteFile(t, ctx, idx, sampleFile("app/models/nullable.rb"))
+	fileID := mustWriteFile(ctx, t, idx, sampleFile("app/models/nullable.rb"))
 
 	// Write a parent symbol to hold a valid ParentID reference.
-	parentID := mustWriteSymbol(t, ctx, idx, sampleSymbol(fileID, "Nullable", "Nullable", model.KindClass))
+	parentID := mustWriteSymbol(ctx, t, idx, sampleSymbol(fileID, "Nullable", "Nullable", model.KindClass))
 
 	complexity := 7
 	withValues := sampleSymbol(fileID, "withVals", "Nullable#withVals", model.KindMethod)
 	withValues.ParentID = &parentID
 	withValues.Complexity = &complexity
-	id1 := mustWriteSymbol(t, ctx, idx, withValues)
+	id1 := mustWriteSymbol(ctx, t, idx, withValues)
 
 	nilDefaults := sampleSymbol(fileID, "nilDefaults", "Nullable#nilDefaults", model.KindMethod)
 	// ParentID and Complexity remain nil.
-	id2 := mustWriteSymbol(t, ctx, idx, nilDefaults)
+	id2 := mustWriteSymbol(ctx, t, idx, nilDefaults)
 
 	g1, err := idx.ReadSymbol(ctx, id1)
 	if err != nil {
@@ -291,15 +291,15 @@ func testEdgeRoundTrip(t *testing.T, newIdx Factory) {
 	ctx := context.Background()
 	idx := open(t, newIdx)
 
-	fileID := mustWriteFile(t, ctx, idx, sampleFile("app/controllers/orders_controller.rb"))
-	srcID := mustWriteSymbol(t, ctx, idx, sampleSymbol(fileID, "create", "OrdersController#create", model.KindMethod))
-	tgtID := mustWriteSymbol(t, ctx, idx, sampleSymbol(fileID, "call", "CheckoutService.call", model.KindMethod))
+	fileID := mustWriteFile(ctx, t, idx, sampleFile("app/controllers/orders_controller.rb"))
+	srcID := mustWriteSymbol(ctx, t, idx, sampleSymbol(fileID, "create", "OrdersController#create", model.KindMethod))
+	tgtID := mustWriteSymbol(ctx, t, idx, sampleSymbol(fileID, "call", "CheckoutService.call", model.KindMethod))
 
 	// Use a non-default Confidence so an adapter that silently hardcodes 1.0
 	// or zeroes Confidence on read is detected.
 	e := sampleEdge(srcID, tgtID, fileID, model.EdgeCalls)
 	e.Confidence = 0.7
-	mustWriteEdge(t, ctx, idx, e)
+	mustWriteEdge(ctx, t, idx, e)
 
 	src, err := idx.ReadSymbol(ctx, srcID)
 	if err != nil {
@@ -338,15 +338,15 @@ func testEdgeUpsertIdempotent(t *testing.T, newIdx Factory) {
 	ctx := context.Background()
 	idx := open(t, newIdx)
 
-	fileID := mustWriteFile(t, ctx, idx, sampleFile("app/jobs/checkout_job.rb"))
-	srcID := mustWriteSymbol(t, ctx, idx, sampleSymbol(fileID, "perform", "CheckoutJob#perform", model.KindMethod))
-	tgtID := mustWriteSymbol(t, ctx, idx, sampleSymbol(fileID, "call", "CheckoutService.call", model.KindMethod))
+	fileID := mustWriteFile(ctx, t, idx, sampleFile("app/jobs/checkout_job.rb"))
+	srcID := mustWriteSymbol(ctx, t, idx, sampleSymbol(fileID, "perform", "CheckoutJob#perform", model.KindMethod))
+	tgtID := mustWriteSymbol(ctx, t, idx, sampleSymbol(fileID, "call", "CheckoutService.call", model.KindMethod))
 
-	id1 := mustWriteEdge(t, ctx, idx, sampleEdge(srcID, tgtID, fileID, model.EdgeCalls))
+	id1 := mustWriteEdge(ctx, t, idx, sampleEdge(srcID, tgtID, fileID, model.EdgeCalls))
 
 	e2 := sampleEdge(srcID, tgtID, fileID, model.EdgeCalls)
 	e2.Confidence = 0.7
-	id2 := mustWriteEdge(t, ctx, idx, e2)
+	id2 := mustWriteEdge(ctx, t, idx, e2)
 
 	if id1 != id2 {
 		t.Errorf("upsert returned new id: first=%d second=%d", id1, id2)
@@ -387,10 +387,10 @@ func testQueryByKind(t *testing.T, newIdx Factory) {
 	ctx := context.Background()
 	idx := open(t, newIdx)
 
-	fileID := mustWriteFile(t, ctx, idx, sampleFile("app/models/order.rb"))
-	mustWriteSymbol(t, ctx, idx, sampleSymbol(fileID, "Order", "Order", model.KindClass))
-	mustWriteSymbol(t, ctx, idx, sampleSymbol(fileID, "total", "Order#total", model.KindMethod))
-	mustWriteSymbol(t, ctx, idx, sampleSymbol(fileID, "finalize", "Order#finalize", model.KindMethod))
+	fileID := mustWriteFile(ctx, t, idx, sampleFile("app/models/order.rb"))
+	mustWriteSymbol(ctx, t, idx, sampleSymbol(fileID, "Order", "Order", model.KindClass))
+	mustWriteSymbol(ctx, t, idx, sampleSymbol(fileID, "total", "Order#total", model.KindMethod))
+	mustWriteSymbol(ctx, t, idx, sampleSymbol(fileID, "finalize", "Order#finalize", model.KindMethod))
 
 	got, err := idx.Query(ctx, index.Filter{Kind: model.KindMethod})
 	if err != nil {
@@ -410,11 +410,11 @@ func testQueryByFileID(t *testing.T, newIdx Factory) {
 	ctx := context.Background()
 	idx := open(t, newIdx)
 
-	fileA := mustWriteFile(t, ctx, idx, sampleFile("app/models/a.rb"))
-	fileB := mustWriteFile(t, ctx, idx, sampleFile("app/models/b.rb"))
-	mustWriteSymbol(t, ctx, idx, sampleSymbol(fileA, "A", "A", model.KindClass))
-	mustWriteSymbol(t, ctx, idx, sampleSymbol(fileA, "x", "A#x", model.KindMethod))
-	mustWriteSymbol(t, ctx, idx, sampleSymbol(fileB, "B", "B", model.KindClass))
+	fileA := mustWriteFile(ctx, t, idx, sampleFile("app/models/a.rb"))
+	fileB := mustWriteFile(ctx, t, idx, sampleFile("app/models/b.rb"))
+	mustWriteSymbol(ctx, t, idx, sampleSymbol(fileA, "A", "A", model.KindClass))
+	mustWriteSymbol(ctx, t, idx, sampleSymbol(fileA, "x", "A#x", model.KindMethod))
+	mustWriteSymbol(ctx, t, idx, sampleSymbol(fileB, "B", "B", model.KindClass))
 
 	got, err := idx.Query(ctx, index.Filter{FileID: fileA})
 	if err != nil {
@@ -434,9 +434,9 @@ func testQueryByName(t *testing.T, newIdx Factory) {
 	ctx := context.Background()
 	idx := open(t, newIdx)
 
-	fileID := mustWriteFile(t, ctx, idx, sampleFile("app/services/payments.rb"))
-	mustWriteSymbol(t, ctx, idx, sampleSymbol(fileID, "charge", "Payments#charge", model.KindMethod))
-	mustWriteSymbol(t, ctx, idx, sampleSymbol(fileID, "refund", "Payments#refund", model.KindMethod))
+	fileID := mustWriteFile(ctx, t, idx, sampleFile("app/services/payments.rb"))
+	mustWriteSymbol(ctx, t, idx, sampleSymbol(fileID, "charge", "Payments#charge", model.KindMethod))
+	mustWriteSymbol(ctx, t, idx, sampleSymbol(fileID, "refund", "Payments#refund", model.KindMethod))
 
 	got, err := idx.Query(ctx, index.Filter{Name: "charge"})
 	if err != nil {
@@ -451,10 +451,10 @@ func testQueryLimit(t *testing.T, newIdx Factory) {
 	ctx := context.Background()
 	idx := open(t, newIdx)
 
-	fileID := mustWriteFile(t, ctx, idx, sampleFile("app/models/many.rb"))
+	fileID := mustWriteFile(ctx, t, idx, sampleFile("app/models/many.rb"))
 	for i := 0; i < 5; i++ {
 		name := string(rune('a' + i))
-		mustWriteSymbol(t, ctx, idx, sampleSymbol(fileID, name, "Many#"+name, model.KindMethod))
+		mustWriteSymbol(ctx, t, idx, sampleSymbol(fileID, name, "Many#"+name, model.KindMethod))
 	}
 
 	got, err := idx.Query(ctx, index.Filter{Limit: 3})
@@ -470,8 +470,8 @@ func testClear(t *testing.T, newIdx Factory) {
 	ctx := context.Background()
 	idx := open(t, newIdx)
 
-	fileID := mustWriteFile(t, ctx, idx, sampleFile("app/models/temp.rb"))
-	symID := mustWriteSymbol(t, ctx, idx, sampleSymbol(fileID, "Temp", "Temp", model.KindClass))
+	fileID := mustWriteFile(ctx, t, idx, sampleFile("app/models/temp.rb"))
+	symID := mustWriteSymbol(ctx, t, idx, sampleSymbol(fileID, "Temp", "Temp", model.KindClass))
 
 	if err := idx.Clear(ctx); err != nil {
 		t.Fatalf("Clear: %v", err)

--- a/internal/mcpio/graph.go
+++ b/internal/mcpio/graph.go
@@ -198,6 +198,7 @@ func categorizeEdges(outbound, inbound []model.EdgeRef, files FileLookup, direct
 					Symbol: qualifiedOrName(e.Target),
 					File:   fileRefOrNil(e.Target.FileID, files),
 				})
+			default:
 			}
 		}
 	}
@@ -233,6 +234,7 @@ func categorizeEdges(outbound, inbound []model.EdgeRef, files FileLookup, direct
 						Confidence: Confidence(e.Edge.Confidence),
 					})
 				}
+			default:
 			}
 		}
 	}

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -96,14 +96,25 @@ type NextStep struct {
 // that do not compute it (the CLI in 01-04) omit the block entirely;
 // the MCP server in 01-05 always populates it.
 type GraphResponse struct {
-	Symbol             GraphSymbol        `json:"symbol"`
-	Edges              GraphEdges         `json:"edges"`
-	Layers             []GraphLayer       `json:"layers,omitempty"`
-	Truncated          bool               `json:"truncated,omitempty"`
-	TestCallerSummary  *TestCallerSummary `json:"test_caller_summary,omitempty"`
-	SenseMetrics       GraphMetrics       `json:"-"`
-	Freshness          *Freshness         `json:"freshness,omitempty"`
-	NextSteps          []NextStep         `json:"next_steps"`
+	Symbol             GraphSymbol            `json:"symbol"`
+	Edges              GraphEdges             `json:"edges"`
+	DispatchInferred   []DispatchInferredRef  `json:"dispatch_inferred,omitempty"`
+	Layers             []GraphLayer           `json:"layers,omitempty"`
+	Truncated          bool                   `json:"truncated,omitempty"`
+	TestCallerSummary  *TestCallerSummary     `json:"test_caller_summary,omitempty"`
+	SenseMetrics       GraphMetrics           `json:"-"`
+	Freshness          *Freshness             `json:"freshness,omitempty"`
+	NextSteps          []NextStep             `json:"next_steps"`
+}
+
+// DispatchInferredRef is a caller discovered through interface dispatch —
+// the caller invokes a method on a type connected via inherits edges,
+// not the queried symbol directly.
+type DispatchInferredRef struct {
+	Symbol     string     `json:"symbol"`
+	File       *string    `json:"file"`
+	Via        string     `json:"via"`
+	Confidence Confidence `json:"confidence"`
 }
 
 // GraphLayer holds edges discovered at one BFS hop beyond the root.

--- a/internal/mcpserver/dispatch_test.go
+++ b/internal/mcpserver/dispatch_test.go
@@ -1,0 +1,219 @@
+package mcpserver
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/luuuc/sense/internal/mcpio"
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+func openTestAdapter(t *testing.T) (*sqlite.Adapter, *sql.DB) {
+	t.Helper()
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "index.db")
+
+	adapter, err := sqlite.Open(ctx, path)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	db, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	return adapter, db
+}
+
+func seedInterfaceFixture(t *testing.T, db *sql.DB) {
+	t.Helper()
+	ctx := context.Background()
+	stmts := []string{
+		`INSERT INTO sense_files (id, path, language, hash, symbols, indexed_at) VALUES (1, 'iface.go', 'go', 'abc', 0, '2026-01-01T00:00:00Z')`,
+		`INSERT INTO sense_files (id, path, language, hash, symbols, indexed_at) VALUES (2, 'caller.go', 'go', 'def', 0, '2026-01-01T00:00:00Z')`,
+
+		// Interface I with method M
+		`INSERT INTO sense_symbols (id, file_id, name, qualified, kind, line_start, line_end) VALUES (10, 1, 'I', 'pkg.I', 'interface', 1, 10)`,
+		`INSERT INTO sense_symbols (id, file_id, name, qualified, kind, line_start, line_end, parent_id) VALUES (11, 1, 'M', 'pkg.I.M', 'method', 2, 5, 10)`,
+
+		// Struct S implementing I, with method M
+		`INSERT INTO sense_symbols (id, file_id, name, qualified, kind, line_start, line_end) VALUES (20, 1, 'S', 'pkg.S', 'class', 20, 40)`,
+		`INSERT INTO sense_symbols (id, file_id, name, qualified, kind, line_start, line_end, parent_id) VALUES (21, 1, 'M', 'pkg.S.M', 'method', 22, 30, 20)`,
+
+		// S inherits I
+		`INSERT INTO sense_edges (source_id, target_id, kind, file_id, confidence) VALUES (20, 10, 'inherits', 1, 1.0)`,
+
+		// F calls S.M (caller of the struct method)
+		`INSERT INTO sense_symbols (id, file_id, name, qualified, kind, line_start, line_end) VALUES (30, 2, 'F', 'pkg.F', 'function', 1, 5)`,
+		`INSERT INTO sense_edges (source_id, target_id, kind, file_id, confidence) VALUES (30, 21, 'calls', 2, 1.0)`,
+
+		// G calls I.M (caller through the interface)
+		`INSERT INTO sense_symbols (id, file_id, name, qualified, kind, line_start, line_end) VALUES (40, 2, 'G', 'pkg.G', 'function', 10, 15)`,
+		`INSERT INTO sense_edges (source_id, target_id, kind, file_id, confidence) VALUES (40, 11, 'calls', 2, 1.0)`,
+	}
+	for _, q := range stmts {
+		if _, err := db.ExecContext(ctx, q); err != nil {
+			t.Fatalf("seed: %v\nquery: %s", err, q)
+		}
+	}
+}
+
+func makeHandlers(adapter *sqlite.Adapter, db *sql.DB) *handlers {
+	return &handlers{adapter: adapter, db: db}
+}
+
+func fileLookup(files map[int64]string) mcpio.FileLookup {
+	return func(id int64) (string, bool) {
+		p, ok := files[id]
+		return p, ok
+	}
+}
+
+func TestGraphResolvesInterfaceCallers(t *testing.T) {
+	adapter, db := openTestAdapter(t)
+	seedInterfaceFixture(t, db)
+	ctx := context.Background()
+	h := makeHandlers(adapter, db)
+
+	ifaceParent := int64(10)
+	root := &model.SymbolContext{
+		Symbol: model.Symbol{ID: 11, Name: "M", Qualified: "pkg.I.M", Kind: model.KindMethod, ParentID: &ifaceParent},
+	}
+	resp := &mcpio.GraphResponse{
+		Symbol: mcpio.GraphSymbol{Name: "M", Qualified: "pkg.I.M", Kind: "method"},
+		Edges: mcpio.GraphEdges{
+			CalledBy: []mcpio.CallEdgeRef{{Symbol: "pkg.G", File: strPtr("caller.go"), Confidence: 1.0}},
+		},
+	}
+	lookup := fileLookup(map[int64]string{1: "iface.go", 2: "caller.go"})
+
+	inferred := h.resolveDispatchCallers(ctx, root, resp, lookup)
+	if len(inferred) != 1 {
+		t.Fatalf("want 1 inferred caller, got %d: %+v", len(inferred), inferred)
+	}
+	if inferred[0].Symbol != "pkg.F" {
+		t.Errorf("inferred[0].Symbol = %q, want pkg.F", inferred[0].Symbol)
+	}
+	if inferred[0].Via != "pkg.S.M" {
+		t.Errorf("inferred[0].Via = %q, want pkg.S.M", inferred[0].Via)
+	}
+}
+
+func TestGraphResolvesReverseInterfaceCallers(t *testing.T) {
+	adapter, db := openTestAdapter(t)
+	seedInterfaceFixture(t, db)
+	ctx := context.Background()
+	h := makeHandlers(adapter, db)
+
+	structParent := int64(20)
+	root := &model.SymbolContext{
+		Symbol: model.Symbol{ID: 21, Name: "M", Qualified: "pkg.S.M", Kind: model.KindMethod, ParentID: &structParent},
+	}
+	resp := &mcpio.GraphResponse{
+		Symbol: mcpio.GraphSymbol{Name: "M", Qualified: "pkg.S.M", Kind: "method"},
+		Edges: mcpio.GraphEdges{
+			CalledBy: []mcpio.CallEdgeRef{{Symbol: "pkg.F", File: strPtr("caller.go"), Confidence: 1.0}},
+		},
+	}
+	lookup := fileLookup(map[int64]string{1: "iface.go", 2: "caller.go"})
+
+	inferred := h.resolveDispatchCallers(ctx, root, resp, lookup)
+	if len(inferred) != 1 {
+		t.Fatalf("want 1 inferred caller, got %d: %+v", len(inferred), inferred)
+	}
+	if inferred[0].Symbol != "pkg.G" {
+		t.Errorf("inferred[0].Symbol = %q, want pkg.G", inferred[0].Symbol)
+	}
+	if inferred[0].Via != "pkg.I.M" {
+		t.Errorf("inferred[0].Via = %q, want pkg.I.M", inferred[0].Via)
+	}
+}
+
+func TestGraphNoInterfaceResolutionAtThreshold(t *testing.T) {
+	adapter, db := openTestAdapter(t)
+	seedInterfaceFixture(t, db)
+	ctx := context.Background()
+	h := makeHandlers(adapter, db)
+
+	ifaceParent := int64(10)
+	root := &model.SymbolContext{
+		Symbol: model.Symbol{ID: 11, Name: "M", Qualified: "pkg.I.M", Kind: model.KindMethod, ParentID: &ifaceParent},
+	}
+	callers := make([]mcpio.CallEdgeRef, InterfaceResolutionThreshold)
+	for i := range callers {
+		callers[i] = mcpio.CallEdgeRef{Symbol: "caller" + string(rune('A'+i))}
+	}
+	resp := &mcpio.GraphResponse{
+		Symbol: mcpio.GraphSymbol{Name: "M", Qualified: "pkg.I.M", Kind: "method"},
+		Edges:  mcpio.GraphEdges{CalledBy: callers},
+	}
+	lookup := fileLookup(nil)
+
+	inferred := h.resolveDispatchCallers(ctx, root, resp, lookup)
+	if len(inferred) != 0 {
+		t.Errorf("want 0 inferred at threshold (%d callers), got %d", InterfaceResolutionThreshold, len(inferred))
+	}
+}
+
+func TestGraphInterfaceResolutionBelowThreshold(t *testing.T) {
+	adapter, db := openTestAdapter(t)
+	seedInterfaceFixture(t, db)
+	ctx := context.Background()
+	h := makeHandlers(adapter, db)
+
+	ifaceParent := int64(10)
+	root := &model.SymbolContext{
+		Symbol: model.Symbol{ID: 11, Name: "M", Qualified: "pkg.I.M", Kind: model.KindMethod, ParentID: &ifaceParent},
+	}
+	callers := make([]mcpio.CallEdgeRef, InterfaceResolutionThreshold-1)
+	for i := range callers {
+		callers[i] = mcpio.CallEdgeRef{Symbol: "caller" + string(rune('A'+i))}
+	}
+	resp := &mcpio.GraphResponse{
+		Symbol: mcpio.GraphSymbol{Name: "M", Qualified: "pkg.I.M", Kind: "method"},
+		Edges:  mcpio.GraphEdges{CalledBy: callers},
+	}
+	lookup := fileLookup(map[int64]string{1: "iface.go", 2: "caller.go"})
+
+	inferred := h.resolveDispatchCallers(ctx, root, resp, lookup)
+	if len(inferred) == 0 {
+		t.Error("want inferred callers below threshold, got 0")
+	}
+}
+
+func TestGraphConfidenceValue(t *testing.T) {
+	adapter, db := openTestAdapter(t)
+	seedInterfaceFixture(t, db)
+	ctx := context.Background()
+	h := makeHandlers(adapter, db)
+
+	ifaceParent := int64(10)
+	root := &model.SymbolContext{
+		Symbol: model.Symbol{ID: 11, Name: "M", Qualified: "pkg.I.M", Kind: model.KindMethod, ParentID: &ifaceParent},
+	}
+	resp := &mcpio.GraphResponse{
+		Symbol: mcpio.GraphSymbol{Name: "M", Qualified: "pkg.I.M", Kind: "method"},
+		Edges:  mcpio.GraphEdges{CalledBy: []mcpio.CallEdgeRef{}},
+	}
+	lookup := fileLookup(map[int64]string{1: "iface.go", 2: "caller.go"})
+
+	inferred := h.resolveDispatchCallers(ctx, root, resp, lookup)
+	if len(inferred) == 0 {
+		t.Fatal("expected inferred callers")
+	}
+	for i, ref := range inferred {
+		if float64(ref.Confidence) != DispatchInferredConfidence {
+			t.Errorf("inferred[%d].Confidence = %v, want %v", i, ref.Confidence, DispatchInferredConfidence)
+		}
+	}
+}
+
+func strPtr(s string) *string { return &s }

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -40,6 +40,16 @@ import (
 
 const serverInstructions = mcpio.ServerInstructions
 
+const (
+	// Skip interface resolution when direct callers already provide sufficient evidence.
+	InterfaceResolutionThreshold = 3
+	// Interface-dispatch inferred callers are structural but indirect.
+	DispatchInferredConfidence = 0.8
+	// Caps to bound query-time work when an interface has many implementors.
+	maxDispatchEquivalents = 20
+	maxDispatchInferred    = 50
+)
+
 // RunOptions configures the MCP server.
 type RunOptions struct {
 	Dir        string
@@ -243,7 +253,9 @@ func graphTool() mcp.Tool {
 			"inheritance, composition, includes, imports, and test coverage. "+
 			"Use this instead of grep or file reading when the user asks about relationships, dependencies, "+
 			"callers, or how a symbol connects to the rest of the codebase. "+
-			"Returns a pre-computed graph from the Sense index with no context window cost for file contents.\n\n"+
+			"Returns a pre-computed graph from the Sense index with no context window cost for file contents. "+
+			"For symbols called through interfaces or traits, dispatch-inferred callers appear in a separate "+
+			"dispatch_inferred field (confidence 0.8).\n\n"+
 			"When dead_code is true, returns project-wide dead symbols (zero incoming references) instead of "+
 			"per-symbol edges. The symbol, direction, and depth parameters are ignored in this mode."),
 		mcp.WithToolAnnotation(mcp.ToolAnnotation{
@@ -385,6 +397,14 @@ func (h *handlers) handleGraph(ctx context.Context, req mcp.CallToolRequest) (*m
 		SegmentCallers: h.defaults.GraphSegmentCallers,
 	}
 	resp := mcpio.BuildFullGraphResponse(gr, lookup, buildReq)
+
+	if direction != model.DirectionCallees {
+		inferred := h.resolveDispatchCallers(ctx, &gr.Root, &resp, lookup)
+		if len(inferred) > 0 {
+			resp.DispatchInferred = inferred
+		}
+	}
+
 	h.tracker.Record("sense.graph", symbol,
 		resp.SenseMetrics.EstimatedFileReadsAvoided, resp.SenseMetrics.EstimatedTokensSaved)
 
@@ -397,6 +417,74 @@ func (h *handlers) handleGraph(ctx context.Context, req mcp.CallToolRequest) (*m
 		return nil, fmt.Errorf("sense.graph: marshal: %w", err)
 	}
 	return mcp.NewToolResultText(string(out)), nil
+}
+
+func (h *handlers) resolveDispatchCallers(ctx context.Context, root *model.SymbolContext, resp *mcpio.GraphResponse, lookup mcpio.FileLookup) []mcpio.DispatchInferredRef {
+	sym := root.Symbol
+	if sym.Kind != model.KindMethod || sym.ParentID == nil {
+		return nil
+	}
+	if len(resp.Edges.CalledBy) >= InterfaceResolutionThreshold {
+		return nil
+	}
+
+	equivIDs, err := sqlite.DispatchMethodIDs(ctx, h.db, sym.ID)
+	if err != nil || len(equivIDs) == 0 {
+		return nil
+	}
+	if len(equivIDs) > maxDispatchEquivalents {
+		equivIDs = equivIDs[:maxDispatchEquivalents]
+	}
+
+	directCallers := make(map[string]struct{}, len(resp.Edges.CalledBy))
+	for _, c := range resp.Edges.CalledBy {
+		directCallers[c.Symbol] = struct{}{}
+	}
+
+	var inferred []mcpio.DispatchInferredRef
+	for _, eqID := range equivIDs {
+		if len(inferred) >= maxDispatchInferred {
+			break
+		}
+		eqSym, err := h.adapter.ReadSymbol(ctx, eqID)
+		if err != nil {
+			continue
+		}
+		via := qualifiedOrNameRef(eqSym.Symbol)
+
+		for _, e := range eqSym.Inbound {
+			if e.Edge.Kind != model.EdgeCalls {
+				continue
+			}
+			if len(inferred) >= maxDispatchInferred {
+				break
+			}
+			callerName := qualifiedOrNameRef(e.Target)
+			if _, dup := directCallers[callerName]; dup {
+				continue
+			}
+			directCallers[callerName] = struct{}{}
+
+			var filePath *string
+			if p, ok := lookup(e.Target.FileID); ok {
+				filePath = &p
+			}
+			inferred = append(inferred, mcpio.DispatchInferredRef{
+				Symbol:     callerName,
+				File:       filePath,
+				Via:        via,
+				Confidence: mcpio.Confidence(DispatchInferredConfidence),
+			})
+		}
+	}
+	return inferred
+}
+
+func qualifiedOrNameRef(s model.Symbol) string {
+	if s.Qualified != "" {
+		return s.Qualified
+	}
+	return s.Name
 }
 
 func graphHints(resp mcpio.GraphResponse, direction model.Direction) []mcpio.NextStep {

--- a/internal/metrics/tracker_test.go
+++ b/internal/metrics/tracker_test.go
@@ -58,6 +58,7 @@ func TestTrackerTopQuery(t *testing.T) {
 	top := tr.TopQuery()
 	if top == nil {
 		t.Fatal("expected non-nil top query")
+		return
 	}
 	if top.Tool != "sense.blast" {
 		t.Errorf("top tool = %q, want sense.blast", top.Tool)

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -272,6 +272,7 @@ func TestStoreAndLoad(t *testing.T) {
 	loaded := Load(ctx, db)
 	if loaded == nil {
 		t.Fatal("Load returned nil")
+		return
 	}
 	if loaded.Tier != original.Tier {
 		t.Errorf("tier = %q, want %q", loaded.Tier, original.Tier)

--- a/internal/scan/satisfy.go
+++ b/internal/scan/satisfy.go
@@ -85,6 +85,7 @@ func (h *harness) satisfyInterfaces() error {
 				sym:     *s,
 				methods: map[string]bool{},
 			}
+		default:
 		}
 	}
 

--- a/internal/search/hnsw_test.go
+++ b/internal/search/hnsw_test.go
@@ -232,10 +232,8 @@ func TestUpdateHNSWIndexUpsert(t *testing.T) {
 		if len(results) == 0 {
 			t.Error("expected non-empty results after incremental update")
 		}
-	} else {
-		if loaded.Len() != n {
-			t.Fatalf("expected original %d vectors after fallback, got %d", n, loaded.Len())
-		}
+	} else if loaded.Len() != n {
+		t.Fatalf("expected original %d vectors after fallback, got %d", n, loaded.Len())
 	}
 }
 
@@ -292,11 +290,9 @@ func TestUpdateHNSWIndexWithRemoval(t *testing.T) {
 		if len(results) == 0 {
 			t.Error("expected non-empty results after incremental update")
 		}
-	} else {
+	} else if loaded.Len() != n {
 		// Verification caught corruption — original index is untouched
-		if loaded.Len() != n {
-			t.Fatalf("expected original %d vectors after fallback, got %d", n, loaded.Len())
-		}
+		t.Fatalf("expected original %d vectors after fallback, got %d", n, loaded.Len())
 	}
 }
 

--- a/internal/search/normalize_test.go
+++ b/internal/search/normalize_test.go
@@ -42,6 +42,6 @@ func TestNormalizeScoresNormalSpread(t *testing.T) {
 	}
 }
 
-func TestNormalizeScoresEmpty(t *testing.T) {
+func TestNormalizeScoresEmpty(_ *testing.T) {
 	normalizeScores(nil)
 }

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -19,7 +19,7 @@ import (
 
 // seedFusionIndex creates a small index with symbols, edges, and
 // embeddings suitable for testing RRF fusion behavior.
-func seedFusionIndex(t *testing.T, ctx context.Context, a *sqlite.Adapter) {
+func seedFusionIndex(ctx context.Context, t *testing.T, a *sqlite.Adapter) {
 	t.Helper()
 
 	fid, err := a.WriteFile(ctx, &model.File{
@@ -149,7 +149,7 @@ func TestFusionBothBackendsRankHigher(t *testing.T) {
 	}
 	defer func() { _ = a.Close() }()
 
-	seedFusionIndex(t, ctx, a)
+	seedFusionIndex(ctx, t, a)
 
 	embeddings, err := a.LoadEmbeddings(ctx)
 	if err != nil {
@@ -196,7 +196,7 @@ func TestFusionKeywordOnly(t *testing.T) {
 	}
 	defer func() { _ = a.Close() }()
 
-	seedFusionIndex(t, ctx, a)
+	seedFusionIndex(ctx, t, a)
 
 	// No vector index, no embedder → keyword-only
 	engine := search.NewEngine(a, nil, nil)
@@ -314,7 +314,7 @@ func TestFusionMinScore(t *testing.T) {
 	}
 	defer func() { _ = a.Close() }()
 
-	seedFusionIndex(t, ctx, a)
+	seedFusionIndex(ctx, t, a)
 
 	engine := search.NewEngine(a, nil, nil)
 
@@ -340,7 +340,7 @@ func TestNormalizeScoresSpread(t *testing.T) {
 	}
 	defer func() { _ = a.Close() }()
 
-	seedFusionIndex(t, ctx, a)
+	seedFusionIndex(ctx, t, a)
 
 	embeddings, err := a.LoadEmbeddings(ctx)
 	if err != nil {
@@ -455,7 +455,7 @@ func TestSearchModeKeyword(t *testing.T) {
 	}
 	defer func() { _ = a.Close() }()
 
-	seedFusionIndex(t, ctx, a)
+	seedFusionIndex(ctx, t, a)
 
 	engine := search.NewEngine(a, nil, nil)
 	_, meta, err := engine.Search(ctx, search.Options{Query: "payment", Limit: 10})
@@ -476,7 +476,7 @@ func TestSearchModeHybrid(t *testing.T) {
 	}
 	defer func() { _ = a.Close() }()
 
-	seedFusionIndex(t, ctx, a)
+	seedFusionIndex(ctx, t, a)
 
 	embeddings, err := a.LoadEmbeddings(ctx)
 	if err != nil {
@@ -503,7 +503,7 @@ func TestSearchModeUpgradeViaSetVectors(t *testing.T) {
 	}
 	defer func() { _ = a.Close() }()
 
-	seedFusionIndex(t, ctx, a)
+	seedFusionIndex(ctx, t, a)
 
 	engine := search.NewEngine(a, nil, &paymentQueryEmbedder{})
 
@@ -622,7 +622,7 @@ func TestFusionWeightsKeywordOnly(t *testing.T) {
 	}
 	defer func() { _ = a.Close() }()
 
-	seedFusionIndex(t, ctx, a)
+	seedFusionIndex(ctx, t, a)
 
 	engine := search.NewEngine(a, nil, nil)
 	_, meta, err := engine.Search(ctx, search.Options{Query: "payment", Limit: 10})
@@ -646,7 +646,7 @@ func TestFusionWeightsHybrid(t *testing.T) {
 	}
 	defer func() { _ = a.Close() }()
 
-	seedFusionIndex(t, ctx, a)
+	seedFusionIndex(ctx, t, a)
 	embeddings, err := a.LoadEmbeddings(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -694,7 +694,7 @@ func TestLowConfidenceVectorFloor(t *testing.T) {
 	}
 	defer func() { _ = a.Close() }()
 
-	seedFusionIndex(t, ctx, a)
+	seedFusionIndex(ctx, t, a)
 
 	embeddings, err := a.LoadEmbeddings(ctx)
 	if err != nil {
@@ -834,7 +834,7 @@ func TestRerankerChangesOrdering(t *testing.T) {
 	}
 	defer func() { _ = a.Close() }()
 
-	seedFusionIndex(t, ctx, a)
+	seedFusionIndex(ctx, t, a)
 
 	engine := search.NewEngine(a, nil, nil)
 
@@ -879,7 +879,7 @@ func TestRerankerMetaFlag(t *testing.T) {
 	}
 	defer func() { _ = a.Close() }()
 
-	seedFusionIndex(t, ctx, a)
+	seedFusionIndex(ctx, t, a)
 
 	engine := search.NewEngine(a, nil, nil)
 
@@ -910,7 +910,7 @@ func TestRerankerGracefulDegradation(t *testing.T) {
 	}
 	defer func() { _ = a.Close() }()
 
-	seedFusionIndex(t, ctx, a)
+	seedFusionIndex(ctx, t, a)
 
 	engine := search.NewEngine(a, nil, nil)
 

--- a/internal/setup/marker.go
+++ b/internal/setup/marker.go
@@ -73,7 +73,8 @@ func writeMarkerFile(path, section string) (bool, error) {
 
 	content := string(data)
 
-	if strings.Contains(content, markerStart) {
+	switch {
+	case strings.Contains(content, markerStart):
 		startIdx := strings.Index(content, markerStart)
 		endIdx := strings.Index(content, markerEnd)
 		if endIdx < 0 {
@@ -82,9 +83,9 @@ func writeMarkerFile(path, section string) (bool, error) {
 			endIdx += len(markerEnd)
 			content = content[:startIdx] + section + content[endIdx:]
 		}
-	} else if len(content) == 0 {
+	case len(content) == 0:
 		content = section + "\n"
-	} else {
+	default:
 		sep := "\n\n"
 		if strings.HasSuffix(content, "\n\n") {
 			sep = ""

--- a/internal/smoke/smoke_test.go
+++ b/internal/smoke/smoke_test.go
@@ -125,7 +125,7 @@ func TestSmoke(t *testing.T) {
 	t.Cleanup(func() { _ = adapter.Close() })
 
 	if *update {
-		generateGroundTruth(t, ctx, adapter, res)
+		generateGroundTruth(ctx, t, adapter, res)
 		return
 	}
 
@@ -332,7 +332,7 @@ func buildFileLangMap(ctx context.Context, t *testing.T, adapter *sqlite.Adapter
 	return m
 }
 
-func generateGroundTruth(t *testing.T, ctx context.Context, adapter *sqlite.Adapter, res *scan.Result) {
+func generateGroundTruth(ctx context.Context, t *testing.T, adapter *sqlite.Adapter, res *scan.Result) {
 	t.Helper()
 
 	allSymbols, err := adapter.Query(ctx, index.Filter{})

--- a/internal/sqlite/context_test.go
+++ b/internal/sqlite/context_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/luuuc/sense/internal/sqlite"
 )
 
-func seedContextFixture(t *testing.T, ctx context.Context, a *sqlite.Adapter) (fileID int64) {
+func seedContextFixture(ctx context.Context, t *testing.T, a *sqlite.Adapter) (fileID int64) {
 	t.Helper()
 
 	fid, err := a.WriteFile(ctx, &model.File{
@@ -99,7 +99,7 @@ func TestContextForFile(t *testing.T) {
 	}
 	defer func() { _ = a.Close() }()
 
-	fileID := seedContextFixture(t, ctx, a)
+	fileID := seedContextFixture(ctx, t, a)
 
 	result, err := a.ContextForFile(ctx, fileID)
 	if err != nil {
@@ -309,7 +309,7 @@ func TestContextForFileEmpty(t *testing.T) {
 //	sym[n-1] → sym[n-2] → … → sym[1] → sym[0]
 //
 // Returns the symbol IDs in order sym[0]…sym[n-1].
-func seedChain(t *testing.T, ctx context.Context, a *sqlite.Adapter, n int) []int64 {
+func seedChain(ctx context.Context, t *testing.T, a *sqlite.Adapter, n int) []int64 {
 	t.Helper()
 	ids := make([]int64, n)
 	for i := range n {
@@ -350,7 +350,7 @@ func TestReadSymbolGraphDepth(t *testing.T) {
 	defer func() { _ = a.Close() }()
 
 	// Chain: S3 → S2 → S1 → S0
-	ids := seedChain(t, ctx, a, 4)
+	ids := seedChain(ctx, t, a, 4)
 
 	t.Run("depth=1 returns root only", func(t *testing.T) {
 		gr, err := a.ReadSymbolGraph(ctx, ids[0], 1, "both", 200)

--- a/internal/sqlite/dispatch.go
+++ b/internal/sqlite/dispatch.go
@@ -1,0 +1,114 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// DispatchMethodIDs finds methods that share a name with the given method
+// but live on types connected through inherits edges. This covers both
+// directions: if the method's parent is an interface, returns methods on
+// implementing types; if the parent is a concrete type, returns methods on
+// the interfaces it implements. Returns nil when the symbol has no parent
+// or no dispatch equivalents exist.
+func DispatchMethodIDs(ctx context.Context, db *sql.DB, symbolID int64) ([]int64, error) {
+	var name string
+	var parentID sql.NullInt64
+	var parentKind sql.NullString
+	err := db.QueryRowContext(ctx,
+		`SELECT s.name, s.parent_id, p.kind
+		 FROM sense_symbols s
+		 LEFT JOIN sense_symbols p ON p.id = s.parent_id
+		 WHERE s.id = ?`, symbolID,
+	).Scan(&name, &parentID, &parentKind)
+	if err != nil {
+		return nil, fmt.Errorf("dispatch: lookup symbol %d: %w", symbolID, err)
+	}
+	if !parentID.Valid {
+		return nil, nil
+	}
+
+	if parentKind.String == "interface" {
+		return dispatchFromInterface(ctx, db, parentID.Int64, name)
+	}
+	return dispatchFromConcrete(ctx, db, parentID.Int64, name)
+}
+
+// dispatchFromInterface: parent is an interface → find methods with the
+// same name on types that inherit from this interface.
+func dispatchFromInterface(ctx context.Context, db *sql.DB, ifaceID int64, methodName string) ([]int64, error) {
+	const q = `SELECT m.id
+		FROM sense_edges e
+		JOIN sense_symbols m ON m.parent_id = e.source_id AND m.name = ?
+		WHERE e.target_id = ? AND e.kind = 'inherits' AND e.source_id IS NOT NULL`
+
+	return collectIDs(ctx, db, q, methodName, ifaceID)
+}
+
+// dispatchFromConcrete: parent is a concrete type → find methods with the
+// same name on interfaces this type inherits from.
+func dispatchFromConcrete(ctx context.Context, db *sql.DB, typeID int64, methodName string) ([]int64, error) {
+	const q = `SELECT m.id
+		FROM sense_edges e
+		JOIN sense_symbols iface ON e.target_id = iface.id AND iface.kind = 'interface'
+		JOIN sense_symbols m ON m.parent_id = iface.id AND m.name = ?
+		WHERE e.source_id = ? AND e.kind = 'inherits'`
+
+	return collectIDs(ctx, db, q, methodName, typeID)
+}
+
+// InterfaceMethodKey identifies a method on an implementing type by its
+// parent type ID and method name.
+type InterfaceMethodKey struct {
+	ParentID   int64
+	MethodName string
+}
+
+// InterfaceAliveMethods finds interface methods that have callers, then maps
+// those to all types that implement those interfaces. Returns a set of
+// (implementor_parent_id, method_name) pairs. This is the bulk variant of
+// DispatchMethodIDs, used by dead-code detection.
+func InterfaceAliveMethods(ctx context.Context, db *sql.DB) (map[InterfaceMethodKey]struct{}, error) {
+	const q = `SELECT impl.source_id, im.name
+		FROM sense_symbols im
+		JOIN sense_edges ie ON ie.target_id = im.id AND ie.kind = 'calls'
+		JOIN sense_symbols iface ON im.parent_id = iface.id AND iface.kind = 'interface'
+		JOIN sense_edges impl ON impl.target_id = iface.id AND impl.kind = 'inherits' AND impl.source_id IS NOT NULL
+		GROUP BY impl.source_id, im.name`
+
+	rows, err := db.QueryContext(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make(map[InterfaceMethodKey]struct{})
+	for rows.Next() {
+		var parentID int64
+		var methodName string
+		if err := rows.Scan(&parentID, &methodName); err != nil {
+			return nil, err
+		}
+		out[InterfaceMethodKey{ParentID: parentID, MethodName: methodName}] = struct{}{}
+	}
+	return out, rows.Err()
+}
+
+func collectIDs(ctx context.Context, db *sql.DB, q string, args ...any) ([]int64, error) {
+	rows, err := db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}

--- a/internal/sqlite/dispatch_test.go
+++ b/internal/sqlite/dispatch_test.go
@@ -1,0 +1,112 @@
+package sqlite_test
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+func openDispatchDB(t *testing.T) *sql.DB {
+	t.Helper()
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "index.db")
+
+	adapter, err := sqlite.Open(ctx, path)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	_ = adapter.Close()
+
+	db, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func seedDispatchFixture(t *testing.T, db *sql.DB) (ifaceMethodID, structMethodID int64) {
+	t.Helper()
+	ctx := context.Background()
+
+	for _, q := range []string{
+		`INSERT INTO sense_files (id, path, language, hash, symbols, indexed_at) VALUES (1, 'iface.go', 'go', 'abc', 0, '2026-01-01T00:00:00Z')`,
+
+		`INSERT INTO sense_symbols (id, file_id, name, qualified, kind, line_start, line_end)
+		 VALUES (10, 1, 'I', 'pkg.I', 'interface', 1, 10)`,
+		`INSERT INTO sense_symbols (id, file_id, name, qualified, kind, line_start, line_end, parent_id)
+		 VALUES (11, 1, 'M', 'pkg.I.M', 'method', 2, 5, 10)`,
+
+		`INSERT INTO sense_symbols (id, file_id, name, qualified, kind, line_start, line_end)
+		 VALUES (20, 1, 'S', 'pkg.S', 'class', 20, 40)`,
+		`INSERT INTO sense_symbols (id, file_id, name, qualified, kind, line_start, line_end, parent_id)
+		 VALUES (21, 1, 'M', 'pkg.S.M', 'method', 22, 30, 20)`,
+
+		// S inherits I
+		`INSERT INTO sense_edges (source_id, target_id, kind, file_id, confidence)
+		 VALUES (20, 10, 'inherits', 1, 1.0)`,
+	} {
+		if _, err := db.ExecContext(ctx, q); err != nil {
+			t.Fatalf("seed: %v\nquery: %s", err, q)
+		}
+	}
+	return 11, 21
+}
+
+func TestInterfaceImplementorsQuery(t *testing.T) {
+	db := openDispatchDB(t)
+	ifaceMethodID, structMethodID := seedDispatchFixture(t, db)
+	ctx := context.Background()
+
+	ids, err := sqlite.DispatchMethodIDs(ctx, db, ifaceMethodID)
+	if err != nil {
+		t.Fatalf("DispatchMethodIDs(interface method): %v", err)
+	}
+	if len(ids) != 1 || ids[0] != structMethodID {
+		t.Errorf("got %v, want [%d]", ids, structMethodID)
+	}
+}
+
+func TestReverseDispatch(t *testing.T) {
+	db := openDispatchDB(t)
+	ifaceMethodID, structMethodID := seedDispatchFixture(t, db)
+	ctx := context.Background()
+
+	ids, err := sqlite.DispatchMethodIDs(ctx, db, structMethodID)
+	if err != nil {
+		t.Fatalf("DispatchMethodIDs(struct method): %v", err)
+	}
+	if len(ids) != 1 || ids[0] != ifaceMethodID {
+		t.Errorf("got %v, want [%d]", ids, ifaceMethodID)
+	}
+}
+
+func TestDispatchNoParent(t *testing.T) {
+	db := openDispatchDB(t)
+	ctx := context.Background()
+
+	_, err := db.ExecContext(ctx,
+		`INSERT INTO sense_files (id, path, language, hash, symbols, indexed_at) VALUES (1, 'f.go', 'go', 'abc', 0, '2026-01-01T00:00:00Z')`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = db.ExecContext(ctx,
+		`INSERT INTO sense_symbols (id, file_id, name, qualified, kind, line_start, line_end)
+		 VALUES (1, 1, 'Func', 'pkg.Func', 'function', 1, 5)`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ids, err := sqlite.DispatchMethodIDs(ctx, db, 1)
+	if err != nil {
+		t.Fatalf("DispatchMethodIDs: %v", err)
+	}
+	if ids != nil {
+		t.Errorf("want nil for parentless symbol, got %v", ids)
+	}
+}

--- a/internal/sqlite/search_test.go
+++ b/internal/sqlite/search_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/luuuc/sense/internal/sqlite"
 )
 
-func seedSearchIndex(t *testing.T, ctx context.Context, a *sqlite.Adapter) {
+func seedSearchIndex(ctx context.Context, t *testing.T, a *sqlite.Adapter) {
 	t.Helper()
 
 	fid, err := a.WriteFile(ctx, &model.File{
@@ -50,7 +50,7 @@ func TestKeywordSearch(t *testing.T) {
 	}
 	defer func() { _ = a.Close() }()
 
-	seedSearchIndex(t, ctx, a)
+	seedSearchIndex(ctx, t, a)
 
 	tests := []struct {
 		name     string
@@ -198,7 +198,7 @@ func TestKeywordSearchSanitization(t *testing.T) {
 	}
 	defer func() { _ = a.Close() }()
 
-	seedSearchIndex(t, ctx, a)
+	seedSearchIndex(ctx, t, a)
 
 	// These queries contain FTS5 syntax that would cause errors without sanitization.
 	badQueries := []string{
@@ -227,7 +227,7 @@ func TestKeywordSearchSQLInjectionPayloads(t *testing.T) {
 	}
 	defer func() { _ = a.Close() }()
 
-	seedSearchIndex(t, ctx, a)
+	seedSearchIndex(ctx, t, a)
 
 	payloads := []string{
 		"'; DROP TABLE sense_symbols; --",
@@ -343,7 +343,7 @@ func TestSymbolCount(t *testing.T) {
 	}
 	defer func() { _ = a.Close() }()
 
-	seedSearchIndex(t, ctx, a)
+	seedSearchIndex(ctx, t, a)
 
 	count, err := a.SymbolCount(ctx)
 	if err != nil {
@@ -490,7 +490,7 @@ func TestMultiWordQueryUsesOR(t *testing.T) {
 	}
 	defer func() { _ = a.Close() }()
 
-	seedSearchIndex(t, ctx, a)
+	seedSearchIndex(ctx, t, a)
 
 	// "credit" appears only in ProcessPayment's docstring, "user" only in
 	// the User symbol. No single document contains both. With OR, both


### PR DESCRIPTION
## Problem

When an agent asks "who calls X?" for a method invoked through an interface or trait, Sense returns 0 callers because the graph only stores direct call edges. The agent trusts the empty result, stops exploring, and misses the real caller set. This cascades into blast-radius, dead-code, and refactoring tasks that all undercount impact.

## Summary

The graph tool now resolves callers through `inherits` edges at query time — surfacing interface-dispatch callers in a separate `dispatch_inferred` field without changing extractors or schema.

## Changes

**Interface dispatch resolution:**
- New `sqlite.DispatchMethodIDs` query resolves method equivalents through `inherits` edges in both directions (interface→implementors, concrete→interfaces)
- Graph handler calls dispatch resolution when a method has fewer than 3 direct callers, returning inferred callers at 0.8 confidence in `dispatch_inferred`
- Deduplicates against direct callers; caps at 20 equivalents and 50 inferred callers

**Refactor:**
- Extracted `InterfaceAliveMethods` from `dead.go` into shared `sqlite/dispatch.go` alongside the new dispatch query

**Lint hardening:**
- Expanded golangci-lint config with govet, gosec, exhaustive, revive, and others
- Fixed all warnings across the codebase (exhaustive switches, parameter ordering, unused params)

## Test Plan
- [x] `TestGraphResolvesInterfaceCallers` — query callers of interface method, assert implementor's callers appear in `dispatch_inferred`
- [x] `TestGraphResolvesReverseInterfaceCallers` — query callers of struct method, assert interface callers appear
- [x] `TestGraphNoInterfaceResolutionAtThreshold` — 3 direct callers → no dispatch resolution
- [x] `TestGraphInterfaceResolutionBelowThreshold` — 2 direct callers → dispatch resolution fires
- [x] `TestGraphConfidenceValue` — inferred callers carry exactly 0.8 confidence
- [x] `TestInterfaceImplementorsQuery` / `TestReverseDispatch` / `TestDispatchNoParent` — SQL layer unit tests
- [x] `go test ./...` passes
- [x] `make lint` passes with expanded linter set