### PR TITLE
feat(mcpserver): add coverage_note to list-type responses

### DIFF
--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -102,6 +102,7 @@ type GraphResponse struct {
 	Layers             []GraphLayer           `json:"layers,omitempty"`
 	Truncated          bool                   `json:"truncated,omitempty"`
 	TestCallerSummary  *TestCallerSummary     `json:"test_caller_summary,omitempty"`
+	CoverageNote       string                 `json:"coverage_note,omitempty"`
 	SenseMetrics       GraphMetrics           `json:"-"`
 	Freshness          *Freshness             `json:"freshness,omitempty"`
 	NextSteps          []NextStep             `json:"next_steps"`
@@ -274,9 +275,10 @@ type BlastResponse struct {
 	// Tier 3 — affected test count (detail omitted to keep response focused).
 	TestsAffectedCount int `json:"tests_affected_count"`
 
-	ProductionAffected int  `json:"production_affected"`
-	TestAffected       int  `json:"test_affected"`
-	Truncated          bool `json:"truncated,omitempty"`
+	ProductionAffected int    `json:"production_affected"`
+	TestAffected       int    `json:"test_affected"`
+	Truncated          bool   `json:"truncated,omitempty"`
+	CoverageNote       string `json:"coverage_note,omitempty"`
 
 	SenseMetrics BlastMetrics `json:"-"`
 	Freshness    *Freshness   `json:"freshness,omitempty"`
@@ -531,6 +533,7 @@ type DeadCodeResponse struct {
 	TotalSymbols int               `json:"total_symbols"`
 	DeadCount    int               `json:"dead_count"`
 	Note         string            `json:"note,omitempty"`
+	CoverageNote string            `json:"coverage_note,omitempty"`
 	SenseMetrics DeadCodeMetrics   `json:"-"`
 	NextSteps    []NextStep        `json:"next_steps"`
 }

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -454,6 +454,10 @@ func (h *handlers) handleGraph(ctx context.Context, req mcp.CallToolRequest) (*m
 	h.tracker.Record("sense_graph", symbol,
 		resp.SenseMetrics.EstimatedFileReadsAvoided, resp.SenseMetrics.EstimatedTokensSaved, false)
 
+	if len(resp.Edges.CalledBy) > 10 {
+		resp.CoverageNote = "Graph edges from indexed source files — may miss callers in examples/, scripts/, or macro-generated code"
+	}
+
 	freshness := computeFreshness(ctx, h.db, h.dir, false, h.watchState)
 	resp.Freshness = freshness
 	resp.NextSteps = graphHints(resp, direction)
@@ -599,6 +603,7 @@ func (h *handlers) handleDeadCode(ctx context.Context, req mcp.CallToolRequest) 
 
 	rolled := dead.Rollup(result.Dead)
 	resp := mcpio.BuildDeadCodeResponse(rolled, result.TotalSymbols)
+	resp.CoverageNote = "Static analysis — does not trace dynamic dispatch, decorator registration, or external API consumers"
 
 	h.tracker.Record("sense_graph", "dead_code",
 		resp.SenseMetrics.EstimatedFileReadsAvoided, resp.SenseMetrics.EstimatedTokensSaved, false)
@@ -834,6 +839,8 @@ func (h *handlers) handleBlast(ctx context.Context, req mcp.CallToolRequest) (*m
 	if diff != "" {
 		blastArgs = diff
 	}
+	resp.CoverageNote = "Follows static call edges — does not trace reflection, runtime plugins, or cross-repo consumers"
+
 	h.tracker.Record("sense_blast", blastArgs,
 		resp.SenseMetrics.EstimatedFileReadsAvoided, resp.SenseMetrics.EstimatedTokensSaved, false)
 

--- a/internal/setup/marker.go
+++ b/internal/setup/marker.go
@@ -49,6 +49,8 @@ Sense gives you structural understanding of the codebase — symbols, relationsh
 - **Debugging** → ` + "`sense_search`" + `
 - **Refactoring** → ` + "`sense_conventions`" + ` + ` + "`sense_graph`" + `
 
+**Verify list results:** For list outputs (dead code, blast radius, callers), verify a sample with grep before finalizing — static analysis may miss dynamic dispatch or cross-boundary usage.
+
 **When NOT to use Sense** (use grep instead):
 
 - Exact text/string search (regex, log messages, string literals)


### PR DESCRIPTION
## Problem

LLMs treat Sense list outputs (dead code, blast radius, callers) as complete and skip verification. Static analysis has known blind spots — dynamic dispatch, reflection, external consumers — that the LLM doesn't know about.

## Summary

- Add `coverage_note` field to `DeadCodeResponse`, `BlastResponse`, and `GraphResponse`
- Dead code: always present, notes dynamic dispatch/decorator blind spots
- Blast: always present, notes reflection/plugin blind spots
- Graph callers: conditional (>10 callers), notes file-scope limitations
- Update CLAUDE.md template with "verify a sample with grep" guidance

## Changes

- `internal/mcpio/types.go` — add `CoverageNote string` field to three response structs
- `internal/mcpserver/server.go` — populate coverage_note in handlers
- `internal/setup/marker.go` — add verification guidance to CLAUDE.md template

## Test plan

- [x] All existing tests pass (`make ci`)
- [x] Coverage ≥90% on modified functions (handleGraph 91.1%, handleDeadCode 92.9%)
- [x] Field uses `omitempty` — no output change for responses without notes