### PR TITLE
feat(search): add substring fallback and path boosting for hybrid search

### DIFF
--- a/internal/search/fusion_internal_test.go
+++ b/internal/search/fusion_internal_test.go
@@ -16,15 +16,15 @@ func TestFusionWeightsHigh(t *testing.T) {
 
 func TestFusionWeightsMedium(t *testing.T) {
 	kw, vec := fusionWeights(0.5)
-	if kw != 0.7 || vec != 0.3 {
-		t.Errorf("fusionWeights(0.5) = (%v, %v), want (0.7, 0.3)", kw, vec)
+	if kw != 0.6 || vec != 0.4 {
+		t.Errorf("fusionWeights(0.5) = (%v, %v), want (0.6, 0.4)", kw, vec)
 	}
 }
 
 func TestFusionWeightsLow(t *testing.T) {
 	kw, vec := fusionWeights(0.2)
-	if kw != 0.8 || vec != 0.2 {
-		t.Errorf("fusionWeights(0.2) = (%v, %v), want (0.8, 0.2)", kw, vec)
+	if kw != 0.7 || vec != 0.3 {
+		t.Errorf("fusionWeights(0.2) = (%v, %v), want (0.7, 0.3)", kw, vec)
 	}
 }
 
@@ -160,5 +160,58 @@ func TestApplyGraphCentralityBoost(t *testing.T) {
 	}
 	if results[1].Score != 1.0 {
 		t.Error("symbol without callers should not be boosted")
+	}
+}
+
+func TestBoostPathMatches(t *testing.T) {
+	results := []sqlite.SearchResult{
+		{SymbolID: 1, FileID: 10, Score: 1.0},
+		{SymbolID: 2, FileID: 20, Score: 1.0},
+		{SymbolID: 3, FileID: 30, Score: 1.0},
+	}
+	paths := map[int64]string{
+		10: "internal/auth/handler.go",
+		20: "internal/search/engine.go",
+		30: "internal/auth/middleware.go",
+	}
+	boostPathMatches(results, []string{"auth"}, paths)
+
+	if results[0].Score != 1.5 {
+		t.Errorf("auth file score = %v, want 1.5", results[0].Score)
+	}
+	if results[1].Score != 1.0 {
+		t.Errorf("non-auth file score = %v, want 1.0", results[1].Score)
+	}
+	if results[2].Score != 1.5 {
+		t.Errorf("auth middleware score = %v, want 1.5", results[2].Score)
+	}
+}
+
+func TestBoostPathMatchesEmpty(_ *testing.T) {
+	boostPathMatches(nil, []string{"auth"}, nil)
+	boostPathMatches([]sqlite.SearchResult{{SymbolID: 1}}, nil, nil)
+}
+
+func TestDeduplicateResults(t *testing.T) {
+	primary := []sqlite.SearchResult{
+		{SymbolID: 1, Score: 2.0},
+		{SymbolID: 2, Score: 1.5},
+	}
+	secondary := []sqlite.SearchResult{
+		{SymbolID: 2, Score: 1.0}, // duplicate
+		{SymbolID: 3, Score: 0.5}, // new
+	}
+	merged := deduplicateResults(primary, secondary)
+	if len(merged) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(merged))
+	}
+	ids := map[int64]bool{}
+	for _, r := range merged {
+		ids[r.SymbolID] = true
+	}
+	for _, id := range []int64{1, 2, 3} {
+		if !ids[id] {
+			t.Errorf("missing symbol ID %d", id)
+		}
 	}
 }

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -164,6 +164,20 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, SearchMeta
 			}
 		}
 
+		kwResults = e.substringFallback(ctx, kwResults, q, opts.Language, candidateLimit)
+
+		queryTerms := strings.Fields(strings.ToLower(q))
+		kwFileIDs := make([]int64, 0, len(kwResults))
+		kwFileSeen := map[int64]struct{}{}
+		for _, r := range kwResults {
+			if _, ok := kwFileSeen[r.FileID]; !ok {
+				kwFileSeen[r.FileID] = struct{}{}
+				kwFileIDs = append(kwFileIDs, r.FileID)
+			}
+		}
+		kwPaths, _ := e.adapter.FilePathsByIDs(ctx, kwFileIDs)
+		boostPathMatches(kwResults, queryTerms, kwPaths)
+
 		qKwWeight, qVecWeight := 1.0, 0.0
 		if canVector {
 			vecConf := vectorConfidence(vecResults)
@@ -304,9 +318,9 @@ func fusionWeights(vecConfidence float64) (keyword, vector float64) {
 	case vecConfidence >= confidenceHighThreshold:
 		return 0.5, 0.5
 	case vecConfidence >= confidenceLowThreshold:
-		return 0.7, 0.3
+		return 0.6, 0.4
 	default:
-		return 0.8, 0.2
+		return 0.7, 0.3
 	}
 }
 
