### PR TITLE
feat(hooks): upgrade hook responses, inject summary, and add subagent Sense awareness

### DIFF
--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -133,21 +133,24 @@ func TestSubagentStartReturnsGuidance(t *testing.T) {
 	}
 }
 
-func TestPreToolUseSymbolMatchAdvises(t *testing.T) {
+func TestPreToolUseSymbolMatchNudges(t *testing.T) {
 	dir := indexedDir(t)
 	input := `{"tool_name":"Grep","tool_input":{"pattern":"UserService"}}`
 	var buf bytes.Buffer
 	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
 
-	var resp hookResponse
+	var resp nudgeResponse
 	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
 		t.Fatalf("parse response: %v", err)
 	}
+	if resp.SystemMessage == "" {
+		t.Fatal("expected non-empty systemMessage for known symbol grep")
+	}
 	if resp.AdditionalContext == "" {
-		t.Fatal("expected advisory context for known symbol")
+		t.Fatal("expected non-empty additionalContext for known symbol grep")
 	}
 	if !strings.Contains(resp.AdditionalContext, "sense_graph") {
-		t.Error("expected sense_graph suggestion in advisory")
+		t.Error("expected sense_graph suggestion in additionalContext")
 	}
 }
 
@@ -188,21 +191,24 @@ func TestPreToolUseNoMatch(t *testing.T) {
 	}
 }
 
-func TestPreToolUseAgentDeny(t *testing.T) {
+func TestPreToolUseAgentNudge(t *testing.T) {
 	dir := indexedDir(t)
 	input := `{"tool_name":"Agent","tool_input":{"subagent_type":"deep-explore","prompt":"find all callers"}}`
 	var buf bytes.Buffer
 	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
 
-	var resp denyResponse
+	var resp nudgeResponse
 	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
 		t.Fatalf("parse response: %v", err)
 	}
-	if resp.Output.Decision != "deny" {
-		t.Fatalf("expected deny decision for deep-explore, got %q", resp.Output.Decision)
+	if resp.SystemMessage == "" {
+		t.Fatal("expected non-empty systemMessage for known explorer")
 	}
-	if !strings.Contains(resp.Output.Reason, "sense_graph") {
-		t.Error("expected sense_graph in deny reason")
+	if resp.AdditionalContext == "" {
+		t.Fatal("expected non-empty additionalContext for known explorer")
+	}
+	if !strings.Contains(resp.AdditionalContext, "sense_graph") {
+		t.Error("expected sense_graph in additionalContext")
 	}
 }
 
@@ -217,37 +223,57 @@ func TestPreToolUseAgentAllowNonExplore(t *testing.T) {
 	}
 }
 
-func TestPreToolUseGlobPassthrough(t *testing.T) {
+func TestPreToolUseGlobFilePatternNoOp(t *testing.T) {
 	dir := indexedDir(t)
 	cases := []string{
 		`{"tool_name":"Glob","tool_input":{"pattern":"src/controllers/**/*.rb"}}`,
 		`{"tool_name":"Glob","tool_input":{"pattern":"internal/hook/*.go"}}`,
-		`{"tool_name":"Glob","tool_input":{"pattern":"UserService"}}`,
 	}
 	for _, input := range cases {
 		var buf bytes.Buffer
 		Run("pre-tool-use", dir, strings.NewReader(input), &buf)
 		if buf.String() != "{}\n" {
-			t.Errorf("Glob should always pass through, got %q for input %s", buf.String(), input)
+			t.Errorf("Glob with file pattern should be no-op, got %q for input %s", buf.String(), input)
 		}
 	}
 }
 
-func TestPreToolUseBashGrepAdvises(t *testing.T) {
+func TestPreToolUseGlobSymbolNudge(t *testing.T) {
+	dir := indexedDir(t)
+	input := `{"tool_name":"Glob","tool_input":{"pattern":"UserService"}}`
+	var buf bytes.Buffer
+	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
+
+	var resp nudgeResponse
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if resp.SystemMessage == "" {
+		t.Fatal("expected non-empty systemMessage for Glob with symbol pattern")
+	}
+	if resp.AdditionalContext == "" {
+		t.Fatal("expected non-empty additionalContext for Glob with symbol pattern")
+	}
+}
+
+func TestPreToolUseBashGrepNudges(t *testing.T) {
 	dir := indexedDir(t)
 	input := `{"tool_name":"Bash","tool_input":{"command":"grep -rn UserService ."}}`
 	var buf bytes.Buffer
 	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
 
-	var resp hookResponse
+	var resp nudgeResponse
 	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
 		t.Fatalf("parse response: %v", err)
 	}
+	if resp.SystemMessage == "" {
+		t.Fatal("expected non-empty systemMessage for bash grep of known symbol")
+	}
 	if resp.AdditionalContext == "" {
-		t.Fatal("expected advisory for bash grep of known symbol")
+		t.Fatal("expected non-empty additionalContext for bash grep of known symbol")
 	}
 	if !strings.Contains(resp.AdditionalContext, "sense_graph") {
-		t.Error("expected sense_graph suggestion in advisory")
+		t.Error("expected sense_graph suggestion in additionalContext")
 	}
 }
 
@@ -262,18 +288,21 @@ func TestPreToolUseBashNonGrepNoOp(t *testing.T) {
 	}
 }
 
-func TestPreToolUseExploreAgentDeny(t *testing.T) {
+func TestPreToolUseExploreAgentNudge(t *testing.T) {
 	dir := indexedDir(t)
 	input := `{"tool_name":"Agent","tool_input":{"subagent_type":"Explore","prompt":"find implementations"}}`
 	var buf bytes.Buffer
 	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
 
-	var resp denyResponse
+	var resp nudgeResponse
 	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
 		t.Fatalf("parse response: %v", err)
 	}
-	if resp.Output.Decision != "deny" {
-		t.Fatalf("expected deny for Explore agent, got %q", resp.Output.Decision)
+	if resp.SystemMessage == "" {
+		t.Fatal("expected non-empty systemMessage for Explore agent")
+	}
+	if resp.AdditionalContext == "" {
+		t.Fatal("expected non-empty additionalContext for Explore agent")
 	}
 }
 
@@ -334,33 +363,39 @@ func TestIsSymbolShaped(t *testing.T) {
 	}
 }
 
-func TestPreToolUseAgentExplorationIntentAdvise(t *testing.T) {
+func TestPreToolUseAgentExplorationIntentNudge(t *testing.T) {
 	dir := indexedDir(t)
 	input := `{"tool_name":"Agent","tool_input":{"subagent_type":"general-purpose","prompt":"explore the codebase to understand the architecture"}}`
 	var buf bytes.Buffer
 	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
 
-	var resp hookResponse
+	var resp nudgeResponse
 	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
 		t.Fatalf("parse response: %v", err)
 	}
+	if resp.SystemMessage == "" {
+		t.Fatal("expected non-empty systemMessage for exploration-intent agent")
+	}
 	if resp.AdditionalContext == "" {
-		t.Fatal("expected advisory context for exploration-intent agent, got empty")
+		t.Fatal("expected non-empty additionalContext for exploration-intent agent")
 	}
 }
 
-func TestPreToolUseAgentDescriptionFallbackAdvise(t *testing.T) {
+func TestPreToolUseAgentDescriptionFallbackNudge(t *testing.T) {
 	dir := indexedDir(t)
 	input := `{"tool_name":"Agent","tool_input":{"subagent_type":"general-purpose","description":"explore the codebase structure"}}`
 	var buf bytes.Buffer
 	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
 
-	var resp hookResponse
+	var resp nudgeResponse
 	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
 		t.Fatalf("parse response: %v", err)
 	}
+	if resp.SystemMessage == "" {
+		t.Fatal("expected non-empty systemMessage for exploration-intent description")
+	}
 	if resp.AdditionalContext == "" {
-		t.Fatal("expected advisory context for exploration-intent description, got empty")
+		t.Fatal("expected non-empty additionalContext for exploration-intent description")
 	}
 }
 
@@ -375,51 +410,131 @@ func TestPreToolUseAgentNoExplorationIntentPass(t *testing.T) {
 	}
 }
 
