### PR TITLE
feat(mcp): improve small-repo experience with freshness checks, also_called_by, and orientation

### DIFF
--- a/internal/hook/response.go
+++ b/internal/hook/response.go
@@ -1,6 +1,6 @@
 package hook
 
-const toolSearchCmd = `ToolSearch("select:mcp__sense__sense_graph,mcp__sense__sense_search,mcp__sense__sense_blast,mcp__sense__sense_conventions,mcp__sense__sense_status")`
+const toolSearchCmd = `ToolSearch("select:mcp__sense__sense_graph,mcp__sense__sense_search,mcp__sense__sense_blast,mcp__sense__sense_conventions")`
 
 type hookResponse struct {
 	AdditionalContext string `json:"additionalContext,omitempty"`

--- a/internal/hook/session_start.go
+++ b/internal/hook/session_start.go
@@ -3,6 +3,7 @@ package hook
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -23,6 +24,48 @@ func formatScanAge(lastScan string, now time.Time) string {
 		return "just now"
 	}
 	return fmt.Sprintf("%s ago", age)
+}
+
+func checkFreshness(ctx context.Context, db *sql.DB, dir string) string {
+	rows, err := db.QueryContext(ctx, `SELECT path, indexed_at FROM sense_files`)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = rows.Close() }()
+
+	var stale, deleted int
+	for rows.Next() {
+		var path, indexedAtStr string
+		if err := rows.Scan(&path, &indexedAtStr); err != nil {
+			continue
+		}
+		indexedAt, err := time.Parse(time.RFC3339Nano, indexedAtStr)
+		if err != nil {
+			continue
+		}
+		info, err := os.Stat(filepath.Join(dir, path))
+		if err != nil {
+			deleted++
+			continue
+		}
+		if info.ModTime().After(indexedAt) {
+			stale++
+		}
+	}
+	if rows.Err() != nil {
+		return ""
+	}
+	if stale == 0 && deleted == 0 {
+		return "Index is current."
+	}
+	var parts []string
+	if stale > 0 {
+		parts = append(parts, fmt.Sprintf("%d modified", stale))
+	}
+	if deleted > 0 {
+		parts = append(parts, fmt.Sprintf("%d removed", deleted))
+	}
+	return fmt.Sprintf("Index is stale (%s since last scan).", strings.Join(parts, ", "))
 }
 
 func handleSessionStart(ctx context.Context, _ json.RawMessage, adapter *sqlite.Adapter, dir string) (any, error) {
@@ -58,17 +101,28 @@ func handleSessionStart(ctx context.Context, _ json.RawMessage, adapter *sqlite.
 		return nil, err
 	}
 
-	var lastScan string
+	var lastScanStr string
 	row := db.QueryRowContext(ctx, `SELECT MAX(indexed_at) FROM sense_files`)
-	if err := row.Scan(&lastScan); err != nil || lastScan == "" {
-		lastScan = "unknown"
-	} else {
-		lastScan = formatScanAge(lastScan, time.Now())
+	if err := row.Scan(&lastScanStr); err != nil || lastScanStr == "" {
+		lastScanStr = ""
+	}
+
+	now := time.Now()
+	scanAge := "unknown"
+	freshness := ""
+	if lastScanStr != "" {
+		scanAge = formatScanAge(lastScanStr, now)
+		freshness = checkFreshness(ctx, db, dir)
 	}
 
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "Sense index: %d symbols, %d edges, %d languages (%s). Last scan: %s.\n", symbolCount, edgeCount, len(langs), strings.Join(langs, ", "), lastScan)
+	fmt.Fprintf(&sb, "Sense index: %d symbols, %d edges, %d languages (%s). Last scan: %s.", symbolCount, edgeCount, len(langs), strings.Join(langs, ", "), scanAge)
+	if freshness != "" {
+		fmt.Fprintf(&sb, " %s", freshness)
+	}
+	sb.WriteByte('\n')
 	fmt.Fprintf(&sb, "REQUIRED: Your FIRST tool call MUST be %s to load Sense tools.\n", toolSearchCmd)
+	sb.WriteString("Do NOT call sense_status — index health was verified at session start.\n")
 	sb.WriteString("Use Sense MCP tools for ALL codebase understanding — do not use grep, glob, Read, Bash, or agents before loading Sense.")
 
 	summaryPath := filepath.Join(dir, ".sense", "summary.md")

--- a/internal/hook/session_start_test.go
+++ b/internal/hook/session_start_test.go
@@ -74,6 +74,129 @@ func TestHandleSessionStartLangQueryError(t *testing.T) {
 	}
 }
 
