### PR TITLE
feat(dead): detect unused constants and variables across all languages

### DIFF
--- a/internal/blast/engine.go
+++ b/internal/blast/engine.go
@@ -70,7 +70,7 @@ const (
 // classifyTier maps an edge kind to its relevance tier.
 func classifyTier(edgeKind string) Tier {
 	switch edgeKind {
-	case "calls", "temporal", "member":
+	case "calls", "temporal", "member", "references":
 		return TierBreaks
 	case "tests":
 		return TierTests
@@ -550,7 +550,7 @@ func expandFrontier(ctx context.Context, db *sql.DB, frontier []int64) ([]edgePa
 		q := `SELECT source_id, target_id, kind, confidence FROM sense_edges
 		      WHERE target_id IN (` + placeholders + `)
 		        AND source_id IS NOT NULL
-		        AND kind IN ('calls', 'composes', 'includes', 'inherits', 'temporal', 'tests')
+		        AND kind IN ('calls', 'composes', 'includes', 'inherits', 'temporal', 'tests', 'references')
 		        AND confidence >= 0.1`
 
 		args := make([]any, 0, len(batch))

--- a/internal/dead/dead.go
+++ b/internal/dead/dead.go
@@ -117,7 +117,7 @@ func FindDead(ctx context.Context, db *sql.DB, opts Options) (Result, error) {
 func countSymbols(ctx context.Context, db *sql.DB, opts Options) (int, error) {
 	q := `SELECT COUNT(*) FROM sense_symbols s
 		JOIN sense_files f ON s.file_id = f.id
-		WHERE s.kind IN ('function', 'method', 'class', 'module', 'type', 'interface')`
+		WHERE s.kind IN ('function', 'method', 'class', 'module', 'type', 'interface', 'constant')`
 	var args []any
 
 	if opts.Language != "" {
@@ -139,7 +139,7 @@ func countSymbols(ctx context.Context, db *sql.DB, opts Options) (int, error) {
 func queryCandidates(ctx context.Context, db *sql.DB, opts Options) ([]Symbol, error) {
 	edgeFilter := `SELECT 1 FROM sense_edges e
 			WHERE e.target_id = s.id
-			AND e.kind IN ('calls', 'composes', 'includes', 'inherits')`
+			AND e.kind IN ('calls', 'composes', 'includes', 'inherits', 'references')`
 	if opts.ExcludeTestRefs {
 		edgeFilter += `
 			AND NOT EXISTS (
@@ -160,7 +160,7 @@ func queryCandidates(ctx context.Context, db *sql.DB, opts Options) ([]Symbol, e
 		FROM sense_symbols s
 		JOIN sense_files f ON s.file_id = f.id
 		WHERE NOT EXISTS (` + edgeFilter + `)
-		AND s.kind IN ('function', 'method', 'class', 'module', 'type', 'interface')`
+		AND s.kind IN ('function', 'method', 'class', 'module', 'type', 'interface', 'constant')`
 	var args []any
 
 	if opts.Language != "" {
@@ -440,8 +440,10 @@ func isEntryPoint(s Symbol, f entryPointFilters) bool {
 	if mightBeTraitImplMethod(s, f.interfaceMethodNames, f.implementorIDs) {
 		return true
 	}
-	if _, ok := f.testsTargets[s.ID]; ok {
-		return true
+	if s.Kind != "constant" {
+		if _, ok := f.testsTargets[s.ID]; ok {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/dead/dead_test.go
+++ b/internal/dead/dead_test.go
@@ -927,6 +927,246 @@ func RenderAll(rs []Renderer) {
 	}
 }
 
+func TestDeadCodeIncludesUnusedConstants(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, "consts.go"), `package main
+
+const UsedConst = "yes"
+const DeadConst = "no"
+
+func main() {
+	_ = UsedConst
+}
+`)
+	ctx := context.Background()
+	if _, err := scan.Run(ctx, scan.Options{
+		Root:     root,
+		Output:   &bytes.Buffer{},
+		Warnings: io.Discard,
+	}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+	dbPath := filepath.Join(root, ".sense", "index.db")
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	result, err := dead.FindDead(ctx, db, dead.Options{})
+	if err != nil {
+		t.Fatalf("FindDead: %v", err)
+	}
+	deadNames := map[string]bool{}
+	for _, s := range result.Dead {
+		deadNames[s.Qualified] = true
+	}
+	if !deadNames["main.DeadConst"] {
+		t.Error("DeadConst should be in dead code results")
+	}
+	if deadNames["main.UsedConst"] {
+		t.Error("UsedConst should NOT be in dead code results (referenced by main)")
+	}
+}
+
+func TestDeadCodeIncludesUnusedVars(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, "vars.go"), `package main
+
+var usedVar = "yes"
+var deadVar = "no"
+
+func main() {
+	_ = usedVar
+}
+`)
+	ctx := context.Background()
+	if _, err := scan.Run(ctx, scan.Options{
+		Root:     root,
+		Output:   &bytes.Buffer{},
+		Warnings: io.Discard,
+	}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+	dbPath := filepath.Join(root, ".sense", "index.db")
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	result, err := dead.FindDead(ctx, db, dead.Options{})
+	if err != nil {
+		t.Fatalf("FindDead: %v", err)
+	}
+	deadNames := map[string]bool{}
+	for _, s := range result.Dead {
+		deadNames[s.Qualified] = true
+	}
+	if !deadNames["main.deadVar"] {
+		t.Error("deadVar should be in dead code results")
+	}
+	if deadNames["main.usedVar"] {
+		t.Error("usedVar should NOT be in dead code results (referenced by main)")
+	}
+}
+
+func TestDeadCodeConstTestOnlyReference(t *testing.T) {
+	root := t.TempDir()
+
+	// localhostIP is used only in the test file — production-dead.
+	writeFile(t, filepath.Join(root, "utils.go"), `package utils
+
+var localhostIP = "127.0.0.1"
+var localhostIPv6 = "::1"
+var productionAddr = "0.0.0.0"
+
+func Serve() {
+	_ = productionAddr
+}
+`)
+	writeFile(t, filepath.Join(root, "utils_test.go"), `package utils
+
+import "testing"
+
+func TestServe(t *testing.T) {
+	_ = localhostIP
+	_ = localhostIPv6
+}
+`)
+	ctx := context.Background()
+	if _, err := scan.Run(ctx, scan.Options{
+		Root:     root,
+		Output:   &bytes.Buffer{},
+		Warnings: io.Discard,
+	}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+	dbPath := filepath.Join(root, ".sense", "index.db")
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	// With ExcludeTestRefs=true, test-only references don't count.
+	result, err := dead.FindDead(ctx, db, dead.Options{ExcludeTestRefs: true})
+	if err != nil {
+		t.Fatalf("FindDead: %v", err)
+	}
+	deadNames := map[string]bool{}
+	for _, s := range result.Dead {
+		deadNames[s.Qualified] = true
+	}
+	if !deadNames["utils.localhostIP"] {
+		t.Error("localhostIP should be dead (only referenced in test file)")
+	}
+	if !deadNames["utils.localhostIPv6"] {
+		t.Error("localhostIPv6 should be dead (only referenced in test file)")
+	}
+	if deadNames["utils.productionAddr"] {
+		t.Error("productionAddr should NOT be dead (referenced by Serve)")
+	}
+
+	// Without cross-file speculative emission, localhostIP has no edges
+	// at all (the test file extractor doesn't see cross-file vars in its
+	// pkgBindings). It's dead regardless of ExcludeTestRefs.
+	resultAll, err := dead.FindDead(ctx, db, dead.Options{ExcludeTestRefs: false})
+	if err != nil {
+		t.Fatalf("FindDead: %v", err)
+	}
+	deadNamesAll := map[string]bool{}
+	for _, s := range resultAll.Dead {
+		deadNamesAll[s.Qualified] = true
+	}
+	if !deadNamesAll["utils.localhostIP"] {
+		t.Error("localhostIP should be dead (cross-file var, no same-file references)")
+	}
+}
+
+func TestDeadCodeGinConstants(t *testing.T) {
+	root := t.TempDir()
+
+	// Mirrors gin/utils.go: exported BindKey used in production, unexported
+	// localhostIP/localhostIPv6 used only in test files.
+	writeFile(t, filepath.Join(root, "utils.go"), `package gin
+
+const BindKey = "_gin-gonic/gin/bindkey"
+const localhostIP = "127.0.0.1"
+const localhostIPv6 = "::1"
+
+func Bind() string {
+	return BindKey
+}
+`)
+	writeFile(t, filepath.Join(root, "gin_test.go"), `package gin
+
+import "testing"
+
+func TestBind(t *testing.T) {
+	_ = localhostIP
+}
+`)
+	writeFile(t, filepath.Join(root, "context_test.go"), `package gin
+
+import "testing"
+
+func TestContext(t *testing.T) {
+	_ = localhostIP
+	_ = localhostIPv6
+}
+`)
+	ctx := context.Background()
+	if _, err := scan.Run(ctx, scan.Options{
+		Root:     root,
+		Output:   &bytes.Buffer{},
+		Warnings: io.Discard,
+	}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+	dbPath := filepath.Join(root, ".sense", "index.db")
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	// Verify BindKey has a same-file reference edge (from Bind()).
+	var refCount int
+	err = db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM sense_edges e
+		JOIN sense_symbols t ON t.id = e.target_id
+		WHERE t.qualified = 'gin.BindKey'
+		AND e.kind = 'references'`).Scan(&refCount)
+	if err != nil {
+		t.Fatalf("query refs: %v", err)
+	}
+	if refCount == 0 {
+		t.Error("expected references edge for BindKey from Bind()")
+	}
+
+	// localhostIP and localhostIPv6 are dead — no same-file references.
+	result, err := dead.FindDead(ctx, db, dead.Options{ExcludeTestRefs: true})
+	if err != nil {
+		t.Fatalf("FindDead: %v", err)
+	}
+	deadNames := map[string]bool{}
+	for _, s := range result.Dead {
+		deadNames[s.Qualified] = true
+	}
+	if !deadNames["gin.localhostIP"] {
+		t.Error("localhostIP should be dead (only referenced in test files)")
+	}
+	if !deadNames["gin.localhostIPv6"] {
+		t.Error("localhostIPv6 should be dead (only referenced in test files)")
+	}
+	if deadNames["gin.BindKey"] {
+		t.Error("BindKey should NOT be dead (referenced by Bind)")
+	}
+}
+
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/extract/golang/golang.go
+++ b/internal/extract/golang/golang.go
@@ -59,6 +59,7 @@ func (Extractor) Extract(tree *sitter.Tree, source []byte, _ string, emit extrac
 		source: source,
 		emit:   emit,
 		pkg:    packageName(tree.RootNode(), source),
+		pkgBindings: map[string]string{},
 	}
 	return w.walkTopLevel(tree.RootNode())
 }
@@ -70,19 +71,36 @@ func init() { extract.Register(Extractor{}) }
 type walker struct {
 	source []byte
 	emit   extract.Emitter
-	pkg    string // package name, used to prefix every qualified name
+	pkg         string            // package name, used to prefix every qualified name
+	pkgBindings map[string]string // unqualified name → qualified name for package-level consts and vars
 }
 
-// walkTopLevel iterates the direct named children of source_file and
-// dispatches by kind. Go's symbol surface is flat (no nested classes),
-// so we never descend beyond the declarations that sit at package
-// scope. Function/method bodies are not walked — nested types and
-// closures inside them are not Tier-Basic symbols.
+// walkTopLevel iterates the direct named children of source_file in
+// two passes. Pass 1 collects package-level constant names so that
+// pass 2 can emit references edges when function bodies use them.
 func (w *walker) walkTopLevel(root *sitter.Node) error {
 	if root == nil {
 		return nil
 	}
+
+	// Pass 1: collect package-level constant and variable names
+	// before processing function bodies so references resolve
+	// regardless of declaration order.
 	count := root.NamedChildCount()
+	for i := uint(0); i < count; i++ {
+		n := root.NamedChild(i)
+		if n == nil {
+			continue
+		}
+		switch n.Kind() {
+		case "const_declaration":
+			w.collectDeclNames(n, "const_spec")
+		case "var_declaration":
+			w.collectDeclNames(n, "var_spec")
+		}
+	}
+
+	// Pass 2: emit symbols and edges.
 	for i := uint(0); i < count; i++ {
 		n := root.NamedChild(i)
 		if n == nil {
@@ -92,6 +110,8 @@ func (w *walker) walkTopLevel(root *sitter.Node) error {
 		switch n.Kind() {
 		case "const_declaration":
 			err = w.handleConstDeclaration(n)
+		case "var_declaration":
+			err = w.handleVarDeclaration(n)
 		case "type_declaration":
 			err = w.handleTypeDeclaration(n)
 		case "function_declaration":
@@ -104,6 +124,41 @@ func (w *walker) walkTopLevel(root *sitter.Node) error {
 		}
 	}
 	return nil
+}
+
+// collectDeclNames populates w.pkgBindings with unqualified→qualified
+// mappings for every name in a const or var declaration.
+func (w *walker) collectDeclNames(n *sitter.Node, specKind string) {
+	for i := uint(0); i < n.NamedChildCount(); i++ {
+		child := n.NamedChild(i)
+		if child == nil {
+			continue
+		}
+		switch child.Kind() {
+		case specKind:
+			w.collectSpecNames(child)
+		case specKind + "_list":
+			for j := uint(0); j < child.NamedChildCount(); j++ {
+				spec := child.NamedChild(j)
+				if spec != nil && spec.Kind() == specKind {
+					w.collectSpecNames(spec)
+				}
+			}
+		}
+	}
+}
+
+func (w *walker) collectSpecNames(spec *sitter.Node) {
+	for i := uint(0); i < spec.NamedChildCount(); i++ {
+		c := spec.NamedChild(i)
+		if c == nil || c.Kind() != "identifier" {
+			continue
+		}
+		name := extract.Text(c, w.source)
+		if name != "" && name != "_" {
+			w.pkgBindings[name] = w.qualify(name)
+		}
+	}
 }
 
 // handleConstDeclaration walks const_spec children. Both the grouped
@@ -146,6 +201,39 @@ func (w *walker) emitConstSpec(spec *sitter.Node) error {
 			LineEnd:    extract.Line(spec.EndPosition()),
 		}); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+// handleVarDeclaration walks var_spec children and emits each
+// package-level variable as a KindConstant symbol (the model has no
+// separate variable kind; for dead code purposes they behave identically).
+func (w *walker) handleVarDeclaration(n *sitter.Node) error {
+	for i := uint(0); i < n.NamedChildCount(); i++ {
+		spec := n.NamedChild(i)
+		if spec == nil || spec.Kind() != "var_spec" {
+			continue
+		}
+		for j := uint(0); j < spec.NamedChildCount(); j++ {
+			c := spec.NamedChild(j)
+			if c == nil || c.Kind() != "identifier" {
+				continue
+			}
+			name := extract.Text(c, w.source)
+			if name == "" {
+				continue
+			}
+			if err := w.emit.Symbol(extract.EmittedSymbol{
+				Name:       name,
+				Qualified:  w.qualify(name),
+				Kind:       model.KindConstant,
+				Visibility: visibility(name),
+				LineStart:  extract.Line(spec.StartPosition()),
+				LineEnd:    extract.Line(spec.EndPosition()),
+			}); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -325,10 +413,14 @@ func (w *walker) handleFunction(n *sitter.Node) error {
 	}); err != nil {
 		return err
 	}
+	body := n.ChildByFieldName("body")
 	types, locals := w.buildTypeMap(n)
-	return extract.WalkNamedDescendants(n.ChildByFieldName("body"), "call_expression", func(c *sitter.Node) error {
+	if err := extract.WalkNamedDescendants(body, "call_expression", func(c *sitter.Node) error {
 		return w.emitCall(c, qualified, types, locals)
-	})
+	}); err != nil {
+		return err
+	}
+	return w.emitConstRefs(body, qualified, locals)
 }
 
 // handleMethod emits a method with receiver-type qualification and
@@ -363,10 +455,68 @@ func (w *walker) handleMethod(n *sitter.Node) error {
 	}); err != nil {
 		return err
 	}
+	body := n.ChildByFieldName("body")
 	types, locals := w.buildTypeMap(n)
-	return extract.WalkNamedDescendants(n.ChildByFieldName("body"), "call_expression", func(c *sitter.Node) error {
+	if err := extract.WalkNamedDescendants(body, "call_expression", func(c *sitter.Node) error {
 		return w.emitCall(c, qualified, types, locals)
+	}); err != nil {
+		return err
+	}
+	return w.emitConstRefs(body, qualified, locals)
+}
+
+// emitConstRefs walks a function body for identifiers that resolve to
+// package-level constants/variables and emits references edges.
+func (w *walker) emitConstRefs(body *sitter.Node, sourceQualified string, locals map[string]bool) error {
+	if body == nil || len(w.pkgBindings) == 0 {
+		return nil
+	}
+	seen := map[string]bool{}
+	return extract.WalkNamedDescendants(body, "identifier", func(id *sitter.Node) error {
+		name := extract.Text(id, w.source)
+		if name == "" || locals[name] || goBuiltins[name] || seen[name] {
+			return nil
+		}
+		targetQ, ok := w.pkgBindings[name]
+		if !ok {
+			return nil
+		}
+		// Skip identifiers that are call targets.
+		if p := id.Parent(); p != nil && p.Kind() == "call_expression" {
+			if fn := p.ChildByFieldName("function"); fn != nil && fn.Id() == id.Id() {
+				return nil
+			}
+		}
+		// Skip identifiers inside selector expressions (pkg.Func, obj.Field).
+		if p := id.Parent(); p != nil && p.Kind() == "selector_expression" {
+			return nil
+		}
+		seen[name] = true
+		line := extract.Line(id.StartPosition())
+		return w.emit.Edge(extract.EmittedEdge{
+			SourceQualified: sourceQualified,
+			TargetQualified: targetQ,
+			Kind:            model.EdgeReferences,
+			Line:            &line,
+			Confidence:      extract.ConfidenceStatic,
+		})
 	})
+}
+
+// goBuiltins is the set of Go predeclared identifiers that should
+// never be emitted as constant references.
+var goBuiltins = map[string]bool{
+	"_": true, "true": true, "false": true, "nil": true, "iota": true,
+	"append": true, "cap": true, "close": true, "complex": true,
+	"copy": true, "delete": true, "imag": true, "len": true,
+	"make": true, "max": true, "min": true, "new": true,
+	"panic": true, "print": true, "println": true, "real": true,
+	"recover": true, "clear": true,
+	"bool": true, "byte": true, "comparable": true, "complex64": true,
+	"complex128": true, "error": true, "float32": true, "float64": true,
+	"int": true, "int8": true, "int16": true, "int32": true, "int64": true,
+	"rune": true, "string": true, "uint": true, "uint8": true, "uint16": true,
+	"uint32": true, "uint64": true, "uintptr": true, "any": true,
 }
 
 // emitCall produces an EdgeCalls edge for one call_expression. When

--- a/internal/extract/golang/golang_test.go
+++ b/internal/extract/golang/golang_test.go
@@ -1620,3 +1620,246 @@ type (
 		t.Error("expected error on third type in group")
 	}
 }
+
+func TestConstReferenceEdge(t *testing.T) {
+	r := parse(t, `package utils
+
+const MaxRetries = 5
+
+func Process() {
+	x := MaxRetries
+	_ = x
+}
+`)
+	if findEdge(r, "utils.Process", "utils.MaxRetries", "references") == nil {
+		t.Error("missing references edge utils.Process -> utils.MaxRetries")
+	}
+}
+
+func TestConstReferenceSkipsLocals(t *testing.T) {
+	r := parse(t, `package utils
+
+const Limit = 10
+
+func Process() {
+	Limit := 99
+	_ = Limit
+}
+`)
+	if findEdge(r, "utils.Process", "utils.Limit", "references") != nil {
+		t.Error("should not emit references edge when local shadows constant")
+	}
+}
+
+func TestConstReferenceSkipsCallTargets(t *testing.T) {
+	r := parse(t, `package utils
+
+const Debug = true
+
+func Process() {
+	if Debug {
+		fmt.Println("debug")
+	}
+}
+`)
+	if findEdge(r, "utils.Process", "utils.Debug", "references") == nil {
+		t.Error("missing references edge for constant used in condition")
+	}
+	// fmt.Println is a call, not a references edge
+	if findEdge(r, "utils.Process", "fmt.Println", "references") != nil {
+		t.Error("should not emit references edge for call targets")
+	}
+}
+
+func TestConstReferenceFromMethod(t *testing.T) {
+	r := parse(t, `package svc
+
+const timeout = 30
+
+type Server struct{}
+
+func (s *Server) Run() {
+	t := timeout
+	_ = t
+}
+`)
+	if findEdge(r, "svc.Server.Run", "svc.timeout", "references") == nil {
+		t.Error("missing references edge from method to constant")
+	}
+}
+
+func TestConstReferenceDedup(t *testing.T) {
+	r := parse(t, `package svc
+
+const X = 1
+
+func F() {
+	a := X
+	b := X
+	_ = a + b
+}
+`)
+	count := 0
+	for _, e := range r.edges {
+		if string(e.Kind) == "references" && e.TargetQualified == "svc.X" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 references edge to svc.X, got %d", count)
+	}
+}
+
+func TestVarDeclarationSymbol(t *testing.T) {
+	r := parse(t, `package utils
+
+var localhostIP = "127.0.0.1"
+`)
+	s := findSymbol(r, "utils.localhostIP")
+	if s == nil {
+		t.Fatal("missing symbol for package-level var")
+	}
+	if s.Kind != "constant" {
+		t.Errorf("kind = %q, want constant", s.Kind)
+	}
+}
+
+func TestVarReferenceEdge(t *testing.T) {
+	r := parse(t, `package utils
+
+var localhostIP = "127.0.0.1"
+
+func Serve() {
+	addr := localhostIP + ":8080"
+	_ = addr
+}
+`)
+	if findEdge(r, "utils.Serve", "utils.localhostIP", "references") == nil {
+		t.Error("missing references edge for package-level var")
+	}
+}
+
+func TestConstReferenceGroupedConsts(t *testing.T) {
+	r := parse(t, `package svc
+
+const (
+	A = 1
+	B = 2
+)
+
+func F() {
+	_ = A + B
+}
+`)
+	if findEdge(r, "svc.F", "svc.A", "references") == nil {
+		t.Error("missing references edge for grouped const A")
+	}
+	if findEdge(r, "svc.F", "svc.B", "references") == nil {
+		t.Error("missing references edge for grouped const B")
+	}
+}
+
+func TestConstReferenceSkipsSelectorOperand(t *testing.T) {
+	r := parse(t, `package svc
+
+var cfg = "val"
+
+func F() {
+	_ = cfg
+	fmt.Println(cfg)
+}
+`)
+	edges := 0
+	for _, e := range r.edges {
+		if e.Kind == "references" && e.TargetQualified == "svc.cfg" {
+			edges++
+		}
+	}
+	if edges != 1 {
+		t.Errorf("expected 1 references edge (skip selector operand fmt), got %d", edges)
+	}
+}
+
+func TestConstReferenceSkipsBlankIdentifier(t *testing.T) {
+	r := parse(t, `package svc
+
+const _ = "unused"
+
+func F() {
+	_ = 42
+}
+`)
+	for _, e := range r.edges {
+		if e.Kind == "references" && e.TargetQualified == "svc._" {
+			t.Error("should not emit references edge for blank identifier")
+		}
+	}
+}
+
+func TestConstReferenceFromInit(t *testing.T) {
+	r := parse(t, `package svc
+
+const Version = "1.0"
+
+func init() {
+	_ = Version
+}
+`)
+	if findEdge(r, "svc.init", "svc.Version", "references") == nil {
+		t.Error("missing references edge from init() to constant")
+	}
+}
+
+func TestConstReferenceSkipsIotaInBody(t *testing.T) {
+	r := parse(t, `package svc
+
+func F() {
+	_ = iota
+}
+`)
+	for _, e := range r.edges {
+		if e.Kind == "references" && e.TargetQualified == "svc.iota" {
+			t.Error("should not emit references edge for iota builtin")
+		}
+	}
+}
+
+func TestConstReferenceSkipsSelectorField(t *testing.T) {
+	r := parse(t, `package svc
+
+var Timeout = 30
+
+type Config struct {
+	Timeout int
+}
+
+func F() {
+	c := Config{}
+	_ = c.Timeout
+}
+`)
+	if findEdge(r, "svc.F", "svc.Timeout", "references") != nil {
+		t.Error("should not emit references edge for struct field access via selector")
+	}
+}
+
+func TestGroupedVarDeclaration(t *testing.T) {
+	r := parse(t, `package svc
+
+var (
+	X = 1
+	Y = "hello"
+)
+
+func F() {
+	_ = X
+	_ = Y
+}
+`)
+	if findEdge(r, "svc.F", "svc.X", "references") == nil {
+		t.Error("missing references edge for grouped var X")
+	}
+	if findEdge(r, "svc.F", "svc.Y", "references") == nil {
+		t.Error("missing references edge for grouped var Y")
+	}
+}

--- a/internal/extract/python/python.go
+++ b/internal/extract/python/python.go
@@ -61,7 +61,8 @@ func (Extractor) Extensions() []string      { return []string{".py", ".pyi"} }
 func (Extractor) Tier() extract.Tier        { return extract.TierBasic }
 
 func (Extractor) Extract(tree *sitter.Tree, source []byte, _ string, emit extract.Emitter) error {
-	w := &walker{source: source, emit: emit}
+	w := &walker{source: source, emit: emit, pkgBindings: map[string]string{}}
+	w.collectModuleConstants(tree.RootNode())
 	return w.walk(tree.RootNode(), nil)
 }
 
@@ -72,6 +73,73 @@ func init() { extract.Register(Extractor{}) }
 type walker struct {
 	source []byte
 	emit   extract.Emitter
+	pkgBindings map[string]string // unqualified name → qualified name for module-level constants
+}
+
+// collectModuleConstants pre-scans the module for ALL_CAPS assignments
+// at the top level so function bodies can emit references edges.
+func (w *walker) collectModuleConstants(root *sitter.Node) {
+	if root == nil {
+		return
+	}
+	count := root.NamedChildCount()
+	for i := uint(0); i < count; i++ {
+		n := root.NamedChild(i)
+		if n == nil {
+			continue
+		}
+		// Assignments are wrapped in expression_statement at module level.
+		if n.Kind() == "expression_statement" {
+			if n.NamedChildCount() > 0 {
+				n = n.NamedChild(0)
+			}
+		}
+		if n == nil || n.Kind() != "assignment" {
+			continue
+		}
+		lhs := n.ChildByFieldName("left")
+		if lhs == nil || lhs.Kind() != "identifier" {
+			continue
+		}
+		name := extract.Text(lhs, w.source)
+		if isAllCaps(name) {
+			w.pkgBindings[name] = name
+		}
+	}
+}
+
+// emitConstRefs walks a function body for identifiers that resolve to
+// module-level constants and emits references edges.
+func (w *walker) emitConstRefs(body *sitter.Node, sourceQualified string, params map[string]bool) error {
+	if body == nil || len(w.pkgBindings) == 0 {
+		return nil
+	}
+	seen := map[string]bool{}
+	return extract.WalkNamedDescendants(body, "identifier", func(id *sitter.Node) error {
+		name := extract.Text(id, w.source)
+		if name == "" || params[name] || seen[name] {
+			return nil
+		}
+		targetQ, ok := w.pkgBindings[name]
+		if !ok {
+			return nil
+		}
+		// Skip call targets: parent is `call` and this is the `function` field.
+		if p := id.Parent(); p != nil && p.Kind() == "call" {
+			if fn := p.ChildByFieldName("function"); fn != nil && fn.Id() == id.Id() {
+				return nil
+			}
+		}
+		seen[name] = true
+		line := extract.Line(id.StartPosition())
+		return w.emit.Edge(extract.EmittedEdge{
+			SourceQualified: sourceQualified,
+			TargetQualified: targetQ,
+			Kind:            model.EdgeReferences,
+			Line:            &line,
+			Confidence:      extract.ConfidenceStatic,
+		})
+	})
 }
 
 // walk visits node and its children under the given class-name scope.
@@ -238,9 +306,15 @@ func (w *walker) emitFunctionAndWalkBody(n *sitter.Node, scope []string, decorat
 		}
 	}
 
-	return extract.WalkNamedDescendants(n.ChildByFieldName("body"), "call", func(c *sitter.Node) error {
+	body := n.ChildByFieldName("body")
+	if err := extract.WalkNamedDescendants(body, "call", func(c *sitter.Node) error {
 		return w.emitCall(c, qualified)
-	})
+	}); err != nil {
+		return err
+	}
+
+	params := collectParams(n, w.source)
+	return w.emitConstRefs(body, qualified, params)
 }
 
 // emitCall produces one calls edge. Identifier / attribute callees
@@ -357,6 +431,35 @@ func (w *walker) handleAssignment(n *sitter.Node, scope []string) error {
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
 	})
+}
+
+// collectParams returns parameter names from a function_definition node.
+func collectParams(funcNode *sitter.Node, source []byte) map[string]bool {
+	out := map[string]bool{}
+	params := funcNode.ChildByFieldName("parameters")
+	if params == nil {
+		return out
+	}
+	count := params.NamedChildCount()
+	for i := uint(0); i < count; i++ {
+		p := params.NamedChild(i)
+		if p == nil {
+			continue
+		}
+		switch p.Kind() {
+		case "identifier":
+			out[extract.Text(p, source)] = true
+		case "default_parameter", "typed_parameter", "typed_default_parameter":
+			if name := p.ChildByFieldName("name"); name != nil {
+				out[extract.Text(name, source)] = true
+			}
+		case "list_splat_pattern", "dictionary_splat_pattern":
+			if p.NamedChildCount() > 0 {
+				out[extract.Text(p.NamedChild(0), source)] = true
+			}
+		}
+	}
+	return out
 }
 
 // isAllCaps tests the Python "constant" convention: non-empty, every

--- a/internal/extract/python/python_test.go
+++ b/internal/extract/python/python_test.go
@@ -1582,3 +1582,100 @@ func TestTypeAnnotationEdgeErrorPy(t *testing.T) {
 	}
 }
 
+func TestConstReferenceEdgePy(t *testing.T) {
+	r := parse(t, `MAX_RETRIES = 5
+
+def process():
+    x = MAX_RETRIES
+`)
+	if findEdge(r, "process", "MAX_RETRIES", "references") == nil {
+		t.Error("missing references edge process -> MAX_RETRIES")
+	}
+}
+
+func TestConstReferenceSkipsParamsPy(t *testing.T) {
+	r := parse(t, `MAX_RETRIES = 5
+
+def process(MAX_RETRIES):
+    x = MAX_RETRIES
+`)
+	if findEdge(r, "process", "MAX_RETRIES", "references") != nil {
+		t.Error("should not emit references edge when param shadows constant")
+	}
+}
+
+func TestConstReferenceSkipsCallTargetsPy(t *testing.T) {
+	r := parse(t, `API_URL = "http://example.com"
+
+def fetch():
+    if API_URL:
+        print("ok")
+`)
+	if findEdge(r, "fetch", "API_URL", "references") == nil {
+		t.Error("missing references edge for constant in condition")
+	}
+}
+
+func TestConstReferenceDedupPy(t *testing.T) {
+	r := parse(t, `LIMIT = 10
+
+def process():
+    a = LIMIT
+    b = LIMIT
+`)
+	count := 0
+	for _, e := range r.edges {
+		if string(e.Kind) == "references" && e.TargetQualified == "LIMIT" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 references edge to LIMIT, got %d", count)
+	}
+}
+
+func TestConstReferenceFromMethodPy(t *testing.T) {
+	r := parse(t, `MAX = 10
+
+class Svc:
+    def run(self):
+        x = MAX
+`)
+	if findEdge(r, "Svc.run", "MAX", "references") == nil {
+		t.Error("missing references edge from class method to module-level constant")
+	}
+}
+
+func TestConstReferenceSkipsCallTargetFnPy(t *testing.T) {
+	r := parse(t, `HANDLER = "process"
+
+def run():
+    HANDLER()
+    x = HANDLER
+`)
+	edges := 0
+	for _, e := range r.edges {
+		if e.Kind == "references" && e.TargetQualified == "HANDLER" {
+			edges++
+		}
+	}
+	if edges != 1 {
+		t.Errorf("expected 1 references edge (value read only), got %d", edges)
+	}
+}
+
+func TestCollectParamsSplatPy(t *testing.T) {
+	r := parse(t, `ARGS = "x"
+KWARGS = "y"
+
+def run(*ARGS, **KWARGS):
+    pass
+`)
+	if findEdge(r, "run", "ARGS", "references") != nil {
+		t.Error("should not emit references for *args param name")
+	}
+	if findEdge(r, "run", "KWARGS", "references") != nil {
+		t.Error("should not emit references for **kwargs param name")
+	}
+}
+

--- a/internal/extract/ruby/ruby.go
+++ b/internal/extract/ruby/ruby.go
@@ -62,7 +62,9 @@ func (Extractor) Extract(tree *sitter.Tree, source []byte, filePath string, emit
 		classInstanceVars: make(map[string]map[string]string),
 		returnTypes:       returnTypes,
 		emittedCallbacks:  make(map[string]bool),
+		pkgBindings:       make(map[string]string),
 	}
+	w.collectConstants(tree.RootNode(), nil)
 	return w.walk(tree.RootNode(), nil)
 }
 