@@ -755,4 +769,48 @@ func (e *Engine) promoteParents(ctx context.Context, results []Result, limit int
 	})
 
 	return out, nil
+}
+
+const substringFallbackThreshold = 5
+
+func (e *Engine) substringFallback(ctx context.Context, kwResults []sqlite.SearchResult, query, language string, limit int) []sqlite.SearchResult {
+	if len(kwResults) >= substringFallbackThreshold {
+		return kwResults
+	}
+	subResults, err := e.adapter.SubstringSearch(ctx, query, language, limit-len(kwResults))
+	if err != nil {
+		return kwResults
+	}
+	return deduplicateResults(kwResults, subResults)
+}
+
+func deduplicateResults(primary, secondary []sqlite.SearchResult) []sqlite.SearchResult {
+	seen := make(map[int64]bool, len(primary))
+	for _, r := range primary {
+		seen[r.SymbolID] = true
+	}
+	out := make([]sqlite.SearchResult, len(primary))
+	copy(out, primary)
+	for _, r := range secondary {
+		if !seen[r.SymbolID] {
+			seen[r.SymbolID] = true
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func boostPathMatches(results []sqlite.SearchResult, queryTerms []string, pathByID map[int64]string) {
+	if len(queryTerms) == 0 || len(results) == 0 {
+		return
+	}
+	for i := range results {
+		path := strings.ToLower(pathByID[results[i].FileID])
+		for _, term := range queryTerms {
+			if strings.Contains(path, term) {
+				results[i].Score *= 1.5
+				break
+			}
+		}
+	}
 }

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -894,15 +894,14 @@ func TestLowConfidenceVectorFloor(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// With the weight floor, vector weight should be exactly 0.2 when
-	// confidence is below the low threshold.
-	if meta.VectorWeight != 0.2 {
-		t.Errorf("vector weight = %v, want 0.2 (floor)", meta.VectorWeight)
+	// With low confidence, vector weight should be 0.3 and keyword 0.7.
+	if meta.VectorWeight != 0.3 {
+		t.Errorf("vector weight = %v, want 0.3", meta.VectorWeight)
 	}
-	if meta.KeywordWeight != 0.8 {
-		t.Errorf("keyword weight = %v, want 0.8", meta.KeywordWeight)
+	if meta.KeywordWeight != 0.7 {
+		t.Errorf("keyword weight = %v, want 0.7", meta.KeywordWeight)
 	}
-	t.Logf("low confidence floor active: kw=%.2f vec=%.2f", meta.KeywordWeight, meta.VectorWeight)
+	t.Logf("low confidence weights: kw=%.2f vec=%.2f", meta.KeywordWeight, meta.VectorWeight)
 }
 
 func TestGraphEnrichmentBoostsCallees(t *testing.T) {

--- a/internal/sqlite/search.go
+++ b/internal/sqlite/search.go
@@ -460,6 +460,50 @@ func (a *Adapter) parentSymbolsBatch(ctx context.Context, batch []int64, out map
 	return rows.Err()
 }
 
+// SubstringSearch runs a LIKE query against the qualified column in
+// sense_symbols as a fallback when FTS5 returns few results. This catches
+// partial name matches like "middleware" finding "applyMiddlewareStack".
+func (a *Adapter) SubstringSearch(ctx context.Context, query string, language string, limit int) ([]SearchResult, error) {
+	if query == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+	escaped := strings.NewReplacer("%", "\\%", "_", "\\_").Replace(strings.ToLower(query))
+	q := `SELECT s.id, s.name, s.qualified, s.kind, s.file_id, s.line_start,
+	             s.snippet, 1.0 AS score
+	      FROM sense_symbols s
+	      JOIN sense_files f ON f.id = s.file_id
+	      WHERE LOWER(s.qualified) LIKE ? ESCAPE '\'`
+	args := []any{"%" + escaped + "%"}
+	if language != "" {
+		q += " AND f.language = ?"
+		args = append(args, language)
+	}
+	q += " LIMIT ?"
+	args = append(args, limit)
+
+	rows, err := a.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite SubstringSearch: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []SearchResult
+	for rows.Next() {
+		var r SearchResult
+		var snippet sql.NullString
+		if err := rows.Scan(&r.SymbolID, &r.Name, &r.Qualified, &r.Kind,
+			&r.FileID, &r.LineStart, &snippet, &r.Score); err != nil {
+			return nil, fmt.Errorf("sqlite SubstringSearch scan: %w", err)
+		}
+		r.Snippet = snippet.String
+		results = append(results, r)
+	}
+	return results, rows.Err()
+}
+
 // sanitizeFTS5Query quotes each whitespace-delimited token so that
 // FTS5 operator characters (*, ", OR, AND, NOT, NEAR, ^, :) in user
 // input are treated as literals. Embedded double-quotes are escaped

--- a/internal/sqlite/search_test.go
+++ b/internal/sqlite/search_test.go
@@ -664,3 +664,54 @@ func TestEmbeddingsForFilesNoMatch(t *testing.T) {
 		t.Errorf("expected empty map for file with no embeddings, got %d", len(got))
 	}
 }
+
+func TestSubstringSearch(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	a, err := sqlite.Open(ctx, filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+	seedSearchIndex(ctx, t, a)
+
+	results, err := a.SubstringSearch(ctx, "Payment", "", 10)
+	if err != nil {
+		t.Fatalf("SubstringSearch: %v", err)
+	}
+	if len(results) < 2 {
+		t.Fatalf("expected at least 2 results for 'Payment', got %d", len(results))
+	}
+	for _, r := range results {
+		if r.Score != 1.0 {
+			t.Errorf("expected score 1.0, got %v", r.Score)
+		}
+	}
+
+	// Language filter
+	results, err = a.SubstringSearch(ctx, "User", "ruby", 10)
+	if err != nil {
+		t.Fatalf("SubstringSearch with language: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result for 'User' in ruby, got %d", len(results))
+	}
+
+	// Empty query returns nil
+	results, err = a.SubstringSearch(ctx, "", "", 10)
+	if err != nil {
+		t.Fatalf("SubstringSearch empty: %v", err)
+	}
+	if results != nil {
+		t.Errorf("expected nil for empty query, got %d results", len(results))
+	}
+
+	// No match
+	results, err = a.SubstringSearch(ctx, "xyznonexistent", "", 10)
+	if err != nil {
+		t.Fatalf("SubstringSearch no match: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for nonexistent, got %d", len(results))
+	}
+}


### PR DESCRIPTION
## Problem

`sense_search` averages 0.36 on semantic-search tasks. The FTS5 keyword search misses substring matches within compound symbol names (e.g., query "middleware" doesn't find `applyMiddlewareStack`) and doesn't boost results from semantically relevant file paths.

## Summary

- Add `SubstringSearch` LIKE fallback when FTS5 returns <5 results
- Add `boostPathMatches` to boost keyword results in matching directories (1.5x score)
- Tune fusion weights: medium 0.7/0.3 → 0.6/0.4, low 0.8/0.2 → 0.7/0.3
- LIKE wildcards (`%`, `_`) properly escaped to prevent injection

## Changes

- `internal/sqlite/search.go` — add `SubstringSearch` with LIKE ESCAPE
- `internal/search/search.go` — add `substringFallback`, `boostPathMatches`, `deduplicateResults`; integrate into search pipeline; update `fusionWeights`
- Tests for all new functionality + updated existing weight tests

## Test plan

- [x] `TestSubstringSearch` — verifies LIKE matching, language filter, empty/no-match cases
- [x] `TestBoostPathMatches` — verifies path-based score boosting
- [x] `TestDeduplicateResults` — verifies dedup by SymbolID
- [x] Updated `TestFusionWeightsMedium`, `TestFusionWeightsLow`, `TestLowConfidenceVectorFloor`
- [x] All existing tests pass (`make ci`)