### PR TITLE
feat(ruby): resolve multi-hop method chains via return-type map

### DIFF
--- a/internal/extract/ruby/ruby.go
+++ b/internal/extract/ruby/ruby.go
@@ -54,7 +54,14 @@ func (Extractor) Extensions() []string      { return []string{".rb", ".rake", ".
 func (Extractor) Tier() extract.Tier        { return extract.TierBasic }
 
 func (Extractor) Extract(tree *sitter.Tree, source []byte, filePath string, emit extract.Emitter) error {
-	w := &walker{source: source, emit: emit, filePath: filePath, classInstanceVars: make(map[string]map[string]string)}
+	returnTypes := buildFileReturnTypeMap(tree.RootNode(), source)
+	w := &walker{
+		source:            source,
+		emit:              emit,
+		filePath:          filePath,
+		classInstanceVars: make(map[string]map[string]string),
+		returnTypes:       returnTypes,
+	}
 	return w.walk(tree.RootNode(), nil)
 }
 
@@ -69,6 +76,7 @@ type walker struct {
 	routeNS           []string // namespace stack for route files (e.g. ["Admin"])
 	testScope         []string // nested RSpec block descriptions for synthetic scope
 	classInstanceVars map[string]map[string]string // @ivar type map per class
+	returnTypes       map[string]string            // method_qualified → class_name (file-level)
 }
 
 // walk visits node and its children under the given class/module scope.
@@ -696,10 +704,61 @@ func (w *walker) resolveCallTarget(recv *sitter.Node, methodName string, scope [
 		if typ := typeFromNewCall(recv, w.source, scope); typ != "" {
 			return typ + "#" + methodName, extract.ConfidenceDynamic
 		}
+		// Try to resolve multi-hop chains via return-type map.
+		if typ := w.resolveChainReceiver(recv, scope, localTypes, 1); typ != "" {
+			return typ + "#" + methodName, extract.ConfidenceDynamic
+		}
 		return methodName, extract.ConfidenceUnresolved
 	}
 
 	return methodName, extract.ConfidenceUnresolved
+}
+
+// resolveChainReceiver recursively resolves a call-chain receiver to a type
+// by looking up local-variable types and method return types. It caps at 3
+// hops to avoid exponential lookups and absurd qualified names.
+func (w *walker) resolveChainReceiver(recv *sitter.Node, scope []string, localTypes map[string]string, depth int) string {
+	if depth > 3 || recv == nil || recv.Kind() != "call" {
+		return ""
+	}
+	methodNode := recv.ChildByFieldName("method")
+	if methodNode == nil {
+		return ""
+	}
+	methodName := extract.Text(methodNode, w.source)
+	innerRecv := recv.ChildByFieldName("receiver")
+
+	// Case 1: receiver is a local variable with known type.
+	if innerRecv != nil && innerRecv.Kind() == "identifier" {
+		if typ, ok := localTypes[extract.Text(innerRecv, w.source)]; ok {
+			qualified := typ + "#" + methodName
+			if ret, ok := w.returnTypes[qualified]; ok {
+				return ret
+			}
+		}
+	}
+
+	// Case 2: receiver is self (implicit or explicit).
+	if innerRecv == nil || innerRecv.Kind() == "self" {
+		parent := strings.Join(scope, "::")
+		qualified := parent + "#" + methodName
+		if ret, ok := w.returnTypes[qualified]; ok {
+			return ret
+		}
+	}
+
+	// Case 3: receiver is another chain (recursive).
+	if innerRecv != nil && innerRecv.Kind() == "call" {
+		innerType := w.resolveChainReceiver(innerRecv, scope, localTypes, depth+1)
+		if innerType != "" {
+			qualified := innerType + "#" + methodName
+			if ret, ok := w.returnTypes[qualified]; ok {
+				return ret
+			}
+		}
+	}
+
+	return ""
 }
 
 // buildLocalTypeMap scans a method body for local-variable assignments
@@ -784,6 +843,115 @@ func typeFromNewCall(n *sitter.Node, source []byte, scope []string) string {
 		return strings.Join(scope, "::")
 	}
 	return ""
+}
+
+// buildReturnTypeMap scans a class/module body for methods whose body is
+// a single expression or a single `return` statement that calls `Class.new(...)`.
+// It returns a map from qualified method name to the inferred class name.
+func buildReturnTypeMap(body *sitter.Node, source []byte, scope []string) map[string]string {
+	types := make(map[string]string)
+	if body == nil {
+		return types
+	}
+	parent := strings.Join(scope, "::")
+	_ = extract.WalkNamedDescendants(body, "method", func(n *sitter.Node) error {
+		return recordMethodReturnType(n, source, parent, types, false)
+	})
+	_ = extract.WalkNamedDescendants(body, "singleton_method", func(n *sitter.Node) error {
+		return recordMethodReturnType(n, source, parent, types, true)
+	})
+	return types
+}
+
+// recordMethodReturnType extracts the return type from a single method
+// and records it in the map if it matches the simple factory pattern.
+func recordMethodReturnType(n *sitter.Node, source []byte, parent string, types map[string]string, singleton bool) error {
+	nameNode := n.ChildByFieldName("name")
+	if nameNode == nil {
+		return nil
+	}
+	name := extract.Text(nameNode, source)
+	if name == "" {
+		return nil
+	}
+	var qualified string
+	switch {
+	case parent == "":
+		qualified = name
+	case singleton:
+		qualified = parent + "." + name
+	default:
+		qualified = parent + "#" + name
+	}
+	body := n.ChildByFieldName("body")
+	if body == nil {
+		return nil
+	}
+	// Look for a single expression or single return statement.
+	var returnExpr *sitter.Node
+	childCount := body.NamedChildCount()
+	if childCount == 1 {
+		child := body.NamedChild(0)
+		if child.Kind() == "return" {
+			// return node has an argument_list as its first named child
+			if argList := child.NamedChild(0); argList != nil && argList.Kind() == "argument_list" {
+				if argList.NamedChildCount() == 1 {
+					returnExpr = argList.NamedChild(0)
+				}
+			}
+		} else {
+			returnExpr = child
+		}
+	}
+	if returnExpr != nil {
+		if typ := typeFromNewCall(returnExpr, source, nil); typ != "" {
+			types[qualified] = typ
+		}
+	}
+	return nil
+}
+
+// buildFileReturnTypeMap walks the entire AST and builds a map of all
+// method qualified names → return types for simple factory methods.
+func buildFileReturnTypeMap(root *sitter.Node, source []byte) map[string]string {
+	types := make(map[string]string)
+	var walk func(n *sitter.Node, scope []string)
+	walk = func(n *sitter.Node, scope []string) {
+		if n == nil {
+			return
+		}
+		switch n.Kind() {
+		case "class", "module":
+			nameNode := n.ChildByFieldName("name")
+			if nameNode != nil {
+				name := extract.Text(nameNode, source)
+				if name != "" {
+					segments := strings.Split(name, "::")
+					newScope := append(slices.Clone(scope), segments...)
+					body := n.ChildByFieldName("body")
+					if body != nil {
+						classTypes := buildReturnTypeMap(body, source, newScope)
+						for k, v := range classTypes {
+							types[k] = v
+						}
+						// Continue walking children with new scope.
+						count := body.NamedChildCount()
+						for i := uint(0); i < count; i++ {
+							walk(body.NamedChild(i), newScope)
+						}
+					}
+					return
+				}
+			}
+		}
+		// For non-class/module nodes, walk children with current scope.
+		count := n.NamedChildCount()
+		for i := uint(0); i < count; i++ {
+			walk(n.NamedChild(i), scope)
+		}
+	}
+	walk(root, nil)
+	return types
 }
 
 // statementParents is the set of tree-sitter-ruby node kinds whose

--- a/internal/extract/ruby/ruby_test.go
+++ b/internal/extract/ruby/ruby_test.go
@@ -2624,3 +2624,274 @@ end
 		}
 	}
 }
