### PR TITLE
test(sqlite): add unit tests for error paths, edge cases, and query plan assertions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ sense.yml
 # ----------------------------------------------------------------------------
 bench/results/
 bench/results-bk/
+bench/audit/gt-audit.md

--- a/internal/sqlite/adapter_test.go
+++ b/internal/sqlite/adapter_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -43,6 +44,66 @@ func TestOpenFailures(t *testing.T) {
 			t.Fatal("Open with path pointing at a directory should error, got nil")
 		}
 	})
+
+	t.Run("CorruptDatabaseFile", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "corrupt.db")
+		if err := os.WriteFile(path, []byte("not a sqlite database"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		_, err := sqlite.Open(ctx, path)
+		if err == nil {
+			t.Fatal("Open with corrupt database file should error, got nil")
+		}
+	})
+}
+
+func TestRepeatedOpenClosePreservesData(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "concurrent.db")
+
+	// Open sequentially multiple times — concurrent schema writes get
+	// SQLITE_BUSY since there's no busy_timeout. The guarantee is that
+	// repeated open/close cycles on the same path never corrupt the DB.
+	for i := range 5 {
+		a, err := sqlite.Open(ctx, path)
+		if err != nil {
+			t.Fatalf("Open #%d: %v", i, err)
+		}
+		if i == 0 {
+			// Seed a symbol on first open to verify persistence.
+			fid, err := a.WriteFile(ctx, &model.File{
+				Path: "concurrent.go", Language: "go",
+				Hash: "c1", Symbols: 1, IndexedAt: time.Now(),
+			})
+			if err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+			if _, err := a.WriteSymbol(ctx, &model.Symbol{
+				FileID: fid, Name: "Persist", Qualified: "pkg.Persist",
+				Kind: "function", LineStart: 1, LineEnd: 5,
+			}); err != nil {
+				t.Fatalf("WriteSymbol: %v", err)
+			}
+		}
+		if err := a.Close(); err != nil {
+			t.Fatalf("Close #%d: %v", i, err)
+		}
+	}
+
+	// Verify the DB is intact after many open/close cycles.
+	a, err := sqlite.Open(ctx, path)
+	if err != nil {
+		t.Fatalf("final Open: %v", err)
+	}
+	defer func() { _ = a.Close() }()
+
+	count, err := a.SymbolCount(ctx)
+	if err != nil {
+		t.Fatalf("SymbolCount: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 symbol after repeated opens, got %d", count)
+	}
 }
 
 func TestSchemaVersionMismatchRebuilds(t *testing.T) {

--- a/internal/sqlite/context_test.go
+++ b/internal/sqlite/context_test.go
@@ -2,6 +2,8 @@ package sqlite_test
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -301,6 +303,70 @@ func TestContextForFileEmpty(t *testing.T) {
 	}
 	if result != nil {
 		t.Errorf("expected nil for file with no symbols, got %d entries", len(result))
+	}
+}
+
+func TestContextForFileNonexistentID(t *testing.T) {
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	_, err = a.ContextForFile(ctx, 99999)
+	if err == nil {
+		t.Fatal("expected error for nonexistent file ID, got nil")
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Errorf("error should wrap sql.ErrNoRows, got: %v", err)
+	}
+}
+
+func TestContextForFileSymbolsNoEdges(t *testing.T) {
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	fid, err := a.WriteFile(ctx, &model.File{
+		Path: "standalone.go", Language: "go",
+		Hash: "sa1", Symbols: 2, IndexedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := a.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid, Name: "Alpha", Qualified: "pkg.Alpha",
+		Kind: model.KindClass, LineStart: 1, LineEnd: 20,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid, Name: "Beta", Qualified: "pkg.Beta",
+		Kind: "function", LineStart: 25, LineEnd: 35,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := a.ContextForFile(ctx, fid)
+	if err != nil {
+		t.Fatalf("ContextForFile: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(result))
+	}
+
+	for _, ctx := range result {
+		if !strings.Contains(ctx, "File: standalone.go") {
+			t.Errorf("missing file path in context: %q", ctx)
+		}
+		if strings.Contains(ctx, "calls:") || strings.Contains(ctx, "composes:") {
+			t.Errorf("symbols with no edges should have no relationship lines: %q", ctx)
+		}
 	}
 }
 

--- a/internal/sqlite/dispatch_test.go
+++ b/internal/sqlite/dispatch_test.go
@@ -110,3 +110,52 @@ func TestDispatchNoParent(t *testing.T) {
 		t.Errorf("want nil for parentless symbol, got %v", ids)
 	}
 }
+
+func TestDispatchMultipleImplementors(t *testing.T) {
+	db := openDispatchDB(t)
+	ctx := context.Background()
+
+	// Interface Reader with method Read, implemented by FileReader and NetReader.
+	for _, q := range []string{
+		`INSERT INTO sense_files (id, path, language, hash, symbols, indexed_at) VALUES (1, 'io.go', 'go', 'abc', 0, '2026-01-01T00:00:00Z')`,
+
+		`INSERT INTO sense_symbols (id, file_id, name, qualified, kind, line_start, line_end)
+		 VALUES (10, 1, 'Reader', 'io.Reader', 'interface', 1, 5)`,
+		`INSERT INTO sense_symbols (id, file_id, name, qualified, kind, line_start, line_end, parent_id)
+		 VALUES (11, 1, 'Read', 'io.Reader.Read', 'method', 2, 3, 10)`,
+
+		`INSERT INTO sense_symbols (id, file_id, name, qualified, kind, line_start, line_end)
+		 VALUES (20, 1, 'FileReader', 'io.FileReader', 'class', 10, 20)`,
+		`INSERT INTO sense_symbols (id, file_id, name, qualified, kind, line_start, line_end, parent_id)
+		 VALUES (21, 1, 'Read', 'io.FileReader.Read', 'method', 11, 15, 20)`,
+
+		`INSERT INTO sense_symbols (id, file_id, name, qualified, kind, line_start, line_end)
+		 VALUES (30, 1, 'NetReader', 'io.NetReader', 'class', 25, 40)`,
+		`INSERT INTO sense_symbols (id, file_id, name, qualified, kind, line_start, line_end, parent_id)
+		 VALUES (31, 1, 'Read', 'io.NetReader.Read', 'method', 26, 35, 30)`,
+
+		// Both FileReader and NetReader inherit Reader.
+		`INSERT INTO sense_edges (source_id, target_id, kind, file_id, confidence)
+		 VALUES (20, 10, 'inherits', 1, 1.0)`,
+		`INSERT INTO sense_edges (source_id, target_id, kind, file_id, confidence)
+		 VALUES (30, 10, 'inherits', 1, 1.0)`,
+	} {
+		if _, err := db.ExecContext(ctx, q); err != nil {
+			t.Fatalf("seed: %v\nquery: %s", err, q)
+		}
+	}
+
+	// From the interface method, should find both concrete implementations.
+	ids, err := sqlite.DispatchMethodIDs(ctx, db, 11)
+	if err != nil {
+		t.Fatalf("DispatchMethodIDs(interface method): %v", err)
+	}
+	if len(ids) != 2 {
+		t.Fatalf("expected 2 implementors, got %v", ids)
+	}
+
+	got := map[int64]bool{ids[0]: true, ids[1]: true}
+	if !got[21] || !got[31] {
+		t.Errorf("expected IDs [21, 31], got %v", ids)
+	}
+}

--- a/internal/sqlite/plan_test.go
+++ b/internal/sqlite/plan_test.go
@@ -25,7 +25,8 @@ import (
 // wall-clock impact; this test is the structural gate that keeps
 // the planner honest if someone later edits schema.sql and
 // inadvertently removes source_id from the index.
-func TestBlastQueryUsesCoveringIndex(t *testing.T) {
+func openPlanDB(t *testing.T) *sql.DB {
+	t.Helper()
 	ctx := context.Background()
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "plan.db")
@@ -36,28 +37,23 @@ func TestBlastQueryUsesCoveringIndex(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = a.Close() })
 
-	// Open a read-only handle to the same DB for EXPLAIN — the
-	// Adapter's public API doesn't expose EXPLAIN, and reaching into
-	// the unexported db is brittle. modernc.org/sqlite registers the
-	// "sqlite" driver, already loaded transitively via Open above.
 	plan, err := sql.Open("sqlite", "file:"+dbPath)
 	if err != nil {
 		t.Fatalf("sql.Open for EXPLAIN: %v", err)
 	}
 	t.Cleanup(func() { _ = plan.Close() })
+	return plan
+}
 
-	const q = `EXPLAIN QUERY PLAN
-	SELECT source_id FROM sense_edges WHERE target_id = ? AND kind = ?`
-
-	rows, err := plan.QueryContext(ctx, q, 1, "calls")
+func explainPlan(t *testing.T, db *sql.DB, query string, args ...any) string {
+	t.Helper()
+	ctx := context.Background()
+	rows, err := db.QueryContext(ctx, "EXPLAIN QUERY PLAN "+query, args...)
 	if err != nil {
 		t.Fatalf("EXPLAIN QUERY PLAN: %v", err)
 	}
 	defer func() { _ = rows.Close() }()
 
-	// EXPLAIN QUERY PLAN returns four columns: id, parent, notused,
-	// detail. We care about detail — that's the human-readable plan
-	// description ("SEARCH sense_edges USING COVERING INDEX ...").
 	var plans []string
 	for rows.Next() {
 		var id, parent, notused int
@@ -73,9 +69,49 @@ func TestBlastQueryUsesCoveringIndex(t *testing.T) {
 	if len(plans) == 0 {
 		t.Fatal("EXPLAIN QUERY PLAN returned no rows")
 	}
+	return strings.Join(plans, " | ")
+}
 
-	joined := strings.Join(plans, " | ")
+func TestBlastQueryUsesCoveringIndex(t *testing.T) {
+	plan := openPlanDB(t)
+	joined := explainPlan(t, plan,
+		`SELECT source_id FROM sense_edges WHERE target_id = ? AND kind = ?`, 1, "calls")
+
 	if !strings.Contains(joined, "USING COVERING INDEX idx_sense_edges_target") {
 		t.Errorf("BFS query not covered by idx_sense_edges_target\nplan: %s", joined)
+	}
+}
+
+func TestSearchQueryUsesFTS5(t *testing.T) {
+	plan := openPlanDB(t)
+	joined := explainPlan(t, plan,
+		`SELECT s.id, s.name, s.qualified, s.kind, s.file_id, s.line_start, s.snippet, -rank AS score
+		 FROM sense_symbols_fts
+		 JOIN sense_symbols s ON s.id = sense_symbols_fts.rowid
+		 WHERE sense_symbols_fts MATCH ?
+		 ORDER BY rank LIMIT ?`, "test", 10)
+
+	if !strings.Contains(joined, "VIRTUAL TABLE") {
+		t.Errorf("search query should use FTS5 virtual table\nplan: %s", joined)
+	}
+}
+
+func TestSymbolLookupUsesQualifiedIndex(t *testing.T) {
+	plan := openPlanDB(t)
+	joined := explainPlan(t, plan,
+		`SELECT id, file_id, name, kind, line_start, line_end FROM sense_symbols WHERE qualified = ?`, "pkg.Foo")
+
+	if !strings.Contains(joined, "idx_sense_symbols_qualified") {
+		t.Errorf("qualified lookup should use idx_sense_symbols_qualified\nplan: %s", joined)
+	}
+}
+
+func TestEdgeSourceQueryUsesIndex(t *testing.T) {
+	plan := openPlanDB(t)
+	joined := explainPlan(t, plan,
+		`SELECT target_id FROM sense_edges WHERE source_id = ? AND kind = ?`, 1, "calls")
+
+	if !strings.Contains(joined, "USING INDEX") && !strings.Contains(joined, "USING COVERING INDEX") {
+		t.Errorf("edge source query should use an index\nplan: %s", joined)
 	}
 }

--- a/internal/sqlite/search_test.go
+++ b/internal/sqlite/search_test.go
@@ -563,3 +563,51 @@ func TestNamePartsMatchesDecomposed(t *testing.T) {
 		t.Fatal("expected HTTPS to match handleHTTPSError via name_parts, got 0 results")
 	}
 }
+
+func TestLoadEmbeddingsEmpty(t *testing.T) {
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	got, err := a.LoadEmbeddings(ctx)
+	if err != nil {
+		t.Fatalf("LoadEmbeddings on empty table: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty map, got %d entries", len(got))
+	}
+}
+
+func TestEmbeddingsForFilesNoMatch(t *testing.T) {
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	fid, err := a.WriteFile(ctx, &model.File{
+		Path: "no_embeddings.go", Language: "go",
+		Hash: "ne1", Symbols: 1, IndexedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid, Name: "Bare", Qualified: "pkg.Bare",
+		Kind: "function", LineStart: 1, LineEnd: 5,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := a.EmbeddingsForFiles(ctx, []int64{fid})
+	if err != nil {
+		t.Fatalf("EmbeddingsForFiles: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty map for file with no embeddings, got %d", len(got))
+	}
+}


### PR DESCRIPTION
## Problem

`internal/sqlite/` has mixed test coverage — the conformance suite validates the `index.Index` contract but doesn't exercise SQLite-specific behavior: error paths in Open, empty-collection edge cases, context queries for unusual graph shapes, dispatch with multiple implementors, and query plan stability for hot queries.

## Summary

Add targeted unit tests for the gaps the conformance suite misses, plus query plan assertions that protect against accidental index regressions.

## Changes

**Adapter error paths** (`adapter_test.go`)
- Corrupt database file returns a clean error, no panic
- Repeated open/close cycles on the same path preserve data (WAL integrity)

**Search edge cases** (`search_test.go`)
- `LoadEmbeddings` on empty table returns empty map, no error
- `EmbeddingsForFiles` for file with symbols but no embeddings returns empty map

**Context edge cases** (`context_test.go`)
- `ContextForFile` with nonexistent file ID wraps `sql.ErrNoRows`
- `ContextForFile` with symbols but no edges returns headers without relationship lines

**Dispatch edge cases** (`dispatch_test.go`)
- `DispatchMethodIDs` with multiple concrete types implementing the same interface method returns all candidates

**Query plan assertions** (`plan_test.go`)
- Refactor shared `openPlanDB`/`explainPlan` helpers
- FTS5 search uses virtual table index
- Symbol qualified-name lookup uses `idx_sense_symbols_qualified`
- Edge source query uses an index (planner picks covering `idx_sense_edges_unique`)

## Test Plan

- [x] `go test ./internal/sqlite/` — all 40+ tests pass (~0.7s)
- [x] `make ci` — full green (tests + lint)
- [x] No production code changes — test-only diff