### PR TITLE
feat(conventions): surface key symbols by file-reference reach

### DIFF
--- a/bench/quick.sh
+++ b/bench/quick.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BENCH_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+REPO="${1:-gin}"
+TASK="${2:-conventions}"
+TOOL="${3:-sense}"
+
+echo "=== quick bench: $TOOL × $REPO / $TASK ==="
+echo ""
+
+start_time=$(date +%s)
+
+# Run the single combination
+bash "$BENCH_DIR/run.sh" --tool "$TOOL" --repo "$REPO" --task "$TASK" --budget 1.00 --timeout 120
+
+# Score it
+bash "$BENCH_DIR/score.sh" --tool "$TOOL" --repo "$REPO" --task "$TASK"
+
+end_time=$(date +%s)
+wall=$((end_time - start_time))
+
+# Print the score
+result_dir="$BENCH_DIR/results/$TOOL/$REPO/$TASK"
+if [[ -f "$result_dir/scored.json" ]]; then
+  echo ""
+  echo "=== RESULT ($TOOL × $REPO / $TASK) — ${wall}s ==="
+  python3 -c "
+import json, sys
+scored = json.load(open(sys.argv[1]))
+score = scored.get('score', scored.get('correctness_score', 'N/A'))
+print(f'  Score: {score}')
+metrics = scored.get('metrics', {})
+if metrics:
+    parts = []
+    if 'tool_calls' in metrics: parts.append(f\"tools={metrics['tool_calls']}\")
+    if 'token_input' in metrics: parts.append(f\"in={metrics['token_input']}\")
+    if 'token_output' in metrics: parts.append(f\"out={metrics['token_output']}\")
+    if 'wall_time' in metrics: parts.append(f\"time={metrics['wall_time']}s\")
+    if 'misses' in metrics: parts.append(f\"misses={metrics['misses']}\")
+    print(f'  Metrics: {\" | \".join(parts)}')
+keywords = scored.get('matched_keywords', [])
+missing = scored.get('missing_keywords', [])
+if keywords: print(f'  Matched: {keywords}')
+if missing: print(f'  Missing: {missing}')
+" "$result_dir/scored.json"
+else
+  echo ""
+  echo "=== NO SCORE (transcript or scoring failed) — ${wall}s ==="
+  [[ -f "$result_dir/score.log" ]] && cat "$result_dir/score.log"
+fi

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -208,7 +208,11 @@ fi
 # --- Parse task files once and cache ---
 
 TASK_CACHE_DIR=$(mktemp -d)
-trap 'rm -rf "$TASK_CACHE_DIR"' EXIT
+cleanup() {
+  rm -rf "$TASK_CACHE_DIR"
+  restore_user_settings
+}
+trap cleanup EXIT
 
 for task in "${tasks[@]}"; do
   python3 "$LIB_DIR/parse_task.py" "$TASKS_DIR/$task.yaml" > "$TASK_CACHE_DIR/$task.json"
@@ -345,8 +349,67 @@ if $VERIFY_ISOLATION; then
   fi
 fi
 
-# --- Suppress Sense hook injection for all tools (each tool gets MCP via --mcp-config) ---
-export SENSE_BENCH=1
+# --- Neutralize user-level config for fair benchmarking ---
+# Claude Code merges MCP servers and hooks from ~/.claude/settings.json and
+# ~/.claude/.mcp.json into every session. codebase-memory-mcp installs both
+# hooks (PreToolUse blocker, SessionStart reminder) and a global MCP server.
+# These contaminate non-CBM benchmark runs. Back up, strip, restore on exit.
+# CBM tool gets its config restored per-iteration.
+USER_SETTINGS="$HOME/.claude/settings.json"
+USER_MCP_CONFIG="$HOME/.claude/.mcp.json"
+USER_SETTINGS_BACKUP=""
+USER_MCP_BACKUP=""
+
+restore_user_settings() {
+  if [[ -n "${USER_SETTINGS_BACKUP:-}" && -f "$USER_SETTINGS_BACKUP" ]]; then
+    cp "$USER_SETTINGS_BACKUP" "$USER_SETTINGS"
+    rm -f "$USER_SETTINGS_BACKUP"
+    log "Restored ~/.claude/settings.json"
+  fi
+  if [[ -n "${USER_MCP_BACKUP:-}" && -f "$USER_MCP_BACKUP" ]]; then
+    cp "$USER_MCP_BACKUP" "$USER_MCP_CONFIG"
+    rm -f "$USER_MCP_BACKUP"
+    log "Restored ~/.claude/.mcp.json"
+  fi
+}
+
+strip_user_hooks() {
+  python3 -c "
+import json
+with open('$USER_SETTINGS') as f:
+    d = json.load(f)
+d.pop('hooks', None)
+with open('$USER_SETTINGS', 'w') as f:
+    json.dump(d, f, indent=2)
+    f.write('\n')
+"
+}
+
+strip_user_mcp() {
+  python3 -c "
+import json
+with open('$USER_MCP_CONFIG') as f:
+    d = json.load(f)
+d['mcpServers'] = {}
+with open('$USER_MCP_CONFIG', 'w') as f:
+    json.dump(d, f, indent=2)
+    f.write('\n')
+"
+}
+
+if [[ -f "$USER_SETTINGS" ]] && grep -q 'cbm-' "$USER_SETTINGS" 2>/dev/null; then
+  USER_SETTINGS_BACKUP=$(mktemp)
+  cp "$USER_SETTINGS" "$USER_SETTINGS_BACKUP"
+  strip_user_hooks
+  log "Stripped hooks from ~/.claude/settings.json"
+fi
+
+if [[ -f "$USER_MCP_CONFIG" ]] && grep -q 'mcpServers' "$USER_MCP_CONFIG" 2>/dev/null; then
+  USER_MCP_BACKUP=$(mktemp)
+  cp "$USER_MCP_CONFIG" "$USER_MCP_BACKUP"
+  strip_user_mcp
+  log "Stripped MCP servers from ~/.claude/.mcp.json"
+fi
 
 # --- Main loop: tool → repo (setup once) → tasks ---
 
@@ -356,6 +419,16 @@ failed=0
 skipped=0
 
 for tool in "${tools[@]}"; do
+  # Restore user-level hooks + MCP for codebase-memory-mcp (they're part of its offering)
+  if [[ "$tool" == "codebase-memory-mcp" ]]; then
+    [[ -n "${USER_SETTINGS_BACKUP:-}" ]] && cp "$USER_SETTINGS_BACKUP" "$USER_SETTINGS"
+    [[ -n "${USER_MCP_BACKUP:-}" ]] && cp "$USER_MCP_BACKUP" "$USER_MCP_CONFIG"
+    log "Restored user-level hooks + MCP for codebase-memory-mcp"
+  else
+    [[ -n "${USER_SETTINGS_BACKUP:-}" ]] && strip_user_hooks
+    [[ -n "${USER_MCP_BACKUP:-}" ]] && strip_user_mcp
+  fi
+
   for repo in "${all_repos[@]}"; do
     # Ensure per-tool repo copy exists (clones from _reference/ if needed)
     if ! ensure_tool_repo "$tool" "$repo"; then

--- a/internal/mcpio/conventions.go
+++ b/internal/mcpio/conventions.go
@@ -10,12 +10,23 @@ const DefaultTokenBudget = 6000
 // ConventionsResponse is the shape of the sense.conventions tool's reply
 // and the `sense conventions --json` CLI output.
 type ConventionsResponse struct {
+	KeySymbols   []KeySymbolEntry     `json:"key_symbols,omitempty"`
 	Summary      string               `json:"summary,omitempty"`
 	Conventions  []ConventionEntry    `json:"conventions"`
 	Truncated    bool                 `json:"truncated,omitempty"`
 	TokenBudget  int                  `json:"token_budget,omitempty"`
 	SenseMetrics ConventionsMetrics   `json:"-"`
 	NextSteps    []NextStep           `json:"next_steps"`
+}
+
+// KeySymbolEntry is a high-reach type/interface with callers, emitted first
+// in the conventions response to surface concrete symbol names.
+type KeySymbolEntry struct {
+	Name       string   `json:"name"`
+	Kind       string   `json:"kind"`
+	Snippet    string   `json:"snippet,omitempty"`
+	References int      `json:"references"`
+	Callers    []string `json:"callers,omitempty"`
 }
 
 // ConventionEntry is a single detected convention in the wire response.
@@ -89,6 +100,14 @@ func countTypeNames(instances []string) int {
 // MarshalConventions renders a ConventionsResponse with the same
 // normalization + pretty-print contract as MarshalGraph.
 func MarshalConventions(r ConventionsResponse) ([]byte, error) {
+	if r.KeySymbols == nil {
+		r.KeySymbols = []KeySymbolEntry{}
+	}
+	for i := range r.KeySymbols {
+		if r.KeySymbols[i].Callers == nil {
+			r.KeySymbols[i].Callers = []string{}
+		}
+	}
 	if r.Conventions == nil {
 		r.Conventions = []ConventionEntry{}
 	}

--- a/internal/mcpio/conventions_test.go
+++ b/internal/mcpio/conventions_test.go
@@ -1,6 +1,7 @@
 package mcpio
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -136,5 +137,75 @@ func TestBuildConventionsSummaryFewerThanThree(t *testing.T) {
 	BuildConventionsSummary(&resp)
 	if resp.Summary != "Single pattern." {
 		t.Errorf("expected 'Single pattern.', got %q", resp.Summary)
+	}
+}
+
+func TestMarshalConventionsNilSlices(t *testing.T) {
+	resp := ConventionsResponse{
+		KeySymbols:  nil,
+		Conventions: nil,
+		NextSteps:   nil,
+	}
+	out, err := MarshalConventions(resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Conventions and NextSteps don't have omitempty, so nil → [] matters
+	var decoded map[string]json.RawMessage
+	if err := json.Unmarshal(out, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	// conventions field should be "[]" not "null"
+	if string(decoded["conventions"]) == "null" {
+		t.Error("expected conventions to be [] not null")
+	}
+	// next_steps field should be "[]" not "null"
+	if string(decoded["next_steps"]) == "null" {
+		t.Error("expected next_steps to be [] not null")
+	}
+}
+
+func TestMarshalConventionsNilInstances(t *testing.T) {
+	resp := ConventionsResponse{
+		KeySymbols: []KeySymbolEntry{
+			{Name: "Router", Kind: "type", References: 5, Callers: nil},
+			{Name: "Handler", Kind: "type", References: 3, Callers: []string{"main"}},
+		},
+		Conventions: []ConventionEntry{
+			{Category: "design", Description: "test", Instances: nil},
+		},
+	}
+	out, err := MarshalConventions(resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Instances (no omitempty) should become [] not null
+	var decoded struct {
+		KeySymbols []struct {
+			Name    string   `json:"name"`
+			Callers []string `json:"callers"`
+		} `json:"key_symbols"`
+		Conventions []struct {
+			Instances []string `json:"instances"`
+		} `json:"conventions"`
+	}
+	if err := json.Unmarshal(out, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded.Conventions[0].Instances == nil {
+		t.Error("expected nil Instances to become [] in JSON")
+	}
+	// KeySymbols with callers populated should serialize correctly
+	if len(decoded.KeySymbols) != 2 {
+		t.Fatalf("expected 2 key symbols, got %d", len(decoded.KeySymbols))
+	}
+	if decoded.KeySymbols[0].Name != "Router" {
+		t.Errorf("expected first key symbol Router, got %q", decoded.KeySymbols[0].Name)
+	}
+	// Handler has callers — should be present
+	if len(decoded.KeySymbols[1].Callers) != 1 || decoded.KeySymbols[1].Callers[0] != "main" {
+		t.Errorf("expected Handler callers=[main], got %v", decoded.KeySymbols[1].Callers)
 	}
 }

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -354,6 +354,7 @@ type StatusProfile struct {
 type StatusStructure struct {
 	TopNamespaces []StatusNamespace  `json:"top_namespaces"`
 	HubSymbols    []StatusHub        `json:"hub_symbols"`
+	KeySymbols    []KeySymbolEntry   `json:"key_symbols,omitempty"`
 	EntryPoints   []StatusEntryPoint `json:"entry_points"`
 	Frameworks    []string           `json:"frameworks,omitempty"`
 	Fingerprint   string             `json:"fingerprint"`

--- a/internal/mcpserver/handler_conventions_test.go
+++ b/internal/mcpserver/handler_conventions_test.go
@@ -1,0 +1,163 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	mcp "github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/luuuc/sense/internal/mcpio"
+	"github.com/luuuc/sense/internal/metrics"
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/profile"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+func setupHandlerFixture(t *testing.T) *handlers {
+	t.Helper()
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	now := time.Now()
+
+	files := []model.File{
+		{Path: "internal/server/server.go", Language: "go", Hash: "a1", Symbols: 3, IndexedAt: now},
+		{Path: "internal/handler/handler.go", Language: "go", Hash: "a2", Symbols: 2, IndexedAt: now},
+		{Path: "internal/middleware/auth.go", Language: "go", Hash: "a3", Symbols: 1, IndexedAt: now},
+		{Path: "internal/service/order.go", Language: "go", Hash: "a4", Symbols: 1, IndexedAt: now},
+		{Path: "internal/service/payment.go", Language: "go", Hash: "a5", Symbols: 1, IndexedAt: now},
+		{Path: "internal/service/shipping.go", Language: "go", Hash: "a6", Symbols: 1, IndexedAt: now},
+		{Path: "internal/service/refund.go", Language: "go", Hash: "a7", Symbols: 1, IndexedAt: now},
+	}
+	fileIDs := make([]int64, len(files))
+	for i := range files {
+		id, err := adapter.WriteFile(ctx, &files[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		fileIDs[i] = id
+	}
+
+	serverID, _ := adapter.WriteSymbol(ctx, &model.Symbol{
+		FileID: fileIDs[0], Name: "Server", Qualified: "server.Server",
+		Kind: "interface", LineStart: 1, LineEnd: 30,
+		Snippet: "type Server interface {",
+	})
+	handlerID, _ := adapter.WriteSymbol(ctx, &model.Symbol{
+		FileID: fileIDs[1], Name: "Handler", Qualified: "handler.Handler",
+		Kind: "class", LineStart: 1, LineEnd: 20,
+	})
+	authID, _ := adapter.WriteSymbol(ctx, &model.Symbol{
+		FileID: fileIDs[2], Name: "AuthMiddleware", Qualified: "middleware.AuthMiddleware",
+		Kind: "function", LineStart: 1, LineEnd: 15,
+	})
+
+	// Service types for naming patterns
+	for _, s := range []model.Symbol{
+		{FileID: fileIDs[3], Name: "OrderService", Qualified: "service.OrderService", Kind: "class", LineStart: 1, LineEnd: 20},
+		{FileID: fileIDs[4], Name: "PaymentService", Qualified: "service.PaymentService", Kind: "class", LineStart: 1, LineEnd: 20},
+		{FileID: fileIDs[5], Name: "ShippingService", Qualified: "service.ShippingService", Kind: "class", LineStart: 1, LineEnd: 20},
+		{FileID: fileIDs[6], Name: "RefundService", Qualified: "service.RefundService", Kind: "class", LineStart: 1, LineEnd: 20},
+	} {
+		if _, err := adapter.WriteSymbol(ctx, &s); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	intPtr := func(v int) *int { return &v }
+	edges := []model.Edge{
+		{SourceID: model.Int64Ptr(handlerID), TargetID: serverID, Kind: model.EdgeCalls, FileID: fileIDs[1], Line: intPtr(5)},
+		{SourceID: model.Int64Ptr(authID), TargetID: serverID, Kind: model.EdgeCalls, FileID: fileIDs[2], Line: intPtr(3)},
+	}
+	for _, e := range edges {
+		if _, err := adapter.WriteEdge(ctx, &e); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tracker := metrics.NewTracker(adapter.DB())
+	t.Cleanup(func() { tracker.Close() })
+
+	return &handlers{
+		adapter:  adapter,
+		db:       adapter.DB(),
+		dir:      dir,
+		tracker:  tracker,
+		defaults: profile.DefaultParams(),
+	}
+}
+
+func TestHandleConventions(t *testing.T) {
+	h := setupHandlerFixture(t)
+	ctx := context.Background()
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{}
+
+	result, err := h.handleConventions(ctx, req)
+	if err != nil {
+		t.Fatalf("handleConventions: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	// Parse the JSON response
+	text := result.Content[0].(mcp.TextContent).Text
+	var resp mcpio.ConventionsResponse
+	if err := json.Unmarshal([]byte(text), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// Key symbols should be populated from buildKeyEntries
+	if len(resp.KeySymbols) == 0 {
+		t.Error("expected key_symbols in response")
+	}
+
+	// Structure and naming conventions should be filtered out
+	for _, c := range resp.Conventions {
+		if c.Category == "structure" || c.Category == "naming" {
+			t.Errorf("structure/naming convention should be filtered: %s", c.Description)
+		}
+	}
+}
+
+func TestHandleStatus(t *testing.T) {
+	h := setupHandlerFixture(t)
+	ctx := context.Background()
+
+	req := mcp.CallToolRequest{}
+	result, err := h.handleStatus(ctx, req)
+	if err != nil {
+		t.Fatalf("handleStatus: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	text := result.Content[0].(mcp.TextContent).Text
+	var resp mcpio.StatusResponse
+	if err := json.Unmarshal([]byte(text), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if resp.Structure == nil {
+		t.Fatal("expected structure in status response")
+	}
+	if len(resp.Structure.KeySymbols) == 0 {
+		t.Error("expected key_symbols in status structure")
+	}
+}

--- a/internal/mcpserver/key_entries_test.go
+++ b/internal/mcpserver/key_entries_test.go
@@ -1,0 +1,206 @@
+package mcpserver
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+func setupKeyEntriesFixture(t *testing.T) *sqlite.Adapter {
+	t.Helper()
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	now := time.Now()
+
+	fid1, err := adapter.WriteFile(ctx, &model.File{
+		Path: "internal/router/router.go", Language: "go",
+		Hash: "aaa", Symbols: 3, IndexedAt: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fid2, err := adapter.WriteFile(ctx, &model.File{
+		Path: "internal/handler/handler.go", Language: "go",
+		Hash: "bbb", Symbols: 2, IndexedAt: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fid3, err := adapter.WriteFile(ctx, &model.File{
+		Path: "internal/middleware/auth.go", Language: "go",
+		Hash: "ccc", Symbols: 1, IndexedAt: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Engine: type referenced from multiple files
+	engineID, err := adapter.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid1, Name: "Engine", Qualified: "router.Engine",
+		Kind: "type", LineStart: 10, LineEnd: 30,
+		Snippet: "type Engine struct { pool sync.Pool }",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// RouterGroup: type referenced from another file
+	groupID, err := adapter.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid1, Name: "RouterGroup", Qualified: "router.RouterGroup",
+		Kind: "type", LineStart: 32, LineEnd: 50,
+		Snippet: "type RouterGroup struct { basePath string }",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// HandleRequest: caller of Engine
+	handleID, err := adapter.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid2, Name: "HandleRequest", Qualified: "handler.HandleRequest",
+		Kind: "function", LineStart: 5, LineEnd: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// AuthMiddleware: caller of Engine
+	authID, err := adapter.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid3, Name: "AuthMiddleware", Qualified: "middleware.AuthMiddleware",
+		Kind: "function", LineStart: 1, LineEnd: 15,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	intPtr := func(v int) *int { return &v }
+	edges := []model.Edge{
+		// HandleRequest → Engine (from fid2)
+		{SourceID: model.Int64Ptr(handleID), TargetID: engineID, Kind: model.EdgeCalls, FileID: fid2, Line: intPtr(10)},
+		// AuthMiddleware → Engine (from fid3)
+		{SourceID: model.Int64Ptr(authID), TargetID: engineID, Kind: model.EdgeCalls, FileID: fid3, Line: intPtr(5)},
+		// Engine → RouterGroup (from fid1)
+		{SourceID: model.Int64Ptr(engineID), TargetID: groupID, Kind: model.EdgeCalls, FileID: fid1, Line: intPtr(15)},
+		// HandleRequest → RouterGroup (from fid2)
+		{SourceID: model.Int64Ptr(handleID), TargetID: groupID, Kind: model.EdgeCalls, FileID: fid2, Line: intPtr(12)},
+	}
+	for _, e := range edges {
+		if _, err := adapter.WriteEdge(ctx, &e); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return adapter
+}
+
+func TestBuildKeyEntries(t *testing.T) {
+	adapter := setupKeyEntriesFixture(t)
+	ctx := context.Background()
+
+	entries, err := buildKeyEntries(ctx, adapter, "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(entries) == 0 {
+		t.Fatal("expected at least one key entry")
+	}
+
+	// Engine should appear (type with 2 distinct file refs)
+	found := map[string]int{}
+	for i, e := range entries {
+		found[e.Name] = i
+		if e.Kind == "" {
+			t.Errorf("entry %q has empty kind", e.Name)
+		}
+	}
+
+	idx, ok := found["router.Engine"]
+	if !ok {
+		t.Fatalf("expected router.Engine in results, got %v", entries)
+	}
+	engine := entries[idx]
+	if engine.Snippet == "" {
+		t.Error("expected snippet for Engine")
+	}
+	if engine.References < 2 {
+		t.Errorf("expected Engine references >= 2, got %d", engine.References)
+	}
+	// Should have callers populated
+	if len(engine.Callers) == 0 {
+		t.Error("expected callers for Engine")
+	}
+	// Callers should be qualified names
+	for _, c := range engine.Callers {
+		if c == "" {
+			t.Error("caller name should not be empty")
+		}
+	}
+}
+
+func TestBuildKeyEntriesDomainFilter(t *testing.T) {
+	adapter := setupKeyEntriesFixture(t)
+	ctx := context.Background()
+
+	entries, err := buildKeyEntries(ctx, adapter, "internal/router", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// With domain filter, should only return symbols under that path
+	for _, e := range entries {
+		if e.Name != "router.Engine" && e.Name != "router.RouterGroup" {
+			t.Errorf("unexpected symbol %q outside domain internal/router", e.Name)
+		}
+	}
+}
+
+func TestBuildKeyEntriesLimit(t *testing.T) {
+	adapter := setupKeyEntriesFixture(t)
+	ctx := context.Background()
+
+	entries, err := buildKeyEntries(ctx, adapter, "", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(entries) > 1 {
+		t.Errorf("expected at most 1 entry with limit=1, got %d", len(entries))
+	}
+}
+
+func TestBuildKeyEntriesEmptyDB(t *testing.T) {
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	entries, err := buildKeyEntries(ctx, adapter, "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries for empty db, got %d", len(entries))
+	}
+}

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -181,13 +181,7 @@ func RunWithOptions(opts RunOptions) error {
 		server.WithInstructions(serverInstructions),
 	)
 
-	prof := profile.Load(ctx, adapter.DB())
-	var defaults profile.Defaults
-	if prof != nil {
-		defaults = profile.DefaultsForTier(prof.Tier)
-	} else {
-		defaults = profile.DefaultsForTier(profile.TierMedium)
-	}
+	defaults := profile.DefaultParams()
 
 	h := &handlers{adapter: adapter, db: adapter.DB(), dir: dir, search: engine, watchState: opts.WatchState, tracker: tracker, defaults: defaults}
 
@@ -1353,14 +1347,16 @@ func namespacePrefixFromPath(p string) string {
 }
 
 func queryHubSymbols(ctx context.Context, db *sql.DB) ([]mcpio.StatusHub, error) {
-	const q = `SELECT s.name, COUNT(e.id) AS in_degree, s.kind,
+	const q = `SELECT s.name, COUNT(DISTINCT e.file_id) AS reach, s.kind,
 		(SELECT e2.kind FROM sense_edges e2
 		 WHERE e2.target_id = s.id
 		 GROUP BY e2.kind ORDER BY COUNT(*) DESC LIMIT 1) AS dominant_edge
 	FROM sense_symbols s
 	JOIN sense_edges e ON e.target_id = s.id
 	GROUP BY s.id
-	ORDER BY in_degree DESC
+	ORDER BY
+	  CASE WHEN s.kind IN ('class','interface','module','type','struct','trait') THEN 0 ELSE 1 END,
+	  reach DESC
 	LIMIT 5`
 
 	rows, err := db.QueryContext(ctx, q)

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -1038,25 +1038,33 @@ func (h *handlers) handleConventions(ctx context.Context, req mcp.CallToolReques
 		return nil, fmt.Errorf("sense.conventions: %w", err)
 	}
 
+	keyEntries, err := buildKeyEntries(ctx, h.adapter, domain, 15)
+	if err != nil {
+		return nil, fmt.Errorf("sense.conventions: key symbols: %w", err)
+	}
+
 	instanceCap := h.defaults.ConventionsInstanceCap
 	filesAvoided := min(symbolCount/5, 30)
 	resp := mcpio.ConventionsResponse{
-		Conventions: make([]mcpio.ConventionEntry, len(results)),
+		KeySymbols: keyEntries,
 		SenseMetrics: mcpio.ConventionsMetrics{
 			SymbolsAnalyzed:           symbolCount,
 			EstimatedFileReadsAvoided: filesAvoided,
 			EstimatedTokensSaved:      filesAvoided * mcpio.AvgTokensPerFile,
 		},
 	}
-	for i, c := range results {
-		resp.Conventions[i] = mcpio.ConventionEntry{
+	for _, c := range results {
+		if c.Category == conventions.CategoryStructure || c.Category == conventions.CategoryNaming {
+			continue
+		}
+		resp.Conventions = append(resp.Conventions, mcpio.ConventionEntry{
 			Category:       string(c.Category),
 			Description:    c.Description,
 			Strength:       mcpio.Confidence(c.Strength),
 			Instances:      conventions.PickRepresentatives(c.Examples, instanceCap),
 			TotalInstances: c.Instances,
 			KeySymbol:      c.KeySymbol,
-		}
+		})
 	}
 
 	mcpio.ApplyTokenBudget(&resp, h.defaults.ConventionsTokenBudget)
@@ -1101,6 +1109,29 @@ func conventionsHints(resp mcpio.ConventionsResponse, domain string) []mcpio.Nex
 	return hints
 }
 
+func buildKeyEntries(ctx context.Context, adapter *sqlite.Adapter, domain string, limit int) ([]mcpio.KeySymbolEntry, error) {
+	keySymbols, err := adapter.TopSymbolsByReach(ctx, domain, limit)
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]mcpio.KeySymbolEntry, 0, len(keySymbols))
+	for _, ks := range keySymbols {
+		callers, _ := adapter.TopCallers(ctx, ks.ID, 3)
+		callerNames := make([]string, len(callers))
+		for i, c := range callers {
+			callerNames[i] = c.Qualified
+		}
+		entries = append(entries, mcpio.KeySymbolEntry{
+			Name:       ks.Qualified,
+			Kind:       ks.Kind,
+			Snippet:    ks.Snippet,
+			References: ks.RefFiles,
+			Callers:    callerNames,
+		})
+	}
+	return entries, nil
+}
+
 // ---------------------------------------------------------------
 // sense.status handler
 // ---------------------------------------------------------------
@@ -1109,6 +1140,13 @@ func (h *handlers) handleStatus(ctx context.Context, _ mcp.CallToolRequest) (*mc
 	resp, err := buildStatusResponse(ctx, h.db, h.dir, h.watchState)
 	if err != nil {
 		return nil, fmt.Errorf("sense.status: %w", err)
+	}
+
+	if resp.Structure != nil {
+		// Key symbols are optional in status; degrade silently on error.
+		if entries, err := buildKeyEntries(ctx, h.adapter, "", 8); err == nil {
+			resp.Structure.KeySymbols = entries
+		}
 	}
 
 	sess := h.tracker.Session()

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -186,43 +186,16 @@ type Defaults struct {
 	GraphSegmentCallers    bool
 }
 
-func DefaultsForTier(tier string) Defaults {
-	switch tier {
-	case TierSmall:
-		return Defaults{
-			SearchKeywordWeight:    0.5,
-			SearchVectorWeight:     0.5,
-			ConventionsMinStrength: 0.15,
-			ConventionsInstanceCap: 5,
-			ConventionsTokenBudget: 8000,
-			BlastMaxHops:           5,
-			BlastMinConfidence:     0.3,
-			BlastResultCap:         200,
-			GraphSegmentCallers:    false,
-		}
-	case TierLarge:
-		return Defaults{
-			SearchKeywordWeight:    0.6,
-			SearchVectorWeight:     0.4,
-			ConventionsMinStrength: 0.35,
-			ConventionsInstanceCap: 5,
-			ConventionsTokenBudget: 5000,
-			BlastMaxHops:           2,
-			BlastMinConfidence:     0.6,
-			BlastResultCap:         75,
-			GraphSegmentCallers:    true,
-		}
-	default:
-		return Defaults{
-			SearchKeywordWeight:    0.5,
-			SearchVectorWeight:     0.5,
-			ConventionsMinStrength: 0.30,
-			ConventionsInstanceCap: 5,
-			ConventionsTokenBudget: 6000,
-			BlastMaxHops:           3,
-			BlastMinConfidence:     0.5,
-			BlastResultCap:         100,
-			GraphSegmentCallers:    true,
-		}
+func DefaultParams() Defaults {
+	return Defaults{
+		SearchKeywordWeight:    0.5,
+		SearchVectorWeight:     0.5,
+		ConventionsMinStrength: 0.15,
+		ConventionsInstanceCap: 5,
+		ConventionsTokenBudget: 8000,
+		BlastMaxHops:           5,
+		BlastMinConfidence:     0.3,
+		BlastResultCap:         200,
+		GraphSegmentCallers:    false,
 	}
 }

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -41,56 +41,21 @@ func TestComputeTier(t *testing.T) {
 	}
 }
 
-func TestDefaultsForTier(t *testing.T) {
-	small := DefaultsForTier(TierSmall)
-	medium := DefaultsForTier(TierMedium)
-	large := DefaultsForTier(TierLarge)
-
-	if small.BlastMaxHops <= medium.BlastMaxHops {
-		t.Errorf("small BlastMaxHops (%d) should exceed medium (%d)", small.BlastMaxHops, medium.BlastMaxHops)
+func TestDefaultParams(t *testing.T) {
+	d := DefaultParams()
+	want := Defaults{
+		SearchKeywordWeight:    0.5,
+		SearchVectorWeight:     0.5,
+		ConventionsMinStrength: 0.15,
+		ConventionsInstanceCap: 5,
+		ConventionsTokenBudget: 8000,
+		BlastMaxHops:           5,
+		BlastMinConfidence:     0.3,
+		BlastResultCap:         200,
+		GraphSegmentCallers:    false,
 	}
-	if medium.BlastMaxHops <= large.BlastMaxHops {
-		t.Errorf("medium BlastMaxHops (%d) should exceed large (%d)", medium.BlastMaxHops, large.BlastMaxHops)
-	}
-	if small.BlastMinConfidence >= medium.BlastMinConfidence {
-		t.Errorf("small BlastMinConfidence (%.2f) should be less than medium (%.2f)", small.BlastMinConfidence, medium.BlastMinConfidence)
-	}
-	if small.BlastResultCap <= large.BlastResultCap {
-		t.Errorf("small BlastResultCap (%d) should exceed large (%d)", small.BlastResultCap, large.BlastResultCap)
-	}
-	if small.ConventionsMinStrength >= large.ConventionsMinStrength {
-		t.Errorf("small ConventionsMinStrength (%.2f) should be less than large (%.2f)", small.ConventionsMinStrength, large.ConventionsMinStrength)
-	}
-	if small.ConventionsTokenBudget <= large.ConventionsTokenBudget {
-		t.Errorf("small ConventionsTokenBudget (%d) should exceed large (%d)", small.ConventionsTokenBudget, large.ConventionsTokenBudget)
-	}
-	if large.SearchKeywordWeight <= medium.SearchKeywordWeight {
-		t.Errorf("large SearchKeywordWeight (%.2f) should exceed medium (%.2f)", large.SearchKeywordWeight, medium.SearchKeywordWeight)
-	}
-
-	// Unknown tier falls back to medium defaults.
-	unknown := DefaultsForTier("unknown")
-	if unknown != medium {
-		t.Errorf("unknown tier should return medium defaults")
-	}
-}
-
-func TestDefaultsForTierValues(t *testing.T) {
-	large := DefaultsForTier(TierLarge)
-	if large.BlastMaxHops != 2 {
-		t.Errorf("large BlastMaxHops = %d, want 2", large.BlastMaxHops)
-	}
-	if large.BlastMinConfidence != 0.6 {
-		t.Errorf("large BlastMinConfidence = %.2f, want 0.60", large.BlastMinConfidence)
-	}
-	if large.BlastResultCap != 75 {
-		t.Errorf("large BlastResultCap = %d, want 75", large.BlastResultCap)
-	}
-	if large.ConventionsMinStrength != 0.35 {
-		t.Errorf("large ConventionsMinStrength = %.2f, want 0.35", large.ConventionsMinStrength)
-	}
-	if large.ConventionsTokenBudget != 5000 {
-		t.Errorf("large ConventionsTokenBudget = %d, want 5000", large.ConventionsTokenBudget)
+	if d != want {
+		t.Errorf("DefaultParams() = %+v, want %+v", d, want)
 	}
 }
 

--- a/internal/scan/incremental.go
+++ b/internal/scan/incremental.go
@@ -127,7 +127,7 @@ func RunIncremental(ctx context.Context, opts IncrementalOptions) (*Result, erro
 
 	if h.changed > 0 || h.removed > 0 {
 		senseDir := filepath.Join(opts.Root, ".sense")
-		if serr := summary.Generate(ctx, opts.Idx.DB(), senseDir); serr != nil {
+		if serr := summary.Generate(ctx, opts.Idx, senseDir); serr != nil {
 			_, _ = fmt.Fprintf(warn, "warn: generate summary: %v\n", serr)
 		}
 	}

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -306,7 +306,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 		}
 	}
 
-	if serr := summary.Generate(ctx, idx.DB(), senseDir); serr != nil {
+	if serr := summary.Generate(ctx, idx, senseDir); serr != nil {
 		_, _ = fmt.Fprintf(warn, "warn: generate summary: %v\n", serr)
 	}
 

--- a/internal/sqlite/key_symbols.go
+++ b/internal/sqlite/key_symbols.go
@@ -1,0 +1,133 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+// KeySymbol is a high-reach type/interface/class with its declaration snippet.
+type KeySymbol struct {
+	ID        int64
+	Qualified string
+	Kind      string
+	Snippet   string
+	RefFiles  int
+}
+
+// SymbolCaller is a caller of a key symbol with its location.
+type SymbolCaller struct {
+	Qualified string
+	Kind      string
+	File      string
+}
+
+var builtinSymbols = map[string]bool{
+	"new": true, "id": true, "map": true, "each": true,
+	"present?": true, "nil?": true, "Close": true, "Error": true,
+	"String": true, "make": true, "len": true, "append": true,
+	"initialize": true, "to_s": true, "inspect": true,
+}
+
+// TopSymbolsByReach returns the top N types/interfaces/classes ordered by
+// the number of distinct files that reference them (including references to
+// their methods). Domain filters by file path prefix. This query powers the
+// key_symbols section of sense.conventions.
+func (a *Adapter) TopSymbolsByReach(ctx context.Context, domain string, limit int) ([]KeySymbol, error) {
+	if limit <= 0 {
+		limit = 15
+	}
+
+	q := `WITH type_edges AS (
+	          SELECT e.target_id as type_id, e.file_id
+	          FROM sense_edges e
+	          JOIN sense_symbols s ON s.id = e.target_id
+	          WHERE s.kind IN ('class','interface','module','type','struct','trait')
+	          UNION ALL
+	          SELECT child.parent_id as type_id, e.file_id
+	          FROM sense_edges e
+	          JOIN sense_symbols child ON child.id = e.target_id
+	          WHERE child.parent_id IS NOT NULL
+	      )
+	      SELECT s.id, s.qualified, s.kind, s.snippet,
+	             COUNT(DISTINCT te.file_id) as ref_files
+	      FROM sense_symbols s
+	      JOIN sense_files sf ON sf.id = s.file_id
+	      JOIN type_edges te ON te.type_id = s.id
+	      WHERE sf.path LIKE ? || '%'
+	        AND s.kind IN ('class','interface','module','type','struct','trait')
+	        AND sf.path NOT LIKE '%\_test.%' ESCAPE '\'
+	        AND sf.path NOT LIKE '%testdata%'
+	        AND sf.path NOT LIKE '%fixture%'
+	        AND sf.path NOT LIKE '%vendor%'
+	      GROUP BY s.id
+	      ORDER BY ref_files DESC
+	      LIMIT ?`
+
+	args := []any{domain, limit * 2} // fetch extra to filter builtins
+
+	rows, err := a.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite TopSymbolsByReach: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []KeySymbol
+	for rows.Next() {
+		var ks KeySymbol
+		var snippet sql.NullString
+		if err := rows.Scan(&ks.ID, &ks.Qualified, &ks.Kind, &snippet, &ks.RefFiles); err != nil {
+			return nil, fmt.Errorf("sqlite TopSymbolsByReach scan: %w", err)
+		}
+		ks.Snippet = snippet.String
+
+		name := lastPart(ks.Qualified)
+		if builtinSymbols[name] {
+			continue
+		}
+		results = append(results, ks)
+		if len(results) >= limit {
+			break
+		}
+	}
+	return results, rows.Err()
+}
+
+// TopCallers returns the top N callers/references for a given symbol ID.
+func (a *Adapter) TopCallers(ctx context.Context, symbolID int64, limit int) ([]SymbolCaller, error) {
+	if limit <= 0 {
+		limit = 3
+	}
+
+	q := `SELECT src.qualified, src.kind, srcf.path
+	      FROM sense_edges e
+	      JOIN sense_symbols src ON src.id = e.source_id
+	      JOIN sense_files srcf ON srcf.id = src.file_id
+	      WHERE e.target_id = ?
+	      ORDER BY src.kind = 'class' DESC, src.qualified
+	      LIMIT ?`
+
+	rows, err := a.db.QueryContext(ctx, q, symbolID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite TopCallers: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []SymbolCaller
+	for rows.Next() {
+		var c SymbolCaller
+		if err := rows.Scan(&c.Qualified, &c.Kind, &c.File); err != nil {
+			return nil, fmt.Errorf("sqlite TopCallers scan: %w", err)
+		}
+		results = append(results, c)
+	}
+	return results, rows.Err()
+}
+
+func lastPart(qualified string) string {
+	if i := strings.LastIndexByte(qualified, '.'); i >= 0 {
+		return qualified[i+1:]
+	}
+	return qualified
+}

--- a/internal/sqlite/key_symbols_test.go
+++ b/internal/sqlite/key_symbols_test.go
@@ -1,0 +1,200 @@
+package sqlite_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+func seedKeySymbols(ctx context.Context, t *testing.T, a *sqlite.Adapter) {
+	t.Helper()
+
+	fid1, err := a.WriteFile(ctx, &model.File{
+		Path: "internal/router/router.go", Language: "go",
+		Hash: "aaa", Symbols: 3, IndexedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fid2, err := a.WriteFile(ctx, &model.File{
+		Path: "internal/router/group.go", Language: "go",
+		Hash: "bbb", Symbols: 2, IndexedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fid3, err := a.WriteFile(ctx, &model.File{
+		Path: "internal/handler/handler.go", Language: "go",
+		Hash: "ccc", Symbols: 2, IndexedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Key type: Engine (referenced from multiple files)
+	engineID, err := a.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid1, Name: "Engine", Qualified: "router.Engine",
+		Kind: "type", LineStart: 10, LineEnd: 30,
+		Snippet: "type Engine struct { pool sync.Pool }",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Key type: RouterGroup
+	groupID, err := a.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid2, Name: "RouterGroup", Qualified: "router.RouterGroup",
+		Kind: "type", LineStart: 1, LineEnd: 15,
+		Snippet: "type RouterGroup struct { basePath string }",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Function (should be excluded by kind filter)
+	handleID, err := a.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid3, Name: "HandleRequest", Qualified: "handler.HandleRequest",
+		Kind: "function", LineStart: 5, LineEnd: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Builtin (should be excluded by name filter)
+	_, err = a.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid1, Name: "Close", Qualified: "router.Close",
+		Kind: "type", LineStart: 32, LineEnd: 35,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Edges: Engine referenced from 3 files
+	intPtr := func(v int) *int { return &v }
+	edges := []model.Edge{
+		{SourceID: model.Int64Ptr(handleID), TargetID: engineID, Kind: model.EdgeCalls, FileID: fid3, Line: intPtr(10)},
+		{SourceID: model.Int64Ptr(groupID), TargetID: engineID, Kind: model.EdgeCalls, FileID: fid2, Line: intPtr(5)},
+		{SourceID: model.Int64Ptr(engineID), TargetID: groupID, Kind: model.EdgeCalls, FileID: fid1, Line: intPtr(15)},
+		// HandleRequest → RouterGroup (from fid3)
+		{SourceID: model.Int64Ptr(handleID), TargetID: groupID, Kind: model.EdgeCalls, FileID: fid3, Line: intPtr(12)},
+	}
+	for _, e := range edges {
+		if _, err := a.WriteEdge(ctx, &e); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestTopSymbolsByReach(t *testing.T) {
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	seedKeySymbols(ctx, t, a)
+
+	results, err := a.TopSymbolsByReach(ctx, "internal/", 15)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(results) < 2 {
+		t.Fatalf("expected at least 2 key symbols, got %d", len(results))
+	}
+
+	found := map[string]sqlite.KeySymbol{}
+	for _, r := range results {
+		found[r.Qualified] = r
+	}
+
+	// Both Engine and RouterGroup referenced from 2 distinct files each
+	if ks, ok := found["router.Engine"]; !ok {
+		t.Error("expected router.Engine in results")
+	} else {
+		if ks.RefFiles < 2 {
+			t.Errorf("expected Engine ≥2 ref files, got %d", ks.RefFiles)
+		}
+		if ks.Snippet == "" {
+			t.Error("expected snippet to be populated")
+		}
+	}
+	if _, ok := found["router.RouterGroup"]; !ok {
+		t.Error("expected router.RouterGroup in results")
+	}
+
+	// Should not contain HandleRequest (function kind)
+	if _, ok := found["handler.HandleRequest"]; ok {
+		t.Error("functions should be excluded from key symbols")
+	}
+	// Should not contain Close (builtin name)
+	if _, ok := found["router.Close"]; ok {
+		t.Error("builtin names should be excluded from key symbols")
+	}
+}
+
+func TestTopSymbolsByReach_DomainFilter(t *testing.T) {
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	seedKeySymbols(ctx, t, a)
+
+	// Filter to handler/ — no types live there
+	results, err := a.TopSymbolsByReach(ctx, "internal/handler/", 15)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for handler domain, got %d", len(results))
+	}
+}
+
+func TestTopCallers(t *testing.T) {
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	seedKeySymbols(ctx, t, a)
+
+	// Get Engine's ID
+	results, err := a.TopSymbolsByReach(ctx, "internal/", 15)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) == 0 {
+		t.Fatal("no results")
+	}
+
+	callers, err := a.TopCallers(ctx, results[0].ID, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(callers) == 0 {
+		t.Fatal("expected at least one caller for Engine")
+	}
+
+	// Should have handler.HandleRequest and router.RouterGroup as callers
+	found := map[string]bool{}
+	for _, c := range callers {
+		found[c.Qualified] = true
+		if c.File == "" {
+			t.Error("caller file should be populated")
+		}
+	}
+	if !found["handler.HandleRequest"] && !found["router.RouterGroup"] {
+		t.Error("expected at least one of HandleRequest or RouterGroup as caller")
+	}
+}

--- a/internal/summary/render_test.go
+++ b/internal/summary/render_test.go
@@ -190,25 +190,69 @@ func TestRenderMainAreas(t *testing.T) {
 }
 
 func TestRenderKeyAbstractions(t *testing.T) {
-	db, cleanup := seedTestDB(t)
-	defer cleanup()
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "index.db")
 
-	got, err := renderKeyAbstractions(context.Background(), db)
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+
+	now := time.Now()
+	fid1, err := adapter.WriteFile(ctx, &model.File{
+		Path: "internal/server/server.go", Language: "go",
+		Hash: "aaa", Symbols: 2, IndexedAt: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fid2, err := adapter.WriteFile(ctx, &model.File{
+		Path: "internal/handler/handler.go", Language: "go",
+		Hash: "bbb", Symbols: 1, IndexedAt: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	serverID, err := adapter.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid1, Name: "Server", Qualified: "server.Server",
+		Kind: "class", LineStart: 1, LineEnd: 30,
+		Snippet: "type Server struct { router *Router }",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	callerID, err := adapter.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid2, Name: "Handler", Qualified: "handler.Handler",
+		Kind: "class", LineStart: 1, LineEnd: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = adapter.WriteEdge(ctx, &model.Edge{
+		SourceID: model.Int64Ptr(callerID), TargetID: serverID,
+		Kind: model.EdgeCalls, FileID: fid2, Confidence: 1.0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	got, err := renderKeyAbstractions(ctx, adapter)
 	if err != nil {
 		t.Fatalf("renderKeyAbstractions: %v", err)
 	}
 
-	if !strings.Contains(got, "server.Handle") {
-		t.Errorf("expected top hub symbol server.Handle, got: %s", got)
+	if !strings.Contains(got, "server.Server") {
+		t.Errorf("expected server.Server in key abstractions, got: %s", got)
 	}
-	if !strings.Contains(got, "incoming edges") {
-		t.Errorf("expected 'incoming edges' label, got: %s", got)
+	if !strings.Contains(got, "file refs") {
+		t.Errorf("expected 'file refs' label, got: %s", got)
 	}
 	if !strings.Contains(got, "sense_graph") {
 		t.Errorf("expected sense_graph section-level hint, got: %s", got)
-	}
-	if strings.Count(got, "sense_graph") != 1 {
-		t.Errorf("expected exactly one sense_graph hint (section-level), got %d", strings.Count(got, "sense_graph"))
 	}
 }
 
@@ -230,56 +274,59 @@ func TestRenderKeyAbstractionsFiltersUtility(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	closeID, err := adapter.WriteSymbol(ctx, &model.Symbol{
-		FileID: fid, Name: "Close", Qualified: "core.Close",
-		Kind: model.KindMethod, LineStart: 1, LineEnd: 5,
+	fid2, err := adapter.WriteFile(ctx, &model.File{
+		Path: "internal/app/app.go", Language: "go",
+		Hash: "bbb", Symbols: 1, IndexedAt: now,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	runID, err := adapter.WriteSymbol(ctx, &model.Symbol{
-		FileID: fid, Name: "Run", Qualified: "core.Run",
-		Kind: model.KindFunction, LineStart: 10, LineEnd: 50,
+
+	// "Close" is a utility name that should be filtered
+	closeID, err := adapter.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid, Name: "Close", Qualified: "core.Close",
+		Kind: "type", LineStart: 1, LineEnd: 5,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// "Runner" is a real type that should appear
+	runnerID, err := adapter.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid, Name: "Runner", Qualified: "core.Runner",
+		Kind: "class", LineStart: 10, LineEnd: 50,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	callerID, err := adapter.WriteSymbol(ctx, &model.Symbol{
-		FileID: fid, Name: "caller", Qualified: "core.caller",
-		Kind: model.KindFunction, LineStart: 60, LineEnd: 70,
+		FileID: fid2, Name: "App", Qualified: "app.App",
+		Kind: "class", LineStart: 1, LineEnd: 20,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	for _, targetID := range []int64{closeID, runID} {
+	for _, targetID := range []int64{closeID, runnerID} {
 		_, err = adapter.WriteEdge(ctx, &model.Edge{
 			SourceID: model.Int64Ptr(callerID), TargetID: targetID,
-			Kind: model.EdgeCalls, FileID: fid, Confidence: 1.0,
+			Kind: model.EdgeCalls, FileID: fid2, Confidence: 1.0,
 		})
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
-	_ = adapter.Close()
+	defer func() { _ = adapter.Close() }()
 
-	db, err := sql.Open("sqlite", "file:"+dbPath)
-	if err != nil {
-		t.Fatalf("sql.Open: %v", err)
-	}
-	defer func() { _ = db.Close() }()
-
-	got, err := renderKeyAbstractions(ctx, db)
+	got, err := renderKeyAbstractions(ctx, adapter)
 	if err != nil {
 		t.Fatalf("renderKeyAbstractions: %v", err)
 	}
 
 	if strings.Contains(got, "core.Close") {
-		t.Errorf("expected Close filtered as utility hub, got: %s", got)
+		t.Errorf("expected Close filtered as utility name, got: %s", got)
 	}
-	if !strings.Contains(got, "core.Run") {
-		t.Errorf("expected core.Run to be present, got: %s", got)
+	if !strings.Contains(got, "core.Runner") {
+		t.Errorf("expected core.Runner to be present, got: %s", got)
 	}
 }
 

--- a/internal/summary/summary.go
+++ b/internal/summary/summary.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/luuuc/sense/internal/sqlite"
 	"github.com/luuuc/sense/internal/version"
 )
 
@@ -35,7 +36,8 @@ type section struct {
 	render func(ctx context.Context, db *sql.DB) (string, error)
 }
 
-func Generate(ctx context.Context, db *sql.DB, senseDir string) error {
+func Generate(ctx context.Context, adapter *sqlite.Adapter, senseDir string) error {
+	db := adapter.DB()
 	path := filepath.Join(senseDir, "summary.md")
 
 	var fileCount int
@@ -54,7 +56,9 @@ func Generate(ctx context.Context, db *sql.DB, senseDir string) error {
 	sections := []section{
 		{"Fingerprint", renderFingerprint},
 		{"Main Areas", renderMainAreas},
-		{"Key Abstractions", renderKeyAbstractions},
+		{"Key Abstractions", func(ctx context.Context, _ *sql.DB) (string, error) {
+			return renderKeyAbstractions(ctx, adapter)
+		}},
 		{"Reading Path", renderReadingPath},
 		{"Known Noise", renderKnownNoise},
 	}
@@ -231,51 +235,25 @@ func dominantKindDesc(kinds map[string]int) string {
 	}
 }
 
-var utilitySymbols = map[string]bool{
-	"Close": true, "Error": true, "String": true, "make": true,
-	"len": true, "append": true, "New": true, "init": true,
-	"Format": true, "Write": true, "Read": true, "Reset": true,
-	"MarshalJSON": true, "UnmarshalJSON": true,
-}
-
-func renderKeyAbstractions(ctx context.Context, db *sql.DB) (string, error) {
-	rows, err := db.QueryContext(ctx, `SELECT s.qualified, s.name, COUNT(e.id) AS in_degree, s.kind
-		FROM sense_symbols s
-		JOIN sense_edges e ON e.target_id = s.id
-		JOIN sense_files f ON f.id = s.file_id
-		WHERE f.path NOT LIKE '%testdata%'
-		  AND f.path NOT LIKE '%fixture%'
-		  AND f.path NOT LIKE '%vendor%'
-		GROUP BY s.id
-		ORDER BY in_degree DESC
-		LIMIT 30`)
+func renderKeyAbstractions(ctx context.Context, adapter *sqlite.Adapter) (string, error) {
+	results, err := adapter.TopSymbolsByReach(ctx, "", 8)
 	if err != nil {
 		return "", err
 	}
-	defer func() { _ = rows.Close() }()
+	if len(results) == 0 {
+		return "", nil
+	}
 
 	var b strings.Builder
 	b.WriteString("*Drill into any symbol: `sense_graph symbol=\"...\"` or `sense_blast symbol=\"...\"`*\n")
-	n := 0
-	for rows.Next() {
-		var qualified, name, kind string
-		var callers int
-		if err := rows.Scan(&qualified, &name, &callers, &kind); err != nil {
-			return "", err
-		}
-		if utilitySymbols[name] {
-			continue
-		}
-		fmt.Fprintf(&b, "- `%s` (%s) — %d incoming edges\n", qualified, kind, callers)
-		n++
-		if n >= 8 {
-			break
+	for _, ks := range results {
+		if ks.Snippet != "" {
+			fmt.Fprintf(&b, "- `%s` (%s) — %d file refs — `%s`\n", ks.Qualified, ks.Kind, ks.RefFiles, ks.Snippet)
+		} else {
+			fmt.Fprintf(&b, "- `%s` (%s) — %d file refs\n", ks.Qualified, ks.Kind, ks.RefFiles)
 		}
 	}
-	if n == 0 {
-		return "", nil
-	}
-	return b.String(), rows.Err()
+	return b.String(), nil
 }
 
 func renderReadingPath(ctx context.Context, db *sql.DB) (string, error) {

--- a/internal/summary/summary_test.go
+++ b/internal/summary/summary_test.go
@@ -3,7 +3,6 @@ package summary_test
 import (
 	"bytes"
 	"context"
-	"database/sql"
 	"io"
 	"os"
 	"path/filepath"
@@ -92,16 +91,10 @@ func d() {}
 	}
 	t.Cleanup(func() { _ = adapter.Close() })
 
-	db, err := sql.Open("sqlite", "file:"+dbPath)
-	if err != nil {
-		t.Fatalf("sql.Open: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
-
 	t.Setenv("SENSE_SUMMARY_TOKENS", "200")
 
 	outDir := t.TempDir()
-	if err := summary.Generate(ctx, db, outDir); err != nil {
+	if err := summary.Generate(ctx, adapter, outDir); err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
 
@@ -126,16 +119,10 @@ func TestGenerateWritesStubWhenEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sqlite.Open: %v", err)
 	}
-	_ = adapter.Close()
-
-	db, err := sql.Open("sqlite", "file:"+dbPath)
-	if err != nil {
-		t.Fatalf("sql.Open: %v", err)
-	}
-	t.Cleanup(func() { _ = db.Close() })
+	t.Cleanup(func() { _ = adapter.Close() })
 
 	outDir := t.TempDir()
-	if err := summary.Generate(ctx, db, outDir); err != nil {
+	if err := summary.Generate(ctx, adapter, outDir); err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
 


### PR DESCRIPTION
## Problem

`sense.conventions` and `sense.status` report structural patterns (naming, structure categories) but don't surface the concrete high-reach types that anchor a codebase. Consumers have to follow up with `sense_graph` calls to discover which symbols actually matter, and the summary's "Key Abstractions" section uses a raw in-degree edge count that over-weights utility symbols.

## Summary

Add a `key_symbols` section to conventions and status responses, ranking types/interfaces/classes by the number of distinct files that reference them (including references through their methods), with top callers inlined.

## Changes

- **sqlite**: new `TopSymbolsByReach` query (CTE counting distinct file refs through type + child method edges) and `TopCallers` query, with builtin-name filtering
- **mcpio**: add `KeySymbolEntry` wire type; embed in `ConventionsResponse` and `StatusStructure`
- **server**: `buildKeyEntries` helper wires queries into `handleConventions` (limit 15) and `handleStatus` (limit 8); filter out now-redundant structure/naming convention entries
- **summary**: refactor `Generate` to accept `*sqlite.Adapter` instead of `*sql.DB`; replace inline SQL + `utilitySymbols` map with `TopSymbolsByReach`; update scan callers

## Test Plan

- [ ] `TestTopSymbolsByReach` — types ranked by file reach, functions/builtins excluded
- [ ] `TestTopSymbolsByReach_DomainFilter` — path prefix scoping
- [ ] `TestTopCallers` — caller resolution with file paths
- [ ] `TestRenderKeyAbstractions` — summary renders symbol + file ref count
- [ ] `TestRenderKeyAbstractionsFiltersUtility` — builtin names excluded
- [ ] `TestGenerate` / `TestGenerateWritesStubWhenEmpty` — updated signature
- [ ] `go test ./...` passes
- [ ] sense binary builds cleanly