-func TestPreToolUseConceptSearchAdvise(t *testing.T) {
+func TestPreToolUseConceptSearchNudge(t *testing.T) {
 	dir := indexedDir(t)
 	input := `{"tool_name":"Grep","tool_input":{"pattern":"error handling middleware"}}`
 	var buf bytes.Buffer
 	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
 
-	var resp hookResponse
+	var resp nudgeResponse
 	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
 		t.Fatalf("parse response: %v", err)
 	}
+	if resp.SystemMessage == "" {
+		t.Fatal("expected non-empty systemMessage for concept search")
+	}
 	if resp.AdditionalContext == "" {
-		t.Fatal("expected advisory for concept search pattern")
+		t.Fatal("expected non-empty additionalContext for concept search")
 	}
 	if !strings.Contains(resp.AdditionalContext, "sense_search") {
-		t.Error("expected sense_search suggestion in advisory")
+		t.Error("expected sense_search suggestion in additionalContext")
 	}
 }
 
-func TestPreToolUseBashFindCodeAdvise(t *testing.T) {
+func TestPreToolUseBashFindCodeNudge(t *testing.T) {
 	dir := indexedDir(t)
 	input := `{"tool_name":"Bash","tool_input":{"command":"find . -name \"*.go\" -type f"}}`
 	var buf bytes.Buffer
 	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
 
-	var resp hookResponse
+	var resp nudgeResponse
 	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
 		t.Fatalf("parse response: %v", err)
 	}
+	if resp.SystemMessage == "" {
+		t.Fatal("expected non-empty systemMessage for find code files")
+	}
 	if resp.AdditionalContext == "" {
-		t.Fatal("expected advisory for find code files")
+		t.Fatal("expected non-empty additionalContext for find code files")
 	}
 }
 
-func TestPreToolUseBashHeadCodeAdvise(t *testing.T) {
+func TestPreToolUseBashHeadCodeNudge(t *testing.T) {
 	dir := indexedDir(t)
 	input := `{"tool_name":"Bash","tool_input":{"command":"head -20 internal/hook/pre_tool_use.go"}}`
 	var buf bytes.Buffer
 	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
 
-	var resp hookResponse
+	var resp nudgeResponse
 	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
 		t.Fatalf("parse response: %v", err)
 	}
+	if resp.SystemMessage == "" {
+		t.Fatal("expected non-empty systemMessage for head on code file")
+	}
 	if resp.AdditionalContext == "" {
-		t.Fatal("expected advisory for head on code file")
+		t.Fatal("expected non-empty additionalContext for head on code file")
+	}
+}
+
+func TestPreToolUseUnknownToolNoOp(t *testing.T) {
+	dir := indexedDir(t)
+	input := `{"tool_name":"Read","tool_input":{"file_path":"/tmp/foo.go"}}`
+	var buf bytes.Buffer
+	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
+
+	if buf.String() != "{}\n" {
+		t.Errorf("unknown tool should be no-op, got %q", buf.String())
+	}
+}
+
+func TestPreToolUseGlobNoMatchNoOp(t *testing.T) {
+	dir := indexedDir(t)
+	input := `{"tool_name":"Glob","tool_input":{"pattern":"NonexistentSymbol"}}`
+	var buf bytes.Buffer
+	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
+
+	if buf.String() != "{}\n" {
+		t.Errorf("Glob with no matching symbol should be no-op, got %q", buf.String())
+	}
+}
+
+func TestPreToolUseMalformedInput(t *testing.T) {
+	dir := indexedDir(t)
+	var buf bytes.Buffer
+	Run("pre-tool-use", dir, strings.NewReader(`not json`), &buf)
+	if buf.String() != "{}\n" {
+		t.Errorf("malformed input should be no-op, got %q", buf.String())
+	}
+}
+
+func TestPreToolUseGrepRegexField(t *testing.T) {
+	dir := indexedDir(t)
+	input := `{"tool_name":"Grep","tool_input":{"regex":"UserService"}}`
+	var buf bytes.Buffer
+	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
+
+	var resp nudgeResponse
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if resp.SystemMessage == "" {
+		t.Fatal("expected nudge for symbol via regex field")
+	}
+}
+
+func TestPreToolUseGrepCommandField(t *testing.T) {
+	dir := indexedDir(t)
+	input := `{"tool_name":"Grep","tool_input":{"command":"UserService"}}`
+	var buf bytes.Buffer
+	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
+
+	var resp nudgeResponse
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if resp.SystemMessage == "" {
+		t.Fatal("expected nudge for symbol via command field")
+	}
+}
+
+func TestPreToolUseGrepEmptyPatternNoOp(t *testing.T) {
+	dir := indexedDir(t)
+	input := `{"tool_name":"Grep","tool_input":{}}`
+	var buf bytes.Buffer
+	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
+	if buf.String() != "{}\n" {
+		t.Errorf("empty grep pattern should be no-op, got %q", buf.String())
 	}
 }
 

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -113,6 +113,64 @@ func TestPreCompactReturnsHubs(t *testing.T) {
 	}
 }
 