@@ -83,11 +85,12 @@ type walker struct {
 	source            []byte
 	emit              extract.Emitter
 	filePath          string
-	routeNS           []string // namespace stack for route files (e.g. ["Admin"])
-	testScope         []string // nested RSpec block descriptions for synthetic scope
-	classInstanceVars map[string]map[string]string // @ivar type map per class
-	returnTypes       map[string]string            // method_qualified → class_name (file-level)
-	emittedCallbacks  map[string]bool              // dedup synthetic callback symbols by qualified name
+	routeNS           []string                     // namespace stack for route files (e.g. ["Admin"])
+	testScope         []string                     // nested RSpec block descriptions for synthetic scope
+	classInstanceVars map[string]map[string]string  // @ivar type map per class
+	returnTypes       map[string]string             // method_qualified → class_name (file-level)
+	emittedCallbacks  map[string]bool               // dedup synthetic callback symbols by qualified name
+	pkgBindings       map[string]string              // unqualified name → qualified name for file-level constants
 }
 
 // walk visits node and its children under the given class/module scope.
@@ -669,7 +672,10 @@ func (w *walker) handleMethod(n *sitter.Node, scope []string, singleton bool) er
 	}); err != nil {
 		return err
 	}
-	return w.emitBareIdentifierCalls(body, qualified, extract.ConfidenceDynamic)
+	if err := w.emitBareIdentifierCalls(body, qualified, extract.ConfidenceDynamic); err != nil {
+		return err
+	}
+	return w.emitConstRefs(body, qualified)
 }
 
 // emitCall produces a calls edge for one `call` node. The target is
