### PR TITLE
ci(coverage): fix measurement errors and enable race detector

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,19 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+    patch:
+      default:
+        target: 80%
+
+ignore:
+  # benchmark harness and vendored fixture repos
+  - "bench/"
+  # benchmark CLI tooling, not core analysis
+  - "internal/benchmark/"
+  # test conformance suite (test infra, not product code)
+  - "internal/index/indextest/"
+  # CLI entry point — wiring only, smoke-tested
+  - "cmd/sense/main.go"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: make build
 
       - name: Test
-        run: go test -v -coverprofile=coverage.txt ./...
+        run: go test -race -count=1 -v -coverprofile=coverage.txt -coverpkg=./... ./...
 
       - name: Upload coverage
         if: matrix.os == 'linux'


### PR DESCRIPTION
## Problem

Codecov reports 54% coverage, but the actual number is higher due to two measurement errors. First, cross-package golden-file coverage is misattributed — the fixture runner in `extract_test` exercises Go, Python, Ruby, Rust, and TS/JS parsers, but Go's default `-cover` only credits the package running the test, so each sub-package reports 7–14% when the real coverage is ~75%. Second, non-product code (8,163 lines of benchmark harness, test infrastructure, pure types, CLI entry point) inflates the denominator.

## Summary

Fix coverage attribution with `-coverpkg=./...`, exclude non-product code via `.codecov.yml`, and enable the race detector in CI.

## Changes

- Add `-coverpkg=./...` to attribute coverage to the package that owns the code, not the package running the test
- Add `-race` to catch concurrency bugs in MCP server, scan goroutines, and watch mode
- Add `-count=1` to disable test caching for fresh coverage profiles
- Create `.codecov.yml` excluding `bench/`, `internal/benchmark/`, `internal/index/indextest/`, and `cmd/sense/main.go`
- Set `target: auto` (ratchet, no regression) with 2% threshold and `patch: 80%` for new code

## Test Plan

- [x] CI passes on both ubuntu-latest and macos-latest
- [x] Codecov report shows new baseline of 68–75%
- [x] Race detector does not flag false positives
- [x] `go test ./...` passes locally