### PR TITLE
feat(conventions): close Rails convention detection gap

### DIFF
--- a/internal/conventions/conventions.go
+++ b/internal/conventions/conventions.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/luuuc/sense/internal/mcpio"
+	"github.com/luuuc/sense/internal/model"
 )
 
 const minInstances = 3
@@ -585,6 +586,7 @@ func detectComposition(symbols []symbolRow, edges []edgeRow, symbolByID map[int6
 	}
 
 	var out []Convention
+	var serializerExamples []Example
 	for _, g := range groups {
 		if g.count < minInstances {
 			continue
@@ -594,6 +596,10 @@ func detectComposition(symbols []symbolRow, edges []edgeRow, symbolByID map[int6
 			continue
 		}
 		sortExamples(g.examples)
+		if strings.HasSuffix(g.targetName, "Serializer") {
+			serializerExamples = append(serializerExamples, g.examples...)
+			continue
+		}
 		out = append(out, Convention{
 			Category:    CategoryComposition,
 			Description: fmt.Sprintf("%d %s mix in %s for shared behavior (%s)", g.count, pluralize(g.sourceKind), g.targetName, topNames(g.examples)),
@@ -601,6 +607,18 @@ func detectComposition(symbols []symbolRow, edges []edgeRow, symbolByID map[int6
 			Total:       total,
 			Strength:    float64(g.count) / float64(total),
 			Examples:    g.examples,
+		})
+	}
+	if len(serializerExamples) >= minInstances {
+		sortExamples(serializerExamples)
+		totalClasses := kindCounts["class"]
+		out = append(out, Convention{
+			Category:    CategoryComposition,
+			Description: fmt.Sprintf("Serializer composition: %d classes use custom serializers (%s)", len(serializerExamples), topNames(serializerExamples)),
+			Instances:   len(serializerExamples),
+			Total:       totalClasses,
+			Strength:    safeStrength(len(serializerExamples), totalClasses),
+			Examples:    serializerExamples,
 		})
 	}
 	return out
@@ -876,10 +894,19 @@ func detectDesignPatterns(symbols []symbolRow, symbolByID map[int64]symbolRow, f
 
 func detectFrameworkIdioms(symbols []symbolRow, edges []edgeRow, symbolByID map[int64]symbolRow, filePathByID map[int64]string) []Convention {
 	var out []Convention
+	out = append(out, detectRailsConcerns(symbols, edges, symbolByID, filePathByID)...)
+	out = append(out, detectRailsCallbacks(symbols, edges, symbolByID, filePathByID)...)
+	out = append(out, detectScopes(symbols, edges, symbolByID, filePathByID)...)
+	out = append(out, detectGoInterfaces(symbols, edges, symbolByID, filePathByID)...)
+	out = append(out, detectReactHooks(symbols, edges, symbolByID, filePathByID)...)
+	out = append(out, detectGoTypeAliases(symbols, edges, symbolByID, filePathByID)...)
+	out = append(out, detectGoMiddleware(symbols, edges, symbolByID, filePathByID)...)
+	return out
+}
 
-	// Rails concerns: modules in paths containing "concerns" included by multiple classes
+func detectRailsConcerns(symbols []symbolRow, edges []edgeRow, symbolByID map[int64]symbolRow, filePathByID map[int64]string) []Convention {
 	type concernGroup struct {
-		module   symbolRow
+		module    symbolRow
 		includers []Example
 	}
 	concerns := map[int64]*concernGroup{}
@@ -916,6 +943,7 @@ func detectFrameworkIdioms(symbols []symbolRow, edges []edgeRow, symbolByID map[
 			Path: filePathByID[g.module.fileID],
 		})
 	}
+	var out []Convention
 	if len(concernExamples) >= 1 {
 		sortExamples(concernExamples)
 		totalModules := countByKind(symbols, "module")
@@ -934,10 +962,146 @@ func detectFrameworkIdioms(symbols []symbolRow, edges []edgeRow, symbolByID map[
 			})
 		}
 	}
+	return out
+}
 
-	// Go interface satisfaction: interfaces implemented by multiple structs
+func detectRailsCallbacks(symbols []symbolRow, _ []edgeRow, _ map[int64]symbolRow, filePathByID map[int64]string) []Convention {
+	classByID := map[int64]symbolRow{}
+	for _, s := range symbols {
+		if s.kind == "class" {
+			classByID[s.id] = s
+		}
+	}
+	type classCallbacks struct {
+		cls       symbolRow
+		callbacks map[string]bool
+	}
+	byClass := map[int64]*classCallbacks{}
+	for _, s := range symbols {
+		if s.kind != "method" || !model.RailsCallbackNames[s.name] {
+			continue
+		}
+		if s.parentID == nil {
+			continue
+		}
+		cls, ok := classByID[*s.parentID]
+		if !ok {
+			continue
+		}
+		cc, exists := byClass[cls.id]
+		if !exists {
+			cc = &classCallbacks{cls: cls, callbacks: map[string]bool{}}
+			byClass[cls.id] = cc
+		}
+		cc.callbacks[s.name] = true
+	}
+	var examples []Example
+	for _, cc := range byClass {
+		examples = append(examples, Example{
+			Name:      cc.cls.name,
+			Path:      filePathByID[cc.cls.fileID],
+			EdgeCount: len(cc.callbacks),
+		})
+	}
+	if len(examples) < minInstances {
+		return nil
+	}
+	sort.Slice(examples, func(i, j int) bool {
+		return examples[i].EdgeCount > examples[j].EdgeCount
+	})
+	totalClasses := countByKind(symbols, "class")
+	return []Convention{{
+		Category:    CategoryFramework,
+		Description: fmt.Sprintf("Callback patterns: %d classes use Rails lifecycle callbacks (%s)", len(examples), topNames(examples)),
+		Instances:   len(examples),
+		Total:       totalClasses,
+		Strength:    safeStrength(len(examples), totalClasses),
+		Examples:    examples,
+	}}
+}
+
+func detectScopes(symbols []symbolRow, edges []edgeRow, symbolByID map[int64]symbolRow, filePathByID map[int64]string) []Convention {
+	classByID := map[int64]symbolRow{}
+	for _, s := range symbols {
+		if s.kind == "class" {
+			classByID[s.id] = s
+		}
+	}
+	// Positive identification: scope symbols have a calls edge from their
+	// parent class pointing to them (emitted by emitScopeEdge). Regular
+	// class methods from `def self.x` do not have this edge.
+	scopeTargets := map[int64]bool{}
+	for _, e := range edges {
+		if e.kind != "calls" {
+			continue
+		}
+		src, ok := symbolByID[e.sourceID]
+		if !ok || src.kind != "class" {
+			continue
+		}
+		scopeTargets[e.targetID] = true
+	}
+	type classScopes struct {
+		cls    symbolRow
+		scopes []Example
+	}
+	byClass := map[int64]*classScopes{}
+	for _, s := range symbols {
+		if s.kind != "method" || s.parentID == nil {
+			continue
+		}
+		if !scopeTargets[s.id] {
+			continue
+		}
+		fp := filePathByID[s.fileID]
+		if !strings.HasSuffix(fp, ".rb") {
+			continue
+		}
+		if model.RailsCallbackNames[s.name] {
+			continue
+		}
+		cls, ok := classByID[*s.parentID]
+		if !ok {
+			continue
+		}
+		cs, exists := byClass[cls.id]
+		if !exists {
+			cs = &classScopes{cls: cls}
+			byClass[cls.id] = cs
+		}
+		cs.scopes = append(cs.scopes, Example{Name: s.name, Path: fp})
+	}
+	var examples []Example
+	for _, cs := range byClass {
+		if len(cs.scopes) < 2 {
+			continue
+		}
+		examples = append(examples, Example{
+			Name:      cs.cls.name,
+			Path:      filePathByID[cs.cls.fileID],
+			EdgeCount: len(cs.scopes),
+		})
+	}
+	if len(examples) < minInstances {
+		return nil
+	}
+	sort.Slice(examples, func(i, j int) bool {
+		return examples[i].EdgeCount > examples[j].EdgeCount
+	})
+	totalClasses := countByKind(symbols, "class")
+	return []Convention{{
+		Category:    CategoryFramework,
+		Description: fmt.Sprintf("Scope definitions: %d classes define query scopes (%s)", len(examples), topNames(examples)),
+		Instances:   len(examples),
+		Total:       totalClasses,
+		Strength:    safeStrength(len(examples), totalClasses),
+		Examples:    examples,
+	}}
+}
+
+func detectGoInterfaces(symbols []symbolRow, edges []edgeRow, symbolByID map[int64]symbolRow, filePathByID map[int64]string) []Convention {
 	type ifaceGroup struct {
-		iface       symbolRow
+		iface        symbolRow
 		implementors []Example
 	}
 	ifaces := map[int64]*ifaceGroup{}
@@ -960,6 +1124,7 @@ func detectFrameworkIdioms(symbols []symbolRow, edges []edgeRow, symbolByID map[
 		}
 		g.implementors = append(g.implementors, Example{Name: src.name, Path: filePathByID[src.fileID]})
 	}
+	var out []Convention
 	for _, g := range ifaces {
 		if len(g.implementors) < minInterfaceInstances {
 			continue
@@ -976,8 +1141,10 @@ func detectFrameworkIdioms(symbols []symbolRow, edges []edgeRow, symbolByID map[
 			KeySymbol:   g.iface.name,
 		})
 	}
+	return out
+}
 
-	// Hook patterns: use* functions (React/TypeScript only)
+func detectReactHooks(symbols []symbolRow, _ []edgeRow, _ map[int64]symbolRow, filePathByID map[int64]string) []Convention {
 	var hooks []Example
 	for _, s := range symbols {
 		if s.kind != "function" {
@@ -992,20 +1159,22 @@ func detectFrameworkIdioms(symbols []symbolRow, edges []edgeRow, symbolByID map[
 			hooks = append(hooks, Example{Name: s.name, Path: filePathByID[s.fileID]})
 		}
 	}
-	if len(hooks) >= minInstances {
-		sortExamples(hooks)
-		totalFuncs := countByKind(symbols, "function")
-		out = append(out, Convention{
-			Category:    CategoryFramework,
-			Description: fmt.Sprintf("React hook pattern: %s — custom hooks encapsulate stateful logic (%d hooks)", topNames(hooks), len(hooks)),
-			Instances:   len(hooks),
-			Total:       totalFuncs,
-			Strength:    safeStrength(len(hooks), totalFuncs),
-			Examples:    hooks,
-		})
+	if len(hooks) < minInstances {
+		return nil
 	}
+	sortExamples(hooks)
+	totalFuncs := countByKind(symbols, "function")
+	return []Convention{{
+		Category:    CategoryFramework,
+		Description: fmt.Sprintf("React hook pattern: %s — custom hooks encapsulate stateful logic (%d hooks)", topNames(hooks), len(hooks)),
+		Instances:   len(hooks),
+		Total:       totalFuncs,
+		Strength:    safeStrength(len(hooks), totalFuncs),
+		Examples:    hooks,
+	}}
+}
 
-	// Go type aliases: named types wrapping another type (kind="type" in Go means alias/newtype)
+func detectGoTypeAliases(symbols []symbolRow, _ []edgeRow, _ map[int64]symbolRow, filePathByID map[int64]string) []Convention {
 	var goAliases []Example
 	for _, s := range symbols {
 		if s.kind != "type" {
@@ -1017,20 +1186,22 @@ func detectFrameworkIdioms(symbols []symbolRow, edges []edgeRow, symbolByID map[
 		}
 		goAliases = append(goAliases, Example{Name: s.name, Path: fp, Kind: s.kind})
 	}
-	if len(goAliases) >= minInstances {
-		sortExamples(goAliases)
-		totalTypes := countByKind(symbols, "type")
-		out = append(out, Convention{
-			Category:    CategoryStructure,
-			Description: fmt.Sprintf("Type aliases: %s — named domain types (%d aliases)", topNames(goAliases), len(goAliases)),
-			Instances:   len(goAliases),
-			Total:       totalTypes,
-			Strength:    safeStrength(len(goAliases), totalTypes),
-			Examples:    goAliases,
-		})
+	if len(goAliases) < minInstances {
+		return nil
 	}
+	sortExamples(goAliases)
+	totalTypes := countByKind(symbols, "type")
+	return []Convention{{
+		Category:    CategoryStructure,
+		Description: fmt.Sprintf("Type aliases: %s — named domain types (%d aliases)", topNames(goAliases), len(goAliases)),
+		Instances:   len(goAliases),
+		Total:       totalTypes,
+		Strength:    safeStrength(len(goAliases), totalTypes),
+		Examples:    goAliases,
+	}}
+}
 
-	// Go middleware factory pattern: functions called by router methods (Use, GET, POST, etc.)
+func detectGoMiddleware(symbols []symbolRow, edges []edgeRow, symbolByID map[int64]symbolRow, filePathByID map[int64]string) []Convention {
 	routerMethods := map[string]bool{
 		"Use": true, "GET": true, "POST": true, "PUT": true, "DELETE": true,
 		"PATCH": true, "Handle": true, "HandleFunc": true, "Group": true,
@@ -1045,50 +1216,50 @@ func detectFrameworkIdioms(symbols []symbolRow, edges []edgeRow, symbolByID map[
 			}
 		}
 	}
-	if len(routerSymbolIDs) > 0 {
-		handlerCounts := map[int64]int{}
-		for _, e := range edges {
-			if e.kind != "calls" {
-				continue
-			}
-			if !routerSymbolIDs[e.sourceID] {
-				continue
-			}
-			handlerCounts[e.targetID]++
-		}
-		var factories []Example
-		seen := map[string]bool{}
-		for id, count := range handlerCounts {
-			s, ok := symbolByID[id]
-			if !ok || s.kind != "function" {
-				continue
-			}
-			if strings.HasPrefix(s.name, "Test") || strings.HasPrefix(s.name, "Benchmark") {
-				continue
-			}
-			if seen[s.name] {
-				continue
-			}
-			seen[s.name] = true
-			factories = append(factories, Example{Name: s.name, Path: filePathByID[s.fileID], EdgeCount: count})
-		}
-		if len(factories) >= minInstances {
-			sort.Slice(factories, func(i, j int) bool {
-				return factories[i].EdgeCount > factories[j].EdgeCount
-			})
-			totalFuncs := countByKind(symbols, "function")
-			out = append(out, Convention{
-				Category:    CategoryFramework,
-				Description: fmt.Sprintf("Middleware factories: %s return handler functions — composable request pipeline (%d factories)", topNames(factories), len(factories)),
-				Instances:   len(factories),
-				Total:       totalFuncs,
-				Strength:    safeStrength(len(factories), totalFuncs),
-				Examples:    factories,
-			})
-		}
+	if len(routerSymbolIDs) == 0 {
+		return nil
 	}
-
-	return out
+	handlerCounts := map[int64]int{}
+	for _, e := range edges {
+		if e.kind != "calls" {
+			continue
+		}
+		if !routerSymbolIDs[e.sourceID] {
+			continue
+		}
+		handlerCounts[e.targetID]++
+	}
+	var factories []Example
+	seen := map[string]bool{}
+	for id, count := range handlerCounts {
+		s, ok := symbolByID[id]
+		if !ok || s.kind != "function" {
+			continue
+		}
+		if strings.HasPrefix(s.name, "Test") || strings.HasPrefix(s.name, "Benchmark") {
+			continue
+		}
+		if seen[s.name] {
+			continue
+		}
+		seen[s.name] = true
+		factories = append(factories, Example{Name: s.name, Path: filePathByID[s.fileID], EdgeCount: count})
+	}
+	if len(factories) < minInstances {
+		return nil
+	}
+	sort.Slice(factories, func(i, j int) bool {
+		return factories[i].EdgeCount > factories[j].EdgeCount
+	})
+	totalFuncs := countByKind(symbols, "function")
+	return []Convention{{
+		Category:    CategoryFramework,
+		Description: fmt.Sprintf("Middleware factories: %s return handler functions — composable request pipeline (%d factories)", topNames(factories), len(factories)),
+		Instances:   len(factories),
+		Total:       totalFuncs,
+		Strength:    safeStrength(len(factories), totalFuncs),
+		Examples:    factories,
+	}}
 }
 
 func detectArchitectureLayers(symbols []symbolRow, edges []edgeRow, symbolByID map[int64]symbolRow, filePathByID map[int64]string) []Convention {

--- a/internal/conventions/conventions_test.go
+++ b/internal/conventions/conventions_test.go
@@ -1156,3 +1156,560 @@ func TestDetectTestingJavaKotlinFallback(t *testing.T) {
 	}
 }
 
+func setupCallbackFixture(t *testing.T) *sqlite.Adapter {
+	t.Helper()
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	now := time.Now()
+	files := []model.File{
+		{Path: "app/models/order.rb", Language: "ruby", Hash: "a1", Symbols: 1, IndexedAt: now},
+		{Path: "app/models/user.rb", Language: "ruby", Hash: "a2", Symbols: 1, IndexedAt: now},
+		{Path: "app/models/product.rb", Language: "ruby", Hash: "a3", Symbols: 1, IndexedAt: now},
+	}
+	fileIDs := make(map[string]int64)
+	for i := range files {
+		id, err := adapter.WriteFile(ctx, &files[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		fileIDs[files[i].Path] = id
+	}
+
+	type symDef struct {
+		fileKey, name, qualified, kind string
+	}
+	symDefs := []symDef{
+		{"app/models/order.rb", "Order", "Order", "class"},
+		{"app/models/order.rb", "before_save", "Order.before_save", "method"},
+		{"app/models/order.rb", "after_create", "Order.after_create", "method"},
+		{"app/models/user.rb", "User", "User", "class"},
+		{"app/models/user.rb", "before_validation", "User.before_validation", "method"},
+		{"app/models/user.rb", "after_save", "User.after_save", "method"},
+		{"app/models/product.rb", "Product", "Product", "class"},
+		{"app/models/product.rb", "before_destroy", "Product.before_destroy", "method"},
+		{"app/models/product.rb", "after_commit", "Product.after_commit", "method"},
+	}
+
+	symIDs := make(map[string]int64)
+	for _, sd := range symDefs {
+		fid := fileIDs[sd.fileKey]
+		s := &model.Symbol{
+			FileID:    fid,
+			Name:      sd.name,
+			Qualified: sd.qualified,
+			Kind:      model.SymbolKind(sd.kind),
+			LineStart: 1,
+			LineEnd:   10,
+		}
+		id, err := adapter.WriteSymbol(ctx, s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		symIDs[sd.qualified] = id
+	}
+	parents := map[string]string{
+		"Order.before_save":        "Order",
+		"Order.after_create":       "Order",
+		"User.before_validation":   "User",
+		"User.after_save":          "User",
+		"Product.before_destroy":   "Product",
+		"Product.after_commit":     "Product",
+	}
+	for childQ, parentQ := range parents {
+		_, err := adapter.DB().ExecContext(ctx, `UPDATE sense_symbols SET parent_id = ? WHERE id = ?`, symIDs[parentQ], symIDs[childQ])
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	return adapter
+}
+
+func TestDetectRailsCallbacks(t *testing.T) {
+	adapter := setupCallbackFixture(t)
+	ctx := context.Background()
+
+	conventions, _, err := Detect(ctx, adapter.DB(), Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fw := findByCategory(conventions, CategoryFramework)
+	found := false
+	for _, c := range fw {
+		if strings.Contains(c.Description, "Callback patterns") {
+			found = true
+			if c.Instances != 3 {
+				t.Errorf("expected 3 classes with callbacks, got %d", c.Instances)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected Callback patterns convention")
+	}
+}
+
+func TestDetectRailsCallbacksBelowThreshold(t *testing.T) {
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	now := time.Now()
+	f := model.File{Path: "app/models/order.rb", Language: "ruby", Hash: "a1", Symbols: 1, IndexedAt: now}
+	fid, err := adapter.WriteFile(ctx, &f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cls := &model.Symbol{FileID: fid, Name: "Order", Qualified: "Order", Kind: "class", LineStart: 1, LineEnd: 10}
+	clsID, err := adapter.WriteSymbol(ctx, cls)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cb := &model.Symbol{FileID: fid, Name: "before_save", Qualified: "Order.before_save", Kind: "method", LineStart: 2, LineEnd: 2}
+	cbID, err := adapter.WriteSymbol(ctx, cb)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = adapter.DB().ExecContext(ctx, `UPDATE sense_symbols SET parent_id = ? WHERE id = ?`, clsID, cbID)
+
+	conventions, _, err := Detect(ctx, adapter.DB(), Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range findByCategory(conventions, CategoryFramework) {
+		if strings.Contains(c.Description, "Callback patterns") {
+			t.Error("should not detect callback pattern with only 1 class")
+		}
+	}
+}
+
+func setupScopeFixture(t *testing.T) *sqlite.Adapter {
+	t.Helper()
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	now := time.Now()
+	files := []model.File{
+		{Path: "app/models/order.rb", Language: "ruby", Hash: "a1", Symbols: 1, IndexedAt: now},
+		{Path: "app/models/user.rb", Language: "ruby", Hash: "a2", Symbols: 1, IndexedAt: now},
+		{Path: "app/models/product.rb", Language: "ruby", Hash: "a3", Symbols: 1, IndexedAt: now},
+	}
+	fileIDs := make(map[string]int64)
+	for i := range files {
+		id, err := adapter.WriteFile(ctx, &files[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		fileIDs[files[i].Path] = id
+	}
+
+	type symDef struct {
+		fileKey, name, qualified, kind string
+	}
+	symDefs := []symDef{
+		{"app/models/order.rb", "Order", "Order", "class"},
+		{"app/models/order.rb", "active", "Order.active", "method"},
+		{"app/models/order.rb", "recent", "Order.recent", "method"},
+		{"app/models/user.rb", "User", "User", "class"},
+		{"app/models/user.rb", "verified", "User.verified", "method"},
+		{"app/models/user.rb", "admins", "User.admins", "method"},
+		{"app/models/product.rb", "Product", "Product", "class"},
+		{"app/models/product.rb", "published", "Product.published", "method"},
+		{"app/models/product.rb", "featured", "Product.featured", "method"},
+	}
+
+	symIDs := make(map[string]int64)
+	for _, sd := range symDefs {
+		fid := fileIDs[sd.fileKey]
+		s := &model.Symbol{
+			FileID:    fid,
+			Name:      sd.name,
+			Qualified: sd.qualified,
+			Kind:      model.SymbolKind(sd.kind),
+			LineStart: 1,
+			LineEnd:   10,
+		}
+		id, err := adapter.WriteSymbol(ctx, s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		symIDs[sd.qualified] = id
+	}
+	parents := map[string]string{
+		"Order.active":      "Order",
+		"Order.recent":      "Order",
+		"User.verified":     "User",
+		"User.admins":       "User",
+		"Product.published": "Product",
+		"Product.featured":  "Product",
+	}
+	for childQ, parentQ := range parents {
+		_, err := adapter.DB().ExecContext(ctx, `UPDATE sense_symbols SET parent_id = ? WHERE id = ?`, symIDs[parentQ], symIDs[childQ])
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Scope detection uses positive identification: each scope symbol needs a
+	// calls edge from its parent class (as emitted by emitScopeEdge).
+	scopeEdges := []struct{ source, target, file string }{
+		{"Order", "Order.active", "app/models/order.rb"},
+		{"Order", "Order.recent", "app/models/order.rb"},
+		{"User", "User.verified", "app/models/user.rb"},
+		{"User", "User.admins", "app/models/user.rb"},
+		{"Product", "Product.published", "app/models/product.rb"},
+		{"Product", "Product.featured", "app/models/product.rb"},
+	}
+	for _, se := range scopeEdges {
+		srcID := symIDs[se.source]
+		tgtID := symIDs[se.target]
+		fid := fileIDs[se.file]
+		e := &model.Edge{
+			SourceID:   &srcID,
+			TargetID:   tgtID,
+			Kind:       model.EdgeCalls,
+			FileID:     fid,
+			Confidence: 1.0,
+		}
+		if _, err := adapter.WriteEdge(ctx, e); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return adapter
+}
+
+func TestDetectScopes(t *testing.T) {
+	adapter := setupScopeFixture(t)
+	ctx := context.Background()
+
+	conventions, _, err := Detect(ctx, adapter.DB(), Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fw := findByCategory(conventions, CategoryFramework)
+	found := false
+	for _, c := range fw {
+		if strings.Contains(c.Description, "Scope definitions") {
+			found = true
+			if c.Instances != 3 {
+				t.Errorf("expected 3 classes with scopes, got %d", c.Instances)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected Scope definitions convention")
+	}
+}
+
+func TestDetectScopesBelowThreshold(t *testing.T) {
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	now := time.Now()
+	f := model.File{Path: "app/models/order.rb", Language: "ruby", Hash: "a1", Symbols: 1, IndexedAt: now}
+	fid, err := adapter.WriteFile(ctx, &f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cls := &model.Symbol{FileID: fid, Name: "Order", Qualified: "Order", Kind: "class", LineStart: 1, LineEnd: 10}
+	clsID, err := adapter.WriteSymbol(ctx, cls)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scope := &model.Symbol{FileID: fid, Name: "active", Qualified: "Order.active", Kind: "method", LineStart: 2, LineEnd: 2}
+	scopeID, err := adapter.WriteSymbol(ctx, scope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = adapter.DB().ExecContext(ctx, `UPDATE sense_symbols SET parent_id = ? WHERE id = ?`, clsID, scopeID)
+	e := &model.Edge{SourceID: &clsID, TargetID: scopeID, Kind: model.EdgeCalls, FileID: fid, Confidence: 1.0}
+	if _, err := adapter.WriteEdge(ctx, e); err != nil {
+		t.Fatal(err)
+	}
+
+	conventions, _, err := Detect(ctx, adapter.DB(), Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range findByCategory(conventions, CategoryFramework) {
+		if strings.Contains(c.Description, "Scope definitions") {
+			t.Error("should not detect scope pattern with only 1 class")
+		}
+	}
+}
+
+func TestDetectCompositionSerializers(t *testing.T) {
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	now := time.Now()
+	files := []model.File{
+		{Path: "app/serializers/order_serializer.rb", Language: "ruby", Hash: "a1", Symbols: 1, IndexedAt: now},
+		{Path: "app/models/order.rb", Language: "ruby", Hash: "a2", Symbols: 1, IndexedAt: now},
+		{Path: "app/models/user.rb", Language: "ruby", Hash: "a3", Symbols: 1, IndexedAt: now},
+		{Path: "app/models/product.rb", Language: "ruby", Hash: "a4", Symbols: 1, IndexedAt: now},
+	}
+	fileIDs := make(map[string]int64)
+	for i := range files {
+		id, err := adapter.WriteFile(ctx, &files[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		fileIDs[files[i].Path] = id
+	}
+
+	type symDef struct {
+		fileKey, name, qualified, kind string
+	}
+	symDefs := []symDef{
+		{"app/serializers/order_serializer.rb", "OrderSerializer", "OrderSerializer", "class"},
+		{"app/models/order.rb", "Order", "Order", "class"},
+		{"app/models/user.rb", "User", "User", "class"},
+		{"app/models/product.rb", "Product", "Product", "class"},
+	}
+
+	symIDs := make(map[string]int64)
+	for _, sd := range symDefs {
+		fid := fileIDs[sd.fileKey]
+		s := &model.Symbol{
+			FileID:    fid,
+			Name:      sd.name,
+			Qualified: sd.qualified,
+			Kind:      model.SymbolKind(sd.kind),
+			LineStart: 1,
+			LineEnd:   10,
+		}
+		id, err := adapter.WriteSymbol(ctx, s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		symIDs[sd.qualified] = id
+	}
+
+	edgeDefs := []struct{ source, target, kind, file string }{
+		{"Order", "OrderSerializer", "composes", "app/models/order.rb"},
+		{"User", "OrderSerializer", "composes", "app/models/user.rb"},
+		{"Product", "OrderSerializer", "composes", "app/models/product.rb"},
+	}
+	for _, ed := range edgeDefs {
+		srcID := symIDs[ed.source]
+		tgtID := symIDs[ed.target]
+		fid := fileIDs[ed.file]
+		e := &model.Edge{
+			SourceID:   &srcID,
+			TargetID:   tgtID,
+			Kind:       model.EdgeKind(ed.kind),
+			FileID:     fid,
+			Confidence: 1.0,
+		}
+		if _, err := adapter.WriteEdge(ctx, e); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	conventions, _, err := Detect(ctx, adapter.DB(), Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	comp := findByCategory(conventions, CategoryComposition)
+	foundSerializer := false
+	foundGeneric := false
+	for _, c := range comp {
+		if strings.Contains(c.Description, "Serializer composition") {
+			foundSerializer = true
+			if c.Instances != 3 {
+				t.Errorf("expected 3 serializer composition instances, got %d", c.Instances)
+			}
+		}
+		if strings.Contains(c.Description, "mix in OrderSerializer") {
+			foundGeneric = true
+		}
+	}
+	if !foundSerializer {
+		t.Error("expected Serializer composition convention")
+	}
+	if foundGeneric {
+		t.Error("serializer should not appear in generic composition convention")
+	}
+}
+
+func TestDetectCallbacksAndScopesNoCollision(t *testing.T) {
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	now := time.Now()
+	files := []model.File{
+		{Path: "app/models/order.rb", Language: "ruby", Hash: "a1", Symbols: 1, IndexedAt: now},
+		{Path: "app/models/user.rb", Language: "ruby", Hash: "a2", Symbols: 1, IndexedAt: now},
+		{Path: "app/models/product.rb", Language: "ruby", Hash: "a3", Symbols: 1, IndexedAt: now},
+	}
+	fileIDs := make(map[string]int64)
+	for i := range files {
+		id, err := adapter.WriteFile(ctx, &files[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		fileIDs[files[i].Path] = id
+	}
+
+	type symDef struct {
+		fileKey, name, qualified, kind string
+	}
+	symDefs := []symDef{
+		// Each class has callbacks AND scopes
+		{"app/models/order.rb", "Order", "Order", "class"},
+		{"app/models/order.rb", "before_save", "Order.before_save", "method"},
+		{"app/models/order.rb", "active", "Order.active", "method"},
+		{"app/models/order.rb", "recent", "Order.recent", "method"},
+		{"app/models/user.rb", "User", "User", "class"},
+		{"app/models/user.rb", "after_create", "User.after_create", "method"},
+		{"app/models/user.rb", "verified", "User.verified", "method"},
+		{"app/models/user.rb", "admins", "User.admins", "method"},
+		{"app/models/product.rb", "Product", "Product", "class"},
+		{"app/models/product.rb", "before_destroy", "Product.before_destroy", "method"},
+		{"app/models/product.rb", "published", "Product.published", "method"},
+		{"app/models/product.rb", "featured", "Product.featured", "method"},
+	}
+
+	symIDs := make(map[string]int64)
+	for _, sd := range symDefs {
+		fid := fileIDs[sd.fileKey]
+		s := &model.Symbol{
+			FileID:    fid,
+			Name:      sd.name,
+			Qualified: sd.qualified,
+			Kind:      model.SymbolKind(sd.kind),
+			LineStart: 1,
+			LineEnd:   10,
+		}
+		id, err := adapter.WriteSymbol(ctx, s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		symIDs[sd.qualified] = id
+	}
+	parents := map[string]string{
+		"Order.before_save":      "Order",
+		"Order.active":           "Order",
+		"Order.recent":           "Order",
+		"User.after_create":      "User",
+		"User.verified":          "User",
+		"User.admins":            "User",
+		"Product.before_destroy": "Product",
+		"Product.published":      "Product",
+		"Product.featured":       "Product",
+	}
+	for childQ, parentQ := range parents {
+		_, err := adapter.DB().ExecContext(ctx, `UPDATE sense_symbols SET parent_id = ? WHERE id = ?`, symIDs[parentQ], symIDs[childQ])
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Scope edges (positive identification)
+	scopeEdges := []struct{ source, target, file string }{
+		{"Order", "Order.active", "app/models/order.rb"},
+		{"Order", "Order.recent", "app/models/order.rb"},
+		{"User", "User.verified", "app/models/user.rb"},
+		{"User", "User.admins", "app/models/user.rb"},
+		{"Product", "Product.published", "app/models/product.rb"},
+		{"Product", "Product.featured", "app/models/product.rb"},
+	}
+	for _, se := range scopeEdges {
+		srcID := symIDs[se.source]
+		tgtID := symIDs[se.target]
+		fid := fileIDs[se.file]
+		e := &model.Edge{SourceID: &srcID, TargetID: tgtID, Kind: model.EdgeCalls, FileID: fid, Confidence: 1.0}
+		if _, err := adapter.WriteEdge(ctx, e); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	conventions, _, err := Detect(ctx, adapter.DB(), Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fw := findByCategory(conventions, CategoryFramework)
+	var callbackConv, scopeConv *Convention
+	for i, c := range fw {
+		if strings.Contains(c.Description, "Callback patterns") {
+			callbackConv = &fw[i]
+		}
+		if strings.Contains(c.Description, "Scope definitions") {
+			scopeConv = &fw[i]
+		}
+	}
+	if callbackConv == nil {
+		t.Fatal("expected Callback patterns convention")
+	}
+	if scopeConv == nil {
+		t.Fatal("expected Scope definitions convention")
+	}
+	if callbackConv.Instances != 3 {
+		t.Errorf("callback instances = %d, want 3", callbackConv.Instances)
+	}
+	if scopeConv.Instances != 3 {
+		t.Errorf("scope instances = %d, want 3", scopeConv.Instances)
+	}
+	// Verify no cross-contamination: callback names must not appear in scope examples
+	for _, ex := range scopeConv.Examples {
+		if model.RailsCallbackNames[ex.Name] {
+			t.Errorf("scope convention contains callback name %q", ex.Name)
+		}
+	}
+}
+

--- a/internal/extract/ruby/ruby.go
+++ b/internal/extract/ruby/ruby.go
@@ -61,6 +61,7 @@ func (Extractor) Extract(tree *sitter.Tree, source []byte, filePath string, emit
 		filePath:          filePath,
 		classInstanceVars: make(map[string]map[string]string),
 		returnTypes:       returnTypes,
+		emittedCallbacks:  make(map[string]bool),
 	}
 	return w.walk(tree.RootNode(), nil)
 }
@@ -86,6 +87,7 @@ type walker struct {
 	testScope         []string // nested RSpec block descriptions for synthetic scope
 	classInstanceVars map[string]map[string]string // @ivar type map per class
 	returnTypes       map[string]string            // method_qualified → class_name (file-level)
+	emittedCallbacks  map[string]bool              // dedup synthetic callback symbols by qualified name
 }
 
 // walk visits node and its children under the given class/module scope.
@@ -148,9 +150,11 @@ func (w *walker) dispatchCall(n *sitter.Node, scope []string) (bool, error) {
 			return false, w.emitAssociationEdge(n, scope, methodName)
 		case "broadcasts_to", "broadcasts":
 			return false, w.emitBroadcastEdge(n, scope)
+		case "scope":
+			return false, w.emitScopeEdge(n, scope)
 		}
-		if railsCallbacks[methodName] {
-			return false, w.emitCallbackEdges(n, scope)
+		if model.RailsCallbackNames[methodName] {
+			return false, w.emitCallbackEdges(n, scope, methodName)
 		}
 	}
 
@@ -1546,33 +1550,10 @@ func (w *walker) emitAssociationEdge(n *sitter.Node, scope []string, methodName 
 	})
 }
 
-// railsCallbacks is the set of Rails lifecycle callback method names that
-// should emit calls edges when used as class-level declarations.
-var railsCallbacks = map[string]bool{
-	"before_action":     true,
-	"after_action":      true,
-	"around_action":     true,
-	"before_save":       true,
-	"after_save":        true,
-	"around_save":       true,
-	"before_create":     true,
-	"after_create":      true,
-	"around_create":     true,
-	"before_update":     true,
-	"after_update":      true,
-	"around_update":     true,
-	"before_destroy":    true,
-	"after_destroy":     true,
-	"around_destroy":    true,
-	"before_validation": true,
-	"after_validation":  true,
-	"before_commit":     true,
-	"after_commit":      true,
-	"after_rollback":    true,
-}
-
-// emitCallbackEdges emits calls edges for Rails lifecycle callbacks.
-func (w *walker) emitCallbackEdges(n *sitter.Node, scope []string) error {
+// emitCallbackEdges emits calls edges for Rails lifecycle callbacks and
+// a symbol for the callback declaration so convention detection can find it.
+// Duplicate symbols for the same callback name on the same class are suppressed.
+func (w *walker) emitCallbackEdges(n *sitter.Node, scope []string, callbackName string) error {
 	args := n.ChildByFieldName("arguments")
 	if args == nil || args.NamedChildCount() == 0 {
 		return nil
@@ -1581,7 +1562,21 @@ func (w *walker) emitCallbackEdges(n *sitter.Node, scope []string) error {
 	source := strings.Join(scope, "::")
 	line := extract.Line(n.StartPosition())
 
-	// Emit a calls edge for each symbol argument (callbacks can list multiple).
+	qualified := source + "." + callbackName
+	if !w.emittedCallbacks[qualified] {
+		w.emittedCallbacks[qualified] = true
+		if err := w.emit.Symbol(extract.EmittedSymbol{
+			Name:            callbackName,
+			Qualified:       qualified,
+			Kind:            model.KindMethod,
+			ParentQualified: source,
+			LineStart:       line,
+			LineEnd:         line,
+		}); err != nil {
+			return err
+		}
+	}
+
 	count := args.NamedChildCount()
 	for i := uint(0); i < count; i++ {
 		arg := args.NamedChild(i)
@@ -1600,6 +1595,43 @@ func (w *walker) emitCallbackEdges(n *sitter.Node, scope []string) error {
 		}
 	}
 	return nil
+}
+
+// emitScopeEdge handles `scope :name, -> { ... }` declarations.
+// It emits the scope name as a class method symbol and a calls edge
+// from the class to the scope name.
+func (w *walker) emitScopeEdge(n *sitter.Node, scope []string) error {
+	args := n.ChildByFieldName("arguments")
+	if args == nil || args.NamedChildCount() == 0 {
+		return nil
+	}
+	first := args.NamedChild(0)
+	if first == nil || first.Kind() != "simple_symbol" {
+		return nil
+	}
+	name := strings.TrimPrefix(extract.Text(first, w.source), ":")
+	if name == "" {
+		return nil
+	}
+	source := strings.Join(scope, "::")
+	line := extract.Line(n.StartPosition())
+	if err := w.emit.Symbol(extract.EmittedSymbol{
+		Name:            name,
+		Qualified:       source + "." + name,
+		Kind:            model.KindMethod,
+		ParentQualified: source,
+		LineStart:       line,
+		LineEnd:         line,
+	}); err != nil {
+		return err
+	}
+	return w.emit.Edge(extract.EmittedEdge{
+		SourceQualified: source,
+		TargetQualified: source + "." + name,
+		Kind:            model.EdgeCalls,
+		Line:            &line,
+		Confidence:      extract.ConfidenceStatic,
+	})
 }
 
 // emitDescribeEdge detects RSpec.describe/describe with a constant

--- a/internal/extract/ruby/ruby_test.go
+++ b/internal/extract/ruby/ruby_test.go
@@ -460,6 +460,95 @@ end
 	}
 }
 
+func TestCallbackEdgesEmitsSymbol(t *testing.T) {
+	r := parseRuby(t, `class Order
+  before_save :validate_total
+  after_create :send_notification
+end
+`)
+	if s := findSymbol(r, "Order.before_save"); s == nil {
+		t.Error("missing symbol Order.before_save from callback declaration")
+	} else if s.Kind != "method" {
+		t.Errorf("callback symbol kind = %q, want method", s.Kind)
+	}
+	if findSymbol(r, "Order.after_create") == nil {
+		t.Error("missing symbol Order.after_create from callback declaration")
+	}
+}
+
+func TestCallbackEdgesDedup(t *testing.T) {
+	r := parseRuby(t, `class OrdersController
+  before_action :authenticate!
+  before_action :set_order
+end
+`)
+	count := 0
+	for _, s := range r.symbols {
+		if s.Qualified == "OrdersController.before_action" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 before_action symbol, got %d (duplicates not suppressed)", count)
+	}
+}
+
+func TestCallbackEdgesNoArgs(t *testing.T) {
+	r := parseRuby(t, `class Order
+  before_save
+end
+`)
+	if findSymbol(r, "Order.before_save") != nil {
+		t.Error("should not emit symbol for callback with no arguments")
+	}
+}
+
+func TestScopeEdge(t *testing.T) {
+	r := parseRuby(t, `class Product
+  scope :active, -> { where(active: true) }
+  scope :recent, -> { order(created_at: :desc) }
+end
+`)
+	if findSymbol(r, "Product.active") == nil {
+		t.Error("missing symbol Product.active from scope declaration")
+	}
+	if findSymbol(r, "Product.recent") == nil {
+		t.Error("missing symbol Product.recent from scope declaration")
+	}
+	if findEdge(r, "Product", "Product.active", "calls") == nil {
+		t.Error("missing calls edge Product -> Product.active from scope")
+	}
+	if findEdge(r, "Product", "Product.recent", "calls") == nil {
+		t.Error("missing calls edge Product -> Product.recent from scope")
+	}
+}
+
+func TestScopeEdgeNonSymbolArg(t *testing.T) {
+	r := parseRuby(t, `class Product
+  scope "not_a_symbol", -> { where(active: true) }
+end
+`)
+	for _, s := range r.symbols {
+		if s.Name == "not_a_symbol" {
+			t.Error("should not emit symbol for non-symbol scope argument")
+		}
+	}
+}
+
+func TestScopeEdgeNoArgs(t *testing.T) {
+	r := parseRuby(t, `class Product
+  scope
+end
+`)
+	if len(r.edges) > 0 {
+		for _, e := range r.edges {
+			if e.SourceQualified == "Product" && string(e.Kind) == "calls" {
+				t.Error("should not emit calls edge for scope with no arguments")
+			}
+		}
+	}
+}
+
 func TestRSpecDescribe(t *testing.T) {
 	r := parseRuby(t, `RSpec.describe Order do
 end

--- a/internal/extract/testdata/ruby/rails_callbacks.golden.json
+++ b/internal/extract/testdata/ruby/rails_callbacks.golden.json
@@ -40,6 +40,38 @@
       "line_end": 29
     },
     {
+      "name": "after_commit",
+      "qualified": "Invoice.after_commit",
+      "kind": "method",
+      "parent": "Invoice",
+      "line_start": 21,
+      "line_end": 21
+    },
+    {
+      "name": "after_create",
+      "qualified": "Invoice.after_create",
+      "kind": "method",
+      "parent": "Invoice",
+      "line_start": 23,
+      "line_end": 23
+    },
+    {
+      "name": "before_save",
+      "qualified": "Invoice.before_save",
+      "kind": "method",
+      "parent": "Invoice",
+      "line_start": 20,
+      "line_end": 20
+    },
+    {
+      "name": "before_validation",
+      "qualified": "Invoice.before_validation",
+      "kind": "method",
+      "parent": "Invoice",
+      "line_start": 22,
+      "line_end": 22
+    },
+    {
       "name": "NotACallback",
       "qualified": "NotACallback",
       "kind": "class",
@@ -100,6 +132,22 @@
       "parent": "OrdersController",
       "line_start": 12,
       "line_end": 13
+    },
+    {
+      "name": "after_action",
+      "qualified": "OrdersController.after_action",
+      "kind": "method",
+      "parent": "OrdersController",
+      "line_start": 4,
+      "line_end": 4
+    },
+    {
+      "name": "before_action",
+      "qualified": "OrdersController.before_action",
+      "kind": "method",
+      "parent": "OrdersController",
+      "line_start": 2,
+      "line_end": 2
     }
   ],
   "edges": [

--- a/internal/extract/testdata/ruby/rails_concerns.golden.json
+++ b/internal/extract/testdata/ruby/rails_concerns.golden.json
@@ -16,6 +16,14 @@
       "line_end": 23
     },
     {
+      "name": "before_save",
+      "qualified": "Auditable.before_save",
+      "kind": "method",
+      "parent": "Auditable",
+      "line_start": 18,
+      "line_end": 18
+    },
+    {
       "name": "Cacheable",
       "qualified": "Cacheable",
       "kind": "module",
@@ -75,6 +83,14 @@
       "parent": "Searchable",
       "line_start": 9,
       "line_end": 10
+    },
+    {
+      "name": "after_commit",
+      "qualified": "Searchable.after_commit",
+      "kind": "method",
+      "parent": "Searchable",
+      "line_start": 6,
+      "line_end": 6
     }
   ],
   "edges": [

--- a/internal/model/rails.go
+++ b/internal/model/rails.go
@@ -1,0 +1,27 @@
+package model
+
+// RailsCallbackNames is the canonical set of Rails lifecycle callback
+// method names. Both the Ruby extractor and the convention detector
+// reference this single source of truth.
+var RailsCallbackNames = map[string]bool{
+	"before_action":     true,
+	"after_action":      true,
+	"around_action":     true,
+	"before_save":       true,
+	"after_save":        true,
+	"around_save":       true,
+	"before_create":     true,
+	"after_create":      true,
+	"around_create":     true,
+	"before_update":     true,
+	"after_update":      true,
+	"around_update":     true,
+	"before_destroy":    true,
+	"after_destroy":     true,
+	"around_destroy":    true,
+	"before_validation": true,
+	"after_validation":  true,
+	"before_commit":     true,
+	"after_commit":      true,
+	"after_rollback":    true,
+}

--- a/testdata/smoke/dead-golden.json
+++ b/testdata/smoke/dead-golden.json
@@ -36,6 +36,6 @@
       "file": "user.rb"
     }
   ],
-  "total_symbols": 30,
+  "total_symbols": 31,
   "dead_count": 7
 }


### PR DESCRIPTION
## Problem

`sense_conventions` missed 4 Rails patterns — callback patterns, scope definitions, serializer composition, and concern umbrella reporting — scoring 0.6 vs 0.7 on a Ruby/Rails benchmark. Three of four gaps were detector-side problems (the structural data existed in the index but wasn't surfaced as conventions). Only scopes needed new extraction.

## Summary

Decompose the monolithic `detectFrameworkIdioms` into 7 focused functions, add new Rails-specific detectors for callbacks, scopes, and serializer composition, and fix scope extraction in the Ruby extractor.

## Changes

**Extraction (`internal/extract/ruby`)**
- Add `emitScopeEdge` for `scope :name, -> { ... }` declarations — emits a method symbol and a qualified calls edge
- Deduplicate synthetic callback symbols per class (two `before_action` on one controller → one symbol)
- Qualify scope edge targets (`Product.active` instead of bare `active`) to prevent ambiguous resolution

**Convention detection (`internal/conventions`)**
- Decompose `detectFrameworkIdioms` (215 lines) into 7 focused functions with uniform signatures
- Add `detectRailsCallbacks` — finds classes with methods matching known Rails callback names
- Add `detectScopes` — positively identifies scopes via calls edges from parent classes (not a negative heuristic that catches all class methods)
- Split serializer composition from generic composition in `detectComposition` using `safeStrength()` consistently

**Shared model (`internal/model`)**
- Extract `RailsCallbackNames` to `model/rails.go` — single source of truth referenced by both the extractor and convention detector

## Architecture Highlights

- **No new edge kinds** — callbacks and scopes reuse existing `calls` edges. No schema migration, no blast radius changes, no MCP type updates.
- **Positive scope identification** — `detectScopes` uses the calls-edge-from-parent-class signal emitted by `emitScopeEdge`, rather than an exclusion-based heuristic. Regular class methods (`def self.find_by_email`) are not misidentified as scopes.
- **Callback symbol dedup** — the walker tracks emitted callback qualified names to suppress duplicates from repeated declarations.

## Test Plan

- [x] `TestDetectRailsCallbacks` — 3 classes with lifecycle callbacks detected
- [x] `TestDetectRailsCallbacksBelowThreshold` — 1 class filtered out
- [x] `TestDetectScopes` — 3 classes with scope edges detected
- [x] `TestDetectScopesBelowThreshold` — 1 class filtered out
- [x] `TestDetectCompositionSerializers` — serializer split from generic composition, no leakage
- [x] `TestDetectCallbacksAndScopesNoCollision` — classes with both callbacks and scopes, no cross-contamination
- [x] `TestCallbackEdgesDedup` — two `before_action` declarations emit one symbol
- [x] `TestScopeEdge` — qualified calls edge emitted
- [x] `TestScopeEdgeNonSymbolArg` / `TestScopeEdgeNoArgs` — edge cases emit nothing
- [x] Golden fixtures and smoke test updated
- [x] `make ci` passes (tests + lint)
- [x] File-level coverage ≥90% on all changed files