### PR TITLE
feat(ruby): improve call edge resolution via type inference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ sense.yml
 bench/results/
 bench/results-bk/
 bench/audit/gt-audit.md
+/.council

--- a/internal/extract/ruby/ruby.go
+++ b/internal/extract/ruby/ruby.go
@@ -54,7 +54,7 @@ func (Extractor) Extensions() []string      { return []string{".rb", ".rake", ".
 func (Extractor) Tier() extract.Tier        { return extract.TierBasic }
 
 func (Extractor) Extract(tree *sitter.Tree, source []byte, filePath string, emit extract.Emitter) error {
-	w := &walker{source: source, emit: emit, filePath: filePath}
+	w := &walker{source: source, emit: emit, filePath: filePath, classInstanceVars: make(map[string]map[string]string)}
 	return w.walk(tree.RootNode(), nil)
 }
 
@@ -63,11 +63,12 @@ func init() { extract.Register(Extractor{}) }
 // ---- walker ----
 
 type walker struct {
-	source    []byte
-	emit      extract.Emitter
-	filePath  string
-	routeNS   []string // namespace stack for route files (e.g. ["Admin"])
-	testScope []string // nested RSpec block descriptions for synthetic scope
+	source            []byte
+	emit              extract.Emitter
+	filePath          string
+	routeNS           []string // namespace stack for route files (e.g. ["Admin"])
+	testScope         []string // nested RSpec block descriptions for synthetic scope
+	classInstanceVars map[string]map[string]string // @ivar type map per class
 }
 
 // walk visits node and its children under the given class/module scope.
@@ -497,6 +498,8 @@ func (w *walker) handleClassOrModule(n *sitter.Node, scope []string, kind model.
 	}
 
 	if body := n.ChildByFieldName("body"); body != nil {
+		ivarTypes := buildInstanceVarTypeMap(body, w.source)
+		w.classInstanceVars[qualified] = ivarTypes
 		return w.walkChildren(body, newScope)
 	}
 	return nil
@@ -548,8 +551,9 @@ func (w *walker) handleMethod(n *sitter.Node, scope []string, singleton bool) er
 	// edge is an accurate record of what was written.
 	body := n.ChildByFieldName("body")
 	localTypes := buildLocalTypeMap(body, w.source)
+	ivarTypes := w.classInstanceVars[strings.Join(scope, "::")]
 	if err := extract.WalkNamedDescendants(body, "call", func(c *sitter.Node) error {
-		return w.emitCall(c, qualified, scope, localTypes)
+		return w.emitCall(c, qualified, scope, localTypes, ivarTypes)
 	}); err != nil {
 		return err
 	}
@@ -566,7 +570,7 @@ func (w *walker) handleMethod(n *sitter.Node, scope []string, singleton bool) er
 // `public_send` / `__send__` with a literal symbol or string first
 // argument is emitted with confidence 0.7; anything else in that family
 // is skipped.
-func (w *walker) emitCall(n *sitter.Node, source string, scope []string, localTypes map[string]string) error {
+func (w *walker) emitCall(n *sitter.Node, source string, scope []string, localTypes, ivarTypes map[string]string) error {
 	methodNode := n.ChildByFieldName("method")
 	if methodNode == nil {
 		return nil
@@ -593,11 +597,11 @@ func (w *walker) emitCall(n *sitter.Node, source string, scope []string, localTy
 	}
 
 	recv := n.ChildByFieldName("receiver")
-	target, confidence := w.resolveCallTarget(recv, methodName, scope, localTypes)
+	target, confidence := w.resolveCallTarget(recv, methodName, scope, localTypes, ivarTypes)
 	if target == "" {
 		return nil
 	}
-	return w.emitCallWithConfidence(n, source, scope, localTypes, confidence)
+	return w.emitCallWithConfidence(n, source, scope, localTypes, ivarTypes, confidence)
 }
 
 // emitTestCall delegates to emitCall but substitutes ConfidenceTests and
@@ -610,13 +614,13 @@ func (w *walker) emitTestCall(n *sitter.Node, source string, scope []string) err
 	if rspecMatcherMethods[extract.Text(methodNode, w.source)] {
 		return nil
 	}
-	return w.emitCallWithConfidence(n, source, scope, nil, extract.ConfidenceTests)
+	return w.emitCallWithConfidence(n, source, scope, nil, nil, extract.ConfidenceTests)
 }
 
 // emitCallWithConfidence is emitCall's core logic with an injectable
 // confidence value. Used by both production-method emission (1.0 / 0.7)
 // and test-block emission (0.8).
-func (w *walker) emitCallWithConfidence(n *sitter.Node, source string, scope []string, localTypes map[string]string, confidence float64) error {
+func (w *walker) emitCallWithConfidence(n *sitter.Node, source string, scope []string, localTypes, ivarTypes map[string]string, confidence float64) error {
 	methodNode := n.ChildByFieldName("method")
 	if methodNode == nil {
 		return nil
@@ -643,7 +647,7 @@ func (w *walker) emitCallWithConfidence(n *sitter.Node, source string, scope []s
 	}
 
 	recv := n.ChildByFieldName("receiver")
-	target, _ := w.resolveCallTarget(recv, methodName, scope, localTypes)
+	target, _ := w.resolveCallTarget(recv, methodName, scope, localTypes, ivarTypes)
 	if target == "" {
 		return nil
 	}
@@ -658,7 +662,7 @@ func (w *walker) emitCallWithConfidence(n *sitter.Node, source string, scope []s
 
 // resolveCallTarget decides what target string to emit for a call node.
 // It returns the target string and the confidence level.
-func (w *walker) resolveCallTarget(recv *sitter.Node, methodName string, scope []string, localTypes map[string]string) (string, float64) {
+func (w *walker) resolveCallTarget(recv *sitter.Node, methodName string, scope []string, localTypes, ivarTypes map[string]string) (string, float64) {
 	if recv == nil {
 		return "self." + methodName, 1.0
 	}
@@ -673,6 +677,15 @@ func (w *walker) resolveCallTarget(recv *sitter.Node, methodName string, scope [
 	case "identifier":
 		name := extract.Text(recv, w.source)
 		if typ, ok := localTypes[name]; ok {
+			return typ + "#" + methodName, extract.ConfidenceDynamic
+		}
+		return methodName, extract.ConfidenceUnresolved
+	case "instance_variable":
+		name := extract.Text(recv, w.source)
+		if typ, ok := localTypes[name]; ok {
+			return typ + "#" + methodName, extract.ConfidenceDynamic
+		}
+		if typ, ok := ivarTypes[name]; ok {
 			return typ + "#" + methodName, extract.ConfidenceDynamic
 		}
 		return methodName, extract.ConfidenceUnresolved
@@ -711,6 +724,41 @@ func buildLocalTypeMap(body *sitter.Node, source []byte) map[string]string {
 			return nil
 		})
 	}
+	return types
+}
+
+// buildInstanceVarTypeMap scans a class body for `initialize` methods and
+// looks for instance-variable assignments whose RHS is `ClassName.new(...)`.
+// Returns a map from @ivar_name to class_name.
+func buildInstanceVarTypeMap(body *sitter.Node, source []byte) map[string]string {
+	types := make(map[string]string)
+	if body == nil {
+		return types
+	}
+	_ = extract.WalkNamedDescendants(body, "method", func(n *sitter.Node) error {
+		nameNode := n.ChildByFieldName("name")
+		if nameNode == nil || extract.Text(nameNode, source) != "initialize" {
+			return nil
+		}
+		initBody := n.ChildByFieldName("body")
+		if initBody == nil {
+			return nil
+		}
+		for _, kind := range []string{"assignment", "operator_assignment"} {
+			_ = extract.WalkNamedDescendants(initBody, kind, func(a *sitter.Node) error {
+				lhs := a.ChildByFieldName("left")
+				rhs := a.ChildByFieldName("right")
+				if lhs == nil || rhs == nil || lhs.Kind() != "instance_variable" {
+					return nil
+				}
+				if typ := typeFromNewCall(rhs, source, nil); typ != "" {
+					types[extract.Text(lhs, source)] = typ
+				}
+				return nil
+			})
+		}
+		return nil
+	})
 	return types
 }
 

--- a/internal/extract/ruby/ruby.go
+++ b/internal/extract/ruby/ruby.go
@@ -34,6 +34,7 @@
 package ruby
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 
@@ -62,10 +63,11 @@ func init() { extract.Register(Extractor{}) }
 // ---- walker ----
 
 type walker struct {
-	source   []byte
-	emit     extract.Emitter
-	filePath string
-	routeNS  []string // namespace stack for route files (e.g. ["Admin"])
+	source    []byte
+	emit      extract.Emitter
+	filePath  string
+	routeNS   []string // namespace stack for route files (e.g. ["Admin"])
+	testScope []string // nested RSpec block descriptions for synthetic scope
 }
 
 // walk visits node and its children under the given class/module scope.
@@ -137,8 +139,6 @@ func (w *walker) dispatchCall(n *sitter.Node, scope []string) (bool, error) {
 	// Top-level handlers (no enclosing class/module)
 	if !inScope {
 		switch methodName {
-		case "describe":
-			return false, w.emitDescribeEdge(n)
 		case "resources":
 			return true, w.handleResources(n, false)
 		case "resource":
@@ -155,7 +155,32 @@ func (w *walker) dispatchCall(n *sitter.Node, scope []string) (bool, error) {
 		}
 	}
 
+	// RSpec DSL blocks with a body — handled as test scopes.
+	if rspecDSLMethods[methodName] {
+		return w.handleTestBlock(n, scope, methodName)
+	}
+
 	return false, nil
+}
+
+// rspecDSLMethods is the set of RSpec DSL method names that create
+// test scopes when called with a block.
+var rspecDSLMethods = map[string]bool{
+	"it": true, "describe": true, "context": true,
+	"before": true, "after": true, "around": true,
+	"let": true, "expect": true,
+}
+
+// rspecMatcherMethods is the set of RSpec matcher chain methods that
+// should not be emitted as calls edges — they are DSL sugar, not
+// application method invocations.
+var rspecMatcherMethods = map[string]bool{
+	"to": true, "not_to": true, "to_not": true,
+	"eq": true, "be": true, "be_nil": true, "be_empty": true,
+	"be_valid": true, "be_present": true, "be_a": true,
+	"raise_error": true, "change": true, "receive": true,
+	"have_received": true, "match": true, "include": true,
+	"contain_exactly": true, "start_with": true, "end_with": true,
 }
 
 func (w *walker) walkChildren(n *sitter.Node, scope []string) error {
@@ -166,6 +191,246 @@ func (w *walker) walkChildren(n *sitter.Node, scope []string) error {
 		}
 	}
 	return nil
+}
+
+// handleTestBlock processes an RSpec DSL call that has a block body.
+// It builds a synthetic scope name, walks the block for calls/identifiers,
+// and recurses into nested test blocks.  Returns true to signal the node
+// was consumed.
+func (w *walker) handleTestBlock(n *sitter.Node, scope []string, methodName string) (bool, error) {
+	// Emit the conventional tests edge for top-level describe with a
+	// constant argument (e.g. `describe Order do … end`).
+	if methodName == "describe" && len(scope) == 0 {
+		if err := w.emitDescribeEdge(n); err != nil {
+			return true, err
+		}
+	}
+
+	block := getBlockChild(n)
+	if block == nil {
+		// No block — but the arguments may contain calls we still want to
+		// capture (e.g. `expect(TopicCreator.create(...))`).
+		synthetic := w.buildSyntheticSource(scope)
+		return true, extract.WalkNamedDescendants(n, "call", func(c *sitter.Node) error {
+			if w.isInsideNestedTestBlock(c, n) {
+				return nil
+			}
+			methodNode := c.ChildByFieldName("method")
+			if methodNode != nil && rspecDSLMethods[extract.Text(methodNode, w.source)] {
+				return nil
+			}
+			return w.emitTestCall(c, synthetic, scope)
+		})
+	}
+
+	segment := w.buildTestScopeSegment(n, methodName)
+	if segment == "" {
+		// Unnamed / unresolvable block — fall back to file-level scope.
+		return true, w.walkTestBlockWithFallback(block, scope)
+	}
+
+	// Push segment and cap depth at 3.
+	w.testScope = append(w.testScope, segment)
+	if len(w.testScope) > 3 {
+		w.testScope = w.testScope[:len(w.testScope)-1]
+		return true, w.walkTestBlockWithFallback(block, scope)
+	}
+	defer func() {
+		w.testScope = w.testScope[:len(w.testScope)-1]
+	}()
+
+	synthetic := w.buildSyntheticSource(scope)
+	body := getBlockBody(block)
+	if body == nil {
+		return true, nil
+	}
+	return true, w.walkTestBody(body, scope, synthetic)
+}
+
+// buildTestScopeSegment extracts a scope segment from a test DSL call.
+// Returns "" when the block should fall back to file-level scope.
+func (w *walker) buildTestScopeSegment(n *sitter.Node, methodName string) string {
+	args := n.ChildByFieldName("arguments")
+	if args == nil || args.NamedChildCount() == 0 {
+		return ""
+	}
+	first := args.NamedChild(0)
+	if first == nil {
+		return ""
+	}
+
+	switch methodName {
+	case "describe", "context":
+		switch first.Kind() {
+		case "constant", "scope_resolution":
+			return extract.Text(first, w.source)
+		case "string":
+			if hasInterpolation(first) {
+				return ""
+			}
+			desc := extractStringValue(first, w.source)
+			if desc == "" {
+				return ""
+			}
+			if strings.HasPrefix(desc, "#") || strings.HasPrefix(desc, ".") {
+				return desc
+			}
+			return methodName + "_" + sanitizeDesc(desc)
+		default:
+			return ""
+		}
+	case "it":
+		if first.Kind() == "string" {
+			if hasInterpolation(first) {
+				return ""
+			}
+			desc := extractStringValue(first, w.source)
+			if desc == "" {
+				return ""
+			}
+			return "#it_" + sanitizeDesc(desc)
+		}
+		return ""
+	case "before", "after", "around", "let", "expect":
+		// These DSL nodes rarely carry a descriptive string arg;
+		// fall back to file-level scope.
+		return ""
+	default:
+		return ""
+	}
+}
+
+// buildSyntheticSource joins the class/module scope with the test-scope
+// stack into a single synthetic qualified name.
+func (w *walker) buildSyntheticSource(scope []string) string {
+	classScope := strings.Join(scope, "::")
+	testScope := strings.Join(w.testScope, "#")
+
+	if classScope == "" && testScope == "" {
+		return ""
+	}
+	if classScope == "" {
+		return testScope
+	}
+	if testScope == "" {
+		return classScope
+	}
+	return classScope + "#" + testScope
+}
+
+// walkTestBody walks a test block body emitting calls edges with the
+// given synthetic source.  It also recurses into nested test blocks.
+// A single tree walk handles both emission and recursion.
+func (w *walker) walkTestBody(body *sitter.Node, scope []string, source string) error {
+	if err := extract.WalkNamedDescendants(body, "call", func(c *sitter.Node) error {
+		if w.isInsideNestedTestBlock(c, body) {
+			return nil
+		}
+		methodNode := c.ChildByFieldName("method")
+		if methodNode == nil {
+			return nil
+		}
+		methodName := extract.Text(methodNode, w.source)
+		if rspecDSLMethods[methodName] {
+			// Recurse into nested test block.
+			_, err := w.handleTestBlock(c, scope, methodName)
+			return err
+		}
+		return w.emitTestCall(c, source, scope)
+	}); err != nil {
+		return err
+	}
+	// Emit edges for bare identifiers in statement position.
+	return w.emitBareIdentifierCalls(body, source, extract.ConfidenceTests)
+}
+
+// isInsideNestedTestBlock returns true if n sits inside a test DSL call
+// that is a descendant of body (i.e., a nested test block).
+func (w *walker) isInsideNestedTestBlock(n, body *sitter.Node) bool {
+	bodyID := body.Id()
+	for p := n.Parent(); p != nil && p.Id() != bodyID; p = p.Parent() {
+		if p.Kind() == "call" {
+			methodNode := p.ChildByFieldName("method")
+			if methodNode != nil && rspecDSLMethods[extract.Text(methodNode, w.source)] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// walkTestBlockWithFallback walks a test block body using the file path
+// as the source scope (file-level fallback).
+func (w *walker) walkTestBlockWithFallback(block *sitter.Node, scope []string) error {
+	body := getBlockBody(block)
+	if body == nil {
+		return nil
+	}
+	source := w.fileLevelScope(block)
+	return w.walkTestBody(body, scope, source)
+}
+
+// fileLevelScope returns a file-level synthetic scope like "test.rb#L42".
+func (w *walker) fileLevelScope(n *sitter.Node) string {
+	base := w.filePath
+	if i := strings.LastIndex(base, "/"); i >= 0 {
+		base = base[i+1:]
+	}
+	line := extract.Line(n.StartPosition())
+	return fmt.Sprintf("%s#L%d", base, line)
+}
+
+// getBlockChild returns the block child (do_block or block) of a call node.
+func getBlockChild(n *sitter.Node) *sitter.Node {
+	for i := uint(0); i < n.NamedChildCount(); i++ {
+		c := n.NamedChild(i)
+		if c != nil && (c.Kind() == "do_block" || c.Kind() == "block") {
+			return c
+		}
+	}
+	return nil
+}
+
+// getBlockBody returns the body child of a block node.
+func getBlockBody(block *sitter.Node) *sitter.Node {
+	for i := uint(0); i < block.NamedChildCount(); i++ {
+		c := block.NamedChild(i)
+		if c != nil && (c.Kind() == "body_statement" || c.Kind() == "block_body") {
+			return c
+		}
+	}
+	return nil
+}
+
+// hasInterpolation returns true if a string node contains interpolation.
+func hasInterpolation(n *sitter.Node) bool {
+	if n.Kind() != "string" {
+		return false
+	}
+	for i := uint(0); i < n.NamedChildCount(); i++ {
+		c := n.NamedChild(i)
+		if c != nil && c.Kind() == "interpolation" {
+			return true
+		}
+	}
+	return false
+}
+
+// sanitizeDesc turns a human-readable block description into a safe
+// scope segment: spaces → underscores, strip non-alphanumerics.
+func sanitizeDesc(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == ' ':
+			b.WriteRune('_')
+		default:
+			// Drop punctuation.
+		}
+	}
+	return b.String()
 }
 
 // handleClassOrModule emits the symbol, records inheritance (class only),
@@ -288,7 +553,7 @@ func (w *walker) handleMethod(n *sitter.Node, scope []string, singleton bool) er
 	}); err != nil {
 		return err
 	}
-	return w.emitBareIdentifierCalls(body, qualified)
+	return w.emitBareIdentifierCalls(body, qualified, extract.ConfidenceDynamic)
 }
 
 // emitCall produces a calls edge for one `call` node. The target is
@@ -310,6 +575,56 @@ func (w *walker) emitCall(n *sitter.Node, source string, scope []string, localTy
 	if methodName == "" {
 		return nil
 	}
+
+	switch methodName {
+	case "send", "public_send", "__send__":
+		target, ok := literalSendTarget(n, w.source)
+		if !ok {
+			return nil
+		}
+		line := extract.Line(n.StartPosition())
+		return w.emit.Edge(extract.EmittedEdge{
+			SourceQualified: source,
+			TargetQualified: target,
+			Kind:            model.EdgeCalls,
+			Line:            &line,
+			Confidence:      extract.ConfidenceDynamic,
+		})
+	}
+
+	recv := n.ChildByFieldName("receiver")
+	target, confidence := w.resolveCallTarget(recv, methodName, scope, localTypes)
+	if target == "" {
+		return nil
+	}
+	return w.emitCallWithConfidence(n, source, scope, localTypes, confidence)
+}
+
+// emitTestCall delegates to emitCall but substitutes ConfidenceTests and
+// skips RSpec matcher noise (eq, be_valid, raise_error, etc.).
+func (w *walker) emitTestCall(n *sitter.Node, source string, scope []string) error {
+	methodNode := n.ChildByFieldName("method")
+	if methodNode == nil {
+		return nil
+	}
+	if rspecMatcherMethods[extract.Text(methodNode, w.source)] {
+		return nil
+	}
+	return w.emitCallWithConfidence(n, source, scope, nil, extract.ConfidenceTests)
+}
+
+// emitCallWithConfidence is emitCall's core logic with an injectable
+// confidence value. Used by both production-method emission (1.0 / 0.7)
+// and test-block emission (0.8).
+func (w *walker) emitCallWithConfidence(n *sitter.Node, source string, scope []string, localTypes map[string]string, confidence float64) error {
+	methodNode := n.ChildByFieldName("method")
+	if methodNode == nil {
+		return nil
+	}
+	methodName := extract.Text(methodNode, w.source)
+	if methodName == "" {
+		return nil
+	}
 	line := extract.Line(n.StartPosition())
 
 	switch methodName {
@@ -323,12 +638,12 @@ func (w *walker) emitCall(n *sitter.Node, source string, scope []string, localTy
 			TargetQualified: target,
 			Kind:            model.EdgeCalls,
 			Line:            &line,
-			Confidence:      extract.ConfidenceDynamic,
+			Confidence:      confidence,
 		})
 	}
 
 	recv := n.ChildByFieldName("receiver")
-	target, confidence := w.resolveCallTarget(recv, methodName, scope, localTypes)
+	target, _ := w.resolveCallTarget(recv, methodName, scope, localTypes)
 	if target == "" {
 		return nil
 	}
@@ -440,8 +755,11 @@ var statementParents = map[string]bool{
 // calls without parentheses as identifier nodes rather than call
 // nodes; we emit them as `self.name` so the resolver rewrites them to
 // the enclosing class (e.g. `self.validate` → `Order#validate`).
-func (w *walker) emitBareIdentifierCalls(body *sitter.Node, sourceQualified string) error {
+func (w *walker) emitBareIdentifierCalls(body *sitter.Node, sourceQualified string, confidence float64) error {
 	return extract.WalkNamedDescendants(body, "identifier", func(ident *sitter.Node) error {
+		if w.isInsideNestedTestBlock(ident, body) {
+			return nil
+		}
 		parent := ident.Parent()
 		if parent == nil || !statementParents[parent.Kind()] {
 			return nil
@@ -456,7 +774,7 @@ func (w *walker) emitBareIdentifierCalls(body *sitter.Node, sourceQualified stri
 			TargetQualified: "self." + name,
 			Kind:            model.EdgeCalls,
 			Line:            &line,
-			Confidence:      extract.ConfidenceDynamic,
+			Confidence:      confidence,
 		})
 	})
 }

--- a/internal/extract/ruby/ruby.go
+++ b/internal/extract/ruby/ruby.go
@@ -67,6 +67,15 @@ func (Extractor) Extract(tree *sitter.Tree, source []byte, filePath string, emit
 
 func init() { extract.Register(Extractor{}) }
 
+// collectionMethods is the set of method names for which block parameter
+// type inference is supported. When a call with a block uses one of these
+// methods, the block parameter inherits the receiver's element type.
+var collectionMethods = map[string]bool{
+	"each": true, "map": true, "select": true,
+	"reject": true, "find": true, "detect": true,
+	"flat_map": true, "collect": true, "filter": true,
+}
+
 // ---- walker ----
 
 type walker struct {
@@ -411,6 +420,94 @@ func getBlockBody(block *sitter.Node) *sitter.Node {
 	return nil
 }
 
+// isInsideBlock returns true if n is contained within a block or do_block.
+func isInsideBlock(n *sitter.Node) bool {
+	for p := n.Parent(); p != nil; p = p.Parent() {
+		if p.Kind() == "block" || p.Kind() == "do_block" {
+			return true
+		}
+	}
+	return false
+}
+
+// isInsideNestedBlock returns true if n is contained within a block that
+// is a descendant of parent (i.e. a nested block). parent itself should be
+// a block or do_block node.
+func isInsideNestedBlock(n, parent *sitter.Node) bool {
+	parentID := parent.Id()
+	for p := n.Parent(); p != nil && p.Id() != parentID; p = p.Parent() {
+		if p.Kind() == "block" || p.Kind() == "do_block" {
+			return true
+		}
+	}
+	return false
+}
+
+// extractBlockParams pulls simple identifier parameter names from a
+// block_parameters node.
+//
+// Returns nil when:
+//   - the block has no parameters node (e.g. bare block without |...|)
+//   - any parameter is not a simple identifier (destructuring, splat,
+//     optional, etc.)
+//
+// In both cases the caller should skip block parameter type inference
+// and fall back to walking the block body with the original local type
+// map.
+func extractBlockParams(block *sitter.Node, source []byte) []string {
+	paramsNode := block.ChildByFieldName("parameters")
+	if paramsNode == nil {
+		return nil
+	}
+	var params []string
+	count := paramsNode.NamedChildCount()
+	for i := uint(0); i < count; i++ {
+		c := paramsNode.NamedChild(i)
+		if c == nil {
+			continue
+		}
+		switch c.Kind() {
+		case "identifier":
+			params = append(params, extract.Text(c, source))
+		default:
+			// Destructuring, splat, optional parameters — skip the whole block.
+			return nil
+		}
+	}
+	return params
+}
+
+// extractElementType extracts the element type from a collection type string.
+// Handles Array[Type] syntax and falls back to a plural→singular heuristic.
+func extractElementType(collectionType string) string {
+	if collectionType == "" {
+		return ""
+	}
+	// Array[Order] → Order
+	if strings.HasPrefix(collectionType, "Array[") && strings.HasSuffix(collectionType, "]") {
+		return collectionType[6 : len(collectionType)-1]
+	}
+	// Plural → singular heuristic (e.g. orders → Order, users → User)
+	singular := singularize(collectionType)
+	if singular != collectionType {
+		return pascalCase(singular)
+	}
+	return collectionType
+}
+
+// mergeMaps returns a new map containing all entries from base, overlaid
+// with entries from overlay. Neither input map is modified.
+func mergeMaps(base, overlay map[string]string) map[string]string {
+	result := make(map[string]string, len(base)+len(overlay))
+	for k, v := range base {
+		result[k] = v
+	}
+	for k, v := range overlay {
+		result[k] = v
+	}
+	return result
+}
+
 // hasInterpolation returns true if a string node contains interpolation.
 func hasInterpolation(n *sitter.Node) bool {
 	if n.Kind() != "string" {
@@ -561,6 +658,9 @@ func (w *walker) handleMethod(n *sitter.Node, scope []string, singleton bool) er
 	localTypes := buildLocalTypeMap(body, w.source)
 	ivarTypes := w.classInstanceVars[strings.Join(scope, "::")]
 	if err := extract.WalkNamedDescendants(body, "call", func(c *sitter.Node) error {
+		if isInsideBlock(c) {
+			return nil
+		}
 		return w.emitCall(c, qualified, scope, localTypes, ivarTypes)
 	}); err != nil {
 		return err
@@ -659,13 +759,37 @@ func (w *walker) emitCallWithConfidence(n *sitter.Node, source string, scope []s
 	if target == "" {
 		return nil
 	}
-	return w.emit.Edge(extract.EmittedEdge{
+	if err := w.emit.Edge(extract.EmittedEdge{
 		SourceQualified: source,
 		TargetQualified: target,
 		Kind:            model.EdgeCalls,
 		Line:            &line,
 		Confidence:      confidence,
-	})
+	}); err != nil {
+		return err
+	}
+
+	// If this call has a block, infer block parameter types from the
+	// receiver's collection type and walk the block body with an
+	// augmented local type map. When inference is not possible (non-
+	// collection method, destructuring params, unknown receiver type),
+	// we still walk the block so calls inside are not lost.
+	if block := n.ChildByFieldName("block"); block != nil {
+		paramTypes := w.inferBlockParamTypes(n, scope, localTypes, ivarTypes)
+		blockTypes := localTypes
+		if paramTypes != nil {
+			blockTypes = mergeMaps(localTypes, paramTypes)
+		}
+		if err := extract.WalkNamedDescendants(block, "call", func(c *sitter.Node) error {
+			if isInsideNestedBlock(c, block) {
+				return nil
+			}
+			return w.emitCall(c, source, scope, blockTypes, ivarTypes)
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // resolveCallTarget decides what target string to emit for a call node.
@@ -759,6 +883,68 @@ func (w *walker) resolveChainReceiver(recv *sitter.Node, scope []string, localTy
 	}
 
 	return ""
+}
+
+// inferBlockParamTypes determines the element type for block parameters
+// when a call with a block uses a known collection method (each, map, etc.).
+// It looks up the receiver's collection type from local variables, instance
+// variables, or method chains, then extracts the singular element type.
+// Returns nil when the method is not in the whitelist or the type cannot
+// be inferred.
+func (w *walker) inferBlockParamTypes(callNode *sitter.Node, scope []string, localTypes, ivarTypes map[string]string) map[string]string {
+	methodNode := callNode.ChildByFieldName("method")
+	if methodNode == nil {
+		return nil
+	}
+	methodName := extract.Text(methodNode, w.source)
+	if !collectionMethods[methodName] {
+		return nil
+	}
+
+	recv := callNode.ChildByFieldName("receiver")
+	if recv == nil {
+		return nil
+	}
+
+	var collectionType string
+	switch recv.Kind() {
+	case "identifier":
+		collectionType = localTypes[extract.Text(recv, w.source)]
+	case "instance_variable":
+		name := extract.Text(recv, w.source)
+		if typ, ok := localTypes[name]; ok {
+			collectionType = typ
+		} else if typ, ok := ivarTypes[name]; ok {
+			collectionType = typ
+		}
+	case "call":
+		// For chain resolution, e.g. user.orders.each { |order| ... }
+		collectionType = w.resolveChainReceiver(recv, scope, localTypes, 1)
+	}
+
+	if collectionType == "" {
+		return nil
+	}
+
+	elementType := extractElementType(collectionType)
+	if elementType == "" {
+		return nil
+	}
+
+	block := callNode.ChildByFieldName("block")
+	if block == nil {
+		return nil
+	}
+	params := extractBlockParams(block, w.source)
+	if params == nil {
+		return nil
+	}
+
+	result := make(map[string]string)
+	for _, param := range params {
+		result[param] = elementType
+	}
+	return result
 }
 
 // buildLocalTypeMap scans a method body for local-variable assignments

--- a/internal/extract/ruby/ruby.go
+++ b/internal/extract/ruby/ruby.go
@@ -54,7 +54,14 @@ func (Extractor) Extensions() []string      { return []string{".rb", ".rake", ".
 func (Extractor) Tier() extract.Tier        { return extract.TierBasic }
 
 func (Extractor) Extract(tree *sitter.Tree, source []byte, filePath string, emit extract.Emitter) error {
-	w := &walker{source: source, emit: emit, filePath: filePath, classInstanceVars: make(map[string]map[string]string)}
+	returnTypes := buildFileReturnTypeMap(tree.RootNode(), source)
+	w := &walker{
+		source:            source,
+		emit:              emit,
+		filePath:          filePath,
+		classInstanceVars: make(map[string]map[string]string),
+		returnTypes:       returnTypes,
+	}
 	return w.walk(tree.RootNode(), nil)
 }
 
@@ -69,6 +76,7 @@ type walker struct {
 	routeNS           []string // namespace stack for route files (e.g. ["Admin"])
 	testScope         []string // nested RSpec block descriptions for synthetic scope
 	classInstanceVars map[string]map[string]string // @ivar type map per class
+	returnTypes       map[string]string            // method_qualified → class_name (file-level)
 }
 
 // walk visits node and its children under the given class/module scope.
@@ -696,10 +704,61 @@ func (w *walker) resolveCallTarget(recv *sitter.Node, methodName string, scope [
 		if typ := typeFromNewCall(recv, w.source, scope); typ != "" {
 			return typ + "#" + methodName, extract.ConfidenceDynamic
 		}
+		// Try to resolve multi-hop chains via return-type map.
+		if typ := w.resolveChainReceiver(recv, scope, localTypes, 1); typ != "" {
+			return typ + "#" + methodName, extract.ConfidenceDynamic
+		}
 		return methodName, extract.ConfidenceUnresolved
 	}
 
 	return methodName, extract.ConfidenceUnresolved
+}
+
+// resolveChainReceiver recursively resolves a call-chain receiver to a type
+// by looking up local-variable types and method return types. It caps at 3
+// hops to avoid exponential lookups and absurd qualified names.
+func (w *walker) resolveChainReceiver(recv *sitter.Node, scope []string, localTypes map[string]string, depth int) string {
+	if depth > 3 || recv == nil || recv.Kind() != "call" {
+		return ""
+	}
+	methodNode := recv.ChildByFieldName("method")
+	if methodNode == nil {
+		return ""
+	}
+	methodName := extract.Text(methodNode, w.source)
+	innerRecv := recv.ChildByFieldName("receiver")
+
+	// Case 1: receiver is a local variable with known type.
+	if innerRecv != nil && innerRecv.Kind() == "identifier" {
+		if typ, ok := localTypes[extract.Text(innerRecv, w.source)]; ok {
+			qualified := typ + "#" + methodName
+			if ret, ok := w.returnTypes[qualified]; ok {
+				return ret
+			}
+		}
+	}
+
+	// Case 2: receiver is self (implicit or explicit).
+	if innerRecv == nil || innerRecv.Kind() == "self" {
+		parent := strings.Join(scope, "::")
+		qualified := parent + "#" + methodName
+		if ret, ok := w.returnTypes[qualified]; ok {
+			return ret
+		}
+	}
+
+	// Case 3: receiver is another chain (recursive).
+	if innerRecv != nil && innerRecv.Kind() == "call" {
+		innerType := w.resolveChainReceiver(innerRecv, scope, localTypes, depth+1)
+		if innerType != "" {
+			qualified := innerType + "#" + methodName
+			if ret, ok := w.returnTypes[qualified]; ok {
+				return ret
+			}
+		}
+	}
+
+	return ""
 }
 
 // buildLocalTypeMap scans a method body for local-variable assignments
@@ -784,6 +843,115 @@ func typeFromNewCall(n *sitter.Node, source []byte, scope []string) string {
 		return strings.Join(scope, "::")
 	}
 	return ""
+}
+
+// buildReturnTypeMap scans a class/module body for methods whose body is
+// a single expression or a single `return` statement that calls `Class.new(...)`.
+// It returns a map from qualified method name to the inferred class name.
+func buildReturnTypeMap(body *sitter.Node, source []byte, scope []string) map[string]string {
+	types := make(map[string]string)
+	if body == nil {
+		return types
+	}
+	parent := strings.Join(scope, "::")
+	_ = extract.WalkNamedDescendants(body, "method", func(n *sitter.Node) error {
+		return recordMethodReturnType(n, source, parent, types, false)
+	})
+	_ = extract.WalkNamedDescendants(body, "singleton_method", func(n *sitter.Node) error {
+		return recordMethodReturnType(n, source, parent, types, true)
+	})
+	return types
+}
+
+// recordMethodReturnType extracts the return type from a single method
+// and records it in the map if it matches the simple factory pattern.
+func recordMethodReturnType(n *sitter.Node, source []byte, parent string, types map[string]string, singleton bool) error {
+	nameNode := n.ChildByFieldName("name")
+	if nameNode == nil {
+		return nil
+	}
+	name := extract.Text(nameNode, source)
+	if name == "" {
+		return nil
+	}
+	var qualified string
+	switch {
+	case parent == "":
+		qualified = name
+	case singleton:
+		qualified = parent + "." + name
+	default:
+		qualified = parent + "#" + name
+	}
+	body := n.ChildByFieldName("body")
+	if body == nil {
+		return nil
+	}
+	// Look for a single expression or single return statement.
+	var returnExpr *sitter.Node
+	childCount := body.NamedChildCount()
+	if childCount == 1 {
+		child := body.NamedChild(0)
+		if child.Kind() == "return" {
+			// return node has an argument_list as its first named child
+			if argList := child.NamedChild(0); argList != nil && argList.Kind() == "argument_list" {
+				if argList.NamedChildCount() == 1 {
+					returnExpr = argList.NamedChild(0)
+				}
+			}
+		} else {
+			returnExpr = child
+		}
+	}
+	if returnExpr != nil {
+		if typ := typeFromNewCall(returnExpr, source, nil); typ != "" {
+			types[qualified] = typ
+		}
+	}
+	return nil
+}
+
+// buildFileReturnTypeMap walks the entire AST and builds a map of all
+// method qualified names → return types for simple factory methods.
+func buildFileReturnTypeMap(root *sitter.Node, source []byte) map[string]string {
+	types := make(map[string]string)
+	var walk func(n *sitter.Node, scope []string)
+	walk = func(n *sitter.Node, scope []string) {
+		if n == nil {
+			return
+		}
+		switch n.Kind() {
+		case "class", "module":
+			nameNode := n.ChildByFieldName("name")
+			if nameNode != nil {
+				name := extract.Text(nameNode, source)
+				if name != "" {
+					segments := strings.Split(name, "::")
+					newScope := append(slices.Clone(scope), segments...)
+					body := n.ChildByFieldName("body")
+					if body != nil {
+						classTypes := buildReturnTypeMap(body, source, newScope)
+						for k, v := range classTypes {
+							types[k] = v
+						}
+						// Continue walking children with new scope.
+						count := body.NamedChildCount()
+						for i := uint(0); i < count; i++ {
+							walk(body.NamedChild(i), newScope)
+						}
+					}
+					return
+				}
+			}
+		}
+		// For non-class/module nodes, walk children with current scope.
+		count := n.NamedChildCount()
+		for i := uint(0); i < count; i++ {
+			walk(n.NamedChild(i), scope)
+		}
+	}
+	walk(root, nil)
+	return types
 }
 
 // statementParents is the set of tree-sitter-ruby node kinds whose

--- a/internal/extract/ruby/ruby_test.go
+++ b/internal/extract/ruby/ruby_test.go
@@ -2895,3 +2895,424 @@ end
 		t.Errorf("recursive chain: got %q, want %q", got, want)
 	}
 }
+
+// --- block parameter type inference ---
+
+func TestBlockParameterEach(t *testing.T) {
+	r := parseRuby(t, `
+class Order
+  def save; end
+end
+
+class Service
+  def process
+    orders = Order.new
+    orders.each do |order|
+      order.save
+    end
+  end
+end
+`)
+	e := findEdge(r, "Service#process", "Order#save", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge Service#process -> Order#save from block parameter inference")
+	}
+	if e.Confidence != extract.ConfidenceDynamic {
+		t.Errorf("confidence = %v, want %v", e.Confidence, extract.ConfidenceDynamic)
+	}
+	// Verify no duplicate edges — each call should be emitted exactly once.
+	serviceEdges := 0
+	for _, edge := range r.edges {
+		if edge.SourceQualified == "Service#process" {
+			serviceEdges++
+		}
+	}
+	if serviceEdges != 3 {
+		t.Errorf("expected 3 edges from Service#process, got %d", serviceEdges)
+	}
+}
+
+func TestBlockParameterMap(t *testing.T) {
+	r := parseRuby(t, `
+class User
+  def name; end
+end
+
+class Service
+  def process
+    users = User.new
+    users.map { |user| user.name }
+  end
+end
+`)
+	e := findEdge(r, "Service#process", "User#name", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge Service#process -> User#name from block parameter inference")
+	}
+	if e.Confidence != extract.ConfidenceDynamic {
+		t.Errorf("confidence = %v, want %v", e.Confidence, extract.ConfidenceDynamic)
+	}
+}
+
+func TestBlockParameterNestedBlocks(t *testing.T) {
+	r := parseRuby(t, `
+class Item
+  def save; end
+end
+
+class Order
+  def items
+    Item.new
+  end
+end
+
+class Service
+  def process
+    orders = Order.new
+    orders.each do |order|
+      order.items.each do |item|
+        item.save
+      end
+    end
+  end
+end
+`)
+	e := findEdge(r, "Service#process", "Item#save", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge Service#process -> Item#save from nested block parameter inference")
+	}
+	if e.Confidence != extract.ConfidenceDynamic {
+		t.Errorf("confidence = %v, want %v", e.Confidence, extract.ConfidenceDynamic)
+	}
+}
+
+func TestBlockParameterNonCollectionSkipped(t *testing.T) {
+	r := parseRuby(t, `
+class File
+  def read; end
+end
+
+class Service
+  def process
+    File.open("x") { |f| f.read }
+  end
+end
+`)
+	// File.open is not a collection method → no block parameter inference
+	// The call inside the block falls back to bare method name
+	e := findEdge(r, "Service#process", "read", "calls")
+	if e == nil {
+		t.Fatal("missing bare fallback edge for non-collection block")
+	}
+	if e.Confidence != extract.ConfidenceUnresolved {
+		t.Errorf("confidence = %v, want %v", e.Confidence, extract.ConfidenceUnresolved)
+	}
+}
+
+func TestBlockParameterFromLocalVariable(t *testing.T) {
+	r := parseRuby(t, `
+class Order
+  def validate; end
+end
+
+class Service
+  def process
+    orders = Order.new
+    orders.each { |order| order.validate }
+  end
+end
+`)
+	// orders = Order.new makes orders an Order
+	// extractElementType("Order") returns "Order" (already singular)
+	e := findEdge(r, "Service#process", "Order#validate", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge from block parameter with local variable collection")
+	}
+}
+
+func TestBlockParameterMultipleParams(t *testing.T) {
+	r := parseRuby(t, `
+class Order
+  def save; end
+end
+
+class Service
+  def process
+    orders = Order.new
+    orders.each { |order, index| order.save }
+  end
+end
+`)
+	// Multiple params: both get the element type
+	e := findEdge(r, "Service#process", "Order#save", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge from block with multiple parameters")
+	}
+}
+
+func TestBlockParameterDestructuringSkipped(t *testing.T) {
+	r := parseRuby(t, `
+class Order
+  def save; end
+end
+
+class Service
+  def process
+    orders = Order.new
+    orders.each { |(id, name)| id.to_s }
+  end
+end
+`)
+	// Destructuring parameter → skip block parameter inference
+	// The call inside falls back to bare method name
+	e := findEdge(r, "Service#process", "to_s", "calls")
+	if e == nil {
+		t.Fatal("missing bare fallback edge for destructuring block parameter")
+	}
+	if e.Confidence != extract.ConfidenceUnresolved {
+		t.Errorf("confidence = %v, want %v", e.Confidence, extract.ConfidenceUnresolved)
+	}
+}
+
+func TestBlockParameterFromInstanceVariable(t *testing.T) {
+	r := parseRuby(t, `
+class Order
+  def save; end
+end
+
+class Service
+  def initialize
+    @orders = Order.new
+  end
+
+  def process
+    @orders.each { |order| order.save }
+  end
+end
+`)
+	e := findEdge(r, "Service#process", "Order#save", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge from block parameter with instance variable collection")
+	}
+}
+
+func TestBlockParameterFromChain(t *testing.T) {
+	r := parseRuby(t, `
+class Order
+  def save; end
+end
+
+class User
+  def orders
+    Order.new
+  end
+end
+
+class Service
+  def process
+    user = User.new
+    user.orders.each { |order| order.save }
+  end
+end
+`)
+	e := findEdge(r, "Service#process", "Order#save", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge from block parameter with chain receiver")
+	}
+}
+
+func TestExtractBlockParams(t *testing.T) {
+	src := []byte(`orders.each { |order| order.save }`)
+	p := sitter.NewParser()
+	defer p.Close()
+	if err := p.SetLanguage(Extractor{}.Grammar()); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	tree := p.Parse(src, nil)
+	if tree == nil {
+		t.Fatal("Parse returned nil tree")
+	}
+	defer tree.Close()
+
+	callNode := tree.RootNode().NamedChild(0)
+	block := callNode.ChildByFieldName("block")
+	if block == nil {
+		t.Fatal("could not find block")
+	}
+
+	params := extractBlockParams(block, src)
+	if len(params) != 1 || params[0] != "order" {
+		t.Errorf("params = %v, want [order]", params)
+	}
+}
+
+func TestExtractBlockParamsMultiple(t *testing.T) {
+	src := []byte(`orders.each { |order, index| order.save }`)
+	p := sitter.NewParser()
+	defer p.Close()
+	if err := p.SetLanguage(Extractor{}.Grammar()); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	tree := p.Parse(src, nil)
+	if tree == nil {
+		t.Fatal("Parse returned nil tree")
+	}
+	defer tree.Close()
+
+	callNode := tree.RootNode().NamedChild(0)
+	block := callNode.ChildByFieldName("block")
+	params := extractBlockParams(block, src)
+	if len(params) != 2 || params[0] != "order" || params[1] != "index" {
+		t.Errorf("params = %v, want [order index]", params)
+	}
+}
+
+func TestExtractBlockParamsDestructuring(t *testing.T) {
+	src := []byte(`orders.each { |(id, name)| id.to_s }`)
+	p := sitter.NewParser()
+	defer p.Close()
+	if err := p.SetLanguage(Extractor{}.Grammar()); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	tree := p.Parse(src, nil)
+	if tree == nil {
+		t.Fatal("Parse returned nil tree")
+	}
+	defer tree.Close()
+
+	callNode := tree.RootNode().NamedChild(0)
+	block := callNode.ChildByFieldName("block")
+	params := extractBlockParams(block, src)
+	if params != nil {
+		t.Errorf("params = %v, want nil for destructuring", params)
+	}
+}
+
+func TestExtractElementType(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Array[Order]", "Order"},
+		{"Array[Admin::Order]", "Admin::Order"},
+		{"orders", "Order"},
+		{"users", "User"},
+		{"line_items", "LineItem"},
+		{"Order", "Order"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := extractElementType(tc.in); got != tc.want {
+			t.Errorf("extractElementType(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestBlockParameterNoParams(t *testing.T) {
+	// Block without parameters should still be walked, just without type augmentation
+	r := parseRuby(t, `
+class Order
+  def save; end
+end
+
+class Service
+  def process
+    orders = Order.new
+    orders.each { order.save }
+  end
+end
+`)
+	// order is not a block parameter, it's treated as an unresolved identifier
+	// Since it's not in localTypes, it falls back to bare method name
+	e := findEdge(r, "Service#process", "save", "calls")
+	if e == nil {
+		t.Fatal("missing bare fallback edge for block without parameters")
+	}
+	if e.Confidence != extract.ConfidenceUnresolved {
+		t.Errorf("confidence = %v, want %v", e.Confidence, extract.ConfidenceUnresolved)
+	}
+}
+
+func TestBlockParameterUnknownReceiverType(t *testing.T) {
+	// When receiver type is unknown, block body is still walked with original types
+	r := parseRuby(t, `
+class Order
+  def save; end
+end
+
+class Service
+  def process
+    orders.each { |order| order.save }
+  end
+end
+`)
+	// orders is not in localTypes, so each falls back to bare method name
+	// and block parameter inference is skipped
+	e := findEdge(r, "Service#process", "save", "calls")
+	if e == nil {
+		t.Fatal("missing bare fallback edge for unknown receiver type")
+	}
+	if e.Confidence != extract.ConfidenceUnresolved {
+		t.Errorf("confidence = %v, want %v", e.Confidence, extract.ConfidenceUnresolved)
+	}
+}
+
+func TestBlockParameterSplatSkipped(t *testing.T) {
+	// Splat parameter should skip block parameter inference
+	r := parseRuby(t, `
+class Order
+  def save; end
+end
+
+class Service
+  def process
+    orders = Order.new
+    orders.each { |*args| args.first }
+  end
+end
+`)
+	// args.first is a chain call, should fall back to bare method
+	e := findEdge(r, "Service#process", "first", "calls")
+	if e == nil {
+		t.Fatal("missing bare fallback edge for splat parameter")
+	}
+	if e.Confidence != extract.ConfidenceUnresolved {
+		t.Errorf("confidence = %v, want %v", e.Confidence, extract.ConfidenceUnresolved)
+	}
+}
+
+func TestMergeMaps(t *testing.T) {
+	cases := []struct {
+		base, overlay, want map[string]string
+	}{
+		{
+			base:    map[string]string{"a": "1", "b": "2"},
+			overlay: map[string]string{"b": "3", "c": "4"},
+			want:    map[string]string{"a": "1", "b": "3", "c": "4"},
+		},
+		{
+			base:    nil,
+			overlay: map[string]string{"x": "y"},
+			want:    map[string]string{"x": "y"},
+		},
+		{
+			base:    map[string]string{"a": "1"},
+			overlay: nil,
+			want:    map[string]string{"a": "1"},
+		},
+		{
+			base:    nil,
+			overlay: nil,
+			want:    map[string]string{},
+		},
+	}
+	for _, tc := range cases {
+		got := mergeMaps(tc.base, tc.overlay)
+		if len(got) != len(tc.want) {
+			t.Errorf("mergeMaps(%v, %v) = %v, want %v", tc.base, tc.overlay, got, tc.want)
+			continue
+		}
+		for k, v := range tc.want {
+			if got[k] != v {
+				t.Errorf("mergeMaps(%v, %v)[%q] = %q, want %q", tc.base, tc.overlay, k, got[k], v)
+			}
+		}
+	}
+}

--- a/internal/extract/ruby/ruby_test.go
+++ b/internal/extract/ruby/ruby_test.go
@@ -1526,6 +1526,62 @@ end
 	}
 }
 
+func TestTestsEdgeErrorRuby(t *testing.T) {
+	// A class inheriting from a test superclass emits two edges:
+	// inherits + tests. Fail on the second edge to cover the
+	// error return inside the isTestSuperclass block.
+	err := parseWithEmitter(t, `class FooTest < ActiveSupport::TestCase
+end
+`, &failAfterN{symbolsLeft: 100, edgesLeft: 1})
+	if err == nil {
+		t.Error("expected error on tests edge emit")
+	}
+}
+
+func TestEmitCallNilMethodNode(t *testing.T) {
+	// `baz.()` is Ruby lambda shorthand. Tree-sitter parses it as a
+	// call node with a nil method field. emitCall should tolerate this.
+	r := parseRuby(t, `class Foo
+  def bar
+    baz.()
+  end
+end
+`)
+	// No edges expected — the call is skipped due to nil method.
+	if len(r.edges) != 0 {
+		t.Errorf("expected 0 edges for lambda shorthand with nil method, got %d", len(r.edges))
+	}
+}
+
+func TestEmitCallSafeNavNilMethodNode(t *testing.T) {
+	// `baz&.()` — safe navigation with lambda shorthand.
+	r := parseRuby(t, `class Foo
+  def bar
+    baz&.()
+  end
+end
+`)
+	// No edges expected — the call is skipped due to nil method.
+	if len(r.edges) != 0 {
+		t.Errorf("expected 0 edges for safe-nav lambda shorthand with nil method, got %d", len(r.edges))
+	}
+}
+
+func TestEmitCallEmptyMethodName(t *testing.T) {
+	// `foo.''()` produces a call node with an empty method name.
+	// Tree-sitter parses the empty string as an identifier with zero-length text.
+	r := parseRuby(t, `class Foo
+  def bar
+    baz.''()
+  end
+end
+`)
+	// No edges expected — the call is skipped due to empty method name.
+	if len(r.edges) != 0 {
+		t.Errorf("expected 0 edges for empty method name, got %d", len(r.edges))
+	}
+}
+
 func TestIncludeEdgeErrorRuby(t *testing.T) {
 	err := parseWithEmitter(t, `class Foo
   include Comparable
@@ -1612,7 +1668,262 @@ end
 		}
 	}
 	if !found {
-		t.Fatal("missing file-level fallback edge for interpolated description")
+		t.Fatal("missing file-level fallback edge for Product.new")
+	}
+}
+
+func TestInstanceVariableResolution(t *testing.T) {
+	r := parseRuby(t, `
+class TopicCreator
+  def create; end
+end
+
+class PostCreator
+  def initialize
+    @topic_creator = TopicCreator.new
+  end
+
+  def create_topic
+    @topic_creator.create
+  end
+end
+`)
+	// @topic_creator.create should resolve to TopicCreator#create via
+	// class-level instance-variable type map.
+	e := findEdge(r, "PostCreator#create_topic", "TopicCreator#create", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge PostCreator#create_topic -> TopicCreator#create from instance variable resolution")
+	}
+	if e.Confidence != extract.ConfidenceDynamic {
+		t.Errorf("inferred edge confidence = %v, want %v", e.Confidence, extract.ConfidenceDynamic)
+	}
+}
+
+func TestInstanceVariableOperatorAssignment(t *testing.T) {
+	r := parseRuby(t, `
+class Cache
+  def fetch; end
+end
+
+class Service
+  def initialize
+    @cache ||= Cache.new
+  end
+
+  def get
+    @cache.fetch
+  end
+end
+`)
+	// @cache ||= Cache.new should be captured by buildInstanceVarTypeMap.
+	e := findEdge(r, "Service#get", "Cache#fetch", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge Service#get -> Cache#fetch from operator-assignment instance variable")
+	}
+	if e.Confidence != extract.ConfidenceDynamic {
+		t.Errorf("inferred edge confidence = %v, want %v", e.Confidence, extract.ConfidenceDynamic)
+	}
+}
+
+func TestInstanceVariableUnresolvedFallback(t *testing.T) {
+	r := parseRuby(t, `
+class PostCreator
+  def create_topic
+    @unknown.create
+  end
+end
+`)
+	// @unknown is not assigned in initialize, so it falls back to bare method name.
+	e := findEdge(r, "PostCreator#create_topic", "create", "calls")
+	if e == nil {
+		t.Fatal("missing bare fallback edge for unresolved instance variable")
+	}
+	if e.Confidence != extract.ConfidenceUnresolved {
+		t.Errorf("bare fallback confidence = %v, want %v", e.Confidence, extract.ConfidenceUnresolved)
+	}
+}
+
+func TestInstanceVariableLocalOverride(t *testing.T) {
+	r := parseRuby(t, `
+class TopicCreator
+  def create; end
+end
+
+class CommentCreator
+  def create; end
+end
+
+class PostCreator
+  def initialize
+    @topic_creator = TopicCreator.new
+  end
+
+  def create_topic
+    topic_creator = CommentCreator.new
+    topic_creator.create
+    @topic_creator.create
+  end
+end
+`)
+	// Local variable (identifier receiver) resolves via localTypes.
+	eLocal := findEdge(r, "PostCreator#create_topic", "CommentCreator#create", "calls")
+	if eLocal == nil {
+		t.Fatal("missing calls edge from local variable")
+	}
+	if eLocal.Confidence != extract.ConfidenceDynamic {
+		t.Errorf("local edge confidence = %v, want %v", eLocal.Confidence, extract.ConfidenceDynamic)
+	}
+	// Instance variable (instance_variable receiver) resolves via ivarTypes.
+	eIvar := findEdge(r, "PostCreator#create_topic", "TopicCreator#create", "calls")
+	if eIvar == nil {
+		t.Fatal("missing calls edge from instance variable")
+	}
+	if eIvar.Confidence != extract.ConfidenceDynamic {
+		t.Errorf("ivar edge confidence = %v, want %v", eIvar.Confidence, extract.ConfidenceDynamic)
+	}
+}
+
+func TestBuildInstanceVarTypeMap(t *testing.T) {
+	src := []byte(`
+class PostCreator
+  def initialize
+    @topic_creator = TopicCreator.new
+    @cache ||= Cache.new
+    @plain = "string"
+  end
+end
+`)
+	p := sitter.NewParser()
+	defer p.Close()
+	if err := p.SetLanguage(Extractor{}.Grammar()); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	tree := p.Parse(src, nil)
+	if tree == nil {
+		t.Fatal("Parse returned nil tree")
+	}
+	defer tree.Close()
+
+	// Find the class body node
+	root := tree.RootNode()
+	var body *sitter.Node
+	for i := uint(0); i < root.NamedChildCount(); i++ {
+		c := root.NamedChild(i)
+		if c != nil && c.Kind() == "class" {
+			body = c.ChildByFieldName("body")
+			break
+		}
+	}
+	if body == nil {
+		t.Fatal("could not find class body")
+	}
+
+	m := buildInstanceVarTypeMap(body, src)
+	if m["@topic_creator"] != "TopicCreator" {
+		t.Errorf("@topic_creator = %q, want TopicCreator", m["@topic_creator"])
+	}
+	if m["@cache"] != "Cache" {
+		t.Errorf("@cache = %q, want Cache", m["@cache"])
+	}
+	if _, ok := m["@plain"]; ok {
+		t.Error("@plain should not be in map (RHS is not .new)")
+	}
+}
+
+func TestBuildInstanceVarTypeMapNoInitialize(t *testing.T) {
+	src := []byte(`class PostCreator
+  def create_topic
+    @topic_creator.create
+  end
+end
+`)
+	p := sitter.NewParser()
+	defer p.Close()
+	if err := p.SetLanguage(Extractor{}.Grammar()); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	tree := p.Parse(src, nil)
+	if tree == nil {
+		t.Fatal("Parse returned nil tree")
+	}
+	defer tree.Close()
+
+	body := tree.RootNode().NamedChild(0).ChildByFieldName("body")
+	if body == nil {
+		t.Fatal("could not find class body")
+	}
+	m := buildInstanceVarTypeMap(body, src)
+	if len(m) != 0 {
+		t.Errorf("expected empty map, got %v", m)
+	}
+}
+
+func TestBuildInstanceVarTypeMapEmptyInitialize(t *testing.T) {
+	src := []byte(`class PostCreator
+  def initialize
+  end
+
+  def create_topic
+    @topic_creator.create
+  end
+end
+`)
+	p := sitter.NewParser()
+	defer p.Close()
+	if err := p.SetLanguage(Extractor{}.Grammar()); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	tree := p.Parse(src, nil)
+	if tree == nil {
+		t.Fatal("Parse returned nil tree")
+	}
+	defer tree.Close()
+
+	body := tree.RootNode().NamedChild(0).ChildByFieldName("body")
+	if body == nil {
+		t.Fatal("could not find class body")
+	}
+	m := buildInstanceVarTypeMap(body, src)
+	if len(m) != 0 {
+		t.Errorf("expected empty map, got %v", m)
+	}
+}
+
+func TestClassWithNoBody(t *testing.T) {
+	r := parseRuby(t, `class EmptyClass
+end
+`)
+	if len(r.symbols) == 0 {
+		t.Fatal("expected at least the EmptyClass symbol")
+	}
+	s := findSymbol(r, "EmptyClass")
+	if s == nil {
+		t.Fatal("missing EmptyClass symbol")
+	}
+}
+
+func TestInstanceVariableScopeResolution(t *testing.T) {
+	r := parseRuby(t, `
+class Admin::TopicCreator
+  def create; end
+end
+
+class PostCreator
+  def initialize
+    @topic_creator = Admin::TopicCreator.new
+  end
+
+  def create_topic
+    @topic_creator.create
+  end
+end
+`)
+	e := findEdge(r, "PostCreator#create_topic", "Admin::TopicCreator#create", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge for scope-resolution instance variable type")
+	}
+	if e.Confidence != extract.ConfidenceDynamic {
+		t.Errorf("inferred edge confidence = %v, want %v", e.Confidence, extract.ConfidenceDynamic)
 	}
 }
 

--- a/internal/extract/ruby/ruby_test.go
+++ b/internal/extract/ruby/ruby_test.go
@@ -1,6 +1,7 @@
 package ruby
 
 import (
+	"strings"
 	"testing"
 
 	sitter "github.com/tree-sitter/go-tree-sitter"
@@ -1365,6 +1366,34 @@ end
 	}
 }
 
+func TestIncludeNoArgs(t *testing.T) {
+	r := parseRuby(t, `
+class Service
+  include
+end
+`)
+	// No args -> no edge
+	for _, e := range r.edges {
+		if string(e.Kind) == "includes" {
+			t.Error("should not emit includes edge for include with no args")
+		}
+	}
+}
+
+func TestIncludeWithNonConstantArg(t *testing.T) {
+	r := parseRuby(t, `
+class Service
+  include some_method
+end
+`)
+	// Non-constant arg -> no edge
+	for _, e := range r.edges {
+		if string(e.Kind) == "includes" {
+			t.Error("should not emit includes edge for include with non-constant arg")
+		}
+	}
+}
+
 func TestNamespacedRouteResources(t *testing.T) {
 	r := parseRuby(t, `
 namespace :api do
@@ -1514,5 +1543,773 @@ end
 `, &failAfterN{symbolsLeft: 100, edgesLeft: 1})
 	if err == nil {
 		t.Error("expected error on association edge emit")
+	}
+}
+
+func TestRSpecTestBlockConfidence(t *testing.T) {
+	r := parseRuby(t, `describe TopicCreator do
+  it "creates a topic" do
+    TopicCreator.create(user)
+  end
+end
+`)
+	e := findEdge(r, "TopicCreator##it_creates_a_topic", "TopicCreator.create", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge from it block")
+	}
+	if e.Confidence != extract.ConfidenceTests {
+		t.Errorf("confidence = %v, want %v", e.Confidence, extract.ConfidenceTests)
+	}
+}
+
+func TestRSpecTestBlockBareIdentifierConfidence(t *testing.T) {
+	r := parseRuby(t, `describe Service do
+  it "processes" do
+    process_data
+  end
+end
+`)
+	e := findEdge(r, "Service##it_processes", "self.process_data", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge from bare identifier in it block")
+	}
+	if e.Confidence != extract.ConfidenceTests {
+		t.Errorf("confidence = %v, want %v", e.Confidence, extract.ConfidenceTests)
+	}
+}
+
+func TestRSpecNestedDescribeScope(t *testing.T) {
+	r := parseRuby(t, `describe Order do
+  context "when pending" do
+    it "calculates" do
+      Order.new
+    end
+  end
+end
+`)
+	e := findEdge(r, "Order#context_when_pending##it_calculates", "Order.new", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge from nested describe/context/it")
+	}
+}
+
+func TestRSpecFileLevelFallback(t *testing.T) {
+	r := parseRuby(t, `describe Product do
+  it "creates a #{thing}" do
+    Product.new
+  end
+end
+`)
+	found := false
+	for _, e := range r.edges {
+		if e.TargetQualified == "Product.new" && string(e.Kind) == "calls" {
+			if strings.HasPrefix(e.SourceQualified, "test.rb#L") {
+				found = true
+				if e.Confidence != extract.ConfidenceTests {
+					t.Errorf("fallback confidence = %v, want %v", e.Confidence, extract.ConfidenceTests)
+				}
+			}
+		}
+	}
+	if !found {
+		t.Fatal("missing file-level fallback edge for interpolated description")
+	}
+}
+
+func TestRSpecExpectWithCallInArgs(t *testing.T) {
+	// expect(TopicCreator.create(...)) has no block but the argument list
+	// contains a call that should still be extracted.
+	r := parseRuby(t, `describe TopicCreator do
+  it "works" do
+    expect(TopicCreator.create(user)).to be_valid
+  end
+end
+`)
+	e := findEdge(r, "TopicCreator##it_works", "TopicCreator.create", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge from expect() argument list")
+	}
+	if e.Confidence != extract.ConfidenceTests {
+		t.Errorf("confidence = %v, want %v", e.Confidence, extract.ConfidenceTests)
+	}
+}
+
+func TestRSpecDescribeWithConstantSegment(t *testing.T) {
+	// describe(Order) should produce "Order" as the scope segment.
+	r := parseRuby(t, `describe Order do
+  it "creates" do
+    Order.new
+  end
+end
+`)
+	e := findEdge(r, "Order##it_creates", "Order.new", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge from describe with constant arg")
+	}
+}
+
+func TestRSpecContextWithStringSegment(t *testing.T) {
+	// context "when pending" should produce "context_when_pending" segment.
+	r := parseRuby(t, `describe Order do
+  context "when pending" do
+    it "works" do
+      Order.new
+    end
+  end
+end
+`)
+	e := findEdge(r, "Order#context_when_pending##it_works", "Order.new", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge from context with string arg")
+	}
+}
+
+func TestRSpecBeforeAfterFallback(t *testing.T) {
+	// before/after have no string description → file-level fallback.
+	r := parseRuby(t, `describe User do
+  before do
+    setup
+  end
+  after do
+    teardown
+  end
+end
+`)
+	foundSetup := false
+	foundTeardown := false
+	for _, e := range r.edges {
+		if e.TargetQualified == "self.setup" && string(e.Kind) == "calls" {
+			foundSetup = true
+		}
+		if e.TargetQualified == "self.teardown" && string(e.Kind) == "calls" {
+			foundTeardown = true
+		}
+	}
+	if !foundSetup {
+		t.Error("missing file-level fallback edge from before block")
+	}
+	if !foundTeardown {
+		t.Error("missing file-level fallback edge from after block")
+	}
+}
+
+func TestRSpecMatcherSkipped(t *testing.T) {
+	// RSpec matchers like `eq`, `be_valid`, `raise_error` should NOT emit edges.
+	r := parseRuby(t, `describe Order do
+  it "validates" do
+    expect(order).to eq(1)
+    expect(order).to be_valid
+    expect { order.save }.to raise_error
+  end
+end
+`)
+	for _, e := range r.edges {
+		if e.TargetQualified == "eq" || e.TargetQualified == "be_valid" || e.TargetQualified == "raise_error" {
+			t.Errorf("should not emit edge for RSpec matcher %q", e.TargetQualified)
+		}
+	}
+}
+
+func TestRSpecSendInTestBlock(t *testing.T) {
+	// send(:method) inside a test block should emit with ConfidenceTests.
+	r := parseRuby(t, `describe Service do
+  it "invokes" do
+    send(:process)
+  end
+end
+`)
+	e := findEdge(r, "Service##it_invokes", "process", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge from send() inside test block")
+	}
+	if e.Confidence != extract.ConfidenceTests {
+		t.Errorf("confidence = %v, want %v", e.Confidence, extract.ConfidenceTests)
+	}
+}
+
+func TestRSpecLetWithSymbolArg(t *testing.T) {
+	// let(:name) has no string description → file-level fallback.
+	r := parseRuby(t, `describe User do
+  let(:name) do
+    generate_name
+  end
+end
+`)
+	found := false
+	for _, e := range r.edges {
+		if e.TargetQualified == "self.generate_name" && string(e.Kind) == "calls" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("missing file-level fallback edge from let block")
+	}
+}
+
+func TestRSpecDescribeWithScopeResolution(t *testing.T) {
+	// RSpec.describe Admin::Dashboard should produce "Admin::Dashboard" segment.
+	r := parseRuby(t, `RSpec.describe Admin::Dashboard do
+  it "works" do
+    Admin::Dashboard.new
+  end
+end
+`)
+	e := findEdge(r, "Admin::Dashboard##it_works", "Admin::Dashboard.new", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge from describe with scope resolution")
+	}
+}
+
+func TestRSpecTopLevelItBlock(t *testing.T) {
+	// it block without enclosing describe should still emit edges.
+	r := parseRuby(t, `it "works" do
+  TopicCreator.create(user)
+end
+`)
+	e := findEdge(r, "#it_works", "TopicCreator.create", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge from top-level it block")
+	}
+}
+
+func TestRSpecDeepNestingFallback(t *testing.T) {
+	// Depth > 3 triggers file-level fallback.
+	r := parseRuby(t, `describe A do
+  describe "#b" do
+    context "when c" do
+      describe "with d" do
+        it "works" do
+          TopicCreator.create(user)
+        end
+      end
+    end
+  end
+end
+`)
+	// Should fall back to file-level scope for the deepest it block.
+	found := false
+	for _, e := range r.edges {
+		if e.TargetQualified == "TopicCreator.create" && strings.HasPrefix(e.SourceQualified, "test.rb#L") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("missing file-level fallback edge for depth > 3 nesting")
+	}
+}
+
+func TestRSpecDescribeWithScopeResolutionSegment(t *testing.T) {
+	// describe with scope_resolution arg (RSpec.describe Admin::Dashboard).
+	r := parseRuby(t, `RSpec.describe Admin::Dashboard do
+  it "works" do
+    Admin::Dashboard.new
+  end
+end
+`)
+	e := findEdge(r, "Admin::Dashboard##it_works", "Admin::Dashboard.new", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge from describe with scope resolution arg")
+	}
+}
+
+func TestRSpecDescribeWithInterpolation(t *testing.T) {
+	// describe "#{name}" has interpolation → file-level fallback for describe.
+	// But the nested it block still gets a proper scope.
+	r := parseRuby(t, `describe "#{name}" do
+  it "works" do
+    Order.new
+  end
+end
+`)
+	e := findEdge(r, "#it_works", "Order.new", "calls")
+	if e == nil {
+		t.Fatal("missing edge from it block inside describe with interpolation")
+	}
+}
+
+func TestRSpecEmptyDescriptionFallback(t *testing.T) {
+	// it "" should fall back to file-level scope.
+	r := parseRuby(t, `describe Order do
+  it "" do
+    Order.new
+  end
+end
+`)
+	found := false
+	for _, e := range r.edges {
+		if e.TargetQualified == "Order.new" && strings.HasPrefix(e.SourceQualified, "test.rb#L") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("missing file-level fallback edge for empty description")
+	}
+}
+
+func TestRSpecContextWithStringArg(t *testing.T) {
+	// context "when active" should produce "context_when_active" segment.
+	r := parseRuby(t, `describe User do
+  context "when active" do
+    it "works" do
+      User.new
+    end
+  end
+end
+`)
+	e := findEdge(r, "User#context_when_active##it_works", "User.new", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge from context with string arg")
+	}
+}
+
+func TestRSpecDescribeWithMethodString(t *testing.T) {
+	// describe "#create" should preserve the # prefix in the segment.
+	r := parseRuby(t, `describe TopicCreator do
+  describe "#create" do
+    it "works" do
+      TopicCreator.create(user)
+    end
+  end
+end
+`)
+	e := findEdge(r, "TopicCreator##create##it_works", "TopicCreator.create", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge from describe with method string")
+	}
+}
+
+func TestRSpecSendDynamicDispatchInTest(t *testing.T) {
+	// send(:process) inside a test block should emit with ConfidenceTests.
+	r := parseRuby(t, `describe Service do
+  it "invokes" do
+    send(:process)
+  end
+end
+`)
+	e := findEdge(r, "Service##it_invokes", "process", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge from send() inside test block")
+	}
+	if e.Confidence != extract.ConfidenceTests {
+		t.Errorf("confidence = %v, want %v", e.Confidence, extract.ConfidenceTests)
+	}
+}
+
+func TestRSpecPublicSendInTest(t *testing.T) {
+	// public_send("process") inside a test block.
+	r := parseRuby(t, `describe Service do
+  it "invokes" do
+    public_send("process")
+  end
+end
+`)
+	e := findEdge(r, "Service##it_invokes", "process", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge from public_send() inside test block")
+	}
+}
+
+func TestRSpecSendNonLiteralSkippedInTest(t *testing.T) {
+	// send(method_name) with non-literal arg should not emit inside test block.
+	r := parseRuby(t, `describe Service do
+  it "invokes" do
+    send(method_name)
+  end
+end
+`)
+	for _, e := range r.edges {
+		if e.SourceQualified == "Service##it_invokes" && string(e.Kind) == "calls" && e.TargetQualified == "method_name" {
+			t.Error("should not emit calls edge for non-literal send target in test block")
+		}
+	}
+}
+
+func TestRSpecAroundBlockFallback(t *testing.T) {
+	// around blocks have no string description → file-level fallback.
+	r := parseRuby(t, `describe User do
+  around do
+    wrap_test
+  end
+end
+`)
+	found := false
+	for _, e := range r.edges {
+		if e.TargetQualified == "self.wrap_test" && strings.HasPrefix(e.SourceQualified, "test.rb#L") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("missing file-level fallback edge from around block")
+	}
+}
+
+func TestRSpecDescribeWithConstantNoNestedIt(t *testing.T) {
+	// describe(Order) with a call directly in the describe block (no it).
+	r := parseRuby(t, `describe Order do
+  Order.new
+end
+`)
+	e := findEdge(r, "Order", "Order.new", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge from describe block without nested it")
+	}
+}
+
+func TestRSpecExpectNoBlockWithCall(t *testing.T) {
+	// expect(TopicCreator.create(...)) — no block, but call in arg list.
+	r := parseRuby(t, `describe TopicCreator do
+  it "works" do
+    expect(TopicCreator.create(user)).to be_valid
+  end
+end
+`)
+	e := findEdge(r, "TopicCreator##it_works", "TopicCreator.create", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge from expect() with call argument")
+	}
+}
+
+func TestRSpecExpectNoBlockNoCall(t *testing.T) {
+	// expect(topic).to be_valid — no block, no call in args.
+	r := parseRuby(t, `describe TopicCreator do
+  it "works" do
+    expect(topic).to be_valid
+  end
+end
+`)
+	// No calls edge should be emitted for expect() with no call args.
+	for _, e := range r.edges {
+		if e.TargetQualified == "topic" && string(e.Kind) == "calls" {
+			t.Error("should not emit edge for identifier in expect args")
+		}
+	}
+}
+
+func TestRSpecTopLevelExpectWithCall(t *testing.T) {
+	// Top-level expect(TopicCreator.create(...)) — no describe, no it.
+	r := parseRuby(t, `expect(TopicCreator.create(user)).to be_valid
+`)
+	// At top level, scope is empty and testScope is empty.
+	// buildSyntheticSource returns "" which is used as source.
+	for _, e := range r.edges {
+		if e.TargetQualified == "TopicCreator.create" && string(e.Kind) == "calls" {
+			if e.SourceQualified != "" {
+				t.Errorf("top-level expect source should be empty, got %q", e.SourceQualified)
+			}
+			return
+		}
+	}
+	t.Fatal("missing calls edge from top-level expect with call argument")
+}
+
+func TestRSpecDescribeWithNoBlockCall(t *testing.T) {
+	// describe(Order) containing expect(TopicCreator.create(...)) directly
+	// (no it block). The expect has no block, so handleTestBlock's no-block
+	// path is used with classScope="Order" and testScope empty.
+	r := parseRuby(t, `describe Order do
+  expect(TopicCreator.create(user)).to be_valid
+end
+`)
+	for _, e := range r.edges {
+		if e.TargetQualified == "TopicCreator.create" && string(e.Kind) == "calls" {
+			if e.SourceQualified != "Order" {
+				t.Errorf("source should be Order, got %q", e.SourceQualified)
+			}
+			return
+		}
+	}
+	t.Fatal("missing calls edge from expect inside describe block")
+}
+
+func TestRSpecBeforeInsideClass(t *testing.T) {
+	// before block inside a class falls back to file-level scope
+	// because before/after/around have no string description segment.
+	r := parseRuby(t, `class OrderTest < ActiveSupport::TestCase
+  before do
+    setup_test
+  end
+end
+`)
+	found := false
+	for _, e := range r.edges {
+		if e.TargetQualified == "self.setup_test" && string(e.Kind) == "calls" {
+			if !strings.HasPrefix(e.SourceQualified, "test.rb#L") {
+				t.Errorf("source should be file-level fallback, got %q", e.SourceQualified)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("missing calls edge from before block inside class")
+	}
+}
+
+func TestRSpecExpectInsideClass(t *testing.T) {
+	// expect() directly inside a class body (unusual but valid AST).
+	// classScope="Foo", testScope empty → buildSyntheticSource returns "Foo".
+	r := parseRuby(t, `class Foo
+  expect(Bar.new).to eq(1)
+end
+`)
+	for _, e := range r.edges {
+		if e.TargetQualified == "Bar.new" && string(e.Kind) == "calls" {
+			if e.SourceQualified != "Foo" {
+				t.Errorf("source should be Foo, got %q", e.SourceQualified)
+			}
+			return
+		}
+	}
+	t.Fatal("missing calls edge from expect inside class body")
+}
+
+func TestRSpecBlockBodyNil(t *testing.T) {
+	// A do_block with no body_statement (empty block).
+	r := parseRuby(t, `describe Order do
+  it "works" do
+  end
+end
+`)
+	// Should not crash; no edges expected.
+	for _, e := range r.edges {
+		if string(e.Kind) == "calls" && e.SourceQualified == "Order##it_works" {
+			t.Error("unexpected edge from empty it block")
+		}
+	}
+}
+
+func TestRSpecFileLevelScopeWithPath(t *testing.T) {
+	// fileLevelScope strips directory prefix when filePath contains '/'.
+	r := parseRubyWithPath(t, `before do
+  setup
+end
+`, "spec/models/order_spec.rb")
+	found := false
+	for _, e := range r.edges {
+		if e.TargetQualified == "self.setup" && strings.HasPrefix(e.SourceQualified, "order_spec.rb#L") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("missing file-level fallback edge with basename")
+	}
+}
+
+func TestRSpecDescribeWithIntegerArg(t *testing.T) {
+	// describe(123) has an unsupported arg kind → buildTestScopeSegment returns "".
+	// The describe falls back to file-level, but the nested it block has a valid scope.
+	r := parseRuby(t, `describe 123 do
+  it "works" do
+    Order.new
+  end
+end
+`)
+	e := findEdge(r, "#it_works", "Order.new", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge from it block inside describe with integer arg")
+	}
+}
+
+func TestRSpecItWithNonStringArg(t *testing.T) {
+	// it(:symbol) has a non-string arg → buildTestScopeSegment returns "".
+	r := parseRuby(t, `describe Order do
+  it :works do
+    Order.new
+  end
+end
+`)
+	// Falls back to file-level scope.
+	found := false
+	for _, e := range r.edges {
+		if e.TargetQualified == "Order.new" && strings.HasPrefix(e.SourceQualified, "test.rb#L") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("missing file-level fallback edge for it with symbol arg")
+	}
+}
+
+func TestRSpecPublicSendDynamicDispatchInTest(t *testing.T) {
+	// public_send("process") inside a test block.
+	r := parseRuby(t, `describe Service do
+  it "invokes" do
+    public_send("process")
+  end
+end
+`)
+	e := findEdge(r, "Service##it_invokes", "process", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge from public_send() inside test block")
+	}
+	if e.Confidence != extract.ConfidenceTests {
+		t.Errorf("confidence = %v, want %v", e.Confidence, extract.ConfidenceTests)
+	}
+}
+
+func TestRSpecSendWithNonLiteralSkipped(t *testing.T) {
+	// send(method_name) with non-literal arg should not emit in test block.
+	r := parseRuby(t, `describe Service do
+  it "invokes" do
+    send(method_name)
+  end
+end
+`)
+	for _, e := range r.edges {
+		if e.SourceQualified == "Service##it_invokes" && string(e.Kind) == "calls" && e.TargetQualified == "method_name" {
+			t.Error("should not emit calls edge for non-literal send target in test block")
+		}
+	}
+}
+
+// --- coverage for existing functions below 90% ---
+
+func TestBroadcastsToNoArgs(t *testing.T) {
+	r := parseRuby(t, `
+class Message
+  broadcasts_to()
+end
+`)
+	// Empty args -> no edge
+	for _, e := range r.edges {
+		if string(e.Kind) == "calls" && e.SourceQualified == "Message" {
+			t.Error("should not emit calls edge for broadcasts_to with no args")
+		}
+	}
+}
+
+func TestBroadcastsToEmptyString(t *testing.T) {
+	r := parseRuby(t, `
+class Message
+  broadcasts_to ""
+end
+`)
+	// Empty string -> no edge
+	for _, e := range r.edges {
+		if string(e.Kind) == "calls" && e.SourceQualified == "Message" {
+			t.Error("should not emit calls edge for broadcasts_to with empty string")
+		}
+	}
+}
+
+func TestImportmapPinNoArgs(t *testing.T) {
+	r := parseRubyWithPath(t, `pin
+`, "config/importmap.rb")
+	for _, e := range r.edges {
+		if string(e.Kind) == "imports" {
+			t.Error("should not emit imports edge for pin with no args")
+		}
+	}
+}
+
+func TestImportmapPinNonStringArg(t *testing.T) {
+	r := parseRubyWithPath(t, `pin :symbol_arg
+`, "config/importmap.rb")
+	for _, e := range r.edges {
+		if string(e.Kind) == "imports" {
+			t.Error("should not emit imports edge for pin with non-string arg")
+		}
+	}
+}
+
+func TestImportmapPinEmptyString(t *testing.T) {
+	r := parseRubyWithPath(t, `pin ""
+`, "config/importmap.rb")
+	for _, e := range r.edges {
+		if string(e.Kind) == "imports" {
+			t.Error("should not emit imports edge for pin with empty string")
+		}
+	}
+}
+
+// --- coverage for existing functions below 90% ---
+
+func TestBroadcastsToNonLiteralArg(t *testing.T) {
+	r := parseRuby(t, `class Order
+  broadcasts_to some_method
+end
+`)
+	// Non-literal arg -> no edge
+	for _, e := range r.edges {
+		if string(e.Kind) == "calls" && e.SourceQualified == "Message" {
+			t.Error("should not emit calls edge for non-literal broadcasts arg")
+		}
+	}
+}
+
+func TestDescribeNoArgs(t *testing.T) {
+	r := parseRuby(t, `describe do
+end
+`)
+	for _, e := range r.edges {
+		if string(e.Kind) == "tests" {
+			t.Error("should not emit tests edge for describe with no args")
+		}
+	}
+}
+
+func TestDescribeWithStringArgNoEdge(t *testing.T) {
+	r := parseRuby(t, `describe "some behavior" do
+end
+`)
+	for _, e := range r.edges {
+		if string(e.Kind) == "tests" {
+			t.Error("should not emit tests edge for describe with string arg")
+		}
+	}
+}
+
+func TestImportmapPinAllFromNotImportmapFile(t *testing.T) {
+	r := parseRubyWithPath(t, `pin_all_from "app/javascript/controllers"
+`, "config/routes.rb")
+	for _, e := range r.edges {
+		if string(e.Kind) == "imports" {
+			t.Error("should not emit imports edge outside importmap.rb")
+		}
+	}
+}
+
+func TestDescribeWithNonRSpecReceiverAndStringArg(t *testing.T) {
+	r := parseRuby(t, `MyLib.describe "something" do
+end
+`)
+	for _, e := range r.edges {
+		if string(e.Kind) == "tests" {
+			t.Error("should not emit tests edge for non-RSpec describe with string arg")
+		}
+	}
+}
+
+func TestRouteNamespaceNoBlock(t *testing.T) {
+	r := parseRuby(t, `namespace :admin
+`)
+	// Should not crash; no edges expected from namespace without block.
+	for _, e := range r.edges {
+		if strings.Contains(e.TargetQualified, "Admin") {
+			t.Error("should not emit edge for namespace without block")
+		}
+	}
+}
+
+func TestRouteNamespaceNoArgs(t *testing.T) {
+	r := parseRuby(t, `namespace
+`)
+	// Should not crash; no edges expected from namespace without args.
+	for _, e := range r.edges {
+		if strings.Contains(e.TargetQualified, "Admin") {
+			t.Error("should not emit edge for namespace without args")
+		}
+	}
+}
+
+func TestRouteNamespaceStringArg(t *testing.T) {
+	r := parseRuby(t, `namespace "admin" do
+  resources :users
+end
+`)
+	// String arg should be skipped; no namespace prefix applied.
+	for _, e := range r.edges {
+		if strings.Contains(e.TargetQualified, "Admin") {
+			t.Error("should not emit edge with namespace prefix for string arg")
+		}
 	}
 }

--- a/internal/extract/ruby/ruby_test.go
+++ b/internal/extract/ruby/ruby_test.go
@@ -2624,3 +2624,274 @@ end
 		}
 	}
 }
+
+func TestBuildReturnTypeMap(t *testing.T) {
+	src := `class Factory
+  def builder
+    Builder.new
+  end
+
+  def self.create_factory
+    Factory.new
+  end
+
+  def config
+    return Config.new
+  end
+
+  def complex
+    x = 1
+    Builder.new
+  end
+
+  def plain
+    "not a new call"
+  end
+end
+`
+	ex := Extractor{}
+	p := sitter.NewParser()
+	defer p.Close()
+	if err := p.SetLanguage(ex.Grammar()); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	tree := p.Parse([]byte(src), nil)
+	if tree == nil {
+		t.Fatal("Parse returned nil tree")
+	}
+	defer tree.Close()
+
+	// Find the class body node.
+	root := tree.RootNode()
+	var classBody *sitter.Node
+	for i := uint(0); i < root.NamedChildCount(); i++ {
+		child := root.NamedChild(i)
+		if child.Kind() == "class" {
+			classBody = child.ChildByFieldName("body")
+			break
+		}
+	}
+	if classBody == nil {
+		t.Fatal("could not find class body")
+	}
+
+	retTypes := buildReturnTypeMap(classBody, []byte(src), []string{"Factory"})
+
+	if got, want := retTypes["Factory#builder"], "Builder"; got != want {
+		t.Errorf("Factory#builder = %q, want %q", got, want)
+	}
+	if got, want := retTypes["Factory.create_factory"], "Factory"; got != want {
+		t.Errorf("Factory.create_factory = %q, want %q", got, want)
+	}
+	if got, want := retTypes["Factory#config"], "Config"; got != want {
+		t.Errorf("Factory#config = %q, want %q", got, want)
+	}
+	if _, ok := retTypes["Factory#complex"]; ok {
+		t.Error("Factory#complex should not be in return type map (multiple statements)")
+	}
+	if _, ok := retTypes["Factory#plain"]; ok {
+		t.Error("Factory#plain should not be in return type map (not a .new call)")
+	}
+
+	// Test nil body
+	emptyTypes := buildReturnTypeMap(nil, []byte(src), []string{"Factory"})
+	if len(emptyTypes) != 0 {
+		t.Errorf("nil body: expected empty map, got %d entries", len(emptyTypes))
+	}
+
+	// Test top-level method (parent == "")
+	topLevelSrc := `def helper
+  Helper.new
+end
+`
+	topLevelTree := p.Parse([]byte(topLevelSrc), nil)
+	if topLevelTree == nil {
+		t.Fatal("Parse returned nil tree for top-level")
+	}
+	defer topLevelTree.Close()
+
+	topLevelTypes := buildReturnTypeMap(topLevelTree.RootNode(), []byte(topLevelSrc), nil)
+	if got, want := topLevelTypes["helper"], "Helper"; got != want {
+		t.Errorf("top-level method: got %q, want %q", got, want)
+	}
+}
+
+func TestChainResolution(t *testing.T) {
+	r := parseRuby(t, `class Caller
+  def basic_chain
+    factory = Factory.new
+    factory.builder.create
+  end
+end
+
+class Factory
+  def builder
+    Builder.new
+  end
+end
+
+class Builder
+  def create; end
+end
+`)
+	e := findEdge(r, "Caller#basic_chain", "Builder#create", "calls")
+	if e == nil {
+		t.Fatal("missing resolved chain edge Caller#basic_chain -> Builder#create")
+	}
+	if e.Confidence != extract.ConfidenceDynamic {
+		t.Errorf("chain confidence = %v, want %v", e.Confidence, extract.ConfidenceDynamic)
+	}
+}
+
+func TestInstanceVariableLocalTypeOverride(t *testing.T) {
+	// When a local variable shadows an instance variable name,
+	// the local variable type should take precedence.
+	r := parseRuby(t, `class PostCreator
+  def initialize
+    @creator = TopicCreator.new
+  end
+
+  def create
+    creator = CommentCreator.new
+    @creator.create
+  end
+end
+
+class TopicCreator
+  def create; end
+end
+
+class CommentCreator
+  def create; end
+end
+`)
+	e := findEdge(r, "PostCreator#create", "TopicCreator#create", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge for instance variable with local override")
+	}
+	if e.Confidence != extract.ConfidenceDynamic {
+		t.Errorf("confidence = %v, want %v", e.Confidence, extract.ConfidenceDynamic)
+	}
+}
+
+func TestResolveChainReceiver(t *testing.T) {
+	src := `class Service
+  def builder
+    Builder.new
+  end
+end
+
+class Builder
+  def config
+    Config.new
+  end
+end
+`
+	ex := Extractor{}
+	p := sitter.NewParser()
+	defer p.Close()
+	if err := p.SetLanguage(ex.Grammar()); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	tree := p.Parse([]byte(src), nil)
+	if tree == nil {
+		t.Fatal("Parse returned nil tree")
+	}
+	defer tree.Close()
+
+	returnTypes := buildFileReturnTypeMap(tree.RootNode(), []byte(src))
+	localTypes := map[string]string{"svc": "Service"}
+	scope := []string{"Service"}
+
+	// Create a minimal walker to use the method
+	w := &walker{
+		source:      []byte(src),
+		returnTypes: returnTypes,
+	}
+
+	// Case 1: local variable receiver
+	// svc.builder → "Builder"
+	callSrc := `svc.builder`
+	callTree := p.Parse([]byte(callSrc), nil)
+	if callTree == nil {
+		t.Fatal("Parse returned nil tree for call")
+	}
+	defer callTree.Close()
+	callNode := callTree.RootNode().NamedChild(0)
+	if callNode == nil || callNode.Kind() != "call" {
+		t.Fatalf("expected call node, got %s", callNode.Kind())
+	}
+	// Use callSrc as the walker's source so node offsets match
+	w.source = []byte(callSrc)
+	got := w.resolveChainReceiver(callNode, scope, localTypes, 1)
+	if want := "Builder"; got != want {
+		t.Errorf("local var chain: got %q, want %q", got, want)
+	}
+
+	// Case 2: self receiver
+	// self.builder → "Builder"
+	callSrc = `self.builder`
+	callTree = p.Parse([]byte(callSrc), nil)
+	if callTree == nil {
+		t.Fatal("Parse returned nil tree for call")
+	}
+	defer callTree.Close()
+	callNode = callTree.RootNode().NamedChild(0)
+	if callNode == nil || callNode.Kind() != "call" {
+		t.Fatalf("expected call node, got %s", callNode.Kind())
+	}
+	w.source = []byte(callSrc)
+	got = w.resolveChainReceiver(callNode, scope, localTypes, 1)
+	if want := "Builder"; got != want {
+		t.Errorf("self chain: got %q, want %q", got, want)
+	}
+
+	// Case 3: unresolved chain (method not in returnTypes)
+	callSrc = `svc.unknown`
+	callTree = p.Parse([]byte(callSrc), nil)
+	if callTree == nil {
+		t.Fatal("Parse returned nil tree for call")
+	}
+	defer callTree.Close()
+	callNode = callTree.RootNode().NamedChild(0)
+	if callNode == nil || callNode.Kind() != "call" {
+		t.Fatalf("expected call node, got %s", callNode.Kind())
+	}
+	w.source = []byte(callSrc)
+	got = w.resolveChainReceiver(callNode, scope, localTypes, 1)
+	if got != "" {
+		t.Errorf("unresolved chain: got %q, want empty", got)
+	}
+
+	// Case 4: depth limit
+	callSrc = `svc.builder`
+	callTree = p.Parse([]byte(callSrc), nil)
+	if callTree == nil {
+		t.Fatal("Parse returned nil tree for call")
+	}
+	defer callTree.Close()
+	callNode = callTree.RootNode().NamedChild(0)
+	w.source = []byte(callSrc)
+	got = w.resolveChainReceiver(callNode, scope, localTypes, 4)
+	if got != "" {
+		t.Errorf("depth limit: got %q, want empty", got)
+	}
+
+	// Case 5: recursive chain (3 hops)
+	// svc.builder.config where builder returns Builder and config returns Config
+	callSrc = `svc.builder.config`
+	callTree = p.Parse([]byte(callSrc), nil)
+	if callTree == nil {
+		t.Fatal("Parse returned nil tree for call")
+	}
+	defer callTree.Close()
+	callNode = callTree.RootNode().NamedChild(0)
+	if callNode == nil || callNode.Kind() != "call" {
+		t.Fatalf("expected call node, got %s", callNode.Kind())
+	}
+	w.source = []byte(callSrc)
+	got = w.resolveChainReceiver(callNode, scope, localTypes, 1)
+	if want := "Config"; got != want {
+		t.Errorf("recursive chain: got %q, want %q", got, want)
+	}
+}

--- a/internal/extract/testdata/ruby/block_parameters.golden.json
+++ b/internal/extract/testdata/ruby/block_parameters.golden.json
@@ -1,0 +1,196 @@
+{
+  "symbols": [
+    {
+      "name": "Item",
+      "qualified": "Item",
+      "kind": "class",
+      "line_start": 10,
+      "line_end": 12
+    },
+    {
+      "name": "save",
+      "qualified": "Item#save",
+      "kind": "method",
+      "parent": "Item",
+      "line_start": 11,
+      "line_end": 11
+    },
+    {
+      "name": "Order",
+      "qualified": "Order",
+      "kind": "class",
+      "line_start": 1,
+      "line_end": 4
+    },
+    {
+      "name": "save",
+      "qualified": "Order#save",
+      "kind": "method",
+      "parent": "Order",
+      "line_start": 2,
+      "line_end": 2
+    },
+    {
+      "name": "validate",
+      "qualified": "Order#validate",
+      "kind": "method",
+      "parent": "Order",
+      "line_start": 3,
+      "line_end": 3
+    },
+    {
+      "name": "Service",
+      "qualified": "Service",
+      "kind": "class",
+      "line_start": 14,
+      "line_end": 41
+    },
+    {
+      "name": "nested_blocks",
+      "qualified": "Service#nested_blocks",
+      "kind": "method",
+      "parent": "Service",
+      "line_start": 28,
+      "line_end": 36
+    },
+    {
+      "name": "non_collection_block",
+      "qualified": "Service#non_collection_block",
+      "kind": "method",
+      "parent": "Service",
+      "line_start": 38,
+      "line_end": 40
+    },
+    {
+      "name": "process_orders",
+      "qualified": "Service#process_orders",
+      "kind": "method",
+      "parent": "Service",
+      "line_start": 15,
+      "line_end": 21
+    },
+    {
+      "name": "process_users",
+      "qualified": "Service#process_users",
+      "kind": "method",
+      "parent": "Service",
+      "line_start": 23,
+      "line_end": 26
+    },
+    {
+      "name": "User",
+      "qualified": "User",
+      "kind": "class",
+      "line_start": 6,
+      "line_end": 8
+    },
+    {
+      "name": "name",
+      "qualified": "User#name",
+      "kind": "method",
+      "parent": "User",
+      "line_start": 7,
+      "line_end": 7
+    }
+  ],
+  "edges": [
+    {
+      "source": "Service#nested_blocks",
+      "target": "Item#each",
+      "kind": "calls",
+      "line": 32,
+      "confidence": 0.7
+    },
+    {
+      "source": "Service#nested_blocks",
+      "target": "Item#save",
+      "kind": "calls",
+      "line": 33,
+      "confidence": 0.7
+    },
+    {
+      "source": "Service#nested_blocks",
+      "target": "Item.new",
+      "kind": "calls",
+      "line": 31,
+      "confidence": 1
+    },
+    {
+      "source": "Service#nested_blocks",
+      "target": "Order#each",
+      "kind": "calls",
+      "line": 30,
+      "confidence": 0.7
+    },
+    {
+      "source": "Service#nested_blocks",
+      "target": "Order.new",
+      "kind": "calls",
+      "line": 29,
+      "confidence": 1
+    },
+    {
+      "source": "Service#non_collection_block",
+      "target": "File.open",
+      "kind": "calls",
+      "line": 39,
+      "confidence": 1
+    },
+    {
+      "source": "Service#non_collection_block",
+      "target": "read",
+      "kind": "calls",
+      "line": 39,
+      "confidence": 0.5
+    },
+    {
+      "source": "Service#process_orders",
+      "target": "Order#each",
+      "kind": "calls",
+      "line": 17,
+      "confidence": 0.7
+    },
+    {
+      "source": "Service#process_orders",
+      "target": "Order#save",
+      "kind": "calls",
+      "line": 19,
+      "confidence": 0.7
+    },
+    {
+      "source": "Service#process_orders",
+      "target": "Order#validate",
+      "kind": "calls",
+      "line": 18,
+      "confidence": 0.7
+    },
+    {
+      "source": "Service#process_orders",
+      "target": "Order.new",
+      "kind": "calls",
+      "line": 16,
+      "confidence": 1
+    },
+    {
+      "source": "Service#process_users",
+      "target": "User#map",
+      "kind": "calls",
+      "line": 25,
+      "confidence": 0.7
+    },
+    {
+      "source": "Service#process_users",
+      "target": "User#name",
+      "kind": "calls",
+      "line": 25,
+      "confidence": 0.7
+    },
+    {
+      "source": "Service#process_users",
+      "target": "User.new",
+      "kind": "calls",
+      "line": 24,
+      "confidence": 1
+    }
+  ]
+}

--- a/internal/extract/testdata/ruby/block_parameters.rb
+++ b/internal/extract/testdata/ruby/block_parameters.rb
@@ -1,0 +1,41 @@
+class Order
+  def save; end
+  def validate; end
+end
+
+class User
+  def name; end
+end
+
+class Item
+  def save; end
+end
+
+class Service
+  def process_orders
+    orders = Order.new
+    orders.each do |order|
+      order.validate
+      order.save
+    end
+  end
+
+  def process_users
+    users = User.new
+    users.map { |user| user.name }
+  end
+
+  def nested_blocks
+    orders = Order.new
+    orders.each do |order|
+      items = Item.new
+      items.each do |item|
+        item.save
+      end
+    end
+  end
+
+  def non_collection_block
+    File.open("x") { |f| f.read }
+  end
+end

--- a/internal/extract/testdata/ruby/call_patterns.golden.json
+++ b/internal/extract/testdata/ruby/call_patterns.golden.json
@@ -155,6 +155,13 @@
     },
     {
       "source": "Caller#chain_call",
+      "target": "Builder#create",
+      "kind": "calls",
+      "line": 29,
+      "confidence": 0.7
+    },
+    {
+      "source": "Caller#chain_call",
       "target": "Factory#builder",
       "kind": "calls",
       "line": 29,
@@ -166,13 +173,6 @@
       "kind": "calls",
       "line": 28,
       "confidence": 1
-    },
-    {
-      "source": "Caller#chain_call",
-      "target": "create",
-      "kind": "calls",
-      "line": 29,
-      "confidence": 0.5
     },
     {
       "source": "Caller#class_method",

--- a/internal/extract/testdata/ruby/call_patterns.golden.json
+++ b/internal/extract/testdata/ruby/call_patterns.golden.json
@@ -141,17 +141,17 @@
     },
     {
       "source": "Caller#block_call",
+      "target": "List#process",
+      "kind": "calls",
+      "line": 23,
+      "confidence": 0.7
+    },
+    {
+      "source": "Caller#block_call",
       "target": "List.new",
       "kind": "calls",
       "line": 21,
       "confidence": 1
-    },
-    {
-      "source": "Caller#block_call",
-      "target": "process",
-      "kind": "calls",
-      "line": 23,
-      "confidence": 0.5
     },
     {
       "source": "Caller#chain_call",

--- a/internal/extract/testdata/ruby/instance_variables.golden.json
+++ b/internal/extract/testdata/ruby/instance_variables.golden.json
@@ -1,0 +1,94 @@
+{
+  "symbols": [
+    {
+      "name": "Cache",
+      "qualified": "Cache",
+      "kind": "class",
+      "line_start": 5,
+      "line_end": 7
+    },
+    {
+      "name": "fetch",
+      "qualified": "Cache#fetch",
+      "kind": "method",
+      "parent": "Cache",
+      "line_start": 6,
+      "line_end": 6
+    },
+    {
+      "name": "PostCreator",
+      "qualified": "PostCreator",
+      "kind": "class",
+      "line_start": 9,
+      "line_end": 20
+    },
+    {
+      "name": "create_topic",
+      "qualified": "PostCreator#create_topic",
+      "kind": "method",
+      "parent": "PostCreator",
+      "line_start": 15,
+      "line_end": 19
+    },
+    {
+      "name": "initialize",
+      "qualified": "PostCreator#initialize",
+      "kind": "method",
+      "parent": "PostCreator",
+      "line_start": 10,
+      "line_end": 13
+    },
+    {
+      "name": "TopicCreator",
+      "qualified": "TopicCreator",
+      "kind": "class",
+      "line_start": 1,
+      "line_end": 3
+    },
+    {
+      "name": "create",
+      "qualified": "TopicCreator#create",
+      "kind": "method",
+      "parent": "TopicCreator",
+      "line_start": 2,
+      "line_end": 2
+    }
+  ],
+  "edges": [
+    {
+      "source": "PostCreator#create_topic",
+      "target": "Cache#fetch",
+      "kind": "calls",
+      "line": 17,
+      "confidence": 0.7
+    },
+    {
+      "source": "PostCreator#create_topic",
+      "target": "TopicCreator#create",
+      "kind": "calls",
+      "line": 16,
+      "confidence": 0.7
+    },
+    {
+      "source": "PostCreator#create_topic",
+      "target": "create",
+      "kind": "calls",
+      "line": 18,
+      "confidence": 0.5
+    },
+    {
+      "source": "PostCreator#initialize",
+      "target": "Cache.new",
+      "kind": "calls",
+      "line": 12,
+      "confidence": 1
+    },
+    {
+      "source": "PostCreator#initialize",
+      "target": "TopicCreator.new",
+      "kind": "calls",
+      "line": 11,
+      "confidence": 1
+    }
+  ]
+}

--- a/internal/extract/testdata/ruby/instance_variables.rb
+++ b/internal/extract/testdata/ruby/instance_variables.rb
@@ -1,0 +1,20 @@
+class TopicCreator
+  def create; end
+end
+
+class Cache
+  def fetch; end
+end
+
+class PostCreator
+  def initialize
+    @topic_creator = TopicCreator.new
+    @cache ||= Cache.new
+  end
+
+  def create_topic
+    @topic_creator.create
+    @cache.fetch
+    @unknown.create
+  end
+end

--- a/internal/extract/testdata/ruby/method_chains.golden.json
+++ b/internal/extract/testdata/ruby/method_chains.golden.json
@@ -1,0 +1,240 @@
+{
+  "symbols": [
+    {
+      "name": "Builder",
+      "qualified": "Builder",
+      "kind": "class",
+      "line_start": 46,
+      "line_end": 52
+    },
+    {
+      "name": "config",
+      "qualified": "Builder#config",
+      "kind": "method",
+      "parent": "Builder",
+      "line_start": 49,
+      "line_end": 51
+    },
+    {
+      "name": "create",
+      "qualified": "Builder#create",
+      "kind": "method",
+      "parent": "Builder",
+      "line_start": 47,
+      "line_end": 47
+    },
+    {
+      "name": "Caller",
+      "qualified": "Caller",
+      "kind": "class",
+      "line_start": 4,
+      "line_end": 34
+    },
+    {
+      "name": "basic_chain",
+      "qualified": "Caller#basic_chain",
+      "kind": "method",
+      "parent": "Caller",
+      "line_start": 6,
+      "line_end": 9
+    },
+    {
+      "name": "nested_chain",
+      "qualified": "Caller#nested_chain",
+      "kind": "method",
+      "parent": "Caller",
+      "line_start": 29,
+      "line_end": 33
+    },
+    {
+      "name": "self_chain",
+      "qualified": "Caller#self_chain",
+      "kind": "method",
+      "parent": "Caller",
+      "line_start": 12,
+      "line_end": 14
+    },
+    {
+      "name": "three_hop_chain",
+      "qualified": "Caller#three_hop_chain",
+      "kind": "method",
+      "parent": "Caller",
+      "line_start": 17,
+      "line_end": 20
+    },
+    {
+      "name": "unresolved_chain",
+      "qualified": "Caller#unresolved_chain",
+      "kind": "method",
+      "parent": "Caller",
+      "line_start": 23,
+      "line_end": 26
+    },
+    {
+      "name": "Config",
+      "qualified": "Config",
+      "kind": "class",
+      "line_start": 54,
+      "line_end": 56
+    },
+    {
+      "name": "load",
+      "qualified": "Config#load",
+      "kind": "method",
+      "parent": "Config",
+      "line_start": 55,
+      "line_end": 55
+    },
+    {
+      "name": "Factory",
+      "qualified": "Factory",
+      "kind": "class",
+      "line_start": 36,
+      "line_end": 44
+    },
+    {
+      "name": "builder",
+      "qualified": "Factory#builder",
+      "kind": "method",
+      "parent": "Factory",
+      "line_start": 37,
+      "line_end": 39
+    },
+    {
+      "name": "unknown",
+      "qualified": "Factory#unknown",
+      "kind": "method",
+      "parent": "Factory",
+      "line_start": 41,
+      "line_end": 43
+    }
+  ],
+  "edges": [
+    {
+      "source": "Builder#config",
+      "target": "Config.new",
+      "kind": "calls",
+      "line": 50,
+      "confidence": 1
+    },
+    {
+      "source": "Caller#basic_chain",
+      "target": "Builder#create",
+      "kind": "calls",
+      "line": 8,
+      "confidence": 0.7
+    },
+    {
+      "source": "Caller#basic_chain",
+      "target": "Factory#builder",
+      "kind": "calls",
+      "line": 8,
+      "confidence": 0.7
+    },
+    {
+      "source": "Caller#basic_chain",
+      "target": "Factory.new",
+      "kind": "calls",
+      "line": 7,
+      "confidence": 1
+    },
+    {
+      "source": "Caller#nested_chain",
+      "target": "Factory#builder",
+      "kind": "calls",
+      "line": 31,
+      "confidence": 0.7
+    },
+    {
+      "source": "Caller#nested_chain",
+      "target": "Factory.new",
+      "kind": "calls",
+      "line": 30,
+      "confidence": 1
+    },
+    {
+      "source": "Caller#nested_chain",
+      "target": "create",
+      "kind": "calls",
+      "line": 32,
+      "confidence": 0.5
+    },
+    {
+      "source": "Caller#self_chain",
+      "target": "create",
+      "kind": "calls",
+      "line": 13,
+      "confidence": 0.5
+    },
+    {
+      "source": "Caller#self_chain",
+      "target": "self.builder",
+      "kind": "calls",
+      "line": 13,
+      "confidence": 1
+    },
+    {
+      "source": "Caller#three_hop_chain",
+      "target": "Builder#config",
+      "kind": "calls",
+      "line": 19,
+      "confidence": 0.7
+    },
+    {
+      "source": "Caller#three_hop_chain",
+      "target": "Config#load",
+      "kind": "calls",
+      "line": 19,
+      "confidence": 0.7
+    },
+    {
+      "source": "Caller#three_hop_chain",
+      "target": "Factory#builder",
+      "kind": "calls",
+      "line": 19,
+      "confidence": 0.7
+    },
+    {
+      "source": "Caller#three_hop_chain",
+      "target": "Factory.new",
+      "kind": "calls",
+      "line": 18,
+      "confidence": 1
+    },
+    {
+      "source": "Caller#unresolved_chain",
+      "target": "Factory#unknown",
+      "kind": "calls",
+      "line": 25,
+      "confidence": 0.7
+    },
+    {
+      "source": "Caller#unresolved_chain",
+      "target": "Factory.new",
+      "kind": "calls",
+      "line": 24,
+      "confidence": 1
+    },
+    {
+      "source": "Caller#unresolved_chain",
+      "target": "Something#create",
+      "kind": "calls",
+      "line": 25,
+      "confidence": 0.7
+    },
+    {
+      "source": "Factory#builder",
+      "target": "Builder.new",
+      "kind": "calls",
+      "line": 38,
+      "confidence": 1
+    },
+    {
+      "source": "Factory#unknown",
+      "target": "Something.new",
+      "kind": "calls",
+      "line": 42,
+      "confidence": 1
+    }
+  ]
+}

--- a/internal/extract/testdata/ruby/method_chains.rb
+++ b/internal/extract/testdata/ruby/method_chains.rb
@@ -1,0 +1,56 @@
+# Ruby method-chain resolution fixture.
+# Covers multi-hop chains via return-type map inference.
+
+class Caller
+  # Basic two-hop chain: local var → method → method
+  def basic_chain
+    factory = Factory.new
+    factory.builder.create
+  end
+
+  # Self receiver chain: self → method → method
+  def self_chain
+    self.builder.create
+  end
+
+  # Three-hop chain
+  def three_hop_chain
+    factory = Factory.new
+    factory.builder.config.load
+  end
+
+  # Unresolved chain: middle method has no known return type
+  def unresolved_chain
+    factory = Factory.new
+    factory.unknown.create
+  end
+
+  # Nested chain via another local
+  def nested_chain
+    factory = Factory.new
+    builder = factory.builder
+    builder.create
+  end
+end
+
+class Factory
+  def builder
+    Builder.new
+  end
+
+  def unknown
+    Something.new
+  end
+end
+
+class Builder
+  def create; end
+
+  def config
+    Config.new
+  end
+end
+
+class Config
+  def load; end
+end

--- a/internal/extract/testdata/ruby/rspec_test_blocks.golden.json
+++ b/internal/extract/testdata/ruby/rspec_test_blocks.golden.json
@@ -1,0 +1,187 @@
+{
+  "symbols": [],
+  "edges": [
+    {
+      "source": "CategoryTest",
+      "target": "Category",
+      "kind": "tests",
+      "line": 69,
+      "confidence": 0.9
+    },
+    {
+      "source": "Comment",
+      "target": "self.it_behaves_like",
+      "kind": "calls",
+      "line": 57,
+      "confidence": 0.8
+    },
+    {
+      "source": "CommentTest",
+      "target": "Comment",
+      "kind": "tests",
+      "line": 56,
+      "confidence": 0.9
+    },
+    {
+      "source": "ItemTest",
+      "target": "Item",
+      "kind": "tests",
+      "line": 82,
+      "confidence": 0.9
+    },
+    {
+      "source": "Notification##it_sends_email",
+      "target": "Notification.deliver",
+      "kind": "calls",
+      "line": 94,
+      "confidence": 0.8
+    },
+    {
+      "source": "Notification##it_sends_email",
+      "target": "self.notify_user",
+      "kind": "calls",
+      "line": 93,
+      "confidence": 0.8
+    },
+    {
+      "source": "NotificationTest",
+      "target": "Notification",
+      "kind": "tests",
+      "line": 91,
+      "confidence": 0.9
+    },
+    {
+      "source": "Order#context_when_pending##it_calculates_total",
+      "target": "Order.new",
+      "kind": "calls",
+      "line": 21,
+      "confidence": 0.8
+    },
+    {
+      "source": "Order#context_when_pending##it_calculates_total",
+      "target": "calculate_total",
+      "kind": "calls",
+      "line": 22,
+      "confidence": 0.8
+    },
+    {
+      "source": "OrderTest",
+      "target": "Order",
+      "kind": "tests",
+      "line": 18,
+      "confidence": 0.9
+    },
+    {
+      "source": "Post##it_publishes",
+      "target": "Post.new",
+      "kind": "calls",
+      "line": 50,
+      "confidence": 0.8
+    },
+    {
+      "source": "Post##it_publishes",
+      "target": "publish",
+      "kind": "calls",
+      "line": 51,
+      "confidence": 0.8
+    },
+    {
+      "source": "PostTest",
+      "target": "Post",
+      "kind": "tests",
+      "line": 44,
+      "confidence": 0.9
+    },
+    {
+      "source": "ProductTest",
+      "target": "Product",
+      "kind": "tests",
+      "line": 61,
+      "confidence": 0.9
+    },
+    {
+      "source": "TopicCreator##create##it_creates_a_valid_topic",
+      "target": "TopicCreator.create",
+      "kind": "calls",
+      "line": 5,
+      "confidence": 0.8
+    },
+    {
+      "source": "TopicCreatorTest",
+      "target": "TopicCreator",
+      "kind": "tests",
+      "line": 2,
+      "confidence": 0.9
+    },
+    {
+      "source": "User##it_validates_email",
+      "target": "User.new",
+      "kind": "calls",
+      "line": 38,
+      "confidence": 0.8
+    },
+    {
+      "source": "User##it_validates_email",
+      "target": "valid?",
+      "kind": "calls",
+      "line": 39,
+      "confidence": 0.8
+    },
+    {
+      "source": "UserTest",
+      "target": "User",
+      "kind": "tests",
+      "line": 28,
+      "confidence": 0.9
+    },
+    {
+      "source": "rspec_test_blocks.rb#L29",
+      "target": "self.setup_database",
+      "kind": "calls",
+      "line": 30,
+      "confidence": 0.8
+    },
+    {
+      "source": "rspec_test_blocks.rb#L33",
+      "target": "self.teardown_database",
+      "kind": "calls",
+      "line": 34,
+      "confidence": 0.8
+    },
+    {
+      "source": "rspec_test_blocks.rb#L45",
+      "target": "FactoryBot.create",
+      "kind": "calls",
+      "line": 46,
+      "confidence": 0.8
+    },
+    {
+      "source": "rspec_test_blocks.rb#L62",
+      "target": "Product.new",
+      "kind": "calls",
+      "line": 63,
+      "confidence": 0.8
+    },
+    {
+      "source": "rspec_test_blocks.rb#L62",
+      "target": "save",
+      "kind": "calls",
+      "line": 64,
+      "confidence": 0.8
+    },
+    {
+      "source": "rspec_test_blocks.rb#L73",
+      "target": "Category.filtered_list",
+      "kind": "calls",
+      "line": 74,
+      "confidence": 0.8
+    },
+    {
+      "source": "rspec_test_blocks.rb#L84",
+      "target": "Item.process!",
+      "kind": "calls",
+      "line": 85,
+      "confidence": 0.8
+    }
+  ]
+}

--- a/internal/extract/testdata/ruby/rspec_test_blocks.rb
+++ b/internal/extract/testdata/ruby/rspec_test_blocks.rb
@@ -1,0 +1,96 @@
+# Nested describe with constant and method string
+describe TopicCreator do
+  describe "#create" do
+    it "creates a valid topic" do
+      topic = TopicCreator.create(user, guardian, attrs)
+      expect(topic).to be_valid
+    end
+  end
+end
+
+# Top-level it block (no enclosing describe)
+it "works standalone" do
+  result = process_data
+  expect(result).to be_ok
+end
+
+# Context blocks with string descriptions
+describe Order do
+  context "when pending" do
+    it "calculates total" do
+      order = Order.new
+      order.calculate_total
+    end
+  end
+end
+
+# before/after/around hooks — file-level fallback (no string description)
+describe User do
+  before do
+    setup_database
+  end
+
+  after do
+    teardown_database
+  end
+
+  it "validates email" do
+    user = User.new(email: "test@example.com")
+    user.valid?
+  end
+end
+
+# let with symbol arg — file-level fallback
+describe Post do
+  let(:author) do
+    FactoryBot.create(:user)
+  end
+
+  it "publishes" do
+    post = Post.new(author: author)
+    post.publish
+  end
+end
+
+# Shared examples — file-level fallback (it_behaves_like has no block here)
+describe Comment do
+  it_behaves_like "a votable"
+end
+
+# Interpolated description — file-level fallback
+describe Product do
+  it "creates a #{thing}" do
+    product = Product.new
+    product.save
+  end
+end
+
+# Deeply nested blocks (depth > 3 triggers fallback)
+describe Category do
+  describe "#index" do
+    context "when admin" do
+      describe "with filters" do
+        it "returns filtered" do
+          Category.filtered_list
+        end
+      end
+    end
+  end
+end
+
+# Brace block syntax (expect { ... })
+describe Item do
+  it "raises on invalid" do
+    expect {
+      Item.process!(nil)
+    }.to raise_error(ArgumentError)
+  end
+end
+
+# Mixed call and identifier inside test block
+describe Notification do
+  it "sends email" do
+    notify_user
+    Notification.deliver
+  end
+end


### PR DESCRIPTION
## Problem

The Ruby extractor emitted most receiver-based method calls as bare unqualified names (e.g. \`validate\` instead of \`Order#validate\`), producing unresolved edges with low confidence. This happened because the extractor lacked type information for:

- Local variables assigned via \`ClassName.new\`
- Instance variables assigned in \`initialize\`
- Method chains where intermediate return types were known
- Block parameters inside \`each\` / \`map\` / \`select\` and other collection methods

The result was noisy edge data and poor symbol relationship accuracy for Ruby codebases.

## Summary

Add lightweight intra-file type inference to the Ruby extractor so receiver-based method calls resolve to fully-qualified targets when the type is known from local context.

## Changes

- **feat(ruby):** resolve instance variable receivers via initialize type inference
  - Scan \`initialize\` methods for \`@ivar = ClassName.new\` assignments
  - Build per-class instance-variable type maps
  - Emit \`ClassName#method\` edges when \`@ivar.method\` is called

- **feat(ruby):** add multi-hop chain resolution via return-type map
  - Track method return types for single-expression \`.new\` factory methods
  - Resolve chains like \`factory.builder.create\` → \`Builder#create\`

- **feat(ruby):** infer block parameter types from collection methods
  - Support \`each\`, \`map\`, \`select\`, \`reject\`, \`find\`, \`detect\`, \`flat_map\`, \`collect\`, \`filter\`
  - Extract block parameter names from \`block_parameters\` nodes
  - Infer element type from collection receiver (local var, instance var, or chain)
  - Walk block body with augmented local type map
  - Gracefully fall back when inference is not possible

- **feat(ruby):** extract calls from RSpec test blocks with synthetic scopes
  - Build synthetic qualified names from nested \`describe\` / \`context\` / \`it\` blocks
  - Emit calls edges with \`ConfidenceTests\` for test-to-implementation tracing

- **test(ruby):** add fixture tests for all new resolution patterns
  - \`instance_variables.rb\` — \`@ivar\` resolution
  - \`method_chains.rb\` — chain resolution
  - \`block_parameters.rb\` — block parameter inference
  - \`rspec_test_blocks.rb\` — RSpec scope extraction

## Architecture Highlights

- Type inference is file-local and lightweight — no cross-file analysis, no type system complexity
- Return-type map is built in a single pre-pass over the AST before walking
- Block parameter inference reuses the existing \`emitCall\` path with an augmented type map
- All changes are additive; no breaking changes to edge schema or resolution behavior

## Test Plan

- [x] \`go test ./internal/extract/ruby/...\` passes (91.4% coverage)
- [x] \`go test ./internal/extract/...\` passes (all fixture tests)
- [x] \`make ci\` passes (build, test, lint)
- [x] Re-indexed Discourse and verified block parameter calls resolve when collection type is known