### PR TITLE
feat(dead): add false-positive filters for Python dunders, library public API, and trait impl methods

### DIFF
--- a/internal/dead/dead.go
+++ b/internal/dead/dead.go
@@ -31,6 +31,7 @@ type Symbol struct {
 	LineStart  int
 	LineEnd    int
 	ParentID   *int64
+	Visibility string
 	Confidence string
 }
 
@@ -71,7 +72,15 @@ func FindDead(ctx context.Context, db *sql.DB, opts Options) (Result, error) {
 	}
 
 	frameworks := readFrameworks(ctx, db)
-	candidates = excludeEntryPoints(candidates, testsTargets, interfaceIDs, frameworks)
+	hasMain, err := hasMainFunction(ctx, db, opts)
+	if err != nil {
+		return Result{}, err
+	}
+	isLibrary := !hasMain
+	interfaceMethodNames, err := queryInterfaceMethodNames(ctx, db)
+	if err != nil {
+		return Result{}, fmt.Errorf("dead: query interface method names: %w", err)
+	}
 
 	liveContainers, err := findLiveContainers(ctx, db, candidates)
 	if err != nil {
@@ -83,6 +92,15 @@ func FindDead(ctx context.Context, db *sql.DB, opts Options) (Result, error) {
 	if err != nil {
 		return Result{}, fmt.Errorf("dead: interface implementors: %w", err)
 	}
+
+	candidates = excludeEntryPoints(candidates, entryPointFilters{
+		testsTargets:        testsTargets,
+		interfaceIDs:       interfaceIDs,
+		frameworks:         frameworks,
+		isLibrary:          isLibrary,
+		interfaceMethodNames: interfaceMethodNames,
+		implementorIDs:    implementorIDs,
+	})
 
 	candidates = annotateConfidence(candidates, interfaceIDs, implementorIDs)
 
@@ -138,7 +156,7 @@ func queryCandidates(ctx context.Context, db *sql.DB, opts Options) ([]Symbol, e
 			)`
 	}
 
-	q := `SELECT s.id, s.name, s.qualified, s.kind, f.path, s.file_id, f.language, s.line_start, s.line_end, s.parent_id
+	q := `SELECT s.id, s.name, s.qualified, s.kind, f.path, s.file_id, f.language, s.line_start, s.line_end, s.parent_id, s.visibility
 		FROM sense_symbols s
 		JOIN sense_files f ON s.file_id = f.id
 		WHERE NOT EXISTS (` + edgeFilter + `)
@@ -166,10 +184,12 @@ func queryCandidates(ctx context.Context, db *sql.DB, opts Options) ([]Symbol, e
 	for rows.Next() {
 		var sym Symbol
 		var parentID sql.NullInt64
+		var visibility sql.NullString
 		if err := rows.Scan(&sym.ID, &sym.Name, &sym.Qualified, &sym.Kind,
-			&sym.File, &sym.FileID, &sym.Language, &sym.LineStart, &sym.LineEnd, &parentID); err != nil {
+			&sym.File, &sym.FileID, &sym.Language, &sym.LineStart, &sym.LineEnd, &parentID, &visibility); err != nil {
 			return nil, err
 		}
+		sym.Visibility = visibility.String
 		if parentID.Valid {
 			p := parentID.Int64
 			sym.ParentID = &p
@@ -217,6 +237,27 @@ func queryInterfaceIDs(ctx context.Context, db *sql.DB) (map[int64]struct{}, err
 	return out, rows.Err()
 }
 
+func queryInterfaceMethodNames(ctx context.Context, db *sql.DB) (map[string]struct{}, error) {
+	rows, err := db.QueryContext(ctx,
+		`SELECT DISTINCT s.name FROM sense_symbols s
+		JOIN sense_symbols p ON s.parent_id = p.id AND p.kind = 'interface'
+		WHERE s.kind = 'method'`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make(map[string]struct{})
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		out[name] = struct{}{}
+	}
+	return out, rows.Err()
+}
+
 func queryInterfaceImplementors(ctx context.Context, db *sql.DB) (map[int64]struct{}, error) {
 	rows, err := db.QueryContext(ctx,
 		`SELECT DISTINCT e.source_id FROM sense_edges e
@@ -238,10 +279,47 @@ func queryInterfaceImplementors(ctx context.Context, db *sql.DB) (map[int64]stru
 	return out, rows.Err()
 }
 
-func excludeEntryPoints(candidates []Symbol, testsTargets, interfaceIDs map[int64]struct{}, frameworks map[string]struct{}) []Symbol {
+func hasMainFunction(ctx context.Context, db *sql.DB, opts Options) (bool, error) {
+	q := `SELECT 1 FROM sense_symbols s
+		JOIN sense_files f ON s.file_id = f.id
+		WHERE s.name = 'main' AND s.kind = 'function'`
+	var args []any
+
+	if opts.Language != "" {
+		q += " AND f.language = ?"
+		args = append(args, opts.Language)
+	}
+	if opts.Domain != "" {
+		q += " AND f.path LIKE ?"
+		args = append(args, "%"+opts.Domain+"%")
+	}
+
+	q += " LIMIT 1"
+
+	var exists int
+	err := db.QueryRowContext(ctx, q, args...).Scan(&exists)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		return false, fmt.Errorf("dead: detect library: %w", err)
+	}
+	return true, nil
+}
+
+type entryPointFilters struct {
+	testsTargets        map[int64]struct{}
+	interfaceIDs        map[int64]struct{}
+	frameworks          map[string]struct{}
+	isLibrary           bool
+	interfaceMethodNames map[string]struct{}
+	implementorIDs      map[int64]struct{}
+}
+
+func excludeEntryPoints(candidates []Symbol, filters entryPointFilters) []Symbol {
 	var out []Symbol
 	for _, s := range candidates {
-		if isEntryPoint(s, testsTargets, interfaceIDs, frameworks) {
+		if isEntryPoint(s, filters) {
 			continue
 		}
 		out = append(out, s)
@@ -337,7 +415,7 @@ func excludeIDs(candidates []Symbol, exclude map[int64]struct{}) []Symbol {
 	return out
 }
 
-func isEntryPoint(s Symbol, testsTargets, interfaceIDs map[int64]struct{}, frameworks map[string]struct{}) bool {
+func isEntryPoint(s Symbol, f entryPointFilters) bool {
 	if isMainFunction(s) {
 		return true
 	}
@@ -350,16 +428,40 @@ func isEntryPoint(s Symbol, testsTargets, interfaceIDs map[int64]struct{}, frame
 	if isConstructor(s) {
 		return true
 	}
-	if isFrameworkHook(s, frameworks) {
+	if isFrameworkHook(s, f.frameworks) {
 		return true
 	}
-	if isInterfaceMethod(s, interfaceIDs) {
+	if isInterfaceMethod(s, f.interfaceIDs) {
 		return true
 	}
-	if _, ok := testsTargets[s.ID]; ok {
+	if isLibraryPublicAPI(s, f.isLibrary) {
+		return true
+	}
+	if mightBeTraitImplMethod(s, f.interfaceMethodNames, f.implementorIDs) {
+		return true
+	}
+	if _, ok := f.testsTargets[s.ID]; ok {
 		return true
 	}
 	return false
+}
+
+func mightBeTraitImplMethod(s Symbol, interfaceMethodNames map[string]struct{}, implementorIDs map[int64]struct{}) bool {
+	if s.Kind != "method" || s.ParentID == nil {
+		return false
+	}
+	if _, ok := implementorIDs[*s.ParentID]; !ok {
+		return false
+	}
+	_, ok := interfaceMethodNames[s.Name]
+	return ok
+}
+
+func isLibraryPublicAPI(s Symbol, isLibrary bool) bool {
+	if !isLibrary {
+		return false
+	}
+	return s.Visibility == "public" && (s.Kind == "function" || s.Kind == "method" || s.Kind == "class" || s.Kind == "type")
 }
 
 func isMainFunction(s Symbol) bool {
@@ -436,6 +538,9 @@ func isJVMLanguage(lang string) bool {
 }
 
 func isFrameworkHook(s Symbol, frameworks map[string]struct{}) bool {
+	if s.Language == "python" && strings.HasPrefix(s.Name, "__") && strings.HasSuffix(s.Name, "__") {
+		return true
+	}
 	if _, ok := frameworkHooks[s.Name]; ok {
 		return true
 	}

--- a/internal/dead/dead_test.go
+++ b/internal/dead/dead_test.go
@@ -593,6 +593,10 @@ func NewRouter() *Router { return &Router{} }
 
 func unusedFunc() {}
 `)
+	writeFile(t, filepath.Join(root, "main.go"), `package main
+
+func main() {}
+`)
 
 	ctx := context.Background()
 	if _, err := scan.Run(ctx, scan.Options{
@@ -744,6 +748,182 @@ func TestDeadCodeExcludesJVMLifecycle(t *testing.T) {
 		if excluded[s.Name] {
 			t.Errorf("%q should be excluded as JVM lifecycle/framework hook", s.Name)
 		}
+	}
+}
+
+func TestDeadCodeExcludesDunderMethods(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, "widget.py"), `class Widget:
+    def __init__(self):
+        pass
+
+    def __repr__(self):
+        return "Widget()"
+
+    def __str__(self):
+        return "Widget"
+
+    def dead_method(self):
+        pass
+`)
+
+	ctx := context.Background()
+	if _, err := scan.Run(ctx, scan.Options{
+		Root:     root,
+		Output:   &bytes.Buffer{},
+		Warnings: io.Discard,
+	}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+
+	dbPath := filepath.Join(root, ".sense", "index.db")
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	result, err := dead.FindDead(ctx, db, dead.Options{})
+	if err != nil {
+		t.Fatalf("FindDead: %v", err)
+	}
+
+	excluded := map[string]bool{"__init__": true, "__repr__": true, "__str__": true}
+	for _, s := range result.Dead {
+		if excluded[s.Name] {
+			t.Errorf("%q should be excluded as Python dunder method", s.Name)
+		}
+	}
+}
+
+func TestDeadCodeExcludesLibraryPublicAPI(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, "lib.go"), `package lib
+
+func PublicFunc() {}
+
+func privateFunc() {}
+
+type PublicType struct{}
+
+func (p PublicType) PublicMethod() {}
+
+func (p PublicType) privateMethod() {}
+`)
+
+	ctx := context.Background()
+	if _, err := scan.Run(ctx, scan.Options{
+		Root:     root,
+		Output:   &bytes.Buffer{},
+		Warnings: io.Discard,
+	}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+
+	dbPath := filepath.Join(root, ".sense", "index.db")
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	result, err := dead.FindDead(ctx, db, dead.Options{})
+	if err != nil {
+		t.Fatalf("FindDead: %v", err)
+	}
+
+	for _, s := range result.Dead {
+		if s.Name == "PublicFunc" {
+			t.Error("PublicFunc should be excluded as library public API")
+		}
+		if s.Name == "PublicType" {
+			t.Error("PublicType should be excluded as library public API")
+		}
+		if s.Name == "PublicMethod" {
+			t.Error("PublicMethod should be excluded as library public API")
+		}
+	}
+}
+
+func TestDeadCodeExcludesTraitImplMethods(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, "iface.go"), `package render
+
+type Renderer interface {
+	Render() string
+}
+`)
+	writeFile(t, filepath.Join(root, "html.go"), `package render
+
+type HTMLRenderer struct{}
+
+func (h HTMLRenderer) Render() string {
+	return "<html/>"
+}
+
+func (h HTMLRenderer) unusedHelper() string {
+	return "unused"
+}
+`)
+	writeFile(t, filepath.Join(root, "caller.go"), `package render
+
+func RenderAll(rs []Renderer) {
+	for _, r := range rs {
+		r.Render()
+	}
+}
+`)
+
+	ctx := context.Background()
+	if _, err := scan.Run(ctx, scan.Options{
+		Root:     root,
+		Output:   &bytes.Buffer{},
+		Warnings: io.Discard,
+	}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+
+	dbPath := filepath.Join(root, ".sense", "index.db")
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	result, err := dead.FindDead(ctx, db, dead.Options{})
+	if err != nil {
+		t.Fatalf("FindDead: %v", err)
+	}
+
+	deadNames := map[string]bool{}
+	for _, s := range result.Dead {
+		deadNames[s.Qualified] = true
+	}
+
+	if deadNames["render.HTMLRenderer.Render"] {
+		t.Error("HTMLRenderer.Render should be excluded — it implements Renderer.Render")
+	}
+
+	if !deadNames["render.HTMLRenderer.unusedHelper"] {
+		t.Error("HTMLRenderer.unusedHelper should be dead — no callers and no interface match")
 	}
 }
 

--- a/internal/dead/golden_test.go
+++ b/internal/dead/golden_test.go
@@ -136,15 +136,16 @@ func TestDeadCLIIntegration(t *testing.T) {
 		t.Fatal("expected dead symbols in smoke fixture, got none")
 	}
 
-	// Verify known-dead symbols are present.
+	// Verify known-alive symbols are absent.
 	deadSet := map[string]bool{}
 	for _, s := range rolled {
 		deadSet[s.Qualified] = true
 	}
 
-	// PaymentGateway.Refund is never called in the smoke fixture.
-	if !deadSet["smoke.PaymentGateway.Refund"] {
-		t.Error("expected smoke.PaymentGateway.Refund to be dead")
+	// In a library project (no main), public symbols like Refund are
+	// excluded as potential API surface — even if they're never called.
+	if deadSet["smoke.PaymentGateway.Refund"] {
+		t.Error("smoke.PaymentGateway.Refund should be excluded as library public API")
 	}
 
 	// Verify known-alive symbols are absent.

--- a/testdata/smoke/dead-golden.json
+++ b/testdata/smoke/dead-golden.json
@@ -1,29 +1,9 @@
 {
   "dead": [
     {
-      "qualified": "smoke.CheckoutService",
-      "kind": "class",
-      "file": "checkout.go"
-    },
-    {
-      "qualified": "smoke.ShippingService",
-      "kind": "class",
-      "file": "checkout.go"
-    },
-    {
       "qualified": "LineItem#subtotal",
       "kind": "method",
       "file": "line_item.rb"
-    },
-    {
-      "qualified": "smoke.PaymentGateway.Refund",
-      "kind": "method",
-      "file": "payment.go"
-    },
-    {
-      "qualified": "smoke.BaseService.Log",
-      "kind": "method",
-      "file": "service.go"
     },
     {
       "qualified": "Trackable#track_change",
@@ -37,5 +17,5 @@
     }
   ],
   "total_symbols": 31,
-  "dead_count": 7
+  "dead_count": 3
 }


### PR DESCRIPTION
## Problem
Dead code detection surfaces false positives that aren't actually unused: Python dunder methods like `__init__`, public symbols in library-mode projects (libraries don't have a `main` entry point), and methods that implement interface contracts.

## Summary
Adds three targeted exclusion filters to `excludeEntryPoints` that catch common false positive patterns before they reach the dead report, and refactors `isEntryPoint` to use an `entryPointFilters` struct instead of 7 loose parameters.

## Changes
- **Python dunders:** `__init__`, `__repr__`, `__str__`, etc. are now excluded via the existing `isFrameworkHook` path — matching the Python convention that dunder names are hook points, not dead code
- **Library public API:** Projects without a `main` function are treated as libraries; all public symbols (Go/Rust, which extract visibility) are excluded from dead results as potential API surface
- **Trait impl methods:** Methods whose parent type implements an interface AND whose name matches an interface method name are excluded — these are interface contract implementations, not dead code
- **Refactor:** Extracted 6 lookup maps/bools into an `entryPointFilters` struct, reducing `isEntryPoint` from 7 parameters to 2
- **Ordering:** Moved `excludeEntryPoints` after `findLiveContainers` so excluded methods no longer suppress their container types via the "dead child → live parent" rollup logic

## Test Plan
- [x] `TestDeadCodeExcludesDunderMethods` — dunder methods excluded in Python project
- [x] `TestDeadCodeExcludesLibraryPublicAPI` — public Go symbols excluded in library-mode project
- [x] `TestDeadCodeExcludesTraitImplMethods` — interface impl methods excluded; truly dead helpers still flagged
- [x] `TestDeadCLIIntegration` — `PaymentGateway.Refund` correctly excluded as library public API
- [x] `go test ./internal/dead/...` passes
- [x] `make ci` passes