+func TestSubagentStartEmptyIndex(t *testing.T) {
+	root := t.TempDir()
+	// Create DB with schema but no symbols.
+	goFile := filepath.Join(root, "main.go")
+	if err := os.WriteFile(goFile, []byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := scan.Run(context.Background(), scan.Options{
+		Root:     root,
+		Output:   io.Discard,
+		Warnings: io.Discard,
+	}); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	var buf bytes.Buffer
+	Run("subagent-start", root, strings.NewReader("{}"), &buf)
+	if buf.String() != "{}\n" {
+		t.Errorf("expected empty response for empty index, got %q", buf.String())
+	}
+}
+
+func TestSubagentStartEdgeCountFallback(t *testing.T) {
+	root := indexedDir(t)
+	dbPath := filepath.Join(root, ".sense", "index.db")
+
+	// Open db directly, drop edges, and keep connection open
+	// so we can call handleSubagentStart bypassing schema recreation.
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.Exec("DROP TABLE IF EXISTS sense_edges"); err != nil {
+		t.Fatalf("drop table: %v", err)
+	}
+
+	adapter, err := sqlite.Open(context.Background(), dbPath)
+	if err != nil {
+		t.Fatalf("open adapter: %v", err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	// Drop edges again after adapter reopened (schema recreates it).
+	if _, err := adapter.DB().Exec("DROP TABLE sense_edges"); err != nil {
+		t.Fatalf("drop table after adapter open: %v", err)
+	}
+
+	result, err := handleSubagentStart(context.Background(), nil, adapter, root)
+	if err != nil {
+		t.Fatalf("handleSubagentStart: %v", err)
+	}
+	resp := result.(*hookResponse)
+	if !strings.Contains(resp.AdditionalContext, "0 edges") {
+		t.Errorf("expected 0 edges fallback, got %q", resp.AdditionalContext)
+	}
+}
+
 func TestSubagentStartReturnsGuidance(t *testing.T) {
 	dir := indexedDir(t)
 	var buf bytes.Buffer
@@ -122,14 +180,27 @@ func TestSubagentStartReturnsGuidance(t *testing.T) {
 	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
 		t.Fatalf("parse response: %v", err)
 	}
-	if !strings.Contains(resp.AdditionalContext, "Sense index") {
-		t.Errorf("context = %q, expected sense guidance", resp.AdditionalContext)
+	ctx := resp.AdditionalContext
+	if !strings.Contains(ctx, "Sense index") {
+		t.Errorf("context = %q, expected sense guidance", ctx)
 	}
-	if !strings.Contains(resp.AdditionalContext, "sense_graph") {
+	if !strings.Contains(ctx, "ToolSearch") {
+		t.Error("expected ToolSearch command in guidance")
+	}
+	if !strings.Contains(ctx, "sense_graph") {
 		t.Error("expected sense_graph in guidance")
 	}
-	if !strings.Contains(resp.AdditionalContext, "parent agent") {
-		t.Error("expected parent agent delegation guidance")
+	if !strings.Contains(ctx, "sense_search") {
+		t.Error("expected sense_search in guidance")
+	}
+	if !strings.Contains(ctx, "sense_blast") {
+		t.Error("expected sense_blast in guidance")
+	}
+	if !strings.Contains(ctx, "edges") {
+		t.Error("expected edge count in guidance")
+	}
+	if strings.Contains(ctx, "parent agent") {
+		t.Error("should not contain old 'parent agent' delegation message")
 	}
 }
 

--- a/internal/hook/pre_tool_use.go
+++ b/internal/hook/pre_tool_use.go
@@ -72,11 +72,30 @@ func handlePreToolUse(ctx context.Context, input json.RawMessage, adapter *sqlit
 		return handleAgent(ctx, req, adapter)
 	case "Bash":
 		return handleBash(ctx, req, adapter)
-	case "Glob":
-		return nil, nil
-	default:
+	case "Grep":
 		return handleGrep(ctx, req, adapter)
+	case "Glob":
+		return handleGlob(ctx, req, adapter)
+	default:
+		return nil, nil
 	}
+}
+
+func handleGlob(ctx context.Context, req preToolUseInput, adapter *sqlite.Adapter) (any, error) {
+	pattern := req.Input.Pattern
+	if pattern == "" || !isSymbolShaped(pattern) {
+		return nil, nil
+	}
+
+	symbols, err := adapter.Query(ctx, index.Filter{Name: pattern, Limit: 5})
+	if err != nil || len(symbols) == 0 {
+		return nil, nil
+	}
+
+	return nudge(
+		fmt.Sprintf("Sense has %d indexed symbol(s) matching %q — consider sense_graph or sense_search instead of Glob.", len(symbols), pattern),
+		buildContext(len(symbols), pattern, "glob"),
+	), nil
 }
 
 func handleGrep(ctx context.Context, req preToolUseInput, adapter *sqlite.Adapter) (any, error) {
@@ -92,14 +111,18 @@ func handleGrep(ctx context.Context, req preToolUseInput, adapter *sqlite.Adapte
 	symbols, err := adapter.Query(ctx, index.Filter{Name: pattern, Limit: 5})
 	if err != nil || len(symbols) == 0 {
 		if isMultiWordPattern(pattern) {
-			return advise(fmt.Sprintf(
+			ctx := fmt.Sprintf(
 				"Consider sense_search query=%q for semantic code search. "+
-					"Load tools first: %s", pattern, toolSearchCmd)), nil
+					"Load tools first: %s", pattern, toolSearchCmd)
+			return nudge("Sense can do semantic code search — consider sense_search instead of grep.", ctx), nil
 		}
 		return nil, nil
 	}
 
-	return buildAdvice(len(symbols), pattern, "grep"), nil
+	return nudge(
+		fmt.Sprintf("Sense has %d indexed symbol(s) matching %q — consider sense_graph or sense_search instead of grep.", len(symbols), pattern),
+		buildContext(len(symbols), pattern, "grep"),
+	), nil
 }
 
 func handleAgent(ctx context.Context, req preToolUseInput, adapter *sqlite.Adapter) (any, error) {
@@ -130,10 +153,11 @@ func handleAgent(ctx context.Context, req preToolUseInput, adapter *sqlite.Adapt
 		count, toolSearchCmd,
 	)
 
+	tip := "Sense has this project indexed — use Sense MCP tools instead of agents for codebase questions."
 	if isKnownExplorer {
-		return deny(reason), nil
+		tip = "Sense has this project indexed. Use Sense MCP tools instead of Explore/deep-explore agents."
 	}
-	return advise(reason), nil
+	return nudge(tip, reason), nil
 }
 
 func handleBash(ctx context.Context, req preToolUseInput, adapter *sqlite.Adapter) (any, error) {
@@ -143,32 +167,37 @@ func handleBash(ctx context.Context, req preToolUseInput, adapter *sqlite.Adapte
 	if pattern != "" && isSymbolShaped(pattern) {
 		symbols, err := adapter.Query(ctx, index.Filter{Name: pattern, Limit: 5})
 		if err == nil && len(symbols) > 0 {
-			return buildAdvice(len(symbols), pattern, "bash grep"), nil
+			return nudge(
+				fmt.Sprintf("Sense has %d indexed symbol(s) matching %q — consider sense_graph or sense_search instead of bash grep.", len(symbols), pattern),
+				buildContext(len(symbols), pattern, "bash grep"),
+			), nil
 		}
 		if isMultiWordPattern(pattern) {
-			return advise(fmt.Sprintf(
+			ctx := fmt.Sprintf(
 				"Consider sense_search query=%q for semantic code search. "+
-					"Load tools first: %s", pattern, toolSearchCmd)), nil
+					"Load tools first: %s", pattern, toolSearchCmd)
+			return nudge("Sense can do semantic code search — consider sense_search instead of grep.", ctx), nil
 		}
 	}
 
 	if isExplorationCommand(cmd) {
-		return advise(
-			"Sense can answer codebase understanding questions without reading individual files. "+
-				"Load tools first: "+toolSearchCmd), nil
+		ctx := "Sense can answer codebase understanding questions without reading individual files. " +
+			"Load tools first: " + toolSearchCmd
+		return nudge("Sense has this project indexed — consider Sense tools instead of reading files manually.", ctx), nil
 	}
 
 	return nil, nil
 }
 
-func buildAdvice(count int, pattern, source string) *hookResponse {
+func buildContext(count int, pattern, source string) string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "Sense has %d indexed symbol(s) matching %q. Consider Sense MCP tools instead of %s:\n", count, pattern, source)
 	fmt.Fprintf(&sb, "- sense_graph symbol=%q for callers/callees\n", pattern)
 	fmt.Fprintf(&sb, "- sense_search query=%q for semantic matches\n", pattern)
 	fmt.Fprintf(&sb, "Load tools first: %s", toolSearchCmd)
-	return &hookResponse{AdditionalContext: sb.String()}
+	return sb.String()
 }
+
 
 func extractPattern(req preToolUseInput) string {
 	if req.Input.Pattern != "" {

--- a/internal/hook/response.go
+++ b/internal/hook/response.go
@@ -10,26 +10,14 @@ type messageResponse struct {
 	Message string `json:"message,omitempty"`
 }
 
-type denyResponse struct {
-	Output denyOutput `json:"hookSpecificOutput"`
+type nudgeResponse struct {
+	AdditionalContext string `json:"additionalContext,omitempty"`
+	SystemMessage     string `json:"systemMessage,omitempty"`
 }
 
-type denyOutput struct {
-	Event    string `json:"hookEventName"`
-	Decision string `json:"permissionDecision"`
-	Reason   string `json:"permissionDecisionReason"`
-}
-
-func deny(reason string) *denyResponse {
-	return &denyResponse{
-		Output: denyOutput{
-			Event:    "PreToolUse",
-			Decision: "deny",
-			Reason:   reason,
-		},
+func nudge(tip, context string) *nudgeResponse {
+	return &nudgeResponse{
+		SystemMessage:     tip,
+		AdditionalContext: context,
 	}
-}
-
-func advise(msg string) *hookResponse {
-	return &hookResponse{AdditionalContext: msg}
 }

--- a/internal/hook/session_start.go
+++ b/internal/hook/session_start.go
@@ -1,9 +1,12 @@
 package hook
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -22,7 +25,7 @@ func formatScanAge(lastScan string, now time.Time) string {
 	return fmt.Sprintf("%s ago", age)
 }
 
-func handleSessionStart(ctx context.Context, _ json.RawMessage, adapter *sqlite.Adapter, _ string) (any, error) {
+func handleSessionStart(ctx context.Context, _ json.RawMessage, adapter *sqlite.Adapter, dir string) (any, error) {
 	db := adapter.DB()
 
 	var symbolCount, edgeCount int
@@ -67,6 +70,16 @@ func handleSessionStart(ctx context.Context, _ json.RawMessage, adapter *sqlite.
 	fmt.Fprintf(&sb, "Sense index: %d symbols, %d edges, %d languages (%s). Last scan: %s.\n", symbolCount, edgeCount, len(langs), strings.Join(langs, ", "), lastScan)
 	fmt.Fprintf(&sb, "REQUIRED: Your FIRST tool call MUST be %s to load Sense tools.\n", toolSearchCmd)
 	sb.WriteString("Use Sense MCP tools for ALL codebase understanding — do not use grep, glob, Read, Bash, or agents before loading Sense.")
+
+	summaryPath := filepath.Join(dir, ".sense", "summary.md")
+	if summary, err := os.ReadFile(summaryPath); err == nil && len(bytes.TrimSpace(summary)) > 0 {
+		sb.WriteString("\n\n--- Codebase Summary ---\n")
+		sb.Write(summary)
+		if !bytes.HasSuffix(summary, []byte("\n")) {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString("--- End Summary ---")
+	}
 
 	return &messageResponse{Message: sb.String()}, nil
 }

--- a/internal/hook/session_start_test.go
+++ b/internal/hook/session_start_test.go
@@ -13,6 +13,67 @@ import (
 	"github.com/luuuc/sense/internal/sqlite"
 )
 
+func TestHandleSessionStartQueryErrors(t *testing.T) {
+	dir := indexedDir(t)
+	dbPath := filepath.Join(dir, ".sense", "index.db")
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	// Drop sense_symbols to trigger the first query error.
+	if _, err := adapter.DB().ExecContext(ctx, `DROP TABLE sense_symbols`); err != nil {
+		t.Fatal(err)
+	}
+	result, err := handleSessionStart(ctx, nil, adapter, dir)
+	if err == nil {
+		t.Errorf("expected error when sense_symbols table missing, got result: %v", result)
+	}
+}
+
+func TestHandleSessionStartEdgeQueryError(t *testing.T) {
+	dir := indexedDir(t)
+	dbPath := filepath.Join(dir, ".sense", "index.db")
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	// Drop sense_edges to trigger the second query error.
+	if _, err := adapter.DB().ExecContext(ctx, `DROP TABLE sense_edges`); err != nil {
+		t.Fatal(err)
+	}
+	result, err := handleSessionStart(ctx, nil, adapter, dir)
+	if err == nil {
+		t.Errorf("expected error when sense_edges table missing, got result: %v", result)
+	}
+}
+
+func TestHandleSessionStartLangQueryError(t *testing.T) {
+	dir := indexedDir(t)
+	dbPath := filepath.Join(dir, ".sense", "index.db")
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	// Rename sense_files to trigger the language query error
+	// (symbols still exist so we get past the symbolCount check).
+	if _, err := adapter.DB().ExecContext(ctx, `ALTER TABLE sense_files RENAME TO sense_files_bak`); err != nil {
+		t.Fatal(err)
+	}
+	result, err := handleSessionStart(ctx, nil, adapter, dir)
+	if err == nil {
+		t.Errorf("expected error when sense_files table missing, got result: %v", result)
+	}
+}
+
 func TestSessionStartEmptyIndex(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, ".sense", "index.db")
@@ -73,5 +134,103 @@ func TestSessionStartPopulated(t *testing.T) {
 		t.Error("message field is empty")
 	} else if !strings.Contains(msg, "symbols") {
 		t.Errorf("message should mention symbols: %q", msg)
+	}
+}
+
+func TestSessionStartWithSummary(t *testing.T) {
+	dir := indexedDir(t)
+	summaryPath := filepath.Join(dir, ".sense", "summary.md")
+	if err := os.WriteFile(summaryPath, []byte("# Test Summary\nThis is a test project.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	code := Run("session-start", dir, strings.NewReader("{}"), &buf)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	msg := resp["message"]
+	if !strings.Contains(msg, "--- Codebase Summary ---") {
+		t.Error("message should contain summary start marker")
+	}
+	if !strings.Contains(msg, "--- End Summary ---") {
+		t.Error("message should contain summary end marker")
+	}
+	if !strings.Contains(msg, "# Test Summary") {
+		t.Error("message should contain summary content")
+	}
+}
+
+func TestSessionStartWithoutSummary(t *testing.T) {
+	dir := indexedDir(t)
+	summaryPath := filepath.Join(dir, ".sense", "summary.md")
+	_ = os.Remove(summaryPath)
+
+	var buf bytes.Buffer
+	code := Run("session-start", dir, strings.NewReader("{}"), &buf)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	msg := resp["message"]
+	if strings.Contains(msg, "--- Codebase Summary ---") {
+		t.Error("message should not contain summary markers when file is absent")
+	}
+	if !strings.Contains(msg, "symbols") {
+		t.Error("message should still contain index stats")
+	}
+}
+
+func TestSessionStartWithSummaryNoTrailingNewline(t *testing.T) {
+	dir := indexedDir(t)
+	summaryPath := filepath.Join(dir, ".sense", "summary.md")
+	if err := os.WriteFile(summaryPath, []byte("# Summary\nNo trailing newline"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	code := Run("session-start", dir, strings.NewReader("{}"), &buf)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	msg := resp["message"]
+	if !strings.Contains(msg, "No trailing newline\n--- End Summary ---") {
+		t.Errorf("summary without trailing newline should get one added before end marker, got: %q", msg)
+	}
+}
+
+func TestSessionStartWithEmptySummary(t *testing.T) {
+	dir := indexedDir(t)
+	summaryPath := filepath.Join(dir, ".sense", "summary.md")
+	if err := os.WriteFile(summaryPath, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	code := Run("session-start", dir, strings.NewReader("{}"), &buf)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	msg := resp["message"]
+	if strings.Contains(msg, "--- Codebase Summary ---") {
+		t.Error("message should not contain summary markers when file is empty")
+	}
+	if !strings.Contains(msg, "symbols") {
+		t.Error("message should still contain index stats")
 	}
 }

--- a/internal/hook/subagent_start.go
+++ b/internal/hook/subagent_start.go
@@ -10,21 +10,26 @@ import (
 )
 
 func handleSubagentStart(ctx context.Context, _ json.RawMessage, adapter *sqlite.Adapter, _ string) (any, error) {
-	var count int
-	if err := adapter.DB().QueryRowContext(ctx, `SELECT COUNT(*) FROM sense_symbols`).Scan(&count); err != nil || count == 0 {
+	var symbolCount int
+	if err := adapter.DB().QueryRowContext(ctx, `SELECT COUNT(*) FROM sense_symbols`).Scan(&symbolCount); err != nil || symbolCount == 0 {
 		return nil, nil
 	}
 
+	var edgeCount int
+	if err := adapter.DB().QueryRowContext(ctx, `SELECT COUNT(*) FROM sense_edges`).Scan(&edgeCount); err != nil {
+		edgeCount = 0
+	}
+
+	const toolSearchCmd = `ToolSearch("select:mcp__sense__sense_graph,mcp__sense__sense_search,mcp__sense__sense_blast,mcp__sense__sense_conventions,mcp__sense__sense_status")`
+
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "IMPORTANT: This project has a Sense index (%d symbols). ", count)
-	sb.WriteString("You cannot call Sense MCP tools directly, but the parent agent can. ")
-	sb.WriteString("For ANY task involving codebase understanding — finding callers, tracing dependencies, exploring architecture, researching code, or understanding how code works — ")
-	sb.WriteString("report back to the parent agent and recommend it use:\n")
-	sb.WriteString("- sense_graph for symbol relationships (callers, callees, inheritance)\n")
-	sb.WriteString("- sense_search for semantic code search\n")
-	sb.WriteString("- sense_blast for impact analysis\n")
-	sb.WriteString("- sense_conventions for project patterns\n")
-	sb.WriteString("Do not attempt to answer codebase questions with grep or file reading — Sense is faster and more complete.")
+	fmt.Fprintf(&sb, "This project has a Sense index (%d symbols, %d edges).\n\n", symbolCount, edgeCount)
+	sb.WriteString("Before using grep/find/file-walking, load Sense tools:\n")
+	sb.WriteString(toolSearchCmd + "\n\n")
+	sb.WriteString("- Who calls X? What does X depend on? → sense_graph\n")
+	sb.WriteString("- Find code related to a concept → sense_search\n")
+	sb.WriteString("- What breaks if I change X? → sense_blast\n")
+	sb.WriteString("- What patterns does this project follow? → sense_conventions\n")
 
 	return &hookResponse{AdditionalContext: sb.String()}, nil
 }

--- a/internal/setup/agents.go
+++ b/internal/setup/agents.go
@@ -1,0 +1,69 @@
+package setup
+
+import (
+	"os"
+	"path/filepath"
+)
+
+type agent struct {
+	filename string
+	content  string
+}
+
+var agents = []agent{
+	{
+		filename: "deep-explore.md",
+		content: `---
+name: deep-explore
+description: Deep codebase exploration using Sense index. Symbol relationships, semantic search, impact analysis, conventions.
+tools: Read, Bash
+model: inherit
+---
+
+## Instructions
+
+You are a codebase exploration agent with access to Sense MCP tools.
+
+### First Action
+
+Load Sense tools:
+` + "ToolSearch(\"select:mcp__sense__sense_graph,mcp__sense__sense_search,mcp__sense__sense_blast,mcp__sense__sense_conventions,mcp__sense__sense_status\")" + `
+
+### Tools
+
+| Question | Tool |
+|---|---|
+| Who calls X? What does X call? | ` + "`sense_graph symbol=\"X\"`" + ` |
+| Find code related to a concept | ` + "`sense_search query=\"...\"`" + ` |
+| What breaks if I change X? | ` + "`sense_blast symbol=\"X\"`" + ` |
+| What patterns exist? | ` + "`sense_conventions`" + ` |
+
+### Workflow
+
+1. Load Sense tools (ToolSearch — one call)
+2. Use sense_search for broad exploration
+3. Use sense_graph to trace relationships
+4. Use Read only to examine specific file contents
+5. Synthesize findings into a clear summary
+`,
+	},
+}
+
+// writeAgents creates agent files in .claude/agents/. Existing files
+// are overwritten to pick up template changes on re-run.
+func writeAgents(root string) (int, error) {
+	dir := filepath.Join(root, ".claude", "agents")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return 0, err
+	}
+
+	written := 0
+	for _, a := range agents {
+		path := filepath.Join(dir, a.filename)
+		if err := os.WriteFile(path, []byte(a.content), 0o644); err != nil {
+			return written, err
+		}
+		written++
+	}
+	return written, nil
+}

--- a/internal/setup/marker.go
+++ b/internal/setup/marker.go
@@ -16,23 +16,7 @@ const (
 const senseSection = `<!-- sense:start -->
 ## IMPORTANT: This project has a Sense index — you MUST use it
 
-Sense gives you structural understanding of the codebase — symbols, relationships, patterns — without reading dozens of files.
-
-**Your FIRST action in every conversation — before responding, before any tool call — MUST be:**
-
-1. Read ` + "`.sense/summary.md`" + ` — it is the cold-start map (project fingerprint, top namespaces, hub symbols, entry points, conventions)
-2. Load Sense tools: ` + "`ToolSearch(\"select:mcp__sense__sense_graph,mcp__sense__sense_search,mcp__sense__sense_blast,mcp__sense__sense_conventions,mcp__sense__sense_status\")`" + `
-3. Call ` + "`sense_status`" + ` to confirm index health
-4. Use Sense tools for ALL codebase understanding — exploration, research, architecture, callers, dependencies, search
-
-**You MUST NOT:**
-
-- Spawn deep-explore, Explore, or general-purpose agents for codebase questions — Sense answers them directly
-- Use grep/glob to find symbol callers, implementations, or dependencies
-- Skip Sense because tools are deferred — load them with ToolSearch first
-- Fall back to Read/Bash after a hook blocks another tool — the hook is telling you to use Sense
-
-**When to use each tool:**
+Sense tools are loaded at session start. Use them for ALL codebase understanding.
 
 | Question | Tool |
 |---|---|
@@ -41,21 +25,9 @@ Sense gives you structural understanding of the codebase — symbols, relationsh
 | What breaks if I change X? | ` + "`sense_blast symbol=\"X\"`" + ` |
 | What patterns does this project follow? | ` + "`sense_conventions`" + ` |
 
-**Workflows:**
+**You MUST NOT:** spawn Explore/deep-explore agents, use grep/glob for symbol lookup, or skip Sense because tools are deferred.
 
-- **Orientation** → read ` + "`.sense/summary.md`" + `, then ` + "`sense_search`" + ` with broad concepts + ` + "`sense_conventions`" + `
-- **Impact analysis** → ` + "`sense_blast`" + `
-- **Dependency tracing** → ` + "`sense_graph`" + `
-- **Debugging** → ` + "`sense_search`" + `
-- **Refactoring** → ` + "`sense_conventions`" + ` + ` + "`sense_graph`" + `
-
-**Verify list results:** For list outputs (dead code, blast radius, callers), verify a sample with grep before finalizing — static analysis may miss dynamic dispatch or cross-boundary usage.
-
-**When NOT to use Sense** (use grep instead):
-
-- Exact text/string search (regex, log messages, string literals)
-- Reading file contents → use Read
-- Editing code → Sense is read-only
+**Verify list results:** For list outputs (dead code, blast radius, callers), verify a sample with grep before finalizing.
 <!-- sense:end -->`
 
 // writeClaudeMD creates or updates the Sense section in CLAUDE.md.

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -121,6 +121,14 @@ func configureClaudeCode(root string) (*ToolResult, error) {
 		tr.Files = append(tr.Files, fmt.Sprintf("%d skill files in .claude/skills/", n))
 	}
 
+	na, err := writeAgents(root)
+	if err != nil {
+		return nil, fmt.Errorf("write .claude/agents: %w", err)
+	}
+	if na > 0 {
+		tr.Files = append(tr.Files, fmt.Sprintf("%d agent files in .claude/agents/", na))
+	}
+
 	return tr, nil
 }
 

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -212,6 +212,27 @@ func TestClaudeMDAppendToExisting(t *testing.T) {
 	}
 }
 
+func TestClaudeMDAppendToDoubleNewline(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "CLAUDE.md")
+	if err := os.WriteFile(path, []byte("# My Project\n\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Run(root, &bytes.Buffer{}, claudeCodeOnly()); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(path)
+	content := string(data)
+	if strings.Contains(content, "\n\n\n") {
+		t.Error("should not add extra blank lines when content already ends with double newline")
+	}
+	if !strings.Contains(content, markerStart) {
+		t.Error("sense section not appended")
+	}
+}
+
 func TestClaudeMDMissingEndMarker(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "CLAUDE.md")
@@ -652,15 +673,60 @@ func TestResolveToolsDefaultsToClaudeCode(t *testing.T) {
 	}
 }
 
-func TestSenseSectionHasSummaryAsStep1(t *testing.T) {
-	if !strings.Contains(senseSection, "1. Read `.sense/summary.md`") {
-		t.Error("senseSection must include 'Read .sense/summary.md' as step 1 in the numbered cold-start instructions")
+func TestSenseSectionContent(t *testing.T) {
+	if !strings.Contains(senseSection, "sense_graph") {
+		t.Error("senseSection must include tool table with sense_graph")
+	}
+	if !strings.Contains(senseSection, "sense_search") {
+		t.Error("senseSection must include tool table with sense_search")
+	}
+	if !strings.Contains(senseSection, "sense_blast") {
+		t.Error("senseSection must include tool table with sense_blast")
+	}
+	if !strings.Contains(senseSection, "sense_conventions") {
+		t.Error("senseSection must include tool table with sense_conventions")
+	}
+	if !strings.Contains(senseSection, "MUST NOT") {
+		t.Error("senseSection must include MUST NOT rules")
+	}
+	if strings.Contains(senseSection, "FIRST action in every conversation") {
+		t.Error("senseSection must not include cold-start protocol (now handled by SessionStart hook)")
 	}
 	if strings.Contains(senseSection, "sense_orient") || strings.Contains(senseSection, "sense.orient") {
 		t.Error("senseSection must not reference the removed orient tool")
 	}
 	if strings.Contains(mcpio.ServerInstructions, "sense.orient") {
 		t.Error("ServerInstructions must not reference the removed orient tool")
+	}
+	lines := strings.Count(senseSection, "\n")
+	if lines > 20 {
+		t.Errorf("senseSection should be ≤20 lines (cold-start protocol removed), got %d", lines)
+	}
+}
+
+func TestClaudeMDShortenedIdempotent(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "CLAUDE.md")
+	if err := os.WriteFile(path, []byte("# My Project\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 3; i++ {
+		if _, err := Run(root, &bytes.Buffer{}, claudeCodeOnly()); err != nil {
+			t.Fatalf("run %d: %v", i, err)
+		}
+	}
+
+	data, _ := os.ReadFile(path)
+	content := string(data)
+	if c := strings.Count(content, markerStart); c != 1 {
+		t.Errorf("expected 1 marker start after 3 runs, got %d", c)
+	}
+	if c := strings.Count(content, markerEnd); c != 1 {
+		t.Errorf("expected 1 marker end after 3 runs, got %d", c)
+	}
+	if !strings.HasPrefix(content, "# My Project\n") {
+		t.Error("user content before markers was lost")
 	}
 }
 

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -38,6 +38,7 @@ func TestRunCreatesAllFiles(t *testing.T) {
 		".claude/skills/sense-explore.md",
 		".claude/skills/sense-impact.md",
 		".claude/skills/sense-conventions.md",
+		".claude/agents/deep-explore.md",
 	} {
 		if _, err := os.Stat(filepath.Join(root, path)); err != nil {
 			t.Errorf("expected %s to exist: %v", path, err)
@@ -61,6 +62,7 @@ func TestRunIdempotent(t *testing.T) {
 	mcp1, _ := os.ReadFile(filepath.Join(root, ".mcp.json"))
 	settings1, _ := os.ReadFile(filepath.Join(root, ".claude/settings.json"))
 	claude1, _ := os.ReadFile(filepath.Join(root, "CLAUDE.md"))
+	agent1, _ := os.ReadFile(filepath.Join(root, ".claude/agents/deep-explore.md"))
 
 	buf.Reset()
 	if _, err := Run(root, &buf, claudeCodeOnly()); err != nil {
@@ -70,6 +72,7 @@ func TestRunIdempotent(t *testing.T) {
 	mcp2, _ := os.ReadFile(filepath.Join(root, ".mcp.json"))
 	settings2, _ := os.ReadFile(filepath.Join(root, ".claude/settings.json"))
 	claude2, _ := os.ReadFile(filepath.Join(root, "CLAUDE.md"))
+	agent2, _ := os.ReadFile(filepath.Join(root, ".claude/agents/deep-explore.md"))
 
 	if string(mcp1) != string(mcp2) {
 		t.Error(".mcp.json changed between runs")
@@ -79,6 +82,9 @@ func TestRunIdempotent(t *testing.T) {
 	}
 	if string(claude1) != string(claude2) {
 		t.Error("CLAUDE.md changed between runs")
+	}
+	if string(agent1) != string(agent2) {
+		t.Error(".claude/agents/deep-explore.md changed between runs")
 	}
 }
 
@@ -727,6 +733,83 @@ func TestClaudeMDShortenedIdempotent(t *testing.T) {
 	}
 	if !strings.HasPrefix(content, "# My Project\n") {
 		t.Error("user content before markers was lost")
+	}
+}
+
+func TestAgentFileContent(t *testing.T) {
+	root := t.TempDir()
+	if _, err := Run(root, &bytes.Buffer{}, claudeCodeOnly()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(root, ".claude/agents/deep-explore.md"))
+	if err != nil {
+		t.Fatalf("read agent file: %v", err)
+	}
+	content := string(data)
+
+	for _, want := range []string{
+		"name: deep-explore",
+		"ToolSearch",
+		"sense_graph",
+		"sense_search",
+		"sense_blast",
+		"sense_conventions",
+		"sense_status",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("agent file missing %q", want)
+		}
+	}
+}
+
+func TestAgentWriteErrorMkdir(t *testing.T) {
+	root := t.TempDir()
+	// Create .claude/agents as a file so MkdirAll fails.
+	if err := os.MkdirAll(filepath.Join(root, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".claude", "agents"), []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := writeAgents(root)
+	if err == nil {
+		t.Fatal("expected error when agents exists as a file")
+	}
+}
+
+func TestAgentWriteErrorFile(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, ".claude", "agents")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Create agent filename as a directory so WriteFile fails.
+	if err := os.MkdirAll(filepath.Join(dir, "deep-explore.md"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_, err := writeAgents(root)
+	if err == nil {
+		t.Fatal("expected error when agent filename is a directory")
+	}
+}
+
+func TestClaudeCodeAgentWriteError(t *testing.T) {
+	root := t.TempDir()
+	// Create .claude/agents as a file so writeAgents MkdirAll fails
+	// inside configureClaudeCode.
+	if err := os.MkdirAll(filepath.Join(root, ".claude"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".claude", "agents"), []byte{}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := configureClaudeCode(root)
+	if err == nil {
+		t.Fatal("expected error when agents dir is blocked")
+	}
+	if !strings.Contains(err.Error(), "write .claude/agents") {
+		t.Errorf("error = %q, want mention of .claude/agents", err)
 	}
 }
 


### PR DESCRIPTION
## Problem

Sense hooks had three UX issues that reduced adoption:

1. **Blocking responses** — Agent/Explore subagents got a `deny` response, showing a red wall in the UI that made Sense look like an obstacle instead of a helper.
2. **Summary compliance gap** — CLAUDE.md instructed the model to "read `.sense/summary.md` as your FIRST action," but this relied on the model obeying a buried instruction. Skipping the summary read was the single biggest adoption gap.
3. **Subagent blindness** — spawned subagents started without Sense tools loaded and defaulted to grep/file-walking, wasting tokens on 10-30 file reads when one `sense_graph` call would suffice.

## Summary

Replaces deny/advise hook responses with non-blocking nudges (`systemMessage` + `additionalContext`), injects `summary.md` directly into SessionStart output, shortens the CLAUDE.md Sense section from ~50 to ~15 lines, upgrades SubagentStart with tool-loading instructions, and generates a `deep-explore` subagent via `sense setup`.

## Changes

**Hook responses (`response.go`, `pre_tool_use.go`)**
- Replace `denyResponse` and `advise()` with unified `nudgeResponse` / `nudge()` — user sees a friendly tip, Claude gets full context, workflow isn't blocked
- Glob patterns that look like symbols now trigger nudges instead of silently passing through
- Grep now dispatches via explicit case match instead of falling through to default

**Session start (`session_start.go`)**
- Read `.sense/summary.md` and embed its content in the SessionStart `message` field
- Handle missing file, empty file, and no-trailing-newline edge cases

**CLAUDE.md section (`marker.go`)**
- Shorten from ~50 lines to ~15 — cold-start protocol removed since SessionStart hook now handles it

**Subagent awareness (`subagent_start.go`, `agents.go`)**
- SubagentStart now includes edge count and a `ToolSearch(...)` command so subagents can load Sense tools directly
- Remove "report back to parent agent" message — subagents can call MCP tools themselves
- `sense setup` generates `.claude/agents/deep-explore.md` — a purpose-built exploration agent with Sense instructions baked in

**Tests**
- +580 lines of test coverage across hook and setup packages
- New tests for edge cases: empty index, edge count fallback, malformed input, Grep regex/command fields, Glob symbol patterns, summary injection variants, agent file generation errors

## Test Plan

- [x] `go test ./...` passes
- [x] `sense` binary builds cleanly
- [x] `sense setup` in a test project creates `.claude/agents/deep-explore.md`
- [x] Hook responses are valid JSON with `systemMessage` + `additionalContext` (not `deny`)
- [x] SessionStart output includes summary content when `.sense/summary.md` exists
- [x] SubagentStart output includes `ToolSearch(...)` command