### PR TITLE
feat(mcp): add verification hints and ref field to graph/blast responses

### DIFF
--- a/internal/blast/engine.go
+++ b/internal/blast/engine.go
@@ -159,6 +159,8 @@ type Result struct {
 	// a temporal edge. Keyed by symbol ID.
 	DirectTemporalIDs map[int64]bool
 
+	SubjectHasCallees bool
+
 	// Edge-kind groups: filtered views over the same nodes that appear
 	// in DirectCallers/IndirectCallers. A node appears in at most one
 	// group (the edge kind that discovered it first in BFS order).
@@ -198,6 +200,8 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 	if err != nil {
 		return Result{}, fmt.Errorf("blast: load subject %d: %w", symbolIDs[0], err)
 	}
+
+	hasCallees := subjectHasCallees(ctx, db, symbolIDs)
 
 	visited := map[int64]int{}
 	predecessor := map[int64]int64{}
@@ -484,6 +488,7 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 		IndirectCallers:        indirectCallers,
 		AffectedTests:          affectedTests,
 		TotalAffected:          totalAffectedCount,
+		SubjectHasCallees:      hasCallees,
 		DirectTemporalIDs:      directTemporalIDs,
 		AffectedSubclasses:     subclasses,
 		AffectedViaComposition: viaComposition,
@@ -501,6 +506,18 @@ type edgePair struct {
 	target     int64
 	kind       string
 	confidence float64
+}
+
+func subjectHasCallees(ctx context.Context, db *sql.DB, symbolIDs []int64) bool {
+	placeholders := strings.Repeat("?,", len(symbolIDs))
+	placeholders = placeholders[:len(placeholders)-1]
+	q := `SELECT 1 FROM sense_edges WHERE source_id IN (` + placeholders + `) AND kind = 'calls' LIMIT 1`
+	args := make([]any, len(symbolIDs))
+	for i, id := range symbolIDs {
+		args[i] = id
+	}
+	var one int
+	return db.QueryRowContext(ctx, q, args...).Scan(&one) == nil
 }
 
 // expandFrontier runs the BFS hop query: "which symbols reference

--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -42,6 +42,7 @@ func BuildBlastResponse(r blast.Result, files FileLookup) BlastResponse {
 			File:        file,
 			LineStart:   c.LineStart,
 			LineEnd:     c.LineEnd,
+			Ref:         FormatRef(file, c.LineStart),
 			ViaTemporal: r.DirectTemporalIDs[c.ID],
 		}
 
@@ -57,12 +58,17 @@ func BuildBlastResponse(r blast.Result, files FileLookup) BlastResponse {
 	for _, hop := range r.IndirectCallers {
 		if !hasTiers || r.SymbolTiers[hop.Symbol.ID] == blast.TierBreaks {
 			if tier1Count < tier1Cap {
+				var file string
+				if path, ok := files(hop.Symbol.FileID); ok {
+					file = path
+				}
 				resp.IndirectCallers = append(resp.IndirectCallers, BlastIndirect{
 					Symbol:      qualifiedOrName(hop.Symbol),
 					Via:         qualifiedOrName(hop.Via),
 					Hops:        hop.Hops,
 					LineStart:   hop.Symbol.LineStart,
 					LineEnd:     hop.Symbol.LineEnd,
+					Ref:         FormatRef(file, hop.Symbol.LineStart),
 					ViaTemporal: hop.ViaTemporal,
 				})
 				tier1Count++
@@ -77,6 +83,7 @@ func BuildBlastResponse(r blast.Result, files FileLookup) BlastResponse {
 				File:      file,
 				LineStart: hop.Symbol.LineStart,
 				LineEnd:   hop.Symbol.LineEnd,
+				Ref:       FormatRef(file, hop.Symbol.LineStart),
 			})
 		}
 	}
@@ -86,7 +93,7 @@ func BuildBlastResponse(r blast.Result, files FileLookup) BlastResponse {
 		if path, ok := files(s.FileID); ok {
 			file = path
 		}
-		entry := BlastCaller{Symbol: qualifiedOrName(s), File: file, LineStart: s.LineStart, LineEnd: s.LineEnd}
+		entry := BlastCaller{Symbol: qualifiedOrName(s), File: file, LineStart: s.LineStart, LineEnd: s.LineEnd, Ref: FormatRef(file, s.LineStart)}
 		resp.AffectedSubclasses = append(resp.AffectedSubclasses, entry)
 		tier2All = append(tier2All, entry)
 	}
@@ -95,7 +102,7 @@ func BuildBlastResponse(r blast.Result, files FileLookup) BlastResponse {
 		if path, ok := files(s.FileID); ok {
 			file = path
 		}
-		entry := BlastCaller{Symbol: qualifiedOrName(s), File: file, LineStart: s.LineStart, LineEnd: s.LineEnd}
+		entry := BlastCaller{Symbol: qualifiedOrName(s), File: file, LineStart: s.LineStart, LineEnd: s.LineEnd, Ref: FormatRef(file, s.LineStart)}
 		resp.AffectedViaComposition = append(resp.AffectedViaComposition, entry)
 		tier2All = append(tier2All, entry)
 	}
@@ -104,7 +111,7 @@ func BuildBlastResponse(r blast.Result, files FileLookup) BlastResponse {
 		if path, ok := files(s.FileID); ok {
 			file = path
 		}
-		entry := BlastCaller{Symbol: qualifiedOrName(s), File: file, LineStart: s.LineStart, LineEnd: s.LineEnd}
+		entry := BlastCaller{Symbol: qualifiedOrName(s), File: file, LineStart: s.LineStart, LineEnd: s.LineEnd, Ref: FormatRef(file, s.LineStart)}
 		resp.AffectedViaIncludes = append(resp.AffectedViaIncludes, entry)
 		tier2All = append(tier2All, entry)
 	}
@@ -118,7 +125,13 @@ func BuildBlastResponse(r blast.Result, files FileLookup) BlastResponse {
 		Examples: examples,
 	}
 
+	resp.Note = "total_affected counts unique symbols in the blast radius — not source-level references or graph edges traversed."
+
 	segmentBlastCallers(&resp)
+
+	if r.TotalAffected == 0 && r.SubjectHasCallees {
+		resp.VerifyHint = "This symbol has outgoing calls but zero incoming callers in the index. This is unusual — verify with grep before concluding it's unused."
+	}
 
 	uniqueFiles := countUniqueBlastFiles(resp)
 	resp.SenseMetrics = BlastMetrics{
@@ -171,6 +184,7 @@ func BuildDiffBlastResponse(ref string, results []blast.Result, files FileLookup
 				File:      file,
 				LineStart: c.LineStart,
 				LineEnd:   c.LineEnd,
+				Ref:       FormatRef(file, c.LineStart),
 			})
 		}
 		for _, hop := range r.IndirectCallers {
@@ -178,12 +192,17 @@ func BuildDiffBlastResponse(ref string, results []blast.Result, files FileLookup
 				continue
 			}
 			indirectSeen[hop.Symbol.ID] = struct{}{}
+			var file string
+			if path, ok := files(hop.Symbol.FileID); ok {
+				file = path
+			}
 			resp.IndirectCallers = append(resp.IndirectCallers, BlastIndirect{
 				Symbol:    qualifiedOrName(hop.Symbol),
 				Via:       qualifiedOrName(hop.Via),
 				Hops:      hop.Hops,
 				LineStart: hop.Symbol.LineStart,
 				LineEnd:   hop.Symbol.LineEnd,
+				Ref:       FormatRef(file, hop.Symbol.LineStart),
 			})
 		}
 		for _, t := range r.AffectedTests {
@@ -197,6 +216,7 @@ func BuildDiffBlastResponse(ref string, results []blast.Result, files FileLookup
 
 	resp.Risk = risk
 	resp.TotalAffected = len(resp.DirectCallers) + len(resp.IndirectCallers)
+	resp.Note = "total_affected counts unique symbols in the blast radius — not source-level references or graph edges traversed."
 	resp.RiskFactors = []string{
 		fmt.Sprintf("%d modified symbols; %d direct callers", len(results), len(resp.DirectCallers)),
 	}

--- a/internal/mcpio/blast_test.go
+++ b/internal/mcpio/blast_test.go
@@ -398,3 +398,131 @@ func TestBuildBlastResponseSegmentTestFiles(t *testing.T) {
 		t.Errorf("TestAffected = %d, want 5 (test_helper + sub_test + comp_spec + incl_spec + affected_test)", resp.TestAffected)
 	}
 }
+
+func TestBlastResponseRefField(t *testing.T) {
+	r := blast.Result{
+		Symbol:      model.Symbol{ID: 0, Qualified: "Subject"},
+		Risk:        blast.RiskLow,
+		RiskReasons: []string{"2 callers"},
+		DirectCallers: []model.Symbol{
+			{ID: 1, Qualified: "DirectCaller", FileID: 10, LineStart: 25},
+			{ID: 2, Qualified: "NoFileCaller", FileID: 999, LineStart: 10},
+		},
+		IndirectCallers: []blast.CallerHop{
+			{
+				Symbol: model.Symbol{ID: 3, Qualified: "IndirectCaller", FileID: 11, LineStart: 42},
+				Via:    model.Symbol{ID: 1, Qualified: "DirectCaller"},
+				Hops:   2,
+			},
+		},
+		AffectedTests: []string{},
+		TotalAffected: 3,
+	}
+
+	files := func(id int64) (string, bool) {
+		m := map[int64]string{10: "lib/caller.rb", 11: "lib/indirect.rb"}
+		p, ok := m[id]
+		return p, ok
+	}
+
+	resp := BuildBlastResponse(r, files)
+
+	// DirectCallers — with file
+	if resp.DirectCallers[0].Ref != "lib/caller.rb:25" {
+		t.Errorf("DirectCallers[0].Ref = %q, want %q", resp.DirectCallers[0].Ref, "lib/caller.rb:25")
+	}
+	// DirectCallers — no file (lookup miss)
+	if resp.DirectCallers[1].Ref != "" {
+		t.Errorf("DirectCallers[1].Ref = %q, want empty (no file)", resp.DirectCallers[1].Ref)
+	}
+
+	// IndirectCallers
+	if resp.IndirectCallers[0].Ref != "lib/indirect.rb:42" {
+		t.Errorf("IndirectCallers[0].Ref = %q, want %q", resp.IndirectCallers[0].Ref, "lib/indirect.rb:42")
+	}
+}
+
+func TestBlastDiffResponseRefField(t *testing.T) {
+	sharedCaller := model.Symbol{ID: 42, Qualified: "Caller", FileID: 7, LineStart: 15}
+	results := []blast.Result{
+		{
+			Symbol:        model.Symbol{ID: 1, Qualified: "A"},
+			Risk:          blast.RiskLow,
+			DirectCallers: []model.Symbol{sharedCaller},
+			AffectedTests: []string{},
+		},
+	}
+
+	files := func(id int64) (string, bool) {
+		if id == 7 {
+			return "lib/caller.rb", true
+		}
+		return "", false
+	}
+
+	resp := BuildDiffBlastResponse("HEAD~1", results, files)
+
+	if len(resp.DirectCallers) != 1 {
+		t.Fatalf("DirectCallers = %d, want 1", len(resp.DirectCallers))
+	}
+	if resp.DirectCallers[0].Ref != "lib/caller.rb:15" {
+		t.Errorf("DirectCallers[0].Ref = %q, want %q", resp.DirectCallers[0].Ref, "lib/caller.rb:15")
+	}
+}
+
+func TestBlastVerifyHintZeroAffectedWithCallees(t *testing.T) {
+	r := blast.Result{
+		Symbol:            model.Symbol{ID: 1, Qualified: "Unused"},
+		Risk:              blast.RiskLow,
+		RiskReasons:       []string{"0 direct callers"},
+		DirectCallers:     []model.Symbol{},
+		IndirectCallers:   []blast.CallerHop{},
+		AffectedTests:     []string{},
+		TotalAffected:     0,
+		SubjectHasCallees: true,
+	}
+
+	resp := BuildBlastResponse(r, noFiles)
+
+	if resp.VerifyHint == "" {
+		t.Fatal("VerifyHint should be set when TotalAffected=0 and SubjectHasCallees=true")
+	}
+}
+
+func TestBlastVerifyHintNotEmittedWithCallers(t *testing.T) {
+	r := blast.Result{
+		Symbol:            model.Symbol{ID: 1, Qualified: "Used"},
+		Risk:              blast.RiskLow,
+		RiskReasons:       []string{"1 direct caller"},
+		DirectCallers:     []model.Symbol{{ID: 2, Qualified: "Caller", FileID: 10}},
+		IndirectCallers:   []blast.CallerHop{},
+		AffectedTests:     []string{},
+		TotalAffected:     1,
+		SubjectHasCallees: true,
+	}
+
+	resp := BuildBlastResponse(r, noFiles)
+
+	if resp.VerifyHint != "" {
+		t.Errorf("VerifyHint should be empty when TotalAffected > 0, got %q", resp.VerifyHint)
+	}
+}
+
+func TestBlastVerifyHintNotEmittedLeafSymbol(t *testing.T) {
+	r := blast.Result{
+		Symbol:            model.Symbol{ID: 1, Qualified: "Leaf"},
+		Risk:              blast.RiskLow,
+		RiskReasons:       []string{"0 direct callers"},
+		DirectCallers:     []model.Symbol{},
+		IndirectCallers:   []blast.CallerHop{},
+		AffectedTests:     []string{},
+		TotalAffected:     0,
+		SubjectHasCallees: false,
+	}
+
+	resp := BuildBlastResponse(r, noFiles)
+
+	if resp.VerifyHint != "" {
+		t.Errorf("VerifyHint should be empty for leaf symbol, got %q", resp.VerifyHint)
+	}
+}

--- a/internal/mcpio/contract_test.go
+++ b/internal/mcpio/contract_test.go
@@ -152,6 +152,7 @@ func fixtureGraphCheckoutService() GraphResponse {
 			LineStart: 12,
 			LineEnd:   85,
 			Kind:      "class",
+			Ref:       "app/services/checkout_service.rb:12",
 		},
 		Edges: GraphEdges{
 			Calls: []CallEdgeRef{
@@ -191,6 +192,7 @@ func fixtureGraphEmpty() GraphResponse {
 			LineStart: 1,
 			LineEnd:   3,
 			Kind:      "class",
+			Ref:       "app/models/orphan.rb:1",
 		},
 	}
 }

--- a/internal/mcpio/graph.go
+++ b/internal/mcpio/graph.go
@@ -1,6 +1,7 @@
 package mcpio
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/luuuc/sense/internal/model"
@@ -52,6 +53,7 @@ func BuildGraphResponse(sc *model.SymbolContext, files FileLookup, req BuildGrap
 			LineStart: sc.Symbol.LineStart,
 			LineEnd:   sc.Symbol.LineEnd,
 			Kind:      string(sc.Symbol.Kind),
+			Ref:       FormatRef(sc.File.Path, sc.Symbol.LineStart),
 		},
 	}
 
@@ -86,11 +88,13 @@ func BuildGraphResponse(sc *model.SymbolContext, files FileLookup, req BuildGrap
 		if e.Edge.Line != nil {
 			coChanges = *e.Edge.Line
 		}
+		fp := fileRefOrNil(e.Target.FileID, files)
 		resp.Edges.Temporal = append(resp.Edges.Temporal, TemporalEdgeRef{
 			Symbol:    qualifiedOrName(e.Target),
-			File:      fileRefOrNil(e.Target.FileID, files),
+			File:      fp,
 			LineStart: e.Target.LineStart,
 			LineEnd:   e.Target.LineEnd,
+			Ref:       FormatRefPtr(fp, e.Target.LineStart),
 			CoChanges: coChanges,
 			Strength:  Confidence(e.Edge.Confidence),
 		})
@@ -107,11 +111,13 @@ func BuildGraphResponse(sc *model.SymbolContext, files FileLookup, req BuildGrap
 		if e.Edge.Line != nil {
 			coChanges = *e.Edge.Line
 		}
+		fp := fileRefOrNil(e.Target.FileID, files)
 		resp.Edges.Temporal = append(resp.Edges.Temporal, TemporalEdgeRef{
 			Symbol:    qualifiedOrName(e.Target),
-			File:      fileRefOrNil(e.Target.FileID, files),
+			File:      fp,
 			LineStart: e.Target.LineStart,
 			LineEnd:   e.Target.LineEnd,
+			Ref:       FormatRefPtr(fp, e.Target.LineStart),
 			CoChanges: coChanges,
 			Strength:  Confidence(e.Edge.Confidence),
 		})
@@ -120,6 +126,8 @@ func BuildGraphResponse(sc *model.SymbolContext, files FileLookup, req BuildGrap
 	if len(testCallers) > 0 {
 		resp.TestCallerSummary = buildTestCallerSummary(testCallers)
 	}
+
+	resp.VerifyHint = graphVerifyHint(resp)
 
 	symbolsReturned := len(resp.Edges.Calls) + len(resp.Edges.CalledBy) + len(testCallers) +
 		len(resp.Edges.Inherits) + len(resp.Edges.Composes) +
@@ -177,40 +185,50 @@ func categorizeEdges(outbound, inbound []model.EdgeRef, files FileLookup, direct
 		for _, e := range outbound {
 			switch e.Edge.Kind {
 			case model.EdgeCalls:
+				fp := fileRefOrNil(e.Target.FileID, files)
 				edges.Calls = append(edges.Calls, CallEdgeRef{
 					Symbol:     qualifiedOrName(e.Target),
-					File:       fileRefOrNil(e.Target.FileID, files),
+					File:       fp,
 					LineStart:  e.Target.LineStart,
 					LineEnd:    e.Target.LineEnd,
+					Ref:        FormatRefPtr(fp, e.Target.LineStart),
 					Confidence: Confidence(e.Edge.Confidence),
 				})
 			case model.EdgeInherits:
+				fp := fileRefOrNil(e.Target.FileID, files)
 				edges.Inherits = append(edges.Inherits, InheritEdgeRef{
 					Symbol:    qualifiedOrName(e.Target),
-					File:      fileRefOrNil(e.Target.FileID, files),
+					File:      fp,
 					LineStart: e.Target.LineStart,
 					LineEnd:   e.Target.LineEnd,
+					Ref:       FormatRefPtr(fp, e.Target.LineStart),
 				})
 			case model.EdgeComposes:
+				fp := fileRefOrNil(e.Target.FileID, files)
 				edges.Composes = append(edges.Composes, ComposeEdgeRef{
 					Symbol:    qualifiedOrName(e.Target),
-					File:      fileRefOrNil(e.Target.FileID, files),
+					File:      fp,
 					LineStart: e.Target.LineStart,
 					LineEnd:   e.Target.LineEnd,
+					Ref:       FormatRefPtr(fp, e.Target.LineStart),
 				})
 			case model.EdgeIncludes:
+				fp := fileRefOrNil(e.Target.FileID, files)
 				edges.Includes = append(edges.Includes, IncludeEdgeRef{
 					Symbol:    qualifiedOrName(e.Target),
-					File:      fileRefOrNil(e.Target.FileID, files),
+					File:      fp,
 					LineStart: e.Target.LineStart,
 					LineEnd:   e.Target.LineEnd,
+					Ref:       FormatRefPtr(fp, e.Target.LineStart),
 				})
 			case model.EdgeImports:
+				fp := fileRefOrNil(e.Target.FileID, files)
 				edges.Imports = append(edges.Imports, ImportEdgeRef{
 					Symbol:    qualifiedOrName(e.Target),
-					File:      fileRefOrNil(e.Target.FileID, files),
+					File:      fp,
 					LineStart: e.Target.LineStart,
 					LineEnd:   e.Target.LineEnd,
+					Ref:       FormatRefPtr(fp, e.Target.LineStart),
 				})
 			default:
 			}
@@ -221,33 +239,41 @@ func categorizeEdges(outbound, inbound []model.EdgeRef, files FileLookup, direct
 		for _, e := range inbound {
 			switch e.Edge.Kind {
 			case model.EdgeCalls:
+				fp := fileRefOrNil(e.Target.FileID, files)
 				edges.CalledBy = append(edges.CalledBy, CallEdgeRef{
 					Symbol:     qualifiedOrName(e.Target),
-					File:       fileRefOrNil(e.Target.FileID, files),
+					File:       fp,
 					LineStart:  e.Target.LineStart,
 					LineEnd:    e.Target.LineEnd,
+					Ref:        FormatRefPtr(fp, e.Target.LineStart),
 					Confidence: Confidence(e.Edge.Confidence),
 				})
 			case model.EdgeComposes:
+				fp := fileRefOrNil(e.Target.FileID, files)
 				edges.Composes = append(edges.Composes, ComposeEdgeRef{
 					Symbol:    qualifiedOrName(e.Target),
-					File:      fileRefOrNil(e.Target.FileID, files),
+					File:      fp,
 					LineStart: e.Target.LineStart,
 					LineEnd:   e.Target.LineEnd,
+					Ref:       FormatRefPtr(fp, e.Target.LineStart),
 				})
 			case model.EdgeIncludes:
+				fp := fileRefOrNil(e.Target.FileID, files)
 				edges.Includes = append(edges.Includes, IncludeEdgeRef{
 					Symbol:    qualifiedOrName(e.Target),
-					File:      fileRefOrNil(e.Target.FileID, files),
+					File:      fp,
 					LineStart: e.Target.LineStart,
 					LineEnd:   e.Target.LineEnd,
+					Ref:       FormatRefPtr(fp, e.Target.LineStart),
 				})
 			case model.EdgeImports:
+				fp := fileRefOrNil(e.Target.FileID, files)
 				edges.Imports = append(edges.Imports, ImportEdgeRef{
 					Symbol:    qualifiedOrName(e.Target),
-					File:      fileRefOrNil(e.Target.FileID, files),
+					File:      fp,
 					LineStart: e.Target.LineStart,
 					LineEnd:   e.Target.LineEnd,
+					Ref:       FormatRefPtr(fp, e.Target.LineStart),
 				})
 			case model.EdgeTests:
 				if path, ok := files(e.Target.FileID); ok {
@@ -371,6 +397,39 @@ func buildTestCallerSummary(callers []CallEdgeRef) *TestCallerSummary {
 		summary.Examples = examples[:3]
 	}
 	return summary
+}
+
+// FormatRef builds a copy-paste-ready "file:line" reference string.
+func FormatRef(file string, lineStart int) string {
+	if file == "" || lineStart == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%s:%d", file, lineStart)
+}
+
+// FormatRefPtr is FormatRef for nullable file pointers (edge endpoints).
+func FormatRefPtr(file *string, lineStart int) string {
+	if file == nil {
+		return ""
+	}
+	return FormatRef(*file, lineStart)
+}
+
+func graphVerifyHint(resp GraphResponse) string {
+	if len(resp.Edges.CalledBy) > 0 {
+		return ""
+	}
+	kind := resp.Symbol.Kind
+	if kind != string(model.KindConstant) && kind != string(model.KindFunction) {
+		return ""
+	}
+	if len(resp.Edges.Calls) == 0 {
+		return ""
+	}
+	return fmt.Sprintf(
+		"Zero callers found in the index. Constants and short functions may have callers not captured by static analysis. Verify with: grep -rn '%s' .",
+		resp.Symbol.Name,
+	)
 }
 
 // IsTestPath returns true if the file path matches common test

--- a/internal/mcpio/graph_test.go
+++ b/internal/mcpio/graph_test.go
@@ -519,3 +519,298 @@ func TestBuildTestCallerSummaryDuplicateFiles(t *testing.T) {
 		t.Errorf("Examples len = %d, want 1 (deduplicated to 1 unique file)", len(sum.Examples))
 	}
 }
+
+func TestGraphVerifyHintConstantZeroCallers(t *testing.T) {
+	sc := &model.SymbolContext{
+		Symbol: model.Symbol{
+			Name: "NEXT_REQUEST_ID_HEADER", Qualified: "NEXT_REQUEST_ID_HEADER",
+			Kind: model.KindConstant, FileID: 1, LineStart: 5, LineEnd: 5,
+		},
+		File: model.File{Path: "lib/headers.rb"},
+		Outbound: []model.EdgeRef{
+			{Edge: model.Edge{Kind: model.EdgeCalls, Confidence: 1.0}, Target: model.Symbol{Qualified: "String#freeze", FileID: 2}},
+		},
+	}
+	files := func(id int64) (string, bool) {
+		m := map[int64]string{1: "lib/headers.rb", 2: "lib/string.rb"}
+		p, ok := m[id]
+		return p, ok
+	}
+
+	resp := BuildGraphResponse(sc, files, BuildGraphRequest{})
+
+	if resp.VerifyHint == "" {
+		t.Fatal("VerifyHint should be set for constant with zero callers and outgoing calls")
+	}
+	if resp.VerifyHint == "" || len(resp.VerifyHint) < 10 {
+		t.Errorf("VerifyHint too short: %q", resp.VerifyHint)
+	}
+}
+
+func TestGraphVerifyHintFunctionZeroCallers(t *testing.T) {
+	sc := &model.SymbolContext{
+		Symbol: model.Symbol{
+			Name: "helper", Qualified: "helper",
+			Kind: model.KindFunction, FileID: 1, LineStart: 10, LineEnd: 20,
+		},
+		File: model.File{Path: "lib/utils.go"},
+		Outbound: []model.EdgeRef{
+			{Edge: model.Edge{Kind: model.EdgeCalls, Confidence: 1.0}, Target: model.Symbol{Qualified: "fmt.Println"}},
+		},
+	}
+	files := func(int64) (string, bool) { return "", false }
+
+	resp := BuildGraphResponse(sc, files, BuildGraphRequest{})
+
+	if resp.VerifyHint == "" {
+		t.Fatal("VerifyHint should be set for function with zero callers and outgoing calls")
+	}
+}
+
+func TestGraphVerifyHintNotEmittedWithCallers(t *testing.T) {
+	sc := &model.SymbolContext{
+		Symbol: model.Symbol{
+			Name: "MY_CONST", Qualified: "MY_CONST",
+			Kind: model.KindConstant, FileID: 1, LineStart: 1, LineEnd: 1,
+		},
+		File: model.File{Path: "lib/const.rb"},
+		Outbound: []model.EdgeRef{
+			{Edge: model.Edge{Kind: model.EdgeCalls, Confidence: 1.0}, Target: model.Symbol{Qualified: "String#freeze"}},
+		},
+		Inbound: []model.EdgeRef{
+			{Edge: model.Edge{Kind: model.EdgeCalls, Confidence: 1.0}, Target: model.Symbol{Qualified: "Caller#use_const", FileID: 2}},
+		},
+	}
+	files := func(id int64) (string, bool) {
+		m := map[int64]string{1: "lib/const.rb", 2: "lib/caller.rb"}
+		p, ok := m[id]
+		return p, ok
+	}
+
+	resp := BuildGraphResponse(sc, files, BuildGraphRequest{})
+
+	if resp.VerifyHint != "" {
+		t.Errorf("VerifyHint should be empty when callers exist, got %q", resp.VerifyHint)
+	}
+}
+
+func TestGraphVerifyHintNotEmittedForClass(t *testing.T) {
+	sc := &model.SymbolContext{
+		Symbol: model.Symbol{
+			Name: "User", Qualified: "User",
+			Kind: model.KindClass, FileID: 1, LineStart: 1, LineEnd: 50,
+		},
+		File: model.File{Path: "app/models/user.rb"},
+		Outbound: []model.EdgeRef{
+			{Edge: model.Edge{Kind: model.EdgeCalls, Confidence: 1.0}, Target: model.Symbol{Qualified: "Order"}},
+		},
+	}
+	files := func(int64) (string, bool) { return "", false }
+
+	resp := BuildGraphResponse(sc, files, BuildGraphRequest{})
+
+	if resp.VerifyHint != "" {
+		t.Errorf("VerifyHint should be empty for class kind, got %q", resp.VerifyHint)
+	}
+}
+
+func TestCategorizeEdgesInboundIncludesImportsTests(t *testing.T) {
+	filePaths := map[int64]string{
+		1: "app/models/user.rb",
+		2: "app/concerns/soft_deletable.rb",
+		3: "src/utils.ts",
+		4: "spec/models/user_spec.rb",
+	}
+	files := func(id int64) (string, bool) {
+		p, ok := filePaths[id]
+		return p, ok
+	}
+
+	sc := &model.SymbolContext{
+		Symbol: model.Symbol{
+			Name: "User", Qualified: "User",
+			Kind: model.KindClass, FileID: 1, LineStart: 1, LineEnd: 50,
+		},
+		File: model.File{Path: "app/models/user.rb"},
+		Inbound: []model.EdgeRef{
+			{Edge: model.Edge{Kind: model.EdgeIncludes}, Target: model.Symbol{Qualified: "SoftDeletable", FileID: 2, LineStart: 1}},
+			{Edge: model.Edge{Kind: model.EdgeImports}, Target: model.Symbol{Qualified: "utils", FileID: 3, LineStart: 1}},
+			{Edge: model.Edge{Kind: model.EdgeTests, Confidence: 0.8}, Target: model.Symbol{FileID: 4}},
+		},
+	}
+
+	resp := BuildGraphResponse(sc, files, BuildGraphRequest{Direction: model.DirectionCallers})
+
+	if len(resp.Edges.Includes) != 1 || resp.Edges.Includes[0].Symbol != "SoftDeletable" {
+		t.Errorf("Includes = %+v, want [SoftDeletable]", resp.Edges.Includes)
+	}
+	if resp.Edges.Includes[0].Ref != "app/concerns/soft_deletable.rb:1" {
+		t.Errorf("Includes[0].Ref = %q, want %q", resp.Edges.Includes[0].Ref, "app/concerns/soft_deletable.rb:1")
+	}
+	if len(resp.Edges.Imports) != 1 || resp.Edges.Imports[0].Symbol != "utils" {
+		t.Errorf("Imports = %+v, want [utils]", resp.Edges.Imports)
+	}
+	if len(resp.Edges.Tests) != 1 || resp.Edges.Tests[0].File != "spec/models/user_spec.rb" {
+		t.Errorf("Tests = %+v, want [spec/models/user_spec.rb]", resp.Edges.Tests)
+	}
+}
+
+func TestBuildGraphResponseInboundOnlyTemporal(t *testing.T) {
+	coChanges := 7
+	sc := &model.SymbolContext{
+		Symbol: model.Symbol{Name: "A", Qualified: "A", Kind: "class", FileID: 1},
+		File:   model.File{Path: "a.rb"},
+		Inbound: []model.EdgeRef{
+			{
+				Edge:   model.Edge{Kind: model.EdgeTemporal, Confidence: 0.6, Line: &coChanges},
+				Target: model.Symbol{ID: 3, Qualified: "C", FileID: 3, LineStart: 10},
+			},
+		},
+	}
+	filePaths := map[int64]string{3: "c.rb"}
+	files := func(id int64) (string, bool) {
+		p, ok := filePaths[id]
+		return p, ok
+	}
+
+	resp := BuildGraphResponse(sc, files, BuildGraphRequest{})
+
+	if len(resp.Edges.Temporal) != 1 {
+		t.Fatalf("Temporal = %d, want 1", len(resp.Edges.Temporal))
+	}
+	if resp.Edges.Temporal[0].Symbol != "C" {
+		t.Errorf("Temporal[0].Symbol = %q, want C", resp.Edges.Temporal[0].Symbol)
+	}
+	if resp.Edges.Temporal[0].Ref != "c.rb:10" {
+		t.Errorf("Temporal[0].Ref = %q, want c.rb:10", resp.Edges.Temporal[0].Ref)
+	}
+	if resp.Edges.Temporal[0].CoChanges != 7 {
+		t.Errorf("Temporal[0].CoChanges = %d, want 7", resp.Edges.Temporal[0].CoChanges)
+	}
+}
+
+func TestFormatRef(t *testing.T) {
+	tests := []struct {
+		file      string
+		lineStart int
+		want      string
+	}{
+		{"app/models/user.rb", 42, "app/models/user.rb:42"},
+		{"app/models/user.rb", 0, ""},
+		{"", 10, ""},
+		{"", 0, ""},
+	}
+	for _, tc := range tests {
+		got := FormatRef(tc.file, tc.lineStart)
+		if got != tc.want {
+			t.Errorf("FormatRef(%q, %d) = %q, want %q", tc.file, tc.lineStart, got, tc.want)
+		}
+	}
+}
+
+func TestFormatRefPtr(t *testing.T) {
+	f := "lib/foo.rb"
+	if got := FormatRefPtr(&f, 10); got != "lib/foo.rb:10" {
+		t.Errorf("FormatRefPtr(&%q, 10) = %q, want %q", f, got, "lib/foo.rb:10")
+	}
+	if got := FormatRefPtr(nil, 10); got != "" {
+		t.Errorf("FormatRefPtr(nil, 10) = %q, want empty", got)
+	}
+	if got := FormatRefPtr(&f, 0); got != "" {
+		t.Errorf("FormatRefPtr(&%q, 0) = %q, want empty", f, got)
+	}
+}
+
+func TestBuildGraphResponseRefField(t *testing.T) {
+	filePaths := map[int64]string{
+		1: "app/models/user.rb",
+		2: "app/services/auth.rb",
+		3: "app/concerns/soft_deletable.rb",
+		4: "app/models/order.rb",
+		5: "src/utils.ts",
+		6: "app/jobs/export_cron.rb",
+	}
+	files := func(id int64) (string, bool) {
+		p, ok := filePaths[id]
+		return p, ok
+	}
+
+	coChanges := 5
+	sc := &model.SymbolContext{
+		Symbol: model.Symbol{
+			Name: "User", Qualified: "User",
+			Kind: model.KindClass, FileID: 1, LineStart: 10, LineEnd: 50,
+		},
+		File: model.File{Path: "app/models/user.rb"},
+		Outbound: []model.EdgeRef{
+			{Edge: model.Edge{Kind: model.EdgeCalls, Confidence: 1.0}, Target: model.Symbol{Qualified: "Auth#login", FileID: 2, LineStart: 20}},
+			{Edge: model.Edge{Kind: model.EdgeCalls, Confidence: 0.9}, Target: model.Symbol{Qualified: "External.api", FileID: 999}},
+			{Edge: model.Edge{Kind: model.EdgeInherits, Confidence: 1.0}, Target: model.Symbol{Qualified: "Base", FileID: 0}},
+			{Edge: model.Edge{Kind: model.EdgeComposes, Confidence: 1.0}, Target: model.Symbol{Qualified: "Order", FileID: 4, LineStart: 1}},
+			{Edge: model.Edge{Kind: model.EdgeIncludes}, Target: model.Symbol{Qualified: "SoftDeletable", FileID: 3, LineStart: 5}},
+			{Edge: model.Edge{Kind: model.EdgeImports}, Target: model.Symbol{Qualified: "utils", FileID: 5, LineStart: 1}},
+			{Edge: model.Edge{Kind: model.EdgeTemporal, Confidence: 0.7, Line: &coChanges}, Target: model.Symbol{ID: 6, Qualified: "ExportCron", FileID: 6, LineStart: 3}},
+		},
+		Inbound: []model.EdgeRef{
+			{Edge: model.Edge{Kind: model.EdgeCalls, Confidence: 1.0}, Target: model.Symbol{Qualified: "Controller#index", FileID: 2, LineStart: 55}},
+		},
+	}
+
+	resp := BuildGraphResponse(sc, files, BuildGraphRequest{})
+
+	// Focal symbol ref
+	if resp.Symbol.Ref != "app/models/user.rb:10" {
+		t.Errorf("Symbol.Ref = %q, want %q", resp.Symbol.Ref, "app/models/user.rb:10")
+	}
+
+	// Calls — with file
+	if resp.Edges.Calls[0].Ref != "app/services/auth.rb:20" {
+		t.Errorf("Calls[0].Ref = %q, want %q", resp.Edges.Calls[0].Ref, "app/services/auth.rb:20")
+	}
+	// Calls — nil file (external)
+	if resp.Edges.Calls[1].Ref != "" {
+		t.Errorf("Calls[1].Ref = %q, want empty (nil file)", resp.Edges.Calls[1].Ref)
+	}
+
+	// CalledBy
+	if resp.Edges.CalledBy[0].Ref != "app/services/auth.rb:55" {
+		t.Errorf("CalledBy[0].Ref = %q, want %q", resp.Edges.CalledBy[0].Ref, "app/services/auth.rb:55")
+	}
+
+	// Composes
+	if resp.Edges.Composes[0].Ref != "app/models/order.rb:1" {
+		t.Errorf("Composes[0].Ref = %q, want %q", resp.Edges.Composes[0].Ref, "app/models/order.rb:1")
+	}
+
+	// Includes
+	if resp.Edges.Includes[0].Ref != "app/concerns/soft_deletable.rb:5" {
+		t.Errorf("Includes[0].Ref = %q, want %q", resp.Edges.Includes[0].Ref, "app/concerns/soft_deletable.rb:5")
+	}
+
+	// Imports
+	if resp.Edges.Imports[0].Ref != "src/utils.ts:1" {
+		t.Errorf("Imports[0].Ref = %q, want %q", resp.Edges.Imports[0].Ref, "src/utils.ts:1")
+	}
+
+	// Temporal
+	if resp.Edges.Temporal[0].Ref != "app/jobs/export_cron.rb:3" {
+		t.Errorf("Temporal[0].Ref = %q, want %q", resp.Edges.Temporal[0].Ref, "app/jobs/export_cron.rb:3")
+	}
+}
+
+func TestGraphVerifyHintNotEmittedWithoutCallees(t *testing.T) {
+	sc := &model.SymbolContext{
+		Symbol: model.Symbol{
+			Name: "ORPHAN_CONST", Qualified: "ORPHAN_CONST",
+			Kind: model.KindConstant, FileID: 1, LineStart: 1, LineEnd: 1,
+		},
+		File: model.File{Path: "lib/orphan.rb"},
+	}
+	files := func(int64) (string, bool) { return "", false }
+
+	resp := BuildGraphResponse(sc, files, BuildGraphRequest{})
+
+	if resp.VerifyHint != "" {
+		t.Errorf("VerifyHint should be empty for leaf symbol with no callees, got %q", resp.VerifyHint)
+	}
+}

--- a/internal/mcpio/testdata/graph_checkout_service.json
+++ b/internal/mcpio/testdata/graph_checkout_service.json
@@ -5,7 +5,8 @@
     "file": "app/services/checkout_service.rb",
     "line_start": 12,
     "line_end": 85,
-    "kind": "class"
+    "kind": "class",
+    "ref": "app/services/checkout_service.rb:12"
   },
   "edges": {
     "calls": [

--- a/internal/mcpio/testdata/graph_empty.json
+++ b/internal/mcpio/testdata/graph_empty.json
@@ -5,7 +5,8 @@
     "file": "app/models/orphan.rb",
     "line_start": 1,
     "line_end": 3,
-    "kind": "class"
+    "kind": "class",
+    "ref": "app/models/orphan.rb:1"
   },
   "edges": {
     "calls": [],

--- a/internal/mcpio/testdata/graph_with_freshness.json
+++ b/internal/mcpio/testdata/graph_with_freshness.json
@@ -5,7 +5,8 @@
     "file": "app/services/checkout_service.rb",
     "line_start": 12,
     "line_end": 85,
-    "kind": "class"
+    "kind": "class",
+    "ref": "app/services/checkout_service.rb:12"
   },
   "edges": {
     "calls": [

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -103,6 +103,7 @@ type GraphResponse struct {
 	Truncated          bool                   `json:"truncated,omitempty"`
 	TestCallerSummary  *TestCallerSummary     `json:"test_caller_summary,omitempty"`
 	CoverageNote       string                 `json:"coverage_note,omitempty"`
+	VerifyHint         string                 `json:"verify_hint,omitempty"`
 	SenseMetrics       GraphMetrics           `json:"-"`
 	Freshness          *Freshness             `json:"freshness,omitempty"`
 	NextSteps          []NextStep             `json:"next_steps"`
@@ -116,6 +117,7 @@ type DispatchInferredRef struct {
 	File       *string    `json:"file"`
 	LineStart  int        `json:"line_start,omitempty"`
 	LineEnd    int        `json:"line_end,omitempty"`
+	Ref        string     `json:"ref,omitempty"`
 	Via        string     `json:"via"`
 	Confidence Confidence `json:"confidence"`
 }
@@ -149,6 +151,7 @@ type GraphSymbol struct {
 	LineStart int    `json:"line_start"`
 	LineEnd   int    `json:"line_end"`
 	Kind      string `json:"kind"`
+	Ref       string `json:"ref"`
 }
 
 // GraphEdges groups the subject's relationships by kind. Every kind
@@ -175,6 +178,7 @@ type CallEdgeRef struct {
 	File       *string    `json:"file"`
 	LineStart  int        `json:"line_start,omitempty"`
 	LineEnd    int        `json:"line_end,omitempty"`
+	Ref        string     `json:"ref,omitempty"`
 	Confidence Confidence `json:"confidence"`
 }
 
@@ -187,6 +191,7 @@ type InheritEdgeRef struct {
 	File      *string `json:"file"`
 	LineStart int     `json:"line_start,omitempty"`
 	LineEnd   int     `json:"line_end,omitempty"`
+	Ref       string  `json:"ref,omitempty"`
 }
 
 // ComposeEdgeRef is the shape of a composes edge entry (has_many,
@@ -198,6 +203,7 @@ type ComposeEdgeRef struct {
 	File      *string `json:"file"`
 	LineStart int     `json:"line_start,omitempty"`
 	LineEnd   int     `json:"line_end,omitempty"`
+	Ref       string  `json:"ref,omitempty"`
 }
 
 // IncludeEdgeRef is the shape of an includes edge entry (Ruby
@@ -208,6 +214,7 @@ type IncludeEdgeRef struct {
 	File      *string `json:"file"`
 	LineStart int     `json:"line_start,omitempty"`
 	LineEnd   int     `json:"line_end,omitempty"`
+	Ref       string  `json:"ref,omitempty"`
 }
 
 // ImportEdgeRef is the shape of an imports edge entry (JS/TS
@@ -218,6 +225,7 @@ type ImportEdgeRef struct {
 	File      *string `json:"file"`
 	LineStart int     `json:"line_start,omitempty"`
 	LineEnd   int     `json:"line_end,omitempty"`
+	Ref       string  `json:"ref,omitempty"`
 }
 
 // TestEdgeRef points at a test file rather than a symbol: the
@@ -236,6 +244,7 @@ type TemporalEdgeRef struct {
 	File      *string    `json:"file"`
 	LineStart int        `json:"line_start,omitempty"`
 	LineEnd   int        `json:"line_end,omitempty"`
+	Ref       string     `json:"ref,omitempty"`
 	CoChanges int        `json:"co_changes"`
 	Strength  Confidence `json:"strength"`
 }
@@ -275,11 +284,13 @@ type BlastResponse struct {
 	// Tier 3 — affected test count (detail omitted to keep response focused).
 	TestsAffectedCount int `json:"tests_affected_count"`
 
+	Note               string `json:"note,omitempty"`
 	ProductionAffected int    `json:"production_affected"`
 	TestAffected       int    `json:"test_affected"`
 	Truncated          bool   `json:"truncated,omitempty"`
 	CoverageNote       string `json:"coverage_note,omitempty"`
 
+	VerifyHint   string       `json:"verify_hint,omitempty"`
 	SenseMetrics BlastMetrics `json:"-"`
 	Freshness    *Freshness   `json:"freshness,omitempty"`
 	NextSteps    []NextStep   `json:"next_steps"`
@@ -298,6 +309,7 @@ type BlastCaller struct {
 	File        string `json:"file"`
 	LineStart   int    `json:"line_start,omitempty"`
 	LineEnd     int    `json:"line_end,omitempty"`
+	Ref         string `json:"ref,omitempty"`
 	ViaTemporal bool   `json:"via_temporal,omitempty"`
 }
 
@@ -311,6 +323,7 @@ type BlastIndirect struct {
 	Hops        int    `json:"hops"`
 	LineStart   int    `json:"line_start,omitempty"`
 	LineEnd     int    `json:"line_end,omitempty"`
+	Ref         string `json:"ref,omitempty"`
 	ViaTemporal bool   `json:"via_temporal,omitempty"`
 }
 

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -524,6 +524,7 @@ func (h *handlers) resolveDispatchCallers(ctx context.Context, root *model.Symbo
 				File:       filePath,
 				LineStart:  e.Target.LineStart,
 				LineEnd:    e.Target.LineEnd,
+				Ref:        mcpio.FormatRefPtr(filePath, e.Target.LineStart),
 				Via:        via,
 				Confidence: mcpio.Confidence(DispatchInferredConfidence),
 			})


### PR DESCRIPTION
## Problem

When an LLM queries Sense, it treats structured JSON responses as ground truth and stops verifying. Bench2 transcripts show three failure modes: (1) zero-caller results stated as fact when grep finds active references, (2) graph edge counts misreported as "source references" (inflating blast radius 6×), and (3) line numbers misquoted in prose because the LLM interpolates separate fields instead of copying a single string.

## Summary

Add `verify_hint`, disambiguation `note`, and pre-formatted `ref` fields to graph and blast MCP responses so the LLM has structured signals to self-correct.

## Changes

**verify_hint** — flags structurally suspect results
- Graph: emits when callers are empty for constant/function symbols that have outgoing calls
- Blast: emits when `total_affected` is 0 for symbols with callees (via new lightweight `subjectHasCallees` EXISTS query in blast engine)

**note** — disambiguates blast counts
- Always present on blast responses, clarifying that `total_affected` counts unique symbols, not source-level references or graph edges

**ref** — copy-paste-ready file references
- Pre-formatted `file:line_start` string added to all symbol entry types across graph and blast responses (`GraphSymbol`, `CallEdgeRef`, `InheritEdgeRef`, `ComposeEdgeRef`, `IncludeEdgeRef`, `ImportEdgeRef`, `TemporalEdgeRef`, `DispatchInferredRef`, `BlastCaller`, `BlastIndirect`)
- Exported `FormatRef` / `FormatRefPtr` helpers in mcpio package

## Test Plan

- [x] `verify_hint` emits for constant with zero callers and outgoing calls
- [x] `verify_hint` emits for function with zero callers and outgoing calls
- [x] `verify_hint` does NOT emit when callers exist, kind is class, or no callees
- [x] Blast `verify_hint` emits when `total_affected=0` with callees, not otherwise
- [x] `ref` field format is `file:line_start` across all edge types
- [x] `ref` is empty for nil-file entries and zero line_start
- [x] Contract golden files updated and passing
- [x] Coverage: graph.go 99.4%, blast.go 99.2%, types.go 100%
- [x] `make ci` passes (build + test + lint)