### PR TITLE
feat(extract): populate docstring column from per-language extractors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,4 +108,6 @@ bench/docker/sense/preindex/
 
 # Local-only bench result snapshots (manual backups before full sweeps).
 bench/results.snapshot-*/
+bench/results/report-*.md
 bench/results/report-for-humans-*.md
+bench/bench-sense-local.sh

--- a/internal/extract/extractor.go
+++ b/internal/extract/extractor.go
@@ -158,6 +158,11 @@ type EmittedSymbol struct {
 	LineStart       int
 	LineEnd         int
 	Snippet         string
+	// Docstring is the doc comment attached to this symbol per language
+	// convention (godoc, RDoc, JSDoc, PEP 257, /// & /** */). Empty when
+	// no comment is attached or when the candidate is filtered (license
+	// header, magic comment, blank-line gap).
+	Docstring string
 }
 
 // EmittedEdge is the pre-insert form of an intra-file edge. Both

--- a/internal/extract/golang/docstring.go
+++ b/internal/extract/golang/docstring.go
@@ -14,9 +14,6 @@ import (
 // previous-sibling `comment` nodes as long as no blank line separates
 // them; license headers and invalid UTF-8 are filtered.
 func docstringFor(node *sitter.Node, source []byte) string {
-	if node == nil {
-		return ""
-	}
 	var comments []*sitter.Node
 	cur := node
 	for {
@@ -25,22 +22,26 @@ func docstringFor(node *sitter.Node, source []byte) string {
 			break
 		}
 		// Gap rule: a blank line between this comment and its forward
-		// neighbour detaches it. A blank line is two `\n` with only
-		// horizontal whitespace between them.
+		// neighbour detaches it. The loop counts `\n` and ignores
+		// everything else — non-newline bytes are transparent.
+		//
+		// Safe under tree-sitter's invariant that inter-named-sibling
+		// gaps contain only whitespace (the tokenizer places non-
+		// whitespace bytes inside named or anonymous nodes, never in
+		// the gap). If a future grammar bump ever violates that, this
+		// loop detaches more aggressively than the previous reset-on-
+		// non-whitespace form did: a stray byte between two `\n` would
+		// still trigger detachment. That's the trade for the simpler
+		// shape; document if it ever bites.
 		gap := source[prev.EndByte():cur.StartByte()]
 		nl := 0
 		blank := false
 		for _, b := range gap {
-			switch b {
-			case '\n':
+			if b == '\n' {
 				nl++
 				if nl >= 2 {
 					blank = true
 				}
-			case ' ', '\t', '\r':
-				// whitespace doesn't reset
-			default:
-				nl = 0
 			}
 		}
 		if blank {
@@ -96,27 +97,25 @@ func stripCommentMarkers(text string) []string {
 		body = strings.TrimPrefix(body, " ")
 		return []string{body}
 	}
-	if strings.HasPrefix(text, "/*") && strings.HasSuffix(text, "*/") {
-		body := strings.TrimSuffix(strings.TrimPrefix(text, "/*"), "*/")
-		var out []string
-		for _, raw := range strings.Split(body, "\n") {
-			line := strings.TrimSpace(raw)
-			line = strings.TrimPrefix(line, "*")
-			line = strings.TrimPrefix(line, " ")
-			out = append(out, line)
-		}
-		// Strip purely-empty leading and trailing lines that the
-		// `/*\n…\n*/` shape introduces — but preserve blank lines
-		// in the middle of a multi-paragraph block.
-		for len(out) > 0 && out[0] == "" {
-			out = out[1:]
-		}
-		for len(out) > 0 && out[len(out)-1] == "" {
-			out = out[:len(out)-1]
-		}
-		return out
+	// Only other shape tree-sitter-go emits under `comment` is `/* */`.
+	body := strings.TrimSuffix(strings.TrimPrefix(text, "/*"), "*/")
+	var out []string
+	for _, raw := range strings.Split(body, "\n") {
+		line := strings.TrimSpace(raw)
+		line = strings.TrimPrefix(line, "*")
+		line = strings.TrimPrefix(line, " ")
+		out = append(out, line)
 	}
-	return nil
+	// Strip purely-empty leading and trailing lines that the
+	// `/*\n…\n*/` shape introduces — but preserve blank lines
+	// in the middle of a multi-paragraph block.
+	for len(out) > 0 && out[0] == "" {
+		out = out[1:]
+	}
+	for len(out) > 0 && out[len(out)-1] == "" {
+		out = out[:len(out)-1]
+	}
+	return out
 }
 
 // isLicenseHeader recognises the conventional headers that should never

--- a/internal/extract/golang/docstring.go
+++ b/internal/extract/golang/docstring.go
@@ -1,0 +1,134 @@
+package golang
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+)
+
+// docstringFor returns the godoc-style doc comment attached to the
+// given declaration node, or "" if none is attached. Attachment walks
+// previous-sibling `comment` nodes as long as no blank line separates
+// them; license headers and invalid UTF-8 are filtered.
+func docstringFor(node *sitter.Node, source []byte) string {
+	if node == nil {
+		return ""
+	}
+	var comments []*sitter.Node
+	cur := node
+	for {
+		prev := cur.PrevNamedSibling()
+		if prev == nil || prev.Kind() != "comment" {
+			break
+		}
+		// Gap rule: a blank line between this comment and its forward
+		// neighbour detaches it. A blank line is two `\n` with only
+		// horizontal whitespace between them.
+		gap := source[prev.EndByte():cur.StartByte()]
+		nl := 0
+		blank := false
+		for _, b := range gap {
+			switch b {
+			case '\n':
+				nl++
+				if nl >= 2 {
+					blank = true
+				}
+			case ' ', '\t', '\r':
+				// whitespace doesn't reset
+			default:
+				nl = 0
+			}
+		}
+		if blank {
+			break
+		}
+		comments = append([]*sitter.Node{prev}, comments...)
+		cur = prev
+	}
+	if len(comments) == 0 {
+		return ""
+	}
+	return formatGoComments(comments, source)
+}
+
+// formatGoComments joins comment nodes into a single docstring, stripping
+// markers and applying filters. Returns "" when filters fire or the
+// joined text is not valid UTF-8.
+func formatGoComments(nodes []*sitter.Node, source []byte) string {
+	var lines []string
+	for _, n := range nodes {
+		lines = append(lines, stripCommentMarkers(extract.Text(n, source))...)
+	}
+	// Find the first non-empty line for the license-header filter.
+	firstIdx := -1
+	for i, l := range lines {
+		if strings.TrimSpace(l) != "" {
+			firstIdx = i
+			break
+		}
+	}
+	if firstIdx < 0 {
+		return ""
+	}
+	first := strings.TrimSpace(lines[firstIdx])
+	if isLicenseHeader(first) {
+		return ""
+	}
+	out := strings.Join(lines, "\n")
+	if !utf8.ValidString(out) {
+		return ""
+	}
+	return strings.TrimRight(out, "\n")
+}
+
+// stripCommentMarkers turns one comment node's raw text (which still
+// has `//` or `/* */` markers) into zero or more body lines with
+// markers removed. The leading space godoc convention writes (`// foo`)
+// is trimmed; a block-continuation ` *` prefix is also trimmed.
+func stripCommentMarkers(text string) []string {
+	text = strings.TrimRight(text, "\n")
+	if strings.HasPrefix(text, "//") {
+		body := strings.TrimPrefix(text, "//")
+		body = strings.TrimPrefix(body, " ")
+		return []string{body}
+	}
+	if strings.HasPrefix(text, "/*") && strings.HasSuffix(text, "*/") {
+		body := strings.TrimSuffix(strings.TrimPrefix(text, "/*"), "*/")
+		var out []string
+		for _, raw := range strings.Split(body, "\n") {
+			line := strings.TrimSpace(raw)
+			line = strings.TrimPrefix(line, "*")
+			line = strings.TrimPrefix(line, " ")
+			out = append(out, line)
+		}
+		// Strip purely-empty leading and trailing lines that the
+		// `/*\n…\n*/` shape introduces — but preserve blank lines
+		// in the middle of a multi-paragraph block.
+		for len(out) > 0 && out[0] == "" {
+			out = out[1:]
+		}
+		for len(out) > 0 && out[len(out)-1] == "" {
+			out = out[:len(out)-1]
+		}
+		return out
+	}
+	return nil
+}
+
+// isLicenseHeader recognises the conventional headers that should never
+// be promoted into a symbol's docstring. The list is intentionally tight
+// — false positives here would silently drop real godoc — so only the
+// two prefixes that are unambiguous in Go source qualify. The pitch's
+// general guidance also mentions a `<` (HTML/XML preamble) prefix; it
+// is omitted here because godoc legitimately uses `<nil>`, `<see X>`,
+// and similar bracket-led phrases, and HTML preambles do not appear in
+// Go source.
+func isLicenseHeader(line string) bool {
+	return strings.HasPrefix(line, "Copyright") ||
+		strings.HasPrefix(line, "SPDX-")
+}
+

--- a/internal/extract/golang/docstring_test.go
+++ b/internal/extract/golang/docstring_test.go
@@ -1,0 +1,264 @@
+package golang
+
+import (
+	"testing"
+)
+
+// TestDocstring_Standard pins case (a): a one-line godoc above a
+// function attaches and is stored as the exact comment text, marker
+// stripped. Anything weaker than exact-equal would let "found a comment
+// somewhere" silently substitute for "found the right comment".
+func TestDocstring_Standard(t *testing.T) {
+	src := `package p
+
+// Foo returns the answer to life.
+func Foo() int { return 42 }
+`
+	r := parse(t, src)
+	sym := findSymbol(r, "p.Foo")
+	if sym == nil {
+		t.Fatalf("symbol p.Foo missing")
+	}
+	if got, want := sym.Docstring, "Foo returns the answer to life."; got != want {
+		t.Errorf("Docstring = %q, want %q", got, want)
+	}
+}
+
+// TestDocstring_MultiLine pins case (b): a run of consecutive `// ` lines
+// without a blank-line gap is preserved as a single joined block. The
+// internal newline is significant — a flatten-to-single-line bug would
+// pass a "contains" assertion but fail exact-equal.
+func TestDocstring_MultiLine(t *testing.T) {
+	src := `package p
+
+// Bar does the thing.
+// It does it well.
+// Across three lines.
+func Bar() {}
+`
+	r := parse(t, src)
+	sym := findSymbol(r, "p.Bar")
+	if sym == nil {
+		t.Fatalf("symbol p.Bar missing")
+	}
+	want := "Bar does the thing.\nIt does it well.\nAcross three lines."
+	if sym.Docstring != want {
+		t.Errorf("Docstring = %q, want %q", sym.Docstring, want)
+	}
+}
+
+// TestDocstring_BlankLineGap pins case (c): a blank line between a
+// comment and a function detaches the comment. The follow-up function
+// must still get its own godoc — the helper must not "consume" the
+// orphaned comment for the wrong target.
+func TestDocstring_BlankLineGap(t *testing.T) {
+	src := `package p
+
+// An orphaned comment block that belongs to nothing.
+
+func Skip() {}
+
+// Use is documented.
+func Use() {}
+`
+	r := parse(t, src)
+	skip := findSymbol(r, "p.Skip")
+	use := findSymbol(r, "p.Use")
+	if skip == nil || use == nil {
+		t.Fatalf("missing symbols: skip=%v use=%v", skip, use)
+	}
+	if skip.Docstring != "" {
+		t.Errorf("Skip.Docstring = %q, want \"\" (blank-line gap should detach)", skip.Docstring)
+	}
+	if use.Docstring != "Use is documented." {
+		t.Errorf("Use.Docstring = %q, want \"Use is documented.\"", use.Docstring)
+	}
+}
+
+// TestDocstring_LicenseHeaderFiltered pins case (d): a `Copyright`-led
+// comment block directly above a function is dropped (it's a license
+// header, not a docstring). The next function below must still get its
+// own godoc — the filter must not poison forward attachment.
+func TestDocstring_LicenseHeaderFiltered(t *testing.T) {
+	src := `package p
+
+// Copyright 2026 Acme Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+func main() {}
+
+// Helper does help.
+func Helper() {}
+`
+	r := parse(t, src)
+	main := findSymbol(r, "p.main")
+	helper := findSymbol(r, "p.Helper")
+	if main == nil || helper == nil {
+		t.Fatalf("missing symbols: main=%v helper=%v", main, helper)
+	}
+	if main.Docstring != "" {
+		t.Errorf("main.Docstring = %q, want \"\" (license header should be filtered)", main.Docstring)
+	}
+	if helper.Docstring != "Helper does help." {
+		t.Errorf("Helper.Docstring = %q, want \"Helper does help.\"", helper.Docstring)
+	}
+}
+
+// TestDocstring_MalformedUTF8 pins case (e): a comment containing
+// invalid UTF-8 bytes does not panic the extractor and produces an
+// empty docstring. SQLite stores TEXT as UTF-8; allowing invalid bytes
+// through would corrupt the column and break downstream FTS5 readers.
+func TestDocstring_MalformedUTF8(t *testing.T) {
+	// Embed a lone continuation byte 0x80 (invalid UTF-8 in isolation).
+	src := "package p\n\n// junk \x80\nfunc Bad() {}\n"
+	r := parse(t, src)
+	sym := findSymbol(r, "p.Bad")
+	if sym == nil {
+		t.Fatalf("symbol p.Bad missing")
+	}
+	if sym.Docstring != "" {
+		t.Errorf("Docstring on malformed-UTF-8 comment = %q, want \"\"", sym.Docstring)
+	}
+}
+
+// TestDocstring_BlockComment exercises the /* … */ comment form. Go
+// programmers rarely use it for godoc, but the grammar produces the
+// same `comment` node kind, so a missing branch in the marker-stripping
+// helper would silently regress users who do.
+func TestDocstring_BlockComment(t *testing.T) {
+	src := `package p
+
+/*
+Block is documented with a slash-star block.
+Second line.
+*/
+func Block() {}
+`
+	r := parse(t, src)
+	sym := findSymbol(r, "p.Block")
+	if sym == nil {
+		t.Fatalf("symbol p.Block missing")
+	}
+	want := "Block is documented with a slash-star block.\nSecond line."
+	if sym.Docstring != want {
+		t.Errorf("Docstring = %q, want %q", sym.Docstring, want)
+	}
+}
+
+// TestDocstring_TypeAndConstAndMethod pins that the extractor wires
+// the helper into every emit site — function (covered above), type,
+// const, and method. A wiring miss on any one would let users see
+// docstrings on functions but mysteriously not on types or methods.
+func TestDocstring_TypeAndConstAndMethod(t *testing.T) {
+	src := `package p
+
+// MaxRetries caps the retry loop.
+const MaxRetries = 3
+
+// Pi is the constant.
+var Pi = 3.14
+
+// Order represents a customer order.
+type Order struct{}
+
+// Total computes the order total.
+func (o Order) Total() int { return 0 }
+`
+	r := parse(t, src)
+	for _, want := range []struct {
+		qual, doc string
+	}{
+		{"p.MaxRetries", "MaxRetries caps the retry loop."},
+		{"p.Pi", "Pi is the constant."},
+		{"p.Order", "Order represents a customer order."},
+		{"p.Order.Total", "Total computes the order total."},
+	} {
+		sym := findSymbol(r, want.qual)
+		if sym == nil {
+			t.Errorf("symbol %s missing", want.qual)
+			continue
+		}
+		if sym.Docstring != want.doc {
+			t.Errorf("%s.Docstring = %q, want %q", want.qual, sym.Docstring, want.doc)
+		}
+	}
+}
+
+// TestDocstring_InterfaceMethod pins the sixth emit site —
+// emitInterfaceMethods (golang.go:330). Interface method comments are
+// siblings of the method_elem inside an interface_type body; the helper
+// must walk that level too, not just top-level declarations.
+func TestDocstring_InterfaceMethod(t *testing.T) {
+	src := `package p
+
+type Reader interface {
+	// Read reads up to len(p) bytes.
+	Read(p []byte) (int, error)
+}
+`
+	r := parse(t, src)
+	sym := findSymbol(r, "p.Reader.Read")
+	if sym == nil {
+		t.Fatalf("symbol p.Reader.Read missing")
+	}
+	want := "Read reads up to len(p) bytes."
+	if sym.Docstring != want {
+		t.Errorf("Docstring = %q, want %q", sym.Docstring, want)
+	}
+}
+
+// TestDocstring_LicenseFilterBranches pins each prefix recognised by
+// the license filter individually. The headline LicenseHeaderFiltered
+// test exercises Copyright in combination with SPDX; this test pins
+// SPDX standalone so a typo or accidental delete of that filter branch
+// is caught on its own.
+//
+// The companion sub-case proves a *non-license* docstring whose first
+// word coincidentally begins with `License…` (a function named License,
+// docstring starting "License returns the active license") survives the
+// filter — guarding against an over-eager pattern that would silently
+// drop real godoc.
+func TestDocstring_LicenseFilterBranches(t *testing.T) {
+	t.Run("SPDX-stripped", func(t *testing.T) {
+		src := "package p\n\n// SPDX-License-Identifier: MIT\nfunc X() {}\n"
+		r := parse(t, src)
+		sym := findSymbol(r, "p.X")
+		if sym == nil {
+			t.Fatalf("p.X missing")
+		}
+		if sym.Docstring != "" {
+			t.Errorf("Docstring = %q, want \"\" (SPDX prefix should filter)", sym.Docstring)
+		}
+	})
+
+	t.Run("LicensePrefix-preserved", func(t *testing.T) {
+		src := "package p\n\n// License returns the active license.\nfunc License() string { return \"\" }\n"
+		r := parse(t, src)
+		sym := findSymbol(r, "p.License")
+		if sym == nil {
+			t.Fatalf("p.License missing")
+		}
+		want := "License returns the active license."
+		if sym.Docstring != want {
+			t.Errorf("Docstring = %q, want %q (filter should NOT swallow legitimate godoc)", sym.Docstring, want)
+		}
+	})
+}
+
+// TestDocstring_NoComment pins the negative path: a function with no
+// preceding comment must yield Docstring == "". Without this assertion
+// the test suite would not catch a bug that emitted some default text.
+func TestDocstring_NoComment(t *testing.T) {
+	src := `package p
+
+func Bare() {}
+`
+	r := parse(t, src)
+	sym := findSymbol(r, "p.Bare")
+	if sym == nil {
+		t.Fatalf("symbol p.Bare missing")
+	}
+	if sym.Docstring != "" {
+		t.Errorf("Docstring on commentless func = %q, want \"\"", sym.Docstring)
+	}
+}
+

--- a/internal/extract/golang/docstring_test.go
+++ b/internal/extract/golang/docstring_test.go
@@ -262,3 +262,31 @@ func Bare() {}
 	}
 }
 
+// TestDocstring_AllBlankComments pins that a run of `//` markers with
+// no body text does not panic the extractor and yields "". The explicit
+// recover guards the load-bearing path: stripCommentMarkers returns an
+// empty slice for body-less comments, and formatGoComments must handle
+// that without indexing lines[-1] (an earlier draft did, and would
+// panic here).
+func TestDocstring_AllBlankComments(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("extractor panicked on body-less comments: %v", r)
+		}
+	}()
+	src := `package p
+
+//
+//
+func Hush() {}
+`
+	r := parse(t, src)
+	sym := findSymbol(r, "p.Hush")
+	if sym == nil {
+		t.Fatalf("symbol p.Hush missing")
+	}
+	if sym.Docstring != "" {
+		t.Errorf("Docstring on body-less comments = %q, want \"\"", sym.Docstring)
+	}
+}
+