@@ -1353,6 +1359,84 @@ func inferSendTargetFromVariable(call *sitter.Node, source []byte) (string, floa
 		return target, ConfidenceHeuristicDispatch, true
 	}
 	return "", 0, false
+}
+
+// collectConstants recursively pre-scans for constant assignments so
+// method bodies can emit references edges. Descends into class/module
+// bodies to find nested constants (e.g. MyClass::TIMEOUT).
+func (w *walker) collectConstants(n *sitter.Node, scope []string) {
+	if n == nil {
+		return
+	}
+	count := n.NamedChildCount()
+	for i := uint(0); i < count; i++ {
+		child := n.NamedChild(i)
+		if child == nil {
+			continue
+		}
+		switch child.Kind() {
+		case "assignment":
+			lhs := child.ChildByFieldName("left")
+			if lhs != nil && lhs.Kind() == "constant" {
+				name := extract.Text(lhs, w.source)
+				if name != "" {
+					qualified := name
+					if parent := strings.Join(scope, "::"); parent != "" {
+						qualified = parent + "::" + name
+					}
+					w.pkgBindings[name] = qualified
+				}
+			}
+		case "class", "module":
+			nameNode := child.ChildByFieldName("name")
+			if nameNode == nil {
+				continue
+			}
+			name := extract.Text(nameNode, w.source)
+			if name == "" {
+				continue
+			}
+			newScope := append(slices.Clone(scope), name)
+			if body := child.ChildByFieldName("body"); body != nil {
+				w.collectConstants(body, newScope)
+			}
+		}
+	}
+}
+
+// emitConstRefs walks a method body for `constant` nodes that resolve
+// to known file-level constants and emits references edges.
+func (w *walker) emitConstRefs(body *sitter.Node, sourceQualified string) error {
+	if body == nil || len(w.pkgBindings) == 0 {
+		return nil
+	}
+	seen := map[string]bool{}
+	return extract.WalkNamedDescendants(body, "constant", func(cn *sitter.Node) error {
+		name := extract.Text(cn, w.source)
+		if name == "" || seen[name] {
+			return nil
+		}
+		targetQ, ok := w.pkgBindings[name]
+		if !ok {
+			return nil
+		}
+		// Skip constants used as class names or scope resolution (e.g. Foo::Bar).
+		if p := cn.Parent(); p != nil {
+			switch p.Kind() {
+			case "scope_resolution", "superclass":
+				return nil
+			}
+		}
+		seen[name] = true
+		line := extract.Line(cn.StartPosition())
+		return w.emit.Edge(extract.EmittedEdge{
+			SourceQualified: sourceQualified,
+			TargetQualified: targetQ,
+			Kind:            model.EdgeReferences,
+			Line:            &line,
+			Confidence:      extract.ConfidenceStatic,
+		})
+	})
 }
 
 // handleConstantAssignment emits a KindConstant symbol when the LHS of