+
+func TestBuildReturnTypeMap(t *testing.T) {
+	src := `class Factory
+  def builder
+    Builder.new
+  end
+
+  def self.create_factory
+    Factory.new
+  end
+
+  def config
+    return Config.new
+  end
+
+  def complex
+    x = 1
+    Builder.new
+  end
+
+  def plain
+    "not a new call"
+  end
+end
+`
+	ex := Extractor{}
+	p := sitter.NewParser()
+	defer p.Close()
+	if err := p.SetLanguage(ex.Grammar()); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	tree := p.Parse([]byte(src), nil)
+	if tree == nil {
+		t.Fatal("Parse returned nil tree")
+	}
+	defer tree.Close()
+
+	// Find the class body node.
+	root := tree.RootNode()
+	var classBody *sitter.Node
+	for i := uint(0); i < root.NamedChildCount(); i++ {
+		child := root.NamedChild(i)
+		if child.Kind() == "class" {
+			classBody = child.ChildByFieldName("body")
+			break
+		}
+	}
+	if classBody == nil {
+		t.Fatal("could not find class body")
+	}
+
+	retTypes := buildReturnTypeMap(classBody, []byte(src), []string{"Factory"})
+
+	if got, want := retTypes["Factory#builder"], "Builder"; got != want {
+		t.Errorf("Factory#builder = %q, want %q", got, want)
+	}
+	if got, want := retTypes["Factory.create_factory"], "Factory"; got != want {
+		t.Errorf("Factory.create_factory = %q, want %q", got, want)
+	}
+	if got, want := retTypes["Factory#config"], "Config"; got != want {
+		t.Errorf("Factory#config = %q, want %q", got, want)
+	}
+	if _, ok := retTypes["Factory#complex"]; ok {
+		t.Error("Factory#complex should not be in return type map (multiple statements)")
+	}
+	if _, ok := retTypes["Factory#plain"]; ok {
+		t.Error("Factory#plain should not be in return type map (not a .new call)")
+	}
+
+	// Test nil body
+	emptyTypes := buildReturnTypeMap(nil, []byte(src), []string{"Factory"})
+	if len(emptyTypes) != 0 {
+		t.Errorf("nil body: expected empty map, got %d entries", len(emptyTypes))
+	}
+
+	// Test top-level method (parent == "")
+	topLevelSrc := `def helper
+  Helper.new
+end
+`
+	topLevelTree := p.Parse([]byte(topLevelSrc), nil)
+	if topLevelTree == nil {
+		t.Fatal("Parse returned nil tree for top-level")
+	}
+	defer topLevelTree.Close()
+
+	topLevelTypes := buildReturnTypeMap(topLevelTree.RootNode(), []byte(topLevelSrc), nil)
+	if got, want := topLevelTypes["helper"], "Helper"; got != want {
+		t.Errorf("top-level method: got %q, want %q", got, want)
+	}
+}
+
+func TestChainResolution(t *testing.T) {
+	r := parseRuby(t, `class Caller
+  def basic_chain
+    factory = Factory.new
+    factory.builder.create
+  end
+end
+
+class Factory
+  def builder
+    Builder.new
+  end
+end
+
+class Builder
+  def create; end
+end
+`)
+	e := findEdge(r, "Caller#basic_chain", "Builder#create", "calls")
+	if e == nil {
+		t.Fatal("missing resolved chain edge Caller#basic_chain -> Builder#create")
+	}
+	if e.Confidence != extract.ConfidenceDynamic {
+		t.Errorf("chain confidence = %v, want %v", e.Confidence, extract.ConfidenceDynamic)
+	}
+}
+
+func TestInstanceVariableLocalTypeOverride(t *testing.T) {
+	// When a local variable shadows an instance variable name,
+	// the local variable type should take precedence.
+	r := parseRuby(t, `class PostCreator
+  def initialize
+    @creator = TopicCreator.new
+  end
+
+  def create
+    creator = CommentCreator.new
+    @creator.create
+  end
+end
+
+class TopicCreator
+  def create; end
+end
+
+class CommentCreator
+  def create; end
+end
+`)
+	e := findEdge(r, "PostCreator#create", "TopicCreator#create", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge for instance variable with local override")
+	}
+	if e.Confidence != extract.ConfidenceDynamic {
+		t.Errorf("confidence = %v, want %v", e.Confidence, extract.ConfidenceDynamic)
+	}
+}
+
+func TestResolveChainReceiver(t *testing.T) {
+	src := `class Service
+  def builder
+    Builder.new
+  end
+end
+
+class Builder
+  def config
+    Config.new
+  end
+end
+`
+	ex := Extractor{}
+	p := sitter.NewParser()
+	defer p.Close()
+	if err := p.SetLanguage(ex.Grammar()); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	tree := p.Parse([]byte(src), nil)
+	if tree == nil {
+		t.Fatal("Parse returned nil tree")
+	}
+	defer tree.Close()
+
+	returnTypes := buildFileReturnTypeMap(tree.RootNode(), []byte(src))
+	localTypes := map[string]string{"svc": "Service"}
+	scope := []string{"Service"}
+
+	// Create a minimal walker to use the method
+	w := &walker{
+		source:      []byte(src),
+		returnTypes: returnTypes,
+	}
+
+	// Case 1: local variable receiver
+	// svc.builder → "Builder"
+	callSrc := `svc.builder`
+	callTree := p.Parse([]byte(callSrc), nil)
+	if callTree == nil {
+		t.Fatal("Parse returned nil tree for call")
+	}
+	defer callTree.Close()
+	callNode := callTree.RootNode().NamedChild(0)
+	if callNode == nil || callNode.Kind() != "call" {
+		t.Fatalf("expected call node, got %s", callNode.Kind())
+	}
+	// Use callSrc as the walker's source so node offsets match
+	w.source = []byte(callSrc)
+	got := w.resolveChainReceiver(callNode, scope, localTypes, 1)
+	if want := "Builder"; got != want {
+		t.Errorf("local var chain: got %q, want %q", got, want)
+	}
+
+	// Case 2: self receiver
+	// self.builder → "Builder"
+	callSrc = `self.builder`
+	callTree = p.Parse([]byte(callSrc), nil)
+	if callTree == nil {
+		t.Fatal("Parse returned nil tree for call")
+	}
+	defer callTree.Close()
+	callNode = callTree.RootNode().NamedChild(0)
+	if callNode == nil || callNode.Kind() != "call" {
+		t.Fatalf("expected call node, got %s", callNode.Kind())
+	}
+	w.source = []byte(callSrc)
+	got = w.resolveChainReceiver(callNode, scope, localTypes, 1)
+	if want := "Builder"; got != want {
+		t.Errorf("self chain: got %q, want %q", got, want)
+	}
+
+	// Case 3: unresolved chain (method not in returnTypes)
+	callSrc = `svc.unknown`
+	callTree = p.Parse([]byte(callSrc), nil)
+	if callTree == nil {
+		t.Fatal("Parse returned nil tree for call")
+	}
+	defer callTree.Close()
+	callNode = callTree.RootNode().NamedChild(0)
+	if callNode == nil || callNode.Kind() != "call" {
+		t.Fatalf("expected call node, got %s", callNode.Kind())
+	}
+	w.source = []byte(callSrc)
+	got = w.resolveChainReceiver(callNode, scope, localTypes, 1)
+	if got != "" {
+		t.Errorf("unresolved chain: got %q, want empty", got)
+	}
+
+	// Case 4: depth limit
+	callSrc = `svc.builder`
+	callTree = p.Parse([]byte(callSrc), nil)
+	if callTree == nil {
+		t.Fatal("Parse returned nil tree for call")
+	}
+	defer callTree.Close()
+	callNode = callTree.RootNode().NamedChild(0)
+	w.source = []byte(callSrc)
+	got = w.resolveChainReceiver(callNode, scope, localTypes, 4)
+	if got != "" {
+		t.Errorf("depth limit: got %q, want empty", got)
+	}
+
+	// Case 5: recursive chain (3 hops)
+	// svc.builder.config where builder returns Builder and config returns Config
+	callSrc = `svc.builder.config`
+	callTree = p.Parse([]byte(callSrc), nil)
+	if callTree == nil {
+		t.Fatal("Parse returned nil tree for call")
+	}
+	defer callTree.Close()
+	callNode = callTree.RootNode().NamedChild(0)
+	if callNode == nil || callNode.Kind() != "call" {
+		t.Fatalf("expected call node, got %s", callNode.Kind())
+	}
+	w.source = []byte(callSrc)
+	got = w.resolveChainReceiver(callNode, scope, localTypes, 1)
+	if want := "Config"; got != want {
+		t.Errorf("recursive chain: got %q, want %q", got, want)
+	}
+}

