### PR TITLE
feat(mcp): add response compaction for large result sets

### DIFF
--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -498,6 +498,7 @@ type SearchResultEntry struct {
 	Snippet    string      `json:"snippet"`
 	References int         `json:"references,omitempty"`
 	Source     string      `json:"source"`
+	Seen       bool        `json:"seen,omitempty"`
 }
 
 // SearchScore is a relative relevance score. Scores are normalized

--- a/internal/mcpserver/compaction_test.go
+++ b/internal/mcpserver/compaction_test.go
@@ -1,0 +1,432 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/internal/mcpio"
+	"github.com/luuuc/sense/internal/metrics"
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/profile"
+	"github.com/luuuc/sense/internal/search"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+func setupCompactionFixture(t *testing.T) *handlers {
+	t.Helper()
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	now := time.Now()
+
+	files := []model.File{
+		{Path: "internal/service/service.go", Language: "go", Hash: "a1", Symbols: 20, IndexedAt: now},
+	}
+	fileIDs := make([]int64, len(files))
+	for i := range files {
+		id, err := adapter.WriteFile(ctx, &files[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		fileIDs[i] = id
+	}
+
+	targetID, _ := adapter.WriteSymbol(ctx, &model.Symbol{
+		FileID: fileIDs[0], Name: "Target", Qualified: "service.Target",
+		Kind: "function", LineStart: 1, LineEnd: 30,
+		Snippet: "func Target() {}",
+	})
+
+	// Create 15 callers to test compaction
+	for i := 0; i < 15; i++ {
+		callerName := fmt.Sprintf("Caller%d", i)
+		callerID, _ := adapter.WriteSymbol(ctx, &model.Symbol{
+			FileID: fileIDs[0], Name: callerName, Qualified: fmt.Sprintf("service.%s", callerName),
+			Kind: "function", LineStart: i + 1, LineEnd: i + 10,
+		})
+		_, err := adapter.WriteEdge(ctx, &model.Edge{
+			SourceID: model.Int64Ptr(callerID), TargetID: targetID, Kind: model.EdgeCalls,
+			FileID: fileIDs[0], Line: intPtr(i + 1), Confidence: 1.0,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tracker := metrics.NewTracker(adapter.DB())
+	t.Cleanup(func() { tracker.Close() })
+
+	return &handlers{
+		adapter:      adapter,
+		db:           adapter.DB(),
+		dir:          dir,
+		search:       search.NewEngine(adapter, nil, nil),
+		tracker:      tracker,
+		defaults:     profile.DefaultParams(),
+		seenSymbols:  make(map[int64]bool),
+	}
+}
+
+func TestCompactCallEdges(t *testing.T) {
+	edges := make([]mcpio.CallEdgeRef, 15)
+	for i := range edges {
+		edges[i] = mcpio.CallEdgeRef{
+			Symbol:    fmt.Sprintf("Caller%d", i),
+			LineStart: i + 1,
+			LineEnd:   i + 5,
+		}
+	}
+
+	compactCallEdges(edges)
+
+	for i := 0; i < 10; i++ {
+		if edges[i].LineStart == 0 {
+			t.Errorf("entry %d: expected line_start preserved, got 0", i)
+		}
+		if edges[i].LineEnd == 0 {
+			t.Errorf("entry %d: expected line_end preserved, got 0", i)
+		}
+	}
+	for i := 10; i < 15; i++ {
+		if edges[i].LineStart != 0 {
+			t.Errorf("entry %d: expected line_start stripped, got %d", i, edges[i].LineStart)
+		}
+		if edges[i].LineEnd != 0 {
+			t.Errorf("entry %d: expected line_end stripped, got %d", i, edges[i].LineEnd)
+		}
+	}
+}
+
+func TestCompactDispatchInferred(t *testing.T) {
+	edges := make([]mcpio.DispatchInferredRef, 15)
+	for i := range edges {
+		edges[i] = mcpio.DispatchInferredRef{
+			Symbol:    fmt.Sprintf("Caller%d", i),
+			LineStart: i + 1,
+			LineEnd:   i + 5,
+		}
+	}
+
+	compactDispatchInferred(edges)
+
+	for i := 0; i < 10; i++ {
+		if edges[i].LineStart == 0 {
+			t.Errorf("entry %d: expected line_start preserved, got 0", i)
+		}
+		if edges[i].LineEnd == 0 {
+			t.Errorf("entry %d: expected line_end preserved, got 0", i)
+		}
+	}
+	for i := 10; i < 15; i++ {
+		if edges[i].LineStart != 0 {
+			t.Errorf("entry %d: expected line_start stripped, got %d", i, edges[i].LineStart)
+		}
+		if edges[i].LineEnd != 0 {
+			t.Errorf("entry %d: expected line_end stripped, got %d", i, edges[i].LineEnd)
+		}
+	}
+}
+
+func TestHandleGraphCompactsEdges(t *testing.T) {
+	h := setupCompactionFixture(t)
+	ctx := context.Background()
+
+	result, err := h.handleGraph(ctx, toolReq(map[string]any{
+		"symbol": "service.Target",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", resultText(t, result))
+	}
+
+	text := resultText(t, result)
+	var resp mcpio.GraphResponse
+	if err := json.Unmarshal([]byte(text), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(resp.Edges.CalledBy) < 15 {
+		t.Fatalf("expected at least 15 callers, got %d", len(resp.Edges.CalledBy))
+	}
+
+	for i, edge := range resp.Edges.CalledBy {
+		if i < 10 && edge.LineStart == 0 {
+			t.Errorf("called_by entry %d: expected line_start preserved", i)
+		}
+		if i >= 10 && edge.LineStart != 0 {
+			t.Errorf("called_by entry %d: expected line_start stripped", i)
+		}
+	}
+}
+
+func TestHandleSearchStripsSnippets(t *testing.T) {
+	ts := setupTestServer(t)
+	h := ts.handlers
+	ctx := context.Background()
+
+	result, err := h.handleSearch(ctx, toolReq(map[string]any{
+		"query": "auth",
+		"limit": 10,
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", resultText(t, result))
+	}
+
+	text := resultText(t, result)
+	var resp mcpio.SearchResponse
+	if err := json.Unmarshal([]byte(text), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	for i, result := range resp.Results {
+		if i < 5 && result.Snippet == "" {
+			t.Errorf("result %d: expected snippet for top 5, got empty", i)
+		}
+		if i >= 5 && result.Snippet != "" {
+			t.Errorf("result %d: expected no snippet for results 6+, got %q", i, result.Snippet)
+		}
+	}
+}
+
+func TestHandleSearchSessionDedup(t *testing.T) {
+	ts := setupTestServer(t)
+	h := ts.handlers
+	ctx := context.Background()
+
+	// First search
+	result1, err := h.handleSearch(ctx, toolReq(map[string]any{
+		"query": "Verify",
+		"limit": 10,
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result1.IsError {
+		t.Fatalf("unexpected error: %s", resultText(t, result1))
+	}
+
+	var resp1 mcpio.SearchResponse
+	if err := json.Unmarshal([]byte(resultText(t, result1)), &resp1); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// Second search with overlapping results
+	result2, err := h.handleSearch(ctx, toolReq(map[string]any{
+		"query": "auth",
+		"limit": 10,
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result2.IsError {
+		t.Fatalf("unexpected error: %s", resultText(t, result2))
+	}
+
+	var resp2 mcpio.SearchResponse
+	if err := json.Unmarshal([]byte(resultText(t, result2)), &resp2); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// Find symbols that appeared in both searches
+	seenSymbols := make(map[string]bool)
+	for _, r := range resp1.Results {
+		seenSymbols[r.Symbol] = true
+	}
+
+	var foundDedup bool
+	for _, r := range resp2.Results {
+		if seenSymbols[r.Symbol] {
+			if !r.Seen {
+				t.Errorf("symbol %q appeared in first search but not marked seen", r.Symbol)
+			}
+			if r.Snippet != "" {
+				t.Errorf("symbol %q should have snippet stripped when seen", r.Symbol)
+			}
+			foundDedup = true
+		}
+	}
+
+	if !foundDedup {
+		t.Skip("no overlapping symbols between searches — dedup not testable with this fixture")
+	}
+}
+
+func TestHandleGraphTracksSeenSymbols(t *testing.T) {
+	ts := setupTestServer(t)
+	h := ts.handlers
+	ctx := context.Background()
+
+	result1, err := h.handleGraph(ctx, toolReq(map[string]any{
+		"symbol": "auth.Verify",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result1.IsError {
+		t.Fatalf("unexpected error: %s", resultText(t, result1))
+	}
+
+	// auth.Verify should now be in seenSymbols
+	if !h.seenSymbols[ts.symbols["auth.Verify"]] {
+		t.Error("expected auth.Verify to be tracked in seenSymbols after graph call")
+	}
+}
+
+func TestConventionsKeySymbolsLimit(t *testing.T) {
+	ts := setupTestServer(t)
+	h := ts.handlers
+	ctx := context.Background()
+
+	result, err := h.handleConventions(ctx, toolReq(map[string]any{}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", resultText(t, result))
+	}
+
+	var resp mcpio.ConventionsResponse
+	if err := json.Unmarshal([]byte(resultText(t, result)), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(resp.KeySymbols) > 8 {
+		t.Errorf("expected at most 8 key symbols, got %d", len(resp.KeySymbols))
+	}
+}
+
+func TestHandleGraphWithDispatchInferred(t *testing.T) {
+	// Setup interface dispatch fixture similar to dispatch_test.go
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	now := time.Now()
+	files := []model.File{
+		{Path: "iface.go", Language: "go", Hash: "abc", Symbols: 3, IndexedAt: now},
+		{Path: "caller.go", Language: "go", Hash: "def", Symbols: 2, IndexedAt: now},
+	}
+	fileIDs := make([]int64, len(files))
+	for i := range files {
+		id, err := adapter.WriteFile(ctx, &files[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+		fileIDs[i] = id
+	}
+
+	// Interface I with method M
+	ifaceID, _ := adapter.WriteSymbol(ctx, &model.Symbol{
+		FileID: fileIDs[0], Name: "I", Qualified: "pkg.I",
+		Kind: "interface", LineStart: 1, LineEnd: 10,
+	})
+	methodID, _ := adapter.WriteSymbol(ctx, &model.Symbol{
+		FileID: fileIDs[0], Name: "M", Qualified: "pkg.I.M",
+		Kind: "method", LineStart: 2, LineEnd: 5, ParentID: &ifaceID,
+	})
+
+	// Struct S implementing I, with method M
+	structID, _ := adapter.WriteSymbol(ctx, &model.Symbol{
+		FileID: fileIDs[0], Name: "S", Qualified: "pkg.S",
+		Kind: "class", LineStart: 20, LineEnd: 40,
+	})
+	structMethodID, _ := adapter.WriteSymbol(ctx, &model.Symbol{
+		FileID: fileIDs[0], Name: "M", Qualified: "pkg.S.M",
+		Kind: "method", LineStart: 22, LineEnd: 30, ParentID: &structID,
+	})
+
+	// S inherits I
+	_, err = adapter.WriteEdge(ctx, &model.Edge{
+		SourceID: model.Int64Ptr(structID), TargetID: ifaceID, Kind: model.EdgeInherits,
+		FileID: fileIDs[0], Confidence: 1.0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// F calls S.M (caller of the struct method)
+	funcID, _ := adapter.WriteSymbol(ctx, &model.Symbol{
+		FileID: fileIDs[1], Name: "F", Qualified: "pkg.F",
+		Kind: "function", LineStart: 1, LineEnd: 5,
+	})
+	_, err = adapter.WriteEdge(ctx, &model.Edge{
+		SourceID: model.Int64Ptr(funcID), TargetID: structMethodID, Kind: model.EdgeCalls,
+		FileID: fileIDs[1], Confidence: 1.0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// G calls I.M (caller through the interface)
+	func2ID, _ := adapter.WriteSymbol(ctx, &model.Symbol{
+		FileID: fileIDs[1], Name: "G", Qualified: "pkg.G",
+		Kind: "function", LineStart: 10, LineEnd: 15,
+	})
+	_, err = adapter.WriteEdge(ctx, &model.Edge{
+		SourceID: model.Int64Ptr(func2ID), TargetID: methodID, Kind: model.EdgeCalls,
+		FileID: fileIDs[1], Confidence: 1.0,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tracker := metrics.NewTracker(adapter.DB())
+	defer tracker.Close()
+
+	h := &handlers{
+		adapter:     adapter,
+		db:          adapter.DB(),
+		dir:         dir,
+		search:      search.NewEngine(adapter, nil, nil),
+		tracker:     tracker,
+		defaults:    profile.DefaultParams(),
+		seenSymbols: make(map[int64]bool),
+	}
+
+	result, err := h.handleGraph(ctx, toolReq(map[string]any{
+		"symbol": "pkg.I.M",
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", resultText(t, result))
+	}
+
+	text := resultText(t, result)
+	var resp mcpio.GraphResponse
+	if err := json.Unmarshal([]byte(text), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(resp.DispatchInferred) == 0 {
+		t.Error("expected dispatch_inferred to be populated")
+	}
+}

--- a/internal/mcpserver/handler_conventions_test.go
+++ b/internal/mcpserver/handler_conventions_test.go
@@ -92,11 +92,12 @@ func setupHandlerFixture(t *testing.T) *handlers {
 	t.Cleanup(func() { tracker.Close() })
 
 	return &handlers{
-		adapter:  adapter,
-		db:       adapter.DB(),
-		dir:      dir,
-		tracker:  tracker,
-		defaults: profile.DefaultParams(),
+		adapter:     adapter,
+		db:          adapter.DB(),
+		dir:         dir,
+		tracker:     tracker,
+		defaults:    profile.DefaultParams(),
+		seenSymbols: make(map[int64]bool),
 	}
 }
 

--- a/internal/mcpserver/handler_test.go
+++ b/internal/mcpserver/handler_test.go
@@ -129,12 +129,13 @@ func setupTestServer(t *testing.T) *testServer {
 	t.Cleanup(func() { tracker.Close() })
 
 	h := &handlers{
-		adapter:  adapter,
-		db:       adapter.DB(),
-		dir:      dir,
-		search:   engine,
-		tracker:  tracker,
-		defaults: profile.DefaultParams(),
+		adapter:     adapter,
+		db:          adapter.DB(),
+		dir:         dir,
+		search:      engine,
+		tracker:     tracker,
+		defaults:    profile.DefaultParams(),
+		seenSymbols: make(map[int64]bool),
 	}
 
 	return &testServer{handlers: h, symbols: symIDs, files: fileIDs}

--- a/internal/mcpserver/helpers_test.go
+++ b/internal/mcpserver/helpers_test.go
@@ -691,6 +691,12 @@ func TestHandleSearchTextFallback(t *testing.T) {
 	ts := setupTestServer(t)
 	ctx := context.Background()
 
+	// Create a source file with text that matches the query
+	authFile := filepath.Join(ts.handlers.dir, "auth_helper.go")
+	if err := os.WriteFile(authFile, []byte("package main\n\n// auth helper function\nfunc authHelper() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
 	// Enable text fallback if ripgrep is available.
 	tf := search.NewTextFallback()
 	if !tf.Available() {
@@ -707,6 +713,29 @@ func TestHandleSearchTextFallback(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatal("handleSearch returned nil result")
+	}
+
+	text := resultText(t, result)
+	var resp mcpio.SearchResponse
+	if err := json.Unmarshal([]byte(text), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// Verify text fallback fired by checking mode
+	if !strings.Contains(resp.SearchMode, "+text") {
+		t.Errorf("expected search mode to contain '+text', got %q", resp.SearchMode)
+	}
+
+	// Verify text fallback results were added
+	var hasTextResult bool
+	for _, r := range resp.Results {
+		if r.Source == "text" {
+			hasTextResult = true
+			break
+		}
+	}
+	if !hasTextResult {
+		t.Error("expected at least one text fallback result")
 	}
 }
 
@@ -823,6 +852,30 @@ func TestCountStaleFilesWithMtime(t *testing.T) {
 	}
 	if maxMtime == nil {
 		t.Fatal("expected non-nil maxMtime when stale files exist")
+	}
+}
+
+func TestCountStaleFilesClosedDB(t *testing.T) {
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "closed.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Close DB before calling countStaleFiles
+	_ = adapter.Close()
+
+	count, maxMtime := countStaleFiles(ctx, adapter.DB(), dir)
+	if count != 0 {
+		t.Errorf("expected 0 stale files with closed DB, got %d", count)
+	}
+	if maxMtime != nil {
+		t.Error("expected nil maxMtime with closed DB")
 	}
 }
 

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 	"unicode"
 	"unicode/utf8"
@@ -48,6 +49,11 @@ const (
 	// Caps to bound query-time work when an interface has many implementors.
 	maxDispatchEquivalents = 20
 	maxDispatchInferred    = 50
+
+	// Response compaction thresholds (pitch 22-05).
+	compactEdgeKeepCount  = 10 // keep full line details for first N edges
+	snippetStripThreshold = 5  // strip snippets from results beyond this index
+	keySymbolsLimit       = 8  // max key symbols in conventions response
 )
 
 // RunOptions configures the MCP server.
@@ -199,7 +205,7 @@ func buildMCPServer(opts RunOptions) (*server.MCPServer, *handlers, func(), erro
 
 	textFallback := search.NewTextFallback()
 
-	h := &handlers{adapter: adapter, db: adapter.DB(), dir: dir, search: engine, textFallback: textFallback, watchState: opts.WatchState, tracker: tracker, defaults: defaults}
+	h := &handlers{adapter: adapter, db: adapter.DB(), dir: dir, search: engine, textFallback: textFallback, watchState: opts.WatchState, tracker: tracker, defaults: defaults, seenSymbols: make(map[int64]bool)}
 
 	s.AddTool(searchTool(), h.handleSearch)
 	s.AddTool(graphTool(), h.handleGraph)
@@ -235,6 +241,8 @@ type handlers struct {
 	watchState   *mcpio.WatchState
 	tracker      *metrics.Tracker
 	defaults     profile.Defaults
+	seenSymbols  map[int64]bool
+	seenMu       sync.Mutex
 }
 
 // ---------------------------------------------------------------
@@ -429,6 +437,20 @@ func (h *handlers) handleGraph(ctx context.Context, req mcp.CallToolRequest) (*m
 		}
 	}
 
+	if len(resp.Edges.CalledBy) > compactEdgeKeepCount {
+		compactCallEdges(resp.Edges.CalledBy)
+	}
+	if len(resp.Edges.Calls) > compactEdgeKeepCount {
+		compactCallEdges(resp.Edges.Calls)
+	}
+	if len(resp.DispatchInferred) > compactEdgeKeepCount {
+		compactDispatchInferred(resp.DispatchInferred)
+	}
+
+	h.seenMu.Lock()
+	h.seenSymbols[gr.Root.Symbol.ID] = true
+	h.seenMu.Unlock()
+
 	h.tracker.Record("sense_graph", symbol,
 		resp.SenseMetrics.EstimatedFileReadsAvoided, resp.SenseMetrics.EstimatedTokensSaved, false)
 
@@ -511,6 +533,20 @@ func qualifiedOrNameRef(s model.Symbol) string {
 		return s.Qualified
 	}
 	return s.Name
+}
+
+func compactCallEdges(edges []mcpio.CallEdgeRef) {
+	for i := compactEdgeKeepCount; i < len(edges); i++ {
+		edges[i].LineStart = 0
+		edges[i].LineEnd = 0
+	}
+}
+
+func compactDispatchInferred(edges []mcpio.DispatchInferredRef) {
+	for i := compactEdgeKeepCount; i < len(edges); i++ {
+		edges[i].LineStart = 0
+		edges[i].LineEnd = 0
+	}
 }
 
 func graphHints(resp mcpio.GraphResponse, direction model.Direction) []mcpio.NextStep {
@@ -646,6 +682,16 @@ func (h *handlers) handleSearch(ctx context.Context, req mcp.CallToolRequest) (*
 			References: r.References,
 			Source:     "structural",
 		}
+		h.seenMu.Lock()
+		if h.seenSymbols[r.SymbolID] {
+			entries[i].Seen = true
+			entries[i].Snippet = ""
+		}
+		if i >= snippetStripThreshold {
+			entries[i].Snippet = ""
+		}
+		h.seenSymbols[r.SymbolID] = true
+		h.seenMu.Unlock()
 		if path != "" {
 			uniqueFiles[path] = struct{}{}
 		}
@@ -1094,7 +1140,7 @@ func (h *handlers) handleConventions(ctx context.Context, req mcp.CallToolReques
 		return nil, fmt.Errorf("sense_conventions: %w", err)
 	}
 
-	keyEntries, err := buildKeyEntries(ctx, h.adapter, domain, 15)
+	keyEntries, err := buildKeyEntries(ctx, h.adapter, domain, keySymbolsLimit)
 	if err != nil {
 		return nil, fmt.Errorf("sense_conventions: key symbols: %w", err)
 	}


### PR DESCRIPTION
## Problem
The MCP server can return large, verbose responses when dealing with symbols that have many callers, callees, or search results. These large responses strain LLM context windows and increase token costs unnecessarily.

## Summary
Adds response compaction at three points: graph edge line numbers, search result snippets, and conventions key symbol limits. Previously-seen symbols in a session are marked with a `Seen` flag and their snippets stripped.

## Changes
- **Schema**: Add `Seen` field to `SearchResultEntry` for client-side dedup signaling
- **Graph compaction**: Zero out line numbers beyond the first 10 edges in `CalledBy`, `Calls`, and `DispatchInferred` responses
- **Search compaction**: Strip snippets from results at index 5+ and from any previously-seen symbol within the session
- **Conventions**: Reduce key symbol limit from 15 to 8
- **Tests**: Add 7 new tests covering compaction behavior, session dedup, and edge cases

## Breaking Changes
None.

## Test Plan
- [x] `go test ./internal/mcpserver/...` passes
- [x] `go test -race ./internal/mcpserver/...` passes (session dedup race safety)
- [x] `make ci` passes
- [x] Compacted edges retain symbol, file, and line info for the first 10 entries