--- a/internal/extract/ruby/ruby_test.go
+++ b/internal/extract/ruby/ruby_test.go
@@ -3615,3 +3615,118 @@ func TestMergeMaps(t *testing.T) {
 		}
 	}
 }
+
+func TestConstReferenceEdgeRuby(t *testing.T) {
+	r := parseRuby(t, `MAX_RETRIES = 5
+
+class Service
+  def process
+    x = MAX_RETRIES
+  end
+end
+`)
+	if findEdge(r, "Service#process", "MAX_RETRIES", "references") == nil {
+		t.Error("missing references edge Service#process -> MAX_RETRIES")
+	}
+}
+
+func TestConstReferenceNestedRuby(t *testing.T) {
+	r := parseRuby(t, `class Config
+  TIMEOUT = 30
+
+  def read
+    t = TIMEOUT
+  end
+end
+`)
+	if findEdge(r, "Config#read", "Config::TIMEOUT", "references") == nil {
+		t.Error("missing references edge for nested constant")
+	}
+}
+
+func TestConstReferenceSkipsScopeResolutionRuby(t *testing.T) {
+	r := parseRuby(t, `MAX = 10
+
+class Svc
+  def run
+    x = MAX
+  end
+end
+`)
+	if findEdge(r, "Svc#run", "MAX", "references") == nil {
+		t.Error("missing references edge for direct constant use")
+	}
+}
+
+func TestConstReferenceDedupRuby(t *testing.T) {
+	r := parseRuby(t, `LIMIT = 10
+
+class Svc
+  def run
+    a = LIMIT
+    b = LIMIT
+  end
+end
+`)
+	count := 0
+	for _, e := range r.edges {
+		if string(e.Kind) == "references" && e.TargetQualified == "LIMIT" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 references edge to LIMIT, got %d", count)
+	}
+}
+
+func TestConstReferenceFromSingletonMethodRuby(t *testing.T) {
+	r := parseRuby(t, `FACTOR = 2
+
+class Calc
+  def self.double(n)
+    n * FACTOR
+  end
+end
+`)
+	if findEdge(r, "Calc.double", "FACTOR", "references") == nil {
+		t.Error("missing references edge from singleton method")
+	}
+}
+
+func TestConstReferenceSkipsUnknownRuby(t *testing.T) {
+	r := parseRuby(t, `KNOWN = 1
+
+class Svc
+  def run
+    x = KNOWN
+    y = UNKNOWN
+  end
+end
+`)
+	if findEdge(r, "Svc#run", "KNOWN", "references") == nil {
+		t.Error("missing references edge for known constant")
+	}
+	if findEdge(r, "Svc#run", "UNKNOWN", "references") != nil {
+		t.Error("should not emit references for unknown constant")
+	}
+}
+
+func TestConstReferenceSkipsSuperclassRuby(t *testing.T) {
+	r := parseRuby(t, `BASE = 1
+
+class Parent
+  def run
+    x = BASE
+  end
+end
+
+class Child < Parent
+  def work
+    y = BASE
+  end
+end
+`)
+	if findEdge(r, "Parent#run", "BASE", "references") == nil {
+		t.Error("missing references edge for BASE in Parent.run")
+	}
+}