--- a/internal/extract/testdata/ruby/call_patterns.golden.json
+++ b/internal/extract/testdata/ruby/call_patterns.golden.json
@@ -155,6 +155,13 @@
     },
     {
       "source": "Caller#chain_call",
+      "target": "Builder#create",
+      "kind": "calls",
+      "line": 29,
+      "confidence": 0.7
+    },
+    {
+      "source": "Caller#chain_call",
       "target": "Factory#builder",
       "kind": "calls",
       "line": 29,
@@ -166,13 +173,6 @@
       "kind": "calls",
       "line": 28,
       "confidence": 1
-    },
-    {
-      "source": "Caller#chain_call",
-      "target": "create",
-      "kind": "calls",
-      "line": 29,
-      "confidence": 0.5
     },
     {
       "source": "Caller#class_method",

--- a/internal/extract/testdata/ruby/method_chains.golden.json
+++ b/internal/extract/testdata/ruby/method_chains.golden.json
@@ -1,0 +1,240 @@
+{
+  "symbols": [
+    {
+      "name": "Builder",
+      "qualified": "Builder",
+      "kind": "class",
+      "line_start": 46,
+      "line_end": 52
+    },
+    {
+      "name": "config",
+      "qualified": "Builder#config",
+      "kind": "method",
+      "parent": "Builder",
+      "line_start": 49,
+      "line_end": 51
+    },
+    {
+      "name": "create",
+      "qualified": "Builder#create",
+      "kind": "method",
+      "parent": "Builder",
+      "line_start": 47,
+      "line_end": 47
+    },
+    {
+      "name": "Caller",
+      "qualified": "Caller",
+      "kind": "class",
+      "line_start": 4,
+      "line_end": 34
+    },
+    {
+      "name": "basic_chain",
+      "qualified": "Caller#basic_chain",
+      "kind": "method",
+      "parent": "Caller",
+      "line_start": 6,
+      "line_end": 9
+    },
+    {
+      "name": "nested_chain",
+      "qualified": "Caller#nested_chain",
+      "kind": "method",
+      "parent": "Caller",
+      "line_start": 29,
+      "line_end": 33
+    },
+    {
+      "name": "self_chain",
+      "qualified": "Caller#self_chain",
+      "kind": "method",
+      "parent": "Caller",
+      "line_start": 12,
+      "line_end": 14
+    },
+    {
+      "name": "three_hop_chain",
+      "qualified": "Caller#three_hop_chain",
+      "kind": "method",
+      "parent": "Caller",
+      "line_start": 17,
+      "line_end": 20
+    },
+    {
+      "name": "unresolved_chain",
+      "qualified": "Caller#unresolved_chain",
+      "kind": "method",
+      "parent": "Caller",
+      "line_start": 23,
+      "line_end": 26
+    },
+    {
+      "name": "Config",
+      "qualified": "Config",
+      "kind": "class",
+      "line_start": 54,
+      "line_end": 56
+    },
+    {
+      "name": "load",
+      "qualified": "Config#load",
+      "kind": "method",
+      "parent": "Config",
+      "line_start": 55,
+      "line_end": 55
+    },
+    {
+      "name": "Factory",
+      "qualified": "Factory",
+      "kind": "class",
+      "line_start": 36,
+      "line_end": 44
+    },
+    {
+      "name": "builder",
+      "qualified": "Factory#builder",
+      "kind": "method",
+      "parent": "Factory",
+      "line_start": 37,
+      "line_end": 39
+    },
+    {
+      "name": "unknown",
+      "qualified": "Factory#unknown",
+      "kind": "method",
+      "parent": "Factory",
+      "line_start": 41,
+      "line_end": 43
+    }
+  ],
+  "edges": [
+    {
+      "source": "Builder#config",
+      "target": "Config.new",
+      "kind": "calls",
+      "line": 50,
+      "confidence": 1
+    },
+    {
+      "source": "Caller#basic_chain",
+      "target": "Builder#create",
+      "kind": "calls",
+      "line": 8,
+      "confidence": 0.7
+    },
+    {
+      "source": "Caller#basic_chain",
+      "target": "Factory#builder",
+      "kind": "calls",
+      "line": 8,
+      "confidence": 0.7
+    },
+    {
+      "source": "Caller#basic_chain",
+      "target": "Factory.new",
+      "kind": "calls",
+      "line": 7,
+      "confidence": 1
+    },
+    {
+      "source": "Caller#nested_chain",
+      "target": "Factory#builder",
+      "kind": "calls",
+      "line": 31,
+      "confidence": 0.7
+    },
+    {
+      "source": "Caller#nested_chain",
+      "target": "Factory.new",
+      "kind": "calls",
+      "line": 30,
+      "confidence": 1
+    },
+    {
+      "source": "Caller#nested_chain",
+      "target": "create",
+      "kind": "calls",
+      "line": 32,
+      "confidence": 0.5
+    },
+    {
+      "source": "Caller#self_chain",
+      "target": "create",
+      "kind": "calls",
+      "line": 13,
+      "confidence": 0.5
+    },
+    {
+      "source": "Caller#self_chain",
+      "target": "self.builder",
+      "kind": "calls",
+      "line": 13,
+      "confidence": 1
+    },
+    {
+      "source": "Caller#three_hop_chain",
+      "target": "Builder#config",
+      "kind": "calls",
+      "line": 19,
+      "confidence": 0.7
+    },
+    {
+      "source": "Caller#three_hop_chain",
+      "target": "Config#load",
+      "kind": "calls",
+      "line": 19,
+      "confidence": 0.7
+    },
+    {
+      "source": "Caller#three_hop_chain",
+      "target": "Factory#builder",
+      "kind": "calls",
+      "line": 19,
+      "confidence": 0.7
+    },
+    {
+      "source": "Caller#three_hop_chain",
+      "target": "Factory.new",
+      "kind": "calls",
+      "line": 18,
+      "confidence": 1
+    },
+    {
+      "source": "Caller#unresolved_chain",
+      "target": "Factory#unknown",
+      "kind": "calls",
+      "line": 25,
+      "confidence": 0.7
+    },
+    {
+      "source": "Caller#unresolved_chain",
+      "target": "Factory.new",
+      "kind": "calls",
+      "line": 24,
+      "confidence": 1
+    },
+    {
+      "source": "Caller#unresolved_chain",
+      "target": "Something#create",
+      "kind": "calls",
+      "line": 25,
+      "confidence": 0.7
+    },
+    {
+      "source": "Factory#builder",
+      "target": "Builder.new",
+      "kind": "calls",
+      "line": 38,
+      "confidence": 1
+    },
+    {
+      "source": "Factory#unknown",
+      "target": "Something.new",
+      "kind": "calls",
+      "line": 42,
+      "confidence": 1
+    }
+  ]
+}

--- a/internal/extract/testdata/ruby/method_chains.rb
+++ b/internal/extract/testdata/ruby/method_chains.rb
@@ -1,0 +1,56 @@
+# Ruby method-chain resolution fixture.
+# Covers multi-hop chains via return-type map inference.
+
+class Caller
+  # Basic two-hop chain: local var → method → method
+  def basic_chain
+    factory = Factory.new
+    factory.builder.create
+  end
+
+  # Self receiver chain: self → method → method
+  def self_chain
+    self.builder.create
+  end
+
+  # Three-hop chain
+  def three_hop_chain
+    factory = Factory.new
+    factory.builder.config.load
+  end
+
+  # Unresolved chain: middle method has no known return type
+  def unresolved_chain
+    factory = Factory.new
+    factory.unknown.create
+  end
+
+  # Nested chain via another local
+  def nested_chain
+    factory = Factory.new
+    builder = factory.builder
+    builder.create
+  end
+end
+
+class Factory
+  def builder
+    Builder.new
+  end
+
+  def unknown
+    Something.new
+  end
+end
+
+class Builder
+  def create; end
+
+  def config
+    Config.new
+  end
+end
+
+class Config
+  def load; end
+end


### PR DESCRIPTION
## Problem

Ruby method chains like `factory.builder.create` are currently emitted as bare unresolved method names (`"create"`). The extractor handles single-hop resolution (`obj.method` via local variable type map) but has no mechanism to resolve multi-hop chains where the intermediate method returns an instance of a known class.

This produces false edges in the index and misses genuine call relationships for factory/builder patterns common in Ruby codebases.

## Summary

Build a lightweight file-level return-type map for factory methods (methods whose body is a single `Class.new(...)` expression) and use it to resolve multi-hop chains up to 3 levels deep.

## Changes

- **Core resolution:**
  - Add `buildFileReturnTypeMap` to pre-scan the AST for factory methods returning `Class.new(...)` (single-expression or single-return only)
  - Add `resolveChainReceiver` recursive method on `walker` with 3-hop depth cap
  - Thread return-type map through `walker` struct (avoids parameter drilling per council review)

- **Resolution cases handled:**
  - Local variable chains: `factory.builder.create` → `Builder#create`
  - Self-receiver chains: `self.builder.create` → `Builder#create`
  - Nested chains up to 3 hops: `factory.builder.config.load` → `Config#load`
  - Graceful fallback to bare name when intermediate method has no known return type

- **Tests and fixtures:**
  - Unit tests: `TestBuildReturnTypeMap`, `TestChainResolution`, `TestResolveChainReceiver`, `TestInstanceVariableLocalTypeOverride`
  - New fixture: `method_chains.rb` covering 2-hop, 3-hop, self, and unresolved chains
  - Updated `call_patterns.golden.json` to reflect resolved chain edges

## Architecture Highlights

- The return-type map is built once per file before the main extraction walk, keeping the resolution logic stateless and simple
- Depth cap of 3 prevents exponential lookups on deeply nested chains
- `ConfidenceDynamic` (0.7) is used for resolved chains — lower than direct constant receivers (1.0) because resolution depends on the return-type map being correct

## Test Plan

- [x] `go test ./internal/extract/ruby -v` passes (91.4% coverage)
- [x] `go test ./internal/extract -run TestFixtures` passes
- [x] `make ci` passes (build + test + lint)
- [x] Discourse re-index succeeds (863 edges resolved, 0 regressions)