+func TestCheckFreshnessCurrent(t *testing.T) {
+	dir := indexedDir(t)
+	dbPath := filepath.Join(dir, ".sense", "index.db")
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	result := checkFreshness(ctx, adapter.DB(), dir)
+	if result != "Index is current." {
+		t.Errorf("expected fresh index, got %q", result)
+	}
+}
+
+func TestCheckFreshnessStale(t *testing.T) {
+	dir := indexedDir(t)
+	dbPath := filepath.Join(dir, ".sense", "index.db")
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	// Touch the source file to make it newer than the scan.
+	goFile := filepath.Join(dir, "main.go")
+	future := time.Now().Add(time.Hour)
+	if err := os.Chtimes(goFile, future, future); err != nil {
+		t.Fatal(err)
+	}
+
+	result := checkFreshness(ctx, adapter.DB(), dir)
+	if !strings.Contains(result, "stale") {
+		t.Errorf("expected stale result, got %q", result)
+	}
+	if !strings.Contains(result, "1 modified") {
+		t.Errorf("expected 1 modified file, got %q", result)
+	}
+}
+
+func TestCheckFreshnessDeletedFile(t *testing.T) {
+	dir := indexedDir(t)
+	dbPath := filepath.Join(dir, ".sense", "index.db")
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	if err := os.Remove(filepath.Join(dir, "main.go")); err != nil {
+		t.Fatal(err)
+	}
+
+	result := checkFreshness(ctx, adapter.DB(), dir)
+	if !strings.Contains(result, "stale") {
+		t.Errorf("expected stale result for deleted file, got %q", result)
+	}
+	if !strings.Contains(result, "removed") {
+		t.Errorf("expected 'removed' in result, got %q", result)
+	}
+}
+
+func TestCheckFreshnessMissingIndex(t *testing.T) {
+	dir := indexedDir(t)
+	dbPath := filepath.Join(dir, ".sense", "index.db")
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	// Drop sense_files to simulate missing table.
+	if _, err := adapter.DB().ExecContext(ctx, `DROP TABLE sense_files`); err != nil {
+		t.Fatal(err)
+	}
+
+	result := checkFreshness(ctx, adapter.DB(), dir)
+	if result != "" {
+		t.Errorf("expected empty string on error, got %q", result)
+	}
+}
+
+func TestSessionStartIncludesFreshness(t *testing.T) {
+	dir := indexedDir(t)
+	var buf bytes.Buffer
+	code := Run("session-start", dir, strings.NewReader("{}"), &buf)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	msg := resp["message"]
+	if !strings.Contains(msg, "Index is current.") && !strings.Contains(msg, "Index is stale") {
+		t.Errorf("message should contain freshness info, got: %q", msg)
+	}
+}
+
+func TestSessionStartNoSenseStatusInstruction(t *testing.T) {
+	dir := indexedDir(t)
+	var buf bytes.Buffer
+	code := Run("session-start", dir, strings.NewReader("{}"), &buf)
+	if code != 0 {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	msg := resp["message"]
+	if strings.Contains(msg, "sense_status\"") {
+		t.Error("ToolSearch command should not include sense_status")
+	}
+	if !strings.Contains(msg, "Do NOT call sense_status") {
+		t.Error("message should instruct LLM not to call sense_status")
+	}
+}
+
 func TestSessionStartEmptyIndex(t *testing.T) {
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, ".sense", "index.db")

--- a/internal/hook/subagent_start.go
+++ b/internal/hook/subagent_start.go
@@ -20,8 +20,6 @@ func handleSubagentStart(ctx context.Context, _ json.RawMessage, adapter *sqlite
 		edgeCount = 0
 	}
 
-	const toolSearchCmd = `ToolSearch("select:mcp__sense__sense_graph,mcp__sense__sense_search,mcp__sense__sense_blast,mcp__sense__sense_conventions,mcp__sense__sense_status")`
-
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "This project has a Sense index (%d symbols, %d edges).\n\n", symbolCount, edgeCount)
 	sb.WriteString("Before using grep/find/file-walking, load Sense tools:\n")

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -175,13 +175,14 @@ type GraphEdges struct {
 // may have no indexed file — the documented example includes
 // `"file": null` for exactly that case.
 type CallEdgeRef struct {
-	Symbol     string     `json:"symbol"`
-	File       *string    `json:"file"`
-	LineStart  int        `json:"line_start,omitempty"`
-	LineEnd    int        `json:"line_end,omitempty"`
-	Ref        string     `json:"ref,omitempty"`
-	Confidence Confidence `json:"confidence"`
-	CallSite   *CallSite  `json:"call_site,omitempty"`
+	Symbol       string     `json:"symbol"`
+	File         *string    `json:"file"`
+	LineStart    int        `json:"line_start,omitempty"`
+	LineEnd      int        `json:"line_end,omitempty"`
+	Ref          string     `json:"ref,omitempty"`
+	Confidence   Confidence `json:"confidence"`
+	CallSite     *CallSite  `json:"call_site,omitempty"`
+	AlsoCalledBy []string   `json:"also_called_by,omitempty"`
 }
 
 // InheritEdgeRef is the shape of an inherits edge entry. The

--- a/internal/mcpserver/also_called_by_test.go
+++ b/internal/mcpserver/also_called_by_test.go
@@ -1,0 +1,261 @@
+package mcpserver
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/luuuc/sense/internal/mcpio"
+	"github.com/luuuc/sense/internal/model"
+)
+
+// seedAlsoCalledByFixture creates:
+//   - A (id=1) calls B (id=2) and C (id=3)
+//   - D (id=4) also calls B
+//   - E (id=5) also calls C
+//
+// All in file_id=1, symbolCount total = 5 (well under 5000).
+func seedAlsoCalledByFixture(t *testing.T, db *sql.DB) {
+	t.Helper()
+	ctx := context.Background()
+	stmts := []string{
+		`INSERT INTO sense_files (id, path, language, hash, symbols, indexed_at) VALUES (1, 'main.go', 'go', 'aaa', 5, '2026-01-01T00:00:00Z')`,
+		`INSERT INTO sense_symbols (id, file_id, name, qualified, kind, line_start, line_end) VALUES (1, 1, 'A', 'pkg.A', 'function', 1, 5)`,
+		`INSERT INTO sense_symbols (id, file_id, name, qualified, kind, line_start, line_end) VALUES (2, 1, 'B', 'pkg.B', 'function', 10, 15)`,
+		`INSERT INTO sense_symbols (id, file_id, name, qualified, kind, line_start, line_end) VALUES (3, 1, 'C', 'pkg.C', 'function', 20, 25)`,
+		`INSERT INTO sense_symbols (id, file_id, name, qualified, kind, line_start, line_end) VALUES (4, 1, 'D', 'pkg.D', 'function', 30, 35)`,
+		`INSERT INTO sense_symbols (id, file_id, name, qualified, kind, line_start, line_end) VALUES (5, 1, 'E', 'pkg.E', 'function', 40, 45)`,
+		// A calls B and C
+		`INSERT INTO sense_edges (source_id, target_id, kind, file_id, confidence) VALUES (1, 2, 'calls', 1, 1.0)`,
+		`INSERT INTO sense_edges (source_id, target_id, kind, file_id, confidence) VALUES (1, 3, 'calls', 1, 1.0)`,
+		// D also calls B
+		`INSERT INTO sense_edges (source_id, target_id, kind, file_id, confidence) VALUES (4, 2, 'calls', 1, 1.0)`,
+		// E also calls C
+		`INSERT INTO sense_edges (source_id, target_id, kind, file_id, confidence) VALUES (5, 3, 'calls', 1, 1.0)`,
+	}
+	for _, q := range stmts {
+		if _, err := db.ExecContext(ctx, q); err != nil {
+			t.Fatalf("seed: %v\nquery: %s", err, q)
+		}
+	}
+}
+
+func TestEnrichAlsoCalledBySmallRepo(t *testing.T) {
+	adapter, db := openTestAdapter(t)
+	seedAlsoCalledByFixture(t, db)
+	ctx := context.Background()
+
+	gr := &model.GraphResult{
+		Root: model.SymbolContext{
+			Symbol: model.Symbol{ID: 1, Name: "A", Qualified: "pkg.A"},
+			Outbound: []model.EdgeRef{
+				{Edge: model.Edge{Kind: model.EdgeCalls}, Target: model.Symbol{ID: 2, Qualified: "pkg.B"}},
+				{Edge: model.Edge{Kind: model.EdgeCalls}, Target: model.Symbol{ID: 3, Qualified: "pkg.C"}},
+			},
+		},
+	}
+	resp := &mcpio.GraphResponse{
+		Edges: mcpio.GraphEdges{
+			Calls: []mcpio.CallEdgeRef{
+				{Symbol: "pkg.B", Confidence: 1.0},
+				{Symbol: "pkg.C", Confidence: 1.0},
+			},
+		},
+	}
+
+	enrichAlsoCalledBy(ctx, adapter, 5, gr, resp)
+
+	// B should have also_called_by = ["pkg.D"]
+	if len(resp.Edges.Calls[0].AlsoCalledBy) != 1 || resp.Edges.Calls[0].AlsoCalledBy[0] != "pkg.D" {
+		t.Errorf("B also_called_by = %v, want [pkg.D]", resp.Edges.Calls[0].AlsoCalledBy)
+	}
+	// C should have also_called_by = ["pkg.E"]
+	if len(resp.Edges.Calls[1].AlsoCalledBy) != 1 || resp.Edges.Calls[1].AlsoCalledBy[0] != "pkg.E" {
+		t.Errorf("C also_called_by = %v, want [pkg.E]", resp.Edges.Calls[1].AlsoCalledBy)
+	}
+}
+
+func TestEnrichAlsoCalledByLargeRepoSuppressed(t *testing.T) {
+	adapter, _ := openTestAdapter(t)
+	ctx := context.Background()
+
+	gr := &model.GraphResult{
+		Root: model.SymbolContext{
+			Symbol: model.Symbol{ID: 1, Name: "A", Qualified: "pkg.A"},
+			Outbound: []model.EdgeRef{
+				{Edge: model.Edge{Kind: model.EdgeCalls}, Target: model.Symbol{ID: 2, Qualified: "pkg.B"}},
+			},
+		},
+	}
+	resp := &mcpio.GraphResponse{
+		Edges: mcpio.GraphEdges{
+			Calls: []mcpio.CallEdgeRef{
+				{Symbol: "pkg.B", Confidence: 1.0},
+			},
+		},
+	}
+
+	enrichAlsoCalledBy(ctx, adapter, 5000, gr, resp)
+
+	if resp.Edges.Calls[0].AlsoCalledBy != nil {
+		t.Errorf("large repo should suppress also_called_by, got %v", resp.Edges.Calls[0].AlsoCalledBy)
+	}
+}
+
+func TestEnrichAlsoCalledByAtThresholdBoundary(t *testing.T) {
+	adapter, db := openTestAdapter(t)
+	seedAlsoCalledByFixture(t, db)
+	ctx := context.Background()
+
+	gr := &model.GraphResult{
+		Root: model.SymbolContext{
+			Symbol: model.Symbol{ID: 1, Name: "A", Qualified: "pkg.A"},
+			Outbound: []model.EdgeRef{
+				{Edge: model.Edge{Kind: model.EdgeCalls}, Target: model.Symbol{ID: 2, Qualified: "pkg.B"}},
+			},
+		},
+	}
+	resp := &mcpio.GraphResponse{
+		Edges: mcpio.GraphEdges{
+			Calls: []mcpio.CallEdgeRef{
+				{Symbol: "pkg.B", Confidence: 1.0},
+			},
+		},
+	}
+
+	// At exactly 4999: should enrich.
+	enrichAlsoCalledBy(ctx, adapter, 4999, gr, resp)
+	if len(resp.Edges.Calls[0].AlsoCalledBy) == 0 {
+		t.Error("at 4999 symbols, also_called_by should be populated")
+	}
+
+	// At exactly 5000: should suppress.
+	resp.Edges.Calls[0].AlsoCalledBy = nil
+	enrichAlsoCalledBy(ctx, adapter, 5000, gr, resp)
+	if resp.Edges.Calls[0].AlsoCalledBy != nil {
+		t.Errorf("at 5000 symbols, also_called_by should be suppressed, got %v", resp.Edges.Calls[0].AlsoCalledBy)
+	}
+}
+
+func TestEnrichAlsoCalledByHighCallerSuppressed(t *testing.T) {
+	adapter, db := openTestAdapter(t)
+	seedAlsoCalledByFixture(t, db)
+	ctx := context.Background()
+
+	// Add 21 more callers of B (total = 22 including A and D), exceeding the 20-caller cap.
+	for i := 100; i < 121; i++ {
+		symQ := fmt.Sprintf(`INSERT INTO sense_symbols (id, file_id, name, qualified, kind, line_start, line_end) VALUES (%d, 1, 'X%d', 'pkg.X%d', 'function', 1, 1)`, i, i, i)
+		edgeQ := fmt.Sprintf(`INSERT INTO sense_edges (source_id, target_id, kind, file_id, confidence) VALUES (%d, 2, 'calls', 1, 1.0)`, i)
+		if _, err := db.ExecContext(ctx, symQ); err != nil {
+			t.Fatalf("seed extra sym: %v", err)
+		}
+		if _, err := db.ExecContext(ctx, edgeQ); err != nil {
+			t.Fatalf("seed extra edge: %v", err)
+		}
+	}
+
+	gr := &model.GraphResult{
+		Root: model.SymbolContext{
+			Symbol: model.Symbol{ID: 1, Name: "A", Qualified: "pkg.A"},
+			Outbound: []model.EdgeRef{
+				{Edge: model.Edge{Kind: model.EdgeCalls}, Target: model.Symbol{ID: 2, Qualified: "pkg.B"}},
+				{Edge: model.Edge{Kind: model.EdgeCalls}, Target: model.Symbol{ID: 3, Qualified: "pkg.C"}},
+			},
+		},
+	}
+	resp := &mcpio.GraphResponse{
+		Edges: mcpio.GraphEdges{
+			Calls: []mcpio.CallEdgeRef{
+				{Symbol: "pkg.B", Confidence: 1.0},
+				{Symbol: "pkg.C", Confidence: 1.0},
+			},
+		},
+	}
+
+	enrichAlsoCalledBy(ctx, adapter, 5, gr, resp)
+
+	// B has > 20 callers — should be suppressed.
+	if resp.Edges.Calls[0].AlsoCalledBy != nil {
+		t.Errorf("high-caller callee should suppress also_called_by, got %v", resp.Edges.Calls[0].AlsoCalledBy)
+	}
+	// C still has only 1 other caller (E) — should still populate.
+	if len(resp.Edges.Calls[1].AlsoCalledBy) != 1 {
+		t.Errorf("C also_called_by = %v, want [pkg.E]", resp.Edges.Calls[1].AlsoCalledBy)
+	}
+}
+
+func TestEnrichAlsoCalledByEmptyCalls(t *testing.T) {
+	adapter, _ := openTestAdapter(t)
+	ctx := context.Background()
+
+	gr := &model.GraphResult{
+		Root: model.SymbolContext{
+			Symbol: model.Symbol{ID: 1, Name: "A", Qualified: "pkg.A"},
+		},
+	}
+	resp := &mcpio.GraphResponse{
+		Edges: mcpio.GraphEdges{},
+	}
+
+	// Should not panic on empty calls.
+	enrichAlsoCalledBy(ctx, adapter, 5, gr, resp)
+}
+
+func TestEnrichAlsoCalledByUnqualifiedFallback(t *testing.T) {
+	adapter, db := openTestAdapter(t)
+	seedAlsoCalledByFixture(t, db)
+	ctx := context.Background()
+
+	// Use Name instead of Qualified in the outbound edge to exercise the fallback.
+	gr := &model.GraphResult{
+		Root: model.SymbolContext{
+			Symbol: model.Symbol{ID: 1, Name: "A", Qualified: "pkg.A"},
+			Outbound: []model.EdgeRef{
+				{Edge: model.Edge{Kind: model.EdgeCalls}, Target: model.Symbol{ID: 2, Name: "B"}},
+			},
+		},
+	}
+	resp := &mcpio.GraphResponse{
+		Edges: mcpio.GraphEdges{
+			Calls: []mcpio.CallEdgeRef{
+				{Symbol: "B", Confidence: 1.0},
+			},
+		},
+	}
+
+	enrichAlsoCalledBy(ctx, adapter, 5, gr, resp)
+
+	if len(resp.Edges.Calls[0].AlsoCalledBy) != 1 || resp.Edges.Calls[0].AlsoCalledBy[0] != "pkg.D" {
+		t.Errorf("unqualified fallback: B also_called_by = %v, want [pkg.D]", resp.Edges.Calls[0].AlsoCalledBy)
+	}
+}
+
+func TestEnrichAlsoCalledByNoMatchingCallees(t *testing.T) {
+	adapter, db := openTestAdapter(t)
+	seedAlsoCalledByFixture(t, db)
+	ctx := context.Background()
+
+	// Outbound edges exist but resp.Edges.Calls has a symbol not in outbound.
+	gr := &model.GraphResult{
+		Root: model.SymbolContext{
+			Symbol: model.Symbol{ID: 1, Name: "A", Qualified: "pkg.A"},
+			Outbound: []model.EdgeRef{
+				{Edge: model.Edge{Kind: model.EdgeCalls}, Target: model.Symbol{ID: 2, Qualified: "pkg.B"}},
+			},
+		},
+	}
+	resp := &mcpio.GraphResponse{
+		Edges: mcpio.GraphEdges{
+			Calls: []mcpio.CallEdgeRef{
+				{Symbol: "pkg.Z", Confidence: 1.0},
+			},
+		},
+	}
+
+	enrichAlsoCalledBy(ctx, adapter, 5, gr, resp)
+
+	if resp.Edges.Calls[0].AlsoCalledBy != nil {
+		t.Errorf("non-matching callee should have nil also_called_by, got %v", resp.Edges.Calls[0].AlsoCalledBy)
+	}
+}

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -243,6 +243,9 @@ type handlers struct {
 	defaults     profile.Defaults
 	seenSymbols  map[int64]bool
 	seenMu       sync.Mutex
+
+	symbolCountOnce sync.Once
+	symbolCountVal  int
 }
 
 // ---------------------------------------------------------------