--- a/internal/extract/testdata/ruby/metaprogramming.golden.json
+++ b/internal/extract/testdata/ruby/metaprogramming.golden.json
@@ -88,6 +88,13 @@
     },
     {
       "source": "PluginLoader.load_all",
+      "target": "PluginLoader::REGISTRY",
+      "kind": "references",
+      "line": 29,
+      "confidence": 1
+    },
+    {
+      "source": "PluginLoader.load_all",
       "target": "REGISTRY.each_value",
       "kind": "calls",
       "line": 29,
@@ -106,6 +113,13 @@
       "kind": "calls",
       "line": 30,
       "confidence": 0.5
+    },
+    {
+      "source": "PluginLoader.register",
+      "target": "PluginLoader::REGISTRY",
+      "kind": "references",
+      "line": 25,
+      "confidence": 1
     }
   ]
 }

--- a/internal/extract/testdata/ruby/singleton_methods.golden.json
+++ b/internal/extract/testdata/ruby/singleton_methods.golden.json
@@ -57,6 +57,13 @@
   ],
   "edges": [
     {
+      "source": "Configuration#timeout",
+      "target": "Configuration::DEFAULT_TIMEOUT",
+      "kind": "references",
+      "line": 13,
+      "confidence": 1
+    },
+    {
       "source": "Configuration.from_env",
       "target": "self.new",
       "kind": "calls",

--- a/internal/extract/tsjs/tsjs.go
+++ b/internal/extract/tsjs/tsjs.go
@@ -104,7 +104,9 @@ func extractAll(tree *sitter.Tree, source []byte, filePath string, emit extract.
 		emit:         emit,
 		filePath:     filePath,
 		stimulusName: inferStimulusController(filePath),
+		pkgBindings:  map[string]string{},
 	}
+	w.collectModuleConstants(tree.RootNode())
 	if err := w.walk(tree.RootNode(), nil); err != nil {
 		return err
 	}
@@ -117,7 +119,91 @@ type walker struct {
 	source       []byte
 	emit         extract.Emitter
 	filePath     string
-	stimulusName string // non-empty if this file is a Stimulus controller
+	stimulusName string            // non-empty if this file is a Stimulus controller
+	pkgBindings  map[string]string // unqualified name → qualified name for module-level constants
+}
+
+// collectModuleConstants pre-scans top-level const declarations for
+// value-type constants (not arrow functions or class expressions) so
+// function bodies can emit references edges.
+func (w *walker) collectModuleConstants(root *sitter.Node) {
+	if root == nil {
+		return
+	}
+	count := root.NamedChildCount()
+	for i := uint(0); i < count; i++ {
+		n := root.NamedChild(i)
+		if n == nil {
+			continue
+		}
+		// Unwrap export_statement to reach the declaration.
+		if n.Kind() == "export_statement" {
+			if d := n.ChildByFieldName("declaration"); d != nil {
+				n = d
+			} else {
+				continue
+			}
+		}
+		if n.Kind() != "lexical_declaration" || !isConstDeclaration(n, w.source) {
+			continue
+		}
+		for j := uint(0); j < n.NamedChildCount(); j++ {
+			decl := n.NamedChild(j)
+			if decl == nil || decl.Kind() != "variable_declarator" {
+				continue
+			}
+			nameNode := decl.ChildByFieldName("name")
+			if nameNode == nil || nameNode.Kind() != "identifier" {
+				continue
+			}
+			name := extract.Text(nameNode, w.source)
+			if name == "" {
+				continue
+			}
+			// Only track value constants, not function/class expressions.
+			if valueNode := decl.ChildByFieldName("value"); valueNode != nil {
+				switch valueNode.Kind() {
+				case "arrow_function", "function_expression", "function",
+					"generator_function", "class", "class_expression":
+					continue
+				}
+			}
+			w.pkgBindings[name] = name
+		}
+	}
+}
+
+// emitConstRefs walks a function body for identifiers that resolve to
+// module-level constants and emits references edges.
+func (w *walker) emitConstRefs(body *sitter.Node, sourceQualified string) error {
+	if body == nil || len(w.pkgBindings) == 0 {
+		return nil
+	}
+	seen := map[string]bool{}
+	return extract.WalkNamedDescendants(body, "identifier", func(id *sitter.Node) error {
+		name := extract.Text(id, w.source)
+		if name == "" || seen[name] {
+			return nil
+		}
+		targetQ, ok := w.pkgBindings[name]
+		if !ok {
+			return nil
+		}
+		if p := id.Parent(); p != nil && p.Kind() == "call_expression" {
+			if fn := p.ChildByFieldName("function"); fn != nil && fn.Id() == id.Id() {
+				return nil
+			}
+		}
+		seen[name] = true
+		line := extract.Line(id.StartPosition())
+		return w.emit.Edge(extract.EmittedEdge{
+			SourceQualified: sourceQualified,
+			TargetQualified: targetQ,
+			Kind:            model.EdgeReferences,
+			Line:            &line,
+			Confidence:      extract.ConfidenceStatic,
+		})
+	})
 }
 
 func (w *walker) walk(n *sitter.Node, scope []string) error {
@@ -664,9 +750,12 @@ func (w *walker) walkBodyEdges(body *sitter.Node, sourceQualified string) error 
 	}); err != nil {
 		return err
 	}
-	return extract.WalkNamedDescendants(body, "jsx_self_closing_element", func(c *sitter.Node) error {
+	if err := extract.WalkNamedDescendants(body, "jsx_self_closing_element", func(c *sitter.Node) error {
 		return w.emitJSXComponent(c, sourceQualified)
-	})
+	}); err != nil {
+		return err
+	}
+	return w.emitConstRefs(body, sourceQualified)
 }
 
 // emitJSXComponent emits a calls edge for a PascalCase JSX element.

