### PR TITLE
fix(bench2): four loop bugs surfaced by the 2-iter e2e

### DIFF
--- a/bench2/improvement-loop/improve-loop.sh
+++ b/bench2/improvement-loop/improve-loop.sh
@@ -138,9 +138,11 @@ for iter in $(seq 1 "$ITERATIONS"); do
   echo ""
 
   ITER_DIR="$LOOP_DIR/results/loop-1-iter-${iter}"
-  mkdir -p "$ITER_DIR"
 
   # ── Halt-before-overspend check ──
+  # IMPORTANT: do this BEFORE `mkdir $ITER_DIR`. Otherwise an empty iter
+  # directory gets created and readiness.py picks it as the "latest iter"
+  # with no data inside, masking the real last iter's results.
   if ! $DRY_RUN; then
     python3 "$BENCH2_DIR/lib/cost_tracker.py" predict \
       --loop-dir "$LOOP_DIR/results" \
@@ -155,6 +157,8 @@ for iter in $(seq 1 "$ITERATIONS"); do
       echo "WARN: cost_tracker predict rc=$cost_rc — continuing anyway." >&2
     fi
   fi
+
+  mkdir -p "$ITER_DIR"
 
   # ── Phase 1: Run scenarios, score, analyze ──
   echo "--- Phase 1: Run & Analyze ---"

--- a/bench2/improvement-loop/scripts/phases/phase1-run-analysis.sh
+++ b/bench2/improvement-loop/scripts/phases/phase1-run-analysis.sh
@@ -55,13 +55,31 @@ score_args=()
 
 bash "$BENCH2_DIR/score.sh" "${score_args[@]}"
 
-# Step 2b: Regenerate report.md so anyone observing the loop sees fresh
+# Step 2b: Run judge so analyze-transcripts can compute real fairness
+# scores. Without this, post-analysis.json has sense=None/baseline=None
+# for every repo (the loop's earlier Phase-3 ordering bug); the
+# convergence rank-stability check then sees zero shared repos and
+# defers criterion 2 spuriously. Skipped when ANTHROPIC_API_KEY is
+# unset (subscription-only callers can't run urllib judge).
+if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+  echo "  Judging..."
+  judge_args=()
+  [[ -n "$REPO_FILTER" ]] && judge_args+=(--repo "$REPO_FILTER")
+  [[ -n "$TOOL_FILTER" ]] && judge_args+=(--tool "$TOOL_FILTER")
+  bash "$BENCH2_DIR/judge.sh" ${judge_args[@]+"${judge_args[@]}"} \
+    > "$ITER_DIR/phase1-judge.log" 2>&1 \
+    || echo "  WARN: judge.sh failed; analyze-transcripts will produce None fairness for affected runs"
+else
+  echo "  WARN: ANTHROPIC_API_KEY unset; skipping judge (fairness scores will be None)"
+fi
+
+# Step 2c: Regenerate report.md so anyone observing the loop sees fresh
 # numbers immediately. Without this, report.md only updates at the end of
 # improve-loop.sh — and a mid-loop crash leaves it stale for hours.
 echo "  Refreshing report.md..."
 bash "$BENCH2_DIR/report.sh" --md > /dev/null
 
-# Step 3: Analyze transcripts
+# Step 3: Analyze transcripts (uses judged.json from Step 2b for fairness)
 echo "  Analyzing transcripts..."
 python3 "$TOOLS_DIR/analyze-transcripts.py" \
   --results-dir "$BENCH2_DIR/results" \

--- a/bench2/improvement-loop/scripts/phases/phase3-run-validate.sh
+++ b/bench2/improvement-loop/scripts/phases/phase3-run-validate.sh
@@ -57,11 +57,30 @@ score_args=()
 
 bash "$BENCH2_DIR/score.sh" "${score_args[@]}"
 