--- a/internal/extract/golang/golang.go
+++ b/internal/extract/golang/golang.go
@@ -165,12 +165,13 @@ func (w *walker) collectSpecNames(spec *sitter.Node) {
 // form (`const ( A = 1; B = 2 )`) and the single form (`const A = 1`)
 // produce const_spec children.
 func (w *walker) handleConstDeclaration(n *sitter.Node) error {
+	doc := docstringFor(n, w.source)
 	for i := uint(0); i < n.NamedChildCount(); i++ {
 		spec := n.NamedChild(i)
 		if spec == nil || spec.Kind() != "const_spec" {
 			continue
 		}
-		if err := w.emitConstSpec(spec); err != nil {
+		if err := w.emitConstSpec(spec, doc); err != nil {
 			return err
 		}
 	}
@@ -179,8 +180,8 @@ func (w *walker) handleConstDeclaration(n *sitter.Node) error {
 
 // emitConstSpec emits one Symbol per name in a const_spec. Specs like
 // `const A, B = 1, 2` declare multiple names simultaneously — each
-// becomes its own symbol.
-func (w *walker) emitConstSpec(spec *sitter.Node) error {
+// becomes its own symbol and shares the declaration-level docstring.
+func (w *walker) emitConstSpec(spec *sitter.Node, doc string) error {
 	// `name` is a repeated field on const_spec; ChildrenByFieldName
 	// needs a cursor, so iterate manually by field-name match.
 	for i := uint(0); i < spec.NamedChildCount(); i++ {
@@ -199,6 +200,7 @@ func (w *walker) emitConstSpec(spec *sitter.Node) error {
 			Visibility: visibility(name),
 			LineStart:  extract.Line(spec.StartPosition()),
 			LineEnd:    extract.Line(spec.EndPosition()),
+			Docstring:  doc,
 		}); err != nil {
 			return err
 		}
@@ -210,6 +212,7 @@ func (w *walker) emitConstSpec(spec *sitter.Node) error {
 // package-level variable as a KindConstant symbol (the model has no
 // separate variable kind; for dead code purposes they behave identically).
 func (w *walker) handleVarDeclaration(n *sitter.Node) error {
+	doc := docstringFor(n, w.source)
 	for i := uint(0); i < n.NamedChildCount(); i++ {
 		spec := n.NamedChild(i)
 		if spec == nil || spec.Kind() != "var_spec" {
@@ -231,6 +234,7 @@ func (w *walker) handleVarDeclaration(n *sitter.Node) error {
 				Visibility: visibility(name),
 				LineStart:  extract.Line(spec.StartPosition()),
 				LineEnd:    extract.Line(spec.EndPosition()),
+				Docstring:  doc,
 			}); err != nil {
 				return err
 			}
@@ -242,6 +246,7 @@ func (w *walker) handleVarDeclaration(n *sitter.Node) error {
 // handleTypeDeclaration walks type_spec / type_alias children. Both
 // forms classify by the inner `type` field's kind.
 func (w *walker) handleTypeDeclaration(n *sitter.Node) error {
+	doc := docstringFor(n, w.source)
 	for i := uint(0); i < n.NamedChildCount(); i++ {
 		spec := n.NamedChild(i)
 		if spec == nil {
@@ -249,11 +254,11 @@ func (w *walker) handleTypeDeclaration(n *sitter.Node) error {
 		}
 		switch spec.Kind() {
 		case "type_spec":
-			if err := w.emitTypeSpec(spec, false); err != nil {
+			if err := w.emitTypeSpec(spec, false, doc); err != nil {
 				return err
 			}
 		case "type_alias":
-			if err := w.emitTypeSpec(spec, true); err != nil {
+			if err := w.emitTypeSpec(spec, true, doc); err != nil {
 				return err
 			}
 		}
@@ -261,7 +266,7 @@ func (w *walker) handleTypeDeclaration(n *sitter.Node) error {
 	return nil
 }
 
-func (w *walker) emitTypeSpec(spec *sitter.Node, isAlias bool) error {
+func (w *walker) emitTypeSpec(spec *sitter.Node, isAlias bool, doc string) error {
 	nameNode := spec.ChildByFieldName("name")
 	if nameNode == nil {
 		return nil
@@ -294,6 +299,7 @@ func (w *walker) emitTypeSpec(spec *sitter.Node, isAlias bool) error {
 		Visibility: visibility(name),
 		LineStart:  extract.Line(spec.StartPosition()),
 		LineEnd:    extract.Line(spec.EndPosition()),
+		Docstring:  doc,
 	}); err != nil {
 		return err
 	}
@@ -335,6 +341,7 @@ func (w *walker) emitInterfaceMethods(ifaceNode *sitter.Node, ifaceQualified str
 			ParentQualified: ifaceQualified,
 			LineStart:       extract.Line(me.StartPosition()),
 			LineEnd:         extract.Line(me.EndPosition()),
+			Docstring:       docstringFor(me, w.source),
 		}); err != nil {
 			return err
 		}
@@ -410,6 +417,7 @@ func (w *walker) handleFunction(n *sitter.Node) error {
 		Visibility: visibility(name),
 		LineStart:  extract.Line(n.StartPosition()),
 		LineEnd:    extract.Line(n.EndPosition()),
+		Docstring:  docstringFor(n, w.source),
 	}); err != nil {
 		return err
 	}
@@ -452,6 +460,7 @@ func (w *walker) handleMethod(n *sitter.Node) error {
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
+		Docstring:       docstringFor(n, w.source),
 	}); err != nil {
 		return err
 	}

--- a/internal/extract/python/docstring.go
+++ b/internal/extract/python/docstring.go
@@ -1,0 +1,67 @@
+package python
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+// docstringFor returns the PEP 257 docstring attached to the given
+// function or class node, or "" if the body's first statement is not a
+// string literal. Reading the body's first statement (not a preceding
+// comment) is what distinguishes Python documentation from C-family
+// conventions and is the reason decorators don't interfere — the body
+// is reached via the `body` field on the definition node, never by
+// walking siblings backward.
+//
+// License headers and invalid UTF-8 are filtered to "".
+func docstringFor(node *sitter.Node, source []byte) string {
+	// Walk: definition node → body block → first statement → string.
+	// Each step either yields the next or short-circuits to "". The
+	// helper is bounded to the tree shapes tree-sitter-python emits;
+	// non-string first statements (pass, assignment, return) bail at
+	// the kind check below, which is the most common "no docstring"
+	// path in practice.
+	body := node.ChildByFieldName("body")
+	if body == nil {
+		return ""
+	}
+	first := body.NamedChild(0)
+	if first == nil || first.Kind() != "expression_statement" {
+		return ""
+	}
+	str := first.NamedChild(0)
+	if str == nil || str.Kind() != "string" {
+		return ""
+	}
+	// Strip leading/trailing whitespace introduced by `"""\n…\n"""`
+	// formatting. Internal indentation is preserved — a
+	// textwrap.dedent-equivalent pass would mutate bytes a Python
+	// author wrote, for marginal reader gain.
+	out := strings.TrimSpace(stringContent(str, source))
+	if out == "" || !utf8.ValidString(out) {
+		return ""
+	}
+	// License-header filter on the first non-blank line.
+	for _, line := range strings.Split(out, "\n") {
+		t := strings.TrimSpace(line)
+		if t == "" {
+			continue
+		}
+		if isLicenseHeader(t) {
+			return ""
+		}
+		break
+	}
+	return out
+}
+
+// isLicenseHeader recognises the conventional file-top headers that
+// must not be promoted into a symbol's docstring. The list mirrors the
+// other extractors — Copyright and SPDX- are unambiguous; broader
+// prefixes risk dropping real PEP 257 prose.
+func isLicenseHeader(line string) bool {
+	return strings.HasPrefix(line, "Copyright") ||
+		strings.HasPrefix(line, "SPDX-")
+}

--- a/internal/extract/python/docstring.go
+++ b/internal/extract/python/docstring.go
@@ -23,6 +23,12 @@ func docstringFor(node *sitter.Node, source []byte) string {
 	// non-string first statements (pass, assignment, return) bail at
 	// the kind check below, which is the most common "no docstring"
 	// path in practice.
+	//
+	// ChildByFieldName is a grammar contract, not a caller contract:
+	// tree-sitter-python today always emits the `body` field on
+	// function/class definitions, but grammar churn (PEP 695, future
+	// "function signature" nodes) could change that. A nil body would
+	// segfault on NamedChild below — guard explicitly.
 	body := node.ChildByFieldName("body")
 	if body == nil {
 		return ""
@@ -43,16 +49,15 @@ func docstringFor(node *sitter.Node, source []byte) string {
 	if out == "" || !utf8.ValidString(out) {
 		return ""
 	}
-	// License-header filter on the first non-blank line.
-	for _, line := range strings.Split(out, "\n") {
-		t := strings.TrimSpace(line)
-		if t == "" {
-			continue
-		}
-		if isLicenseHeader(t) {
-			return ""
-		}
-		break
+	// License-header filter on the first line. TrimSpace above
+	// guarantees the first byte is non-whitespace, so the first line
+	// of the split is always non-blank.
+	firstLine := out
+	if idx := strings.IndexByte(out, '\n'); idx >= 0 {
+		firstLine = out[:idx]
+	}
+	if isLicenseHeader(strings.TrimSpace(firstLine)) {
+		return ""
 	}
 	return out
 }

--- a/internal/extract/python/docstring_test.go
+++ b/internal/extract/python/docstring_test.go
@@ -1,0 +1,195 @@
+package python
+
+import (
+	"testing"
+)
+
+// TestDocstring_TripleQuotedMultiLine pins case (a): a multi-line
+// triple-quoted docstring as the first statement of a function body
+// attaches as the exact body text. Trim-leading/trailing whitespace
+// normalisation is applied (artefacts of the `"""…"""` wrapper); the
+// internal blank line is preserved.
+func TestDocstring_TripleQuotedMultiLine(t *testing.T) {
+	src := `def foo():
+    """foo does the thing.
+
+    Across multiple lines.
+    """
+    pass
+`
+	r := parse(t, src)
+	sym := findSymbol(r, "foo")
+	if sym == nil {
+		t.Fatalf("symbol foo missing")
+	}
+	want := "foo does the thing.\n\n    Across multiple lines."
+	if sym.Docstring != want {
+		t.Errorf("Docstring = %q, want %q", sym.Docstring, want)
+	}
+}
+
+// TestDocstring_SingleLineTriple pins case (b): a one-line
+// `"""…"""` docstring stores the exact text between the quotes.
+func TestDocstring_SingleLineTriple(t *testing.T) {
+	src := `def bar():
+    """bar is brief."""
+    pass
+`
+	r := parse(t, src)
+	sym := findSymbol(r, "bar")
+	if sym == nil {
+		t.Fatalf("symbol bar missing")
+	}
+	want := "bar is brief."
+	if sym.Docstring != want {
+		t.Errorf("Docstring = %q, want %q", sym.Docstring, want)
+	}
+}
+
+// TestDocstring_PassOnlyBody pins case (c): a function whose body is
+// only `pass` (no docstring) yields Docstring == "". Without this
+// fixture an implementation that read any first-statement bytes
+// (rather than checking the statement kind) would smuggle the
+// `pass_statement` text into the column.
+func TestDocstring_PassOnlyBody(t *testing.T) {
+	src := `def empty():
+    pass
+`
+	r := parse(t, src)
+	sym := findSymbol(r, "empty")
+	if sym == nil {
+		t.Fatalf("symbol empty missing")
+	}
+	if sym.Docstring != "" {
+		t.Errorf("Docstring = %q, want \"\" (pass-only body has no docstring)", sym.Docstring)
+	}
+}
+
+// TestDocstring_DecoratorClass pins case (d): a `@dataclass`-decorated
+// class's docstring is the body's first string literal, NOT the
+// decorator's argument. The pedagogical danger is an implementation
+// that walks PRECEDING comments or inspects the decorator's call
+// arguments — both would silently store `dataclass` (or similar) in
+// the column instead of the real docstring.
+func TestDocstring_DecoratorClass(t *testing.T) {
+	src := `@dataclass
+class Decorated:
+    """decorated body doc"""
+    pass
+`
+	r := parse(t, src)
+	sym := findSymbol(r, "Decorated")
+	if sym == nil {
+		t.Fatalf("symbol Decorated missing")
+	}
+	want := "decorated body doc"
+	if sym.Docstring != want {
+		t.Errorf("Docstring = %q, want %q (must be body string, not decorator argument)", sym.Docstring, want)
+	}
+}
+
+// TestDocstring_ModuleLevelSkipped pins case (e): a module-level
+// docstring (the first string literal of the file) is NOT promoted
+// to any symbol — there is no owning symbol for it. The test asserts
+// that the only emitted class's Docstring is its OWN body string,
+// untouched by the module-level docstring above it.
+func TestDocstring_ModuleLevelSkipped(t *testing.T) {
+	src := `"""Module-level docstring that has nowhere to attach."""
+
+class Owner:
+    """class doc"""
+    pass
+`
+	r := parse(t, src)
+	sym := findSymbol(r, "Owner")
+	if sym == nil {
+		t.Fatalf("symbol Owner missing")
+	}
+	want := "class doc"
+	if sym.Docstring != want {
+		t.Errorf("Owner.Docstring = %q, want %q (module-level must not leak)", sym.Docstring, want)
+	}
+}
+
+// TestDocstring_ClassAndMethod pins that wiring fires at BOTH emit
+// sites in this card (handleClass + emitFunctionAndWalkBody for
+// methods). A wiring miss on either would let users see one but not
+// the other.
+func TestDocstring_ClassAndMethod(t *testing.T) {
+	src := `class Service:
+    """Service is the documented class."""
+
+    def do(self):
+        """do is a method."""
+        return 1
+`
+	r := parse(t, src)
+	for _, want := range []struct {
+		qual, doc string
+	}{
+		{"Service", "Service is the documented class."},
+		{"Service.do", "do is a method."},
+	} {
+		sym := findSymbol(r, want.qual)
+		if sym == nil {
+			t.Errorf("symbol %s missing", want.qual)
+			continue
+		}
+		if sym.Docstring != want.doc {
+			t.Errorf("%s.Docstring = %q, want %q", want.qual, sym.Docstring, want.doc)
+		}
+	}
+}
+
+// TestDocstring_FirstStatementNonString pins the negative path: a
+// function whose first statement is anything other than a string
+// literal yields empty docstring. Without this the helper might
+// emit text for an unrelated first expression.
+func TestDocstring_FirstStatementNonString(t *testing.T) {
+	src := `def noDoc():
+    x = 1
+    return x
+`
+	r := parse(t, src)
+	sym := findSymbol(r, "noDoc")
+	if sym == nil {
+		t.Fatalf("symbol noDoc missing")
+	}
+	if sym.Docstring != "" {
+		t.Errorf("Docstring = %q, want \"\" (first statement is assignment, not string)", sym.Docstring)
+	}
+}
+
+// TestDocstring_LicenseHeaderFiltered pins that a function whose
+// docstring text starts with a license-header prefix is dropped.
+// Rare in Python (typically only at module scope, which we skip
+// anyway) but the filter applies for parity with the other extractors.
+func TestDocstring_LicenseHeaderFiltered(t *testing.T) {
+	src := `def f():
+    """Copyright 2026 Acme Inc."""
+    pass
+`
+	r := parse(t, src)
+	sym := findSymbol(r, "f")
+	if sym == nil {
+		t.Fatalf("symbol f missing")
+	}
+	if sym.Docstring != "" {
+		t.Errorf("Docstring = %q, want \"\" (Copyright prefix should filter)", sym.Docstring)
+	}
+}
+
+// TestDocstring_MalformedUTF8 pins that invalid UTF-8 in the docstring
+// content yields empty docstring and does not panic. Python source
+// can contain non-UTF-8 bytes in literal strings; we must defend.
+func TestDocstring_MalformedUTF8(t *testing.T) {
+	src := "def bad():\n    \"junk \x80\"\n    pass\n"
+	r := parse(t, src)
+	sym := findSymbol(r, "bad")
+	if sym == nil {
+		t.Fatalf("symbol bad missing")
+	}
+	if sym.Docstring != "" {
+		t.Errorf("Docstring on malformed-UTF-8 = %q, want \"\"", sym.Docstring)
+	}
+}

--- a/internal/extract/python/python.go
+++ b/internal/extract/python/python.go
@@ -218,6 +218,7 @@ func (w *walker) handleClass(n *sitter.Node, scope []string) error {
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
+		Docstring:       docstringFor(n, w.source),
 	}); err != nil {
 		return err
 	}
@@ -291,6 +292,7 @@ func (w *walker) emitFunctionAndWalkBody(n *sitter.Node, scope []string, decorat
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
+		Docstring:       docstringFor(n, w.source),
 	}); err != nil {
 		return err
 	}

--- a/internal/extract/ruby/docstring.go
+++ b/internal/extract/ruby/docstring.go
@@ -16,9 +16,6 @@ import (
 // Magic comments (frozen_string_literal, encoding, etc.), license
 // headers, and invalid UTF-8 are filtered to "".
 func docstringFor(node *sitter.Node, source []byte) string {
-	if node == nil {
-		return ""
-	}
 	cur := node
 	// tree-sitter-ruby wraps a class/module body in a `body_statement`
 	// node. When the target is the first (or only) statement inside that
@@ -34,20 +31,18 @@ func docstringFor(node *sitter.Node, source []byte) string {
 		if prev == nil || prev.Kind() != "comment" {
 			break
 		}
+		// Gap rule: see golang/docstring.go for the contract — only `\n`
+		// matters; non-newline bytes are transparent. Safe under tree-
+		// sitter's whitespace-only-between-siblings invariant.
 		gap := source[prev.EndByte():cur.StartByte()]
 		nl := 0
 		blank := false
 		for _, b := range gap {
-			switch b {
-			case '\n':
+			if b == '\n' {
 				nl++
 				if nl >= 2 {
 					blank = true
 				}
-			case ' ', '\t', '\r':
-				// horizontal whitespace doesn't reset
-			default:
-				nl = 0
 			}
 		}
 		if blank {

--- a/internal/extract/ruby/docstring.go
+++ b/internal/extract/ruby/docstring.go
@@ -1,0 +1,147 @@
+package ruby
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+)
+
+// docstringFor returns the RDoc-style doc comment attached to the given
+// declaration node, or "" if none is attached. Attachment walks
+// previous-sibling `comment` nodes (stacked `# ` lines or a single
+// `=begin/=end` block) as long as no blank line separates them.
+// Magic comments (frozen_string_literal, encoding, etc.), license
+// headers, and invalid UTF-8 are filtered to "".
+func docstringFor(node *sitter.Node, source []byte) string {
+	if node == nil {
+		return ""
+	}
+	cur := node
+	// tree-sitter-ruby wraps a class/module body in a `body_statement`
+	// node. When the target is the first (or only) statement inside that
+	// wrapper, its preceding comment lives one level up — as a sibling of
+	// the body_statement, not as a sibling of the target. Walk past the
+	// wrapper so the sibling lookup below finds the comment.
+	for cur.Parent() != nil && cur.Parent().Kind() == "body_statement" && cur.PrevNamedSibling() == nil {
+		cur = cur.Parent()
+	}
+	var comments []*sitter.Node
+	for {
+		prev := cur.PrevNamedSibling()
+		if prev == nil || prev.Kind() != "comment" {
+			break
+		}
+		gap := source[prev.EndByte():cur.StartByte()]
+		nl := 0
+		blank := false
+		for _, b := range gap {
+			switch b {
+			case '\n':
+				nl++
+				if nl >= 2 {
+					blank = true
+				}
+			case ' ', '\t', '\r':
+				// horizontal whitespace doesn't reset
+			default:
+				nl = 0
+			}
+		}
+		if blank {
+			break
+		}
+		comments = append([]*sitter.Node{prev}, comments...)
+		cur = prev
+	}
+	if len(comments) == 0 {
+		return ""
+	}
+	return formatRubyComments(comments, source)
+}
+
+// formatRubyComments joins comment nodes into a single docstring,
+// stripping markers and applying the magic-comment / license filters.
+func formatRubyComments(nodes []*sitter.Node, source []byte) string {
+	var lines []string
+	for _, n := range nodes {
+		lines = append(lines, stripCommentMarkers(extract.Text(n, source))...)
+	}
+	firstIdx := -1
+	for i, l := range lines {
+		if strings.TrimSpace(l) != "" {
+			firstIdx = i
+			break
+		}
+	}
+	if firstIdx < 0 {
+		return ""
+	}
+	first := strings.TrimSpace(lines[firstIdx])
+	if isMagicComment(first) || isLicenseHeader(first) {
+		return ""
+	}
+	out := strings.Join(lines, "\n")
+	if !utf8.ValidString(out) {
+		return ""
+	}
+	return strings.TrimRight(out, "\n")
+}
+
+// stripCommentMarkers turns one comment node's raw text into body
+// lines with markers removed. Line comments (`# foo`) strip the `#`
+// and one optional space; `=begin/=end` blocks take the body between
+// the delimiters, one line per source line. tree-sitter-ruby emits
+// only these two forms under the `comment` node kind, so the second
+// branch handles everything that isn't `#`-led.
+func stripCommentMarkers(text string) []string {
+	text = strings.TrimRight(text, "\n")
+	if strings.HasPrefix(text, "#") {
+		body := strings.TrimPrefix(text, "#")
+		body = strings.TrimPrefix(body, " ")
+		return []string{body}
+	}
+	body := strings.TrimPrefix(text, "=begin")
+	body = strings.TrimSuffix(body, "=end")
+	body = strings.TrimSuffix(body, "\n")
+	out := strings.Split(body, "\n")
+	for len(out) > 0 && strings.TrimSpace(out[0]) == "" {
+		out = out[1:]
+	}
+	for len(out) > 0 && strings.TrimSpace(out[len(out)-1]) == "" {
+		out = out[:len(out)-1]
+	}
+	return out
+}
+
+// magicCommentPrefixes lists the file-top Ruby directives that look
+// like comments but carry no documentation value. Kept tight on
+// purpose: each prefix here risks dropping a real RDoc line whose first
+// word happens to match, so only the ones that are unambiguous in
+// practice belong. Tool-specific magic comments (Sorbet `# typed:`,
+// RuboCop `# rubocop:`) are out of scope for this extractor.
+var magicCommentPrefixes = []string{
+	"frozen_string_literal:",
+	"encoding:",
+	"coding:",
+}
+
+func isMagicComment(line string) bool {
+	for _, p := range magicCommentPrefixes {
+		if strings.HasPrefix(line, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// isLicenseHeader recognises the conventional file-top headers that
+// must not be promoted into a symbol's docstring. The list is kept
+// tight for the same reason as in the Go extractor — false positives
+// here silently drop real RDoc.
+func isLicenseHeader(line string) bool {
+	return strings.HasPrefix(line, "Copyright") ||
+		strings.HasPrefix(line, "SPDX-")
+}

--- a/internal/extract/ruby/docstring_test.go
+++ b/internal/extract/ruby/docstring_test.go
@@ -268,3 +268,48 @@ func TestDocstring_MalformedUTF8(t *testing.T) {
 		t.Errorf("Docstring on malformed-UTF-8 comment = %q, want \"\"", sym.Docstring)
 	}
 }
+
+// TestDocstring_AllBlankComments pins that a run of comment markers
+// with no body text (e.g. `#\n#\n`) does not panic the extractor and
+// yields "". The explicit recover guards the load-bearing path:
+// formatRubyComments must handle the body-less case without indexing
+// lines[firstIdx] when firstIdx is -1.
+func TestDocstring_AllBlankComments(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("extractor panicked on body-less comments: %v", r)
+		}
+	}()
+	src := "#\n#\ndef hush\nend\n"
+	r := parseRuby(t, src)
+	sym := findSymbol(r, "hush")
+	if sym == nil {
+		t.Fatalf("symbol hush missing")
+	}
+	if sym.Docstring != "" {
+		t.Errorf("Docstring on body-less comments = %q, want \"\"", sym.Docstring)
+	}
+}
+
+// TestDocstring_BeginEndTrailingBlank pins that a `=begin/=end` block
+// with trailing blank lines before `=end` trims them rather than
+// preserving them as empty docstring lines.
+func TestDocstring_BeginEndTrailingBlank(t *testing.T) {
+	src := `=begin
+Block body.
+
+
+=end
+class Trim
+end
+`
+	r := parseRuby(t, src)
+	sym := findSymbol(r, "Trim")
+	if sym == nil {
+		t.Fatalf("symbol Trim missing")
+	}
+	want := "Block body."
+	if sym.Docstring != want {
+		t.Errorf("Docstring = %q, want %q (trailing blanks must be trimmed)", sym.Docstring, want)
+	}
+}

--- a/internal/extract/ruby/docstring_test.go
+++ b/internal/extract/ruby/docstring_test.go
@@ -1,0 +1,270 @@
+package ruby
+
+import (
+	"testing"
+)
+
+// TestDocstring_StackedHash pins case (a): a run of stacked `# ` lines
+// above `def foo` attaches as the joined docstring with markers stripped.
+// Asserting exact text catches a "found a comment, any comment" bug that
+// would pass a non-empty check.
+func TestDocstring_StackedHash(t *testing.T) {
+	src := `# Computes the total in cents.
+# Returns an integer.
+def total
+end
+`
+	r := parseRuby(t, src)
+	sym := findSymbol(r, "total")
+	if sym == nil {
+		t.Fatalf("symbol total missing")
+	}
+	want := "Computes the total in cents.\nReturns an integer."
+	if sym.Docstring != want {
+		t.Errorf("Docstring = %q, want %q", sym.Docstring, want)
+	}
+}
+
+// TestDocstring_BeginEnd pins case (b): a `=begin/=end` block above a
+// class declaration attaches as its body text, delimiters stripped.
+// This form is rare in modern Ruby but the grammar emits the same
+// `comment` node kind, so a missing branch in the marker-stripping
+// helper would silently regress users who use it.
+func TestDocstring_BeginEnd(t *testing.T) {
+	src := `=begin
+Multiline RDoc block.
+Second paragraph.
+=end
+class Foo
+end
+`
+	r := parseRuby(t, src)
+	sym := findSymbol(r, "Foo")
+	if sym == nil {
+		t.Fatalf("symbol Foo missing")
+	}
+	want := "Multiline RDoc block.\nSecond paragraph."
+	if sym.Docstring != want {
+		t.Errorf("Docstring = %q, want %q", sym.Docstring, want)
+	}
+}
+
+// TestDocstring_BlankLineGap pins case (c): a blank line between a `#`
+// comment and a `def` detaches the comment. Asserting `Docstring == ""`
+// catches a bug that would walk past the gap, AND the negative case
+// would fail without this fixture (no other test exercises the gap
+// rule for Ruby).
+func TestDocstring_BlankLineGap(t *testing.T) {
+	src := `# Orphaned comment, no def follows immediately.
+
+def bar
+end
+`
+	r := parseRuby(t, src)
+	sym := findSymbol(r, "bar")
+	if sym == nil {
+		t.Fatalf("symbol bar missing")
+	}
+	if sym.Docstring != "" {
+		t.Errorf("Docstring = %q, want \"\" (blank-line gap should detach)", sym.Docstring)
+	}
+}
+
+// TestDocstring_MagicCommentFiltered pins case (d) from the pitch: a
+// `# frozen_string_literal: true` magic comment above two consecutive
+// `def`s must result in BOTH having empty docstrings.
+//
+// The pedagogical assertion: without the magic-comment filter, `first`
+// would receive "frozen_string_literal: true" as its docstring (the
+// attachment rule fires). The filter ensures it's dropped. The
+// `second` assertion guards against unintended forward propagation —
+// it must be empty because no comment is immediately above it (the
+// preceding sibling is `first`'s def, not a comment), not because of
+// any blank-line magic.
+func TestDocstring_MagicCommentFiltered(t *testing.T) {
+	src := `# frozen_string_literal: true
+def first
+end
+def second
+end
+`
+	r := parseRuby(t, src)
+	first := findSymbol(r, "first")
+	second := findSymbol(r, "second")
+	if first == nil || second == nil {
+		t.Fatalf("missing symbols: first=%v second=%v", first, second)
+	}
+	if first.Docstring != "" {
+		t.Errorf("first.Docstring = %q, want \"\" (magic comment must be filtered)", first.Docstring)
+	}
+	if second.Docstring != "" {
+		t.Errorf("second.Docstring = %q, want \"\" (no comment above; def is the previous sibling)", second.Docstring)
+	}
+}
+
+// TestDocstring_EncodingMagicComment pins the second magic-comment
+// branch — `# encoding: utf-8` is the pre-Ruby-2.0 file-top form and
+// still appears widely. Without this fixture the only-frozen-string-
+// literal case above would let an `encoding:` or `coding:` directive
+// silently bleed into a class docstring.
+func TestDocstring_EncodingMagicComment(t *testing.T) {
+	src := `# encoding: utf-8
+class Doc
+end
+`
+	r := parseRuby(t, src)
+	sym := findSymbol(r, "Doc")
+	if sym == nil {
+		t.Fatalf("symbol Doc missing")
+	}
+	if sym.Docstring != "" {
+		t.Errorf("Docstring = %q, want \"\" (encoding magic comment must be filtered)", sym.Docstring)
+	}
+}
+
+// TestDocstring_ClassAndConstantAndScope pins wiring at the remaining
+// emit sites the pitch names by line number: class (handleClassOrModule),
+// constant (handleConstantAssignment), and the Rails `scope` macro
+// (emitScopeEdge). Without per-site coverage a wiring miss on any one
+// would let users see method docstrings but mysteriously not class or
+// constant docstrings.
+func TestDocstring_ClassAndConstantAndScope(t *testing.T) {
+	src := `# Order is a value object.
+class Order
+  # MAX_ITEMS caps cart size.
+  MAX_ITEMS = 100
+
+  # scope: only paid orders
+  scope :paid, -> { where(paid: true) }
+end
+`
+	r := parseRuby(t, src)
+	for _, want := range []struct {
+		qual, doc string
+	}{
+		{"Order", "Order is a value object."},
+		{"Order::MAX_ITEMS", "MAX_ITEMS caps cart size."},
+		{"Order.paid", "scope: only paid orders"},
+	} {
+		sym := findSymbol(r, want.qual)
+		if sym == nil {
+			t.Errorf("symbol %s missing", want.qual)
+			continue
+		}
+		if sym.Docstring != want.doc {
+			t.Errorf("%s.Docstring = %q, want %q", want.qual, sym.Docstring, want.doc)
+		}
+	}
+}
+
+// TestDocstring_RailsCallback pins the emitCallbackEdges emit site —
+// the synthetic symbol for `before_save :compute_total` should carry
+// the comment that documents that callback.
+func TestDocstring_RailsCallback(t *testing.T) {
+	src := `class Order < ApplicationRecord
+  # runs before every save
+  before_save :compute_total
+end
+`
+	r := parseRuby(t, src)
+	sym := findSymbol(r, "Order.before_save")
+	if sym == nil {
+		t.Fatalf("symbol Order.before_save missing")
+	}
+	want := "runs before every save"
+	if sym.Docstring != want {
+		t.Errorf("Docstring = %q, want %q", sym.Docstring, want)
+	}
+}
+
+// TestDocstring_MultipleMethodsInClass pins the body_statement walk-up
+// path against the direct-sibling path in a single fixture. The first
+// method's comment lives one level up (sibling of body_statement); the
+// second method's comment is a direct sibling inside body_statement.
+// A bug in either branch fails this test.
+func TestDocstring_MultipleMethodsInClass(t *testing.T) {
+	src := `class Box
+  # doc for first
+  def first
+  end
+
+  # doc for second
+  def second
+  end
+end
+`
+	r := parseRuby(t, src)
+	first := findSymbol(r, "Box#first")
+	second := findSymbol(r, "Box#second")
+	if first == nil || second == nil {
+		t.Fatalf("missing symbols: first=%v second=%v", first, second)
+	}
+	if first.Docstring != "doc for first" {
+		t.Errorf("first.Docstring = %q, want \"doc for first\" (walk-up through body_statement)", first.Docstring)
+	}
+	if second.Docstring != "doc for second" {
+		t.Errorf("second.Docstring = %q, want \"doc for second\" (direct sibling)", second.Docstring)
+	}
+}
+
+// TestDocstring_NoComment pins the negative path: a method with no
+// preceding comment yields Docstring == "". Without this guard a bug
+// that emitted some default text would slip through.
+func TestDocstring_NoComment(t *testing.T) {
+	src := `def bare
+end
+`
+	r := parseRuby(t, src)
+	sym := findSymbol(r, "bare")
+	if sym == nil {
+		t.Fatalf("symbol bare missing")
+	}
+	if sym.Docstring != "" {
+		t.Errorf("Docstring on commentless def = %q, want \"\"", sym.Docstring)
+	}
+}
+
+// TestDocstring_LicenseHeaderFiltered pins that the Copyright/SPDX-
+// filter applies in the Ruby context just as it does in Go — a license
+// block sitting directly above a class must not be promoted to the
+// class's docstring, AND the next class below must still get its own
+// RDoc (proving the filter doesn't poison forward attachment).
+func TestDocstring_LicenseHeaderFiltered(t *testing.T) {
+	src := `# Copyright 2026 Acme Inc.
+# SPDX-License-Identifier: MIT
+class First
+end
+
+# Second is documented.
+class Second
+end
+`
+	r := parseRuby(t, src)
+	first := findSymbol(r, "First")
+	second := findSymbol(r, "Second")
+	if first == nil || second == nil {
+		t.Fatalf("missing symbols: first=%v second=%v", first, second)
+	}
+	if first.Docstring != "" {
+		t.Errorf("First.Docstring = %q, want \"\" (license header should filter)", first.Docstring)
+	}
+	if second.Docstring != "Second is documented." {
+		t.Errorf("Second.Docstring = %q, want \"Second is documented.\"", second.Docstring)
+	}
+}
+
+// TestDocstring_MalformedUTF8 pins that a comment containing invalid
+// UTF-8 bytes does not panic the extractor and produces an empty
+// docstring. SQLite stores TEXT as UTF-8; allowing invalid bytes
+// through would corrupt the column and break downstream FTS5 readers.
+func TestDocstring_MalformedUTF8(t *testing.T) {
+	src := "# junk \x80\ndef bad\nend\n"
+	r := parseRuby(t, src)
+	sym := findSymbol(r, "bad")
+	if sym == nil {
+		t.Fatalf("symbol bad missing")
+	}
+	if sym.Docstring != "" {
+		t.Errorf("Docstring on malformed-UTF-8 comment = %q, want \"\"", sym.Docstring)
+	}
+}

--- a/internal/extract/ruby/ruby.go
+++ b/internal/extract/ruby/ruby.go
@@ -572,6 +572,7 @@ func (w *walker) handleClassOrModule(n *sitter.Node, scope []string, kind model.
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
+		Docstring:       docstringFor(n, w.source),
 	}); err != nil {
 		return err
 	}
@@ -653,6 +654,7 @@ func (w *walker) handleMethod(n *sitter.Node, scope []string, singleton bool) er
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
+		Docstring:       docstringFor(n, w.source),
 	}); err != nil {
 		return err
 	}
@@ -1464,6 +1466,7 @@ func (w *walker) handleConstantAssignment(n *sitter.Node, scope []string) error 
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
+		Docstring:       docstringFor(n, w.source),
 	})
 }
 
@@ -1656,6 +1659,7 @@ func (w *walker) emitCallbackEdges(n *sitter.Node, scope []string, callbackName 
 			ParentQualified: source,
 			LineStart:       line,
 			LineEnd:         line,
+			Docstring:       docstringFor(n, w.source),
 		}); err != nil {
 			return err
 		}
@@ -1706,6 +1710,7 @@ func (w *walker) emitScopeEdge(n *sitter.Node, scope []string) error {
 		ParentQualified: source,
 		LineStart:       line,
 		LineEnd:         line,
+		Docstring:       docstringFor(n, w.source),
 	}); err != nil {
 		return err
 	}

--- a/internal/extract/rust/docstring.go
+++ b/internal/extract/rust/docstring.go
@@ -1,0 +1,148 @@
+package rust
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+)
+
+// docstringFor returns the rustdoc-style doc comment attached to the
+// given item node, or "" if none is attached. Outer doc comments
+// (`///` and `/** … */`) attach; `attribute_item` nodes in between
+// are skipped per rustdoc convention; a blank line between any
+// adjacent pair detaches.
+func docstringFor(node *sitter.Node, source []byte) string {
+	if node == nil {
+		return ""
+	}
+	var blocks []string
+	cur := node
+	for {
+		prev := cur.PrevNamedSibling()
+		if prev == nil {
+			break
+		}
+		if prev.Kind() == "attribute_item" {
+			if hasBlankLineGap(source, prev.EndByte(), cur.StartByte()) {
+				break
+			}
+			cur = prev
+			continue
+		}
+		if prev.Kind() != "line_comment" && prev.Kind() != "block_comment" {
+			break
+		}
+		if !isOuterDocComment(prev) {
+			break
+		}
+		if hasBlankLineGap(source, prev.EndByte(), cur.StartByte()) {
+			break
+		}
+		blocks = append([]string{extractDocBody(prev, source)}, blocks...)
+		cur = prev
+	}
+	if len(blocks) == 0 {
+		return ""
+	}
+	out := strings.TrimRight(strings.Join(blocks, "\n"), "\n")
+	if out == "" || !utf8.ValidString(out) {
+		return ""
+	}
+	for _, line := range strings.Split(out, "\n") {
+		t := strings.TrimSpace(line)
+		if t == "" {
+			continue
+		}
+		if isLicenseHeader(t) {
+			return ""
+		}
+		break
+	}
+	return out
+}
+
+// isOuterDocComment reports whether a `line_comment` or `block_comment`
+// node is an outer doc comment (`///` or `/** … */`). The grammar
+// signals this with an `outer_doc_comment_marker` first child; regular
+// `//` and `/* */` comments have no such child.
+func isOuterDocComment(n *sitter.Node) bool {
+	if n.NamedChildCount() == 0 {
+		return false
+	}
+	return n.NamedChild(0).Kind() == "outer_doc_comment_marker"
+}
+
+// extractDocBody pulls the documentation text out of a doc-comment
+// node. The grammar's `doc_comment` child holds the body with outer
+// markers already stripped; this helper drops the per-line `*`
+// continuation prefix and surrounding blank lines.
+func extractDocBody(n *sitter.Node, source []byte) string {
+	var body string
+	for i := uint(0); i < n.NamedChildCount(); i++ {
+		c := n.NamedChild(i)
+		if c != nil && c.Kind() == "doc_comment" {
+			body = extract.Text(c, source)
+			break
+		}
+	}
+	if body == "" {
+		return ""
+	}
+	lines := strings.Split(body, "\n")
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		trimmed = strings.TrimPrefix(trimmed, "*")
+		trimmed = strings.TrimPrefix(trimmed, " ")
+		out = append(out, trimmed)
+	}
+	for len(out) > 0 && out[0] == "" {
+		out = out[1:]
+	}
+	for len(out) > 0 && out[len(out)-1] == "" {
+		out = out[:len(out)-1]
+	}
+	return strings.Join(out, "\n")
+}
+
+// hasBlankLineGap reports whether the byte range [start, end) in source
+// contains a blank line. Unlike the Go/TS extractors, the Rust grammar
+// includes the trailing `\n` inside `line_comment` ranges — so this
+// helper compensates: if `start` points to a byte just past a `\n`, we
+// roll start back one so the comment's terminator is counted as part
+// of the inter-node gap. With that adjustment a blank line is always
+// `\n\n` regardless of whether the previous neighbour was a line- or
+// block-comment.
+func hasBlankLineGap(source []byte, start, end uint) bool {
+	if start > 0 && source[start-1] == '\n' {
+		start--
+	}
+	if start >= end || end > uint(len(source)) {
+		return false
+	}
+	nl := 0
+	for _, b := range source[start:end] {
+		switch b {
+		case '\n':
+			nl++
+			if nl >= 2 {
+				return true
+			}
+		case ' ', '\t', '\r':
+			// horizontal whitespace doesn't reset
+		default:
+			nl = 0
+		}
+	}
+	return false
+}
+
+// isLicenseHeader recognises file-top headers that must not be
+// promoted into a symbol's docstring.
+func isLicenseHeader(line string) bool {
+	return strings.HasPrefix(line, "Copyright") ||
+		strings.HasPrefix(line, "SPDX-")
+}

--- a/internal/extract/rust/docstring.go
+++ b/internal/extract/rust/docstring.go
@@ -15,9 +15,6 @@ import (
 // are skipped per rustdoc convention; a blank line between any
 // adjacent pair detaches.
 func docstringFor(node *sitter.Node, source []byte) string {
-	if node == nil {
-		return ""
-	}
 	var blocks []string
 	cur := node
 	for {
@@ -51,15 +48,14 @@ func docstringFor(node *sitter.Node, source []byte) string {
 	if out == "" || !utf8.ValidString(out) {
 		return ""
 	}
-	for _, line := range strings.Split(out, "\n") {
-		t := strings.TrimSpace(line)
-		if t == "" {
-			continue
-		}
-		if isLicenseHeader(t) {
-			return ""
-		}
-		break
+	// extractDocBody strips leading blank lines per block, so the join's
+	// first line is the first non-blank line of the run.
+	firstLine := out
+	if idx := strings.IndexByte(out, '\n'); idx >= 0 {
+		firstLine = out[:idx]
+	}
+	if isLicenseHeader(strings.TrimSpace(firstLine)) {
+		return ""
 	}
 	return out
 }
@@ -88,9 +84,6 @@ func extractDocBody(n *sitter.Node, source []byte) string {
 			break
 		}
 	}
-	if body == "" {
-		return ""
-	}
 	lines := strings.Split(body, "\n")
 	out := make([]string, 0, len(lines))
 	for _, line := range lines {
@@ -116,25 +109,23 @@ func extractDocBody(n *sitter.Node, source []byte) string {
 // of the inter-node gap. With that adjustment a blank line is always
 // `\n\n` regardless of whether the previous neighbour was a line- or
 // block-comment.
+//
+// Gap rule: only `\n` counts — non-newline bytes are transparent. Safe
+// under tree-sitter's invariant that inter-named-sibling gaps contain
+// only whitespace. Caller guarantees start <= end <= len(source); the
+// callers in docstringFor pass prev.EndByte() and cur.StartByte() of
+// adjacent named siblings, which satisfies that by tree ordering.
 func hasBlankLineGap(source []byte, start, end uint) bool {
 	if start > 0 && source[start-1] == '\n' {
 		start--
 	}
-	if start >= end || end > uint(len(source)) {
-		return false
-	}
 	nl := 0
 	for _, b := range source[start:end] {
-		switch b {
-		case '\n':
+		if b == '\n' {
 			nl++
 			if nl >= 2 {
 				return true
 			}
-		case ' ', '\t', '\r':
-			// horizontal whitespace doesn't reset
-		default:
-			nl = 0
 		}
 	}
 	return false

--- a/internal/extract/rust/docstring_test.go
+++ b/internal/extract/rust/docstring_test.go
@@ -227,3 +227,55 @@ func TestDocstring_MalformedUTF8(t *testing.T) {
 		t.Errorf("Docstring on malformed-UTF-8 = %q, want \"\"", sym.Docstring)
 	}
 }
+
+// TestHasBlankLineGap_Contract pins the post-simplification contract of
+// the gap helper directly, since the inline copies in the Go/Ruby/TS
+// extractors share the same shape. Two cases matter:
+//
+//  1. `\n \n` (whitespace-only gap) returns true — the real-input case,
+//     produced by tree-sitter for blank-line-separated siblings.
+//  2. `\nX\n` (stray non-newline byte between two newlines) returns true
+//     too — documents the simplification: non-newline bytes are
+//     transparent. The previous switch-based form would have returned
+//     false here. Tree-sitter doesn't produce this shape today; pinning
+//     it makes the contract change visible if a future grammar bump
+//     ever does.
+func TestHasBlankLineGap_Contract(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		src     string
+		s, e    uint
+		want    bool
+	}{
+		{"whitespace-only blank gap", "a\n \nb", 1, 4, true},
+		{"non-newline byte transparent", "a\nx\nb", 1, 4, true},
+		{"single newline is not blank", "a\nb", 1, 2, false},
+		{"no newlines is not blank", "abc", 1, 2, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasBlankLineGap([]byte(tc.src), tc.s, tc.e); got != tc.want {
+				t.Errorf("hasBlankLineGap(%q, %d, %d) = %v, want %v", tc.src, tc.s, tc.e, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDocstring_BlankLineAfterAttribute pins that a blank line between
+// the attribute_item and the item it decorates detaches any `///`
+// above the attribute. Without this, a visually-separated derive macro
+// would silently carry doc text from above into the struct.
+func TestDocstring_BlankLineAfterAttribute(t *testing.T) {
+	src := `/// orphaned doc above attribute
+#[derive(Debug)]
+
+struct Detached {}
+`
+	r := parse(t, src)
+	sym := findSymbol(r, "Detached")
+	if sym == nil {
+		t.Fatalf("symbol Detached missing")
+	}
+	if sym.Docstring != "" {
+		t.Errorf("Docstring = %q, want \"\" (blank line below attribute detaches the chain)", sym.Docstring)
+	}
+}

--- a/internal/extract/rust/docstring_test.go
+++ b/internal/extract/rust/docstring_test.go
@@ -1,0 +1,229 @@
+package rust
+
+import (
+	"testing"
+)
+
+// TestDocstring_TripleSlash pins case (a): a run of `///` lines above
+// `fn foo` attaches as the exact joined text, leading-space-after-
+// slashes stripped per rustdoc convention.
+func TestDocstring_TripleSlash(t *testing.T) {
+	src := `/// foo computes the answer.
+/// Across two lines.
+fn foo() {}
+`
+	r := parse(t, src)
+	sym := findSymbol(r, "foo")
+	if sym == nil {
+		t.Fatalf("symbol foo missing")
+	}
+	want := "foo computes the answer.\nAcross two lines."
+	if sym.Docstring != want {
+		t.Errorf("Docstring = %q, want %q", sym.Docstring, want)
+	}
+}
+
+// TestDocstring_BlockComment pins case (b): a `/** … */` block above a
+// `struct Bar` attaches as the body text with `/**`, `*/`, and the
+// per-line `*` continuation prefix stripped. The grammar exposes a
+// `doc_comment` child node whose body already excludes the outer
+// markers; the per-line strip pass handles the inner ` * ` prefix.
+func TestDocstring_BlockComment(t *testing.T) {
+	src := `/**
+ * Bar is a documented struct.
+ * Second line.
+ */
+struct Bar {}
+`
+	r := parse(t, src)
+	sym := findSymbol(r, "Bar")
+	if sym == nil {
+		t.Fatalf("symbol Bar missing")
+	}
+	want := "Bar is a documented struct.\nSecond line."
+	if sym.Docstring != want {
+		t.Errorf("Docstring = %q, want %q", sym.Docstring, want)
+	}
+}
+
+// TestDocstring_AttributeSkipped pins case (c): a `#[derive(Debug)]`
+// attribute between the `///` comment and the struct must NOT break
+// attachment. The walker steps over attribute_item nodes when looking
+// for the preceding doc comment. Without this skip, every derive-
+// macro'd struct in the codebase would silently lose its docstring.
+func TestDocstring_AttributeSkipped(t *testing.T) {
+	src := `/// Skipping attributes works.
+#[derive(Debug, Clone)]
+struct Wrapped {}
+`
+	r := parse(t, src)
+	sym := findSymbol(r, "Wrapped")
+	if sym == nil {
+		t.Fatalf("symbol Wrapped missing")
+	}
+	want := "Skipping attributes works."
+	if sym.Docstring != want {
+		t.Errorf("Docstring = %q, want %q (attribute_item must be skipped, not block attachment)", sym.Docstring, want)
+	}
+}
+
+// TestDocstring_AttributeOnlyNoDoc pins case (d): an attribute above
+// an item with NO `///` comment above the attribute must yield empty
+// docstring. Distinguishes "attribute filtered" from "comment found
+// by accident": without this, the walker might emit attribute text.
+func TestDocstring_AttributeOnlyNoDoc(t *testing.T) {
+	src := `#[derive(Debug)]
+struct Bare {}
+`
+	r := parse(t, src)
+	sym := findSymbol(r, "Bare")
+	if sym == nil {
+		t.Fatalf("symbol Bare missing")
+	}
+	if sym.Docstring != "" {
+		t.Errorf("Docstring = %q, want \"\" (attribute alone is not documentation)", sym.Docstring)
+	}
+}
+
+// TestDocstring_BlankLineGap pins case (e): a blank line between `///`
+// and the item detaches the comment. The next item below (with its own
+// `///` and no gap) must still attach — proves the helper doesn't
+// poison forward attachment.
+func TestDocstring_BlankLineGap(t *testing.T) {
+	src := `/// Orphaned line.
+
+fn detached() {}
+
+/// Attached doc.
+fn attached() {}
+`
+	r := parse(t, src)
+	det := findSymbol(r, "detached")
+	att := findSymbol(r, "attached")
+	if det == nil || att == nil {
+		t.Fatalf("missing symbols: detached=%v attached=%v", det, att)
+	}
+	if det.Docstring != "" {
+		t.Errorf("detached.Docstring = %q, want \"\" (blank-line gap detaches)", det.Docstring)
+	}
+	if att.Docstring != "Attached doc." {
+		t.Errorf("attached.Docstring = %q, want \"Attached doc.\"", att.Docstring)
+	}
+}
+
+// TestDocstring_PlainLineCommentIgnored pins that a plain `// foo`
+// comment (no third slash) is NOT a doc comment and yields empty
+// docstring. The grammar distinguishes via the outer_doc_comment_marker
+// child; this test pins that we check that, not just kind=="line_comment".
+func TestDocstring_PlainLineCommentIgnored(t *testing.T) {
+	src := `// not a doc comment
+fn plain() {}
+`
+	r := parse(t, src)
+	sym := findSymbol(r, "plain")
+	if sym == nil {
+		t.Fatalf("symbol plain missing")
+	}
+	if sym.Docstring != "" {
+		t.Errorf("Docstring = %q, want \"\" (`//` is not a doc comment)", sym.Docstring)
+	}
+}
+
+// TestDocstring_ConstAndModAndTrait pins wiring at the const, module,
+// and trait (via handleTypeDef) emit sites. Without per-site coverage
+// a wiring miss on any one would silently regress users of those
+// item kinds.
+func TestDocstring_ConstAndModAndTrait(t *testing.T) {
+	src := `/// MAX_RETRIES caps the loop.
+const MAX_RETRIES: u32 = 3;
+
+/// shapes module.
+mod shapes {
+    /// Drawable can be drawn.
+    pub trait Drawable {
+        /// draw renders to a canvas.
+        fn draw(&self);
+    }
+}
+`
+	r := parse(t, src)
+	for _, want := range []struct {
+		qual, doc string
+	}{
+		{"MAX_RETRIES", "MAX_RETRIES caps the loop."},
+		{"shapes", "shapes module."},
+		{"shapes::Drawable", "Drawable can be drawn."},
+		{"shapes::Drawable::draw", "draw renders to a canvas."},
+	} {
+		sym := findSymbol(r, want.qual)
+		if sym == nil {
+			t.Errorf("symbol %s missing", want.qual)
+			continue
+		}
+		if sym.Docstring != want.doc {
+			t.Errorf("%s.Docstring = %q, want %q", want.qual, sym.Docstring, want.doc)
+		}
+	}
+}
+
+// TestDocstring_ImplMethod pins the impl-method emit site
+// (handleImpl). Without this test a wiring miss on impl-method
+// docstrings would not be caught by the trait or top-level function
+// tests above.
+func TestDocstring_ImplMethod(t *testing.T) {
+	src := `struct Point;
+
+impl Point {
+    /// origin returns the zero point.
+    pub fn origin() -> Self {
+        Point
+    }
+}
+`
+	r := parse(t, src)
+	sym := findSymbol(r, "Point::origin")
+	if sym == nil {
+		t.Fatalf("symbol Point::origin missing")
+	}
+	want := "origin returns the zero point."
+	if sym.Docstring != want {
+		t.Errorf("Docstring = %q, want %q", sym.Docstring, want)
+	}
+}
+
+// TestDocstring_LicenseHeaderFiltered pins the Copyright/SPDX filter
+// in Rust context.
+func TestDocstring_LicenseHeaderFiltered(t *testing.T) {
+	src := `/// Copyright 2026 Acme Inc.
+struct First {}
+
+/// Second is documented.
+struct Second {}
+`
+	r := parse(t, src)
+	first := findSymbol(r, "First")
+	second := findSymbol(r, "Second")
+	if first == nil || second == nil {
+		t.Fatalf("missing symbols: first=%v second=%v", first, second)
+	}
+	if first.Docstring != "" {
+		t.Errorf("First.Docstring = %q, want \"\" (license header filter)", first.Docstring)
+	}
+	if second.Docstring != "Second is documented." {
+		t.Errorf("Second.Docstring = %q, want \"Second is documented.\"", second.Docstring)
+	}
+}
+
+// TestDocstring_MalformedUTF8 pins that invalid UTF-8 in a doc
+// comment yields empty docstring without panicking.
+func TestDocstring_MalformedUTF8(t *testing.T) {
+	src := "/// junk \x80\nfn bad() {}\n"
+	r := parse(t, src)
+	sym := findSymbol(r, "bad")
+	if sym == nil {
+		t.Fatalf("symbol bad missing")
+	}
+	if sym.Docstring != "" {
+		t.Errorf("Docstring on malformed-UTF-8 = %q, want \"\"", sym.Docstring)
+	}
+}

--- a/internal/extract/rust/rust.go
+++ b/internal/extract/rust/rust.go
@@ -311,6 +311,7 @@ func (w *walker) handleTypeDef(n *sitter.Node, scope []string, kind model.Symbol
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
+		Docstring:       docstringFor(n, w.source),
 	}); err != nil {
 		return err
 	}
@@ -360,6 +361,7 @@ func (w *walker) handleConstItem(n *sitter.Node, scope []string) error {
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
+		Docstring:       docstringFor(n, w.source),
 	})
 }
 
@@ -385,6 +387,7 @@ func (w *walker) handleFunction(n *sitter.Node, scope []string) error {
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
+		Docstring:       docstringFor(n, w.source),
 	}); err != nil {
 		return err
 	}
@@ -455,6 +458,7 @@ func (w *walker) handleImpl(n *sitter.Node, scope []string) error {
 			ParentQualified: typeQualified,
 			LineStart:       extract.Line(child.StartPosition()),
 			LineEnd:         extract.Line(child.EndPosition()),
+			Docstring:       docstringFor(child, w.source),
 		}); err != nil {
 			return err
 		}
@@ -561,6 +565,7 @@ func (w *walker) handleMod(n *sitter.Node, scope []string) error {
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
+		Docstring:       docstringFor(n, w.source),
 	}); err != nil {
 		return err
 	}
@@ -620,6 +625,7 @@ func (w *walker) emitTraitMethods(traitNode *sitter.Node, traitQualified string)
 			ParentQualified: traitQualified,
 			LineStart:       extract.Line(child.StartPosition()),
 			LineEnd:         extract.Line(child.EndPosition()),
+			Docstring:       docstringFor(child, w.source),
 		}); err != nil {
 			return err
 		}

--- a/internal/extract/tsjs/docstring.go
+++ b/internal/extract/tsjs/docstring.go
@@ -16,9 +16,6 @@ import (
 // the target is the first child, so JSDoc above a wrapper reaches the
 // inner declaration.
 func docstringFor(node *sitter.Node, source []byte) string {
-	if node == nil {
-		return ""
-	}
 	cur := node
 	for cur.Parent() != nil && isJSDocWrapper(cur.Parent().Kind()) && cur.PrevNamedSibling() == nil {
 		cur = cur.Parent()
@@ -33,20 +30,18 @@ func docstringFor(node *sitter.Node, source []byte) string {
 		if !isJSDocText(text) {
 			break // a `//` or plain `/*` comment ends the JSDoc chain
 		}
+		// Gap rule: see golang/docstring.go for the contract — only `\n`
+		// matters; non-newline bytes are transparent. Safe under tree-
+		// sitter's whitespace-only-between-siblings invariant.
 		gap := source[prev.EndByte():cur.StartByte()]
 		nl := 0
 		blank := false
 		for _, b := range gap {
-			switch b {
-			case '\n':
+			if b == '\n' {
 				nl++
 				if nl >= 2 {
 					blank = true
 				}
-			case ' ', '\t', '\r':
-				// horizontal whitespace doesn't reset
-			default:
-				nl = 0
 			}
 		}
 		if blank {

--- a/internal/extract/tsjs/docstring.go
+++ b/internal/extract/tsjs/docstring.go
@@ -1,0 +1,141 @@
+package tsjs
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+)
+
+// docstringFor returns the JSDoc comment attached to the given
+// declaration node, or "" if none is attached. Only `/** … */` blocks
+// count as JSDoc; plain `//` and plain `/* … */` break the chain.
+// Transparent wrappers (see isJSDocWrapper) are walked through when
+// the target is the first child, so JSDoc above a wrapper reaches the
+// inner declaration.
+func docstringFor(node *sitter.Node, source []byte) string {
+	if node == nil {
+		return ""
+	}
+	cur := node
+	for cur.Parent() != nil && isJSDocWrapper(cur.Parent().Kind()) && cur.PrevNamedSibling() == nil {
+		cur = cur.Parent()
+	}
+	var comments []*sitter.Node
+	for {
+		prev := cur.PrevNamedSibling()
+		if prev == nil || prev.Kind() != "comment" {
+			break
+		}
+		text := extract.Text(prev, source)
+		if !isJSDocText(text) {
+			break // a `//` or plain `/*` comment ends the JSDoc chain
+		}
+		gap := source[prev.EndByte():cur.StartByte()]
+		nl := 0
+		blank := false
+		for _, b := range gap {
+			switch b {
+			case '\n':
+				nl++
+				if nl >= 2 {
+					blank = true
+				}
+			case ' ', '\t', '\r':
+				// horizontal whitespace doesn't reset
+			default:
+				nl = 0
+			}
+		}
+		if blank {
+			break
+		}
+		comments = append([]*sitter.Node{prev}, comments...)
+		cur = prev
+	}
+	if len(comments) == 0 {
+		return ""
+	}
+	return formatJSDocComments(comments, source)
+}
+
+// isJSDocWrapper reports whether a node kind is a transparent wrapper
+// that JSDoc may sit above rather than next to the inner declaration.
+func isJSDocWrapper(kind string) bool {
+	switch kind {
+	case "lexical_declaration", "variable_declaration", "export_statement":
+		return true
+	}
+	return false
+}
+
+// isJSDocText reports whether a comment node's raw text is a JSDoc
+// block (`/** … */`). Plain `//` and `/* … */` (single-star) are not
+// documentation per JSDoc convention.
+func isJSDocText(text string) bool {
+	return strings.HasPrefix(text, "/**") && strings.HasSuffix(text, "*/")
+}
+
+// formatJSDocComments joins JSDoc blocks into a single docstring,
+// stripping `/**`, `*/`, and the conventional ` * ` continuation
+// prefix from each line. License and invalid-UTF-8 filters apply.
+func formatJSDocComments(nodes []*sitter.Node, source []byte) string {
+	var lines []string
+	for _, n := range nodes {
+		lines = append(lines, stripCommentMarkers(extract.Text(n, source))...)
+	}
+	firstIdx := -1
+	for i, l := range lines {
+		if strings.TrimSpace(l) != "" {
+			firstIdx = i
+			break
+		}
+	}
+	if firstIdx < 0 {
+		return ""
+	}
+	first := strings.TrimSpace(lines[firstIdx])
+	if isLicenseHeader(first) {
+		return ""
+	}
+	out := strings.Join(lines, "\n")
+	if !utf8.ValidString(out) {
+		return ""
+	}
+	return strings.TrimRight(out, "\n")
+}
+
+// stripCommentMarkers turns one JSDoc block's raw text into body lines:
+// strips the opening `/**` and closing `*/`, then strips the leading
+// ` * ` continuation prefix from each interior line and one optional
+// leading space from the first/last line. Leading and trailing empty
+// lines (the convention `/**\n * body\n */` introduces) are dropped;
+// internal blank lines are preserved.
+func stripCommentMarkers(text string) []string {
+	body := strings.TrimPrefix(text, "/**")
+	body = strings.TrimSuffix(body, "*/")
+	raw := strings.Split(body, "\n")
+	out := make([]string, 0, len(raw))
+	for _, line := range raw {
+		trimmed := strings.TrimSpace(line)
+		trimmed = strings.TrimPrefix(trimmed, "*")
+		trimmed = strings.TrimPrefix(trimmed, " ")
+		out = append(out, trimmed)
+	}
+	for len(out) > 0 && out[0] == "" {
+		out = out[1:]
+	}
+	for len(out) > 0 && out[len(out)-1] == "" {
+		out = out[:len(out)-1]
+	}
+	return out
+}
+
+// isLicenseHeader recognises the conventional file-top headers that
+// must not be promoted into a symbol's docstring.
+func isLicenseHeader(line string) bool {
+	return strings.HasPrefix(line, "Copyright") ||
+		strings.HasPrefix(line, "SPDX-")
+}

--- a/internal/extract/tsjs/docstring_test.go
+++ b/internal/extract/tsjs/docstring_test.go
@@ -1,0 +1,275 @@
+package tsjs
+
+import (
+	"testing"
+)
+
+// TestDocstring_FunctionClassConst pins case (a): a JSDoc block above a
+// function, a class, and a const each attaches as the exact comment
+// text, markers stripped. One test, three targets — covers the wiring
+// at handleFunction, emitClassWithBody, and handleVariableDeclarator.
+func TestDocstring_FunctionClassConst(t *testing.T) {
+	src := `/** Sum returns the sum of a and b. */
+function sum(a: number, b: number) { return a + b }
+
+/** Greeter says hello. */
+class Greeter {}
+
+/** PI is the constant. */
+const PI = 3.14
+`
+	r := parseTS(t, src, "test.ts")
+	for _, want := range []struct {
+		qual, doc string
+	}{
+		{"sum", "Sum returns the sum of a and b."},
+		{"Greeter", "Greeter says hello."},
+		{"PI", "PI is the constant."},
+	} {
+		sym := findSym(r, want.qual)
+		if sym == nil {
+			t.Errorf("symbol %s missing", want.qual)
+			continue
+		}
+		if sym.Docstring != want.doc {
+			t.Errorf("%s.Docstring = %q, want %q", want.qual, sym.Docstring, want.doc)
+		}
+	}
+}
+
+// TestDocstring_AtParamPreserved pins case (b): @param annotations
+// are stored byte-for-byte (no special parsing, no stripping of the
+// @ tag — JSDoc tag semantics are out of scope; preservation is in).
+func TestDocstring_AtParamPreserved(t *testing.T) {
+	src := `/**
+ * Transfer moves money between accounts.
+ * @param from source account
+ * @param amount cents
+ */
+function transfer(from: string, amount: number) {}
+`
+	r := parseTS(t, src, "test.ts")
+	sym := findSym(r, "transfer")
+	if sym == nil {
+		t.Fatalf("symbol transfer missing")
+	}
+	want := "Transfer moves money between accounts.\n@param from source account\n@param amount cents"
+	if sym.Docstring != want {
+		t.Errorf("Docstring = %q, want %q", sym.Docstring, want)
+	}
+}
+
+// TestDocstring_ExportDefault pins case (c): JSDoc above `export
+// default function` must reach the default-exported function symbol.
+// This exercises the export_statement walk-up — without it, the
+// function_declaration's PrevNamedSibling is nil because the comment
+// lives one level up.
+func TestDocstring_ExportDefault(t *testing.T) {
+	src := `/** Default doc applies to the export. */
+export default function qux() {}
+`
+	r := parseTS(t, src, "test.ts")
+	sym := findSym(r, "qux")
+	if sym == nil {
+		t.Fatalf("symbol qux missing")
+	}
+	want := "Default doc applies to the export."
+	if sym.Docstring != want {
+		t.Errorf("Docstring = %q, want %q", sym.Docstring, want)
+	}
+}
+
+// TestDocstring_ArrowFunction pins case (d): JSDoc above
+// `const x = () => {}` must reach the const symbol. Exercises the
+// lexical_declaration walk-up — the JSDoc is above the declaration,
+// not the inner variable_declarator that emits the symbol.
+func TestDocstring_ArrowFunction(t *testing.T) {
+	src := `/** doc for arrow */
+const arrow = () => 1
+`
+	r := parseTS(t, src, "test.ts")
+	sym := findSym(r, "arrow")
+	if sym == nil {
+		t.Fatalf("symbol arrow missing")
+	}
+	want := "doc for arrow"
+	if sym.Docstring != want {
+		t.Errorf("Docstring = %q, want %q", sym.Docstring, want)
+	}
+}
+
+// TestDocstring_DecoratorThroughClass pins case (e): a JSDoc block
+// above a decorated class must reach the class with the decorator-
+// argument text NOT mistaken for the docstring. The conservative
+// danger here is a "find the first comment-like thing inside the
+// class" implementation pulling the decorator's identifier as
+// docstring text — which is silent corruption.
+func TestDocstring_DecoratorThroughClass(t *testing.T) {
+	src := `/** Cls is the documented class. */
+@Component()
+class Cls {}
+`
+	r := parseTS(t, src, "test.ts")
+	sym := findSym(r, "Cls")
+	if sym == nil {
+		t.Fatalf("symbol Cls missing")
+	}
+	want := "Cls is the documented class."
+	if sym.Docstring != want {
+		t.Errorf("Docstring = %q, want %q (must reach class through decorator, not pull decorator argument)", sym.Docstring, want)
+	}
+}
+
+// TestDocstring_PlainSlashSlashIgnored pins case (f): a plain `//`
+// comment above a function is NOT JSDoc and must yield empty docstring.
+// This guards against an implementation that treats all comments
+// uniformly.
+func TestDocstring_PlainSlashSlashIgnored(t *testing.T) {
+	src := `// not a JSDoc comment
+function noDoc() {}
+`
+	r := parseTS(t, src, "test.ts")
+	sym := findSym(r, "noDoc")
+	if sym == nil {
+		t.Fatalf("symbol noDoc missing")
+	}
+	if sym.Docstring != "" {
+		t.Errorf("Docstring = %q, want \"\" (`//` is not JSDoc)", sym.Docstring)
+	}
+}
+
+// TestDocstring_BlankLineGap pins case (g): a blank line between a
+// JSDoc block and the function detaches the comment. The next function
+// (with its own JSDoc, no gap) must still attach correctly — proves
+// the helper doesn't poison forward attachment.
+func TestDocstring_BlankLineGap(t *testing.T) {
+	src := `/** Orphan doc. */
+
+function detached() {}
+
+/** Attached doc. */
+function attached() {}
+`
+	r := parseTS(t, src, "test.ts")
+	det := findSym(r, "detached")
+	att := findSym(r, "attached")
+	if det == nil || att == nil {
+		t.Fatalf("missing symbols: detached=%v attached=%v", det, att)
+	}
+	if det.Docstring != "" {
+		t.Errorf("detached.Docstring = %q, want \"\" (blank-line gap detaches)", det.Docstring)
+	}
+	if att.Docstring != "Attached doc." {
+		t.Errorf("attached.Docstring = %q, want \"Attached doc.\"", att.Docstring)
+	}
+}
+
+// TestDocstring_PlainSlashStarIgnored pins that plain `/* … */`
+// (single star) is NOT JSDoc either. JSDoc requires the double-star
+// `/**`. Without this test, the strip helper might silently treat
+// every block comment as documentation.
+func TestDocstring_PlainSlashStarIgnored(t *testing.T) {
+	src := `/* plain block, not JSDoc */
+function f() {}
+`
+	r := parseTS(t, src, "test.ts")
+	sym := findSym(r, "f")
+	if sym == nil {
+		t.Fatalf("symbol f missing")
+	}
+	if sym.Docstring != "" {
+		t.Errorf("Docstring = %q, want \"\" (single-star block is not JSDoc)", sym.Docstring)
+	}
+}
+
+// TestDocstring_InterfaceTypeAliasEnum pins wiring at the remaining
+// emit sites the pitch identifies (handleInterface, handleTypeAlias,
+// handleEnum). Without per-site coverage a wiring miss on any one
+// would silently regress users who document their type-only API.
+func TestDocstring_InterfaceTypeAliasEnum(t *testing.T) {
+	src := `/** Account is an account contract. */
+interface Account { id: string }
+
+/** UserID is a branded string. */
+type UserID = string
+
+/** Color enumerates the brand palette. */
+enum Color { Red, Green }
+`
+	r := parseTS(t, src, "test.ts")
+	for _, want := range []struct {
+		qual, doc string
+	}{
+		{"Account", "Account is an account contract."},
+		{"UserID", "UserID is a branded string."},
+		{"Color", "Color enumerates the brand palette."},
+	} {
+		sym := findSym(r, want.qual)
+		if sym == nil {
+			t.Errorf("symbol %s missing", want.qual)
+			continue
+		}
+		if sym.Docstring != want.doc {
+			t.Errorf("%s.Docstring = %q, want %q", want.qual, sym.Docstring, want.doc)
+		}
+	}
+}
+
+// TestDocstring_ClassMethod pins that JSDoc on a class method (inside
+// the class body) attaches. Without this test, a wiring miss on
+// handleMethod would not be caught — the body-level walk is its own
+// path through docstringFor.
+func TestDocstring_ClassMethod(t *testing.T) {
+	src := `class Service {
+  /** doStuff is a method. */
+  doStuff() {}
+}
+`
+	r := parseTS(t, src, "test.ts")
+	sym := findSym(r, "Service.doStuff")
+	if sym == nil {
+		t.Fatalf("symbol Service.doStuff missing")
+	}
+	want := "doStuff is a method."
+	if sym.Docstring != want {
+		t.Errorf("Docstring = %q, want %q", sym.Docstring, want)
+	}
+}
+
+// TestDocstring_LicenseHeaderFiltered pins the Copyright/SPDX filter
+// in TS/JS context. A license header directly above a class must not
+// attach; the next class below must still get its own JSDoc.
+func TestDocstring_LicenseHeaderFiltered(t *testing.T) {
+	src := `/** Copyright 2026 Acme Inc. */
+class First {}
+
+/** Second is documented. */
+class Second {}
+`
+	r := parseTS(t, src, "test.ts")
+	first := findSym(r, "First")
+	second := findSym(r, "Second")
+	if first == nil || second == nil {
+		t.Fatalf("missing symbols: first=%v second=%v", first, second)
+	}
+	if first.Docstring != "" {
+		t.Errorf("First.Docstring = %q, want \"\" (license header filter)", first.Docstring)
+	}
+	if second.Docstring != "Second is documented." {
+		t.Errorf("Second.Docstring = %q, want \"Second is documented.\"", second.Docstring)
+	}
+}
+
+// TestDocstring_MalformedUTF8 pins that invalid UTF-8 bytes in a JSDoc
+// comment yield empty docstring and do not panic.
+func TestDocstring_MalformedUTF8(t *testing.T) {
+	src := "/** junk \x80 */\nfunction bad() {}\n"
+	r := parseTS(t, src, "test.ts")
+	sym := findSym(r, "bad")
+	if sym == nil {
+		t.Fatalf("symbol bad missing")
+	}
+	if sym.Docstring != "" {
+		t.Errorf("Docstring on malformed-UTF-8 comment = %q, want \"\"", sym.Docstring)
+	}
+}

--- a/internal/extract/tsjs/docstring_test.go
+++ b/internal/extract/tsjs/docstring_test.go
@@ -273,3 +273,25 @@ func TestDocstring_MalformedUTF8(t *testing.T) {
 		t.Errorf("Docstring on malformed-UTF-8 comment = %q, want \"\"", sym.Docstring)
 	}
 }
+
+// TestDocstring_AllBlankJSDoc pins that a JSDoc block whose body is
+// only the wrapper markers (e.g. `/** */`) does not panic the extractor
+// and yields "". The explicit recover guards the load-bearing path:
+// formatJSDocComments must handle the empty-body case without indexing
+// lines[firstIdx] when firstIdx is -1.
+func TestDocstring_AllBlankJSDoc(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("extractor panicked on body-less JSDoc: %v", r)
+		}
+	}()
+	src := "/** */\nfunction hush() {}\n"
+	r := parseTS(t, src, "test.ts")
+	sym := findSym(r, "hush")
+	if sym == nil {
+		t.Fatalf("symbol hush missing")
+	}
+	if sym.Docstring != "" {
+		t.Errorf("Docstring on body-less JSDoc = %q, want \"\"", sym.Docstring)
+	}
+}

--- a/internal/extract/tsjs/tsjs.go
+++ b/internal/extract/tsjs/tsjs.go
@@ -296,6 +296,7 @@ func (w *walker) emitClassWithBody(n *sitter.Node, name string, scope []string) 
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
+		Docstring:       docstringFor(n, w.source),
 	}); err != nil {
 		return err
 	}
@@ -429,6 +430,7 @@ func (w *walker) handleMethod(n *sitter.Node, scope []string) error {
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
+		Docstring:       docstringFor(n, w.source),
 	}); err != nil {
 		return err
 	}
@@ -461,6 +463,7 @@ func (w *walker) handleInterface(n *sitter.Node, scope []string) error {
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
+		Docstring:       docstringFor(n, w.source),
 	}); err != nil {
 		return err
 	}
@@ -501,6 +504,7 @@ func (w *walker) handleTypeAlias(n *sitter.Node, scope []string) error {
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
+		Docstring:       docstringFor(n, w.source),
 	}); err != nil {
 		return err
 	}
@@ -625,6 +629,7 @@ func (w *walker) handleEnum(n *sitter.Node, scope []string) error {
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
+		Docstring:       docstringFor(n, w.source),
 	})
 }
 
@@ -659,6 +664,7 @@ func (w *walker) emitFunctionWithBody(n *sitter.Node, name string, scope []strin
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
+		Docstring:       docstringFor(n, w.source),
 	}); err != nil {
 		return err
 	}
@@ -725,6 +731,7 @@ func (w *walker) handleVariableDeclarator(decl *sitter.Node, scope []string) err
 		ParentQualified: parent,
 		LineStart:       extract.Line(decl.StartPosition()),
 		LineEnd:         extract.Line(decl.EndPosition()),
+		Docstring:       docstringFor(decl, w.source),
 	}); err != nil {
 		return err
 	}

--- a/internal/scan/capdocstring_test.go
+++ b/internal/scan/capdocstring_test.go
@@ -1,0 +1,60 @@
+package scan
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCapDocstring_UnderCap returns the input unchanged.
+func TestCapDocstring_UnderCap(t *testing.T) {
+	in := "short docstring"
+	got := capDocstring(in)
+	if got != in {
+		t.Errorf("capDocstring(%q) = %q, want unchanged", in, got)
+	}
+}
+
+// TestCapDocstring_AtCap returns the input unchanged at the boundary.
+func TestCapDocstring_AtCap(t *testing.T) {
+	in := strings.Repeat("a", docstringMaxBytes)
+	got := capDocstring(in)
+	if got != in {
+		t.Errorf("capDocstring at exact cap mutated the value (len %d → %d)", len(in), len(got))
+	}
+}
+
+// TestCapDocstring_OverCap truncates to within the cap and appends the
+// marker. The cap is the entire raison d'être of the helper; an input
+// even one byte over the budget must come back inside it.
+func TestCapDocstring_OverCap(t *testing.T) {
+	in := strings.Repeat("a", docstringMaxBytes+1)
+	got := capDocstring(in)
+	if len(got) > docstringMaxBytes {
+		t.Errorf("len(got) = %d, want ≤ %d", len(got), docstringMaxBytes)
+	}
+	if !strings.HasSuffix(got, docstringTruncMarker) {
+		t.Errorf("missing truncation marker; tail = %q", got[max(0, len(got)-8):])
+	}
+}
+
+// TestCapDocstring_RuneBoundary cuts on a rune boundary so the appended
+// marker isn't glued to a half-multibyte sequence. Filling the buffer
+// with three-byte runes (`日`) forces the truncation point to land
+// inside a rune; the walk-back to the nearest rune start is what keeps
+// the stored UTF-8 valid.
+func TestCapDocstring_RuneBoundary(t *testing.T) {
+	in := strings.Repeat("日", (docstringMaxBytes/3)+1) // > cap, all 3-byte runes
+	got := capDocstring(in)
+	if len(got) > docstringMaxBytes {
+		t.Errorf("len(got) = %d, want ≤ %d", len(got), docstringMaxBytes)
+	}
+	// Strip the marker; the remaining prefix must be valid UTF-8 made
+	// only of `日` runes.
+	prefix := strings.TrimSuffix(got, docstringTruncMarker)
+	if strings.ContainsRune(prefix, '�') {
+		t.Errorf("prefix contains replacement rune; cut mid-rune")
+	}
+	if !strings.HasPrefix(in, prefix) {
+		t.Errorf("prefix is not a prefix of input — cut shifted past rune start")
+	}
+}

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	sitter "github.com/tree-sitter/go-tree-sitter"
 	"golang.org/x/sync/errgroup"
@@ -97,6 +98,16 @@ type Result struct {
 // Large minified lines (bundled JS, generated protos) would otherwise
 // balloon the index with source text that nobody reads.
 const snippetMaxBytes = 200
+
+// docstringMaxBytes caps the stored docstring at 2 KB. Real doc comments
+// are almost always <300 chars; the cap is a sanity bound so a pathological
+// 50 KB block comment can't bloat the symbols table.
+const docstringMaxBytes = 2048
+
+// docstringTruncMarker is appended (in place of the cut tail) when a
+// docstring exceeds docstringMaxBytes. The single rune is enough to
+// signal truncation to a reader without inflating storage.
+const docstringTruncMarker = "…"
 
 // Run ensures the .sense directory and index.db exist, walks the
 // working tree, parses each file with a registered extractor, and
@@ -1003,6 +1014,7 @@ func (h *harness) writeFileInner(fr *fileResult) (int, error) {
 			ParentID:   parentID,
 			LineStart:  s.LineStart,
 			LineEnd:    s.LineEnd,
+			Docstring:  capDocstring(s.Docstring),
 			Snippet:    snippetForLine(fr.Source, s.LineStart),
 		}
 		var id int64
@@ -1205,6 +1217,21 @@ func (c *collector) Edge(e extract.EmittedEdge) error     { c.edges = append(c.e
 func hashSource(source []byte) string {
 	sum := sha256.Sum256(source)
 	return hex.EncodeToString(sum[:8])
+}
+
+// capDocstring enforces the 2 KB storage cap on a per-symbol docstring.
+// Truncation is byte-bounded but rune-safe: cuts at the last whole rune
+// boundary before docstringMaxBytes and appends docstringTruncMarker.
+// Returns the input unchanged when within the cap.
+func capDocstring(s string) string {
+	if len(s) <= docstringMaxBytes {
+		return s
+	}
+	cut := docstringMaxBytes - len(docstringTruncMarker)
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + docstringTruncMarker
 }
 
 // snippetForLine returns the trimmed content of the given 1-indexed

--- a/internal/scan/scan_docstring_test.go
+++ b/internal/scan/scan_docstring_test.go
@@ -1,0 +1,129 @@
+package scan_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/index"
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/scan"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// docstrTestExtractor drives the scan harness without coupling Card 1's
+// wiring tests to a real per-language extractor (the per-language cards
+// land later in this pitch). It emits exactly one symbol per file whose
+// Docstring is the file's contents verbatim, so a round-trip assertion
+// compares the on-disk source bytes to what came back out of the index.
+//
+// The ".docstrwire" extension is reserved for this test file. Any other
+// test attempting to register an extractor for that extension will trip
+// the duplicate-registration panic in extract.Register.
+type docstrTestExtractor struct{}
+
+func (docstrTestExtractor) Language() string          { return "docstrwiretest" }
+func (docstrTestExtractor) Extensions() []string      { return []string{".docstrwire"} }
+func (docstrTestExtractor) Grammar() *sitter.Language { return nil }
+func (docstrTestExtractor) Tier() extract.Tier        { return extract.TierBasic }
+func (docstrTestExtractor) Extract(*sitter.Tree, []byte, string, extract.Emitter) error {
+	return nil
+}
+
+func (docstrTestExtractor) ExtractRaw(source []byte, filePath string, emit extract.Emitter) error {
+	name := strings.TrimSuffix(filepath.Base(filePath), ".docstrwire")
+	return emit.Symbol(extract.EmittedSymbol{
+		Name:      name,
+		Qualified: name,
+		Kind:      model.KindFunction,
+		LineStart: 1,
+		LineEnd:   1,
+		Docstring: string(source),
+	})
+}
+
+func init() { extract.Register(docstrTestExtractor{}) }
+
+// querySymbol opens the scanned index and returns the single symbol with
+// the given qualified name, or fails the test if zero or more than one
+// matches.
+func querySymbol(t *testing.T, root, qualified string) model.Symbol {
+	t.Helper()
+	ctx := context.Background()
+	dbPath := filepath.Join(root, ".sense", "index.db")
+	a, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = a.Close() })
+
+	rows, err := a.Query(ctx, index.Filter{Name: qualified})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("Query(name=%q): got %d rows, want 1", qualified, len(rows))
+	}
+	return rows[0]
+}
+
+// TestDocstringRoundTrip pins the wiring added in this card: a non-empty
+// Docstring set by an extractor must travel through scan.Run into the
+// SQLite row and read back byte-for-byte. The test extractor emits the
+// file's contents as the docstring, so this assertion would fail if any
+// step truncated, normalised, or stripped the value.
+func TestDocstringRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	const docstring = "validate payment amount before charging the card"
+	src := []byte(docstring)
+	if err := os.WriteFile(filepath.Join(root, "check.docstrwire"), src, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := scan.Run(context.Background(), scan.Options{
+		Root:     root,
+		Output:   &bytes.Buffer{},
+		Warnings: io.Discard,
+	}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+
+	got := querySymbol(t, root, "check")
+	if got.Docstring != docstring {
+		t.Errorf("Docstring round-trip mismatch\nhave: %q\nwant: %q", got.Docstring, docstring)
+	}
+}
+
+// TestDocstringEmptyRoundTrip pins the zero-value path: a symbol whose
+// extractor emits Docstring="" must read back as the empty string — not
+// NULL, not a fallback, and not a panic. This guards against a future
+// change that swaps the column for sql.NullString or adds a "missing
+// docstring" sentinel: either would silently regress every extractor
+// that legitimately has no comment to attach.
+func TestDocstringEmptyRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	// Empty file → extractor emits Docstring="".
+	if err := os.WriteFile(filepath.Join(root, "bare.docstrwire"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := scan.Run(context.Background(), scan.Options{
+		Root:     root,
+		Output:   &bytes.Buffer{},
+		Warnings: io.Discard,
+	}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+
+	got := querySymbol(t, root, "bare")
+	if got.Docstring != "" {
+		t.Errorf("Docstring on empty-input symbol = %q, want \"\"", got.Docstring)
+	}
+}

--- a/internal/sqlite/fts5_docstring_test.go
+++ b/internal/sqlite/fts5_docstring_test.go
@@ -1,0 +1,115 @@
+package sqlite_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// TestFTS5DocstringStaleRowUpsert pins the FTS5 contract that pitch
+// 25-07's Card 7 calls out: every prior-version scan wrote
+// `docstring=''` rows into sense_symbols_fts (the column existed long
+// before any extractor populated it). When a re-scan UPSERTs the same
+// (file_id, qualified) symbol with a new non-empty docstring, the
+// FTS5 update trigger must overwrite the stale empty row so a MATCH
+// against words that exist ONLY in the new docstring returns the
+// expected symbol_id.
+//
+// The test deliberately renames the symbol on UPSERT to a generic
+// term that doesn't contain the search words — that way a passing
+// assertion *can only* be the docstring-driven match, not a stale
+// name-driven match.
+//
+// Companion assertion: the same MATCH on the pre-UPSERT (stale-empty)
+// row returns nothing, proving the test isn't passing by accident on
+// the original name or snippet.
+func TestFTS5DocstringStaleRowUpsert(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	a, err := sqlite.Open(ctx, filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	fid, err := a.WriteFile(ctx, &model.File{
+		Path: "billing/payment.go", Language: "go",
+		Hash: "v1", Symbols: 1, IndexedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-seed: symbol named `validate_payment` with EMPTY docstring,
+	// matching the on-disk state every prior-version index is in.
+	seeded := &model.Symbol{
+		FileID: fid, Name: "validate_payment", Qualified: "billing.validate_payment",
+		Kind: "function", LineStart: 1, LineEnd: 10,
+		Snippet:   "func validate_payment() {}",
+		Docstring: "",
+	}
+	seededID, err := a.WriteSymbol(ctx, seeded)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Sanity: the seeded row must actually exist in sense_symbols_fts.
+	// Without this guard a regression that stopped inserting empty-
+	// docstring rows entirely (rather than inserting them as stale) would
+	// still pass the post-UPSERT assertion, because the UPSERT would
+	// happen to insert a fresh non-stale row. Asserting an FTS hit on
+	// the symbol's pre-UPSERT name pins the "row exists" precondition.
+	seedHit, err := a.KeywordSearch(ctx, "validate_payment", "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(seedHit) != 1 || seedHit[0].SymbolID != seededID {
+		t.Fatalf("seed precondition: expected FTS5 row for validate_payment with id %d, got %+v", seededID, seedHit)
+	}
+
+	// Companion: MATCH against words that will only be in the NEW
+	// docstring. Pre-UPSERT, the row's docstring is "", name is
+	// "validate_payment", snippet is "func validate_payment() {}".
+	// None of those contain "amount before charging".
+	pre, err := a.KeywordSearch(ctx, "amount before charging", "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pre) != 0 {
+		t.Fatalf("pre-UPSERT: expected 0 results for stale row, got %d (rows: %+v)", len(pre), pre)
+	}
+
+	// UPSERT the same (file_id, qualified) with a docstring containing
+	// the search words AND a generic name that doesn't, so the only
+	// possible match path is the docstring column.
+	updated := &model.Symbol{
+		FileID: fid, Name: "check", Qualified: "billing.validate_payment",
+		Kind: "function", LineStart: 1, LineEnd: 10,
+		Snippet:   "func check() {}",
+		Docstring: "validate payment amount before charging",
+	}
+	updatedID, err := a.WriteSymbol(ctx, updated)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updatedID != seededID {
+		t.Fatalf("UPSERT returned new id %d (want same as seed %d) — upsert key broken",
+			updatedID, seededID)
+	}
+
+	post, err := a.KeywordSearch(ctx, "amount before charging", "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(post) != 1 {
+		t.Fatalf("post-UPSERT: expected 1 result, got %d (rows: %+v)", len(post), post)
+	}
+	if post[0].SymbolID != seededID {
+		t.Errorf("post-UPSERT: symbol_id = %d, want %d (the seeded row, proving the FTS update trigger fired on UPSERT)",
+			post[0].SymbolID, seededID)
+	}
+}


### PR DESCRIPTION
## Problem

`sense_symbols.docstring` is a schema column the data model describes as the extracted doc comment for each symbol. The FTS5 virtual table already declares `docstring` as a searchable column, and the SQLite triggers already mirror it on every insert/update/delete. But the pipe was empty: no extractor populated the column for real projects, so a keyword query like *"validate payment amount before charging"* never matched a method whose godoc said exactly that.

## Summary

Wire `Docstring` from every Tier-Full extractor (Go, Ruby, TS/JS) plus Python and Rust into the existing schema and FTS5 columns, lighting up keyword search against doc-comment prose.

## Changes

- **Foundation:** add `Docstring` to `extract.EmittedSymbol`; thread it through the scan harness into `sense_symbols.docstring` with a 2 KB rune-safe cap (`capDocstring`) against pathological block comments.
- **Go (`extract/golang`):** stacked `// ` lines or `/* */` blocks above declarations, godoc convention.
- **Ruby (`extract/ruby`):** stacked `# ` lines or `=begin/=end` blocks; magic comments (`frozen_string_literal:`, `encoding:`, `coding:`) filtered. Includes a walk-up through tree-sitter-ruby's `body_statement` wrapper.
- **TS/JS (`extract/tsjs`):** `/** … */` blocks only; plain `//` and plain `/* */` break the chain. Walks up through `lexical_declaration`, `variable_declaration`, and `export_statement` wrappers.
- **Python (`extract/python`):** PEP 257 — first statement of the body when it's a string literal. Different shape from the C-family helpers: reads into the body rather than back through siblings, so decorators don't interfere.
- **Rust (`extract/rust`):** `///` lines and `/** */` blocks with `outer_doc_comment_marker`. Attribute items (`#[derive(...)]`, `#[cfg(...)]`) between the comment and the item are skipped. Includes a one-byte gap-detection adjustment for tree-sitter-rust's habit of including the trailing `\n` inside `line_comment` ranges.
- **Cross-language filters:** `Copyright` / `SPDX-` headers and invalid UTF-8 dropped to empty.
- **FTS5 contract pinned (`sqlite`):** new test asserts that a stale empty-docstring row gets overwritten on UPSERT and that a MATCH against words present only in the new docstring returns the exact seeded `symbol_id`.

## Architecture Highlights

- Per-language `docstring.go` files keep each convention close to its extractor; collapsing the duplicated plumbing (`isLicenseHeader`, gap-detection loop, per-line strip) into a shared package is a known follow-up for once a sixth language is on the horizon.
- 2 KB cap lives at the writer (`scan.go`), not in extractors — storage policy belongs to the writer.

## Test Plan

- [x] `go test ./...` passes
- [x] `make lint` clean
- [x] `make ci` green
- [x] Round-trip + empty-input + truncation tests on the scan-harness path
- [x] Per-language fixtures cover the named edge cases: blank-line gap, license-header filter, malformed UTF-8, plus the load-bearing per-language traps (Ruby magic comment, TS `@Component` decorator, Python module-level skipped, Rust attribute-skip)
- [x] FTS5 stale-row test exercises the UPSERT trigger with a name rename, so the post-UPSERT match can only be docstring-driven