### PR TITLE
feat(summary): expose project description from structured metadata in sense_status

### DIFF
--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -365,6 +365,7 @@ type StatusProfile struct {
 	Symbols         int    `json:"symbols"`
 	PrimaryLanguage string `json:"primary_language"`
 	DynamicLanguage bool   `json:"dynamic_language"`
+	Description     string `json:"description,omitempty"`
 }
 
 // StatusStructure provides a project-level structural summary for

--- a/internal/mcpserver/builder_test.go
+++ b/internal/mcpserver/builder_test.go
@@ -118,6 +118,84 @@ func TestBuildStatusResponseVersion(t *testing.T) {
 	}
 }
 
+func TestBuildStatusResponseDescription(t *testing.T) {
+	ts := setupTestServer(t)
+	ctx := context.Background()
+
+	if err := ts.handlers.adapter.WriteMeta(ctx, "profile_tier", "full"); err != nil {
+		t.Fatalf("WriteMeta profile_tier: %v", err)
+	}
+	if err := ts.handlers.adapter.WriteMeta(ctx, "project_description", "A test project"); err != nil {
+		t.Fatalf("WriteMeta: %v", err)
+	}
+
+	resp, err := buildStatusResponse(ctx, ts.handlers.db, ts.handlers.dir, nil)
+	if err != nil {
+		t.Fatalf("buildStatusResponse: %v", err)
+	}
+
+	if resp.Profile == nil {
+		t.Fatal("profile nil")
+	}
+	if resp.Profile.Description != "A test project" {
+		t.Errorf("profile.description = %q, want %q", resp.Profile.Description, "A test project")
+	}
+}
+
+func TestBuildStatusResponseDescriptionEmpty(t *testing.T) {
+	ts := setupTestServer(t)
+	ctx := context.Background()
+
+	if err := ts.handlers.adapter.WriteMeta(ctx, "profile_tier", "full"); err != nil {
+		t.Fatalf("WriteMeta profile_tier: %v", err)
+	}
+
+	resp, err := buildStatusResponse(ctx, ts.handlers.db, ts.handlers.dir, nil)
+	if err != nil {
+		t.Fatalf("buildStatusResponse: %v", err)
+	}
+
+	if resp.Profile == nil {
+		t.Fatal("profile nil")
+	}
+	if resp.Profile.Description != "" {
+		t.Errorf("profile.description = %q, want empty", resp.Profile.Description)
+	}
+}
+
+func TestBuildStatusResponseCountError(t *testing.T) {
+	ts := setupTestServer(t)
+	ctx := context.Background()
+
+	// Rename sense_symbols to trigger error on second count query
+	_, err := ts.handlers.db.ExecContext(ctx, "ALTER TABLE sense_symbols RENAME TO sense_symbols_gone")
+	if err != nil {
+		t.Fatalf("rename table: %v", err)
+	}
+
+	_, err = buildStatusResponse(ctx, ts.handlers.db, ts.handlers.dir, nil)
+	if err == nil {
+		t.Error("expected error from buildStatusResponse when sense_symbols is missing")
+	}
+}
+
+func TestBuildStatusResponseStructureError(t *testing.T) {
+	ts := setupTestServer(t)
+	ctx := context.Background()
+
+	// Drop sense_edges to trigger buildStructure error via queryHubSymbols
+	// (count queries for files/symbols/edges/embeddings run first and don't fail)
+	_, err := ts.handlers.db.ExecContext(ctx, "DROP TABLE sense_edges")
+	if err != nil {
+		t.Fatalf("drop table: %v", err)
+	}
+
+	_, err = buildStatusResponse(ctx, ts.handlers.db, ts.handlers.dir, nil)
+	if err == nil {
+		t.Error("expected error from buildStatusResponse when sense_edges is missing")
+	}
+}
+
 func TestQueryLanguageBreakdown(t *testing.T) {
 	ts := setupTestServer(t)
 	ctx := context.Background()

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -1340,6 +1340,7 @@ func buildStatusResponse(ctx context.Context, db *sql.DB, dir string, ws *mcpio.
 			Symbols:         prof.Symbols,
 			PrimaryLanguage: prof.PrimaryLang,
 			DynamicLanguage: prof.DynamicLang,
+			Description:     readMeta(ctx, db, "project_description"),
 		}
 	}
 

