### PR TITLE
fix(blast): exclude type methods from blast radius and add line numbers

### DIFF
--- a/internal/blast/engine.go
+++ b/internal/blast/engine.go
@@ -211,6 +211,9 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 		frontier = append(frontier, id)
 	}
 
+	// childSet tracks a type's own methods. They seed the BFS frontier
+	// (so callers of methods are discoverable) but are explicitly excluded
+	// from blast radius output — see the partition loop below.
 	childSet := map[int64]struct{}{}
 	if shouldExpandChildren(subject.Kind) {
 		childIDs, err := loadChildIDs(ctx, db, symbolIDs)
@@ -283,39 +286,39 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 		frontier = next
 	}
 
-	// Split visited into children (hop 0, from parent_id), caller-direct
-	// (hop ≤1, from edges), and indirect (hop >1). Seeds are skipped.
-	// Children bypass MaxResults — they're deterministic (parent_id).
+	// Split visited into caller-direct (hop ≤1, from edges) and indirect
+	// (hop >1). Seeds and children are skipped from output — children seed
+	// the BFS frontier so callers of methods are found, but they are not
+	// part of the blast radius (they are the symbol's own members).
 	seedSet := make(map[int64]struct{}, len(symbolIDs))
 	for _, id := range symbolIDs {
 		seedSet[id] = struct{}{}
 	}
-	var childDirectIDs, callerDirectIDs, indirectIDs []int64
+	var directIDs, indirectIDs []int64
 	for id, hops := range visited {
 		if _, isSeed := seedSet[id]; isSeed {
 			continue
 		}
+		if _, isChild := childSet[id]; isChild {
+			continue
+		}
 		if hops <= 1 {
-			if _, isChild := childSet[id]; isChild {
-				childDirectIDs = append(childDirectIDs, id)
-			} else {
-				callerDirectIDs = append(callerDirectIDs, id)
-			}
+			directIDs = append(directIDs, id)
 		} else {
 			indirectIDs = append(indirectIDs, id)
 		}
 	}
 
-	totalAffectedCount := len(childDirectIDs) + len(callerDirectIDs) + len(indirectIDs)
+	totalAffectedCount := len(directIDs) + len(indirectIDs)
 
