### PR TITLE
test(mcpserver): add in-process unit tests for handlers, resolution, and builders

### DIFF
--- a/internal/mcpserver/builder_test.go
+++ b/internal/mcpserver/builder_test.go
@@ -1,0 +1,147 @@
+package mcpserver
+
+import (
+	"context"
+	"testing"
+)
+
+func TestBuildStatusResponse(t *testing.T) {
+	ts := setupTestServer(t)
+	ctx := context.Background()
+
+	resp, err := buildStatusResponse(ctx, ts.handlers.db, ts.handlers.dir, nil)
+	if err != nil {
+		t.Fatalf("buildStatusResponse: %v", err)
+	}
+
+	// Index counts should match seeded data
+	if resp.Index.Files != 7 {
+		t.Errorf("index.files = %d, want 7", resp.Index.Files)
+	}
+	if resp.Index.Symbols != 12 {
+		t.Errorf("index.symbols = %d, want 12", resp.Index.Symbols)
+	}
+	if resp.Index.Edges != 8 {
+		t.Errorf("index.edges = %d, want 8", resp.Index.Edges)
+	}
+
+	// Index path should be relative
+	if resp.Index.Path != ".sense/index.db" {
+		t.Errorf("index.path = %q, want .sense/index.db", resp.Index.Path)
+	}
+
+	// Size should be non-zero (real file on disk)
+	if resp.Index.SizeBytes == 0 {
+		t.Error("index.size_bytes = 0, want non-zero")
+	}
+}
+
+func TestBuildStatusResponseLanguageBreakdown(t *testing.T) {
+	ts := setupTestServer(t)
+	ctx := context.Background()
+
+	resp, err := buildStatusResponse(ctx, ts.handlers.db, ts.handlers.dir, nil)
+	if err != nil {
+		t.Fatalf("buildStatusResponse: %v", err)
+	}
+
+	if resp.Languages == nil {
+		t.Fatal("languages nil")
+	}
+
+	goLang, ok := resp.Languages["go"]
+	if !ok {
+		t.Fatal("missing 'go' in language breakdown")
+	}
+	if goLang.Files != 7 {
+		t.Errorf("go.files = %d, want 7", goLang.Files)
+	}
+	if goLang.Symbols != 12 {
+		t.Errorf("go.symbols = %d, want 12", goLang.Symbols)
+	}
+	if goLang.Tier != "full" {
+		t.Errorf("go.tier = %q, want full", goLang.Tier)
+	}
+}
+
+func TestBuildStatusResponseFreshness(t *testing.T) {
+	ts := setupTestServer(t)
+	ctx := context.Background()
+
+	resp, err := buildStatusResponse(ctx, ts.handlers.db, ts.handlers.dir, nil)
+	if err != nil {
+		t.Fatalf("buildStatusResponse: %v", err)
+	}
+
+	if resp.Freshness.LastScan == nil {
+		t.Error("freshness.last_scan nil")
+	}
+}
+
+func TestBuildStatusResponseStructure(t *testing.T) {
+	ts := setupTestServer(t)
+	ctx := context.Background()
+
+	resp, err := buildStatusResponse(ctx, ts.handlers.db, ts.handlers.dir, nil)
+	if err != nil {
+		t.Fatalf("buildStatusResponse: %v", err)
+	}
+
+	if resp.Structure == nil {
+		t.Fatal("structure nil")
+	}
+	if len(resp.Structure.TopNamespaces) == 0 {
+		t.Error("expected top namespaces")
+	}
+	if resp.Structure.Fingerprint == "" {
+		t.Error("expected non-empty fingerprint")
+	}
+}
+
+func TestBuildStatusResponseVersion(t *testing.T) {
+	ts := setupTestServer(t)
+	ctx := context.Background()
+
+	resp, err := buildStatusResponse(ctx, ts.handlers.db, ts.handlers.dir, nil)
+	if err != nil {
+		t.Fatalf("buildStatusResponse: %v", err)
+	}
+
+	if resp.Version == nil {
+		t.Fatal("version nil")
+	}
+	if resp.Version.Binary == "" {
+		t.Error("version.binary empty")
+	}
+	if resp.Version.EmbeddingModel == "" {
+		t.Error("version.embedding_model empty")
+	}
+}
+
+func TestQueryLanguageBreakdown(t *testing.T) {
+	ts := setupTestServer(t)
+	ctx := context.Background()
+
+	langs, err := queryLanguageBreakdown(ctx, ts.handlers.db)
+	if err != nil {
+		t.Fatalf("queryLanguageBreakdown: %v", err)
+	}
+
+	if len(langs) == 0 {
+		t.Fatal("expected at least one language")
+	}
+
+	goLang, ok := langs["go"]
+	if !ok {
+		t.Fatal("missing 'go' entry")
+	}
+	if goLang.Files == 0 {
+		t.Error("go.files = 0")
+	}
+	if goLang.Symbols == 0 {
+		t.Error("go.symbols = 0")
+	}
+	if goLang.Tier == "" {
+		t.Error("go.tier empty")
+	}
+}

