### PR TITLE
feat(search,dead): tune centrality boost and dead-code framework exclusions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,14 @@ jobs:
         run: make build
 
       - name: Test
-        run: go test -v ./...
+        run: go test -v -coverprofile=coverage.txt ./...
+
+      - name: Upload coverage
+        if: matrix.os == 'linux'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.txt
 
       - name: Smoke
         run: make smoke

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/luuuc/sense/actions/workflows/ci.yml/badge.svg)](https://github.com/luuuc/sense/actions/workflows/ci.yml)  [![CodeQL](https://github.com/luuuc/sense/actions/workflows/codeql.yml/badge.svg)](https://github.com/luuuc/sense/actions/workflows/codeql.yml) [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12729/badge)](https://www.bestpractices.dev/projects/12729)
+[![CI](https://github.com/luuuc/sense/actions/workflows/ci.yml/badge.svg)](https://github.com/luuuc/sense/actions/workflows/ci.yml)  [![CodeQL](https://github.com/luuuc/sense/actions/workflows/codeql.yml/badge.svg)](https://github.com/luuuc/sense/actions/workflows/codeql.yml) [![Go Report Card](https://goreportcard.com/badge/github.com/luuuc/sense)](https://goreportcard.com/report/github.com/luuuc/sense) [![codecov](https://codecov.io/gh/luuuc/sense/branch/main/graph/badge.svg)](https://codecov.io/gh/luuuc/sense) [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12729/badge)](https://www.bestpractices.dev/projects/12729)
 
 # Sense ⠎⠑⠝⠎⠑
 

--- a/internal/dead/dead.go
+++ b/internal/dead/dead.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/luuuc/sense/internal/sqlite"
@@ -459,10 +460,12 @@ func readFrameworks(ctx context.Context, db *sql.DB) map[string]struct{} {
 		return out
 	}
 	var names []string
-	if json.Unmarshal([]byte(raw), &names) == nil {
-		for _, n := range names {
-			out[n] = struct{}{}
-		}
+	if err := json.Unmarshal([]byte(raw), &names); err != nil {
+		log.Printf("dead: corrupt frameworks meta: %v", err)
+		return out
+	}
+	for _, n := range names {
+		out[n] = struct{}{}
 	}
 	return out
 }

--- a/internal/dead/dead.go
+++ b/internal/dead/dead.go
@@ -3,6 +3,7 @@ package dead
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -25,6 +26,7 @@ type Symbol struct {
 	Kind       string
 	File       string
 	FileID     int64
+	Language   string
 	LineStart  int
 	LineEnd    int
 	ParentID   *int64
@@ -67,7 +69,8 @@ func FindDead(ctx context.Context, db *sql.DB, opts Options) (Result, error) {
 		return Result{}, fmt.Errorf("dead: query interface IDs: %w", err)
 	}
 
-	candidates = excludeEntryPoints(candidates, testsTargets, interfaceIDs)
+	frameworks := readFrameworks(ctx, db)
+	candidates = excludeEntryPoints(candidates, testsTargets, interfaceIDs, frameworks)
 
 	liveContainers, err := findLiveContainers(ctx, db, candidates)
 	if err != nil {
@@ -134,7 +137,7 @@ func queryCandidates(ctx context.Context, db *sql.DB, opts Options) ([]Symbol, e
 			)`
 	}
 
-	q := `SELECT s.id, s.name, s.qualified, s.kind, f.path, s.file_id, s.line_start, s.line_end, s.parent_id
+	q := `SELECT s.id, s.name, s.qualified, s.kind, f.path, s.file_id, f.language, s.line_start, s.line_end, s.parent_id
 		FROM sense_symbols s
 		JOIN sense_files f ON s.file_id = f.id
 		WHERE NOT EXISTS (` + edgeFilter + `)
@@ -163,7 +166,7 @@ func queryCandidates(ctx context.Context, db *sql.DB, opts Options) ([]Symbol, e
 		var sym Symbol
 		var parentID sql.NullInt64
 		if err := rows.Scan(&sym.ID, &sym.Name, &sym.Qualified, &sym.Kind,
-			&sym.File, &sym.FileID, &sym.LineStart, &sym.LineEnd, &parentID); err != nil {
+			&sym.File, &sym.FileID, &sym.Language, &sym.LineStart, &sym.LineEnd, &parentID); err != nil {
 			return nil, err
 		}
 		if parentID.Valid {
@@ -234,10 +237,10 @@ func queryInterfaceImplementors(ctx context.Context, db *sql.DB) (map[int64]stru
 	return out, rows.Err()
 }
 
-func excludeEntryPoints(candidates []Symbol, testsTargets, interfaceIDs map[int64]struct{}) []Symbol {
+func excludeEntryPoints(candidates []Symbol, testsTargets, interfaceIDs map[int64]struct{}, frameworks map[string]struct{}) []Symbol {
 	var out []Symbol
 	for _, s := range candidates {
-		if isEntryPoint(s, testsTargets, interfaceIDs) {
+		if isEntryPoint(s, testsTargets, interfaceIDs, frameworks) {
 			continue
 		}
 		out = append(out, s)
@@ -333,7 +336,7 @@ func excludeIDs(candidates []Symbol, exclude map[int64]struct{}) []Symbol {
 	return out
 }
 
-func isEntryPoint(s Symbol, testsTargets map[int64]struct{}, interfaceIDs map[int64]struct{}) bool {
+func isEntryPoint(s Symbol, testsTargets, interfaceIDs map[int64]struct{}, frameworks map[string]struct{}) bool {
 	if isMainFunction(s) {
 		return true
 	}
@@ -346,7 +349,7 @@ func isEntryPoint(s Symbol, testsTargets map[int64]struct{}, interfaceIDs map[in
 	if isConstructor(s) {
 		return true
 	}
-	if isFrameworkHook(s) {
+	if isFrameworkHook(s, frameworks) {
 		return true
 	}
 	if isInterfaceMethod(s, interfaceIDs) {
@@ -393,20 +396,75 @@ func isConstructor(s Symbol) bool {
 }
 
 var frameworkHooks = map[string]struct{}{
+	// Test lifecycle
 	"setUp": {}, "tearDown": {}, "setUpClass": {}, "tearDownClass": {},
+	"setup": {}, "teardown": {},
+	"BeforeEach": {}, "AfterEach": {}, "BeforeAll": {}, "AfterAll": {},
+	// Rails callbacks
 	"before_action": {}, "after_action": {}, "around_action": {},
 	"before_create": {}, "after_create": {}, "before_save": {}, "after_save": {},
 	"before_destroy": {}, "after_destroy": {}, "before_update": {}, "after_update": {},
 	"before_validation": {}, "after_validation": {},
-	"setup": {}, "teardown": {},
-	"BeforeEach": {}, "AfterEach": {}, "BeforeAll": {}, "AfterAll": {},
+	// React lifecycle
 	"componentDidMount": {}, "componentWillUnmount": {}, "componentDidUpdate": {},
+	// Go HTTP
 	"ServeHTTP": {},
+	// Android lifecycle (unique prefixes, safe globally)
+	"onCreate": {}, "onResume": {}, "onDestroy": {}, "onBind": {}, "onStartCommand": {},
 }
 
-func isFrameworkHook(s Symbol) bool {
-	_, ok := frameworkHooks[s.Name]
-	return ok
+// jvmFrameworkHooks are entry points too generic for all languages
+// but valid in Java/Kotlin/Scala. Includes functional interface
+// method names and common SAM type names (SAM detection was cut
+// because the graph lacks abstract method tagging).
+var jvmFrameworkHooks = map[string]struct{}{
+	"handle": {}, "create": {}, "configure": {}, "routes": {}, "addEndpoints": {}, "register": {},
+	"accept": {}, "apply": {}, "run": {}, "get": {}, "test": {}, "compare": {},
+	"Runnable": {}, "Callable": {}, "Supplier": {}, "Consumer": {}, "Function": {}, "Predicate": {},
+	"EndpointGroup": {}, "ExceptionHandler": {}, "ThrowingConsumer": {}, "ThrowingRunnable": {},
+	"RequestLogger": {},
+}
+
+var railsHooks = map[string]struct{}{
+	"after_commit": {}, "included": {}, "class_methods": {},
+	"before_commit": {}, "after_rollback": {},
+}
+
+func isJVMLanguage(lang string) bool {
+	return lang == "java" || lang == "kotlin" || lang == "scala"
+}
+
+func isFrameworkHook(s Symbol, frameworks map[string]struct{}) bool {
+	if _, ok := frameworkHooks[s.Name]; ok {
+		return true
+	}
+	if isJVMLanguage(s.Language) {
+		if _, ok := jvmFrameworkHooks[s.Name]; ok {
+			return true
+		}
+	}
+	if _, ok := frameworks["Rails"]; ok {
+		if _, ok := railsHooks[s.Name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func readFrameworks(ctx context.Context, db *sql.DB) map[string]struct{} {
+	out := map[string]struct{}{}
+	var raw string
+	err := db.QueryRowContext(ctx, `SELECT value FROM sense_meta WHERE key = 'frameworks'`).Scan(&raw)
+	if err != nil {
+		return out
+	}
+	var names []string
+	if json.Unmarshal([]byte(raw), &names) == nil {
+		for _, n := range names {
+			out[n] = struct{}{}
+		}
+	}
+	return out
 }
 
 func isInterfaceMethod(s Symbol, interfaceIDs map[int64]struct{}) bool {
@@ -438,6 +496,10 @@ const (
 	ConfidencePossibly = "possibly_dead"
 )
 
+func isGoConstructor(s Symbol) bool {
+	return s.Language == "go" && strings.HasPrefix(s.Name, "New") && s.Kind == "function"
+}
+
 func annotateConfidence(candidates []Symbol, interfaceIDs, implementorIDs map[int64]struct{}) []Symbol {
 	for i := range candidates {
 		s := &candidates[i]
@@ -450,6 +512,10 @@ func annotateConfidence(candidates []Symbol, interfaceIDs, implementorIDs map[in
 				s.Confidence = ConfidencePossibly
 				continue
 			}
+		}
+		if isGoConstructor(*s) {
+			s.Confidence = ConfidencePossibly
+			continue
 		}
 		s.Confidence = ConfidenceDead
 	}

--- a/internal/dead/dead_test.go
+++ b/internal/dead/dead_test.go
@@ -582,6 +582,171 @@ func TestFindDeadNullSourceID(t *testing.T) {
 	}
 }
 
+func TestDeadCodeNewFuncIsPossiblyDead(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, "router.go"), `package router
+
+type Router struct{}
+
+func NewRouter() *Router { return &Router{} }
+
+func unusedFunc() {}
+`)
+
+	ctx := context.Background()
+	if _, err := scan.Run(ctx, scan.Options{
+		Root:     root,
+		Output:   &bytes.Buffer{},
+		Warnings: io.Discard,
+	}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+
+	dbPath := filepath.Join(root, ".sense", "index.db")
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	result, err := dead.FindDead(ctx, db, dead.Options{})
+	if err != nil {
+		t.Fatalf("FindDead: %v", err)
+	}
+
+	for _, s := range result.Dead {
+		if s.Name == "NewRouter" {
+			if s.Confidence != dead.ConfidencePossibly {
+				t.Errorf("NewRouter confidence = %q, want %q", s.Confidence, dead.ConfidencePossibly)
+			}
+			return
+		}
+	}
+	t.Error("NewRouter not found in dead results")
+}
+
+func TestDeadCodeExcludesFrameworkHooks(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, "Gemfile"), `source "https://rubygems.org"
+gem "rails", "~> 7.0"
+`)
+	writeFile(t, filepath.Join(root, "concern.rb"), `module Auditable
+  extend ActiveSupport::Concern
+
+  included do
+    before_save :audit_trail
+  end
+
+  class_methods do
+    def auditable?
+      true
+    end
+  end
+
+  def after_commit
+    log_change
+  end
+
+  def dead_method
+    nil
+  end
+end
+`)
+
+	ctx := context.Background()
+	if _, err := scan.Run(ctx, scan.Options{
+		Root:     root,
+		Output:   &bytes.Buffer{},
+		Warnings: io.Discard,
+	}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+
+	dbPath := filepath.Join(root, ".sense", "index.db")
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	result, err := dead.FindDead(ctx, db, dead.Options{})
+	if err != nil {
+		t.Fatalf("FindDead: %v", err)
+	}
+
+	excluded := map[string]bool{"included": true, "class_methods": true, "after_commit": true}
+	for _, s := range result.Dead {
+		if excluded[s.Name] {
+			t.Errorf("%q should be excluded as Rails framework hook", s.Name)
+		}
+	}
+}
+
+func TestDeadCodeExcludesJVMLifecycle(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, "Handler.java"), `public class Handler {
+    public void handle() {
+        System.out.println("handling");
+    }
+    public void onCreate() {
+        System.out.println("created");
+    }
+    public void configure() {
+        System.out.println("configured");
+    }
+    public void deadMethod() {
+        System.out.println("dead");
+    }
+}
+`)
+
+	ctx := context.Background()
+	if _, err := scan.Run(ctx, scan.Options{
+		Root:     root,
+		Output:   &bytes.Buffer{},
+		Warnings: io.Discard,
+	}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+
+	dbPath := filepath.Join(root, ".sense", "index.db")
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	result, err := dead.FindDead(ctx, db, dead.Options{})
+	if err != nil {
+		t.Fatalf("FindDead: %v", err)
+	}
+
+	excluded := map[string]bool{"handle": true, "onCreate": true, "configure": true}
+	for _, s := range result.Dead {
+		if excluded[s.Name] {
+			t.Errorf("%q should be excluded as JVM lifecycle/framework hook", s.Name)
+		}
+	}
+}
+
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/mcpio/marshal_test.go
+++ b/internal/mcpio/marshal_test.go
@@ -128,6 +128,38 @@ func TestMarshalZeroValueEmptySlices(t *testing.T) {
 	}
 }
 
+func TestSearchResponseIncludesReferences(t *testing.T) {
+	resp := SearchResponse{
+		Results: []SearchResultEntry{
+			{Symbol: "pkg.HandleRequest", File: "handler.go", Kind: "function", Score: 0.95, References: 50},
+			{Symbol: "pkg.Helper", File: "helper.go", Kind: "function", Score: 0.8, References: 0},
+		},
+		SearchMode: "hybrid",
+	}
+	raw, err := MarshalSearch(resp)
+	if err != nil {
+		t.Fatalf("MarshalSearch: %v", err)
+	}
+	s := string(raw)
+
+	if !strings.Contains(s, `"references": 50`) {
+		t.Errorf("expected references: 50 in output:\n%s", s)
+	}
+	// omitempty: references should not appear for 0-value entries
+	var parsed struct {
+		Results []json.RawMessage `json:"results"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(parsed.Results) < 2 {
+		t.Fatalf("expected 2 results, got %d", len(parsed.Results))
+	}
+	if strings.Contains(string(parsed.Results[1]), `"references"`) {
+		t.Errorf("references with value 0 should be omitted (omitempty):\n%s", parsed.Results[1])
+	}
+}
+
 func TestResponseOmitsMetrics(t *testing.T) {
 	graph := GraphResponse{
 		Symbol:       GraphSymbol{Name: "X", Qualified: "X", File: "x.go", Kind: "function"},

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -477,10 +477,10 @@ type SearchResultEntry struct {
 	References int         `json:"references,omitempty"`
 }
 
-// SearchScore is a fused relevance score. It renders with two decimal
-// places on the wire so JSON consumers see `0.03` instead of
-// `0.032786885245901636`. The documented examples show two-decimal
-// scores (`0.92`, `0.87`).
+// SearchScore is a relative relevance score. Scores are normalized
+// then boosted by graph centrality, so values may exceed 1.0 for
+// hub symbols with many callers. Renders with two decimal places
+// on the wire (`0.92`, `1.17`).
 type SearchScore float64
 
 func (s SearchScore) MarshalJSON() ([]byte, error) {

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -611,12 +611,13 @@ func (h *handlers) handleSearch(ctx context.Context, req mcp.CallToolRequest) (*
 	for i, r := range results {
 		path := pathByID[r.FileID]
 		entries[i] = mcpio.SearchResultEntry{
-			Symbol:  r.Qualified,
-			File:    path,
-			Line:    r.LineStart,
-			Kind:    r.Kind,
-			Score:   mcpio.SearchScore(r.Score),
-			Snippet: r.Snippet,
+			Symbol:     r.Qualified,
+			File:       path,
+			Line:       r.LineStart,
+			Kind:       r.Kind,
+			Score:      mcpio.SearchScore(r.Score),
+			Snippet:    r.Snippet,
+			References: r.References,
 		}
 		if path != "" {
 			uniqueFiles[path] = struct{}{}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -431,8 +431,8 @@ func normalizeScores(results []Result) {
 }
 
 const (
-	TestPathDemotion = 0.5 // symbols in test file paths
-	TestNameDemotion = 0.3 // symbols whose name signals test/mock
+	testPathDemotion = 0.5 // symbols in test file paths
+	testNameDemotion = 0.3 // symbols whose name signals test/mock
 )
 
 var testNamePrefixes = []string{"Test", "Mock", "Fake", "Stub"}
@@ -444,7 +444,7 @@ func applyKindWeights(results []Result) {
 		}
 		for _, prefix := range testNamePrefixes {
 			if strings.HasPrefix(results[i].Name, prefix) {
-				results[i].Score *= TestNameDemotion
+				results[i].Score *= testNameDemotion
 				break
 			}
 		}
@@ -462,34 +462,34 @@ var demotedPathSegments = []struct {
 	{"db/post_migrate/", 0.3},
 	{"script/", 0.3},
 	{"scripts/", 0.3},
-	{"/test/", TestPathDemotion},
-	{"/tests/", TestPathDemotion},
-	{"/spec/", TestPathDemotion},
-	{"/mock/", TestPathDemotion},
-	{"/mocks/", TestPathDemotion},
-	{"/fixture/", TestPathDemotion},
-	{"/fixtures/", TestPathDemotion},
+	{"/test/", testPathDemotion},
+	{"/tests/", testPathDemotion},
+	{"/spec/", testPathDemotion},
+	{"/mock/", testPathDemotion},
+	{"/mocks/", testPathDemotion},
+	{"/fixture/", testPathDemotion},
+	{"/fixtures/", testPathDemotion},
 	{"/generated/", 0.4},
-	{"/testdata/", TestPathDemotion},
-	{"_test.rb", TestPathDemotion},
-	{"_spec.rb", TestPathDemotion},
-	{"_test.go", TestPathDemotion},
-	{".test.ts", TestPathDemotion},
-	{".test.js", TestPathDemotion},
-	{".spec.ts", TestPathDemotion},
-	{".spec.js", TestPathDemotion},
-	{"Test.java", TestPathDemotion},
-	{"Test.kt", TestPathDemotion},
-	{"_test.py", TestPathDemotion},
-	{"/__tests__/", TestPathDemotion},
+	{"/testdata/", testPathDemotion},
+	{"_test.rb", testPathDemotion},
+	{"_spec.rb", testPathDemotion},
+	{"_test.go", testPathDemotion},
+	{".test.ts", testPathDemotion},
+	{".test.js", testPathDemotion},
+	{".spec.ts", testPathDemotion},
+	{".spec.js", testPathDemotion},
+	{"Test.java", testPathDemotion},
+	{"Test.kt", testPathDemotion},
+	{"_test.py", testPathDemotion},
+	{"/__tests__/", testPathDemotion},
 }
 
 var demotedPathPrefixes = []struct {
 	prefix  string
 	penalty float64
 }{
-	{"spec/", TestPathDemotion},
-	{"test/", TestPathDemotion},
+	{"spec/", testPathDemotion},
+	{"test/", testPathDemotion},
 }
 
 // boostedPathPrefixes lists path prefixes for primary source directories
@@ -557,9 +557,9 @@ func vectorConfidence(results []VectorResult) float64 {
 	return sum / float64(n)
 }
 
-// CentralityCoefficient controls the multiplicative centrality boost.
+// centralityCoefficient controls the multiplicative centrality boost.
 // 50 callers → 1.28x; 200 callers → 1.39x; 1 caller → 1.05x.
-const CentralityCoefficient = 0.05
+const centralityCoefficient = 0.05
 
 func applyGraphCentrality(results []Result, centrality map[int64]int) {
 	if len(centrality) == 0 {
@@ -567,7 +567,7 @@ func applyGraphCentrality(results []Result, centrality map[int64]int) {
 	}
 	for i := range results {
 		if count, ok := centrality[results[i].SymbolID]; ok && count > 0 {
-			boost := 1.0 + math.Log2(1+float64(count))*CentralityCoefficient
+			boost := 1.0 + math.Log2(1+float64(count))*centralityCoefficient
 			results[i].Score *= boost
 			results[i].References = count
 		}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -225,7 +225,6 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, SearchMeta
 	if err != nil {
 		return nil, SearchMeta{}, fmt.Errorf("search centrality: %w", err)
 	}
-	applyGraphCentrality(fused, centrality)
 	applyKindWeights(fused)
 
 	// Path-based re-ranking: demote infrastructure code.
@@ -244,6 +243,7 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, SearchMeta
 	applyPathWeights(fused, pathByID)
 
 	normalizeScores(fused)
+	applyGraphCentrality(fused, centrality)
 
 	// Sort by final score descending.
 	sort.Slice(fused, func(i, j int) bool {
@@ -430,13 +430,23 @@ func normalizeScores(results []Result) {
 	}
 }
 
-// applyKindWeights demotes namespace-level symbols (modules) which
-// tend to appear in many files and dominate search results over the
-// specific classes/methods users actually want.
+const (
+	TestPathDemotion = 0.5 // symbols in test file paths
+	TestNameDemotion = 0.3 // symbols whose name signals test/mock
+)
+
+var testNamePrefixes = []string{"Test", "Mock", "Fake", "Stub"}
+
 func applyKindWeights(results []Result) {
 	for i := range results {
 		if results[i].Kind == "module" {
 			results[i].Score *= 0.5
+		}
+		for _, prefix := range testNamePrefixes {
+			if strings.HasPrefix(results[i].Name, prefix) {
+				results[i].Score *= TestNameDemotion
+				break
+			}
 		}
 	}
 }
@@ -452,37 +462,34 @@ var demotedPathSegments = []struct {
 	{"db/post_migrate/", 0.3},
 	{"script/", 0.3},
 	{"scripts/", 0.3},
-	{"/test/", 0.5},
-	{"/tests/", 0.5},
-	{"/spec/", 0.5},
-	{"/mock/", 0.5},
-	{"/mocks/", 0.5},
-	{"/fixture/", 0.5},
-	{"/fixtures/", 0.5},
+	{"/test/", TestPathDemotion},
+	{"/tests/", TestPathDemotion},
+	{"/spec/", TestPathDemotion},
+	{"/mock/", TestPathDemotion},
+	{"/mocks/", TestPathDemotion},
+	{"/fixture/", TestPathDemotion},
+	{"/fixtures/", TestPathDemotion},
 	{"/generated/", 0.4},
-	{"/testdata/", 0.5},
-	{"_test.rb", 0.5},
-	{"_spec.rb", 0.5},
-	{"_test.go", 0.5},
-	{".test.ts", 0.5},
-	{".test.js", 0.5},
-	{".spec.ts", 0.5},
-	{".spec.js", 0.5},
-	{"Test.java", 0.5},
-	{"Test.kt", 0.5},
-	{"_test.py", 0.5},
-	{"/__tests__/", 0.5},
+	{"/testdata/", TestPathDemotion},
+	{"_test.rb", TestPathDemotion},
+	{"_spec.rb", TestPathDemotion},
+	{"_test.go", TestPathDemotion},
+	{".test.ts", TestPathDemotion},
+	{".test.js", TestPathDemotion},
+	{".spec.ts", TestPathDemotion},
+	{".spec.js", TestPathDemotion},
+	{"Test.java", TestPathDemotion},
+	{"Test.kt", TestPathDemotion},
+	{"_test.py", TestPathDemotion},
+	{"/__tests__/", TestPathDemotion},
 }
 
-// demotedPathPrefixes lists root-level test/spec directories that should
-// be demoted. Separate from demotedPathSegments because these must use
-// HasPrefix to avoid false positives (e.g. "spec/" inside "specification/").
 var demotedPathPrefixes = []struct {
 	prefix  string
 	penalty float64
 }{
-	{"spec/", 0.5},
-	{"test/", 0.5},
+	{"spec/", TestPathDemotion},
+	{"test/", TestPathDemotion},
 }
 
 // boostedPathPrefixes lists path prefixes for primary source directories
@@ -550,17 +557,18 @@ func vectorConfidence(results []VectorResult) float64 {
 	return sum / float64(n)
 }
 
-// applyGraphCentrality boosts scores by graph importance. Symbols with
-// more inbound edges (callers, inheritors, testers) are hub nodes and
-// rank higher. The boost is additive and log-scaled:
-// boost = log2(1 + inbound_count) * 0.01.
+// CentralityCoefficient controls the multiplicative centrality boost.
+// 50 callers → 1.28x; 200 callers → 1.39x; 1 caller → 1.05x.
+const CentralityCoefficient = 0.05
+
 func applyGraphCentrality(results []Result, centrality map[int64]int) {
 	if len(centrality) == 0 {
 		return
 	}
 	for i := range results {
 		if count, ok := centrality[results[i].SymbolID]; ok && count > 0 {
-			results[i].Score += math.Log2(1+float64(count)) * 0.01
+			boost := 1.0 + math.Log2(1+float64(count))*CentralityCoefficient
+			results[i].Score *= boost
 			results[i].References = count
 		}
 	}

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -305,6 +305,110 @@ func TestFusionCentralityBreaksTie(t *testing.T) {
 	}
 }
 
+func TestSearchRanksHubSymbolHigher(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	a, err := sqlite.Open(ctx, filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	fid, err := a.WriteFile(ctx, &model.File{
+		Path: "handler.go", Language: "go",
+		Hash: "h1", Symbols: 2, IndexedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sidHub, err := a.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid, Name: "HandleRequest", Qualified: "pkg.HandleRequest",
+		Kind: "function", LineStart: 1, LineEnd: 20,
+		Docstring: "handles incoming request",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sidHelper, err := a.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid, Name: "HandleRequestHelper", Qualified: "pkg.HandleRequestHelper",
+		Kind: "function", LineStart: 25, LineEnd: 40,
+		Docstring: "helper for handling request setup",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	callerFile, err := a.WriteFile(ctx, &model.File{
+		Path: "callers.go", Language: "go",
+		Hash: "c1", Symbols: 32, IndexedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Hub: 30 inbound edges.
+	for i := range 30 {
+		callerID, err := a.WriteSymbol(ctx, &model.Symbol{
+			FileID: callerFile, Name: fmt.Sprintf("Caller%d", i),
+			Qualified: fmt.Sprintf("pkg.Caller%d", i),
+			Kind: "function", LineStart: i * 10, LineEnd: i*10 + 5,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := a.WriteEdge(ctx, &model.Edge{
+			SourceID: &callerID, TargetID: sidHub,
+			Kind: model.EdgeCalls, FileID: callerFile, Confidence: 1.0,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Helper: 2 inbound edges.
+	for i := range 2 {
+		callerID, err := a.WriteSymbol(ctx, &model.Symbol{
+			FileID: callerFile, Name: fmt.Sprintf("HelperCaller%d", i),
+			Qualified: fmt.Sprintf("pkg.HelperCaller%d", i),
+			Kind: "function", LineStart: 300 + i*10, LineEnd: 305 + i*10,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := a.WriteEdge(ctx, &model.Edge{
+			SourceID: &callerID, TargetID: sidHelper,
+			Kind: model.EdgeCalls, FileID: callerFile, Confidence: 1.0,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	engine := search.NewEngine(a, nil, nil)
+	results, _, err := engine.Search(ctx, search.Options{
+		Query: "handle request",
+		Limit: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(results) < 2 {
+		t.Fatalf("expected at least 2 results, got %d", len(results))
+	}
+
+	if results[0].Qualified != "pkg.HandleRequest" {
+		t.Errorf("hub symbol (30 callers) should rank above helper (2 callers); got %q first", results[0].Qualified)
+	}
+
+	if results[0].References != 30 {
+		t.Errorf("hub symbol references = %d, want 30", results[0].References)
+	}
+
+	t.Logf("hub vs helper ranking:")
+	for i, r := range results[:min(5, len(results))] {
+		t.Logf("  %d. %s (score=%.4f, refs=%d)", i+1, r.Qualified, r.Score, r.References)
+	}
+}
+
 func TestFusionMinScore(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
@@ -443,6 +547,86 @@ func TestKindWeightsDemotesModules(t *testing.T) {
 	}
 	if !hasModule {
 		t.Error("module symbol missing from results entirely — test setup issue")
+	}
+}
+
+func TestSearchDemotesTestSymbols(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	a, err := sqlite.Open(ctx, filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	fid, err := a.WriteFile(ctx, &model.File{
+		Path: "handler.go", Language: "go",
+		Hash: "h1", Symbols: 2, IndexedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sidReal, err := a.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid, Name: "HandleRequest", Qualified: "pkg.HandleRequest",
+		Kind: "function", LineStart: 1, LineEnd: 20,
+		Docstring: "handles incoming request",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid, Name: "TestHandleRequest", Qualified: "pkg.TestHandleRequest",
+		Kind: "function", LineStart: 25, LineEnd: 40,
+		Docstring: "test for handle request",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	callerFile, err := a.WriteFile(ctx, &model.File{
+		Path: "callers.go", Language: "go",
+		Hash: "c1", Symbols: 10, IndexedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range 10 {
+		callerID, err := a.WriteSymbol(ctx, &model.Symbol{
+			FileID: callerFile, Name: fmt.Sprintf("Caller%d", i),
+			Qualified: fmt.Sprintf("pkg.Caller%d", i),
+			Kind: "function", LineStart: i * 10, LineEnd: i*10 + 5,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := a.WriteEdge(ctx, &model.Edge{
+			SourceID: &callerID, TargetID: sidReal,
+			Kind: model.EdgeCalls, FileID: callerFile, Confidence: 1.0,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	engine := search.NewEngine(a, nil, nil)
+	results, _, err := engine.Search(ctx, search.Options{
+		Query: "handle request",
+		Limit: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(results) < 2 {
+		t.Fatalf("expected at least 2 results, got %d", len(results))
+	}
+
+	if results[0].Qualified != "pkg.HandleRequest" {
+		t.Errorf("HandleRequest should rank above TestHandleRequest; got %q first", results[0].Qualified)
+	}
+
+	t.Logf("test demotion ranking:")
+	for i, r := range results[:min(5, len(results))] {
+		t.Logf("  %d. %s (score=%.4f)", i+1, r.Qualified, r.Score)
 	}
 }
 


### PR DESCRIPTION
## Problem

Search centrality was additive and applied before normalization, making hub symbols with dozens of callers effectively invisible — a test helper with a good docstring easily outranked `Context.Next` (50+ callers). Dead-code detection lacked JVM lifecycle method exclusions and flagged Go constructors (`New*`) as hard-dead, eroding trust in reports for Java/Kotlin projects and Go repos alike.

## Summary

Switch search centrality from additive to multiplicative (applied post-normalization), add test/mock symbol name demotion, extend dead-code framework hooks for JVM and Rails, and demote Go `New*` constructors to `possibly_dead`.

## Changes

**Search ranking (`internal/search/`)**
- Multiplicative centrality boost (`0.05` coefficient) applied after score normalization — 50 callers → 1.28x
- Test/mock/fake/stub name demotion (0.3x) in `applyKindWeights`
- Named constants for `testPathDemotion` (0.5) and `testNameDemotion` (0.3)
- Expose `references` count in MCP search response (was computed but not surfaced)
- Updated `SearchScore` doc to note scores may exceed 1.0

**Dead-code detection (`internal/dead/`)**
- Language-aware JVM framework hooks (`handle`, `configure`, `accept`, `apply`, SAM type names, etc.)
- Framework-aware Rails hooks (`after_commit`, `included`, `class_methods`) via `readFrameworks`
- Go constructor `New*` functions marked `possibly_dead` instead of `dead`
- Added `Language` field to `Symbol` struct, queried from `sense_files`
- Log corrupt `frameworks` meta instead of silently swallowing

**CI**
- Codecov coverage upload on Linux runners
- Go Report Card and Codecov badges in README

## Test Plan

- [ ] `TestSearchRanksHubSymbolHigher` — hub with 30 callers outranks helper with 2
- [ ] `TestSearchDemotesTestSymbols` — `HandleRequest` outranks `TestHandleRequest`
- [ ] `TestSearchResponseIncludesReferences` — MCP JSON includes `references` with omitempty
- [ ] `TestDeadCodeExcludesJVMLifecycle` — `handle`, `onCreate`, `configure` excluded for Java
- [ ] `TestDeadCodeExcludesFrameworkHooks` — Rails hooks excluded when Gemfile detected
- [ ] `TestDeadCodeNewFuncIsPossiblyDead` — `NewRouter` gets `possibly_dead` confidence
- [ ] `go test ./...` passes
- [ ] `sense` binary builds cleanly