### PR TITLE
feat(snippet): add call-site context snippets to graph and blast responses

### DIFF
--- a/internal/benchmark/benchmark.go
+++ b/internal/benchmark/benchmark.go
@@ -239,7 +239,7 @@ func benchGraph(ctx context.Context, adapter *sqlite.Adapter, hub, mid, leaf sym
 				p, ok := paths[id]
 				return p, ok
 			}
-			_ = mcpio.BuildGraphResponse(sc, lookup, mcpio.BuildGraphRequest{})
+			_ = mcpio.BuildGraphResponse(ctx, sc, lookup, mcpio.BuildGraphRequest{})
 		}
 		durations = append(durations, time.Since(start))
 	}

--- a/internal/blast/engine.go
+++ b/internal/blast/engine.go
@@ -147,6 +147,12 @@ type CallerHop struct {
 // module boundary") when the pitch's extension clause triggers.
 // AffectedTests is populated only when Options.IncludeTests is set;
 // the empty, non-nil default keeps JSON encoders stable.
+// EdgeSite records the file and line of an edge for snippet generation.
+type EdgeSite struct {
+	FileID *int64
+	Line   *int
+}
+
 type Result struct {
 	Symbol          model.Symbol
 	Risk            string
@@ -158,6 +164,10 @@ type Result struct {
 	// DirectTemporalIDs tracks which direct callers were reached via
 	// a temporal edge. Keyed by symbol ID.
 	DirectTemporalIDs map[int64]bool
+
+	// DirectEdgeSites records the edge file/line for each direct caller,
+	// keyed by symbol ID. Used for call-site snippet generation.
+	DirectEdgeSites map[int64]EdgeSite
 
 	EdgesTraversed    int
 	SubjectHasCallees bool
@@ -209,6 +219,7 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 	viaTemporal := map[int64]bool{}
 	visitedKind := map[int64]string{}
 	pathConf := map[int64]float64{}
+	edgeSites := map[int64]EdgeSite{}
 	frontier := make([]int64, 0, len(symbolIDs))
 	for _, id := range symbolIDs {
 		visited[id] = 0
@@ -264,6 +275,8 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 			predecessor[pair.source] = pair.target
 			visitedKind[pair.source] = pair.kind
 			pathConf[pair.source] = cumConf
+			edgeSites[pair.source] = EdgeSite{FileID: pair.fileID, Line: pair.line}
+
 			if pair.kind == "temporal" {
 				viaTemporal[pair.source] = true
 			}
@@ -386,6 +399,7 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 	excluded := 0
 	directCallers := make([]model.Symbol, 0, len(directIDs))
 	directTemporalIDs := map[int64]bool{}
+	directEdgeSites := make(map[int64]EdgeSite, len(directIDs))
 	for _, id := range directIDs {
 		sym, ok := symbolsByID[id]
 		if !ok {
@@ -398,6 +412,9 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 		directCallers = append(directCallers, sym)
 		if viaTemporal[id] {
 			directTemporalIDs[id] = true
+		}
+		if es, ok := edgeSites[id]; ok {
+			directEdgeSites[id] = es
 		}
 	}
 	sortSymbolsByID(directCallers)
@@ -494,6 +511,7 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 		EdgesTraversed:         edgesTraversed,
 		SubjectHasCallees:      hasCallees,
 		DirectTemporalIDs:      directTemporalIDs,
+		DirectEdgeSites:        directEdgeSites,
 		AffectedSubclasses:     subclasses,
 		AffectedViaComposition: viaComposition,
 		AffectedViaIncludes:    viaIncludes,
@@ -510,6 +528,8 @@ type edgePair struct {
 	target     int64
 	kind       string
 	confidence float64
+	fileID     *int64
+	line       *int
 }
 
 func subjectHasCallees(ctx context.Context, db *sql.DB, symbolIDs []int64) bool {
@@ -547,7 +567,7 @@ func expandFrontier(ctx context.Context, db *sql.DB, frontier []int64) ([]edgePa
 		placeholders := strings.Repeat("?,", len(batch))
 		placeholders = placeholders[:len(placeholders)-1]
 
-		q := `SELECT source_id, target_id, kind, confidence FROM sense_edges
+		q := `SELECT source_id, target_id, kind, confidence, file_id, line FROM sense_edges
 		      WHERE target_id IN (` + placeholders + `)
 		        AND source_id IS NOT NULL
 		        AND kind IN ('calls', 'composes', 'includes', 'inherits', 'temporal', 'tests', 'references')
@@ -564,7 +584,7 @@ func expandFrontier(ctx context.Context, db *sql.DB, frontier []int64) ([]edgePa
 		}
 		for rows.Next() {
 			var p edgePair
-			if err := rows.Scan(&p.source, &p.target, &p.kind, &p.confidence); err != nil {
+			if err := rows.Scan(&p.source, &p.target, &p.kind, &p.confidence, &p.fileID, &p.line); err != nil {
 				_ = rows.Close()
 				return nil, err
 			}

--- a/internal/cli/blast.go
+++ b/internal/cli/blast.go
@@ -141,7 +141,7 @@ func runBlastDiff(cio IO, opts blastOptions) int {
 		return p, ok
 	}
 
-	resp := mcpio.BuildDiffBlastResponse(opts.Diff, results, lookup)
+	resp := mcpio.BuildDiffBlastResponse(ctx, opts.Diff, results, lookup, nil)
 
 	if opts.JSON {
 		out, merr := mcpio.MarshalBlast(resp)
@@ -238,7 +238,7 @@ func runBlastSymbol(cio IO, opts blastOptions) int {
 		return p, ok
 	}
 
-	resp := mcpio.BuildBlastResponse(result, lookup)
+	resp := mcpio.BuildBlastResponse(ctx, result, lookup, nil)
 
 	if opts.JSON {
 		out, merr := mcpio.MarshalBlast(resp)

--- a/internal/cli/graph.go
+++ b/internal/cli/graph.go
@@ -136,7 +136,7 @@ func RunGraph(args []string, cio IO) int {
 	buildReq := mcpio.BuildGraphRequest{
 		Direction: opts.Direction,
 	}
-	resp := mcpio.BuildFullGraphResponse(gr, lookup, buildReq)
+	resp := mcpio.BuildFullGraphResponse(ctx, gr, lookup, buildReq)
 
 	if opts.JSON {
 		out, merr := mcpio.MarshalGraph(resp)

--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -1,6 +1,7 @@
 package mcpio
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/luuuc/sense/internal/blast"
@@ -17,7 +18,7 @@ const (
 //   - Tier 1 (breaks): full detail, capped at 200 items
 //   - Tier 2 (references): count + top 5 examples
 //   - Tier 3 (tests): count only
-func BuildBlastResponse(r blast.Result, files FileLookup) BlastResponse {
+func BuildBlastResponse(ctx context.Context, r blast.Result, files FileLookup, snippets *SnippetReader) BlastResponse {
 	resp := BlastResponse{
 		Symbol:             qualifiedOrName(r.Symbol),
 		Risk:               r.Risk,
@@ -44,6 +45,7 @@ func BuildBlastResponse(r blast.Result, files FileLookup) BlastResponse {
 			LineEnd:     c.LineEnd,
 			Ref:         FormatRef(file, c.LineStart),
 			ViaTemporal: r.DirectTemporalIDs[c.ID],
+			CallSite:    snippets.ReadBlastEdgeSite(ctx, c.ID, r.DirectEdgeSites, files),
 		}
 
 		if !hasTiers || r.SymbolTiers[c.ID] == blast.TierBreaks {
@@ -125,6 +127,8 @@ func BuildBlastResponse(r blast.Result, files FileLookup) BlastResponse {
 		Examples: examples,
 	}
 
+	resp.SnippetsTruncated = snippets.Truncated(len(r.DirectCallers))
+
 	resp.AffectedSymbols = r.TotalAffected
 	resp.GraphEdgesTraversed = r.EdgesTraversed
 	resp.Note = "affected_symbols counts unique symbols in the blast radius — not source-level references or graph edges traversed. total_affected is an alias for affected_symbols."
@@ -159,7 +163,7 @@ func BuildBlastResponse(r blast.Result, files FileLookup) BlastResponse {
 // The documented schema's BlastResponse does not define a separate
 // diff shape; reusing the same response type keeps 01-05's MCP
 // surface one tool, one response.
-func BuildDiffBlastResponse(ref string, results []blast.Result, files FileLookup) BlastResponse {
+func BuildDiffBlastResponse(ctx context.Context, ref string, results []blast.Result, files FileLookup, snippets *SnippetReader) BlastResponse {
 	resp := BlastResponse{
 		Symbol: "diff:" + ref,
 	}
@@ -190,6 +194,7 @@ func BuildDiffBlastResponse(ref string, results []blast.Result, files FileLookup
 				LineStart: c.LineStart,
 				LineEnd:   c.LineEnd,
 				Ref:       FormatRef(file, c.LineStart),
+				CallSite:  snippets.ReadBlastEdgeSite(ctx, c.ID, r.DirectEdgeSites, files),
 			})
 		}
 		for _, hop := range r.IndirectCallers {

--- a/internal/mcpio/blast_test.go
+++ b/internal/mcpio/blast_test.go
@@ -1,6 +1,7 @@
 package mcpio
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -13,6 +14,8 @@ import (
 // BlastCaller.File will be "" under this lookup, which matches the
 // documented "lookup miss → empty string" contract.
 var noFiles FileLookup = func(int64) (string, bool) { return "", false }
+
+func int64p(v int64) *int64 { return &v }
 
 // TestBuildDiffBlastResponseMaxRisk pins the conservative risk
 // aggregation: if any modified subject classifies as "high", the
@@ -36,7 +39,7 @@ func TestBuildDiffBlastResponseMaxRisk(t *testing.T) {
 			for i, r := range tc.risks {
 				results[i] = blast.Result{Risk: r}
 			}
-			resp := BuildDiffBlastResponse("HEAD~1", results, noFiles)
+			resp := BuildDiffBlastResponse(context.Background(), "HEAD~1", results, noFiles, nil)
 			if resp.Risk != tc.want {
 				t.Errorf("Risk = %q, want %q", resp.Risk, tc.want)
 			}
@@ -75,7 +78,7 @@ func TestBuildDiffBlastResponseDedupCallers(t *testing.T) {
 		},
 	}
 
-	resp := BuildDiffBlastResponse("HEAD~1", results, noFiles)
+	resp := BuildDiffBlastResponse(context.Background(), "HEAD~1", results, noFiles, nil)
 	if len(resp.DirectCallers) != 1 {
 		t.Errorf("DirectCallers = %d, want 1 (shared caller appears in both subjects)",
 			len(resp.DirectCallers))
@@ -124,7 +127,7 @@ func TestBuildBlastResponseViaTemporal(t *testing.T) {
 		return p, ok
 	}
 
-	resp := BuildBlastResponse(r, files)
+	resp := BuildBlastResponse(context.Background(), r, files, nil)
 
 	if len(resp.DirectCallers) != 1 {
 		t.Fatalf("DirectCallers = %d, want 1", len(resp.DirectCallers))
@@ -168,7 +171,7 @@ func TestBuildBlastResponseTier1Cap(t *testing.T) {
 		SymbolTiers:   tiers,
 	}
 
-	resp := BuildBlastResponse(r, noFiles)
+	resp := BuildBlastResponse(context.Background(), r, noFiles, nil)
 
 	if len(resp.DirectCallers) != 200 {
 		t.Errorf("DirectCallers = %d, want 200 (tier1 cap)", len(resp.DirectCallers))
@@ -205,7 +208,7 @@ func TestBuildBlastResponseTierPartitioning(t *testing.T) {
 		SymbolTiers:   tiers,
 	}
 
-	resp := BuildBlastResponse(r, noFiles)
+	resp := BuildBlastResponse(context.Background(), r, noFiles, nil)
 
 	if len(resp.DirectCallers) != 3 {
 		t.Errorf("DirectCallers = %d, want 3 (Tier 1 only)", len(resp.DirectCallers))
@@ -251,7 +254,7 @@ func TestBuildBlastResponseEdgeKindGroups(t *testing.T) {
 		return p, ok
 	}
 
-	resp := BuildBlastResponse(r, files)
+	resp := BuildBlastResponse(context.Background(), r, files, nil)
 
 	if len(resp.AffectedSubclasses) != 1 || resp.AffectedSubclasses[0].Symbol != "SubA" {
 		t.Errorf("AffectedSubclasses = %+v, want [SubA]", resp.AffectedSubclasses)
@@ -302,7 +305,7 @@ func TestBuildBlastResponseIndirectTier2(t *testing.T) {
 		return p, ok
 	}
 
-	resp := BuildBlastResponse(r, files)
+	resp := BuildBlastResponse(context.Background(), r, files, nil)
 
 	if len(resp.IndirectCallers) != 1 || resp.IndirectCallers[0].Symbol != "Tier1Indirect" {
 		t.Errorf("IndirectCallers = %+v, want [Tier1Indirect] (tier-1 only)", resp.IndirectCallers)
@@ -335,7 +338,7 @@ func TestBuildBlastResponseTier2ExamplesCap(t *testing.T) {
 		SymbolTiers:   tiers,
 	}
 
-	resp := BuildBlastResponse(r, noFiles)
+	resp := BuildBlastResponse(context.Background(), r, noFiles, nil)
 
 	if len(resp.DirectCallers) != 0 {
 		t.Errorf("DirectCallers = %d, want 0 (all tier-2)", len(resp.DirectCallers))
@@ -389,7 +392,7 @@ func TestBuildBlastResponseSegmentTestFiles(t *testing.T) {
 		return p, ok
 	}
 
-	resp := BuildBlastResponse(r, files)
+	resp := BuildBlastResponse(context.Background(), r, files, nil)
 
 	if resp.ProductionAffected != 1 {
 		t.Errorf("ProductionAffected = %d, want 1 (only lib/prod.rb)", resp.ProductionAffected)
@@ -425,7 +428,7 @@ func TestBlastResponseRefField(t *testing.T) {
 		return p, ok
 	}
 
-	resp := BuildBlastResponse(r, files)
+	resp := BuildBlastResponse(context.Background(), r, files, nil)
 
 	// DirectCallers — with file
 	if resp.DirectCallers[0].Ref != "lib/caller.rb:25" {
@@ -460,7 +463,7 @@ func TestBlastDiffResponseRefField(t *testing.T) {
 		return "", false
 	}
 
-	resp := BuildDiffBlastResponse("HEAD~1", results, files)
+	resp := BuildDiffBlastResponse(context.Background(), "HEAD~1", results, files, nil)
 
 	if len(resp.DirectCallers) != 1 {
 		t.Fatalf("DirectCallers = %d, want 1", len(resp.DirectCallers))
@@ -482,7 +485,7 @@ func TestBlastVerifyHintZeroAffectedWithCallees(t *testing.T) {
 		SubjectHasCallees: true,
 	}
 
-	resp := BuildBlastResponse(r, noFiles)
+	resp := BuildBlastResponse(context.Background(), r, noFiles, nil)
 
 	if resp.VerifyHint == "" {
 		t.Fatal("VerifyHint should be set when TotalAffected=0 and SubjectHasCallees=true")
@@ -501,7 +504,7 @@ func TestBlastVerifyHintNotEmittedWithCallers(t *testing.T) {
 		SubjectHasCallees: true,
 	}
 
-	resp := BuildBlastResponse(r, noFiles)
+	resp := BuildBlastResponse(context.Background(), r, noFiles, nil)
 
 	if resp.VerifyHint != "" {
 		t.Errorf("VerifyHint should be empty when TotalAffected > 0, got %q", resp.VerifyHint)
@@ -535,7 +538,7 @@ func TestBuildBlastResponseAffectedSymbolsAndFiles(t *testing.T) {
 		return p, ok
 	}
 
-	resp := BuildBlastResponse(r, files)
+	resp := BuildBlastResponse(context.Background(), r, files, nil)
 
 	if resp.AffectedSymbols != 3 {
 		t.Errorf("AffectedSymbols = %d, want 3", resp.AffectedSymbols)
@@ -577,7 +580,7 @@ func TestBuildDiffBlastResponseAffectedSymbolsAndFiles(t *testing.T) {
 		return p, ok
 	}
 
-	resp := BuildDiffBlastResponse("HEAD~1", results, files)
+	resp := BuildDiffBlastResponse(context.Background(), "HEAD~1", results, files, nil)
 
 	if resp.AffectedSymbols != 2 {
 		t.Errorf("AffectedSymbols = %d, want 2", resp.AffectedSymbols)
@@ -605,7 +608,7 @@ func TestBuildBlastResponseZeroEdges(t *testing.T) {
 		EdgesTraversed: 0,
 	}
 
-	resp := BuildBlastResponse(r, noFiles)
+	resp := BuildBlastResponse(context.Background(), r, noFiles, nil)
 
 	if resp.AffectedSymbols != 0 {
 		t.Errorf("AffectedSymbols = %d, want 0", resp.AffectedSymbols)
@@ -630,9 +633,220 @@ func TestBlastVerifyHintNotEmittedLeafSymbol(t *testing.T) {
 		SubjectHasCallees: false,
 	}
 
-	resp := BuildBlastResponse(r, noFiles)
+	resp := BuildBlastResponse(context.Background(), r, noFiles, nil)
 
 	if resp.VerifyHint != "" {
 		t.Errorf("VerifyHint should be empty for leaf symbol, got %q", resp.VerifyHint)
+	}
+}
+
+func TestBuildBlastResponseCallSiteSnippets(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "caller.go", "package main\n\nfunc caller() {\n\ttarget()\n\treturn\n}\n")
+
+	line := 4
+	filePaths := map[int64]string{
+		1: "target.go",
+		2: "caller.go",
+	}
+	files := func(id int64) (string, bool) {
+		p, ok := filePaths[id]
+		return p, ok
+	}
+
+	r := blast.Result{
+		Symbol: model.Symbol{Name: "target", Qualified: "target"},
+		Risk:   blast.RiskLow,
+		DirectCallers: []model.Symbol{
+			{ID: 10, Name: "caller", Qualified: "caller", FileID: 2, LineStart: 3, LineEnd: 6},
+		},
+		DirectEdgeSites: map[int64]blast.EdgeSite{
+			10: {FileID: int64p(2), Line: &line},
+		},
+		AffectedTests: []string{},
+		RiskReasons:   []string{},
+	}
+
+	snippets := NewSnippetReader(dir, 2)
+	resp := BuildBlastResponse(context.Background(), r, files, snippets)
+
+	if len(resp.DirectCallers) != 1 {
+		t.Fatalf("DirectCallers = %d, want 1", len(resp.DirectCallers))
+	}
+	c := resp.DirectCallers[0]
+	if c.CallSite == nil {
+		t.Fatal("CallSite is nil, want non-nil")
+	}
+	if c.CallSite.Line != 4 {
+		t.Errorf("CallSite.Line = %d, want 4", c.CallSite.Line)
+	}
+	lines := splitLines(c.CallSite.Snippet)
+	if len(lines) != 5 {
+		t.Errorf("snippet lines = %d, want 5; snippet:\n%s", len(lines), c.CallSite.Snippet)
+	}
+}
+
+func TestBuildBlastResponseCallSiteZeroSuppresses(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "caller.go", "package main\n\nfunc caller() {\n\ttarget()\n}\n")
+
+	line := 4
+	files := func(id int64) (string, bool) {
+		if id == 2 {
+			return "caller.go", true
+		}
+		return "", false
+	}
+
+	r := blast.Result{
+		Symbol: model.Symbol{Name: "target", Qualified: "target"},
+		Risk:   blast.RiskLow,
+		DirectCallers: []model.Symbol{
+			{ID: 10, Name: "caller", Qualified: "caller", FileID: 2, LineStart: 3},
+		},
+		DirectEdgeSites: map[int64]blast.EdgeSite{
+			10: {FileID: int64p(2), Line: &line},
+		},
+		AffectedTests: []string{},
+		RiskReasons:   []string{},
+	}
+
+	snippets := NewSnippetReader(dir, 0)
+	resp := BuildBlastResponse(context.Background(), r, files, snippets)
+
+	if resp.DirectCallers[0].CallSite != nil {
+		t.Error("CallSite should be nil when context_lines=0")
+	}
+}
+
+func TestBuildBlastResponseCallSiteMissingEdgeSite(t *testing.T) {
+	files := func(_ int64) (string, bool) { return "x.go", true }
+
+	r := blast.Result{
+		Symbol: model.Symbol{Name: "target", Qualified: "target"},
+		Risk:   blast.RiskLow,
+		DirectCallers: []model.Symbol{
+			{ID: 10, Name: "caller", Qualified: "caller", FileID: 1, LineStart: 3},
+		},
+		AffectedTests: []string{},
+		RiskReasons:   []string{},
+	}
+
+	snippets := NewSnippetReader(t.TempDir(), 2)
+	resp := BuildBlastResponse(context.Background(), r, files, snippets)
+
+	if resp.DirectCallers[0].CallSite != nil {
+		t.Error("CallSite should be nil when no edge site exists")
+	}
+}
+
+func TestBuildBlastResponseCallSiteEdgeFileMissing(t *testing.T) {
+	noFiles := func(int64) (string, bool) { return "", false }
+
+	line := 4
+	r := blast.Result{
+		Symbol: model.Symbol{Name: "target", Qualified: "target"},
+		Risk:   blast.RiskLow,
+		DirectCallers: []model.Symbol{
+			{ID: 10, Name: "caller", Qualified: "caller", FileID: 2, LineStart: 3},
+		},
+		DirectEdgeSites: map[int64]blast.EdgeSite{
+			10: {FileID: int64p(99), Line: &line},
+		},
+		AffectedTests: []string{},
+		RiskReasons:   []string{},
+	}
+
+	snippets := NewSnippetReader(t.TempDir(), 2)
+	resp := BuildBlastResponse(context.Background(), r, noFiles, snippets)
+
+	if resp.DirectCallers[0].CallSite != nil {
+		t.Error("CallSite should be nil when edge file not in lookup")
+	}
+}
+
+func TestBuildDiffBlastResponseCallSiteSnippets(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "caller.go", "package main\n\nfunc caller() {\n\ttarget()\n\treturn\n}\n")
+
+	line := 4
+	filePaths := map[int64]string{
+		1: "target.go",
+		2: "caller.go",
+	}
+	files := func(id int64) (string, bool) {
+		p, ok := filePaths[id]
+		return p, ok
+	}
+
+	results := []blast.Result{
+		{
+			Symbol: model.Symbol{ID: 1, Name: "target", Qualified: "target"},
+			Risk:   blast.RiskLow,
+			DirectCallers: []model.Symbol{
+				{ID: 10, Name: "caller", Qualified: "caller", FileID: 2, LineStart: 3, LineEnd: 6},
+			},
+			DirectEdgeSites: map[int64]blast.EdgeSite{
+				10: {FileID: int64p(2), Line: &line},
+			},
+			AffectedTests: []string{},
+		},
+	}
+
+	snippets := NewSnippetReader(dir, 2)
+	resp := BuildDiffBlastResponse(context.Background(), "HEAD~1", results, files, snippets)
+
+	if len(resp.DirectCallers) != 1 {
+		t.Fatalf("DirectCallers = %d, want 1", len(resp.DirectCallers))
+	}
+	c := resp.DirectCallers[0]
+	if c.CallSite == nil {
+		t.Fatal("CallSite is nil in diff blast, want non-nil")
+	}
+	if c.CallSite.Line != 4 {
+		t.Errorf("CallSite.Line = %d, want 4", c.CallSite.Line)
+	}
+}
+
+func TestBuildBlastResponseSnippetsTruncated(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "caller.go", "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n")
+
+	files := func(_ int64) (string, bool) { return "caller.go", true }
+
+	var callers []model.Symbol
+	edgeSites := map[int64]blast.EdgeSite{}
+	for i := 0; i < 15; i++ {
+		line := i + 1
+		callers = append(callers, model.Symbol{
+			ID: int64(i + 10), Name: "c", Qualified: "c", FileID: 1, LineStart: line,
+		})
+		edgeSites[int64(i+10)] = blast.EdgeSite{FileID: int64p(1), Line: &line}
+	}
+
+	r := blast.Result{
+		Symbol:          model.Symbol{Name: "target", Qualified: "target"},
+		Risk:            blast.RiskLow,
+		DirectCallers:   callers,
+		DirectEdgeSites: edgeSites,
+		AffectedTests:   []string{},
+		RiskReasons:     []string{},
+	}
+
+	snippets := NewSnippetReader(dir, 1)
+	resp := BuildBlastResponse(context.Background(), r, files, snippets)
+
+	if !resp.SnippetsTruncated {
+		t.Error("SnippetsTruncated should be true")
+	}
+
+	withSnippet := 0
+	for _, c := range resp.DirectCallers {
+		if c.CallSite != nil {
+			withSnippet++
+		}
+	}
+	if withSnippet != SnippetCap {
+		t.Errorf("snippets with content = %d, want %d", withSnippet, SnippetCap)
 	}
 }

--- a/internal/mcpio/coverage_test.go
+++ b/internal/mcpio/coverage_test.go
@@ -1,6 +1,7 @@
 package mcpio
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -223,7 +224,7 @@ func TestBuildGraphLayer(t *testing.T) {
 	files := func(int64) (string, bool) { return "", false }
 	req := BuildGraphRequest{Direction: model.DirectionBoth}
 
-	layer := BuildGraphLayer(hop, 2, files, req)
+	layer := BuildGraphLayer(context.Background(), hop, 2, files, req)
 	if layer.Depth != 2 {
 		t.Errorf("Depth = %d, want 2", layer.Depth)
 	}
@@ -266,7 +267,7 @@ func TestBuildFullGraphResponse(t *testing.T) {
 	}
 	req := BuildGraphRequest{Direction: model.DirectionBoth}
 
-	resp := BuildFullGraphResponse(gr, files, req)
+	resp := BuildFullGraphResponse(context.Background(), gr, files, req)
 	if len(resp.Layers) != 1 {
 		t.Errorf("Layers = %d, want 1", len(resp.Layers))
 	}

--- a/internal/mcpio/graph.go
+++ b/internal/mcpio/graph.go
@@ -1,6 +1,7 @@
 package mcpio
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -27,7 +28,8 @@ type FileLookup func(fileID int64) (path string, ok bool)
 // from the DB layer.
 type BuildGraphRequest struct {
 	Direction       model.Direction // DirectionBoth, DirectionCallers, DirectionCallees; "" == both
-	SegmentCallers  bool   // split callers into production vs test
+	SegmentCallers  bool
+	Snippets        *SnippetReader
 }
 
 // BuildGraphResponse assembles the wire-shape response from the
@@ -44,7 +46,7 @@ type BuildGraphRequest struct {
 // Test edges with an unknown file are dropped entirely — the test
 // row is (file, confidence) only, so without a file there is no
 // row to emit.
-func BuildGraphResponse(sc *model.SymbolContext, files FileLookup, req BuildGraphRequest) GraphResponse {
+func BuildGraphResponse(ctx context.Context, sc *model.SymbolContext, files FileLookup, req BuildGraphRequest) GraphResponse {
 	resp := GraphResponse{
 		Symbol: GraphSymbol{
 			Name:      sc.Symbol.Name,
@@ -57,7 +59,8 @@ func BuildGraphResponse(sc *model.SymbolContext, files FileLookup, req BuildGrap
 		},
 	}
 
-	resp.Edges = categorizeEdges(sc.Outbound, sc.Inbound, files, req.Direction)
+	resp.Edges = categorizeEdges(ctx, sc.Outbound, sc.Inbound, files, req.Direction, req.Snippets)
+	resp.SnippetsTruncated = req.Snippets.Truncated(len(sc.Outbound) + len(sc.Inbound))
 
 	// Test-caller segmentation: split test callers out of CalledBy.
 	var testCallers []CallEdgeRef
@@ -147,12 +150,17 @@ func BuildGraphResponse(sc *model.SymbolContext, files FileLookup, req BuildGrap
 // graph result, including root edges and any transitive layers.
 // Metrics are recomputed after layers are added so they account for
 // the full traversal, not just depth-1 edges.
-func BuildFullGraphResponse(gr *model.GraphResult, files FileLookup, req BuildGraphRequest) GraphResponse {
-	resp := BuildGraphResponse(&gr.Root, files, req)
+func BuildFullGraphResponse(ctx context.Context, gr *model.GraphResult, files FileLookup, req BuildGraphRequest) GraphResponse {
+	resp := BuildGraphResponse(ctx, &gr.Root, files, req)
 	for i, layer := range gr.Layers {
-		resp.Layers = append(resp.Layers, BuildGraphLayer(layer, i+2, files, req))
+		resp.Layers = append(resp.Layers, BuildGraphLayer(ctx, layer, i+2, files, req))
 	}
 	resp.Truncated = gr.Truncated
+	totalEdges := len(gr.Root.Outbound) + len(gr.Root.Inbound)
+	for _, l := range gr.Layers {
+		totalEdges += len(l.Outbound) + len(l.Inbound)
+	}
+	resp.SnippetsTruncated = req.Snippets.Truncated(totalEdges)
 
 	if len(resp.Layers) > 0 {
 		for _, l := range resp.Layers {
@@ -167,10 +175,10 @@ func BuildFullGraphResponse(gr *model.GraphResult, files FileLookup, req BuildGr
 
 // BuildGraphLayer converts a model.HopEdges into a wire-format
 // GraphLayer for the given hop depth.
-func BuildGraphLayer(hop model.HopEdges, depth int, files FileLookup, req BuildGraphRequest) GraphLayer {
+func BuildGraphLayer(ctx context.Context, hop model.HopEdges, depth int, files FileLookup, req BuildGraphRequest) GraphLayer {
 	return GraphLayer{
 		Depth: depth,
-		Edges: categorizeEdges(hop.Outbound, hop.Inbound, files, req.Direction),
+		Edges: categorizeEdges(ctx, hop.Outbound, hop.Inbound, files, req.Direction, req.Snippets),
 	}
 }
 
@@ -178,13 +186,24 @@ func BuildGraphLayer(hop model.HopEdges, depth int, files FileLookup, req BuildG
 // shape, dispatching each edge kind to the right bucket. Temporal edges
 // and test-caller segmentation are root-only concerns handled by
 // BuildGraphResponse on top of this.
-func categorizeEdges(outbound, inbound []model.EdgeRef, files FileLookup, direction model.Direction) GraphEdges {
+func categorizeEdges(ctx context.Context, outbound, inbound []model.EdgeRef, files FileLookup, direction model.Direction, snippets *SnippetReader) GraphEdges {
 	var edges GraphEdges
+
+	readSnippet := func(e model.EdgeRef) *CallSite {
+		if e.Edge.Line == nil {
+			return nil
+		}
+		edgeFile, ok := files(e.Edge.FileID)
+		if !ok {
+			return nil
+		}
+		return snippets.Read(ctx, edgeFile, *e.Edge.Line)
+	}
 
 	if direction != model.DirectionCallers {
 		for _, e := range outbound {
 			switch e.Edge.Kind {
-			case model.EdgeCalls:
+			case model.EdgeCalls, model.EdgeReferences:
 				fp := fileRefOrNil(e.Target.FileID, files)
 				edges.Calls = append(edges.Calls, CallEdgeRef{
 					Symbol:     qualifiedOrName(e.Target),
@@ -193,6 +212,7 @@ func categorizeEdges(outbound, inbound []model.EdgeRef, files FileLookup, direct
 					LineEnd:    e.Target.LineEnd,
 					Ref:        FormatRefPtr(fp, e.Target.LineStart),
 					Confidence: Confidence(e.Edge.Confidence),
+					CallSite:   readSnippet(e),
 				})
 			case model.EdgeInherits:
 				fp := fileRefOrNil(e.Target.FileID, files)
@@ -238,7 +258,7 @@ func categorizeEdges(outbound, inbound []model.EdgeRef, files FileLookup, direct
 	if direction != model.DirectionCallees {
 		for _, e := range inbound {
 			switch e.Edge.Kind {
-			case model.EdgeCalls:
+			case model.EdgeCalls, model.EdgeReferences:
 				fp := fileRefOrNil(e.Target.FileID, files)
 				edges.CalledBy = append(edges.CalledBy, CallEdgeRef{
 					Symbol:     qualifiedOrName(e.Target),
@@ -247,6 +267,7 @@ func categorizeEdges(outbound, inbound []model.EdgeRef, files FileLookup, direct
 					LineEnd:    e.Target.LineEnd,
 					Ref:        FormatRefPtr(fp, e.Target.LineStart),
 					Confidence: Confidence(e.Edge.Confidence),
+					CallSite:   readSnippet(e),
 				})
 			case model.EdgeComposes:
 				fp := fileRefOrNil(e.Target.FileID, files)

--- a/internal/mcpio/graph_test.go
+++ b/internal/mcpio/graph_test.go
@@ -1,6 +1,7 @@
 package mcpio
 
 import (
+	"context"
 	"testing"
 
 	"github.com/luuuc/sense/internal/model"
@@ -41,7 +42,7 @@ func TestBuildGraphResponseComposesEdges(t *testing.T) {
 		},
 	}
 
-	resp := BuildGraphResponse(sc, files, BuildGraphRequest{})
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{})
 
 	if len(resp.Edges.Composes) != 3 {
 		t.Fatalf("Composes = %d, want 3 (2 outbound + 1 inbound)", len(resp.Edges.Composes))
@@ -73,12 +74,12 @@ func TestBuildGraphResponseComposesDirection(t *testing.T) {
 	}
 	files := func(int64) (string, bool) { return "", false }
 
-	resp := BuildGraphResponse(sc, files, BuildGraphRequest{Direction: model.DirectionCallees})
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{Direction: model.DirectionCallees})
 	if len(resp.Edges.Composes) != 1 || resp.Edges.Composes[0].Symbol != "Order" {
 		t.Errorf("callees direction: want only outbound Order, got %v", resp.Edges.Composes)
 	}
 
-	resp = BuildGraphResponse(sc, files, BuildGraphRequest{Direction: model.DirectionCallers})
+	resp = BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{Direction: model.DirectionCallers})
 	if len(resp.Edges.Composes) != 1 || resp.Edges.Composes[0].Symbol != "Profile" {
 		t.Errorf("callers direction: want only inbound Profile, got %v", resp.Edges.Composes)
 	}
@@ -113,7 +114,7 @@ func TestBuildGraphResponseIncludesImports(t *testing.T) {
 		},
 	}
 
-	resp := BuildGraphResponse(sc, files, BuildGraphRequest{})
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{})
 
 	if len(resp.Edges.Includes) != 1 {
 		t.Fatalf("Includes = %d, want 1", len(resp.Edges.Includes))
@@ -161,7 +162,7 @@ func TestBuildGraphResponseTemporalEdges(t *testing.T) {
 		},
 	}
 
-	resp := BuildGraphResponse(sc, files, BuildGraphRequest{})
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{})
 
 	// Temporal edges are deduplicated — even though the same symbol appears
 	// in both inbound and outbound, only one entry should appear.
@@ -189,7 +190,7 @@ func TestBuildGraphResponseTemporalEmptyWhenNoEdges(t *testing.T) {
 		File:   model.File{Path: "foo.rb"},
 	}
 	files := func(int64) (string, bool) { return "", false }
-	resp := BuildGraphResponse(sc, files, BuildGraphRequest{})
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{})
 	if resp.Edges.Temporal != nil {
 		t.Errorf("Temporal should be nil (not empty slice) before normalization, got %v", resp.Edges.Temporal)
 	}
@@ -211,7 +212,7 @@ func TestBuildGraphResponseTemporalDirectionIndependent(t *testing.T) {
 
 	// Temporal should appear regardless of direction filter.
 	for _, dir := range []model.Direction{model.DirectionBoth, model.DirectionCallers, model.DirectionCallees} {
-		resp := BuildGraphResponse(sc, files, BuildGraphRequest{Direction: dir})
+		resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{Direction: dir})
 		if len(resp.Edges.Temporal) != 1 {
 			t.Errorf("direction=%q: Temporal = %d, want 1", dir, len(resp.Edges.Temporal))
 		}
@@ -247,7 +248,7 @@ func TestCallerSegmentation(t *testing.T) {
 		},
 	}
 
-	resp := BuildGraphResponse(sc, files, BuildGraphRequest{Direction: model.DirectionCallers, SegmentCallers: true})
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{Direction: model.DirectionCallers, SegmentCallers: true})
 
 	if len(resp.Edges.CalledBy) != 2 {
 		t.Fatalf("CalledBy (production) = %d, want 2", len(resp.Edges.CalledBy))
@@ -263,7 +264,7 @@ func TestCallerSegmentation(t *testing.T) {
 	}
 
 	// Without SegmentCallers, all callers stay in CalledBy.
-	resp = BuildGraphResponse(sc, files, BuildGraphRequest{Direction: model.DirectionCallers, SegmentCallers: false})
+	resp = BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{Direction: model.DirectionCallers, SegmentCallers: false})
 	if len(resp.Edges.CalledBy) != 5 {
 		t.Fatalf("CalledBy (unsegmented) = %d, want 5", len(resp.Edges.CalledBy))
 	}
@@ -311,7 +312,7 @@ func TestCallerSegmentationCollapseOver20(t *testing.T) {
 		Inbound: inbound,
 	}
 
-	resp := BuildGraphResponse(sc, files, BuildGraphRequest{Direction: model.DirectionCallers, SegmentCallers: true})
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{Direction: model.DirectionCallers, SegmentCallers: true})
 
 	if len(resp.Edges.CalledBy) != 1 {
 		t.Fatalf("CalledBy (production) = %d, want 1", len(resp.Edges.CalledBy))
@@ -344,7 +345,7 @@ func TestBuildGraphResponseTemporalCountsInMetrics(t *testing.T) {
 		p, ok := filePaths[id]
 		return p, ok
 	}
-	resp := BuildGraphResponse(sc, files, BuildGraphRequest{})
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{})
 	if resp.SenseMetrics.SymbolsReturned != 1 {
 		t.Errorf("SymbolsReturned = %d, want 1", resp.SenseMetrics.SymbolsReturned)
 	}
@@ -537,7 +538,7 @@ func TestGraphVerifyHintConstantZeroCallers(t *testing.T) {
 		return p, ok
 	}
 
-	resp := BuildGraphResponse(sc, files, BuildGraphRequest{})
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{})
 
 	if resp.VerifyHint == "" {
 		t.Fatal("VerifyHint should be set for constant with zero callers and outgoing calls")
@@ -560,7 +561,7 @@ func TestGraphVerifyHintFunctionZeroCallers(t *testing.T) {
 	}
 	files := func(int64) (string, bool) { return "", false }
 
-	resp := BuildGraphResponse(sc, files, BuildGraphRequest{})
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{})
 
 	if resp.VerifyHint == "" {
 		t.Fatal("VerifyHint should be set for function with zero callers and outgoing calls")
@@ -587,7 +588,7 @@ func TestGraphVerifyHintNotEmittedWithCallers(t *testing.T) {
 		return p, ok
 	}
 
-	resp := BuildGraphResponse(sc, files, BuildGraphRequest{})
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{})
 
 	if resp.VerifyHint != "" {
 		t.Errorf("VerifyHint should be empty when callers exist, got %q", resp.VerifyHint)
@@ -607,7 +608,7 @@ func TestGraphVerifyHintNotEmittedForClass(t *testing.T) {
 	}
 	files := func(int64) (string, bool) { return "", false }
 
-	resp := BuildGraphResponse(sc, files, BuildGraphRequest{})
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{})
 
 	if resp.VerifyHint != "" {
 		t.Errorf("VerifyHint should be empty for class kind, got %q", resp.VerifyHint)
@@ -639,7 +640,7 @@ func TestCategorizeEdgesInboundIncludesImportsTests(t *testing.T) {
 		},
 	}
 
-	resp := BuildGraphResponse(sc, files, BuildGraphRequest{Direction: model.DirectionCallers})
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{Direction: model.DirectionCallers})
 
 	if len(resp.Edges.Includes) != 1 || resp.Edges.Includes[0].Symbol != "SoftDeletable" {
 		t.Errorf("Includes = %+v, want [SoftDeletable]", resp.Edges.Includes)
@@ -673,7 +674,7 @@ func TestBuildGraphResponseInboundOnlyTemporal(t *testing.T) {
 		return p, ok
 	}
 
-	resp := BuildGraphResponse(sc, files, BuildGraphRequest{})
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{})
 
 	if len(resp.Edges.Temporal) != 1 {
 		t.Fatalf("Temporal = %d, want 1", len(resp.Edges.Temporal))
@@ -756,7 +757,7 @@ func TestBuildGraphResponseRefField(t *testing.T) {
 		},
 	}
 
-	resp := BuildGraphResponse(sc, files, BuildGraphRequest{})
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{})
 
 	// Focal symbol ref
 	if resp.Symbol.Ref != "app/models/user.rb:10" {
@@ -808,9 +809,356 @@ func TestGraphVerifyHintNotEmittedWithoutCallees(t *testing.T) {
 	}
 	files := func(int64) (string, bool) { return "", false }
 
-	resp := BuildGraphResponse(sc, files, BuildGraphRequest{})
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{})
 
 	if resp.VerifyHint != "" {
 		t.Errorf("VerifyHint should be empty for leaf symbol with no callees, got %q", resp.VerifyHint)
+	}
+}
+
+func TestGraphCallSiteSnippet(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "caller.go", "package main\n\nimport \"fmt\"\n\nfunc caller() {\n\tfmt.Println(target())\n\treturn\n}\n")
+
+	line := 6
+	filePaths := map[int64]string{
+		1: "target.go",
+		2: "caller.go",
+	}
+	files := func(id int64) (string, bool) {
+		p, ok := filePaths[id]
+		return p, ok
+	}
+
+	sc := &model.SymbolContext{
+		Symbol: model.Symbol{Name: "target", Qualified: "target", Kind: "function", FileID: 1, LineStart: 1},
+		File:   model.File{Path: "target.go"},
+		Inbound: []model.EdgeRef{
+			{
+				Edge:   model.Edge{Kind: model.EdgeCalls, Confidence: 1.0, FileID: 2, Line: &line},
+				Target: model.Symbol{Qualified: "caller", FileID: 2, LineStart: 5, LineEnd: 7},
+			},
+		},
+	}
+
+	snippets := NewSnippetReader(dir, 2)
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{
+		Direction: model.DirectionCallers,
+		Snippets:  snippets,
+	})
+
+	if len(resp.Edges.CalledBy) != 1 {
+		t.Fatalf("CalledBy = %d, want 1", len(resp.Edges.CalledBy))
+	}
+	ref := resp.Edges.CalledBy[0]
+	if ref.CallSite == nil {
+		t.Fatal("CallSite is nil, want non-nil")
+	}
+	if ref.CallSite.Line != 6 {
+		t.Errorf("CallSite.Line = %d, want 6", ref.CallSite.Line)
+	}
+	lines := splitLines(ref.CallSite.Snippet)
+	if len(lines) != 5 {
+		t.Errorf("snippet lines = %d, want 5; snippet:\n%s", len(lines), ref.CallSite.Snippet)
+	}
+}
+
+func TestGraphCallSiteZeroContextSuppresses(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "caller.go", "package main\n\nfunc caller() {\n\ttarget()\n}\n")
+
+	line := 4
+	files := func(id int64) (string, bool) {
+		if id == 1 {
+			return "caller.go", true
+		}
+		return "", false
+	}
+
+	sc := &model.SymbolContext{
+		Symbol: model.Symbol{Name: "target", Qualified: "target", Kind: "function"},
+		File:   model.File{Path: "target.go"},
+		Inbound: []model.EdgeRef{
+			{
+				Edge:   model.Edge{Kind: model.EdgeCalls, Confidence: 1.0, FileID: 1, Line: &line},
+				Target: model.Symbol{Qualified: "caller", FileID: 1, LineStart: 3},
+			},
+		},
+	}
+
+	snippets := NewSnippetReader(dir, 0)
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{
+		Direction: model.DirectionCallers,
+		Snippets:  snippets,
+	})
+
+	if len(resp.Edges.CalledBy) != 1 {
+		t.Fatalf("CalledBy = %d, want 1", len(resp.Edges.CalledBy))
+	}
+	if resp.Edges.CalledBy[0].CallSite != nil {
+		t.Error("CallSite should be nil when context_lines=0")
+	}
+}
+
+func TestGraphCallSiteNoSnippetForNonCallEdges(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "parent.go", "package main\n\ntype Parent struct{}\n")
+
+	line := 3
+	files := func(id int64) (string, bool) {
+		if id == 1 {
+			return "parent.go", true
+		}
+		return "", false
+	}
+
+	sc := &model.SymbolContext{
+		Symbol: model.Symbol{Name: "Child", Qualified: "Child", Kind: "class"},
+		File:   model.File{Path: "child.go"},
+		Outbound: []model.EdgeRef{
+			{
+				Edge:   model.Edge{Kind: model.EdgeInherits, Confidence: 1.0, FileID: 1, Line: &line},
+				Target: model.Symbol{Qualified: "Parent", FileID: 1, LineStart: 3},
+			},
+		},
+	}
+
+	snippets := NewSnippetReader(dir, 2)
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{Snippets: snippets})
+
+	if len(resp.Edges.Inherits) != 1 {
+		t.Fatalf("Inherits = %d, want 1", len(resp.Edges.Inherits))
+	}
+}
+
+func TestGraphCallSiteMissingFile(t *testing.T) {
+	dir := t.TempDir()
+
+	line := 5
+	files := func(id int64) (string, bool) {
+		if id == 1 {
+			return "nonexistent.go", true
+		}
+		return "", false
+	}
+
+	sc := &model.SymbolContext{
+		Symbol: model.Symbol{Name: "target", Qualified: "target", Kind: "function"},
+		File:   model.File{Path: "target.go"},
+		Inbound: []model.EdgeRef{
+			{
+				Edge:   model.Edge{Kind: model.EdgeCalls, Confidence: 1.0, FileID: 1, Line: &line},
+				Target: model.Symbol{Qualified: "caller", FileID: 1, LineStart: 3},
+			},
+		},
+	}
+
+	snippets := NewSnippetReader(dir, 2)
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{
+		Direction: model.DirectionCallers,
+		Snippets:  snippets,
+	})
+
+	if len(resp.Edges.CalledBy) != 1 {
+		t.Fatalf("CalledBy = %d, want 1", len(resp.Edges.CalledBy))
+	}
+	if resp.Edges.CalledBy[0].CallSite != nil {
+		t.Error("CallSite should be nil when source file doesn't exist")
+	}
+}
+
+func TestGraphCallSiteReferencesEdge(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "ref.go", "package main\n\nvar x = CONSTANT\n")
+
+	line := 3
+	files := func(id int64) (string, bool) {
+		if id == 1 {
+			return "ref.go", true
+		}
+		return "", false
+	}
+
+	sc := &model.SymbolContext{
+		Symbol: model.Symbol{Name: "CONSTANT", Qualified: "CONSTANT", Kind: "constant"},
+		File:   model.File{Path: "const.go"},
+		Inbound: []model.EdgeRef{
+			{
+				Edge:   model.Edge{Kind: model.EdgeReferences, Confidence: 1.0, FileID: 1, Line: &line},
+				Target: model.Symbol{Qualified: "main.init", FileID: 1, LineStart: 1},
+			},
+		},
+	}
+
+	snippets := NewSnippetReader(dir, 2)
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{
+		Direction: model.DirectionCallers,
+		Snippets:  snippets,
+	})
+
+	if len(resp.Edges.CalledBy) != 1 {
+		t.Fatalf("CalledBy = %d, want 1", len(resp.Edges.CalledBy))
+	}
+	ref := resp.Edges.CalledBy[0]
+	if ref.CallSite == nil {
+		t.Fatal("CallSite is nil for references edge, want non-nil")
+	}
+	if ref.CallSite.Line != 3 {
+		t.Errorf("CallSite.Line = %d, want 3", ref.CallSite.Line)
+	}
+}
+
+func TestGraphSnippetsTruncated(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "caller.go", "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n")
+
+	files := func(_ int64) (string, bool) {
+		return "caller.go", true
+	}
+
+	var inbound []model.EdgeRef
+	for i := 0; i < 15; i++ {
+		line := i + 1
+		inbound = append(inbound, model.EdgeRef{
+			Edge:   model.Edge{Kind: model.EdgeCalls, Confidence: 1.0, FileID: 1, Line: &line},
+			Target: model.Symbol{ID: int64(i + 10), Qualified: "caller" + string(rune('A'+i)), FileID: 1, LineStart: line},
+		})
+	}
+
+	sc := &model.SymbolContext{
+		Symbol: model.Symbol{Name: "target", Qualified: "target", Kind: "function"},
+		File:   model.File{Path: "target.go"},
+		Inbound: inbound,
+	}
+
+	snippets := NewSnippetReader(dir, 1)
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{
+		Direction: model.DirectionCallers,
+		Snippets:  snippets,
+	})
+
+	if !resp.SnippetsTruncated {
+		t.Error("SnippetsTruncated should be true when more edges than SnippetCap")
+	}
+
+	withSnippet := 0
+	for _, ref := range resp.Edges.CalledBy {
+		if ref.CallSite != nil {
+			withSnippet++
+		}
+	}
+	if withSnippet != SnippetCap {
+		t.Errorf("snippets with content = %d, want %d", withSnippet, SnippetCap)
+	}
+}
+
+func TestGraphCallSiteOutboundSnippet(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "main.go", "package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(hello())\n\treturn\n}\n")
+
+	line := 6
+	filePaths := map[int64]string{
+		1: "main.go",
+		2: "hello.go",
+	}
+	files := func(id int64) (string, bool) {
+		p, ok := filePaths[id]
+		return p, ok
+	}
+
+	sc := &model.SymbolContext{
+		Symbol: model.Symbol{Name: "main", Qualified: "main", Kind: "function", FileID: 1, LineStart: 5},
+		File:   model.File{Path: "main.go"},
+		Outbound: []model.EdgeRef{
+			{
+				Edge:   model.Edge{Kind: model.EdgeCalls, Confidence: 1.0, FileID: 1, Line: &line},
+				Target: model.Symbol{Qualified: "hello", FileID: 2, LineStart: 1, LineEnd: 3},
+			},
+		},
+	}
+
+	snippets := NewSnippetReader(dir, 2)
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{
+		Direction: model.DirectionCallees,
+		Snippets:  snippets,
+	})
+
+	if len(resp.Edges.Calls) != 1 {
+		t.Fatalf("Calls = %d, want 1", len(resp.Edges.Calls))
+	}
+	ref := resp.Edges.Calls[0]
+	if ref.CallSite == nil {
+		t.Fatal("CallSite is nil on outbound call, want non-nil")
+	}
+	if ref.CallSite.Line != 6 {
+		t.Errorf("CallSite.Line = %d, want 6", ref.CallSite.Line)
+	}
+}
+
+func TestFullGraphResponseSharedSnippetBudget(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "caller.go", "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n20\n")
+
+	files := func(_ int64) (string, bool) {
+		return "caller.go", true
+	}
+
+	var rootInbound []model.EdgeRef
+	for i := 0; i < 8; i++ {
+		line := i + 1
+		rootInbound = append(rootInbound, model.EdgeRef{
+			Edge:   model.Edge{Kind: model.EdgeCalls, Confidence: 1.0, FileID: 1, Line: &line},
+			Target: model.Symbol{ID: int64(i + 10), Qualified: "caller" + string(rune('A'+i)), FileID: 1, LineStart: line},
+		})
+	}
+
+	var layerInbound []model.EdgeRef
+	for i := 0; i < 8; i++ {
+		line := i + 11
+		layerInbound = append(layerInbound, model.EdgeRef{
+			Edge:   model.Edge{Kind: model.EdgeCalls, Confidence: 1.0, FileID: 1, Line: &line},
+			Target: model.Symbol{ID: int64(i + 20), Qualified: "layer" + string(rune('A'+i)), FileID: 1, LineStart: line},
+		})
+	}
+
+	gr := &model.GraphResult{
+		Root: model.SymbolContext{
+			Symbol:  model.Symbol{Name: "target", Qualified: "target", Kind: "function"},
+			File:    model.File{Path: "target.go"},
+			Inbound: rootInbound,
+		},
+		Layers: []model.HopEdges{
+			{Inbound: layerInbound},
+		},
+	}
+
+	snippets := NewSnippetReader(dir, 1)
+	resp := BuildFullGraphResponse(context.Background(), gr, files, BuildGraphRequest{
+		Direction: model.DirectionCallers,
+		Snippets:  snippets,
+	})
+
+	rootSnippets := 0
+	for _, ref := range resp.Edges.CalledBy {
+		if ref.CallSite != nil {
+			rootSnippets++
+		}
+	}
+	layerSnippets := 0
+	if len(resp.Layers) > 0 {
+		for _, ref := range resp.Layers[0].Edges.CalledBy {
+			if ref.CallSite != nil {
+				layerSnippets++
+			}
+		}
+	}
+
+	total := rootSnippets + layerSnippets
+	if total > SnippetCap {
+		t.Errorf("total snippets = %d (root=%d + layer=%d), want <= %d (shared budget)",
+			total, rootSnippets, layerSnippets, SnippetCap)
+	}
+	if !resp.SnippetsTruncated {
+		t.Error("SnippetsTruncated should be true when total edges exceed cap")
 	}
 }

--- a/internal/mcpio/snippet.go
+++ b/internal/mcpio/snippet.go
@@ -1,0 +1,107 @@
+package mcpio
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/luuuc/sense/internal/blast"
+)
+
+const (
+	DefaultContextLines = 2
+	SnippetCap          = 10
+)
+
+type CallSite struct {
+	Line    int    `json:"line"`
+	Snippet string `json:"snippet"`
+}
+
+type SnippetReader struct {
+	root         string
+	contextLines int
+	count        int
+}
+
+func NewSnippetReader(root string, contextLines int) *SnippetReader {
+	if contextLines < 0 {
+		contextLines = 0
+	}
+	return &SnippetReader{root: root, contextLines: contextLines}
+}
+
+func (r *SnippetReader) Enabled() bool {
+	return r != nil && r.contextLines > 0
+}
+
+func (r *SnippetReader) Exhausted() bool {
+	return r == nil || r.count >= SnippetCap
+}
+
+func (r *SnippetReader) Truncated(totalEdges int) bool {
+	return r != nil && r.count >= SnippetCap && totalEdges > r.count
+}
+
+func (r *SnippetReader) Read(ctx context.Context, relPath string, line int) *CallSite {
+	if r == nil || r.contextLines <= 0 || r.count >= SnippetCap || line <= 0 || relPath == "" {
+		return nil
+	}
+	if err := ctx.Err(); err != nil {
+		return nil
+	}
+	abs := filepath.Join(r.root, relPath)
+	f, err := os.Open(abs)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = f.Close() }()
+
+	start := line - r.contextLines
+	if start < 1 {
+		start = 1
+	}
+	end := line + r.contextLines
+
+	var lines []string
+	scanner := bufio.NewScanner(f)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		if lineNum > end {
+			break
+		}
+		if lineNum >= start {
+			lines = append(lines, scanner.Text())
+		}
+	}
+	if len(lines) == 0 {
+		return nil
+	}
+	r.count++
+	return &CallSite{
+		Line:    line,
+		Snippet: strings.Join(lines, "\n"),
+	}
+}
+
+// ReadBlastEdgeSite resolves an edge site from a blast result into a snippet.
+func (r *SnippetReader) ReadBlastEdgeSite(ctx context.Context, callerID int64, sites map[int64]blast.EdgeSite, files FileLookup) *CallSite {
+	if !r.Enabled() || r.Exhausted() {
+		return nil
+	}
+	es, ok := sites[callerID]
+	if !ok || es.Line == nil {
+		return nil
+	}
+	if es.FileID == nil {
+		return nil
+	}
+	edgeFile, ok := files(*es.FileID)
+	if !ok {
+		return nil
+	}
+	return r.Read(ctx, edgeFile, *es.Line)
+}

--- a/internal/mcpio/snippet_test.go
+++ b/internal/mcpio/snippet_test.go
@@ -1,0 +1,152 @@
+package mcpio
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTestFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSnippetReaderDefault(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "main.go", "package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"hello\")\n}\n")
+
+	r := NewSnippetReader(dir, 2)
+	cs := r.Read(context.Background(), "main.go", 5)
+	if cs == nil {
+		t.Fatal("expected call site")
+	}
+	if cs.Line != 5 {
+		t.Errorf("line = %d, want 5", cs.Line)
+	}
+	lines := splitLines(cs.Snippet)
+	if len(lines) != 5 {
+		t.Errorf("snippet lines = %d, want 5; snippet:\n%s", len(lines), cs.Snippet)
+	}
+}
+
+func TestSnippetReaderStartOfFile(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "a.go", "line1\nline2\nline3\nline4\nline5\n")
+
+	r := NewSnippetReader(dir, 2)
+	cs := r.Read(context.Background(), "a.go", 1)
+	if cs == nil {
+		t.Fatal("expected call site")
+	}
+	lines := splitLines(cs.Snippet)
+	if len(lines) != 3 {
+		t.Errorf("snippet lines = %d, want 3 (line 1 + 2 after); snippet:\n%s", len(lines), cs.Snippet)
+	}
+	if lines[0] != "line1" {
+		t.Errorf("first line = %q, want %q", lines[0], "line1")
+	}
+}
+
+func TestSnippetReaderEndOfFile(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "a.go", "line1\nline2\nline3\nline4\nline5")
+
+	r := NewSnippetReader(dir, 2)
+	cs := r.Read(context.Background(), "a.go", 5)
+	if cs == nil {
+		t.Fatal("expected call site")
+	}
+	lines := splitLines(cs.Snippet)
+	if len(lines) != 3 {
+		t.Errorf("snippet lines = %d, want 3 (2 before + line 5); snippet:\n%s", len(lines), cs.Snippet)
+	}
+	if lines[len(lines)-1] != "line5" {
+		t.Errorf("last line = %q, want %q", lines[len(lines)-1], "line5")
+	}
+}
+
+func TestSnippetReaderMissingFile(t *testing.T) {
+	r := NewSnippetReader(t.TempDir(), 2)
+	cs := r.Read(context.Background(), "nonexistent.go", 5)
+	if cs != nil {
+		t.Error("expected nil for missing file")
+	}
+}
+
+func TestSnippetReaderZeroContextLines(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "a.go", "line1\nline2\nline3\n")
+
+	r := NewSnippetReader(dir, 0)
+	if r.Enabled() {
+		t.Error("expected Enabled() == false for context_lines=0")
+	}
+	cs := r.Read(context.Background(), "a.go", 2)
+	if cs != nil {
+		t.Error("expected nil when context_lines=0")
+	}
+}
+
+func TestSnippetReaderNegativeContextLines(t *testing.T) {
+	r := NewSnippetReader(t.TempDir(), -1)
+	if r.Enabled() {
+		t.Error("expected Enabled() == false for negative context_lines")
+	}
+}
+
+func TestSnippetReaderZeroLine(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "a.go", "line1\nline2\n")
+
+	r := NewSnippetReader(dir, 2)
+	cs := r.Read(context.Background(), "a.go", 0)
+	if cs != nil {
+		t.Error("expected nil for line=0")
+	}
+}
+
+func TestSnippetReaderEmptyPath(t *testing.T) {
+	r := NewSnippetReader(t.TempDir(), 2)
+	cs := r.Read(context.Background(), "", 5)
+	if cs != nil {
+		t.Error("expected nil for empty path")
+	}
+}
+
+func TestSnippetReaderCustomContextLines(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "a.go", "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n")
+
+	r := NewSnippetReader(dir, 3)
+	cs := r.Read(context.Background(), "a.go", 5)
+	if cs == nil {
+		t.Fatal("expected call site")
+	}
+	lines := splitLines(cs.Snippet)
+	if len(lines) != 7 {
+		t.Errorf("snippet lines = %d, want 7 (3+1+3); snippet:\n%s", len(lines), cs.Snippet)
+	}
+}
+
+func TestSnippetReaderLineBeyondFile(t *testing.T) {
+	dir := t.TempDir()
+	writeTestFile(t, dir, "a.go", "line1\nline2\n")
+
+	r := NewSnippetReader(dir, 2)
+	cs := r.Read(context.Background(), "a.go", 100)
+	if cs != nil {
+		t.Error("expected nil for line beyond file length")
+	}
+}
+
+func splitLines(s string) []string {
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, "\n")
+}

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -100,8 +100,9 @@ type GraphResponse struct {
 	Edges              GraphEdges             `json:"edges"`
 	DispatchInferred   []DispatchInferredRef  `json:"dispatch_inferred,omitempty"`
 	Layers             []GraphLayer           `json:"layers,omitempty"`
-	Truncated          bool                   `json:"truncated,omitempty"`
-	TestCallerSummary  *TestCallerSummary     `json:"test_caller_summary,omitempty"`
+	Truncated          bool               `json:"truncated,omitempty"`
+	SnippetsTruncated  bool               `json:"snippets_truncated,omitempty"`
+	TestCallerSummary  *TestCallerSummary `json:"test_caller_summary,omitempty"`
 	CoverageNote       string                 `json:"coverage_note,omitempty"`
 	VerifyHint         string                 `json:"verify_hint,omitempty"`
 	SenseMetrics       GraphMetrics           `json:"-"`
@@ -180,6 +181,7 @@ type CallEdgeRef struct {
 	LineEnd    int        `json:"line_end,omitempty"`
 	Ref        string     `json:"ref,omitempty"`
 	Confidence Confidence `json:"confidence"`
+	CallSite   *CallSite  `json:"call_site,omitempty"`
 }
 
 // InheritEdgeRef is the shape of an inherits edge entry. The
@@ -273,10 +275,10 @@ type BlastResponse struct {
 	DirectCallers   []BlastCaller   `json:"direct_callers"`
 	IndirectCallers []BlastIndirect `json:"indirect_callers"`
 	AffectedTests   []string        `json:"affected_tests"`
-	AffectedSymbols      int             `json:"affected_symbols"`
-	AffectedFiles        int             `json:"affected_files"`
-	GraphEdgesTraversed  int             `json:"graph_edges_traversed"`
-	TotalAffected        int             `json:"total_affected"`
+	AffectedSymbols     int `json:"affected_symbols"`
+	AffectedFiles       int `json:"affected_files"`
+	GraphEdgesTraversed int `json:"graph_edges_traversed"`
+	TotalAffected       int `json:"total_affected"`
 
 	AffectedSubclasses     []BlastCaller `json:"affected_subclasses"`
 	AffectedViaComposition []BlastCaller `json:"affected_via_composition"`
@@ -291,6 +293,7 @@ type BlastResponse struct {
 	ProductionAffected int    `json:"production_affected"`
 	TestAffected       int    `json:"test_affected"`
 	Truncated          bool   `json:"truncated,omitempty"`
+	SnippetsTruncated  bool   `json:"snippets_truncated,omitempty"`
 	CoverageNote       string `json:"coverage_note,omitempty"`
 
 	VerifyHint   string       `json:"verify_hint,omitempty"`
@@ -308,12 +311,13 @@ type BlastTierSummary struct {
 
 // BlastCaller is the shape of a direct_callers entry.
 type BlastCaller struct {
-	Symbol      string `json:"symbol"`
-	File        string `json:"file"`
-	LineStart   int    `json:"line_start,omitempty"`
-	LineEnd     int    `json:"line_end,omitempty"`
-	Ref         string `json:"ref,omitempty"`
-	ViaTemporal bool   `json:"via_temporal,omitempty"`
+	Symbol      string    `json:"symbol"`
+	File        string    `json:"file"`
+	LineStart   int       `json:"line_start,omitempty"`
+	LineEnd     int       `json:"line_end,omitempty"`
+	Ref         string    `json:"ref,omitempty"`
+	ViaTemporal bool      `json:"via_temporal,omitempty"`
+	CallSite    *CallSite `json:"call_site,omitempty"`
 }
 
 // BlastIndirect is the shape of an indirect_callers entry. Via names

--- a/internal/mcpserver/blastdiff_test.go
+++ b/internal/mcpserver/blastdiff_test.go
@@ -124,7 +124,7 @@ func TestBlastDiffEmptyDiff(t *testing.T) {
 	defer cleanup()
 
 	ctx := context.Background()
-	resp, err := h.blastDiff(ctx, "HEAD", blast.Options{MaxHops: 1})
+	resp, err := h.blastDiff(ctx, "HEAD", blast.Options{MaxHops: 1}, nil)
 	if err != nil {
 		t.Fatalf("blastDiff empty diff: %v", err)
 	}
@@ -149,7 +149,7 @@ func TestBlastDiffSingleChange(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	resp, err := h.blastDiff(ctx, "HEAD", blast.Options{MaxHops: 1})
+	resp, err := h.blastDiff(ctx, "HEAD", blast.Options{MaxHops: 1}, nil)
 	if err != nil {
 		t.Fatalf("blastDiff single change: %v", err)
 	}
@@ -170,7 +170,7 @@ func TestBlastDiffInvalidRef(t *testing.T) {
 	defer cleanup()
 
 	ctx := context.Background()
-	_, err := h.blastDiff(ctx, "invalid-ref-12345", blast.Options{MaxHops: 1})
+	_, err := h.blastDiff(ctx, "invalid-ref-12345", blast.Options{MaxHops: 1}, nil)
 	if err == nil {
 		t.Fatal("expected error for invalid git ref")
 	}
@@ -183,7 +183,7 @@ func TestBlastDiffNonGitDirectory(t *testing.T) {
 	ts := setupTestServer(t)
 	ctx := context.Background()
 
-	_, err := ts.handlers.blastDiff(ctx, "HEAD", blast.Options{MaxHops: 1})
+	_, err := ts.handlers.blastDiff(ctx, "HEAD", blast.Options{MaxHops: 1}, nil)
 	if err == nil {
 		t.Fatal("expected error for non-git directory")
 	}
@@ -246,7 +246,7 @@ func TestBlastDiffMultipleFiles(t *testing.T) {
 		t.Fatalf("git add: %v\n%s", err, out)
 	}
 
-	resp, err := h.blastDiff(ctx, "HEAD", blast.Options{MaxHops: 1})
+	resp, err := h.blastDiff(ctx, "HEAD", blast.Options{MaxHops: 1}, nil)
 	if err != nil {
 		t.Fatalf("blastDiff multiple files: %v", err)
 	}

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -316,6 +316,9 @@ func graphTool() mcp.Tool {
 		mcp.WithString("domain",
 			mcp.Description("Filter dead code results to a path substring, e.g. 'services', 'models'. Only used when dead_code is true."),
 		),
+		mcp.WithNumber("context_lines",
+			mcp.Description("Lines of source context around each call site (default 2, 0 to suppress snippets)"),
+		),
 	)
 }
 
@@ -347,6 +350,9 @@ func blastTool() mcp.Tool {
 		),
 		mcp.WithBoolean("include_tests",
 			mcp.Description("Include affected test files in the results (default true)"),
+		),
+		mcp.WithNumber("context_lines",
+			mcp.Description("Lines of source context around each call site (default 2, 0 to suppress snippets)"),
 		),
 	)
 }
@@ -424,11 +430,13 @@ func (h *handlers) handleGraph(ctx context.Context, req mcp.CallToolRequest) (*m
 		return p, ok
 	}
 
+	contextLines := req.GetInt("context_lines", mcpio.DefaultContextLines)
 	buildReq := mcpio.BuildGraphRequest{
 		Direction:      direction,
 		SegmentCallers: h.defaults.GraphSegmentCallers,
+		Snippets:       mcpio.NewSnippetReader(h.dir, contextLines),
 	}
-	resp := mcpio.BuildFullGraphResponse(gr, lookup, buildReq)
+	resp := mcpio.BuildFullGraphResponse(ctx, gr, lookup, buildReq)
 
 	if direction != model.DirectionCallees {
 		inferred := h.resolveDispatchCallers(ctx, &gr.Root, &resp, lookup)
@@ -814,16 +822,19 @@ func (h *handlers) handleBlast(ctx context.Context, req mcp.CallToolRequest) (*m
 		IncludeTests:  includeTests,
 	}
 
+	contextLines := req.GetInt("context_lines", mcpio.DefaultContextLines)
+	snippets := mcpio.NewSnippetReader(h.dir, contextLines)
+
 	var resp mcpio.BlastResponse
 
 	if diff != "" {
-		resp2, err := h.blastDiff(ctx, diff, opts)
+		resp2, err := h.blastDiff(ctx, diff, opts, snippets)
 		if err != nil {
 			return nil, err
 		}
 		resp = resp2
 	} else {
-		resp2, err := h.blastSymbol(ctx, symbol, opts)
+		resp2, err := h.blastSymbol(ctx, symbol, opts, snippets)
 		if err != nil {
 			if re, ok := err.(*resolveError); ok {
 				return re.result, nil
@@ -1046,7 +1057,7 @@ func (h *handlers) disambiguationResult(ctx context.Context, symbol string, matc
 	return mcp.NewToolResultText(string(out))
 }
 
-func (h *handlers) blastSymbol(ctx context.Context, symbol string, opts blast.Options) (mcpio.BlastResponse, error) {
+func (h *handlers) blastSymbol(ctx context.Context, symbol string, opts blast.Options, snippets *mcpio.SnippetReader) (mcpio.BlastResponse, error) {
 	match, err := h.resolveSymbol(ctx, "sense_blast", symbol)
 	if err != nil {
 		return mcpio.BlastResponse{}, err
@@ -1076,10 +1087,10 @@ func (h *handlers) blastSymbol(ctx context.Context, symbol string, opts blast.Op
 		return p, ok
 	}
 
-	return mcpio.BuildBlastResponse(blastResult, lookup), nil
+	return mcpio.BuildBlastResponse(ctx, blastResult, lookup, snippets), nil
 }
 
-func (h *handlers) blastDiff(ctx context.Context, ref string, opts blast.Options) (mcpio.BlastResponse, error) {
+func (h *handlers) blastDiff(ctx context.Context, ref string, opts blast.Options, snippets *mcpio.SnippetReader) (mcpio.BlastResponse, error) {
 	paths, err := cli.GitDiffFiles(ctx, h.dir, ref)
 	if err != nil {
 		return mcpio.BlastResponse{}, fmt.Errorf("sense_blast: %w", err)
@@ -1112,7 +1123,7 @@ func (h *handlers) blastDiff(ctx context.Context, ref string, opts blast.Options
 		return p, ok
 	}
 
-	return mcpio.BuildDiffBlastResponse(ref, results, lookup), nil
+	return mcpio.BuildDiffBlastResponse(ctx, ref, results, lookup, snippets), nil
 }
 
 // ---------------------------------------------------------------


### PR DESCRIPTION
## Problem

When sense_graph or sense_blast reports callers, the AI consumer sees WHERE a symbol is called (file + line) but not HOW — the actual source context around the call site. This forces the agent to open each file and read around the line to understand usage patterns, negating the file-reads-avoided benefit Sense provides.

## Summary

Add optional source-context snippets to call edges in both graph and blast responses, showing a configurable window of source lines around each call site.

## Changes

### SnippetReader (`mcpio/snippet.go` — new)
- Reads N context lines around a call site from the working tree
- Owns the per-request snippet budget (cap=10) internally — no external counter threading
- Nil-receiver safe: callers pass nil to suppress snippets without guards
- Accepts `context.Context` for cancellation on client disconnect
- `ReadBlastEdgeSite` helper eliminates duplicated edge-site resolution logic

### Blast engine (`blast/engine.go`)
- `expandFrontier` SQL now selects `file_id, line` from `sense_edges`
- `EdgeSite.FileID` is `*int64` (not `int64`) for NULL safety on edges without file context
- Edge sites threaded through BFS and exposed on `Result.DirectEdgeSites`

### Wire types (`mcpio/types.go`)
- `CallSite{Line, Snippet}` added to `CallEdgeRef` and `BlastCaller`
- `SnippetsTruncated` flag on `GraphResponse` and `BlastResponse`
- Fixed tab alignment drift on `GraphResponse` and `BlastResponse` fields

### Response builders (`mcpio/blast.go`, `mcpio/graph.go`)
- `BuildBlastResponse` and `BuildDiffBlastResponse` use shared `ReadBlastEdgeSite`
- `categorizeEdges` attaches snippets to `EdgeCalls` and `EdgeReferences` edges
- Single shared snippet budget across root + all graph layers (fixes double-budget bug)

### MCP server (`mcpserver/server.go`)
- `context_lines` parameter on both `sense_graph` and `sense_blast` (default 2, 0 to suppress)

## Test Plan

- [x] SnippetReader: start-of-file, end-of-file, beyond-EOF, missing file, zero/negative context, custom window
- [x] Blast snippets: happy path, zero-suppression, missing edge site, missing edge file, truncation at cap
- [x] Graph snippets: inbound callers, outbound calls, references edges, non-call edges excluded
- [x] Shared budget: multi-hop graph verifies root + layers share single SnippetCap (total ≤ 10)
- [x] All existing blast/graph/coverage tests updated and passing with new signatures
- [x] `make ci` passes (tests + lint)
- [x] File/function coverage: new file 96–100%, modified functions 97–100%