--- a/internal/mcpserver/handler_test.go
+++ b/internal/mcpserver/handler_test.go
@@ -1,0 +1,624 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	mcp "github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/luuuc/sense/internal/mcpio"
+	"github.com/luuuc/sense/internal/metrics"
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/profile"
+	"github.com/luuuc/sense/internal/search"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+type testServer struct {
+	handlers *handlers
+	symbols  map[string]int64
+	files    map[string]int64
+}
+
+func setupTestServer(t *testing.T) *testServer {
+	t.Helper()
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	now := time.Now()
+
+	fileData := []model.File{
+		{Path: "internal/auth/auth.go", Language: "go", Hash: "h1", Symbols: 3, IndexedAt: now},
+		{Path: "internal/auth/token.go", Language: "go", Hash: "h2", Symbols: 2, IndexedAt: now},
+		{Path: "internal/handler/handler.go", Language: "go", Hash: "h3", Symbols: 2, IndexedAt: now},
+		{Path: "internal/model/user.go", Language: "go", Hash: "h4", Symbols: 2, IndexedAt: now},
+		{Path: "internal/model/order.go", Language: "go", Hash: "h5", Symbols: 1, IndexedAt: now},
+		{Path: "cmd/main.go", Language: "go", Hash: "h6", Symbols: 1, IndexedAt: now},
+		{Path: "internal/auth/auth_test.go", Language: "go", Hash: "h7", Symbols: 1, IndexedAt: now},
+	}
+	fileIDs := make(map[string]int64, len(fileData))
+	for i := range fileData {
+		id, err := adapter.WriteFile(ctx, &fileData[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		fileIDs[fileData[i].Path] = id
+	}
+
+	type symDef struct {
+		file      string
+		name      string
+		qualified string
+		kind      model.SymbolKind
+		snippet   string
+	}
+	symDefs := []symDef{
+		{"internal/auth/auth.go", "Authenticator", "auth.Authenticator", "interface", "type Authenticator interface {"},
+		{"internal/auth/auth.go", "Verify", "auth.Verify", "function", "func Verify(token string) error {"},
+		{"internal/auth/auth.go", "NewAuth", "auth.NewAuth", "function", "func NewAuth() *Auth {"},
+		{"internal/auth/token.go", "Token", "auth.Token", "class", "type Token struct {"},
+		{"internal/auth/token.go", "Parse", "auth.Parse", "function", "func Parse(raw string) (*Token, error) {"},
+		{"internal/handler/handler.go", "HandleRequest", "handler.HandleRequest", "function", "func HandleRequest(w http.ResponseWriter, r *http.Request) {"},
+		{"internal/handler/handler.go", "Handler", "handler.Handler", "class", "type Handler struct {"},
+		{"internal/model/user.go", "User", "model.User", "class", "type User struct {"},
+		{"internal/model/user.go", "FindUser", "model.FindUser", "function", "func FindUser(id int) (*User, error) {"},
+		{"internal/model/order.go", "Order", "model.Order", "class", "type Order struct {"},
+		{"cmd/main.go", "main", "main.main", "function", "func main() {"},
+		{"internal/auth/auth_test.go", "TestVerify", "auth_test.TestVerify", "function", "func TestVerify(t *testing.T) {"},
+	}
+
+	symIDs := make(map[string]int64, len(symDefs))
+	for _, sd := range symDefs {
+		s := &model.Symbol{
+			FileID:    fileIDs[sd.file],
+			Name:      sd.name,
+			Qualified: sd.qualified,
+			Kind:      sd.kind,
+			LineStart: 1,
+			LineEnd:   20,
+			Snippet:   sd.snippet,
+		}
+		id, err := adapter.WriteSymbol(ctx, s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		symIDs[sd.qualified] = id
+	}
+
+	edges := []model.Edge{
+		// handler.HandleRequest → auth.Verify
+		{SourceID: model.Int64Ptr(symIDs["handler.HandleRequest"]), TargetID: symIDs["auth.Verify"], Kind: model.EdgeCalls, FileID: fileIDs["internal/handler/handler.go"], Line: intPtr(10), Confidence: 1.0},
+		// handler.HandleRequest → model.FindUser
+		{SourceID: model.Int64Ptr(symIDs["handler.HandleRequest"]), TargetID: symIDs["model.FindUser"], Kind: model.EdgeCalls, FileID: fileIDs["internal/handler/handler.go"], Line: intPtr(12), Confidence: 1.0},
+		// auth.Verify → auth.Parse
+		{SourceID: model.Int64Ptr(symIDs["auth.Verify"]), TargetID: symIDs["auth.Parse"], Kind: model.EdgeCalls, FileID: fileIDs["internal/auth/auth.go"], Line: intPtr(5), Confidence: 1.0},
+		// auth.Parse → auth.Token
+		{SourceID: model.Int64Ptr(symIDs["auth.Parse"]), TargetID: symIDs["auth.Token"], Kind: model.EdgeCalls, FileID: fileIDs["internal/auth/token.go"], Line: intPtr(8), Confidence: 1.0},
+		// model.FindUser → model.User
+		{SourceID: model.Int64Ptr(symIDs["model.FindUser"]), TargetID: symIDs["model.User"], Kind: model.EdgeCalls, FileID: fileIDs["internal/model/user.go"], Line: intPtr(3), Confidence: 1.0},
+		// handler.Handler inherits auth.Authenticator
+		{SourceID: model.Int64Ptr(symIDs["handler.Handler"]), TargetID: symIDs["auth.Authenticator"], Kind: model.EdgeInherits, FileID: fileIDs["internal/handler/handler.go"], Confidence: 1.0},
+		// main → handler.HandleRequest
+		{SourceID: model.Int64Ptr(symIDs["main.main"]), TargetID: symIDs["handler.HandleRequest"], Kind: model.EdgeCalls, FileID: fileIDs["cmd/main.go"], Line: intPtr(5), Confidence: 1.0},
+		// auth_test.TestVerify → auth.Verify
+		{SourceID: model.Int64Ptr(symIDs["auth_test.TestVerify"]), TargetID: symIDs["auth.Verify"], Kind: model.EdgeCalls, FileID: fileIDs["internal/auth/auth_test.go"], Line: intPtr(3), Confidence: 1.0},
+	}
+	for _, e := range edges {
+		if _, err := adapter.WriteEdge(ctx, &e); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	engine := search.NewEngine(adapter, nil, nil)
+
+	tracker := metrics.NewTracker(adapter.DB())
+	t.Cleanup(func() { tracker.Close() })
+
+	h := &handlers{
+		adapter:  adapter,
+		db:       adapter.DB(),
+		dir:      dir,
+		search:   engine,
+		tracker:  tracker,
+		defaults: profile.DefaultParams(),
+	}
+
+	return &testServer{handlers: h, symbols: symIDs, files: fileIDs}
+}
+
+func toolReq(args map[string]any) mcp.CallToolRequest {
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = args
+	return req
+}
+
+func resultText(t *testing.T, result *mcp.CallToolResult) string {
+	t.Helper()
+	if len(result.Content) == 0 {
+		t.Fatal("empty content in result")
+	}
+	tc, ok := result.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("first content block is not TextContent: %T", result.Content[0])
+	}
+	return tc.Text
+}
+
+// --- handleGraph tests ---
+
+func TestHandleGraph(t *testing.T) {
+	ts := setupTestServer(t)
+	h := ts.handlers
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		args      map[string]any
+		isError   bool
+		checkJSON func(t *testing.T, text string)
+	}{
+		{
+			name: "known symbol returns edges",
+			args: map[string]any{"symbol": "auth.Verify"},
+			checkJSON: func(t *testing.T, text string) {
+				var resp mcpio.GraphResponse
+				if err := json.Unmarshal([]byte(text), &resp); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if resp.Symbol.Name != "Verify" {
+					t.Errorf("symbol.name = %q, want Verify", resp.Symbol.Name)
+				}
+				if len(resp.Edges.CalledBy) == 0 {
+					t.Error("expected callers for auth.Verify")
+				}
+			},
+		},
+		{
+			name:    "empty symbol returns error",
+			args:    map[string]any{},
+			isError: true,
+			checkJSON: func(t *testing.T, text string) {
+				if !strings.Contains(text, "missing required parameter") {
+					t.Errorf("expected missing parameter error, got %q", text)
+				}
+			},
+		},
+		{
+			name:    "invalid direction returns error",
+			args:    map[string]any{"symbol": "auth.Verify", "direction": "invalid"},
+			isError: true,
+			checkJSON: func(t *testing.T, text string) {
+				if !strings.Contains(text, "direction must be") {
+					t.Errorf("expected direction error, got %q", text)
+				}
+			},
+		},
+		{
+			name: "unknown symbol returns not-found",
+			args: map[string]any{"symbol": "nonexistent.Symbol"},
+			checkJSON: func(t *testing.T, text string) {
+				if !strings.Contains(text, "symbol not found") {
+					t.Errorf("expected not-found, got %q", text)
+				}
+			},
+		},
+		{
+			name: "direction callers",
+			args: map[string]any{"symbol": "auth.Verify", "direction": "callers"},
+			checkJSON: func(t *testing.T, text string) {
+				var resp mcpio.GraphResponse
+				if err := json.Unmarshal([]byte(text), &resp); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if resp.Symbol.Name != "Verify" {
+					t.Errorf("symbol.name = %q, want Verify", resp.Symbol.Name)
+				}
+			},
+		},
+		{
+			name: "direction callees",
+			args: map[string]any{"symbol": "auth.Verify", "direction": "callees"},
+			checkJSON: func(t *testing.T, text string) {
+				var resp mcpio.GraphResponse
+				if err := json.Unmarshal([]byte(text), &resp); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if len(resp.Edges.Calls) == 0 {
+					t.Error("expected callees for auth.Verify")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := h.handleGraph(ctx, toolReq(tt.args))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.isError && !result.IsError {
+				t.Error("expected IsError=true")
+			}
+			if tt.checkJSON != nil {
+				tt.checkJSON(t, resultText(t, result))
+			}
+		})
+	}
+}
+
+// --- handleSearch tests ---
+
+func TestHandleSearch(t *testing.T) {
+	ts := setupTestServer(t)
+	h := ts.handlers
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		args      map[string]any
+		isError   bool
+		checkJSON func(t *testing.T, text string)
+	}{
+		{
+			name: "keyword query returns results",
+			args: map[string]any{"query": "Verify"},
+			checkJSON: func(t *testing.T, text string) {
+				var resp mcpio.SearchResponse
+				if err := json.Unmarshal([]byte(text), &resp); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if len(resp.Results) == 0 {
+					t.Error("expected results for 'Verify' query")
+				}
+			},
+		},
+		{
+			name:    "empty query returns error",
+			args:    map[string]any{},
+			isError: true,
+			checkJSON: func(t *testing.T, text string) {
+				if !strings.Contains(text, "missing required parameter") {
+					t.Errorf("expected missing parameter error, got %q", text)
+				}
+			},
+		},
+		{
+			name: "language filter restricts results",
+			args: map[string]any{"query": "Verify", "language": "ruby"},
+			checkJSON: func(t *testing.T, text string) {
+				var resp mcpio.SearchResponse
+				if err := json.Unmarshal([]byte(text), &resp); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				for _, r := range resp.Results {
+					if strings.Contains(r.File, ".go") {
+						t.Errorf("language=ruby should exclude .go files, got %s", r.File)
+					}
+				}
+			},
+		},
+		{
+			name: "limit caps results",
+			args: map[string]any{"query": "auth", "limit": 2},
+			checkJSON: func(t *testing.T, text string) {
+				var resp mcpio.SearchResponse
+				if err := json.Unmarshal([]byte(text), &resp); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if len(resp.Results) > 2 {
+					t.Errorf("expected at most 2 results with limit=2, got %d", len(resp.Results))
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := h.handleSearch(ctx, toolReq(tt.args))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.isError && !result.IsError {
+				t.Error("expected IsError=true")
+			}
+			if tt.checkJSON != nil {
+				tt.checkJSON(t, resultText(t, result))
+			}
+		})
+	}
+}
+
+// --- handleBlast tests ---
+
+func TestHandleBlast(t *testing.T) {
+	ts := setupTestServer(t)
+	h := ts.handlers
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		args      map[string]any
+		isError   bool
+		checkJSON func(t *testing.T, text string)
+	}{
+		{
+			name: "known symbol returns callers and risk",
+			args: map[string]any{"symbol": "auth.Verify"},
+			checkJSON: func(t *testing.T, text string) {
+				var resp mcpio.BlastResponse
+				if err := json.Unmarshal([]byte(text), &resp); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if resp.Symbol == "" {
+					t.Error("expected non-empty symbol")
+				}
+				switch resp.Risk {
+				case "low", "medium", "high":
+				default:
+					t.Errorf("risk = %q, want low/medium/high", resp.Risk)
+				}
+				if len(resp.DirectCallers) == 0 {
+					t.Error("expected direct callers")
+				}
+				if resp.TotalAffected == 0 {
+					t.Error("expected total_affected > 0")
+				}
+			},
+		},
+		{
+			name:    "missing both symbol and diff",
+			args:    map[string]any{},
+			isError: true,
+			checkJSON: func(t *testing.T, text string) {
+				if !strings.Contains(text, "pass either") {
+					t.Errorf("expected parameter error, got %q", text)
+				}
+			},
+		},
+		{
+			name:    "both symbol and diff",
+			args:    map[string]any{"symbol": "auth.Verify", "diff": "HEAD~1"},
+			isError: true,
+			checkJSON: func(t *testing.T, text string) {
+				if !strings.Contains(text, "not both") {
+					t.Errorf("expected mutual exclusion error, got %q", text)
+				}
+			},
+		},
+		{
+			name: "unknown symbol returns not-found",
+			args: map[string]any{"symbol": "nonexistent.Foo"},
+			checkJSON: func(t *testing.T, text string) {
+				if !strings.Contains(text, "symbol not found") {
+					t.Errorf("expected not-found, got %q", text)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := h.handleBlast(ctx, toolReq(tt.args))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.isError && !result.IsError {
+				t.Error("expected IsError=true")
+			}
+			if tt.checkJSON != nil {
+				tt.checkJSON(t, resultText(t, result))
+			}
+		})
+	}
+}
+
+// --- handleConventions tests ---
+
+func TestHandleConventionsTableDriven(t *testing.T) {
+	ts := setupTestServer(t)
+	h := ts.handlers
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		args      map[string]any
+		checkJSON func(t *testing.T, text string)
+	}{
+		{
+			name: "returns conventions",
+			args: map[string]any{},
+			checkJSON: func(t *testing.T, text string) {
+				var resp mcpio.ConventionsResponse
+				if err := json.Unmarshal([]byte(text), &resp); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if len(resp.KeySymbols) == 0 {
+					t.Error("expected key_symbols")
+				}
+			},
+		},
+		{
+			name: "domain filter scopes results",
+			args: map[string]any{"domain": "internal/auth"},
+			checkJSON: func(t *testing.T, text string) {
+				var resp mcpio.ConventionsResponse
+				if err := json.Unmarshal([]byte(text), &resp); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				// Domain filter should return fewer key symbols than unfiltered
+				var unfilteredResp mcpio.ConventionsResponse
+				unfilteredResult, err := h.handleConventions(ctx, toolReq(map[string]any{}))
+				if err != nil {
+					t.Fatalf("unfiltered call: %v", err)
+				}
+				if err := json.Unmarshal([]byte(resultText(t, unfilteredResult)), &unfilteredResp); err != nil {
+					t.Fatalf("unmarshal unfiltered: %v", err)
+				}
+				if len(resp.KeySymbols) >= len(unfilteredResp.KeySymbols) && len(unfilteredResp.KeySymbols) > 0 {
+					t.Errorf("domain filter should scope results: filtered=%d, unfiltered=%d",
+						len(resp.KeySymbols), len(unfilteredResp.KeySymbols))
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := h.handleConventions(ctx, toolReq(tt.args))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.IsError {
+				t.Fatalf("unexpected tool error: %s", resultText(t, result))
+			}
+			if tt.checkJSON != nil {
+				tt.checkJSON(t, resultText(t, result))
+			}
+		})
+	}
+}
+
+// --- handleStatus tests ---
+
+func TestHandleStatusTableDriven(t *testing.T) {
+	ts := setupTestServer(t)
+	h := ts.handlers
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		checkJSON func(t *testing.T, text string)
+	}{
+		{
+			name: "returns index health and structure",
+			checkJSON: func(t *testing.T, text string) {
+				var resp mcpio.StatusResponse
+				if err := json.Unmarshal([]byte(text), &resp); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if resp.Index.Files == 0 {
+					t.Error("index.files == 0")
+				}
+				if resp.Index.Symbols == 0 {
+					t.Error("index.symbols == 0")
+				}
+				if resp.Structure == nil {
+					t.Error("expected structure block")
+				}
+			},
+		},
+		{
+			name: "includes session metrics",
+			checkJSON: func(t *testing.T, text string) {
+				var resp mcpio.StatusResponse
+				if err := json.Unmarshal([]byte(text), &resp); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if resp.Session == nil {
+					t.Error("expected session block")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := h.handleStatus(ctx, mcp.CallToolRequest{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.IsError {
+				t.Fatalf("unexpected tool error: %s", resultText(t, result))
+			}
+			if tt.checkJSON != nil {
+				tt.checkJSON(t, resultText(t, result))
+			}
+		})
+	}
+}
+
+// --- handleDeadCode tests ---
+
+func TestHandleDeadCode(t *testing.T) {
+	ts := setupTestServer(t)
+	h := ts.handlers
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		args      map[string]any
+		checkJSON func(t *testing.T, text string)
+	}{
+		{
+			name: "returns dead symbols",
+			args: map[string]any{"dead_code": true},
+			checkJSON: func(t *testing.T, text string) {
+				var resp mcpio.DeadCodeResponse
+				if err := json.Unmarshal([]byte(text), &resp); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if resp.DeadCount == 0 {
+					t.Error("expected dead symbols (model.Order has zero incoming edges)")
+				}
+			},
+		},
+		{
+			name: "language filter",
+			args: map[string]any{"dead_code": true, "language": "go"},
+			checkJSON: func(t *testing.T, text string) {
+				var resp mcpio.DeadCodeResponse
+				if err := json.Unmarshal([]byte(text), &resp); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				// All seeded files are go, so this should return some dead symbols
+				if resp.TotalSymbols == 0 {
+					t.Error("expected total_symbols > 0 with language=go")
+				}
+			},
+		},
+		{
+			name: "domain filter",
+			args: map[string]any{"dead_code": true, "domain": "internal/model"},
+			checkJSON: func(t *testing.T, text string) {
+				var resp mcpio.DeadCodeResponse
+				if err := json.Unmarshal([]byte(text), &resp); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				for _, ds := range resp.DeadSymbols {
+					if !strings.Contains(ds.File, "internal/model") {
+						t.Errorf("expected domain-scoped dead symbol, got file %q", ds.File)
+					}
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := h.handleGraph(ctx, toolReq(tt.args))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.IsError {
+				t.Fatalf("unexpected tool error: %s", resultText(t, result))
+			}
+			if tt.checkJSON != nil {
+				tt.checkJSON(t, resultText(t, result))
+			}
+		})
+	}
+}

--- a/internal/mcpserver/hints_test.go
+++ b/internal/mcpserver/hints_test.go
@@ -564,4 +564,46 @@ func TestResponseCapsNextSteps(t *testing.T) {
 	}
 }
 
+func TestDeadCodeHintsWithDead(t *testing.T) {
+	resp := mcpio.DeadCodeResponse{
+		DeadCount: 3,
+		DeadSymbols: []mcpio.DeadSymbolEntry{
+			{Symbol: "Order", Qualified: "model.Order", File: "internal/model/order.go"},
+			{Symbol: "Unused", Qualified: "pkg.Unused", File: "internal/pkg/unused.go"},
+		},
+	}
+	hints := deadCodeHints(resp)
+	if len(hints) != 1 {
+		t.Fatalf("want 1 hint, got %d", len(hints))
+	}
+	if hints[0].Tool != "sense.graph" {
+		t.Errorf("tool = %q, want sense.graph", hints[0].Tool)
+	}
+	if hints[0].Args["symbol"] != "model.Order" {
+		t.Errorf("args.symbol = %q, want model.Order", hints[0].Args["symbol"])
+	}
+}
+
+func TestDeadCodeHintsEmpty(t *testing.T) {
+	resp := mcpio.DeadCodeResponse{
+		DeadCount:   0,
+		DeadSymbols: []mcpio.DeadSymbolEntry{},
+	}
+	hints := deadCodeHints(resp)
+	if hints != nil {
+		t.Fatalf("want nil hints for no dead symbols, got %d", len(hints))
+	}
+}
+
+func TestDeadCodeHintsCountMismatch(t *testing.T) {
+	resp := mcpio.DeadCodeResponse{
+		DeadCount:   5,
+		DeadSymbols: []mcpio.DeadSymbolEntry{},
+	}
+	hints := deadCodeHints(resp)
+	if hints != nil {
+		t.Fatalf("want nil hints when DeadSymbols is empty despite DeadCount>0, got %d", len(hints))
+	}
+}
+
 func intPtr(v int) *int { return &v }

--- a/internal/mcpserver/resolve_test.go
+++ b/internal/mcpserver/resolve_test.go
@@ -1,0 +1,296 @@
+package mcpserver
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/internal/cli"
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+type resolveFixture struct {
+	db      *sql.DB
+	adapter *sqlite.Adapter
+	h       *handlers
+	symbols map[string]int64
+}
+
+func setupResolveFixture(t *testing.T) *resolveFixture {
+	t.Helper()
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	now := time.Now()
+
+	fid1, _ := adapter.WriteFile(ctx, &model.File{Path: "pkg/auth/auth.go", Language: "go", Hash: "a", Symbols: 2, IndexedAt: now})
+	fid2, _ := adapter.WriteFile(ctx, &model.File{Path: "pkg/http/handler.go", Language: "go", Hash: "b", Symbols: 2, IndexedAt: now})
+	fid3, _ := adapter.WriteFile(ctx, &model.File{Path: "pkg/grpc/handler.go", Language: "go", Hash: "c", Symbols: 1, IndexedAt: now})
+	fid4, _ := adapter.WriteFile(ctx, &model.File{Path: "pkg/util/parse.go", Language: "go", Hash: "d", Symbols: 1, IndexedAt: now})
+	fid5, _ := adapter.WriteFile(ctx, &model.File{Path: "pkg/caller.go", Language: "go", Hash: "e", Symbols: 1, IndexedAt: now})
+
+	symIDs := map[string]int64{}
+
+	// Unique symbol — exact qualified match
+	id, _ := adapter.WriteSymbol(ctx, &model.Symbol{FileID: fid1, Name: "Authenticate", Qualified: "auth.Authenticate", Kind: "function", LineStart: 1, LineEnd: 10})
+	symIDs["auth.Authenticate"] = id
+
+	// Two symbols with same unqualified name "Handle" — for disambiguation
+	id, _ = adapter.WriteSymbol(ctx, &model.Symbol{FileID: fid2, Name: "Handle", Qualified: "http.Handle", Kind: "function", LineStart: 1, LineEnd: 20})
+	symIDs["http.Handle"] = id
+	id, _ = adapter.WriteSymbol(ctx, &model.Symbol{FileID: fid3, Name: "Handle", Qualified: "grpc.Handle", Kind: "function", LineStart: 1, LineEnd: 15})
+	symIDs["grpc.Handle"] = id
+
+	// Three symbols with same name "Parse" — one dominant (many edges), others weak
+	id, _ = adapter.WriteSymbol(ctx, &model.Symbol{FileID: fid1, Name: "Parse", Qualified: "auth.Parse", Kind: "function", LineStart: 15, LineEnd: 30})
+	symIDs["auth.Parse"] = id
+	id, _ = adapter.WriteSymbol(ctx, &model.Symbol{FileID: fid4, Name: "Parse", Qualified: "util.Parse", Kind: "function", LineStart: 1, LineEnd: 10})
+	symIDs["util.Parse"] = id
+	id, _ = adapter.WriteSymbol(ctx, &model.Symbol{FileID: fid2, Name: "Parse", Qualified: "http.Parse", Kind: "function", LineStart: 25, LineEnd: 35})
+	symIDs["http.Parse"] = id
+
+	// A caller to create edges
+	callerID, _ := adapter.WriteSymbol(ctx, &model.Symbol{FileID: fid5, Name: "Main", Qualified: "caller.Main", Kind: "function", LineStart: 1, LineEnd: 5})
+	symIDs["caller.Main"] = callerID
+
+	// Give auth.Parse many edges (dominant), others zero/one
+	for i := 0; i < 10; i++ {
+		cID, _ := adapter.WriteSymbol(ctx, &model.Symbol{
+			FileID: fid5, Name: "c" + string(rune('A'+i)), Qualified: "caller.c" + string(rune('A'+i)),
+			Kind: "function", LineStart: 10 + i, LineEnd: 12 + i,
+		})
+		_, _ = adapter.WriteEdge(ctx, &model.Edge{SourceID: model.Int64Ptr(cID), TargetID: symIDs["auth.Parse"], Kind: model.EdgeCalls, FileID: fid5, Confidence: 1.0})
+	}
+	// Give util.Parse 1 edge (runner-up)
+	_, _ = adapter.WriteEdge(ctx, &model.Edge{SourceID: model.Int64Ptr(callerID), TargetID: symIDs["util.Parse"], Kind: model.EdgeCalls, FileID: fid5, Confidence: 1.0})
+
+	// Give both Handle symbols similar edge counts (3 each) — no dominant
+	for i := 0; i < 3; i++ {
+		cID, _ := adapter.WriteSymbol(ctx, &model.Symbol{
+			FileID: fid5, Name: "h" + string(rune('A'+i)), Qualified: "caller.h" + string(rune('A'+i)),
+			Kind: "function", LineStart: 30 + i, LineEnd: 32 + i,
+		})
+		_, _ = adapter.WriteEdge(ctx, &model.Edge{SourceID: model.Int64Ptr(cID), TargetID: symIDs["http.Handle"], Kind: model.EdgeCalls, FileID: fid5, Confidence: 1.0})
+	}
+	for i := 0; i < 3; i++ {
+		cID, _ := adapter.WriteSymbol(ctx, &model.Symbol{
+			FileID: fid5, Name: "g" + string(rune('A'+i)), Qualified: "caller.g" + string(rune('A'+i)),
+			Kind: "function", LineStart: 40 + i, LineEnd: 42 + i,
+		})
+		_, _ = adapter.WriteEdge(ctx, &model.Edge{SourceID: model.Int64Ptr(cID), TargetID: symIDs["grpc.Handle"], Kind: model.EdgeCalls, FileID: fid5, Confidence: 1.0})
+	}
+
+	h := makeHandlers(adapter, adapter.DB())
+
+	return &resolveFixture{db: adapter.DB(), adapter: adapter, h: h, symbols: symIDs}
+}
+
+// --- resolveSymbol tests ---
+
+func TestResolveSymbol(t *testing.T) {
+	rf := setupResolveFixture(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name   string
+		symbol string
+		wantOK bool
+		check  func(t *testing.T, err error)
+	}{
+		{
+			name:   "exact qualified match",
+			symbol: "auth.Authenticate",
+			wantOK: true,
+		},
+		{
+			name:   "single name match",
+			symbol: "Authenticate",
+			wantOK: true,
+		},
+		{
+			name:   "ambiguous name with dominant resolves",
+			symbol: "Parse",
+			wantOK: true,
+			check: func(t *testing.T, err error) {
+				// Should not error — auth.Parse dominates
+				if err != nil {
+					t.Errorf("expected dominantMatch to resolve Parse, got error")
+				}
+			},
+		},
+		{
+			name:   "ambiguous name without dominant returns disambiguation",
+			symbol: "Handle",
+			wantOK: false,
+			check: func(t *testing.T, err error) {
+				re, ok := err.(*resolveError)
+				if !ok {
+					t.Fatalf("expected *resolveError, got %T: %v", err, err)
+				}
+				raw := resultText(t, re.result)
+				var resp map[string]any
+				if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if resp["ambiguous"] != true {
+					t.Error("expected ambiguous=true")
+				}
+				matches, ok := resp["top_matches"].([]any)
+				if !ok || len(matches) < 2 {
+					t.Errorf("expected at least 2 top_matches, got %v", resp["top_matches"])
+				}
+			},
+		},
+		{
+			name:   "no match returns not-found",
+			symbol: "CompletelyUnknown",
+			wantOK: false,
+			check: func(t *testing.T, err error) {
+				re, ok := err.(*resolveError)
+				if !ok {
+					t.Fatalf("expected *resolveError, got %T: %v", err, err)
+				}
+				if !re.result.IsError {
+					t.Error("expected IsError for not-found")
+				}
+			},
+		},
+		{
+			name:   "qualified name prioritized over unqualified",
+			symbol: "http.Handle",
+			wantOK: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			match, err := rf.h.resolveSymbol(ctx, "test", tt.symbol)
+			if tt.wantOK {
+				if err != nil {
+					t.Fatalf("expected success, got error: %v", err)
+				}
+				if match.ID == 0 {
+					t.Error("expected non-zero match ID")
+				}
+				if tt.check != nil {
+					tt.check(t, nil)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("expected error, got match: %+v", match)
+				}
+				if tt.check != nil {
+					tt.check(t, err)
+				}
+			}
+		})
+	}
+}
+
+// --- dominantMatch tests ---
+
+func TestDominantMatch(t *testing.T) {
+	rf := setupResolveFixture(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		symbol  string
+		wantWin bool
+	}{
+		{
+			name:    "auth.Parse dominates with 10 edges vs 1",
+			symbol:  "Parse",
+			wantWin: true,
+		},
+		{
+			name:    "Handle has no dominant (3 vs 3)",
+			symbol:  "Handle",
+			wantWin: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches, err := lookupByNameForTest(ctx, rf.db, tt.symbol)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(matches) < 2 {
+				t.Fatalf("expected ambiguous matches for %q, got %d", tt.symbol, len(matches))
+			}
+
+			winner, ok := rf.h.dominantMatch(ctx, matches)
+			if tt.wantWin {
+				if !ok {
+					t.Error("expected dominant match")
+				}
+				if winner.Qualified != "auth.Parse" {
+					t.Errorf("expected auth.Parse to win, got %q", winner.Qualified)
+				}
+			} else if ok {
+				t.Errorf("expected no dominant, got winner: %+v", winner)
+			}
+		})
+	}
+}
+
+// --- disambiguationResult tests ---
+
+func TestDisambiguationResult(t *testing.T) {
+	rf := setupResolveFixture(t)
+	ctx := context.Background()
+
+	matches, err := lookupByNameForTest(ctx, rf.db, "Handle")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) < 2 {
+		t.Fatalf("expected ambiguous matches, got %d", len(matches))
+	}
+
+	result := rf.h.disambiguationResult(ctx, "Handle", matches)
+	text := resultText(t, result)
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(text), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if resp["ambiguous"] != true {
+		t.Error("expected ambiguous=true")
+	}
+	if resp["query"] != "Handle" {
+		t.Errorf("query = %v, want Handle", resp["query"])
+	}
+	topMatches, ok := resp["top_matches"].([]any)
+	if !ok {
+		t.Fatal("top_matches missing or wrong type")
+	}
+	if len(topMatches) < 2 {
+		t.Errorf("expected >= 2 top_matches, got %d", len(topMatches))
+	}
+	if resp["hint"] == nil || resp["hint"] == "" {
+		t.Error("expected non-empty hint")
+	}
+}
+
+// lookupByNameForTest wraps cli.Lookup for test use — we call it directly
+// to get the raw match slice before resolveSymbol processes it.
+func lookupByNameForTest(ctx context.Context, db *sql.DB, name string) ([]cli.Match, error) {
+	return cli.Lookup(ctx, db, name)
+}


### PR DESCRIPTION
## Problem

`internal/mcpserver/server.go` is 1,638 lines with 27.7% statement coverage — the largest file and the largest coverage gap. The existing tests are either coarse-grained subprocess integration tests or narrow unit tests for dispatch and hints. The 45 handler and builder functions lack in-process coverage, meaning regressions in the primary MCP interface can ship undetected.

## Summary

Add 36 table-driven unit tests that exercise handlers, resolution logic, and status builders directly against a real SQLite database — no mocks, no MCP SDK framing.

## Changes

**Handler tests** (`handler_test.go`)
- Shared `setupTestServer` helper: seeds 7 files, 12 symbols, 8 edges into a temp SQLite database
- Table-driven tests for all 6 tool handlers: graph (6 cases), search (4), blast (4), conventions (2), status (2), dead-code (3)

**Resolution tests** (`resolve_test.go`)
- Dedicated fixture with duplicate symbol names and varying edge counts
- Tests for `resolveSymbol` (exact, name, dominant, disambiguation, not-found, qualified priority)
- Tests for `dominantMatch` (dominant win, no dominant)
- Test for `disambiguationResult` output shape

**Builder tests** (`builder_test.go`)
- `buildStatusResponse`: index counts, relative path, file size, language breakdown, freshness, structure, version
- `queryLanguageBreakdown`: file/symbol aggregation and tier assignment

**Hint coverage** (`hints_test.go`)
- 3 tests for the previously untested `deadCodeHints` generator

## Test Plan

- [x] `go test ./internal/mcpserver/` — 36 new tests pass
- [x] `make ci` — build, full test suite, and lint all green
- [x] No production code changes (test-only)