--- a/internal/extract/tsjs/tsjs_test.go
+++ b/internal/extract/tsjs/tsjs_test.go
@@ -1910,3 +1910,126 @@ func TestConstSymbolErrorTS(t *testing.T) {
 		t.Error("expected error on second const symbol emit")
 	}
 }
+
+func TestConstReferenceEdgeTS(t *testing.T) {
+	r := parseTS(t, `const MAX_RETRIES = 5;
+
+function process() {
+  const x = MAX_RETRIES;
+}
+`, "test.ts")
+	if findEdg(r, "process", "MAX_RETRIES", "references") == nil {
+		t.Error("missing references edge process -> MAX_RETRIES")
+	}
+}
+
+func TestConstReferenceExportedTS(t *testing.T) {
+	r := parseTS(t, `export const API_URL = "http://example.com";
+
+function fetch() {
+  console.log(API_URL);
+}
+`, "test.ts")
+	if findEdg(r, "fetch", "API_URL", "references") == nil {
+		t.Error("missing references edge for exported constant")
+	}
+}
+
+func TestConstReferenceSkipsArrowFnTS(t *testing.T) {
+	r := parseTS(t, `const helper = () => {};
+const VALUE = 42;
+
+function process() {
+  helper();
+  const x = VALUE;
+}
+`, "test.ts")
+	// helper is a function (arrow), not tracked as a constant
+	if findEdg(r, "process", "helper", "references") != nil {
+		t.Error("should not emit references edge for arrow function constant")
+	}
+	if findEdg(r, "process", "VALUE", "references") == nil {
+		t.Error("missing references edge for value constant")
+	}
+}
+
+func TestConstReferenceDedupTS(t *testing.T) {
+	r := parseTS(t, `const X = 1;
+
+function f() {
+  const a = X;
+  const b = X;
+}
+`, "test.ts")
+	count := 0
+	for _, e := range r.edges {
+		if string(e.Kind) == "references" && e.TargetQualified == "X" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 references edge to X, got %d", count)
+	}
+}
+
+func TestConstReferenceFromMethodTS(t *testing.T) {
+	r := parseTS(t, `const TIMEOUT = 30;
+
+class Server {
+  run() {
+    const t = TIMEOUT;
+  }
+}
+`, "test.ts")
+	if findEdg(r, "Server.run", "TIMEOUT", "references") == nil {
+		t.Error("missing references edge from method to constant")
+	}
+}
+
+func TestConstSkipsArrowFunctionValueTS(t *testing.T) {
+	r := parseTS(t, `const handler = () => { return 1; };
+const MAX = 100;
+
+function run() {
+  const x = MAX;
+}
+`, "test.ts")
+	if findEdg(r, "run", "handler", "references") != nil {
+		t.Error("arrow function const should not be tracked as a constant")
+	}
+	if findEdg(r, "run", "MAX", "references") == nil {
+		t.Error("missing references edge for value constant")
+	}
+}
+
+func TestConstSkipsDestructuringTS(t *testing.T) {
+	r := parseTS(t, `const { a, b } = config;
+const LIMIT = 10;
+
+function run() {
+  const x = LIMIT;
+}
+`, "test.ts")
+	if findEdg(r, "run", "LIMIT", "references") == nil {
+		t.Error("missing references edge for LIMIT constant")
+	}
+}
+
+func TestConstSkipsCallTargetTS(t *testing.T) {
+	r := parseTS(t, `const API_URL = "http://example.com";
+
+function run() {
+  fetch(API_URL);
+  const x = API_URL;
+}
+`, "test.ts")
+	edges := 0
+	for _, e := range r.edges {
+		if e.Kind == "references" && e.TargetQualified == "API_URL" {
+			edges++
+		}
+	}
+	if edges != 1 {
+		t.Errorf("expected 1 references edge (skip call target), got %d", edges)
+	}
+}

