### PR TITLE
feat(ruby): resolve instance variable receivers via initialize type inference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ sense.yml
 bench/results/
 bench/results-bk/
 bench/audit/gt-audit.md
+/.council

--- a/internal/extract/ruby/ruby.go
+++ b/internal/extract/ruby/ruby.go
@@ -54,7 +54,7 @@ func (Extractor) Extensions() []string      { return []string{".rb", ".rake", ".
 func (Extractor) Tier() extract.Tier        { return extract.TierBasic }
 
 func (Extractor) Extract(tree *sitter.Tree, source []byte, filePath string, emit extract.Emitter) error {
-	w := &walker{source: source, emit: emit, filePath: filePath}
+	w := &walker{source: source, emit: emit, filePath: filePath, classInstanceVars: make(map[string]map[string]string)}
 	return w.walk(tree.RootNode(), nil)
 }
 
@@ -63,11 +63,12 @@ func init() { extract.Register(Extractor{}) }
 // ---- walker ----
 
 type walker struct {
-	source    []byte
-	emit      extract.Emitter
-	filePath  string
-	routeNS   []string // namespace stack for route files (e.g. ["Admin"])
-	testScope []string // nested RSpec block descriptions for synthetic scope
+	source            []byte
+	emit              extract.Emitter
+	filePath          string
+	routeNS           []string // namespace stack for route files (e.g. ["Admin"])
+	testScope         []string // nested RSpec block descriptions for synthetic scope
+	classInstanceVars map[string]map[string]string // @ivar type map per class
 }
 
 // walk visits node and its children under the given class/module scope.
@@ -497,6 +498,8 @@ func (w *walker) handleClassOrModule(n *sitter.Node, scope []string, kind model.
 	}
 
 	if body := n.ChildByFieldName("body"); body != nil {
+		ivarTypes := buildInstanceVarTypeMap(body, w.source)
+		w.classInstanceVars[qualified] = ivarTypes
 		return w.walkChildren(body, newScope)
 	}
 	return nil
@@ -548,8 +551,9 @@ func (w *walker) handleMethod(n *sitter.Node, scope []string, singleton bool) er
 	// edge is an accurate record of what was written.
 	body := n.ChildByFieldName("body")
 	localTypes := buildLocalTypeMap(body, w.source)
+	ivarTypes := w.classInstanceVars[strings.Join(scope, "::")]
 	if err := extract.WalkNamedDescendants(body, "call", func(c *sitter.Node) error {
-		return w.emitCall(c, qualified, scope, localTypes)
+		return w.emitCall(c, qualified, scope, localTypes, ivarTypes)
 	}); err != nil {
 		return err
 	}
@@ -566,7 +570,7 @@ func (w *walker) handleMethod(n *sitter.Node, scope []string, singleton bool) er
 // `public_send` / `__send__` with a literal symbol or string first
 // argument is emitted with confidence 0.7; anything else in that family
 // is skipped.
-func (w *walker) emitCall(n *sitter.Node, source string, scope []string, localTypes map[string]string) error {
+func (w *walker) emitCall(n *sitter.Node, source string, scope []string, localTypes, ivarTypes map[string]string) error {
 	methodNode := n.ChildByFieldName("method")
 	if methodNode == nil {
 		return nil
@@ -593,11 +597,11 @@ func (w *walker) emitCall(n *sitter.Node, source string, scope []string, localTy
 	}
 
 	recv := n.ChildByFieldName("receiver")
-	target, confidence := w.resolveCallTarget(recv, methodName, scope, localTypes)
+	target, confidence := w.resolveCallTarget(recv, methodName, scope, localTypes, ivarTypes)
 	if target == "" {
 		return nil
 	}
-	return w.emitCallWithConfidence(n, source, scope, localTypes, confidence)
+	return w.emitCallWithConfidence(n, source, scope, localTypes, ivarTypes, confidence)
 }
 
 // emitTestCall delegates to emitCall but substitutes ConfidenceTests and
@@ -610,13 +614,13 @@ func (w *walker) emitTestCall(n *sitter.Node, source string, scope []string) err
 	if rspecMatcherMethods[extract.Text(methodNode, w.source)] {
 		return nil
 	}
-	return w.emitCallWithConfidence(n, source, scope, nil, extract.ConfidenceTests)
+	return w.emitCallWithConfidence(n, source, scope, nil, nil, extract.ConfidenceTests)
 }
 
 // emitCallWithConfidence is emitCall's core logic with an injectable
 // confidence value. Used by both production-method emission (1.0 / 0.7)
 // and test-block emission (0.8).
-func (w *walker) emitCallWithConfidence(n *sitter.Node, source string, scope []string, localTypes map[string]string, confidence float64) error {
+func (w *walker) emitCallWithConfidence(n *sitter.Node, source string, scope []string, localTypes, ivarTypes map[string]string, confidence float64) error {
 	methodNode := n.ChildByFieldName("method")
 	if methodNode == nil {
 		return nil
@@ -643,7 +647,7 @@ func (w *walker) emitCallWithConfidence(n *sitter.Node, source string, scope []s
 	}
 
 	recv := n.ChildByFieldName("receiver")
-	target, _ := w.resolveCallTarget(recv, methodName, scope, localTypes)
+	target, _ := w.resolveCallTarget(recv, methodName, scope, localTypes, ivarTypes)
 	if target == "" {
 		return nil
 	}
@@ -658,7 +662,7 @@ func (w *walker) emitCallWithConfidence(n *sitter.Node, source string, scope []s
 
 // resolveCallTarget decides what target string to emit for a call node.
 // It returns the target string and the confidence level.
-func (w *walker) resolveCallTarget(recv *sitter.Node, methodName string, scope []string, localTypes map[string]string) (string, float64) {
+func (w *walker) resolveCallTarget(recv *sitter.Node, methodName string, scope []string, localTypes, ivarTypes map[string]string) (string, float64) {
 	if recv == nil {
 		return "self." + methodName, 1.0
 	}
@@ -673,6 +677,15 @@ func (w *walker) resolveCallTarget(recv *sitter.Node, methodName string, scope [
 	case "identifier":
 		name := extract.Text(recv, w.source)
 		if typ, ok := localTypes[name]; ok {
+			return typ + "#" + methodName, extract.ConfidenceDynamic
+		}
+		return methodName, extract.ConfidenceUnresolved
+	case "instance_variable":
+		name := extract.Text(recv, w.source)
+		if typ, ok := localTypes[name]; ok {
+			return typ + "#" + methodName, extract.ConfidenceDynamic
+		}
+		if typ, ok := ivarTypes[name]; ok {
 			return typ + "#" + methodName, extract.ConfidenceDynamic
 		}
 		return methodName, extract.ConfidenceUnresolved
@@ -711,6 +724,41 @@ func buildLocalTypeMap(body *sitter.Node, source []byte) map[string]string {
 			return nil
 		})
 	}
+	return types
+}
+
+// buildInstanceVarTypeMap scans a class body for `initialize` methods and
+// looks for instance-variable assignments whose RHS is `ClassName.new(...)`.
+// Returns a map from @ivar_name to class_name.
+func buildInstanceVarTypeMap(body *sitter.Node, source []byte) map[string]string {
+	types := make(map[string]string)
+	if body == nil {
+		return types
+	}
+	_ = extract.WalkNamedDescendants(body, "method", func(n *sitter.Node) error {
+		nameNode := n.ChildByFieldName("name")
+		if nameNode == nil || extract.Text(nameNode, source) != "initialize" {
+			return nil
+		}
+		initBody := n.ChildByFieldName("body")
+		if initBody == nil {
+			return nil
+		}
+		for _, kind := range []string{"assignment", "operator_assignment"} {
+			_ = extract.WalkNamedDescendants(initBody, kind, func(a *sitter.Node) error {
+				lhs := a.ChildByFieldName("left")
+				rhs := a.ChildByFieldName("right")
+				if lhs == nil || rhs == nil || lhs.Kind() != "instance_variable" {
+					return nil
+				}
+				if typ := typeFromNewCall(rhs, source, nil); typ != "" {
+					types[extract.Text(lhs, source)] = typ
+				}
+				return nil
+			})
+		}
+		return nil
+	})
 	return types
 }
 

--- a/internal/extract/ruby/ruby_test.go
+++ b/internal/extract/ruby/ruby_test.go
@@ -1526,6 +1526,62 @@ end
 	}
 }
 
+func TestTestsEdgeErrorRuby(t *testing.T) {
+	// A class inheriting from a test superclass emits two edges:
+	// inherits + tests. Fail on the second edge to cover the
+	// error return inside the isTestSuperclass block.
+	err := parseWithEmitter(t, `class FooTest < ActiveSupport::TestCase
+end
+`, &failAfterN{symbolsLeft: 100, edgesLeft: 1})
+	if err == nil {
+		t.Error("expected error on tests edge emit")
+	}
+}
+
+func TestEmitCallNilMethodNode(t *testing.T) {
+	// `baz.()` is Ruby lambda shorthand. Tree-sitter parses it as a
+	// call node with a nil method field. emitCall should tolerate this.
+	r := parseRuby(t, `class Foo
+  def bar
+    baz.()
+  end
+end
+`)
+	// No edges expected — the call is skipped due to nil method.
+	if len(r.edges) != 0 {
+		t.Errorf("expected 0 edges for lambda shorthand with nil method, got %d", len(r.edges))
+	}
+}
+
+func TestEmitCallSafeNavNilMethodNode(t *testing.T) {
+	// `baz&.()` — safe navigation with lambda shorthand.
+	r := parseRuby(t, `class Foo
+  def bar
+    baz&.()
+  end
+end
+`)
+	// No edges expected — the call is skipped due to nil method.
+	if len(r.edges) != 0 {
+		t.Errorf("expected 0 edges for safe-nav lambda shorthand with nil method, got %d", len(r.edges))
+	}
+}
+
+func TestEmitCallEmptyMethodName(t *testing.T) {
+	// `foo.''()` produces a call node with an empty method name.
+	// Tree-sitter parses the empty string as an identifier with zero-length text.
+	r := parseRuby(t, `class Foo
+  def bar
+    baz.''()
+  end
+end
+`)
+	// No edges expected — the call is skipped due to empty method name.
+	if len(r.edges) != 0 {
+		t.Errorf("expected 0 edges for empty method name, got %d", len(r.edges))
+	}
+}
+
 func TestIncludeEdgeErrorRuby(t *testing.T) {
 	err := parseWithEmitter(t, `class Foo
   include Comparable
@@ -1612,7 +1668,262 @@ end
 		}
 	}
 	if !found {
-		t.Fatal("missing file-level fallback edge for interpolated description")
+		t.Fatal("missing file-level fallback edge for Product.new")
+	}
+}
+
+func TestInstanceVariableResolution(t *testing.T) {
+	r := parseRuby(t, `
+class TopicCreator
+  def create; end
+end
+
+class PostCreator
+  def initialize
+    @topic_creator = TopicCreator.new
+  end
+
+  def create_topic
+    @topic_creator.create
+  end
+end
+`)
+	// @topic_creator.create should resolve to TopicCreator#create via
+	// class-level instance-variable type map.
+	e := findEdge(r, "PostCreator#create_topic", "TopicCreator#create", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge PostCreator#create_topic -> TopicCreator#create from instance variable resolution")
+	}
+	if e.Confidence != extract.ConfidenceDynamic {
+		t.Errorf("inferred edge confidence = %v, want %v", e.Confidence, extract.ConfidenceDynamic)
+	}
+}
+
+func TestInstanceVariableOperatorAssignment(t *testing.T) {
+	r := parseRuby(t, `
+class Cache
+  def fetch; end
+end
+
+class Service
+  def initialize
+    @cache ||= Cache.new
+  end
+
+  def get
+    @cache.fetch
+  end
+end
+`)
+	// @cache ||= Cache.new should be captured by buildInstanceVarTypeMap.
+	e := findEdge(r, "Service#get", "Cache#fetch", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge Service#get -> Cache#fetch from operator-assignment instance variable")
+	}
+	if e.Confidence != extract.ConfidenceDynamic {
+		t.Errorf("inferred edge confidence = %v, want %v", e.Confidence, extract.ConfidenceDynamic)
+	}
+}
+
+func TestInstanceVariableUnresolvedFallback(t *testing.T) {
+	r := parseRuby(t, `
+class PostCreator
+  def create_topic
+    @unknown.create
+  end
+end
+`)
+	// @unknown is not assigned in initialize, so it falls back to bare method name.
+	e := findEdge(r, "PostCreator#create_topic", "create", "calls")
+	if e == nil {
+		t.Fatal("missing bare fallback edge for unresolved instance variable")
+	}
+	if e.Confidence != extract.ConfidenceUnresolved {
+		t.Errorf("bare fallback confidence = %v, want %v", e.Confidence, extract.ConfidenceUnresolved)
+	}
+}
+
+func TestInstanceVariableLocalOverride(t *testing.T) {
+	r := parseRuby(t, `
+class TopicCreator
+  def create; end
+end
+
+class CommentCreator
+  def create; end
+end
+
+class PostCreator
+  def initialize
+    @topic_creator = TopicCreator.new
+  end
+
+  def create_topic
+    topic_creator = CommentCreator.new
+    topic_creator.create
+    @topic_creator.create
+  end
+end
+`)
+	// Local variable (identifier receiver) resolves via localTypes.
+	eLocal := findEdge(r, "PostCreator#create_topic", "CommentCreator#create", "calls")
+	if eLocal == nil {
+		t.Fatal("missing calls edge from local variable")
+	}
+	if eLocal.Confidence != extract.ConfidenceDynamic {
+		t.Errorf("local edge confidence = %v, want %v", eLocal.Confidence, extract.ConfidenceDynamic)
+	}
+	// Instance variable (instance_variable receiver) resolves via ivarTypes.
+	eIvar := findEdge(r, "PostCreator#create_topic", "TopicCreator#create", "calls")
+	if eIvar == nil {
+		t.Fatal("missing calls edge from instance variable")
+	}
+	if eIvar.Confidence != extract.ConfidenceDynamic {
+		t.Errorf("ivar edge confidence = %v, want %v", eIvar.Confidence, extract.ConfidenceDynamic)
+	}
+}
+
+func TestBuildInstanceVarTypeMap(t *testing.T) {
+	src := []byte(`
+class PostCreator
+  def initialize
+    @topic_creator = TopicCreator.new
+    @cache ||= Cache.new
+    @plain = "string"
+  end
+end
+`)
+	p := sitter.NewParser()
+	defer p.Close()
+	if err := p.SetLanguage(Extractor{}.Grammar()); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	tree := p.Parse(src, nil)
+	if tree == nil {
+		t.Fatal("Parse returned nil tree")
+	}
+	defer tree.Close()
+
+	// Find the class body node
+	root := tree.RootNode()
+	var body *sitter.Node
+	for i := uint(0); i < root.NamedChildCount(); i++ {
+		c := root.NamedChild(i)
+		if c != nil && c.Kind() == "class" {
+			body = c.ChildByFieldName("body")
+			break
+		}
+	}
+	if body == nil {
+		t.Fatal("could not find class body")
+	}
+
+	m := buildInstanceVarTypeMap(body, src)
+	if m["@topic_creator"] != "TopicCreator" {
+		t.Errorf("@topic_creator = %q, want TopicCreator", m["@topic_creator"])
+	}
+	if m["@cache"] != "Cache" {
+		t.Errorf("@cache = %q, want Cache", m["@cache"])
+	}
+	if _, ok := m["@plain"]; ok {
+		t.Error("@plain should not be in map (RHS is not .new)")
+	}
+}
+
+func TestBuildInstanceVarTypeMapNoInitialize(t *testing.T) {
+	src := []byte(`class PostCreator
+  def create_topic
+    @topic_creator.create
+  end
+end
+`)
+	p := sitter.NewParser()
+	defer p.Close()
+	if err := p.SetLanguage(Extractor{}.Grammar()); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	tree := p.Parse(src, nil)
+	if tree == nil {
+		t.Fatal("Parse returned nil tree")
+	}
+	defer tree.Close()
+
+	body := tree.RootNode().NamedChild(0).ChildByFieldName("body")
+	if body == nil {
+		t.Fatal("could not find class body")
+	}
+	m := buildInstanceVarTypeMap(body, src)
+	if len(m) != 0 {
+		t.Errorf("expected empty map, got %v", m)
+	}
+}
+
+func TestBuildInstanceVarTypeMapEmptyInitialize(t *testing.T) {
+	src := []byte(`class PostCreator
+  def initialize
+  end
+
+  def create_topic
+    @topic_creator.create
+  end
+end
+`)
+	p := sitter.NewParser()
+	defer p.Close()
+	if err := p.SetLanguage(Extractor{}.Grammar()); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	tree := p.Parse(src, nil)
+	if tree == nil {
+		t.Fatal("Parse returned nil tree")
+	}
+	defer tree.Close()
+
+	body := tree.RootNode().NamedChild(0).ChildByFieldName("body")
+	if body == nil {
+		t.Fatal("could not find class body")
+	}
+	m := buildInstanceVarTypeMap(body, src)
+	if len(m) != 0 {
+		t.Errorf("expected empty map, got %v", m)
+	}
+}
+
+func TestClassWithNoBody(t *testing.T) {
+	r := parseRuby(t, `class EmptyClass
+end
+`)
+	if len(r.symbols) == 0 {
+		t.Fatal("expected at least the EmptyClass symbol")
+	}
+	s := findSymbol(r, "EmptyClass")
+	if s == nil {
+		t.Fatal("missing EmptyClass symbol")
+	}
+}
+
+func TestInstanceVariableScopeResolution(t *testing.T) {
+	r := parseRuby(t, `
+class Admin::TopicCreator
+  def create; end
+end
+
+class PostCreator
+  def initialize
+    @topic_creator = Admin::TopicCreator.new
+  end
+
+  def create_topic
+    @topic_creator.create
+  end
+end
+`)
+	e := findEdge(r, "PostCreator#create_topic", "Admin::TopicCreator#create", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge for scope-resolution instance variable type")
+	}
+	if e.Confidence != extract.ConfidenceDynamic {
+		t.Errorf("inferred edge confidence = %v, want %v", e.Confidence, extract.ConfidenceDynamic)
 	}
 }
 

--- a/internal/extract/testdata/ruby/instance_variables.golden.json
+++ b/internal/extract/testdata/ruby/instance_variables.golden.json
@@ -1,0 +1,94 @@
+{
+  "symbols": [
+    {
+      "name": "Cache",
+      "qualified": "Cache",
+      "kind": "class",
+      "line_start": 5,
+      "line_end": 7
+    },
+    {
+      "name": "fetch",
+      "qualified": "Cache#fetch",
+      "kind": "method",
+      "parent": "Cache",
+      "line_start": 6,
+      "line_end": 6
+    },
+    {
+      "name": "PostCreator",
+      "qualified": "PostCreator",
+      "kind": "class",
+      "line_start": 9,
+      "line_end": 20
+    },
+    {
+      "name": "create_topic",
+      "qualified": "PostCreator#create_topic",
+      "kind": "method",
+      "parent": "PostCreator",
+      "line_start": 15,
+      "line_end": 19
+    },
+    {
+      "name": "initialize",
+      "qualified": "PostCreator#initialize",
+      "kind": "method",
+      "parent": "PostCreator",
+      "line_start": 10,
+      "line_end": 13
+    },
+    {
+      "name": "TopicCreator",
+      "qualified": "TopicCreator",
+      "kind": "class",
+      "line_start": 1,
+      "line_end": 3
+    },
+    {
+      "name": "create",
+      "qualified": "TopicCreator#create",
+      "kind": "method",
+      "parent": "TopicCreator",
+      "line_start": 2,
+      "line_end": 2
+    }
+  ],
+  "edges": [
+    {
+      "source": "PostCreator#create_topic",
+      "target": "Cache#fetch",
+      "kind": "calls",
+      "line": 17,
+      "confidence": 0.7
+    },
+    {
+      "source": "PostCreator#create_topic",
+      "target": "TopicCreator#create",
+      "kind": "calls",
+      "line": 16,
+      "confidence": 0.7
+    },
+    {
+      "source": "PostCreator#create_topic",
+      "target": "create",
+      "kind": "calls",
+      "line": 18,
+      "confidence": 0.5
+    },
+    {
+      "source": "PostCreator#initialize",
+      "target": "Cache.new",
+      "kind": "calls",
+      "line": 12,
+      "confidence": 1
+    },
+    {
+      "source": "PostCreator#initialize",
+      "target": "TopicCreator.new",
+      "kind": "calls",
+      "line": 11,
+      "confidence": 1
+    }
+  ]
+}

--- a/internal/extract/testdata/ruby/instance_variables.rb
+++ b/internal/extract/testdata/ruby/instance_variables.rb
@@ -1,0 +1,20 @@
+class TopicCreator
+  def create; end
+end
+
+class Cache
+  def fetch; end
+end
+
+class PostCreator
+  def initialize
+    @topic_creator = TopicCreator.new
+    @cache ||= Cache.new
+  end
+
+  def create_topic
+    @topic_creator.create
+    @cache.fetch
+    @unknown.create
+  end
+end


### PR DESCRIPTION
## Problem

After fixing local-variable receiver resolution, instance variable calls like `@topic_creator.create` remained unresolved. The call `@topic_creator.create` parses with an `instance_variable` receiver, not an `identifier`, so `resolveCallTarget` fell back to the bare method name `create`. In the Discourse index, this produced false edges like `PostCreator#create_topic -> PostCreator#create` instead of `PostCreator#create_topic -> TopicCreator#create`.

Instance variables are extremely common in Ruby. In Discourse's `lib/` directory alone, there are ~200 calls on instance variables (`@user`, `@guardian`, `@topic`, `@post`, etc.).

## Summary

Extends the Ruby extractor to resolve `@ivar.method` calls by building a class-level type map from `initialize` methods. When a class sets `@ivar = ClassName.new(...)` in `initialize`, subsequent `@ivar.method` calls resolve to `ClassName#method` with confidence 0.7 (dynamic), matching the existing local-variable resolution pattern.

## Changes

- **Core resolution** (`internal/extract/ruby/ruby.go`):
  - Added `buildInstanceVarTypeMap` helper that scans `initialize` methods for `@ivar = Class.new(...)` and `@ivar ||= Class.new(...)` assignments
  - Added `classInstanceVars` field to walker to store per-class type maps
  - Added `instance_variable` case to `resolveCallTarget` that looks up types from the class-level map
  - Threads `ivarTypes` through `emitCall` -> `resolveCallTarget` call chain

- **Test coverage** (`internal/extract/ruby/ruby_test.go`):
  - Main feature tests: `TestInstanceVariableResolution`, `TestInstanceVariableOperatorAssignment`
  - Edge cases: unresolved fallback, local variable override, scope-resolution class names
  - Unit tests for `buildInstanceVarTypeMap` including empty initialize / no initialize
  - Defensive tests: nil method node, empty method name, safe navigation lambda shorthand
  - Coverage for `handleClassOrModule` error path (tests edge emission failure)

- **Fixture test** (`internal/extract/testdata/ruby/instance_variables.*`):
  - Golden file covering all four patterns: direct assignment, operator assignment, method body usage, unresolved fallback

## Architecture Highlights

- Two-phase type inference: `buildLocalTypeMap` (method body, local vars) + `buildInstanceVarTypeMap` (class body, instance vars from `initialize`)
- Local variables checked first in `resolveCallTarget` for the `instance_variable` case (defensive, though names don't collide in practice)
- Known limitations documented: parent class initialization not analyzed, non-|.new` assignments skipped

## Test Plan

- [x] `go test ./internal/extract/ruby/...` passes
- [x] `go test ./internal/extract/...` passes (fixture tests)
- [x] `make ci` fully green (build + test + lint)
- [x] Verified on Discourse: `@request.xhr?` in `Auth::DefaultCurrentUserProvider#should_update_last_seen?` now resolves to `Rack::Request#xhr?`