+# Re-judge against the new transcripts so post-analysis can compute
+# fairness. Without this, post-analysis.json has sense=None /
+# baseline=None for every repo and downstream convergence checks
+# silently defer.
+if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+  echo "  Judging..."
+  judge_args=()
+  [[ -n "$REPO_FILTER" ]] && judge_args+=(--repo "$REPO_FILTER")
+  [[ -n "$TOOL_FILTER" ]] && judge_args+=(--tool "$TOOL_FILTER")
+  # --force because the previous judged.json was scored against the
+  # pre-improvement scenario YAMLs; the new transcripts need fresh
+  # judgments against the post-improvement structure.
+  bash "$BENCH2_DIR/judge.sh" --force ${judge_args[@]+"${judge_args[@]}"} \
+    > "$ITER_DIR/phase3-judge.log" 2>&1 \
+    || echo "  WARN: judge.sh failed; post-analysis fairness may be incomplete"
+else
+  echo "  WARN: ANTHROPIC_API_KEY unset; skipping judge (post-analysis fairness will be None)"
+fi
+
 # Refresh report.md immediately so observers see fresh numbers even if the
 # rest of phase 3 fails or rolls back.
 bash "$BENCH2_DIR/report.sh" --md > /dev/null
 
-# Step 3: Post-run analysis
+# Step 3: Post-run analysis (uses fresh judged.json for fairness)
 echo "  Analyzing new results..."
 python3 "$TOOLS_DIR/analyze-transcripts.py" \
   --results-dir "$BENCH2_DIR/results" \

--- a/bench2/improvement-loop/scripts/tools/validate-changes.py
+++ b/bench2/improvement-loop/scripts/tools/validate-changes.py
@@ -74,9 +74,17 @@ def pre_run_validate(original_dir, improved_dir, backup_dir=None):
                     1 for c in new_step.get("checks", []) if c.get("required", True)
                 )
                 if new_required_count < orig_required_count:
-                    errors.append(
+                    # Downgraded to a warning post-Card-15: `remove_check`
+                    # is a permitted_action in locked.yaml, and Phase 3's
+                    # regression check is the real safety net. Treating
+                    # required-count decrease as a hard error contradicts
+                    # the locked policy and stalls the loop on legitimate
+                    # tuning (e.g. removing a check both tools verify is
+                    # off-topic). Phase 3 will roll back if scores regress.
+                    warnings.append(
                         f"{fname}: step {si} required checks decreased "
-                        f"from {orig_required_count} to {new_required_count}"
+                        f"from {orig_required_count} to {new_required_count} "
+                        f"(allowed — Phase 3 regression check is the safety net)"
                     )
                 new_total = len(new_step.get("checks", []))
                 orig_total = len(step.get("checks", []))

--- a/bench2/lib/convergence.py
+++ b/bench2/lib/convergence.py
@@ -37,7 +37,12 @@ from typing import Any
 # --- Thresholds (mirror locked.yaml; encoded here for stdlib independence) ---
 DISAGREEMENT_THRESHOLD = 0.05            # criterion 1
 DISCRIMINATION_GAP_THRESHOLD = 0.10      # criterion 3
-DISCRIMINATION_MIN_SCENARIOS = 4         # criterion 3
+# Criterion 3 wants ≥4 of 6 scenarios above threshold on the full bench.
+# When the loop runs on a subset (e.g. `--repo flask,gin,axum`), the
+# absolute 4 is mathematically impossible. evaluate_discrimination
+# scales this proportionally: min(DISCRIMINATION_MIN_SCENARIOS, 2/3 of
+# scenarios present, rounded up).
+DISCRIMINATION_MIN_SCENARIOS = 4         # criterion 3 target on full bench
 HELD_OUT_CORRELATION_THRESHOLD = 0.85    # criterion 4
 
 
@@ -168,9 +173,26 @@ def evaluate_rank_stability(
                 {"repo": repo, "prev": prev_ranks[repo], "current": cur_ranks[repo]}
             )
 
+    if len(shared) == 0:
+        # post-analysis.json present on both sides but neither yielded
+        # any (sense, baseline) score pairs — almost always means
+        # analyze-transcripts ran before judge.sh, so current_scores
+        # are all None. Surface the cause instead of an empty reason.
+        return {
+            "pass": False,
+            "deferred": True,
+            "reason": (
+                "post-analysis present on both iters but no repo has "
+                "both sense and baseline scores — likely judge hasn't "
+                "run yet for the current iter (Phase 3/4 ordering)"
+            ),
+            "shared_repos": 0,
+            "flips": [],
+        }
+
     return {
-        "pass": len(flips) == 0 and len(shared) > 0,
-        "deferred": len(shared) == 0,
+        "pass": len(flips) == 0,
+        "deferred": False,
         "shared_repos": len(shared),
         "flips": flips,
     }
@@ -199,12 +221,23 @@ def evaluate_discrimination(iter_dir: str) -> dict[str, Any]:
         else:
             repos_below.append({"repo": repo, "gap": round(gap, 4)})
 
+    total = len(repos_above) + len(repos_below)
+    # Scale the required count when running on a subset surface:
+    # min(target, ceil(2/3 of present)). Full bench (6 repos) → 4.
+    # 3-repo subset → 2. Keeps the criterion meaningful at any surface.
+    min_required = (
+        DISCRIMINATION_MIN_SCENARIOS
+        if total >= DISCRIMINATION_MIN_SCENARIOS
+        else (total * 2 + 2) // 3  # ceil(2*total/3)
+    )
+
     return {
-        "pass": len(repos_above) >= DISCRIMINATION_MIN_SCENARIOS,
+        "pass": len(repos_above) >= min_required,
         "deferred": False,
         "scenarios_above_threshold": len(repos_above),
         "scenarios_below_threshold": len(repos_below),
-        "min_required": DISCRIMINATION_MIN_SCENARIOS,
+        "min_required": min_required,
+        "min_required_full_bench": DISCRIMINATION_MIN_SCENARIOS,
         "gap_threshold": DISCRIMINATION_GAP_THRESHOLD,
         "above": repos_above,
         "below": repos_below,


### PR DESCRIPTION
## Summary

Follow-up to #84. A 2-iter end-to-end run on a 3-repo subset surface (`flask,gin,axum`) surfaced four real bugs in the loop infrastructure that the single-iter verification couldn't catch. All four were silent failures — the loop ran "successfully" but produced misleading data.

1. **Phase 2 validation rejected `remove_check` as fatal** — `remove_check` is in `locked.yaml`'s `permitted_actions`, but `validate-changes.py` treated any required-count decrease as a hard error. The loop halted on legitimate tuning. **Downgraded to a warning** — Phase 3's regression check is the real safety net for bad removals.

2. **`improve-loop.sh` mkdir order** — `mkdir $ITER_DIR` ran BEFORE the predict-halt check. When the loop halted before iter N could start, an empty iter-N directory was created, and `readiness.py`'s "latest iter" logic picked it (no data → all criteria look deferred). Moved mkdir after the halt check.

3. **`convergence.py` `DISCRIMINATION_MIN_SCENARIOS` hardcoded to 4** — sized for the full 6-repo bench. On `--repo flask,gin,axum` subsets, criterion 3 became mathematically impossible ("≥4 of 3"). Now scales: `ceil(2/3 of repos present)`, capped at 4.

4. **Phase 1 + Phase 3 wrote `post-analysis.json` BEFORE judge ran** — `_avg_fairness` needs `judged.json` to compute fairness. The previous ordering produced `sense=None/baseline=None` for every repo. Downstream convergence rank-stability check then saw zero shared (sense, baseline) pairs and silently deferred criterion 2. Phase 1 + Phase 3 now run `judge.sh` between score and analyze-transcripts (+~$2.50/iter judge cost; unblocks rank-stability + delta-score table + readiness fairness-gap-by-scenario).

Bonus: `convergence.py` rank-stability deferred message no longer ships an empty reason. Now names the Phase 3/4 ordering issue when 0 shared repos.

## Test plan

- [ ] `bash bench2/improvement-loop/improve-loop.sh --dry-run --iterations 1 --repo flask` — sanity-checks the mkdir order without spending.
- [ ] Inspect `bench2/improvement-loop/results/loop-1-iter-1/convergence.json` after a real run — criterion 3 should show `min_required` scaled to surface size.
- [ ] Confirm `post-analysis.json` has real `current_scores.sense / .baseline` values (not None) after running on a subset.
- [ ] `bash bench2/improvement-loop/improve-loop.sh --iterations 3 --max-cost-usd 35 --first-iter-prior 15 --repo flask,gin,axum` — the canonical 2-iter verification run (~$30, exercises convergence streak and rank-stability across iters).

🤖 Surfaced + fixed during the 2-iter e2e on 2026-05-13. The 1-iter verification in PR #84 could not have caught any of these — they all require either subset surfaces or iter-2 boundary conditions.