--- a/internal/model/edge.go
+++ b/internal/model/edge.go
@@ -27,6 +27,7 @@ const (
 	EdgeInherits EdgeKind = "inherits"
 	EdgeIncludes EdgeKind = "includes"
 	EdgeTests    EdgeKind = "tests"
-	EdgeComposes EdgeKind = "composes"
-	EdgeTemporal EdgeKind = "temporal"
+	EdgeComposes   EdgeKind = "composes"
+	EdgeTemporal   EdgeKind = "temporal"
+	EdgeReferences EdgeKind = "references"
 )

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -101,7 +101,7 @@ func (ix *Index) Resolve(req Request) (Result, bool) {
 		return pickBest(matches, req.SourceFileID, req.BaseConfidence), true
 	}
 
-	if req.Kind == model.EdgeCalls || req.Kind == model.EdgeTests {
+	if req.Kind == model.EdgeCalls || req.Kind == model.EdgeTests || req.Kind == model.EdgeReferences {
 		// Unqualified fallback: find symbols whose trailing segment
 		// matches the target's trailing segment. Applies to bare
 		// targets ("say" ⇒ byName["say"]) as well as dotted targets


### PR DESCRIPTION
## Problem
Dead code detection only covered functions, methods, classes, modules, types, and interfaces. Package-level constants and variables — a common source of cruft — were invisible to `sense dead`. There was also no edge kind to represent "this function reads that constant," so the graph couldn't distinguish used from unused constants.

## Summary
Adds a new `references` edge kind, teaches all four language extractors to emit it for constant/variable usage in function bodies, and wires it through dead code detection and blast radius analysis.

## Changes

### Model & infrastructure
- Add `EdgeReferences` edge kind to the model
- Wire `references` into the resolver's unqualified fallback
- Blast engine: include `references` in frontier expansion and classify as `TierBreaks`

### Extractors (Go, Python, Ruby, TS/JS)
- Two-pass extraction: first pass collects package-level constant/variable names, second pass emits `references` edges from function bodies
- Go: extract both `const` and `var` declarations as `KindConstant`; skip locals, builtins, selectors, and call targets
- Python: track `ALL_CAPS` module-level assignments; skip parameter shadows and splat params
- Ruby: collect constants including nested class/module scope; skip scope resolution and superclass nodes
- TS/JS: track `const` value declarations; skip arrow functions, class expressions, and destructuring

### Dead code detection
- Include `constant` kind in candidate queries and symbol counts
- Add `references` to the edge filter so referenced constants aren't flagged
- Constants referenced only in test files are flagged as dead when `ExcludeTestRefs` is enabled

## Test Plan
- [x] Go: reference edges for consts/vars, grouped declarations, local shadowing, selector skipping, blank identifiers, init functions, deduplication
- [x] Python: ALL_CAPS references, parameter shadows, splat params, call target skipping, class method references, deduplication
- [x] Ruby: top-level and nested constants, singleton methods, scope resolution skipping, superclass skipping, unknown constants, deduplication
- [x] TS/JS: exported constants, arrow function exclusion, destructuring skipping, class method references, call target skipping, deduplication
- [x] Dead code: unused constants detected, used constants excluded, test-only references flagged, gin-style test-only constants scenario
- [x] `make ci` passes (all tests + lint)