### PR TITLE
feat(blast): add affected_symbols, affected_files, and graph_edges_traversed fields

### DIFF
--- a/internal/blast/engine.go
+++ b/internal/blast/engine.go
@@ -159,6 +159,7 @@ type Result struct {
 	// a temporal edge. Keyed by symbol ID.
 	DirectTemporalIDs map[int64]bool
 
+	EdgesTraversed    int
 	SubjectHasCallees bool
 
 	// Edge-kind groups: filtered views over the same nodes that appear
@@ -236,6 +237,7 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 	}
 
 	truncated := false
+	edgesTraversed := 0
 	for hop := 1; hop <= opts.MaxHops; hop++ {
 		if err := ctx.Err(); err != nil {
 			return Result{}, fmt.Errorf("blast: cancelled at hop %d: %w", hop, err)
@@ -244,6 +246,7 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 		if err != nil {
 			return Result{}, fmt.Errorf("blast: hop %d: %w", hop, err)
 		}
+		edgesTraversed += len(pairs)
 		var next []int64
 		for _, pair := range pairs {
 			if _, seen := visited[pair.source]; seen {
@@ -488,6 +491,7 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 		IndirectCallers:        indirectCallers,
 		AffectedTests:          affectedTests,
 		TotalAffected:          totalAffectedCount,
+		EdgesTraversed:         edgesTraversed,
 		SubjectHasCallees:      hasCallees,
 		DirectTemporalIDs:      directTemporalIDs,
 		AffectedSubclasses:     subclasses,

--- a/internal/cli/blast_test.go
+++ b/internal/cli/blast_test.go
@@ -97,7 +97,7 @@ func TestRunBlastHumanSuccess(t *testing.T) {
 		"Indirect callers (1):",
 		"WebhookJob#process  via OrdersController#create (2 hops)",
 		"Tests affected: 1",
-		"Total affected: 2",
+		"Affected: 2 symbols across",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("missing %q\ngot:\n%s", want, out)
@@ -391,8 +391,8 @@ func TestRunBlastDiffEmptyWhenNoIndexedFiles(t *testing.T) {
 	if code != ExitSuccess {
 		t.Fatalf("exit = %d stderr=%s", code, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "Total affected: 0") {
-		t.Errorf("expected Total affected: 0, got:\n%s", stdout.String())
+	if !strings.Contains(stdout.String(), "Affected: 0 symbols across 0 files") {
+		t.Errorf("expected 'Affected: 0 symbols across 0 files', got:\n%s", stdout.String())
 	}
 }
 

--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -236,5 +236,5 @@ func RenderBlastHuman(w io.Writer, resp mcpio.BlastResponse) {
 			_, _ = fmt.Fprintf(w, "  %s\n", t)
 		}
 	}
-	_, _ = fmt.Fprintf(w, "\nTotal affected: %d\n", resp.TotalAffected)
+	_, _ = fmt.Fprintf(w, "\nAffected: %d symbols across %d files\n", resp.AffectedSymbols, resp.AffectedFiles)
 }

--- a/internal/cli/render_test.go
+++ b/internal/cli/render_test.go
@@ -501,8 +501,10 @@ func TestRenderBlastHumanFullSections(t *testing.T) {
 				{Symbol: "RefB", File: "b.rb"},
 			},
 		},
-		AffectedTests: []string{"test/checkout_test.rb", "test/cart_test.rb"},
-		TotalAffected: 15,
+		AffectedTests:   []string{"test/checkout_test.rb", "test/cart_test.rb"},
+		AffectedSymbols: 15,
+		AffectedFiles:   8,
+		TotalAffected:   15,
 	}
 
 	var buf bytes.Buffer
@@ -529,7 +531,7 @@ func TestRenderBlastHumanFullSections(t *testing.T) {
 		"Affected tests (2):",
 		"test/checkout_test.rb",
 		"test/cart_test.rb",
-		"Total affected: 15",
+		"Affected: 15 symbols across 8 files",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("missing %q\ngot:\n%s", want, out)

--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -125,7 +125,9 @@ func BuildBlastResponse(r blast.Result, files FileLookup) BlastResponse {
 		Examples: examples,
 	}
 
-	resp.Note = "total_affected counts unique symbols in the blast radius — not source-level references or graph edges traversed."
+	resp.AffectedSymbols = r.TotalAffected
+	resp.GraphEdgesTraversed = r.EdgesTraversed
+	resp.Note = "affected_symbols counts unique symbols in the blast radius — not source-level references or graph edges traversed. total_affected is an alias for affected_symbols."
 
 	segmentBlastCallers(&resp)
 
@@ -134,6 +136,7 @@ func BuildBlastResponse(r blast.Result, files FileLookup) BlastResponse {
 	}
 
 	uniqueFiles := countUniqueBlastFiles(resp)
+	resp.AffectedFiles = uniqueFiles
 	resp.SenseMetrics = BlastMetrics{
 		SymbolsTraversed:          1 + len(r.DirectCallers) + len(r.IndirectCallers),
 		EstimatedFileReadsAvoided: uniqueFiles,
@@ -165,8 +168,10 @@ func BuildDiffBlastResponse(ref string, results []blast.Result, files FileLookup
 	indirectSeen := map[int64]struct{}{}
 	testsSeen := map[string]struct{}{}
 	risk := blast.RiskLow
+	totalEdges := 0
 
 	for _, r := range results {
+		totalEdges += r.EdgesTraversed
 		if riskRank(r.Risk) > riskRank(risk) {
 			risk = r.Risk
 		}
@@ -216,7 +221,9 @@ func BuildDiffBlastResponse(ref string, results []blast.Result, files FileLookup
 
 	resp.Risk = risk
 	resp.TotalAffected = len(resp.DirectCallers) + len(resp.IndirectCallers)
-	resp.Note = "total_affected counts unique symbols in the blast radius — not source-level references or graph edges traversed."
+	resp.AffectedSymbols = resp.TotalAffected
+	resp.GraphEdgesTraversed = totalEdges
+	resp.Note = "affected_symbols counts unique symbols in the blast radius — not source-level references or graph edges traversed. total_affected is an alias for affected_symbols."
 	resp.RiskFactors = []string{
 		fmt.Sprintf("%d modified symbols; %d direct callers", len(results), len(resp.DirectCallers)),
 	}
@@ -224,6 +231,7 @@ func BuildDiffBlastResponse(ref string, results []blast.Result, files FileLookup
 	segmentBlastCallers(&resp)
 
 	uniqueFiles := countUniqueBlastFiles(resp)
+	resp.AffectedFiles = uniqueFiles
 	resp.SenseMetrics = BlastMetrics{
 		SymbolsTraversed:          len(results) + len(resp.DirectCallers) + len(resp.IndirectCallers),
 		EstimatedFileReadsAvoided: uniqueFiles,

--- a/internal/mcpio/blast_test.go
+++ b/internal/mcpio/blast_test.go
@@ -508,6 +508,116 @@ func TestBlastVerifyHintNotEmittedWithCallers(t *testing.T) {
 	}
 }
 
+func TestBuildBlastResponseAffectedSymbolsAndFiles(t *testing.T) {
+	r := blast.Result{
+		Symbol:      model.Symbol{ID: 0, Qualified: "Subject"},
+		Risk:        blast.RiskLow,
+		RiskReasons: []string{"3 callers"},
+		DirectCallers: []model.Symbol{
+			{ID: 1, Qualified: "CallerA", FileID: 10, LineStart: 5},
+			{ID: 2, Qualified: "CallerB", FileID: 11, LineStart: 10},
+		},
+		IndirectCallers: []blast.CallerHop{
+			{
+				Symbol: model.Symbol{ID: 3, Qualified: "IndirectC", FileID: 10, LineStart: 20},
+				Via:    model.Symbol{ID: 1, Qualified: "CallerA"},
+				Hops:   2,
+			},
+		},
+		AffectedTests:  []string{"test/subject_test.rb"},
+		TotalAffected:  3,
+		EdgesTraversed: 47,
+	}
+
+	files := func(id int64) (string, bool) {
+		m := map[int64]string{10: "lib/a.rb", 11: "lib/b.rb"}
+		p, ok := m[id]
+		return p, ok
+	}
+
+	resp := BuildBlastResponse(r, files)
+
+	if resp.AffectedSymbols != 3 {
+		t.Errorf("AffectedSymbols = %d, want 3", resp.AffectedSymbols)
+	}
+	if resp.AffectedSymbols != resp.TotalAffected {
+		t.Errorf("AffectedSymbols (%d) != TotalAffected (%d), should be aliases",
+			resp.AffectedSymbols, resp.TotalAffected)
+	}
+	// lib/a.rb, lib/b.rb, test/subject_test.rb = 3 unique files
+	if resp.AffectedFiles != 3 {
+		t.Errorf("AffectedFiles = %d, want 3 (2 caller files + 1 test)", resp.AffectedFiles)
+	}
+	if resp.GraphEdgesTraversed != 47 {
+		t.Errorf("GraphEdgesTraversed = %d, want 47", resp.GraphEdgesTraversed)
+	}
+}
+
+func TestBuildDiffBlastResponseAffectedSymbolsAndFiles(t *testing.T) {
+	results := []blast.Result{
+		{
+			Symbol:         model.Symbol{ID: 1, Qualified: "A"},
+			Risk:           blast.RiskLow,
+			DirectCallers:  []model.Symbol{{ID: 10, Qualified: "C1", FileID: 100}},
+			AffectedTests:  []string{"test/a_test.rb"},
+			EdgesTraversed: 20,
+		},
+		{
+			Symbol:         model.Symbol{ID: 2, Qualified: "B"},
+			Risk:           blast.RiskLow,
+			DirectCallers:  []model.Symbol{{ID: 11, Qualified: "C2", FileID: 101}},
+			AffectedTests:  []string{"test/b_test.rb"},
+			EdgesTraversed: 15,
+		},
+	}
+
+	files := func(id int64) (string, bool) {
+		m := map[int64]string{100: "lib/c1.rb", 101: "lib/c2.rb"}
+		p, ok := m[id]
+		return p, ok
+	}
+
+	resp := BuildDiffBlastResponse("HEAD~1", results, files)
+
+	if resp.AffectedSymbols != 2 {
+		t.Errorf("AffectedSymbols = %d, want 2", resp.AffectedSymbols)
+	}
+	if resp.AffectedSymbols != resp.TotalAffected {
+		t.Errorf("AffectedSymbols (%d) != TotalAffected (%d)", resp.AffectedSymbols, resp.TotalAffected)
+	}
+	// lib/c1.rb, lib/c2.rb, test/a_test.rb, test/b_test.rb = 4
+	if resp.AffectedFiles != 4 {
+		t.Errorf("AffectedFiles = %d, want 4", resp.AffectedFiles)
+	}
+	if resp.GraphEdgesTraversed != 35 {
+		t.Errorf("GraphEdgesTraversed = %d, want 35 (20+15)", resp.GraphEdgesTraversed)
+	}
+}
+
+func TestBuildBlastResponseZeroEdges(t *testing.T) {
+	r := blast.Result{
+		Symbol:         model.Symbol{ID: 1, Qualified: "Isolated"},
+		Risk:           blast.RiskLow,
+		RiskReasons:    []string{"0 direct callers"},
+		DirectCallers:  []model.Symbol{},
+		AffectedTests:  []string{},
+		TotalAffected:  0,
+		EdgesTraversed: 0,
+	}
+
+	resp := BuildBlastResponse(r, noFiles)
+
+	if resp.AffectedSymbols != 0 {
+		t.Errorf("AffectedSymbols = %d, want 0", resp.AffectedSymbols)
+	}
+	if resp.AffectedFiles != 0 {
+		t.Errorf("AffectedFiles = %d, want 0", resp.AffectedFiles)
+	}
+	if resp.GraphEdgesTraversed != 0 {
+		t.Errorf("GraphEdgesTraversed = %d, want 0", resp.GraphEdgesTraversed)
+	}
+}
+
 func TestBlastVerifyHintNotEmittedLeafSymbol(t *testing.T) {
 	r := blast.Result{
 		Symbol:            model.Symbol{ID: 1, Qualified: "Leaf"},

--- a/internal/mcpio/contract_test.go
+++ b/internal/mcpio/contract_test.go
@@ -254,7 +254,10 @@ func fixtureBlastUserEmailVerified() BlastResponse {
 			"test/controllers/admin/users_controller_test.rb",
 			"test/controllers/orders_controller_test.rb",
 		},
-		TotalAffected:      11,
+		AffectedSymbols:     11,
+		AffectedFiles:       10,
+		GraphEdgesTraversed: 91,
+		TotalAffected:       11,
 		ProductionAffected: 5,
 		TestAffected:       6,
 		SenseMetrics: BlastMetrics{

--- a/internal/mcpio/testdata/blast_diff.json
+++ b/internal/mcpio/testdata/blast_diff.json
@@ -38,6 +38,9 @@
     "test/controllers/orders_controller_test.rb",
     "test/controllers/sessions_controller_test.rb"
   ],
+  "affected_symbols": 0,
+  "affected_files": 0,
+  "graph_edges_traversed": 0,
   "total_affected": 6,
   "affected_subclasses": [],
   "affected_via_composition": [],

--- a/internal/mcpio/testdata/blast_user_email_verified.json
+++ b/internal/mcpio/testdata/blast_user_email_verified.json
@@ -39,6 +39,9 @@
     "test/controllers/admin/users_controller_test.rb",
     "test/controllers/orders_controller_test.rb"
   ],
+  "affected_symbols": 11,
+  "affected_files": 10,
+  "graph_edges_traversed": 91,
   "total_affected": 11,
   "affected_subclasses": [],
   "affected_via_composition": [],

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -273,7 +273,10 @@ type BlastResponse struct {
 	DirectCallers   []BlastCaller   `json:"direct_callers"`
 	IndirectCallers []BlastIndirect `json:"indirect_callers"`
 	AffectedTests   []string        `json:"affected_tests"`
-	TotalAffected   int             `json:"total_affected"`
+	AffectedSymbols      int             `json:"affected_symbols"`
+	AffectedFiles        int             `json:"affected_files"`
+	GraphEdgesTraversed  int             `json:"graph_edges_traversed"`
+	TotalAffected        int             `json:"total_affected"`
 
 	AffectedSubclasses     []BlastCaller `json:"affected_subclasses"`
 	AffectedViaComposition []BlastCaller `json:"affected_via_composition"`


### PR DESCRIPTION
## Problem

Blast responses report `total_affected` which counts unique symbols, but the BFS traversal also walks many more edges. LLMs conflate "graph edges traversed" with "source-level references" — in the Axum benchmark, the LLM reported "91 BoxedIntoRoute references" when actual affected symbols were 15. This 6x overestimate distorts cost-benefit analysis for changes.

## Summary

Add three new fields to the blast response that make the distinction unambiguous: `affected_symbols` (renamed semantic), `affected_files` (unique file count), and `graph_edges_traversed` (BFS diagnostic). CLI output now shows "N symbols across M files" instead of a raw total.

## Changes

- **blast engine**: track edge count during BFS traversal, expose as `EdgesTraversed` on `blast.Result`
- **BlastResponse**: add `affected_symbols`, `affected_files`, `graph_edges_traversed` fields
- **backward compat**: keep `total_affected` as alias for `affected_symbols` (same value)
- **CLI output**: show "Affected: N symbols across M files" instead of "Total affected: N"; edge count suppressed from CLI (diagnostic only, available in JSON)
- **tests**: 3 new tests covering both symbol and diff blast paths plus zero-edge boundary; existing CLI tests updated

## Test Plan

- [ ] `affected_symbols` equals `total_affected` in all responses
- [ ] `affected_files` counts unique files across callers + tests
- [ ] `graph_edges_traversed` reflects actual BFS edge expansion count
- [ ] CLI shows symbol/file counts, not edge count
- [ ] `go test ./...` passes
- [ ] `make ci` passes (lint + tests)