@@ -445,6 +448,10 @@ func (h *handlers) handleGraph(ctx context.Context, req mcp.CallToolRequest) (*m
 		}
 	}
 
+	if direction == model.DirectionCallees || direction == model.DirectionBoth {
+		enrichAlsoCalledBy(ctx, h.adapter, h.cachedSymbolCount(ctx), gr, &resp)
+	}
+
 	if len(resp.Edges.CalledBy) > compactEdgeKeepCount {
 		compactCallEdges(resp.Edges.CalledBy)
 	}
@@ -475,6 +482,66 @@ func (h *handlers) handleGraph(ctx context.Context, req mcp.CallToolRequest) (*m
 		return nil, fmt.Errorf("sense_graph: marshal: %w", err)
 	}
 	return mcp.NewToolResultText(string(out)), nil
+}
+
+const (
+	// Thresholds for also_called_by enrichment on graph callee queries.
+	// 5000: small enough that the batch caller query is fast; covers repos
+	// where reading all files is still feasible for an LLM.
+	alsoCalledBySymbolThreshold = 5000
+	// 20: suppress noisy hub symbols that everything calls.
+	alsoCalledByCallerCap = 20
+)
+
+func (h *handlers) cachedSymbolCount(ctx context.Context) int {
+	h.symbolCountOnce.Do(func() {
+		_ = h.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM sense_symbols`).Scan(&h.symbolCountVal)
+	})
+	return h.symbolCountVal
+}
+
+func enrichAlsoCalledBy(ctx context.Context, adapter *sqlite.Adapter, symbolCount int, gr *model.GraphResult, resp *mcpio.GraphResponse) {
+	if len(resp.Edges.Calls) == 0 {
+		return
+	}
+	if symbolCount >= alsoCalledBySymbolThreshold {
+		return
+	}
+
+	nameToID := make(map[string]int64)
+	for _, e := range gr.Root.Outbound {
+		if e.Edge.Kind == model.EdgeCalls || e.Edge.Kind == model.EdgeReferences {
+			nameToID[qualifiedOrNameRef(e.Target)] = e.Target.ID
+		}
+	}
+
+	var targetIDs []int64
+	for _, c := range resp.Edges.Calls {
+		if id, ok := nameToID[c.Symbol]; ok {
+			targetIDs = append(targetIDs, id)
+		}
+	}
+	if len(targetIDs) == 0 {
+		return
+	}
+
+	// Fetch cap+1 so we can detect overflow: if we get more than cap, suppress the callee.
+	callerMap, err := adapter.CallersOfTargets(ctx, targetIDs, gr.Root.Symbol.ID, alsoCalledByCallerCap+1)
+	if err != nil {
+		return
+	}
+
+	for i := range resp.Edges.Calls {
+		id, ok := nameToID[resp.Edges.Calls[i].Symbol]
+		if !ok {
+			continue
+		}
+		callers := callerMap[id]
+		if len(callers) == 0 || len(callers) > alsoCalledByCallerCap {
+			continue
+		}
+		resp.Edges.Calls[i].AlsoCalledBy = callers
+	}
 }
 
 func (h *handlers) resolveDispatchCallers(ctx context.Context, root *model.SymbolContext, resp *mcpio.GraphResponse, lookup mcpio.FileLookup) []mcpio.DispatchInferredRef {

--- a/internal/sqlite/key_symbols.go
+++ b/internal/sqlite/key_symbols.go
@@ -133,6 +133,54 @@ func (a *Adapter) TopCallers(ctx context.Context, symbolID int64, limit int) ([]
 	return results, rows.Err()
 }
 
+// CallersOfTargets returns the qualified names of callers for each target
+// symbol ID, excluding callers that match excludeSourceID (typically the
+// root symbol being queried). maxPerTarget caps results per target.
+func (a *Adapter) CallersOfTargets(ctx context.Context, targetIDs []int64, excludeSourceID int64, maxPerTarget int) (map[int64][]string, error) {
+	if len(targetIDs) == 0 {
+		return nil, nil
+	}
+	if maxPerTarget <= 0 {
+		maxPerTarget = 20
+	}
+
+	placeholders := make([]string, len(targetIDs))
+	args := make([]any, len(targetIDs))
+	for i, id := range targetIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+
+	q := fmt.Sprintf(`SELECT e.target_id, src.qualified `+ //nolint:gosec // placeholders are literal "?" strings, not user input
+		`FROM sense_edges e
+		JOIN sense_symbols src ON src.id = e.source_id
+		WHERE e.target_id IN (%s)
+		  AND e.source_id != ?
+		  AND e.kind IN ('calls', 'references')
+		ORDER BY e.target_id, src.qualified`,
+		strings.Join(placeholders, ","))
+	args = append(args, excludeSourceID)
+
+	rows, err := a.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite CallersOfTargets: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	result := make(map[int64][]string)
+	for rows.Next() {
+		var targetID int64
+		var qualified string
+		if err := rows.Scan(&targetID, &qualified); err != nil {
+			return nil, fmt.Errorf("sqlite CallersOfTargets scan: %w", err)
+		}
+		if len(result[targetID]) < maxPerTarget {
+			result[targetID] = append(result[targetID], qualified)
+		}
+	}
+	return result, rows.Err()
+}
+
 func lastPart(qualified string) string {
 	if i := strings.LastIndexByte(qualified, '.'); i >= 0 {
 		return qualified[i+1:]

--- a/internal/sqlite/key_symbols_test.go
+++ b/internal/sqlite/key_symbols_test.go
@@ -2,6 +2,7 @@ package sqlite_test
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -437,5 +438,122 @@ func TestTopCallers(t *testing.T) {
 	}
 	if !found["handler.HandleRequest"] && !found["router.RouterGroup"] {
 		t.Error("expected at least one of HandleRequest or RouterGroup as caller")
+	}
+}
+
+func TestCallersOfTargets(t *testing.T) {
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	now := time.Now()
+	intPtr := func(v int) *int { return &v }
+
+	fid, _ := a.WriteFile(ctx, &model.File{
+		Path: "main.go", Language: "go", Hash: "aaa", Symbols: 4, IndexedAt: now,
+	})
+	aID, _ := a.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid, Name: "A", Qualified: "pkg.A", Kind: "function", LineStart: 1, LineEnd: 5,
+	})
+	bID, _ := a.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid, Name: "B", Qualified: "pkg.B", Kind: "function", LineStart: 10, LineEnd: 15,
+	})
+	cID, _ := a.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid, Name: "C", Qualified: "pkg.C", Kind: "function", LineStart: 20, LineEnd: 25,
+	})
+	dID, _ := a.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid, Name: "D", Qualified: "pkg.D", Kind: "function", LineStart: 30, LineEnd: 35,
+	})
+
+	// A calls B, C calls B, D calls B
+	if _, err := a.WriteEdge(ctx, &model.Edge{SourceID: model.Int64Ptr(aID), TargetID: bID, Kind: model.EdgeCalls, FileID: fid, Line: intPtr(2)}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.WriteEdge(ctx, &model.Edge{SourceID: model.Int64Ptr(cID), TargetID: bID, Kind: model.EdgeCalls, FileID: fid, Line: intPtr(22)}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.WriteEdge(ctx, &model.Edge{SourceID: model.Int64Ptr(dID), TargetID: bID, Kind: model.EdgeCalls, FileID: fid, Line: intPtr(32)}); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := a.CallersOfTargets(ctx, []int64{bID}, aID, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	callers := result[bID]
+	if len(callers) != 2 {
+		t.Fatalf("expected 2 callers (excluding A), got %d: %v", len(callers), callers)
+	}
+	callerSet := map[string]bool{}
+	for _, c := range callers {
+		callerSet[c] = true
+	}
+	if !callerSet["pkg.C"] || !callerSet["pkg.D"] {
+		t.Errorf("expected pkg.C and pkg.D, got %v", callers)
+	}
+}
+
+func TestCallersOfTargetsMaxPerTarget(t *testing.T) {
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	now := time.Now()
+	intPtr := func(v int) *int { return &v }
+
+	fid, _ := a.WriteFile(ctx, &model.File{
+		Path: "main.go", Language: "go", Hash: "aaa", Symbols: 10, IndexedAt: now,
+	})
+	targetID, _ := a.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid, Name: "Target", Qualified: "pkg.Target", Kind: "function", LineStart: 1, LineEnd: 5,
+	})
+	rootID, _ := a.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid, Name: "Root", Qualified: "pkg.Root", Kind: "function", LineStart: 10, LineEnd: 15,
+	})
+
+	// Create 5 callers (excluding root).
+	for i := 0; i < 5; i++ {
+		cID, _ := a.WriteSymbol(ctx, &model.Symbol{
+			FileID: fid, Name: fmt.Sprintf("C%d", i), Qualified: fmt.Sprintf("pkg.C%d", i),
+			Kind: "function", LineStart: 20 + i*10, LineEnd: 25 + i*10,
+		})
+		if _, err := a.WriteEdge(ctx, &model.Edge{
+			SourceID: model.Int64Ptr(cID), TargetID: targetID, Kind: model.EdgeCalls, FileID: fid, Line: intPtr(21 + i*10),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Request maxPerTarget=2: should only get 2 of the 5 callers.
+	result, err := a.CallersOfTargets(ctx, []int64{targetID}, rootID, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	callers := result[targetID]
+	if len(callers) != 2 {
+		t.Fatalf("expected 2 callers with maxPerTarget=2, got %d: %v", len(callers), callers)
+	}
+}
+
+func TestCallersOfTargetsEmpty(t *testing.T) {
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	result, err := a.CallersOfTargets(ctx, nil, 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != nil {
+		t.Errorf("expected nil for empty input, got %v", result)
 	}
 }

--- a/internal/summary/summary.go
+++ b/internal/summary/summary.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/luuuc/sense/internal/sqlite"
@@ -73,6 +74,7 @@ func Generate(ctx context.Context, adapter *sqlite.Adapter, senseDir, repoRoot s
 		{"Project", func(_ context.Context, _ *sql.DB) (string, error) {
 			return desc, nil
 		}},
+		{"Quick Orientation", renderQuickOrientation},
 		{"Main Areas", renderMainAreas},
 		{"Key Abstractions", func(ctx context.Context, _ *sql.DB) (string, error) {
 			return renderKeyAbstractions(ctx, adapter)
@@ -613,8 +615,136 @@ func commonPrefix(a, b string) string {
 }
 
 func capitalize(s string) string {
-	if s == "" {
+	r, size := utf8.DecodeRuneInString(s)
+	if r == utf8.RuneError || size == 0 {
 		return s
 	}
-	return strings.ToUpper(s[:1]) + s[1:]
+	return string(unicode.ToUpper(r)) + s[size:]
+}
+
+func queryStrings(ctx context.Context, db *sql.DB, query string) []string {
+	rows, err := db.QueryContext(ctx, query)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = rows.Close() }()
+	var out []string
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+func renderQuickOrientation(ctx context.Context, db *sql.DB) (string, error) {
+	var b strings.Builder
+	if s := renderEntryPoints(ctx, db); s != "" {
+		b.WriteString(s)
+	}
+	if s := renderHubSymbols(ctx, db); s != "" {
+		b.WriteString(s)
+	}
+	if s := renderTestStructure(ctx, db); s != "" {
+		b.WriteString(s)
+	}
+	return b.String(), nil
+}
+
+func renderEntryPoints(ctx context.Context, db *sql.DB) string {
+	rows, err := db.QueryContext(ctx, `
+		WITH outgoing AS (
+			SELECT source_id, COUNT(*) AS cnt
+			FROM sense_edges WHERE kind IN ('calls', 'references')
+			GROUP BY source_id
+		),
+		incoming AS (
+			SELECT DISTINCT target_id FROM sense_edges
+			WHERE kind IN ('calls', 'references')
+		)
+		SELECT s.qualified, f.path, s.line_start
+		FROM sense_symbols s
+		JOIN sense_files f ON f.id = s.file_id
+		JOIN outgoing o ON o.source_id = s.id
+		WHERE s.id NOT IN (SELECT target_id FROM incoming)
+		  AND o.cnt >= 1
+		ORDER BY o.cnt DESC
+		LIMIT 5`)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = rows.Close() }()
+
+	var entries []string
+	for rows.Next() {
+		var qual, file string
+		var line int
+		if err := rows.Scan(&qual, &file, &line); err != nil {
+			continue
+		}
+		entries = append(entries, fmt.Sprintf("`%s` (%s:%d)", qual, file, line))
+	}
+	if len(entries) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("- Entry points: %s\n", strings.Join(entries, ", "))
+}
+
+func renderHubSymbols(ctx context.Context, db *sql.DB) string {
+	rows, err := db.QueryContext(ctx, `
+		SELECT s.qualified, COUNT(e.id) as callers
+		FROM sense_symbols s
+		JOIN sense_edges e ON e.target_id = s.id
+		WHERE e.kind IN ('calls', 'references')
+		GROUP BY s.id
+		ORDER BY callers DESC
+		LIMIT 5`)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = rows.Close() }()
+
+	var hubs []string
+	for rows.Next() {
+		var qual string
+		var count int
+		if err := rows.Scan(&qual, &count); err != nil {
+			continue
+		}
+		hubs = append(hubs, fmt.Sprintf("`%s` (%d callers)", qual, count))
+	}
+	if len(hubs) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("- Hub symbols: %s\n", strings.Join(hubs, ", "))
+}
+
+func renderTestStructure(ctx context.Context, db *sql.DB) string {
+	testPaths := queryStrings(ctx, db, `
+		SELECT f.path FROM sense_files f
+		WHERE f.path LIKE '%_test.%'
+		   OR f.path LIKE '%.test.%'
+		   OR f.path LIKE '%/test/%'
+		   OR f.path LIKE '%/tests/%'
+		   OR f.path LIKE '%/spec/%'
+		ORDER BY f.path
+		LIMIT 100`)
+	if len(testPaths) == 0 {
+		return ""
+	}
+	dirs := map[string]int{}
+	for _, p := range testPaths {
+		dirs[filepath.Dir(p)]++
+	}
+	dirNames := make([]string, 0, len(dirs))
+	for d := range dirs {
+		dirNames = append(dirNames, d)
+	}
+	sort.Strings(dirNames)
+	if len(dirNames) > 3 {
+		dirNames = dirNames[:3]
+	}
+	return fmt.Sprintf("- Test structure: %d test files in %s\n", len(testPaths), strings.Join(dirNames, ", "))
 }

--- a/internal/summary/summary_test.go
+++ b/internal/summary/summary_test.go
@@ -279,6 +279,139 @@ func main() {}
 	}
 }
 
+func TestGenerateIncludesQuickOrientation(t *testing.T) {
+	root := t.TempDir()
+
+	// main calls A, B, C — so main is an entry point (zero callers, ≥3 callees).
+	// A is called by main and by helper — A is a hub symbol (2 callers).
+	writeFile(t, filepath.Join(root, "main.go"), `package main
+
+func main() { A(); B(); C() }
+func A() {}
+func B() {}
+func C() {}
+func helper() { A() }
+`)
+
+	ctx := context.Background()
+	if _, err := scan.Run(ctx, scan.Options{
+		Root:     root,
+		Output:   &bytes.Buffer{},
+		Warnings: io.Discard,
+	}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+
+	senseDir := filepath.Join(root, ".sense")
+	data, err := os.ReadFile(filepath.Join(senseDir, "summary.md"))
+	if err != nil {
+		t.Fatalf("summary.md not created: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "Quick Orientation") {
+		t.Error("missing Quick Orientation section")
+	}
+	// main has zero callers and calls A, B, C (≥3 callees) — should be an entry point.
+	if !strings.Contains(content, "Entry points") {
+		t.Error("Quick Orientation should contain entry points")
+	}
+	if !strings.Contains(content, "main.main") {
+		t.Error("Quick Orientation entry points should include main.main (qualified)")
+	}
+	// A has 2 callers (main + helper) — should appear in hub symbols.
+	if !strings.Contains(content, "Hub symbols") {
+		t.Error("Quick Orientation should contain hub symbols")
+	}
+}
+
+func TestGenerateQuickOrientationTestStructure(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, "main.go"), `package main
+
+func main() { A(); B(); C() }
+func A() {}
+func B() {}
+func C() {}
+`)
+	writeFile(t, filepath.Join(root, "main_test.go"), `package main
+
+import "testing"
+
+func TestA(t *testing.T) { A() }
+func TestB(t *testing.T) { B() }
+`)
+
+	ctx := context.Background()
+	if _, err := scan.Run(ctx, scan.Options{
+		Root:     root,
+		Output:   &bytes.Buffer{},
+		Warnings: io.Discard,
+	}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(root, ".sense", "summary.md"))
+	if err != nil {
+		t.Fatalf("summary.md not created: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "Test structure") {
+		t.Error("Quick Orientation should contain test structure when test files exist")
+	}
+	if !strings.Contains(content, "test file") {
+		t.Error("Test structure should mention test files")
+	}
+	if strings.Contains(content, "Key patterns") {
+		t.Error("Quick Orientation should not contain key patterns (removed)")
+	}
+}
+
+func TestGenerateQuickOrientationHubOrder(t *testing.T) {
+	root := t.TempDir()
+
+	// Create a fixture where hub ordering is clear:
+	// Hub called by 3 callers, Other called by 1.
+	writeFile(t, filepath.Join(root, "main.go"), `package main
+
+func Hub() {}
+func Other() {}
+func C1() { Hub() }
+func C2() { Hub() }
+func C3() { Hub(); Other() }
+`)
+
+	ctx := context.Background()
+	if _, err := scan.Run(ctx, scan.Options{
+		Root:     root,
+		Output:   &bytes.Buffer{},
+		Warnings: io.Discard,
+	}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(root, ".sense", "summary.md"))
+	if err != nil {
+		t.Fatalf("summary.md not created: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "Hub symbols") {
+		t.Fatal("missing Hub symbols line")
+	}
+	// Hub should appear before Other (more callers).
+	hubIdx := strings.Index(content, "`main.Hub`")
+	otherIdx := strings.Index(content, "`main.Other`")
+	if hubIdx < 0 {
+		t.Error("Hub should appear in hub symbols")
+	}
+	if otherIdx >= 0 && hubIdx > otherIdx {
+		t.Error("Hub should appear before Other (more callers)")
+	}
+}
+
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {


### PR DESCRIPTION
## Problem

Small repos (under ~5000 symbols) get the same sparse MCP responses as large codebases. The LLM wastes a tool call on `sense_status` even though the hook already verified the index, and graph callee queries don't surface cross-references that would save additional round-trips. Generated summaries also lack quick-start guidance like entry points and hub symbols.

## Summary

Three improvements that make Sense more useful on small repos: upfront freshness reporting, automatic also-called-by annotations on graph callees, and a Quick Orientation section in summaries.

## Changes

**Session start hook**
- Add `checkFreshness()` — compares file mtimes against `indexed_at` to report stale/deleted files
- Drop `sense_status` from the ToolSearch command and instruct the LLM not to call it
- Remove duplicate `toolSearchCmd` const from subagent_start.go

**Graph callee enrichment**
- Add `also_called_by` field to `CallEdgeRef` — for repos <5000 symbols, each callee is annotated with its other callers
- Add `CallersOfTargets` batch query to the sqlite adapter
- Suppress hub symbols with >20 callers to avoid noise

**Summary quick orientation**
- New "Quick Orientation" section with entry points (zero callers, high fan-out), hub symbols (most callers), and test file distribution
- Fix `capitalize` for Unicode correctness

## Test Plan
- [x] `checkFreshness` tests: current index, stale file, deleted file, missing table
- [x] Session start message includes freshness info and no-sense_status instruction
- [x] `enrichAlsoCalledBy` tests: small repo, large repo suppressed, threshold boundary, high-caller suppressed, empty calls, unqualified fallback, no-match
- [x] `CallersOfTargets` tests: basic exclusion, maxPerTarget cap, empty input
- [x] Quick orientation tests: entry points + hubs present, test structure, hub ordering
- [x] `go test ./...` passes
- [x] `make lint` passes