### PR TITLE
test(ruby): verify cross-file includes resolution

### DIFF
--- a/internal/extract/ruby/ruby.go
+++ b/internal/extract/ruby/ruby.go
@@ -1249,8 +1249,10 @@ func (w *walker) emitIncludeEdge(n *sitter.Node, scope []string) error {
 	}
 	source := strings.Join(scope, "::")
 	line := extract.Line(n.StartPosition())
-	// Each argument becomes a separate edge. Only simple constants are
-	// resolvable intra-file — skip anything else (dynamic include expressions).
+	// Each argument becomes a separate edge. Emit edges for static
+	// module references (constant and scope_resolution nodes); the
+	// resolver handles cross-file lookup. Skip dynamic expressions
+	// where the target cannot be determined (target == "").
 	count := args.NamedChildCount()
 	for i := uint(0); i < count; i++ {
 		arg := args.NamedChild(i)

--- a/internal/extract/testdata/ruby/inheritance_and_mixins.golden.json
+++ b/internal/extract/testdata/ruby/inheritance_and_mixins.golden.json
@@ -20,15 +20,15 @@
       "qualified": "Child",
       "kind": "class",
       "line_start": 12,
-      "line_end": 18
+      "line_end": 19
     },
     {
       "name": "greet",
       "qualified": "Child#greet",
       "kind": "method",
       "parent": "Child",
-      "line_start": 16,
-      "line_end": 17
+      "line_start": 17,
+      "line_end": 18
     },
     {
       "name": "Printable",
@@ -52,6 +52,13 @@
       "target": "Base",
       "kind": "inherits",
       "line": 12,
+      "confidence": 1
+    },
+    {
+      "source": "Child",
+      "target": "Enumerable",
+      "kind": "includes",
+      "line": 15,
       "confidence": 1
     },
     {

--- a/internal/extract/testdata/ruby/inheritance_and_mixins.rb
+++ b/internal/extract/testdata/ruby/inheritance_and_mixins.rb
@@ -12,6 +12,7 @@ end
 class Child < Base
   include Printable
   extend Printable
+  prepend Enumerable
 
   def greet
   end

--- a/internal/resolve/resolver_test.go
+++ b/internal/resolve/resolver_test.go
@@ -303,3 +303,58 @@ func TestResolveBareTargetNoFallback(t *testing.T) {
 		t.Error("expected miss for bare target with no matches")
 	}
 }
+
+func TestResolveIncludesCrossFile(t *testing.T) {
+	// Include edges resolve cross-file via byQualified just like any
+	// other edge kind — there is no intra-file restriction.
+	tests := []struct {
+		name       string
+		refs       []model.SymbolRef
+		target     string
+		wantOK     bool
+		wantID     int64
+		wantConf   float64
+	}{
+		{
+			name:   "bare target cross-file",
+			refs:   []model.SymbolRef{{ID: 1, Qualified: "Topic", FileID: 10}, {ID: 2, Qualified: "HasErrors", FileID: 20}},
+			target: "HasErrors",
+			wantOK: true, wantID: 2, wantConf: 1.0,
+		},
+		{
+			name:   "scope resolution cross-file",
+			refs:   []model.SymbolRef{{ID: 1, Qualified: "Topic", FileID: 10}, {ID: 2, Qualified: "RateLimiter::OnCreate", FileID: 30}},
+			target: "RateLimiter::OnCreate",
+			wantOK: true, wantID: 2, wantConf: 1.0,
+		},
+		{
+			name:   "unresolved target",
+			refs:   []model.SymbolRef{{ID: 1, Qualified: "Topic", FileID: 10}},
+			target: "NonExistent",
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ix := resolve.NewIndex(tt.refs)
+			r, ok := ix.Resolve(resolve.Request{
+				Target:         tt.target,
+				Kind:           model.EdgeIncludes,
+				SourceFileID:   10,
+				BaseConfidence: 1.0,
+			})
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if r.SymbolID != tt.wantID {
+				t.Errorf("SymbolID = %d, want %d", r.SymbolID, tt.wantID)
+			}
+			if r.Confidence != tt.wantConf {
+				t.Errorf("Confidence = %v, want %v", r.Confidence, tt.wantConf)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The `emitIncludeEdge` function in the Ruby extractor carried a misleading comment claiming includes only resolved "intra-file" (same-file). In reality, the code already emitted edges for all `constant` and `scope_resolution` arguments, and the resolver's `byQualified` index handled cross-file matching. This comment could mislead future maintainers into thinking a non-existent restriction existed, or worse, prompt someone to add the guard the comment described.

## Summary

Correct the misleading comment and add tests verifying that include/extend/prepend edges resolve cross-file via the resolver's qualified-name index. No code behavior changes — the fix is documentation and test coverage.

## Changes

- `internal/extract/ruby/ruby.go`: Fix comment in `emitIncludeEdge` to accurately describe cross-file resolution behavior
- `internal/extract/testdata/ruby/inheritance_and_mixins.rb`: Add `prepend Enumerable` to cover all three mixin keywords in one fixture
- `internal/extract/testdata/ruby/inheritance_and_mixins.golden.json`: Regenerate to include the new `prepend Enumerable` edge
- `internal/resolve/resolver_test.go`: Add table-driven tests covering:
  - Bare target cross-file resolution (e.g. `include HasErrors`)
  - Scope-resolution cross-file resolution (e.g. `include RateLimiter::OnCreate`)
  - Unresolved target negative case (clean miss, no panic)

## Test Plan

- [x] `go test ./internal/extract/ruby/... ./internal/resolve/...` passes
- [x] `make ci` passes (lint + test + build)
- [x] Verified on Discourse codebase: `Topic` class shows `includes` edges to `HasCustomFields`, `RateLimiter::OnCreateRecord`, `Searchable`, `Trashable`, `LimitedEdit`, `Localizable` (all cross-file)