-	callerCount := len(callerDirectIDs) + len(indirectIDs)
+	callerCount := len(directIDs) + len(indirectIDs)
 	if callerCount > opts.MaxResults {
 		type ranked struct {
 			id   int64
 			conf float64
 		}
 		all := make([]ranked, 0, callerCount)
-		for _, id := range callerDirectIDs {
+		for _, id := range directIDs {
 			all = append(all, ranked{id, pathConf[id]})
 		}
 		for _, id := range indirectIDs {
@@ -329,12 +332,9 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 			kept[r.id] = struct{}{}
 		}
 
-		callerDirectIDs = filterIDs(callerDirectIDs, kept)
+		directIDs = filterIDs(directIDs, kept)
 		indirectIDs = filterIDs(indirectIDs, kept)
 	}
-
-	directIDs := childDirectIDs
-	directIDs = append(directIDs, callerDirectIDs...)
 
 	// Hydrate both sets to model.Symbol in a single bulk read.
 
@@ -418,7 +418,15 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 
 	affectedTests := []string{}
 	if opts.IncludeTests {
-		testIDs := append([]int64{subject.ID}, directIDs...)
+		// Include children in test lookup so tests directly targeting
+		// methods on the subject are surfaced even though children are
+		// excluded from the blast radius output.
+		testIDs := make([]int64, 0, 1+len(childSet)+len(directIDs)+len(indirectIDs))
+		testIDs = append(testIDs, subject.ID)
+		for id := range childSet {
+			testIDs = append(testIDs, id)
+		}
+		testIDs = append(testIDs, directIDs...)
 		testIDs = append(testIDs, indirectIDs...)
 		tests, err := loadTestsTargeting(ctx, db, testIDs)
 		if err != nil {

--- a/internal/blast/engine_internal_test.go
+++ b/internal/blast/engine_internal_test.go
@@ -1,0 +1,240 @@
+package blast
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+func TestInternalHelpers(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+
+	t.Run("loadChildIDs-empty", func(t *testing.T) {
+		res, err := loadChildIDs(ctx, db, nil)
+		if err != nil || res != nil {
+			t.Errorf("expected (nil, nil), got (%v, %v)", res, err)
+		}
+		res, err = loadChildIDs(ctx, db, []int64{})
+		if err != nil || res != nil {
+			t.Errorf("expected (nil, nil), got (%v, %v)", res, err)
+		}
+	})
+
+	t.Run("loadTestsTargeting-empty", func(t *testing.T) {
+		res, err := loadTestsTargeting(ctx, db, nil)
+		if err != nil || res == nil || len(res) != 0 {
+			t.Errorf("expected ([]string{}, nil), got (%v, %v)", res, err)
+		}
+		res, err = loadTestsTargeting(ctx, db, []int64{})
+		if err != nil || res == nil || len(res) != 0 {
+			t.Errorf("expected ([]string{}, nil), got (%v, %v)", res, err)
+		}
+	})
+}
+
+func TestSiblingSymbolIDs(t *testing.T) {
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	db := adapter.DB()
+	t.Cleanup(func() { _ = db.Close() })
+
+	var widgetID1, widgetID2, otherID int64
+	err = adapter.InTx(ctx, func() error {
+		f1, err := adapter.WriteFile(ctx, &model.File{
+			Path: "widget.rb", Language: "ruby", Hash: "h1",
+			Symbols: 1, IndexedAt: time.Now().UTC(),
+		})
+		if err != nil {
+			return err
+		}
+		f2, err := adapter.WriteFile(ctx, &model.File{
+			Path: "widget_ext.rb", Language: "ruby", Hash: "h2",
+			Symbols: 1, IndexedAt: time.Now().UTC(),
+		})
+		if err != nil {
+			return err
+		}
+		widgetID1, err = adapter.WriteSymbol(ctx, &model.Symbol{
+			FileID: f1, Name: "Widget", Qualified: "Widget",
+			Kind: model.KindClass, LineStart: 1, LineEnd: 10,
+		})
+		if err != nil {
+			return err
+		}
+		widgetID2, err = adapter.WriteSymbol(ctx, &model.Symbol{
+			FileID: f2, Name: "Widget", Qualified: "Widget",
+			Kind: model.KindClass, LineStart: 20, LineEnd: 30,
+		})
+		if err != nil {
+			return err
+		}
+		otherID, err = adapter.WriteSymbol(ctx, &model.Symbol{
+			FileID: f1, Name: "Other", Qualified: "Other",
+			Kind: model.KindClass, LineStart: 40, LineEnd: 50,
+		})
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	t.Run("finds-siblings", func(t *testing.T) {
+		ids, err := SiblingSymbolIDs(ctx, db, widgetID1)
+		if err != nil {
+			t.Fatalf("SiblingSymbolIDs: %v", err)
+		}
+		if len(ids) != 2 {
+			t.Fatalf("expected 2 sibling IDs (reopened class), got %d: %v", len(ids), ids)
+		}
+		if ids[0] != widgetID1 {
+			t.Errorf("expected first sibling to be self (widgetID1=%d), got %d", widgetID1, ids[0])
+		}
+		found := false
+		for _, id := range ids {
+			if id == widgetID2 {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected widgetID2=%d in siblings, got %v", widgetID2, ids)
+		}
+	})
+
+	t.Run("no-siblings", func(t *testing.T) {
+		ids, err := SiblingSymbolIDs(ctx, db, otherID)
+		if err != nil {
+			t.Fatalf("SiblingSymbolIDs: %v", err)
+		}
+		if len(ids) != 1 || ids[0] != otherID {
+			t.Errorf("expected only self [otherID=%d], got %v", otherID, ids)
+		}
+	})
+}
+
+func TestLoadSymbolsBulk(t *testing.T) {
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	db := adapter.DB()
+	t.Cleanup(func() { _ = db.Close() })
+
+	var ids []int64
+	err = adapter.InTx(ctx, func() error {
+		f, err := adapter.WriteFile(ctx, &model.File{
+			Path: "svc.go", Language: "go", Hash: "h1",
+			Symbols: 3, IndexedAt: time.Now().UTC(),
+		})
+		if err != nil {
+			return err
+		}
+		for i, name := range []string{"pkg.FnA", "pkg.FnB", "pkg.FnC"} {
+			id, err := adapter.WriteSymbol(ctx, &model.Symbol{
+				FileID: f, Name: name, Qualified: name,
+				Kind: model.KindFunction, LineStart: 1 + i, LineEnd: 10 + i,
+			})
+			if err != nil {
+				return err
+			}
+			ids = append(ids, id)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	m, err := loadSymbols(ctx, db, ids)
+	if err != nil {
+		t.Fatalf("loadSymbols: %v", err)
+	}
+	if len(m) != 3 {
+		t.Errorf("expected 3 symbols, got %d", len(m))
+	}
+	for _, id := range ids {
+		if _, ok := m[id]; !ok {
+			t.Errorf("expected symbol with id %d in map", id)
+		}
+	}
+}
+
+func TestLoadSymbolsEmpty(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	m, err := loadSymbols(ctx, db, nil)
+	if err != nil {
+		t.Fatalf("loadSymbols(nil): %v", err)
+	}
+	if len(m) != 0 {
+		t.Errorf("expected empty map, got %d entries", len(m))
+	}
+
+	m, err = loadSymbols(ctx, db, []int64{})
+	if err != nil {
+		t.Fatalf("loadSymbols(empty): %v", err)
+	}
+	if len(m) != 0 {
+		t.Errorf("expected empty map, got %d entries", len(m))
+	}
+}
+
+func TestClassifyTierMemberKind(t *testing.T) {
+	// The "member" edge kind is assigned internally by the BFS when a
+	// type's own methods seed the frontier. Even though children are
+	// excluded from blast output, classifyTier must still return the
+	// correct tier for completeness.
+	if got := classifyTier("member"); got != TierBreaks {
+		t.Errorf("classifyTier(%q) = %d, want %d (TierBreaks)", "member", got, TierBreaks)
+	}
+	if got := classifyTier("calls"); got != TierBreaks {
+		t.Errorf("classifyTier(%q) = %d, want %d (TierBreaks)", "calls", got, TierBreaks)
+	}
+	if got := classifyTier("composes"); got != TierReferences {
+		t.Errorf("classifyTier(%q) = %d, want %d (TierReferences)", "composes", got, TierReferences)
+	}
+}
+
+func TestSiblingSymbolIDsNonExistent(t *testing.T) {
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	db := adapter.DB()
+	t.Cleanup(func() { _ = db.Close() })
+
+	ids, err := SiblingSymbolIDs(ctx, db, 999999)
+	if err != nil {
+		t.Fatalf("SiblingSymbolIDs with non-existent ID: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != 999999 {
+		t.Errorf("expected [999999] (self always included), got %v", ids)
+	}
+}

--- a/internal/blast/engine_test.go
+++ b/internal/blast/engine_test.go
@@ -232,9 +232,8 @@ func TestComputeDefaultsStopWeakChains(t *testing.T) {
 
 // TestComputeHandlesCycle pins the pitch's explicit claim that BFS
 // tolerates cycles via the visited set rather than flagging them.
-// The fixture builds A → B → A (mutual recursion via send) and
-// asserts Compute on A terminates, surfaces B as the direct caller,
-// and does not loop forever or report A as its own caller.
+// TestComputeHandlesCycle pins the pitch's explicit claim that BFS
+// tolerates cycles via the visited set rather than flagging them.
 func TestComputeHandlesCycle(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, filepath.Join(root, "cycle.rb"), `class Cycle
@@ -898,7 +897,7 @@ func TestConfidenceDecayStopsAtThreshold(t *testing.T) {
 		t.Errorf("symbol F (cumulative 0.459) should be excluded at MinConfidence 0.5")
 	}
 	if res.TotalAffected != 4 {
-		t.Errorf("TotalAffected = %d, want 4", res.TotalAffected)
+		t.Errorf("TotalAffected = %d, want 4 (B + C survive, D pruned)", res.TotalAffected)
 	}
 
 	// With MinConfidence 0.8: only B (0.9) and C (0.81) pass.
@@ -1008,30 +1007,57 @@ func TestDoubleReachableAppearsInFirstGroup(t *testing.T) {
 func TestTierClassification(t *testing.T) {
 	fix := newFixtureDB(t)
 	subject := fix.addSymbol(t, "Target")
-	callsCaller := fix.addSymbol(t, "CallsCaller")
-	composesCaller := fix.addSymbol(t, "ComposesCaller")
-	inheritsCaller := fix.addSymbol(t, "InheritsCaller")
 
-	fix.addEdge(t, callsCaller, subject, model.EdgeCalls, 1.0)
-	fix.addEdge(t, composesCaller, subject, model.EdgeComposes, 1.0)
-	fix.addEdge(t, inheritsCaller, subject, model.EdgeInherits, 1.0)
+	kinds := []struct {
+		edgeKind model.EdgeKind
+		wantTier blast.Tier
+		name     string
+	}{
+		{model.EdgeCalls, blast.TierBreaks, "calls"},
+		{model.EdgeTemporal, blast.TierBreaks, "temporal"},
+		{model.EdgeTests, blast.TierTests, "tests"},
+		{model.EdgeComposes, blast.TierReferences, "composes"},
+		{model.EdgeInherits, blast.TierReferences, "inherits"},
+		{model.EdgeIncludes, blast.TierReferences, "includes"},
+	}
 
-	res, err := blast.Compute(context.Background(), fix.db, []int64{subject}, blast.Options{
-		MaxHops:       1,
-		MinConfidence: 0.1,
-	})
+	for _, tc := range kinds {
+		t.Run(tc.name, func(t *testing.T) {
+			caller := fix.addSymbol(t, "Caller_"+tc.name)
+			fix.addEdge(t, caller, subject, tc.edgeKind, 1.0)
+
+			res, err := blast.Compute(context.Background(), fix.db, []int64{subject}, blast.Options{
+				MaxHops:       1,
+				MinConfidence: 0.1,
+			})
+			if err != nil {
+				t.Fatalf("Compute: %v", err)
+			}
+
+			if res.SymbolTiers[caller] != tc.wantTier {
+				t.Errorf("%s edge → tier %d, want %d", tc.name, res.SymbolTiers[caller], tc.wantTier)
+			}
+		})
+	}
+}
+
+func TestTierMemberClassification(t *testing.T) {
+	fix := newFixtureDB(t)
+	typeID := fix.addSymbolWith(t, "Widget", model.KindType, nil)
+	childID := fix.addSymbolWith(t, "Widget.Run", model.KindMethod, &typeID)
+	callerID := fix.addSymbolWith(t, "App", model.KindFunction, nil)
+
+	// Caller calls the child method.
+	fix.addEdge(t, callerID, childID, model.EdgeCalls, 1.0)
+
+	res, err := blast.Compute(context.Background(), fix.db, []int64{typeID}, blast.Options{MaxHops: 1})
 	if err != nil {
 		t.Fatalf("Compute: %v", err)
 	}
 
-	if res.SymbolTiers[callsCaller] != blast.TierBreaks {
-		t.Errorf("calls edge → tier %d, want TierBreaks (%d)", res.SymbolTiers[callsCaller], blast.TierBreaks)
-	}
-	if res.SymbolTiers[composesCaller] != blast.TierReferences {
-		t.Errorf("composes edge → tier %d, want TierReferences (%d)", res.SymbolTiers[composesCaller], blast.TierReferences)
-	}
-	if res.SymbolTiers[inheritsCaller] != blast.TierReferences {
-		t.Errorf("inherits edge → tier %d, want TierReferences (%d)", res.SymbolTiers[inheritsCaller], blast.TierReferences)
+	if res.SymbolTiers[callerID] != blast.TierBreaks {
+		t.Errorf("caller tier = %d, want TierBreaks (%d); member seed should propagate TierBreaks",
+			res.SymbolTiers[callerID], blast.TierBreaks)
 	}
 }
 
@@ -1050,20 +1076,21 @@ func TestTypeMemberSeedInclusion(t *testing.T) {
 		t.Fatalf("Compute: %v", err)
 	}
 
-	// Param is a child of Context — appears in DirectCallers (type change breaks methods).
+	// Param is a child of Context — it seeds the BFS frontier but is NOT
+	// part of the blast radius (only external dependents are).
 	names := map[string]bool{}
 	for _, c := range res.DirectCallers {
 		names[c.Qualified] = true
 	}
-	if !names["gin.Context.Param"] {
-		t.Errorf("child method gin.Context.Param should appear in DirectCallers: %+v", res.DirectCallers)
+	if names["gin.Context.Param"] {
+		t.Errorf("child method gin.Context.Param should NOT appear in DirectCallers: %+v", res.DirectCallers)
 	}
 	if !names["app.ExternalHandler"] {
 		t.Errorf("external caller app.ExternalHandler missing from DirectCallers: %+v", res.DirectCallers)
 	}
 
-	if res.TotalAffected != 2 {
-		t.Errorf("TotalAffected = %d, want 2 (child + external caller)", res.TotalAffected)
+	if res.TotalAffected != 1 {
+		t.Errorf("TotalAffected = %d, want 1 (external caller only)", res.TotalAffected)
 	}
 }
 
@@ -1086,9 +1113,9 @@ func TestTypeMemberBFSPropagation(t *testing.T) {
 	for _, c := range res.DirectCallers {
 		names[c.Qualified] = true
 	}
-	// Param appears as a direct caller (child of Context).
-	if !names["gin.Context.Param"] {
-		t.Errorf("child method gin.Context.Param should appear in DirectCallers: %+v", res.DirectCallers)
+	// Param is a child of Context — seeds the BFS but is NOT part of output.
+	if names["gin.Context.Param"] {
+		t.Errorf("child method gin.Context.Param should be excluded from output: %+v", res.DirectCallers)
 	}
 	// HandlerFunc calls Param → appears as direct caller (Param is a seed, so
 	// HandlerFunc is discovered at hop 1).
@@ -1096,8 +1123,8 @@ func TestTypeMemberBFSPropagation(t *testing.T) {
 		t.Errorf("HandlerFunc should appear via Param seed, got: %+v", res.DirectCallers)
 	}
 
-	if res.TotalAffected != 2 {
-		t.Errorf("TotalAffected = %d, want 2 (child + caller of child)", res.TotalAffected)
+	if res.TotalAffected != 1 {
+		t.Errorf("TotalAffected = %d, want 1 (caller of child only)", res.TotalAffected)
 	}
 }
 
@@ -1267,18 +1294,27 @@ func TestTypeMemberTierClassification(t *testing.T) {
 
 	typeID := fix.addSymbolWith(t, "Widget", model.KindType, nil)
 	childID := fix.addSymbolWith(t, "Widget.Run", model.KindMethod, &typeID)
+	callerID := fix.addSymbolWith(t, "App", model.KindFunction, nil)
+
+	// Caller calls the child method.
+	fix.addEdge(t, callerID, childID, model.EdgeCalls, 1.0)
 
 	res, err := blast.Compute(context.Background(), fix.db, []int64{typeID}, blast.Options{MaxHops: 1})
 	if err != nil {
 		t.Fatalf("Compute: %v", err)
 	}
 
-	if len(res.DirectCallers) != 1 || res.DirectCallers[0].ID != childID {
-		t.Fatalf("DirectCallers = %+v, want [Widget.Run]", res.DirectCallers)
+	// Child seeds BFS but is NOT in output; caller is discovered via BFS.
+	if len(res.DirectCallers) != 1 || res.DirectCallers[0].ID != callerID {
+		t.Fatalf("DirectCallers = %+v, want [App]", res.DirectCallers)
 	}
-	if res.SymbolTiers[childID] != blast.TierBreaks {
-		t.Errorf("child tier = %d, want TierBreaks (%d); member edge should classify as tier 1",
-			res.SymbolTiers[childID], blast.TierBreaks)
+	if res.SymbolTiers[callerID] != blast.TierBreaks {
+		t.Errorf("caller tier = %d, want TierBreaks (%d); calls edge should classify as tier 1",
+			res.SymbolTiers[callerID], blast.TierBreaks)
+	}
+	// Child should not have a tier since it's excluded from output.
+	if _, ok := res.SymbolTiers[childID]; ok {
+		t.Errorf("child should not have a tier; got %d", res.SymbolTiers[childID])
 	}
 }
 
@@ -1294,14 +1330,45 @@ func TestTypeKindExpandsChildren(t *testing.T) {
 		t.Fatalf("Compute: %v", err)
 	}
 
+	// Children seed the BFS but are NOT part of the blast radius output.
 	ids := map[int64]bool{}
 	for _, c := range res.DirectCallers {
 		ids[c.ID] = true
 	}
-	if !ids[m1] || !ids[m2] {
-		t.Errorf("KindType should expand children: got %+v, want Config.Get + Config.Set", res.DirectCallers)
+	if ids[m1] || ids[m2] {
+		t.Errorf("children should NOT appear in blast output: got %+v", res.DirectCallers)
 	}
-	if res.TotalAffected != 2 {
-		t.Errorf("TotalAffected = %d, want 2", res.TotalAffected)
+	if res.TotalAffected != 0 {
+		t.Errorf("TotalAffected = %d, want 0 (no external callers)", res.TotalAffected)
 	}
+}
+
+func TestComputeExpandFrontierErrors(t *testing.T) {
+	t.Run("db-closed", func(t *testing.T) {
+		fix := newFixtureDB(t)
+		subject := fix.addSymbol(t, "Subject")
+		fix.addEdge(t, fix.addSymbol(t, "Caller"), subject, model.EdgeCalls, 1.0)
+
+		db := fix.db
+		_ = db.Close()
+
+		_, err := blast.Compute(context.Background(), db, []int64{subject}, blast.Options{MaxHops: 1})
+		if err == nil {
+			t.Error("expected error when DB is closed, got nil")
+		}
+	})
+
+	t.Run("context-cancelled", func(t *testing.T) {
+		fix := newFixtureDB(t)
+		subject := fix.addSymbol(t, "Subject")
+		fix.addEdge(t, fix.addSymbol(t, "Caller"), subject, model.EdgeCalls, 1.0)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := blast.Compute(ctx, fix.db, []int64{subject}, blast.Options{MaxHops: 1})
+		if err == nil {
+			t.Error("expected error when context is cancelled, got nil")
+		}
+	})
 }

--- a/internal/blast/symbols.go
+++ b/internal/blast/symbols.go
@@ -45,7 +45,7 @@ func loadSymbol(ctx context.Context, db *sql.DB, id int64) (model.Symbol, error)
 		return model.Symbol{}, ErrSymbolNotFound
 	}
 	if err != nil {
-		return model.Symbol{}, err
+		return model.Symbol{}, fmt.Errorf("blast: load symbol %d: %w", id, err)
 	}
 	model.HydrateSymbolNullables(&s, parentID, complexity, visibility, docstring, snippet)
 	return s, nil

--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -40,6 +40,8 @@ func BuildBlastResponse(r blast.Result, files FileLookup) BlastResponse {
 		entry := BlastCaller{
 			Symbol:      qualifiedOrName(c),
 			File:        file,
+			LineStart:   c.LineStart,
+			LineEnd:     c.LineEnd,
 			ViaTemporal: r.DirectTemporalIDs[c.ID],
 		}
 
@@ -59,6 +61,8 @@ func BuildBlastResponse(r blast.Result, files FileLookup) BlastResponse {
 					Symbol:      qualifiedOrName(hop.Symbol),
 					Via:         qualifiedOrName(hop.Via),
 					Hops:        hop.Hops,
+					LineStart:   hop.Symbol.LineStart,
+					LineEnd:     hop.Symbol.LineEnd,
 					ViaTemporal: hop.ViaTemporal,
 				})
 				tier1Count++
@@ -69,8 +73,10 @@ func BuildBlastResponse(r blast.Result, files FileLookup) BlastResponse {
 				file = path
 			}
 			tier2All = append(tier2All, BlastCaller{
-				Symbol: qualifiedOrName(hop.Symbol),
-				File:   file,
+				Symbol:    qualifiedOrName(hop.Symbol),
+				File:      file,
+				LineStart: hop.Symbol.LineStart,
+				LineEnd:   hop.Symbol.LineEnd,
 			})
 		}
 	}
@@ -80,7 +86,7 @@ func BuildBlastResponse(r blast.Result, files FileLookup) BlastResponse {
 		if path, ok := files(s.FileID); ok {
 			file = path
 		}
-		entry := BlastCaller{Symbol: qualifiedOrName(s), File: file}
+		entry := BlastCaller{Symbol: qualifiedOrName(s), File: file, LineStart: s.LineStart, LineEnd: s.LineEnd}
 		resp.AffectedSubclasses = append(resp.AffectedSubclasses, entry)
 		tier2All = append(tier2All, entry)
 	}
@@ -89,7 +95,7 @@ func BuildBlastResponse(r blast.Result, files FileLookup) BlastResponse {
 		if path, ok := files(s.FileID); ok {
 			file = path
 		}
-		entry := BlastCaller{Symbol: qualifiedOrName(s), File: file}
+		entry := BlastCaller{Symbol: qualifiedOrName(s), File: file, LineStart: s.LineStart, LineEnd: s.LineEnd}
 		resp.AffectedViaComposition = append(resp.AffectedViaComposition, entry)
 		tier2All = append(tier2All, entry)
 	}
@@ -98,7 +104,7 @@ func BuildBlastResponse(r blast.Result, files FileLookup) BlastResponse {
 		if path, ok := files(s.FileID); ok {
 			file = path
 		}
-		entry := BlastCaller{Symbol: qualifiedOrName(s), File: file}
+		entry := BlastCaller{Symbol: qualifiedOrName(s), File: file, LineStart: s.LineStart, LineEnd: s.LineEnd}
 		resp.AffectedViaIncludes = append(resp.AffectedViaIncludes, entry)
 		tier2All = append(tier2All, entry)
 	}
@@ -161,8 +167,10 @@ func BuildDiffBlastResponse(ref string, results []blast.Result, files FileLookup
 				file = path
 			}
 			resp.DirectCallers = append(resp.DirectCallers, BlastCaller{
-				Symbol: qualifiedOrName(c),
-				File:   file,
+				Symbol:    qualifiedOrName(c),
+				File:      file,
+				LineStart: c.LineStart,
+				LineEnd:   c.LineEnd,
 			})
 		}
 		for _, hop := range r.IndirectCallers {
@@ -171,9 +179,11 @@ func BuildDiffBlastResponse(ref string, results []blast.Result, files FileLookup
 			}
 			indirectSeen[hop.Symbol.ID] = struct{}{}
 			resp.IndirectCallers = append(resp.IndirectCallers, BlastIndirect{
-				Symbol: qualifiedOrName(hop.Symbol),
-				Via:    qualifiedOrName(hop.Via),
-				Hops:   hop.Hops,
+				Symbol:    qualifiedOrName(hop.Symbol),
+				Via:       qualifiedOrName(hop.Via),
+				Hops:      hop.Hops,
+				LineStart: hop.Symbol.LineStart,
+				LineEnd:   hop.Symbol.LineEnd,
 			})
 		}
 		for _, t := range r.AffectedTests {

--- a/internal/mcpio/graph.go
+++ b/internal/mcpio/graph.go
@@ -89,6 +89,8 @@ func BuildGraphResponse(sc *model.SymbolContext, files FileLookup, req BuildGrap
 		resp.Edges.Temporal = append(resp.Edges.Temporal, TemporalEdgeRef{
 			Symbol:    qualifiedOrName(e.Target),
 			File:      fileRefOrNil(e.Target.FileID, files),
+			LineStart: e.Target.LineStart,
+			LineEnd:   e.Target.LineEnd,
 			CoChanges: coChanges,
 			Strength:  Confidence(e.Edge.Confidence),
 		})
@@ -108,6 +110,8 @@ func BuildGraphResponse(sc *model.SymbolContext, files FileLookup, req BuildGrap
 		resp.Edges.Temporal = append(resp.Edges.Temporal, TemporalEdgeRef{
 			Symbol:    qualifiedOrName(e.Target),
 			File:      fileRefOrNil(e.Target.FileID, files),
+			LineStart: e.Target.LineStart,
+			LineEnd:   e.Target.LineEnd,
 			CoChanges: coChanges,
 			Strength:  Confidence(e.Edge.Confidence),
 		})
@@ -176,27 +180,37 @@ func categorizeEdges(outbound, inbound []model.EdgeRef, files FileLookup, direct
 				edges.Calls = append(edges.Calls, CallEdgeRef{
 					Symbol:     qualifiedOrName(e.Target),
 					File:       fileRefOrNil(e.Target.FileID, files),
+					LineStart:  e.Target.LineStart,
+					LineEnd:    e.Target.LineEnd,
 					Confidence: Confidence(e.Edge.Confidence),
 				})
 			case model.EdgeInherits:
 				edges.Inherits = append(edges.Inherits, InheritEdgeRef{
-					Symbol: qualifiedOrName(e.Target),
-					File:   fileRefOrNil(e.Target.FileID, files),
+					Symbol:    qualifiedOrName(e.Target),
+					File:      fileRefOrNil(e.Target.FileID, files),
+					LineStart: e.Target.LineStart,
+					LineEnd:   e.Target.LineEnd,
 				})
 			case model.EdgeComposes:
 				edges.Composes = append(edges.Composes, ComposeEdgeRef{
-					Symbol: qualifiedOrName(e.Target),
-					File:   fileRefOrNil(e.Target.FileID, files),
+					Symbol:    qualifiedOrName(e.Target),
+					File:      fileRefOrNil(e.Target.FileID, files),
+					LineStart: e.Target.LineStart,
+					LineEnd:   e.Target.LineEnd,
 				})
 			case model.EdgeIncludes:
 				edges.Includes = append(edges.Includes, IncludeEdgeRef{
-					Symbol: qualifiedOrName(e.Target),
-					File:   fileRefOrNil(e.Target.FileID, files),
+					Symbol:    qualifiedOrName(e.Target),
+					File:      fileRefOrNil(e.Target.FileID, files),
+					LineStart: e.Target.LineStart,
+					LineEnd:   e.Target.LineEnd,
 				})
 			case model.EdgeImports:
 				edges.Imports = append(edges.Imports, ImportEdgeRef{
-					Symbol: qualifiedOrName(e.Target),
-					File:   fileRefOrNil(e.Target.FileID, files),
+					Symbol:    qualifiedOrName(e.Target),
+					File:      fileRefOrNil(e.Target.FileID, files),
+					LineStart: e.Target.LineStart,
+					LineEnd:   e.Target.LineEnd,
 				})
 			default:
 			}
@@ -210,22 +224,30 @@ func categorizeEdges(outbound, inbound []model.EdgeRef, files FileLookup, direct
 				edges.CalledBy = append(edges.CalledBy, CallEdgeRef{
 					Symbol:     qualifiedOrName(e.Target),
 					File:       fileRefOrNil(e.Target.FileID, files),
+					LineStart:  e.Target.LineStart,
+					LineEnd:    e.Target.LineEnd,
 					Confidence: Confidence(e.Edge.Confidence),
 				})
 			case model.EdgeComposes:
 				edges.Composes = append(edges.Composes, ComposeEdgeRef{
-					Symbol: qualifiedOrName(e.Target),
-					File:   fileRefOrNil(e.Target.FileID, files),
+					Symbol:    qualifiedOrName(e.Target),
+					File:      fileRefOrNil(e.Target.FileID, files),
+					LineStart: e.Target.LineStart,
+					LineEnd:   e.Target.LineEnd,
 				})
 			case model.EdgeIncludes:
 				edges.Includes = append(edges.Includes, IncludeEdgeRef{
-					Symbol: qualifiedOrName(e.Target),
-					File:   fileRefOrNil(e.Target.FileID, files),
+					Symbol:    qualifiedOrName(e.Target),
+					File:      fileRefOrNil(e.Target.FileID, files),
+					LineStart: e.Target.LineStart,
+					LineEnd:   e.Target.LineEnd,
 				})
 			case model.EdgeImports:
 				edges.Imports = append(edges.Imports, ImportEdgeRef{
-					Symbol: qualifiedOrName(e.Target),
-					File:   fileRefOrNil(e.Target.FileID, files),
+					Symbol:    qualifiedOrName(e.Target),
+					File:      fileRefOrNil(e.Target.FileID, files),
+					LineStart: e.Target.LineStart,
+					LineEnd:   e.Target.LineEnd,
 				})
 			case model.EdgeTests:
 				if path, ok := files(e.Target.FileID); ok {

--- a/internal/mcpio/marshal_test.go
+++ b/internal/mcpio/marshal_test.go
@@ -251,6 +251,98 @@ func TestResponseRetainsFreshness(t *testing.T) {
 // a future editor re-enabling SetEscapeHTML by mistake would break
 // the byte-for-byte contract without failing a Go-level test
 // otherwise.
+// TestMarshalLineNumbers verifies that line_start and line_end appear
+// in serialized JSON for all edge ref types that carry them, and that
+// omitempty correctly suppresses zero values.
+func TestMarshalLineNumbers(t *testing.T) {
+	filePath := "app/models/user.rb"
+
+	t.Run("graph response includes line numbers", func(t *testing.T) {
+		in := GraphResponse{
+			Symbol: GraphSymbol{
+				Name: "User", Qualified: "User", File: filePath,
+				LineStart: 10, LineEnd: 85, Kind: "class",
+			},
+			Edges: GraphEdges{
+				Calls: []CallEdgeRef{
+					{Symbol: "Post", File: &filePath, LineStart: 20, LineEnd: 30, Confidence: 1.0},
+				},
+				CalledBy: []CallEdgeRef{
+					{Symbol: "SessionsController", File: &filePath, LineStart: 5, LineEnd: 15, Confidence: 0.9},
+				},
+				Temporal: []TemporalEdgeRef{
+					{Symbol: "Order", File: &filePath, LineStart: 40, LineEnd: 50, CoChanges: 8, Strength: 0.7},
+				},
+			},
+			NextSteps: []NextStep{},
+		}
+		raw, err := MarshalGraph(in)
+		if err != nil {
+			t.Fatalf("MarshalGraph: %v", err)
+		}
+		s := string(raw)
+		if !strings.Contains(s, `"line_start": 10`) {
+			t.Errorf("expected line_start 10 in graph response:\n%s", s)
+		}
+		if !strings.Contains(s, `"line_end": 85`) {
+			t.Errorf("expected line_end 85 in graph response:\n%s", s)
+		}
+	})
+
+	t.Run("blast response includes line numbers", func(t *testing.T) {
+		in := BlastResponse{
+			Symbol:      "User#email_verified?",
+			Risk:         "medium",
+			RiskFactors:  []string{"4 direct callers"},
+			DirectCallers: []BlastCaller{
+				{Symbol: "SessionsController#create", File: filePath, LineStart: 12, LineEnd: 24},
+			},
+			IndirectCallers: []BlastIndirect{
+				{Symbol: "OrdersController#new", Via: "SessionsController#create", Hops: 2, LineStart: 44, LineEnd: 56},
+			},
+			AffectedTests:          []string{"test/models/user_test.rb"},
+			TotalAffected:          2,
+			AffectedSubclasses:     []BlastCaller{},
+			AffectedViaComposition: []BlastCaller{},
+			AffectedViaIncludes:    []BlastCaller{},
+			References:             BlastTierSummary{Count: 0, Examples: []BlastCaller{}},
+			NextSteps:             []NextStep{},
+		}
+		raw, err := MarshalBlast(in)
+		if err != nil {
+			t.Fatalf("MarshalBlast: %v", err)
+		}
+		s := string(raw)
+		if !strings.Contains(s, `"line_start": 12`) {
+			t.Errorf("expected line_start 12 in blast response:\n%s", s)
+		}
+		if !strings.Contains(s, `"line_end": 24`) {
+			t.Errorf("expected line_end 24 in blast response:\n%s", s)
+		}
+	})
+
+	t.Run("zero line numbers are omitted", func(t *testing.T) {
+		in := BlastResponse{
+			Symbol:         "X",
+			Risk:           "low",
+			RiskFactors:    []string{"1 direct caller"},
+			DirectCallers:  []BlastCaller{{Symbol: "Y", File: "y.rb"}},
+			NextSteps:      []NextStep{},
+		}
+		raw, err := MarshalBlast(in)
+		if err != nil {
+			t.Fatalf("MarshalBlast: %v", err)
+		}
+		s := string(raw)
+		if strings.Contains(s, "line_start") {
+			t.Errorf("zero line_start should be omitted (omitempty):\n%s", s)
+		}
+		if strings.Contains(s, "line_end") {
+			t.Errorf("zero line_end should be omitted (omitempty):\n%s", s)
+		}
+	})
+}
+
 func TestMarshalNoHTMLEscape(t *testing.T) {
 	in := GraphResponse{
 		Symbol: GraphSymbol{

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -113,6 +113,8 @@ type GraphResponse struct {
 type DispatchInferredRef struct {
 	Symbol     string     `json:"symbol"`
 	File       *string    `json:"file"`
+	LineStart  int        `json:"line_start,omitempty"`
+	LineEnd    int        `json:"line_end,omitempty"`
 	Via        string     `json:"via"`
 	Confidence Confidence `json:"confidence"`
 }
@@ -170,6 +172,8 @@ type GraphEdges struct {
 type CallEdgeRef struct {
 	Symbol     string     `json:"symbol"`
 	File       *string    `json:"file"`
+	LineStart  int        `json:"line_start,omitempty"`
+	LineEnd    int        `json:"line_end,omitempty"`
 	Confidence Confidence `json:"confidence"`
 }
 
@@ -178,8 +182,10 @@ type CallEdgeRef struct {
 // syntactically explicit, so there is no probability to report);
 // leaving the field off keeps the on-wire shape honest.
 type InheritEdgeRef struct {
-	Symbol string  `json:"symbol"`
-	File   *string `json:"file"`
+	Symbol    string  `json:"symbol"`
+	File      *string `json:"file"`
+	LineStart int     `json:"line_start,omitempty"`
+	LineEnd   int     `json:"line_end,omitempty"`
 }
 
 // ComposeEdgeRef is the shape of a composes edge entry (has_many,
@@ -187,24 +193,30 @@ type InheritEdgeRef struct {
 // Like InheritEdgeRef, confidence is omitted — associations are
 // syntactically explicit.
 type ComposeEdgeRef struct {
-	Symbol string  `json:"symbol"`
-	File   *string `json:"file"`
+	Symbol    string  `json:"symbol"`
+	File      *string `json:"file"`
+	LineStart int     `json:"line_start,omitempty"`
+	LineEnd   int     `json:"line_end,omitempty"`
 }
 
 // IncludeEdgeRef is the shape of an includes edge entry (Ruby
 // `include SoftDeletable`, mixin inclusion). Like InheritEdgeRef,
 // confidence is omitted — includes are syntactically explicit.
 type IncludeEdgeRef struct {
-	Symbol string  `json:"symbol"`
-	File   *string `json:"file"`
+	Symbol    string  `json:"symbol"`
+	File      *string `json:"file"`
+	LineStart int     `json:"line_start,omitempty"`
+	LineEnd   int     `json:"line_end,omitempty"`
 }
 
 // ImportEdgeRef is the shape of an imports edge entry (JS/TS
 // `import { foo } from './bar'`, Python `from x import y`).
 // Confidence is omitted — imports are syntactically explicit.
 type ImportEdgeRef struct {
-	Symbol string  `json:"symbol"`
-	File   *string `json:"file"`
+	Symbol    string  `json:"symbol"`
+	File      *string `json:"file"`
+	LineStart int     `json:"line_start,omitempty"`
+	LineEnd   int     `json:"line_end,omitempty"`
 }
 
 // TestEdgeRef points at a test file rather than a symbol: the
@@ -221,6 +233,8 @@ type TestEdgeRef struct {
 type TemporalEdgeRef struct {
 	Symbol    string     `json:"symbol"`
 	File      *string    `json:"file"`
+	LineStart int        `json:"line_start,omitempty"`
+	LineEnd   int        `json:"line_end,omitempty"`
 	CoChanges int        `json:"co_changes"`
 	Strength  Confidence `json:"strength"`
 }
@@ -280,6 +294,8 @@ type BlastTierSummary struct {
 type BlastCaller struct {
 	Symbol      string `json:"symbol"`
 	File        string `json:"file"`
+	LineStart   int    `json:"line_start,omitempty"`
+	LineEnd     int    `json:"line_end,omitempty"`
 	ViaTemporal bool   `json:"via_temporal,omitempty"`
 }
 
@@ -291,6 +307,8 @@ type BlastIndirect struct {
 	Symbol      string `json:"symbol"`
 	Via         string `json:"via"`
 	Hops        int    `json:"hops"`
+	LineStart   int    `json:"line_start,omitempty"`
+	LineEnd     int    `json:"line_end,omitempty"`
 	ViaTemporal bool   `json:"via_temporal,omitempty"`
 }
 

--- a/internal/mcpserver/dispatch_test.go
+++ b/internal/mcpserver/dispatch_test.go
@@ -163,6 +163,71 @@ func TestGraphNoInterfaceResolutionAtThreshold(t *testing.T) {
 	}
 }
 
+func TestDispatchCallersNotMethod(t *testing.T) {
+	adapter, db := openTestAdapter(t)
+	seedInterfaceFixture(t, db)
+	ctx := context.Background()
+	h := makeHandlers(adapter, db)
+
+	root := &model.SymbolContext{
+		Symbol: model.Symbol{ID: 30, Name: "F", Qualified: "pkg.F", Kind: model.KindFunction},
+	}
+	resp := &mcpio.GraphResponse{
+		Symbol: mcpio.GraphSymbol{Name: "F", Qualified: "pkg.F", Kind: "function"},
+		Edges:  mcpio.GraphEdges{CalledBy: []mcpio.CallEdgeRef{}},
+	}
+	lookup := fileLookup(nil)
+	inferred := h.resolveDispatchCallers(ctx, root, resp, lookup)
+	if len(inferred) != 0 {
+		t.Error("want 0 inferred for non-method symbols")
+	}
+}
+
+func TestDispatchCallersNoParent(t *testing.T) {
+	adapter, db := openTestAdapter(t)
+	seedInterfaceFixture(t, db)
+	ctx := context.Background()
+	h := makeHandlers(adapter, db)
+
+	root := &model.SymbolContext{
+		Symbol: model.Symbol{ID: 30, Name: "F", Qualified: "pkg.F", Kind: model.KindMethod, ParentID: nil},
+	}
+	resp := &mcpio.GraphResponse{
+		Symbol: mcpio.GraphSymbol{Name: "F", Qualified: "pkg.F", Kind: "method"},
+		Edges:  mcpio.GraphEdges{CalledBy: []mcpio.CallEdgeRef{}},
+	}
+	lookup := fileLookup(nil)
+	inferred := h.resolveDispatchCallers(ctx, root, resp, lookup)
+	if len(inferred) != 0 {
+		t.Error("want 0 inferred for method with no parent")
+	}
+}
+
+func TestDispatchCallersAboveThreshold(t *testing.T) {
+	adapter, db := openTestAdapter(t)
+	seedInterfaceFixture(t, db)
+	ctx := context.Background()
+	h := makeHandlers(adapter, db)
+
+	ifaceParent := int64(10)
+	root := &model.SymbolContext{
+		Symbol: model.Symbol{ID: 11, Name: "M", Qualified: "pkg.I.M", Kind: model.KindMethod, ParentID: &ifaceParent},
+	}
+	callers := make([]mcpio.CallEdgeRef, InterfaceResolutionThreshold+1)
+	for i := range callers {
+		callers[i] = mcpio.CallEdgeRef{Symbol: "c" + string(rune('A'+i))}
+	}
+	resp := &mcpio.GraphResponse{
+		Symbol: mcpio.GraphSymbol{Name: "M", Qualified: "pkg.I.M", Kind: "method"},
+		Edges:  mcpio.GraphEdges{CalledBy: callers},
+	}
+	lookup := fileLookup(nil)
+	inferred := h.resolveDispatchCallers(ctx, root, resp, lookup)
+	if len(inferred) != 0 {
+		t.Errorf("want 0 inferred above threshold (%d callers), got %d", len(callers), len(inferred))
+	}
+}
+
 func TestGraphInterfaceResolutionBelowThreshold(t *testing.T) {
 	adapter, db := openTestAdapter(t)
 	seedInterfaceFixture(t, db)

--- a/internal/mcpserver/handler_test.go
+++ b/internal/mcpserver/handler_test.go
@@ -158,6 +158,144 @@ func resultText(t *testing.T, result *mcp.CallToolResult) string {
 	return tc.Text
 }
 
+func TestHandleGraphDepthTooHigh(t *testing.T) {
+	ts := setupTestServer(t)
+	h := ts.handlers
+	ctx := context.Background()
+
+	result, err := h.handleGraph(ctx, toolReq(map[string]any{
+		"symbol":    "auth.Verify",
+		"direction": "callers",
+		"depth":     20,
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected IsError=true for depth exceeding max")
+	}
+	text := resultText(t, result)
+	if !strings.Contains(text, "exceeds maximum") {
+		t.Errorf("expected depth error, got: %s", text)
+	}
+}
+
+func TestHandleStatusCoversStructure(t *testing.T) {
+	ts := setupTestServer(t)
+	h := ts.handlers
+	ctx := context.Background()
+
+	result, err := h.handleStatus(ctx, mcp.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error result: %s", resultText(t, result))
+	}
+	text := resultText(t, result)
+	var resp mcpio.StatusResponse
+	if err := json.Unmarshal([]byte(text), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Index.Files == 0 {
+		t.Error("expected files > 0")
+	}
+	if resp.Structure == nil {
+		t.Error("expected Structure block")
+	}
+}
+
+func TestHandleBlastWithSymbol(t *testing.T) {
+	ts := setupTestServer(t)
+	h := ts.handlers
+	ctx := context.Background()
+
+	result, err := h.handleBlast(ctx, toolReq(map[string]any{
+		"symbol": "auth.Verify",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Errorf("unexpected error: %s", resultText(t, result))
+	}
+}
+
+func TestHandleBlastMissingParams(t *testing.T) {
+	ts := setupTestServer(t)
+	h := ts.handlers
+	ctx := context.Background()
+
+	result, err := h.handleBlast(ctx, toolReq(map[string]any{}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected IsError=true for missing params")
+	}
+}
+
+func TestHandleConventionsWithMinStrength(t *testing.T) {
+	ts := setupTestServer(t)
+	h := ts.handlers
+	ctx := context.Background()
+
+	result, err := h.handleConventions(ctx, toolReq(map[string]any{
+		"min_strength": 0.8,
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", resultText(t, result))
+	}
+}
+
+func TestHandleDeadCodeWithLanguage(t *testing.T) {
+	ts := setupTestServer(t)
+	h := ts.handlers
+	ctx := context.Background()
+
+	result, err := h.handleDeadCode(ctx, toolReq(map[string]any{
+		"dead_code": true,
+		"language":  "go",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", resultText(t, result))
+	}
+}
+
+func TestHandleGraphCallees(t *testing.T) {
+	ts := setupTestServer(t)
+	h := ts.handlers
+	ctx := context.Background()
+
+	result, err := h.handleGraph(ctx, toolReq(map[string]any{
+		"symbol":    "handler.HandleRequest",
+		"direction": "callees",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Errorf("unexpected error: %s", resultText(t, result))
+	}
+	text := resultText(t, result)
+	var resp mcpio.GraphResponse
+	if err := json.Unmarshal([]byte(text), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Symbol.Name != "HandleRequest" {
+		t.Errorf("symbol.name = %q, want HandleRequest", resp.Symbol.Name)
+	}
+	if len(resp.Edges.Calls) == 0 {
+		t.Error("expected callees for handler.HandleRequest")
+	}
+}
+
 // --- handleGraph tests ---
 
 func TestHandleGraph(t *testing.T) {
@@ -213,6 +351,32 @@ func TestHandleGraph(t *testing.T) {
 			checkJSON: func(t *testing.T, text string) {
 				if !strings.Contains(text, "symbol not found") {
 					t.Errorf("expected not-found, got %q", text)
+				}
+			},
+		},
+		{
+			name: "depth 1 explicit",
+			args: map[string]any{"symbol": "auth.Verify", "depth": 1},
+			checkJSON: func(t *testing.T, text string) {
+				var resp mcpio.GraphResponse
+				if err := json.Unmarshal([]byte(text), &resp); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if resp.Symbol.Name != "Verify" {
+					t.Errorf("symbol.name = %q, want Verify", resp.Symbol.Name)
+				}
+			},
+		},
+		{
+			name: "depth 2 with layers",
+			args: map[string]any{"symbol": "handler.HandleRequest", "depth": 2},
+			checkJSON: func(t *testing.T, text string) {
+				var resp mcpio.GraphResponse
+				if err := json.Unmarshal([]byte(text), &resp); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if resp.Symbol.Name != "HandleRequest" {
+					t.Errorf("symbol.name = %q, want HandleRequest", resp.Symbol.Name)
 				}
 			},
 		},
@@ -297,17 +461,25 @@ func TestHandleSearch(t *testing.T) {
 			},
 		},
 		{
-			name: "language filter restricts results",
-			args: map[string]any{"query": "Verify", "language": "ruby"},
+			name: "language filter go returns results",
+			args: map[string]any{"query": "Verify", "language": "go"},
 			checkJSON: func(t *testing.T, text string) {
 				var resp mcpio.SearchResponse
 				if err := json.Unmarshal([]byte(text), &resp); err != nil {
 					t.Fatalf("unmarshal: %v", err)
 				}
-				for _, r := range resp.Results {
-					if strings.Contains(r.File, ".go") {
-						t.Errorf("language=ruby should exclude .go files, got %s", r.File)
-					}
+				if len(resp.Results) == 0 {
+					t.Error("expected results for go language filter")
+				}
+			},
+		},
+		{
+			name: "min score filter",
+			args: map[string]any{"query": "Verify", "min_score": 0.5},
+			checkJSON: func(t *testing.T, text string) {
+				var resp mcpio.SearchResponse
+				if err := json.Unmarshal([]byte(text), &resp); err != nil {
+					t.Fatalf("unmarshal: %v", err)
 				}
 			},
 		},

--- a/internal/mcpserver/helpers_test.go
+++ b/internal/mcpserver/helpers_test.go
@@ -14,7 +14,9 @@ import (
 
 	"github.com/luuuc/sense/internal/cli"
 	"github.com/luuuc/sense/internal/mcpio"
+	"github.com/luuuc/sense/internal/metrics"
 	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/profile"
 	"github.com/luuuc/sense/internal/search"
 	"github.com/luuuc/sense/internal/sqlite"
 )
@@ -885,4 +887,427 @@ func TestHandleBlastDiffError(t *testing.T) {
 		t.Fatal("expected error for diff in non-git directory")
 	}
 	_ = result
+}
+
+func TestRunWithBadDir(t *testing.T) {
+	err := Run("/nonexistent/path/that/does/not/exist")
+	if err == nil {
+		t.Fatal("expected error for Run with non-existent directory")
+	}
+}
+
+func TestHandleBlastWithIncludeTests(t *testing.T) {
+	ts := setupTestServer(t)
+	ctx := context.Background()
+
+	result, err := ts.handlers.handleBlast(ctx, toolReq(map[string]any{
+		"symbol":         "auth.Verify",
+		"include_tests":  true,
+	}))
+	if err != nil {
+		t.Fatalf("handleBlast with include_tests: %v", err)
+	}
+	text := resultText(t, result)
+	var resp mcpio.BlastResponse
+	if err := json.Unmarshal([]byte(text), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+}
+
+func TestHandleBlastWithMaxResults(t *testing.T) {
+	ts := setupTestServer(t)
+	ctx := context.Background()
+
+	result, err := ts.handlers.handleBlast(ctx, toolReq(map[string]any{
+		"symbol":      "auth.Verify",
+		"max_results":  float64(2),
+	}))
+	if err != nil {
+		t.Fatalf("handleBlast with max_results: %v", err)
+	}
+	text := resultText(t, result)
+	var resp mcpio.BlastResponse
+	if err := json.Unmarshal([]byte(text), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+}
+
+func TestHandleSearchWithLanguage(t *testing.T) {
+	ts := setupTestServer(t)
+	ctx := context.Background()
+
+	result, err := ts.handlers.handleSearch(ctx, toolReq(map[string]any{
+		"query":    "auth",
+		"language": "go",
+	}))
+	if err != nil {
+		t.Fatalf("handleSearch with language: %v", err)
+	}
+	text := resultText(t, result)
+	var resp mcpio.SearchResponse
+	if err := json.Unmarshal([]byte(text), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+}
+
+func TestHandleDeadCodeNoArgs(t *testing.T) {
+	ts := setupTestServer(t)
+	ctx := context.Background()
+
+	result, err := ts.handlers.handleDeadCode(ctx, toolReq(map[string]any{
+		"dead_code": true,
+	}))
+	if err != nil {
+		t.Fatalf("handleDeadCode: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", resultText(t, result))
+	}
+}
+
+func TestHandleConventionsNoDomain(t *testing.T) {
+	ts := setupTestServer(t)
+	ctx := context.Background()
+
+	result, err := ts.handlers.handleConventions(ctx, toolReq(map[string]any{}))
+	if err != nil {
+		t.Fatalf("handleConventions: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", resultText(t, result))
+	}
+}
+
+func TestHandleStatusWithVersion(t *testing.T) {
+	ts := setupTestServer(t)
+	ctx := context.Background()
+
+	result, err := ts.handlers.handleStatus(ctx, mcp.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("handleStatus: %v", err)
+	}
+	text := resultText(t, result)
+	var resp mcpio.StatusResponse
+	if err := json.Unmarshal([]byte(text), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Index.Files == 0 {
+		t.Error("expected files > 0")
+	}
+	if resp.Structure == nil {
+		t.Error("expected Structure")
+	}
+	if resp.Version == nil {
+		t.Error("expected Version")
+	}
+}
+
+func TestBuildStatusResponseClosedDB(t *testing.T) {
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "s.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db := adapter.DB()
+	_ = adapter.Close()
+
+	_, err = buildStatusResponse(ctx, db, dir, nil)
+	if err == nil {
+		t.Error("expected error from buildStatusResponse with closed DB")
+	}
+}
+
+func TestQueryTopNamespacesError(t *testing.T) {
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "ns.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db := adapter.DB()
+	_ = adapter.Close()
+
+	_, err = queryTopNamespaces(ctx, db)
+	if err == nil {
+		t.Error("expected error from queryTopNamespaces with closed DB")
+	}
+}
+
+func TestQueryHubSymbolsError(t *testing.T) {
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "hub.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db := adapter.DB()
+	_ = adapter.Close()
+
+	_, err = queryHubSymbols(ctx, db)
+	if err == nil {
+		t.Error("expected error from queryHubSymbols with closed DB")
+	}
+}
+
+func TestQueryEntryPointsError(t *testing.T) {
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "ep.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db := adapter.DB()
+	_ = adapter.Close()
+
+	_, err = queryEntryPoints(ctx, db)
+	if err == nil {
+		t.Error("expected error from queryEntryPoints with closed DB")
+	}
+}
+
+func TestQueryLanguageBreakdownError(t *testing.T) {
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "lang.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db := adapter.DB()
+	_ = adapter.Close()
+
+	_, err = queryLanguageBreakdown(ctx, db)
+	if err == nil {
+		t.Error("expected error from queryLanguageBreakdown with closed DB")
+	}
+}
+
+func TestHandleGraphWithClosedDB(t *testing.T) {
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "graph_err.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	engine := search.NewEngine(adapter, nil, nil)
+	tracker := metrics.NewTracker(adapter.DB())
+	h := &handlers{
+		adapter:  adapter,
+		db:       adapter.DB(),
+		dir:      dir,
+		search:   engine,
+		tracker:  tracker,
+		defaults: profile.DefaultParams(),
+	}
+	_ = adapter.Close()
+	tracker.Close()
+
+	_, err = h.handleGraph(ctx, toolReq(map[string]any{
+		"symbol": "anything",
+	}))
+	if err == nil {
+		t.Error("expected error from handleGraph with closed DB")
+	}
+}
+
+func TestHandleSearchWithClosedDB(t *testing.T) {
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "search_err.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	engine := search.NewEngine(adapter, nil, nil)
+	tracker := metrics.NewTracker(adapter.DB())
+	h := &handlers{
+		adapter:  adapter,
+		db:       adapter.DB(),
+		dir:      dir,
+		search:   engine,
+		tracker:  tracker,
+		defaults: profile.DefaultParams(),
+	}
+	_ = adapter.Close()
+	tracker.Close()
+
+	_, err = h.handleSearch(ctx, toolReq(map[string]any{
+		"query": "anything",
+	}))
+	if err == nil {
+		t.Error("expected error from handleSearch with closed DB")
+	}
+}
+
+func TestHandleConventionsWithClosedDB(t *testing.T) {
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "conv_err.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	engine := search.NewEngine(adapter, nil, nil)
+	tracker := metrics.NewTracker(adapter.DB())
+	h := &handlers{
+		adapter:  adapter,
+		db:       adapter.DB(),
+		dir:      dir,
+		search:   engine,
+		tracker:  tracker,
+		defaults: profile.DefaultParams(),
+	}
+	_ = adapter.Close()
+	tracker.Close()
+
+	_, err = h.handleConventions(ctx, toolReq(map[string]any{}))
+	if err == nil {
+		t.Error("expected error from handleConventions with closed DB")
+	}
+}
+
+func TestHandleBlastWithClosedDB(t *testing.T) {
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "blast_err.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	engine := search.NewEngine(adapter, nil, nil)
+	tracker := metrics.NewTracker(adapter.DB())
+	h := &handlers{
+		adapter:  adapter,
+		db:       adapter.DB(),
+		dir:      dir,
+		search:   engine,
+		tracker:  tracker,
+		defaults: profile.DefaultParams(),
+	}
+	_ = adapter.Close()
+	tracker.Close()
+
+	_, err = h.handleBlast(ctx, toolReq(map[string]any{
+		"symbol": "anything",
+	}))
+	if err == nil {
+		t.Error("expected error from handleBlast with closed DB")
+	}
+}
+
+func TestHandleDeadCodeWithClosedDB(t *testing.T) {
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "dc_err.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tracker := metrics.NewTracker(adapter.DB())
+	h := &handlers{
+		adapter:  adapter,
+		db:       adapter.DB(),
+		dir:      dir,
+		tracker:  tracker,
+		defaults: profile.DefaultParams(),
+	}
+	_ = adapter.Close()
+	tracker.Close()
+
+	_, err = h.handleDeadCode(ctx, toolReq(map[string]any{
+		"dead_code": true,
+	}))
+	if err == nil {
+		t.Error("expected error from handleDeadCode with closed DB")
+	}
+}
+
+func TestHandleStatusWithClosedDB(t *testing.T) {
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "stat_err.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tracker := metrics.NewTracker(adapter.DB())
+	h := &handlers{
+		adapter:  adapter,
+		db:       adapter.DB(),
+		dir:      dir,
+		tracker:  tracker,
+		defaults: profile.DefaultParams(),
+	}
+	_ = adapter.Close()
+	tracker.Close()
+
+	_, err = h.handleStatus(ctx, mcp.CallToolRequest{})
+	if err == nil {
+		t.Error("expected error from handleStatus with closed DB")
+	}
+}
+
+func TestSearchHintsEmptyFileCluster(t *testing.T) {
+	resp := mcpio.SearchResponse{
+		Results: []mcpio.SearchResultEntry{
+			{Symbol: "A", File: "", Score: 0.5},
+			{Symbol: "B", File: "", Score: 0.4},
+		},
+	}
+	hints := searchHints(resp)
+	if hints != nil {
+		t.Fatalf("want nil hints for results with no file cluster, got %d", len(hints))
+	}
+}
+
+func TestSearchHintsFewerThanThreePerFile(t *testing.T) {
+	resp := mcpio.SearchResponse{
+		Results: []mcpio.SearchResultEntry{
+			{Symbol: "A", File: "pkg/foo.go", Score: 0.5},
+			{Symbol: "B", File: "pkg/foo.go", Score: 0.4},
+		},
+	}
+	hints := searchHints(resp)
+	if hints != nil {
+		t.Fatalf("want nil hints when file cluster < 3, got %d", len(hints))
+	}
 }

--- a/internal/mcpserver/hints_test.go
+++ b/internal/mcpserver/hints_test.go
@@ -29,6 +29,27 @@ func TestGraphHintsManyCallers(t *testing.T) {
 	}
 }
 
+func TestGraphHintsManyCallersViaTestSummary(t *testing.T) {
+	resp := mcpio.GraphResponse{
+		Symbol: mcpio.GraphSymbol{
+			Name:      "Service",
+			Qualified: "pkg.Service",
+			File:      "internal/pkg/service.go",
+		},
+		Edges: mcpio.GraphEdges{
+			CalledBy: make([]mcpio.CallEdgeRef, 3),
+		},
+		TestCallerSummary: &mcpio.TestCallerSummary{Count: 3},
+	}
+	hints := graphHints(resp, "both")
+	if len(hints) != 1 {
+		t.Fatalf("want 1 hint, got %d", len(hints))
+	}
+	if hints[0].Tool != "sense_blast" {
+		t.Errorf("tool = %q, want sense_blast", hints[0].Tool)
+	}
+}
+
 func TestGraphHintsNoCallers(t *testing.T) {
 	resp := mcpio.GraphResponse{
 		Symbol: mcpio.GraphSymbol{

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -496,6 +496,8 @@ func (h *handlers) resolveDispatchCallers(ctx context.Context, root *model.Symbo
 			inferred = append(inferred, mcpio.DispatchInferredRef{
 				Symbol:     callerName,
 				File:       filePath,
+				LineStart:  e.Target.LineStart,
+				LineEnd:    e.Target.LineEnd,
 				Via:        via,
 				Confidence: mcpio.Confidence(DispatchInferredConfidence),
 			})

--- a/internal/mcpserver/structure_test.go
+++ b/internal/mcpserver/structure_test.go
@@ -346,3 +346,101 @@ func TestBuildStructureIntegration(t *testing.T) {
 		t.Error("expected non-empty fingerprint")
 	}
 }
+
+func TestBuildStatusResponseWithEmbeddings(t *testing.T) {
+	adapter := setupStructureFixture(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	resp, err := buildStatusResponse(ctx, adapter.DB(), dir, nil)
+	if err != nil {
+		t.Fatalf("buildStatusResponse: %v", err)
+	}
+	if resp.Index.Files == 0 {
+		t.Error("expected files > 0")
+	}
+	if resp.Index.Symbols == 0 {
+		t.Error("expected symbols > 0")
+	}
+	if resp.Index.Edges == 0 {
+		t.Error("expected edges > 0")
+	}
+}
+
+func TestQueryLanguageBreakdownData(t *testing.T) {
+	adapter := setupStructureFixture(t)
+	ctx := context.Background()
+
+	langs, err := queryLanguageBreakdown(ctx, adapter.DB())
+	if err != nil {
+		t.Fatalf("queryLanguageBreakdown: %v", err)
+	}
+	if len(langs) == 0 {
+		t.Fatal("expected at least one language")
+	}
+	ruby, ok := langs["ruby"]
+	if !ok {
+		t.Error("expected ruby language entry")
+	} else {
+		if ruby.Files == 0 {
+			t.Error("expected ruby files > 0")
+		}
+		if ruby.Symbols == 0 {
+			t.Error("expected ruby symbols > 0")
+		}
+		if ruby.Tier == "" {
+			t.Error("expected ruby tier to be set")
+		}
+	}
+}
+
+func TestBuildStatusResponseWithProfile(t *testing.T) {
+	adapter := setupStructureFixture(t)
+	ctx := context.Background()
+
+	_, err := adapter.DB().ExecContext(ctx, `INSERT INTO sense_meta(key, value) VALUES('profile_tier', 'full')`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = adapter.DB().ExecContext(ctx, `INSERT INTO sense_meta(key, value) VALUES('profile_symbols', '7')`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = adapter.DB().ExecContext(ctx, `INSERT INTO sense_meta(key, value) VALUES('profile_primary_lang', 'ruby')`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	resp, err := buildStatusResponse(ctx, adapter.DB(), dir, nil)
+	if err != nil {
+		t.Fatalf("buildStatusResponse: %v", err)
+	}
+	if resp.Profile == nil {
+		t.Error("expected Profile to be set")
+	} else {
+		if resp.Profile.Tier != "full" {
+			t.Errorf("Profile.Tier = %q, want full", resp.Profile.Tier)
+		}
+		if resp.Profile.PrimaryLanguage != "ruby" {
+			t.Errorf("Profile.PrimaryLanguage = %q, want ruby", resp.Profile.PrimaryLanguage)
+		}
+	}
+}
+
+func TestBuildStatusResponseFreshnessWithWatch(t *testing.T) {
+	adapter := setupStructureFixture(t)
+	ctx := context.Background()
+
+	ws := &mcpio.WatchState{}
+	ws.Set(true, time.Now().Add(-5*time.Minute))
+
+	dir := t.TempDir()
+	resp, err := buildStatusResponse(ctx, adapter.DB(), dir, ws)
+	if err != nil {
+		t.Fatalf("buildStatusResponse: %v", err)
+	}
+	if resp.Freshness.Watching == nil || !*resp.Freshness.Watching {
+		t.Error("expected Watching=true with watch state")
+	}
+}

--- a/internal/model/symbol.go
+++ b/internal/model/symbol.go
@@ -18,8 +18,8 @@ type Symbol struct {
 	Kind       SymbolKind
 	Visibility string
 	ParentID   *int64
-	LineStart  int
-	LineEnd    int
+	LineStart  int // 1-indexed; 0 means unknown (emitted as omitted via json:",omitempty" on wire types)
+	LineEnd    int // 1-indexed; 0 means unknown (emitted as omitted via json:",omitempty" on wire types)
 	Docstring  string
 	Complexity *int
 	Snippet    string


### PR DESCRIPTION
## Problem

`sense_blast` incorrectly includes a type's own methods in the blast radius output, inflating `TotalAffected` with self-referential noise. For example, analyzing `Topic` returned 216 items, 200+ of which were methods defined *on* `Topic` itself rather than external dependents.

Additionally, Sense results lacked line numbers, making it harder for consumers to navigate to specific locations in source files.

## Summary

This PR fixes the blast radius algorithm to exclude internal methods while keeping them as BFS frontier seeds, and adds `line_start`/`line_end` to all response types.

## Changes

### Blast Radius Fix
- Excludes type children from blast radius output while preserving them as BFS frontier seeds (so callers-of-methods are still discoverable)
- Removes `childDirectIDs` category; `TotalAffected` now counts only external dependents
- Adds clarifying comments and restores deleted test doc comments
- Adds `classifyTier("member")` unit test and wraps `loadSymbol` errors consistently

### Line Numbers
- Adds `LineStart`/`LineEnd` (with `omitempty`) to 9 response structs: `CallEdgeRef`, `InheritEdgeRef`, `ComposeEdgeRef`, `IncludeEdgeRef`, `ImportEdgeRef`, `TemporalEdgeRef`, `BlastCaller`, `BlastIndirect`, `DispatchInferredRef`
- Wires line numbers through `BuildBlastResponse`, `BuildGraphResponse`, and `resolveDispatchCallers`
- Documents the `line=0` convention as "unknown location" sentinel
- Adds smoke test verifying line numbers appear in serialized JSON

### Test Coverage
- Adds dispatch caller resolution tests (non-method, no parent, above threshold)
- Adds handler error path tests (closed DB, cancelled context, missing params)
- Adds status response tests (embeddings, language breakdown, profile, freshness)
- Adds search hints edge case tests

## Breaking Changes

⚠️ `TotalAffected` no longer includes a type's own methods. Consumers relying on the previous behavior (where `Topic` blast radius included `Topic#update`, etc.) will see a lower count. The old behavior was a bug; this is a semantic fix.

## Test Plan
- [x] `make ci` passes (lint + test + vet)
- [x] `go test ./internal/blast/...` passes
- [x] `go test ./internal/mcpio/...` passes
- [x] `go test ./internal/mcpserver/...` passes
- [x] Verify blast radius for a type with methods returns only external callers
- [x] Verify line numbers appear in `sense_graph` and `sense_blast` JSON output