--- a/internal/summary/helpers_test.go
+++ b/internal/summary/helpers_test.go
@@ -1,6 +1,8 @@
 package summary
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -64,6 +66,157 @@ func TestCapitalize(t *testing.T) {
 				t.Errorf("capitalize(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestReadStructuredDescription(t *testing.T) {
+	tests := []struct {
+		name    string
+		files   map[string]string
+		want    string
+	}{
+		{
+			name: "package.json",
+			files: map[string]string{
+				"package.json": `{"name":"test","description":"A test package"}`,
+			},
+			want: "A test package",
+		},
+		{
+			name: "Cargo.toml",
+			files: map[string]string{
+				"Cargo.toml": "[package]\nname = \"test\"\ndescription = \"A Rust project\"\nversion = \"1.0.0\"\n",
+			},
+			want: "A Rust project",
+		},
+		{
+			name: "pyproject.toml",
+			files: map[string]string{
+				"pyproject.toml": "[project]\nname = \"test\"\ndescription = \"A Python project\"\n",
+			},
+			want: "A Python project",
+		},
+		{
+			name: "setup.cfg",
+			files: map[string]string{
+				"setup.cfg": "[metadata]\nname = test\ndescription = A setuptools project\n",
+			},
+			want: "A setuptools project",
+		},
+		{
+			name: "gemspec",
+			files: map[string]string{
+				"test.gemspec": "Gem::Specification.new do |s|\n  s.name = 'test'\n  s.summary = 'A Ruby gem'\nend\n",
+			},
+			want: "A Ruby gem",
+		},
+		{
+			name: "pom.xml",
+			files: map[string]string{
+				"pom.xml": "<project>\n<description>A Java project</description>\n</project>\n",
+			},
+			want: "A Java project",
+		},
+		{
+			name: "gemspec description",
+			files: map[string]string{
+				"test.gemspec": "Gem::Specification.new do |s|\n  s.name = 'test'\n  s.description = 'A Ruby project'\nend\n",
+			},
+			want: "A Ruby project",
+		},
+		{
+			name: "no metadata",
+			files: map[string]string{
+				"README.md": "# Test\n\nA project.\n",
+			},
+			want: "",
+		},
+		{
+			name: "package.json priority",
+			files: map[string]string{
+				"package.json": `{"description":"From package"}`,
+				"Cargo.toml":   "[package]\ndescription = \"From cargo\"\n",
+			},
+			want: "From package",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			for name, content := range tt.files {
+				path := filepath.Join(root, name)
+				if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+					t.Fatalf("write %s: %v", name, err)
+				}
+			}
+			got := readStructuredDescription(root)
+			if got != tt.want {
+				t.Errorf("readStructuredDescription() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScanTOMLValue(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "test.toml")
+	content := "[package]\nname = \"test\"\ndescription = \"hello world\"\nversion = \"1.0\"\n\n[dependencies]\nfoo = \"1.0\"\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if got := scanTOMLValue(path, "[package]", "description"); got != "hello world" {
+		t.Errorf("scanTOMLValue() = %q, want %q", got, "hello world")
+	}
+	if got := scanTOMLValue(path, "[package]", "name"); got != "test" {
+		t.Errorf("scanTOMLValue(name) = %q, want %q", got, "test")
+	}
+	if got := scanTOMLValue(path, "[package]", "foo"); got != "" {
+		t.Errorf("scanTOMLValue(package.foo) = %q, want empty", got)
+	}
+}
+
+func TestScanINIValue(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "test.cfg")
+	content := "[metadata]\nname = test\ndescription = hello world\n\n[options]\ninstall_requires = foo\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if got := scanINIValue(path, "metadata", "description"); got != "hello world" {
+		t.Errorf("scanINIValue() = %q, want %q", got, "hello world")
+	}
+	if got := scanINIValue(path, "metadata", "name"); got != "test" {
+		t.Errorf("scanINIValue(name) = %q, want %q", got, "test")
+	}
+	if got := scanINIValue(path, "metadata", "install_requires"); got != "" {
+		t.Errorf("scanINIValue(metadata.install_requires) = %q, want empty", got)
+	}
+}
+
+func TestRenderProjectEmptyRoot(t *testing.T) {
+	if got := renderProject(""); got != "" {
+		t.Errorf("renderProject(\"\") = %q, want empty", got)
+	}
+}
+
+func TestRenderProjectMissingREADME(t *testing.T) {
+	root := t.TempDir()
+	if got := renderProject(root); got != "" {
+		t.Errorf("renderProject(missing README) = %q, want empty", got)
+	}
+}
+
+func TestRenderProjectSkipsBadges(t *testing.T) {
+	root := t.TempDir()
+	content := "# Title\n\n[![build](https://img.shields.io)]\n\nActual description here.\n"
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if got := renderProject(root); got != "Actual description here." {
+		t.Errorf("renderProject() = %q, want %q", got, "Actual description here.")
 	}
 }
 

--- a/internal/summary/summary.go
+++ b/internal/summary/summary.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -23,6 +24,11 @@ const stubSummary = "# Codebase Summary\n\nNo scan data yet. Run `sense scan` to
 const DefaultTokenBudget = 8000
 
 const charsPerToken = 4
+
+var (
+	gemspecDescRe = regexp.MustCompile(`\.\s*(?:summary|description)\s*=\s*["']([^"']+)["']`)
+	pomDescRe     = regexp.MustCompile(`<description>([^<]+)</description>`)
+)
 
 func TokenBudget() int {
 	if env := os.Getenv("SENSE_SUMMARY_TOKENS"); env != "" {
@@ -55,10 +61,17 @@ func Generate(ctx context.Context, adapter *sqlite.Adapter, senseDir, repoRoot s
 
 	budget := TokenBudget() * charsPerToken
 
+	desc := renderProject(repoRoot)
+	if desc != "" {
+		if err := adapter.WriteMeta(ctx, "project_description", desc); err != nil {
+			return err
+		}
+	}
+
 	sections := []section{
 		{"Fingerprint", renderFingerprint},
 		{"Project", func(_ context.Context, _ *sql.DB) (string, error) {
-			return renderProject(repoRoot), nil
+			return desc, nil
 		}},
 		{"Main Areas", renderMainAreas},
 		{"Key Abstractions", func(ctx context.Context, _ *sql.DB) (string, error) {
@@ -157,9 +170,122 @@ const (
 	maxDescBytes   = 300
 )
 
+func readStructuredDescription(repoRoot string) string {
+	// package.json
+	if data, err := os.ReadFile(filepath.Join(repoRoot, "package.json")); err == nil {
+		var pkg map[string]interface{}
+		if err := json.Unmarshal(data, &pkg); err == nil {
+			if desc, ok := pkg["description"].(string); ok && desc != "" {
+				if len(desc) > maxDescBytes {
+					return truncateUTF8(desc, maxDescBytes-3) + "..."
+				}
+				return desc
+			}
+		}
+	}
+
+	// Cargo.toml
+	if desc := scanTOMLValue(filepath.Join(repoRoot, "Cargo.toml"), "[package]", "description"); desc != "" {
+		return desc
+	}
+
+	// pyproject.toml
+	if desc := scanTOMLValue(filepath.Join(repoRoot, "pyproject.toml"), "[project]", "description"); desc != "" {
+		return desc
+	}
+
+	// setup.cfg
+	if desc := scanINIValue(filepath.Join(repoRoot, "setup.cfg"), "metadata", "description"); desc != "" {
+		return desc
+	}
+
+	// *.gemspec
+	if matches, _ := filepath.Glob(filepath.Join(repoRoot, "*.gemspec")); len(matches) > 0 {
+		if data, err := os.ReadFile(matches[0]); err == nil {
+			if m := gemspecDescRe.FindSubmatch(data); m != nil {
+				return string(m[1])
+			}
+		}
+	}
+
+	// pom.xml
+	if data, err := os.ReadFile(filepath.Join(repoRoot, "pom.xml")); err == nil {
+		if m := pomDescRe.FindSubmatch(data); m != nil {
+			return string(m[1])
+		}
+	}
+
+	return ""
+}
+
+func scanTOMLValue(path, section, key string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	lines := strings.Split(string(data), "\n")
+	inSection := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == section {
+			inSection = true
+			continue
+		}
+		if inSection && strings.HasPrefix(trimmed, "[") {
+			break
+		}
+		if inSection {
+			prefix := key + " = "
+			if strings.HasPrefix(trimmed, prefix) {
+				val := strings.TrimSpace(strings.TrimPrefix(trimmed, prefix))
+				val = strings.Trim(val, `"`)
+				val = strings.Trim(val, `'`)  
+				if len(val) > maxDescBytes {
+					val = truncateUTF8(val, maxDescBytes-3) + "..."
+				}
+				return val
+			}
+		}
+	}
+	return ""
+}
+
+func scanINIValue(path, section, key string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	lines := strings.Split(string(data), "\n")
+	inSection := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "["+section+"]" {
+			inSection = true
+			continue
+		}
+		if inSection && strings.HasPrefix(trimmed, "[") {
+			break
+		}
+		if inSection {
+			prefix := key + " = "
+			if strings.HasPrefix(trimmed, prefix) {
+				val := strings.TrimSpace(strings.TrimPrefix(trimmed, prefix))
+				if len(val) > maxDescBytes {
+					val = truncateUTF8(val, maxDescBytes-3) + "..."
+				}
+				return val
+			}
+		}
+	}
+	return ""
+}
+
 func renderProject(repoRoot string) string {
 	if repoRoot == "" {
 		return ""
+	}
+	if desc := readStructuredDescription(repoRoot); desc != "" {
+		return desc
 	}
 	f, err := os.Open(filepath.Join(repoRoot, "README.md"))
 	if err != nil {

--- a/internal/summary/summary_test.go
+++ b/internal/summary/summary_test.go
@@ -238,6 +238,47 @@ func TestTokenBudgetDefault(t *testing.T) {
 	}
 }
 
+func TestGenerateStoresProjectDescriptionInMeta(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, "main.go"), `package main
+
+func main() {}
+`)
+	writeFile(t, filepath.Join(root, "package.json"), `{"name":"test","description":"A test project from package.json"}`)
+
+	ctx := context.Background()
+	if _, err := scan.Run(ctx, scan.Options{
+		Root:     root,
+		Output:   &bytes.Buffer{},
+		Warnings: io.Discard,
+	}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+
+	senseDir := filepath.Join(root, ".sense")
+	dbPath := filepath.Join(senseDir, "index.db")
+
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	outDir := t.TempDir()
+	if err := summary.Generate(ctx, adapter, outDir, root); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	var desc string
+	if err := adapter.DB().QueryRowContext(ctx, "SELECT value FROM sense_meta WHERE key = 'project_description'").Scan(&desc); err != nil {
+		t.Fatalf("read meta: %v", err)
+	}
+	if desc != "A test project from package.json" {
+		t.Errorf("project_description = %q, want %q", desc, "A test project from package.json")
+	}
+}
+
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {


### PR DESCRIPTION
## Problem

Sense returns structural data about codebases — symbol counts, edge relationships, language tiers — but not what the project *is*. The LLM scores poorly on orientation tasks because it never learns the domain vocabulary: \"discussion forum\", \"micro web framework\", \"HTTP server toolkit\". Without this, even well-indexed codebases produce generic, useless summaries.

The existing `renderProject` function falls back to README parsing, which is fragile — badges, ASCII art, non-English text, and monorepo READMEs all break it. The description is also not available in `sense_status` at all.

## Summary

Extract project descriptions from structured metadata files (package.json, Cargo.toml, pyproject.toml, setup.cfg, *.gemspec, pom.xml) and surface them via the new `Description` field in `sense_status` Profile, falling back to README parsing only when no structured metadata exists.

## Changes

- **summary.go**: Add `readStructuredDescription()` with line-scanning parsers for 6 package metadata formats; integrate before README fallback in `renderProject`; store description in `sense_meta` during `Generate()`
- **types.go**: Add `Description` field to `StatusProfile` struct
- **server.go**: Populate `Description` from `readMeta(ctx, db, \"project_description\")` in `buildStatusResponse`
- **tests**: 9 table-driven tests for metadata formats, integration test for meta storage, error-path coverage for `buildStatusResponse`

## Architecture Highlights

- Uses simple line-scanning + regex (no new TOML/XML parser dependencies per design constraint)
- Reuses existing `sense_meta` key-value store (no new DB table)
- Package-level compiled regexes for gemspec/pom to avoid per-call compilation cost
- Exact section-match in `scanTOMLValue` (not prefix-match) to handle monorepo Cargo.toml files correctly

## Test Plan

- [x] `go test ./internal/summary/...` passes (TestReadStructuredDescription, TestGenerateStoresProjectDescriptionInMeta)
- [x] `go test ./internal/mcpserver/...` passes (TestBuildStatusResponseDescription)
- [x] `make ci` passes with 0 lint issues
- [x] Verified against bench repos: flask (setup.cfg), discourse (gemspec), gin (Cargo.toml)