### PR TITLE
fix(extract): record Ruby constant and class references as edges

### DIFF
--- a/internal/blast/invariant_test.go
+++ b/internal/blast/invariant_test.go
@@ -1,0 +1,19 @@
+package blast
+
+import (
+	"testing"
+
+	"github.com/luuuc/sense/internal/extract"
+)
+
+// Name-collision resolutions are stamped at extract.ConfidenceNameCollision
+// specifically so blast's BFS ignores them. That only holds while the stamp
+// stays below the traversal floor — guard the cross-package invariant here so
+// a future change to either constant fails loudly instead of silently
+// re-admitting guesses into impact analysis.
+func TestNameCollisionBelowTraversalFloor(t *testing.T) {
+	if extract.ConfidenceNameCollision >= defaultMinConfidence {
+		t.Fatalf("ConfidenceNameCollision (%v) must stay below blast defaultMinConfidence (%v)",
+			extract.ConfidenceNameCollision, defaultMinConfidence)
+	}
+}

--- a/internal/dead/dead.go
+++ b/internal/dead/dead.go
@@ -94,12 +94,12 @@ func FindDead(ctx context.Context, db *sql.DB, opts Options) (Result, error) {
 	}
 
 	candidates = excludeEntryPoints(candidates, entryPointFilters{
-		testsTargets:        testsTargets,
-		interfaceIDs:       interfaceIDs,
-		frameworks:         frameworks,
-		isLibrary:          isLibrary,
+		testsTargets:         testsTargets,
+		interfaceIDs:         interfaceIDs,
+		frameworks:           frameworks,
+		isLibrary:            isLibrary,
 		interfaceMethodNames: interfaceMethodNames,
-		implementorIDs:    implementorIDs,
+		implementorIDs:       implementorIDs,
 	})
 
 	candidates = annotateConfidence(candidates, interfaceIDs, implementorIDs)
@@ -308,12 +308,12 @@ func hasMainFunction(ctx context.Context, db *sql.DB, opts Options) (bool, error
 }
 
 type entryPointFilters struct {
-	testsTargets        map[int64]struct{}
-	interfaceIDs        map[int64]struct{}
-	frameworks          map[string]struct{}
-	isLibrary           bool
+	testsTargets         map[int64]struct{}
+	interfaceIDs         map[int64]struct{}
+	frameworks           map[string]struct{}
+	isLibrary            bool
 	interfaceMethodNames map[string]struct{}
-	implementorIDs      map[int64]struct{}
+	implementorIDs       map[int64]struct{}
 }
 
 func excludeEntryPoints(candidates []Symbol, filters entryPointFilters) []Symbol {
@@ -627,7 +627,27 @@ func annotateConfidence(candidates []Symbol, interfaceIDs, implementorIDs map[in
 			s.Confidence = ConfidencePossibly
 			continue
 		}
+		if isDynamicallyReferenceable(*s) {
+			s.Confidence = ConfidencePossibly
+			continue
+		}
 		s.Confidence = ConfidenceDead
 	}
 	return candidates
+}
+
+// isDynamicallyReferenceable flags Ruby types and constants that are
+// commonly reached through paths the indexer cannot see — autoloading,
+// const_get / constantize, STI, and other metaprogrammed lookups. They
+// are reported as possibly-dead rather than dead so a reader double-
+// checks before deleting.
+func isDynamicallyReferenceable(s Symbol) bool {
+	if s.Language != "ruby" {
+		return false
+	}
+	switch s.Kind {
+	case "class", "module", "constant":
+		return true
+	}
+	return false
 }

--- a/internal/dead/dead.go
+++ b/internal/dead/dead.go
@@ -102,7 +102,7 @@ func FindDead(ctx context.Context, db *sql.DB, opts Options) (Result, error) {
 		implementorIDs:       implementorIDs,
 	})
 
-	candidates = annotateConfidence(candidates, interfaceIDs, implementorIDs)
+	candidates = annotateConfidence(candidates, interfaceIDs, implementorIDs, usesDynamicAutoload(frameworks))
 
 	if len(candidates) > opts.Limit {
 		candidates = candidates[:opts.Limit]
@@ -610,7 +610,7 @@ func isGoConstructor(s Symbol) bool {
 	return s.Language == "go" && strings.HasPrefix(s.Name, "New") && s.Kind == "function"
 }
 
-func annotateConfidence(candidates []Symbol, interfaceIDs, implementorIDs map[int64]struct{}) []Symbol {
+func annotateConfidence(candidates []Symbol, interfaceIDs, implementorIDs map[int64]struct{}, dynamicFramework bool) []Symbol {
 	for i := range candidates {
 		s := &candidates[i]
 		if s.ParentID != nil {
@@ -627,13 +627,21 @@ func annotateConfidence(candidates []Symbol, interfaceIDs, implementorIDs map[in
 			s.Confidence = ConfidencePossibly
 			continue
 		}
-		if isDynamicallyReferenceable(*s) {
+		if dynamicFramework && isDynamicallyReferenceable(*s) {
 			s.Confidence = ConfidencePossibly
 			continue
 		}
 		s.Confidence = ConfidenceDead
 	}
 	return candidates
+}
+
+// usesDynamicAutoload reports whether the project relies on a framework
+// whose autoloading / const_get / constantize / STI conventions make a
+// statically-unreferenced type genuinely uncertain rather than dead.
+func usesDynamicAutoload(frameworks map[string]struct{}) bool {
+	_, ok := frameworks["Rails"]
+	return ok
 }
 
 // isDynamicallyReferenceable flags Ruby types and constants that are

--- a/internal/dead/tiering_test.go
+++ b/internal/dead/tiering_test.go
@@ -36,3 +36,24 @@ func TestGoConstructorPossiblyDead(t *testing.T) {
 		t.Errorf("go constructor confidence = %q, want %q", got[0].Confidence, ConfidencePossibly)
 	}
 }
+
+// Interface methods and trait/interface-implementor methods are tiered
+// possibly_dead — covers the two ParentID branches in annotateConfidence.
+func TestInterfaceAndImplementorTiering(t *testing.T) {
+	interfaceIDs := map[int64]struct{}{10: {}}
+	implementorIDs := map[int64]struct{}{20: {}}
+	pid10, pid20 := int64(10), int64(20)
+	cases := []struct {
+		name string
+		sym  Symbol
+	}{
+		{"interface method", Symbol{Kind: "method", Name: "Do", ParentID: &pid10}},
+		{"implementor method", Symbol{Kind: "method", Name: "Do", ParentID: &pid20}},
+	}
+	for _, c := range cases {
+		got := annotateConfidence([]Symbol{c.sym}, interfaceIDs, implementorIDs)
+		if got[0].Confidence != ConfidencePossibly {
+			t.Errorf("%s: confidence = %q, want %q", c.name, got[0].Confidence, ConfidencePossibly)
+		}
+	}
+}

--- a/internal/dead/tiering_test.go
+++ b/internal/dead/tiering_test.go
@@ -2,10 +2,10 @@ package dead
 
 import "testing"
 
-// Ruby classes, modules, and constants are reachable through dynamic
-// paths the indexer cannot see (const_get, constantize, autoloading),
-// so a dead candidate of those kinds is tiered possibly_dead, not dead.
-func TestRubyDynamicTypesArePossiblyDead(t *testing.T) {
+// Ruby classes, modules, and constants are reachable through dynamic paths
+// the indexer cannot see (const_get, constantize, autoloading, STI) — but
+// only when the project actually uses a framework that relies on them.
+func TestRubyDynamicTypesTieredUnderFramework(t *testing.T) {
 	cases := []struct {
 		kind string
 		want string
@@ -16,29 +16,30 @@ func TestRubyDynamicTypesArePossiblyDead(t *testing.T) {
 		{"method", ConfidenceDead},
 	}
 	for _, c := range cases {
-		got := annotateConfidence([]Symbol{{Language: "ruby", Kind: c.kind, Name: "X"}}, nil, nil)
+		got := annotateConfidence([]Symbol{{Language: "ruby", Kind: c.kind, Name: "X"}}, nil, nil, true)
 		if got[0].Confidence != c.want {
-			t.Errorf("ruby %s confidence = %q, want %q", c.kind, got[0].Confidence, c.want)
+			t.Errorf("ruby %s (framework): confidence = %q, want %q", c.kind, got[0].Confidence, c.want)
 		}
 	}
-	// Non-Ruby types keep the plain dead tier.
-	got := annotateConfidence([]Symbol{{Language: "python", Kind: "class", Name: "X"}}, nil, nil)
+	// Without a dynamic framework, an unreferenced Ruby class is plain dead.
+	got := annotateConfidence([]Symbol{{Language: "ruby", Kind: "class", Name: "X"}}, nil, nil, false)
 	if got[0].Confidence != ConfidenceDead {
-		t.Errorf("python class confidence = %q, want %q", got[0].Confidence, ConfidenceDead)
+		t.Errorf("ruby class (no framework): confidence = %q, want %q", got[0].Confidence, ConfidenceDead)
+	}
+	// Non-Ruby types are never tiered by this rule.
+	got = annotateConfidence([]Symbol{{Language: "python", Kind: "class", Name: "X"}}, nil, nil, true)
+	if got[0].Confidence != ConfidenceDead {
+		t.Errorf("python class: confidence = %q, want %q", got[0].Confidence, ConfidenceDead)
 	}
 }
 
-// Go constructors remain possibly_dead — guards the branch adjacent to
-// the Ruby dynamic-type tiering so annotateConfidence stays exercised.
 func TestGoConstructorPossiblyDead(t *testing.T) {
-	got := annotateConfidence([]Symbol{{Language: "go", Kind: "function", Name: "NewThing"}}, nil, nil)
+	got := annotateConfidence([]Symbol{{Language: "go", Kind: "function", Name: "NewThing"}}, nil, nil, false)
 	if got[0].Confidence != ConfidencePossibly {
 		t.Errorf("go constructor confidence = %q, want %q", got[0].Confidence, ConfidencePossibly)
 	}
 }
 
-// Interface methods and trait/interface-implementor methods are tiered
-// possibly_dead — covers the two ParentID branches in annotateConfidence.
 func TestInterfaceAndImplementorTiering(t *testing.T) {
 	interfaceIDs := map[int64]struct{}{10: {}}
 	implementorIDs := map[int64]struct{}{20: {}}
@@ -51,9 +52,21 @@ func TestInterfaceAndImplementorTiering(t *testing.T) {
 		{"implementor method", Symbol{Kind: "method", Name: "Do", ParentID: &pid20}},
 	}
 	for _, c := range cases {
-		got := annotateConfidence([]Symbol{c.sym}, interfaceIDs, implementorIDs)
+		got := annotateConfidence([]Symbol{c.sym}, interfaceIDs, implementorIDs, false)
 		if got[0].Confidence != ConfidencePossibly {
 			t.Errorf("%s: confidence = %q, want %q", c.name, got[0].Confidence, ConfidencePossibly)
 		}
+	}
+}
+
+func TestUsesDynamicAutoload(t *testing.T) {
+	if !usesDynamicAutoload(map[string]struct{}{"Rails": {}}) {
+		t.Error("Rails should be treated as a dynamic-autoload framework")
+	}
+	if usesDynamicAutoload(map[string]struct{}{"Sinatra": {}}) {
+		t.Error("non-Rails framework should not enable dynamic tiering")
+	}
+	if usesDynamicAutoload(nil) {
+		t.Error("no frameworks should not enable dynamic tiering")
 	}
 }

--- a/internal/dead/tiering_test.go
+++ b/internal/dead/tiering_test.go
@@ -1,0 +1,38 @@
+package dead
+
+import "testing"
+
+// Ruby classes, modules, and constants are reachable through dynamic
+// paths the indexer cannot see (const_get, constantize, autoloading),
+// so a dead candidate of those kinds is tiered possibly_dead, not dead.
+func TestRubyDynamicTypesArePossiblyDead(t *testing.T) {
+	cases := []struct {
+		kind string
+		want string
+	}{
+		{"class", ConfidencePossibly},
+		{"module", ConfidencePossibly},
+		{"constant", ConfidencePossibly},
+		{"method", ConfidenceDead},
+	}
+	for _, c := range cases {
+		got := annotateConfidence([]Symbol{{Language: "ruby", Kind: c.kind, Name: "X"}}, nil, nil)
+		if got[0].Confidence != c.want {
+			t.Errorf("ruby %s confidence = %q, want %q", c.kind, got[0].Confidence, c.want)
+		}
+	}
+	// Non-Ruby types keep the plain dead tier.
+	got := annotateConfidence([]Symbol{{Language: "python", Kind: "class", Name: "X"}}, nil, nil)
+	if got[0].Confidence != ConfidenceDead {
+		t.Errorf("python class confidence = %q, want %q", got[0].Confidence, ConfidenceDead)
+	}
+}
+
+// Go constructors remain possibly_dead — guards the branch adjacent to
+// the Ruby dynamic-type tiering so annotateConfidence stays exercised.
+func TestGoConstructorPossiblyDead(t *testing.T) {
+	got := annotateConfidence([]Symbol{{Language: "go", Kind: "function", Name: "NewThing"}}, nil, nil)
+	if got[0].Confidence != ConfidencePossibly {
+		t.Errorf("go constructor confidence = %q, want %q", got[0].Confidence, ConfidencePossibly)
+	}
+}

--- a/internal/extract/extractor.go
+++ b/internal/extract/extractor.go
@@ -90,6 +90,13 @@ const (
 	// the edge is intentionally low-confidence to avoid surfacing noisy
 	// cross-class guesses in blast-radius and caller queries.
 	ConfidenceUnresolved = 0.5
+
+	// ConfidenceNameCollision marks an edge whose target resolved only by
+	// bare-name fallback among multiple same-named symbols (no receiver type
+	// to disambiguate). Deliberately below blast's traversal floor (0.5) so
+	// impact analysis ignores the guess, while it still counts as a weak
+	// incoming edge for dead-code liveness.
+	ConfidenceNameCollision = 0.3
 )
 
 // Synthetic qualified-name prefixes for cross-language resolution.

--- a/internal/extract/ruby/ruby.go
+++ b/internal/extract/ruby/ruby.go
@@ -906,7 +906,7 @@ func (w *walker) resolveCallTarget(recv *sitter.Node, methodName string, scope [
 		return unresolvedCall(methodName)
 	}
 
-	return methodName, extract.ConfidenceUnresolved
+	return unresolvedCall(methodName)
 }
 
 // resolveChainReceiver recursively resolves a call-chain receiver to a type

--- a/internal/extract/ruby/ruby.go
+++ b/internal/extract/ruby/ruby.go
@@ -8,10 +8,10 @@
 //
 // Intra-file edges:
 //   - class A < B            → inherits edge (A → B) when B is defined in
-//                              the same file. Cross-file inheritance is
-//                              dropped — 01-03 backfills it.
+//     the same file. Cross-file inheritance is
+//     dropped — 01-03 backfills it.
 //   - include M / extend M   → includes edge (class → M) when M is
-//                              defined in the same file.
+//     defined in the same file.
 //
 // Calls edges:
 //   - Method / singleton-method bodies are walked for `call` nodes. The
@@ -87,10 +87,10 @@ type walker struct {
 	filePath          string
 	routeNS           []string                     // namespace stack for route files (e.g. ["Admin"])
 	testScope         []string                     // nested RSpec block descriptions for synthetic scope
-	classInstanceVars map[string]map[string]string  // @ivar type map per class
-	returnTypes       map[string]string             // method_qualified → class_name (file-level)
-	emittedCallbacks  map[string]bool               // dedup synthetic callback symbols by qualified name
-	pkgBindings       map[string]string              // unqualified name → qualified name for file-level constants
+	classInstanceVars map[string]map[string]string // @ivar type map per class
+	returnTypes       map[string]string            // method_qualified → class_name (file-level)
+	emittedCallbacks  map[string]bool              // dedup synthetic callback symbols by qualified name
+	pkgBindings       map[string]string            // unqualified name → qualified name for file-level constants
 }
 
 // walk visits node and its children under the given class/module scope.
@@ -613,7 +613,15 @@ func (w *walker) handleClassOrModule(n *sitter.Node, scope []string, kind model.
 	if body := n.ChildByFieldName("body"); body != nil {
 		ivarTypes := buildInstanceVarTypeMap(body, w.source)
 		w.classInstanceVars[qualified] = ivarTypes
-		return w.walkChildren(body, newScope)
+		if err := w.walkChildren(body, newScope); err != nil {
+			return err
+		}
+		// Capture references that live at class-body level rather than
+		// inside a method: constant RHS values, and exception/handler
+		// classes named by DSLs like `rescue_from Foo` / `retry_on Bar`.
+		// Method-body references are attributed to their method, so they
+		// are skipped here via the nested-def guard.
+		return w.collectConstRefs(body, qualified, true)
 	}
 	return nil
 }
@@ -677,7 +685,7 @@ func (w *walker) handleMethod(n *sitter.Node, scope []string, singleton bool) er
 	if err := w.emitBareIdentifierCalls(body, qualified, extract.ConfidenceDynamic); err != nil {
 		return err
 	}
-	return w.emitConstRefs(body, qualified)
+	return w.collectConstRefs(body, qualified, false)
 }
 
 // emitCall produces a calls edge for one `call` node. The target is
@@ -831,6 +839,30 @@ func (w *walker) emitCallWithConfidence(n *sitter.Node, source string, scope []s
 	return nil
 }
 
+// coreNoiseMethods are ubiquitous core-Ruby / ActiveSupport methods
+// whose bare name (receiver type unknown) matches far too many unrelated
+// symbols. When the receiver type cannot be inferred we drop the call
+// edge rather than let the resolver's unqualified fallback bind it to an
+// arbitrary same-named method elsewhere — e.g. `count.zero?` resolving
+// to a `Money.zero` singleton. A missing low-confidence edge is cheaper
+// than a false caller that inflates blast radius.
+var coreNoiseMethods = map[string]bool{
+	"zero?": true, "positive?": true, "negative?": true, "nonzero?": true,
+	"present?": true, "blank?": true, "nil?": true, "empty?": true,
+	"to_s": true, "to_i": true, "to_a": true, "to_h": true, "to_sym": true,
+	"freeze": true, "dup": true, "clone": true, "presence": true, "call": true,
+}
+
+// unresolvedCall is the emit decision for a call whose receiver type is
+// unknown: drop ubiquitous core-method names, otherwise emit the bare
+// name at ConfidenceUnresolved for the resolver's unqualified fallback.
+func unresolvedCall(methodName string) (string, float64) {
+	if coreNoiseMethods[methodName] {
+		return "", 0
+	}
+	return methodName, extract.ConfidenceUnresolved
+}
+
 // resolveCallTarget decides what target string to emit for a call node.
 // It returns the target string and the confidence level.
 func (w *walker) resolveCallTarget(recv *sitter.Node, methodName string, scope []string, localTypes, ivarTypes map[string]string) (string, float64) {
@@ -850,7 +882,7 @@ func (w *walker) resolveCallTarget(recv *sitter.Node, methodName string, scope [
 		if typ, ok := localTypes[name]; ok {
 			return typ + "#" + methodName, extract.ConfidenceDynamic
 		}
-		return methodName, extract.ConfidenceUnresolved
+		return unresolvedCall(methodName)
 	case "instance_variable":
 		name := extract.Text(recv, w.source)
 		if typ, ok := localTypes[name]; ok {
@@ -859,7 +891,7 @@ func (w *walker) resolveCallTarget(recv *sitter.Node, methodName string, scope [
 		if typ, ok := ivarTypes[name]; ok {
 			return typ + "#" + methodName, extract.ConfidenceDynamic
 		}
-		return methodName, extract.ConfidenceUnresolved
+		return unresolvedCall(methodName)
 	case "call":
 		// Method chain — strip to the trailing method unless the inner
 		// call is `.new` on a constant or `self`, in which case we can
@@ -871,7 +903,7 @@ func (w *walker) resolveCallTarget(recv *sitter.Node, methodName string, scope [
 		if typ := w.resolveChainReceiver(recv, scope, localTypes, 1); typ != "" {
 			return typ + "#" + methodName, extract.ConfidenceDynamic
 		}
-		return methodName, extract.ConfidenceUnresolved
+		return unresolvedCall(methodName)
 	}
 
 	return methodName, extract.ConfidenceUnresolved
@@ -1398,7 +1430,16 @@ func (w *walker) collectConstants(n *sitter.Node, scope []string) {
 			if name == "" {
 				continue
 			}
-			newScope := append(slices.Clone(scope), name)
+			// Register the class/module name so references to it
+			// (`PriceValue.new`, `rescue ApiError`, bare `Service`) resolve
+			// to the type itself, not just its methods. Keyed by trailing
+			// segment, matching how the name is written at reference sites.
+			segments := strings.Split(name, "::")
+			last := segments[len(segments)-1]
+			if _, exists := w.pkgBindings[last]; !exists {
+				w.pkgBindings[last] = strings.Join(append(slices.Clone(scope), segments...), "::")
+			}
+			newScope := append(slices.Clone(scope), segments...)
 			if body := child.ChildByFieldName("body"); body != nil {
 				w.collectConstants(body, newScope)
 			}
@@ -1406,39 +1447,124 @@ func (w *walker) collectConstants(n *sitter.Node, scope []string) {
 	}
 }
 
-// emitConstRefs walks a method body for `constant` nodes that resolve
-// to known file-level constants and emits references edges.
-func (w *walker) emitConstRefs(body *sitter.Node, sourceQualified string) error {
-	if body == nil || len(w.pkgBindings) == 0 {
+// collectConstRefs walks a method or class body for constant and
+// scope-resolution references and emits references edges to them.
+// Same-file constants/classes resolve to their qualified name via
+// pkgBindings; cross-file references emit their surface text for the
+// resolver to match (exact-qualified first, unqualified fallback
+// second). This is what makes a class show up as referenced — and
+// therefore alive — when it is only ever reached through `Const.new`,
+// `rescue Const`, `Const::CHILD`, or a bare constant mention.
+//
+// Skipped, because other edges already record them or they are
+// definitions rather than references: a constant that is the inner
+// segment of a scope resolution, a superclass, or the left-hand side of
+// an assignment. When skipNestedDefs is set (class-body walks) anything
+// inside a nested def/class/module is skipped too, so a method's
+// references stay attributed to the method, not its enclosing class.
+func (w *walker) collectConstRefs(root *sitter.Node, sourceQualified string, skipNestedDefs bool) error {
+	if root == nil {
 		return nil
 	}
 	seen := map[string]bool{}
-	return extract.WalkNamedDescendants(body, "constant", func(cn *sitter.Node) error {
-		name := extract.Text(cn, w.source)
-		if name == "" || seen[name] {
+	emit := func(node *sitter.Node, target string) error {
+		if target == "" || seen[target] {
 			return nil
 		}
-		targetQ, ok := w.pkgBindings[name]
-		if !ok {
+		seen[target] = true
+		line := extract.Line(node.StartPosition())
+		return w.emit.Edge(extract.EmittedEdge{
+			SourceQualified: sourceQualified,
+			TargetQualified: target,
+			Kind:            model.EdgeReferences,
+			Line:            &line,
+			Confidence:      extract.ConfidenceStatic,
+		})
+	}
+
+	// Bare constant references (`Foo`, `BAR`).
+	if err := extract.WalkNamedDescendants(root, "constant", func(cn *sitter.Node) error {
+		if skipNestedDefs && (isInsideNestedDef(cn, root) || w.isStructuralDSLArg(cn, root)) {
 			return nil
 		}
-		// Skip constants used as class names or scope resolution (e.g. Foo::Bar).
 		if p := cn.Parent(); p != nil {
+			switch p.Kind() {
+			case "scope_resolution", "superclass":
+				return nil
+			case "assignment", "operator_assignment":
+				if left := p.ChildByFieldName("left"); left != nil && left.Id() == cn.Id() {
+					return nil // constant definition, not a reference
+				}
+			}
+		}
+		name := extract.Text(cn, w.source)
+		if name == "" {
+			return nil
+		}
+		target := name
+		if q, ok := w.pkgBindings[name]; ok {
+			target = q
+		}
+		return emit(cn, target)
+	}); err != nil {
+		return err
+	}
+
+	// Namespaced references (`Foo::Bar`, `A::B::CONST`). Emit only the
+	// outermost scope resolution; skip superclasses.
+	return extract.WalkNamedDescendants(root, "scope_resolution", func(sr *sitter.Node) error {
+		if skipNestedDefs && (isInsideNestedDef(sr, root) || w.isStructuralDSLArg(sr, root)) {
+			return nil
+		}
+		if p := sr.Parent(); p != nil {
 			switch p.Kind() {
 			case "scope_resolution", "superclass":
 				return nil
 			}
 		}
-		seen[name] = true
-		line := extract.Line(cn.StartPosition())
-		return w.emit.Edge(extract.EmittedEdge{
-			SourceQualified: sourceQualified,
-			TargetQualified: targetQ,
-			Kind:            model.EdgeReferences,
-			Line:            &line,
-			Confidence:      extract.ConfidenceStatic,
-		})
+		return emit(sr, strings.TrimSpace(extract.Text(sr, w.source)))
 	})
+}
+
+// structuralRefDSLs are class-body DSL calls whose constant arguments
+// already produce a more specific edge (includes / composes / calls).
+// The class-body reference walk skips their arguments so a single
+// `include Foo` does not also emit a redundant references edge.
+// Exception DSLs (rescue_from / retry_on / discard_on) are deliberately
+// absent — their class arguments have no other edge and must be captured.
+var structuralRefDSLs = map[string]bool{
+	"include": true, "extend": true, "prepend": true,
+	"has_many": true, "has_one": true, "belongs_to": true,
+	"has_and_belongs_to_many": true,
+	"broadcasts":              true, "broadcasts_to": true,
+}
+
+// isStructuralDSLArg reports whether n is an argument to a structural DSL
+// call (see structuralRefDSLs) nested below root.
+func (w *walker) isStructuralDSLArg(n, root *sitter.Node) bool {
+	rootID := root.Id()
+	for p := n.Parent(); p != nil && p.Id() != rootID; p = p.Parent() {
+		if p.Kind() == "call" {
+			if mn := p.ChildByFieldName("method"); mn != nil && structuralRefDSLs[extract.Text(mn, w.source)] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isInsideNestedDef reports whether n sits inside a method/class/module
+// nested below root (root excluded). Used by class-body reference walks
+// to avoid re-attributing a method's references to its enclosing class.
+func isInsideNestedDef(n, root *sitter.Node) bool {
+	rootID := root.Id()
+	for p := n.Parent(); p != nil && p.Id() != rootID; p = p.Parent() {
+		switch p.Kind() {
+		case "method", "singleton_method", "class", "module":
+			return true
+		}
+	}
+	return false
 }
 
 // handleConstantAssignment emits a KindConstant symbol when the LHS of

--- a/internal/extract/ruby/ruby_test.go
+++ b/internal/extract/ruby/ruby_test.go
@@ -15,8 +15,11 @@ type recorder struct {
 	edges   []extract.EmittedEdge
 }
 
-func (r *recorder) Symbol(s extract.EmittedSymbol) error { r.symbols = append(r.symbols, s); return nil }
-func (r *recorder) Edge(e extract.EmittedEdge) error     { r.edges = append(r.edges, e); return nil }
+func (r *recorder) Symbol(s extract.EmittedSymbol) error {
+	r.symbols = append(r.symbols, s)
+	return nil
+}
+func (r *recorder) Edge(e extract.EmittedEdge) error { r.edges = append(r.edges, e); return nil }
 
 // counter counts emitted symbols and edges.
 type counter struct {
@@ -804,7 +807,6 @@ end
 		t.Error("lowercase assignment should not be emitted as constant")
 	}
 }
-
 
 func TestSuperclassNameScopeResolution(t *testing.T) {
 	r := parseRuby(t, `
@@ -3220,14 +3222,16 @@ end
 		t.Errorf("confidence = %v, want %v", e.Confidence, extract.ConfidenceDynamic)
 	}
 	// Verify no duplicate edges — each call should be emitted exactly once.
-	serviceEdges := 0
+	// Count calls only; references edges (e.g. to the Order constant) are
+	// emitted separately and are not the subject of this assertion.
+	serviceCalls := 0
 	for _, edge := range r.edges {
-		if edge.SourceQualified == "Service#process" {
-			serviceEdges++
+		if edge.SourceQualified == "Service#process" && string(edge.Kind) == "calls" {
+			serviceCalls++
 		}
 	}
-	if serviceEdges != 3 {
-		t.Errorf("expected 3 edges from Service#process, got %d", serviceEdges)
+	if serviceCalls != 3 {
+		t.Errorf("expected 3 calls edges from Service#process, got %d", serviceCalls)
 	}
 }
 
@@ -3358,13 +3362,15 @@ end
 class Service
   def process
     orders = Order.new
-    orders.each { |(id, name)| id.to_s }
+    orders.each { |(id, name)| id.archive }
   end
 end
 `)
-	// Destructuring parameter → skip block parameter inference
-	// The call inside falls back to bare method name
-	e := findEdge(r, "Service#process", "to_s", "calls")
+	// Destructuring parameter → skip block parameter inference.
+	// The call inside falls back to the bare method name. (A domain method
+	// is used rather than a core method like to_s, which is intentionally
+	// dropped from unknown-receiver calls to avoid name-collision noise.)
+	e := findEdge(r, "Service#process", "archive", "calls")
 	if e == nil {
 		t.Fatal("missing bare fallback edge for destructuring block parameter")
 	}
@@ -3693,7 +3699,13 @@ end
 	}
 }
 
-func TestConstReferenceSkipsUnknownRuby(t *testing.T) {
+func TestConstReferenceEmitsUnknownRuby(t *testing.T) {
+	// A constant defined in this file resolves to its qualified name; one
+	// that is not (defined cross-file, or a gem/stdlib class) is emitted
+	// with its surface text so the resolver can match it against the
+	// global symbol table — and drop it if it resolves to nothing. This is
+	// what lets a class referenced only as `Foo.new` from another file
+	// show up as referenced rather than dead.
 	r := parseRuby(t, `KNOWN = 1
 
 class Svc
@@ -3706,8 +3718,12 @@ end
 	if findEdge(r, "Svc#run", "KNOWN", "references") == nil {
 		t.Error("missing references edge for known constant")
 	}
-	if findEdge(r, "Svc#run", "UNKNOWN", "references") != nil {
-		t.Error("should not emit references for unknown constant")
+	e := findEdge(r, "Svc#run", "UNKNOWN", "references")
+	if e == nil {
+		t.Fatal("missing references edge for unknown constant (needed for cross-file resolution)")
+	}
+	if e.Confidence != extract.ConfidenceStatic {
+		t.Errorf("UNKNOWN reference confidence = %v, want %v", e.Confidence, extract.ConfidenceStatic)
 	}
 }
 
@@ -3728,5 +3744,93 @@ end
 `)
 	if findEdge(r, "Parent#run", "BASE", "references") == nil {
 		t.Error("missing references edge for BASE in Parent.run")
+	}
+}
+
+func TestClassReceiverEmitsReferenceRuby(t *testing.T) {
+	// `Foo.new` must record a reference to the class itself, not just a
+	// call to `new` — otherwise a class reached only via instantiation
+	// looks uncalled (and dead).
+	r := parseRuby(t, `class Order
+  class Processor
+    def run
+      ProcessPaymentService.new
+    end
+  end
+end
+`)
+	if findEdge(r, "Order::Processor#run", "ProcessPaymentService", "references") == nil {
+		t.Error("missing references edge to class used via .new")
+	}
+}
+
+func TestRescueEmitsReferenceRuby(t *testing.T) {
+	r := parseRuby(t, `class Worker
+  def perform
+    do_work
+  rescue ApiError => e
+    handle(e)
+  end
+end
+`)
+	if findEdge(r, "Worker#perform", "ApiError", "references") == nil {
+		t.Error("missing references edge to rescued exception class")
+	}
+}
+
+func TestScopeResolutionRefEmitsReferenceRuby(t *testing.T) {
+	r := parseRuby(t, `class Worker
+  def perform
+    x = SocialCommerce::Meta::ApiError
+  end
+end
+`)
+	if findEdge(r, "Worker#perform", "SocialCommerce::Meta::ApiError", "references") == nil {
+		t.Error("missing references edge to namespaced constant")
+	}
+}
+
+func TestRescueFromEmitsReferenceRuby(t *testing.T) {
+	r := parseRuby(t, `class ApplicationController
+  rescue_from ActiveRecord::RecordNotFound, with: :not_found
+end
+`)
+	if findEdge(r, "ApplicationController", "ActiveRecord::RecordNotFound", "references") == nil {
+		t.Error("missing references edge to rescue_from exception class")
+	}
+}
+
+func TestIncludeDoesNotDoubleEmitReferenceRuby(t *testing.T) {
+	// `include Foo` already yields an includes edge; it must not also
+	// produce a redundant references edge.
+	r := parseRuby(t, `class Widget
+  include Printable
+end
+`)
+	if findEdge(r, "Widget", "Printable", "includes") == nil {
+		t.Error("missing includes edge")
+	}
+	if findEdge(r, "Widget", "Printable", "references") != nil {
+		t.Error("include arg should not also emit a references edge")
+	}
+}
+
+func TestCoreNoiseMethodDroppedRuby(t *testing.T) {
+	// A ubiquitous core method on an unknown receiver must NOT emit a
+	// calls edge — otherwise the resolver's unqualified fallback binds
+	// `count.zero?` to an arbitrary same-named symbol. A non-core method
+	// on an unknown receiver still emits its bare fallback edge.
+	r := parseRuby(t, `class Order
+  def process
+    count.zero?
+    other.archive
+  end
+end
+`)
+	if findEdge(r, "Order#process", "zero?", "calls") != nil {
+		t.Error("core-noise method zero? should be dropped on unknown receiver")
+	}
+	if findEdge(r, "Order#process", "archive", "calls") == nil {
+		t.Error("non-noise method should still emit a fallback calls edge")
 	}
 }

--- a/internal/extract/ruby/ruby_test.go
+++ b/internal/extract/ruby/ruby_test.go
@@ -3834,3 +3834,85 @@ end
 		t.Error("non-noise method should still emit a fallback calls edge")
 	}
 }
+
+func TestCoreNoiseMethodDroppedOnLiteralReceiverRuby(t *testing.T) {
+	// Receiver kinds not matched by resolveCallTarget's switch (string,
+	// array, integer literals) hit the fallthrough; core-noise methods on
+	// them must also be dropped, while a domain method still emits.
+	r := parseRuby(t, `class Order
+  def process
+    "".empty?
+    [].archive
+  end
+end
+`)
+	if findEdge(r, "Order#process", "empty?", "calls") != nil {
+		t.Error("core-noise method empty? on a literal receiver should be dropped")
+	}
+	if findEdge(r, "Order#process", "archive", "calls") == nil {
+		t.Error("non-noise method on a literal receiver should still emit a fallback edge")
+	}
+}
+
+func TestSuperclassNotEmittedAsReferenceRuby(t *testing.T) {
+	// A superclass is recorded as an inherits edge, never as a references edge.
+	r := parseRuby(t, `class Parent
+end
+
+class Child < Parent
+  def work
+    helper
+  end
+end
+`)
+	if findEdge(r, "Child", "Parent", "references") != nil {
+		t.Error("superclass should be inherits, not references")
+	}
+	if findEdge(r, "Child", "Parent", "inherits") == nil {
+		t.Error("missing inherits edge Child -> Parent")
+	}
+}
+
+func TestStructuralDSLArgsNoDoubleReferenceRuby(t *testing.T) {
+	// extend (includes) and has_many (composes via serializer:) already emit
+	// a more specific edge; their constant args must not also emit references.
+	r := parseRuby(t, `class Widget
+  extend Helpers
+  has_many :comments, serializer: CommentSerializer
+end
+`)
+	if findEdge(r, "Widget", "Helpers", "includes") == nil {
+		t.Error("missing includes edge for extend")
+	}
+	if findEdge(r, "Widget", "Helpers", "references") != nil {
+		t.Error("extend arg should not also emit a references edge")
+	}
+	if findEdge(r, "Widget", "CommentSerializer", "references") != nil {
+		t.Error("has_many serializer arg should not also emit a references edge")
+	}
+}
+
+func TestPkgBindingFirstWriteWinsRuby(t *testing.T) {
+	// Two classes share a trailing segment; the bare-name binding resolves to
+	// the first-registered one. Exercises the already-exists guard in
+	// collectConstants.
+	r := parseRuby(t, `module Admin
+  class Account
+  end
+end
+
+module Billing
+  class Account
+  end
+end
+
+class Report
+  def run
+    x = Account
+  end
+end
+`)
+	if findEdge(r, "Report#run", "Admin::Account", "references") == nil {
+		t.Error("bare Account should resolve to first-registered Admin::Account")
+	}
+}

--- a/internal/extract/testdata/ruby/block_parameters.golden.json
+++ b/internal/extract/testdata/ruby/block_parameters.golden.json
@@ -96,6 +96,13 @@
   "edges": [
     {
       "source": "Service#nested_blocks",
+      "target": "Item",
+      "kind": "references",
+      "line": 31,
+      "confidence": 1
+    },
+    {
+      "source": "Service#nested_blocks",
       "target": "Item#each",
       "kind": "calls",
       "line": 32,
@@ -117,6 +124,13 @@
     },
     {
       "source": "Service#nested_blocks",
+      "target": "Order",
+      "kind": "references",
+      "line": 29,
+      "confidence": 1
+    },
+    {
+      "source": "Service#nested_blocks",
       "target": "Order#each",
       "kind": "calls",
       "line": 30,
@@ -127,6 +141,13 @@
       "target": "Order.new",
       "kind": "calls",
       "line": 29,
+      "confidence": 1
+    },
+    {
+      "source": "Service#non_collection_block",
+      "target": "File",
+      "kind": "references",
+      "line": 39,
       "confidence": 1
     },
     {
@@ -142,6 +163,13 @@
       "kind": "calls",
       "line": 39,
       "confidence": 0.5
+    },
+    {
+      "source": "Service#process_orders",
+      "target": "Order",
+      "kind": "references",
+      "line": 16,
+      "confidence": 1
     },
     {
       "source": "Service#process_orders",
@@ -169,6 +197,13 @@
       "target": "Order.new",
       "kind": "calls",
       "line": 16,
+      "confidence": 1
+    },
+    {
+      "source": "Service#process_users",
+      "target": "User",
+      "kind": "references",
+      "line": 24,
       "confidence": 1
     },
     {

--- a/internal/extract/testdata/ruby/call_patterns.golden.json
+++ b/internal/extract/testdata/ruby/call_patterns.golden.json
@@ -134,6 +134,13 @@
     },
     {
       "source": "Caller#block_call",
+      "target": "List",
+      "kind": "references",
+      "line": 21,
+      "confidence": 1
+    },
+    {
+      "source": "Caller#block_call",
       "target": "List#each",
       "kind": "calls",
       "line": 22,
@@ -162,6 +169,13 @@
     },
     {
       "source": "Caller#chain_call",
+      "target": "Factory",
+      "kind": "references",
+      "line": 28,
+      "confidence": 1
+    },
+    {
+      "source": "Caller#chain_call",
       "target": "Factory#builder",
       "kind": "calls",
       "line": 29,
@@ -176,9 +190,23 @@
     },
     {
       "source": "Caller#class_method",
+      "target": "Helper",
+      "kind": "references",
+      "line": 17,
+      "confidence": 1
+    },
+    {
+      "source": "Caller#class_method",
       "target": "Helper.configure",
       "kind": "calls",
       "line": 17,
+      "confidence": 1
+    },
+    {
+      "source": "Caller#explicit_receiver",
+      "target": "Helper",
+      "kind": "references",
+      "line": 4,
       "confidence": 1
     },
     {
@@ -201,6 +229,13 @@
       "kind": "calls",
       "line": 9,
       "confidence": 0.7
+    },
+    {
+      "source": "Factory#builder",
+      "target": "Builder",
+      "kind": "references",
+      "line": 44,
+      "confidence": 1
     },
     {
       "source": "Factory#builder",

--- a/internal/extract/testdata/ruby/instance_variables.golden.json
+++ b/internal/extract/testdata/ruby/instance_variables.golden.json
@@ -78,9 +78,23 @@
     },
     {
       "source": "PostCreator#initialize",
+      "target": "Cache",
+      "kind": "references",
+      "line": 12,
+      "confidence": 1
+    },
+    {
+      "source": "PostCreator#initialize",
       "target": "Cache.new",
       "kind": "calls",
       "line": 12,
+      "confidence": 1
+    },
+    {
+      "source": "PostCreator#initialize",
+      "target": "TopicCreator",
+      "kind": "references",
+      "line": 11,
       "confidence": 1
     },
     {

--- a/internal/extract/testdata/ruby/method_chains.golden.json
+++ b/internal/extract/testdata/ruby/method_chains.golden.json
@@ -112,6 +112,13 @@
   "edges": [
     {
       "source": "Builder#config",
+      "target": "Config",
+      "kind": "references",
+      "line": 50,
+      "confidence": 1
+    },
+    {
+      "source": "Builder#config",
       "target": "Config.new",
       "kind": "calls",
       "line": 50,
@@ -126,6 +133,13 @@
     },
     {
       "source": "Caller#basic_chain",
+      "target": "Factory",
+      "kind": "references",
+      "line": 7,
+      "confidence": 1
+    },
+    {
+      "source": "Caller#basic_chain",
       "target": "Factory#builder",
       "kind": "calls",
       "line": 8,
@@ -136,6 +150,13 @@
       "target": "Factory.new",
       "kind": "calls",
       "line": 7,
+      "confidence": 1
+    },
+    {
+      "source": "Caller#nested_chain",
+      "target": "Factory",
+      "kind": "references",
+      "line": 30,
       "confidence": 1
     },
     {
@@ -189,6 +210,13 @@
     },
     {
       "source": "Caller#three_hop_chain",
+      "target": "Factory",
+      "kind": "references",
+      "line": 18,
+      "confidence": 1
+    },
+    {
+      "source": "Caller#three_hop_chain",
       "target": "Factory#builder",
       "kind": "calls",
       "line": 19,
@@ -199,6 +227,13 @@
       "target": "Factory.new",
       "kind": "calls",
       "line": 18,
+      "confidence": 1
+    },
+    {
+      "source": "Caller#unresolved_chain",
+      "target": "Factory",
+      "kind": "references",
+      "line": 24,
       "confidence": 1
     },
     {
@@ -224,9 +259,23 @@
     },
     {
       "source": "Factory#builder",
+      "target": "Builder",
+      "kind": "references",
+      "line": 38,
+      "confidence": 1
+    },
+    {
+      "source": "Factory#builder",
       "target": "Builder.new",
       "kind": "calls",
       "line": 38,
+      "confidence": 1
+    },
+    {
+      "source": "Factory#unknown",
+      "target": "Something",
+      "kind": "references",
+      "line": 42,
       "confidence": 1
     },
     {

--- a/internal/extract/testdata/ruby/scope_resolution_inherit.golden.json
+++ b/internal/extract/testdata/ruby/scope_resolution_inherit.golden.json
@@ -65,6 +65,13 @@
     },
     {
       "source": "Admin::BaseController#current_admin",
+      "target": "Admin",
+      "kind": "references",
+      "line": 4,
+      "confidence": 1
+    },
+    {
+      "source": "Admin::BaseController#current_admin",
       "target": "Admin.find",
       "kind": "calls",
       "line": 4,
@@ -82,6 +89,13 @@
       "target": "Searchable",
       "kind": "includes",
       "line": 9,
+      "confidence": 1
+    },
+    {
+      "source": "Admin::UsersController#index",
+      "target": "User",
+      "kind": "references",
+      "line": 12,
       "confidence": 1
     },
     {
@@ -110,6 +124,13 @@
       "target": "Auditable",
       "kind": "includes",
       "line": 19,
+      "confidence": 1
+    },
+    {
+      "source": "Api::V2::OrdersController#create",
+      "target": "Order",
+      "kind": "references",
+      "line": 22,
       "confidence": 1
     },
     {

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -78,6 +78,11 @@ type Result struct {
 // policies stay in one place; see that const for the pitch rationale.
 const ambiguousConfidence = extract.ConfidenceAmbiguous
 
+// nameCollisionConfidence is applied to a bare-name fallback that had to
+// pick among multiple same-named symbols. It sits below blast's traversal
+// floor so impact analysis ignores these guesses.
+const nameCollisionConfidence = extract.ConfidenceNameCollision
+
 // Resolve looks up req.Target and returns the best candidate. Returns
 // ok=false when nothing matches — callers (scan) drop unresolved
 // edges today; Card 8 may wire the unresolved set to diagnostic
@@ -114,6 +119,13 @@ func (ix *Index) Resolve(req Request) (Result, bool) {
 				r := pickBest(matches, req.SourceFileID, req.BaseConfidence)
 				if r.Confidence > ambiguousConfidence {
 					r.Confidence = ambiguousConfidence
+				}
+				if r.Ambiguous {
+					// Bare-name fallback among multiple same-named symbols is the
+					// weakest resolution — no receiver type disambiguates it. Drop
+					// it below blast's floor so impact analysis ignores the guess;
+					// it still counts for dead-code liveness.
+					r.Confidence = nameCollisionConfidence
 				}
 				return r, true
 			}

--- a/internal/resolve/resolver_test.go
+++ b/internal/resolve/resolver_test.go
@@ -13,14 +13,14 @@ import (
 func refs() []model.SymbolRef {
 	return []model.SymbolRef{
 		{ID: 1, Qualified: "app.User", FileID: 10},
-		{ID: 2, Qualified: "app.User.email", FileID: 10},   // method on class via `.`
-		{ID: 3, Qualified: "Greeter#hello", FileID: 11},    // Ruby instance method
+		{ID: 2, Qualified: "app.User.email", FileID: 10}, // method on class via `.`
+		{ID: 3, Qualified: "Greeter#hello", FileID: 11},  // Ruby instance method
 		{ID: 4, Qualified: "Greeter#greet", FileID: 11},
-		{ID: 5, Qualified: "Money::new", FileID: 12},       // Rust associated fn
+		{ID: 5, Qualified: "Money::new", FileID: 12}, // Rust associated fn
 		{ID: 6, Qualified: "Money::display", FileID: 12},
-		{ID: 7, Qualified: "test.User", FileID: 20},        // same bare name, different file
-		{ID: 8, Qualified: "helper", FileID: 10},           // top-level fn, no parent
-		{ID: 9, Qualified: "fmt.Sprintf", FileID: 30},      // unqualified target for fallback
+		{ID: 7, Qualified: "test.User", FileID: 20},   // same bare name, different file
+		{ID: 8, Qualified: "helper", FileID: 10},      // top-level fn, no parent
+		{ID: 9, Qualified: "fmt.Sprintf", FileID: 30}, // unqualified target for fallback
 	}
 }
 
@@ -308,12 +308,12 @@ func TestResolveIncludesCrossFile(t *testing.T) {
 	// Include edges resolve cross-file via byQualified just like any
 	// other edge kind — there is no intra-file restriction.
 	tests := []struct {
-		name       string
-		refs       []model.SymbolRef
-		target     string
-		wantOK     bool
-		wantID     int64
-		wantConf   float64
+		name     string
+		refs     []model.SymbolRef
+		target   string
+		wantOK   bool
+		wantID   int64
+		wantConf float64
 	}{
 		{
 			name:   "bare target cross-file",
@@ -356,5 +356,53 @@ func TestResolveIncludesCrossFile(t *testing.T) {
 				t.Errorf("Confidence = %v, want %v", r.Confidence, tt.wantConf)
 			}
 		})
+	}
+}
+
+func TestResolveAmbiguousNameOnlyDroppedBelowBlastFloor(t *testing.T) {
+	// Two symbols share a trailing name but neither matches the target's
+	// qualified form, so resolution falls to the bare-name index with
+	// multiple candidates. That guess must land below blast's 0.5 floor.
+	rs := append(refs(),
+		model.SymbolRef{ID: 200, Qualified: "A.process", FileID: 10},
+		model.SymbolRef{ID: 201, Qualified: "B.process", FileID: 11},
+	)
+	ix := resolve.NewIndex(rs)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "process",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   99,
+		BaseConfidence: 1.0,
+	})
+	if !ok {
+		t.Fatal("expected resolution via name fallback")
+	}
+	if !r.Ambiguous {
+		t.Error("Ambiguous = false, want true (multiple same-named candidates)")
+	}
+	if r.Confidence >= 0.5 {
+		t.Errorf("Confidence = %v, want < 0.5 so blast ignores the guess", r.Confidence)
+	}
+}
+
+func TestResolveSingleNameOnlyKeepsConfidence(t *testing.T) {
+	// A unique bare-name match is trustworthy enough to keep the ambiguous
+	// clamp (0.8) — only multi-candidate fallback is dropped below the floor.
+	rs := append(refs(), model.SymbolRef{ID: 300, Qualified: "Only.unique_method", FileID: 10})
+	ix := resolve.NewIndex(rs)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "unique_method",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   99,
+		BaseConfidence: 1.0,
+	})
+	if !ok {
+		t.Fatal("expected resolution")
+	}
+	if r.Ambiguous {
+		t.Error("single match should not be ambiguous")
+	}
+	if r.Confidence != 0.8 {
+		t.Errorf("Confidence = %v, want 0.8 (single name-only clamp)", r.Confidence)
 	}
 }

--- a/internal/scan/testdata/crossfile/call_across_files/expected.golden.json
+++ b/internal/scan/testdata/crossfile/call_across_files/expected.golden.json
@@ -3,6 +3,14 @@
     {
       "source": "Caller#start",
       "source_file": "caller.rb",
+      "target": "Callee",
+      "target_file": "callee.rb",
+      "kind": "references",
+      "confidence": 1
+    },
+    {
+      "source": "Caller#start",
+      "source_file": "caller.rb",
       "target": "Callee.run",
       "target_file": "callee.rb",
       "kind": "calls",

--- a/internal/sqlite/adapter.go
+++ b/internal/sqlite/adapter.go
@@ -15,6 +15,7 @@ import (
 
 	_ "modernc.org/sqlite" // registers the "sqlite" driver
 
+	"github.com/luuuc/sense/internal/extract"
 	"github.com/luuuc/sense/internal/index"
 	"github.com/luuuc/sense/internal/model"
 )
@@ -582,6 +583,15 @@ func (a *Adapter) ReadSymbolGraph(ctx context.Context, id int64, depth int, dire
 		return nil, err
 	}
 	result := &model.GraphResult{Root: *root}
+	// For container symbols a "who calls this" question is best answered by
+	// who calls the container's members, not only who names the type. Fold
+	// member callers into the root's inbound set so a class/type graph query
+	// reflects real usage — the gap that made graph and blast disagree.
+	if direction != model.DirectionCallees {
+		if err := a.foldMemberCallers(ctx, &result.Root); err != nil {
+			return nil, err
+		}
+	}
 	if depth <= 1 {
 		return result, nil
 	}
@@ -690,6 +700,114 @@ func graphFrontier(sc *model.SymbolContext, direction model.Direction, visited m
 		}
 	}
 	return frontier
+}
+
+// isContainerExpandKind reports the symbol kinds whose member callers are
+// folded into the symbol's own inbound edges by foldMemberCallers. Matches
+// blast's child-expansion set: concrete types whose methods carry the real
+// callers (modules/interfaces are excluded — their children are definitions,
+// not usage).
+func isContainerExpandKind(k model.SymbolKind) bool {
+	return k == model.KindClass || k == model.KindType
+}
+
+// isUsageEdge reports whether an edge kind represents a symbol being used
+// (called or referenced) rather than a structural relationship
+// (inherits/composes/includes) or co-change noise (temporal).
+func isUsageEdge(k model.EdgeKind) bool {
+	return k == model.EdgeCalls || k == model.EdgeReferences
+}
+
+// hasUsageCaller reports whether edges contains at least one above-floor
+// usage edge — a real "someone calls/references this" signal, as opposed to
+// a structural edge or a low-confidence resolution guess.
+func hasUsageCaller(edges []model.EdgeRef) bool {
+	for _, e := range edges {
+		if isUsageEdge(e.Edge.Kind) && e.Edge.Confidence >= extract.ConfidenceUnresolved {
+			return true
+		}
+	}
+	return false
+}
+
+// foldMemberCallers enriches a container symbol's inbound edges with the
+// callers of its own members. Without it, "who calls Order" returns only the
+// edges that name the type (references/inherits), missing every caller that
+// goes through Order's methods. The container and its own members are
+// excluded as callers so internal method-to-method calls don't masquerade as
+// external usage; results are deduped against the existing inbound set.
+func (a *Adapter) foldMemberCallers(ctx context.Context, sc *model.SymbolContext) error {
+	if !isContainerExpandKind(sc.Symbol.Kind) {
+		return nil
+	}
+	// Only enrich when the container has no real direct caller of its own —
+	// the "a referenced class looks unused" case (graph returned [] while
+	// blast found callers via the class's methods). A structural edge
+	// (inherits/composes) or a low-confidence name-collision guess is not a
+	// real caller, so those do not suppress enrichment.
+	if hasUsageCaller(sc.Inbound) {
+		return nil
+	}
+	childIDs, err := a.childSymbolIDs(ctx, sc.Symbol.ID)
+	if err != nil {
+		return err
+	}
+	if len(childIDs) == 0 {
+		return nil
+	}
+	exclude := make(map[int64]struct{}, len(childIDs)+1)
+	exclude[sc.Symbol.ID] = struct{}{}
+	for _, cid := range childIDs {
+		exclude[cid] = struct{}{}
+	}
+	seen := make(map[int64]struct{}, len(sc.Inbound))
+	for _, e := range sc.Inbound {
+		seen[e.Target.ID] = struct{}{}
+	}
+	for _, cid := range childIDs {
+		refs, err := a.loadEdges(ctx, cid, false)
+		if err != nil {
+			return err
+		}
+		for _, e := range refs {
+			if e.Target.ID == 0 || e.Edge.Kind == model.EdgeTemporal {
+				continue
+			}
+			// Don't fold low-confidence guesses (e.g. name-collision
+			// fallbacks stamped below the traversal floor) into the class's
+			// callers — that would re-admit exactly what blast filters out.
+			if e.Edge.Confidence < extract.ConfidenceUnresolved {
+				continue
+			}
+			if _, skip := exclude[e.Target.ID]; skip {
+				continue
+			}
+			if _, dup := seen[e.Target.ID]; dup {
+				continue
+			}
+			seen[e.Target.ID] = struct{}{}
+			sc.Inbound = append(sc.Inbound, e)
+		}
+	}
+	return nil
+}
+
+// childSymbolIDs returns the ids of symbols whose parent is parentID.
+func (a *Adapter) childSymbolIDs(ctx context.Context, parentID int64) ([]int64, error) {
+	rows, err := a.db.QueryContext(ctx, `SELECT id FROM sense_symbols WHERE parent_id = ?`, parentID)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite childSymbolIDs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("sqlite childSymbolIDs scan: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
 }
 
 func (a *Adapter) Query(ctx context.Context, f index.Filter) ([]model.Symbol, error) {

--- a/internal/sqlite/foldcallers_test.go
+++ b/internal/sqlite/foldcallers_test.go
@@ -1,0 +1,131 @@
+package sqlite_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+func newFoldAdapter(t *testing.T) (*sqlite.Adapter, int64) {
+	t.Helper()
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(t.TempDir(), "fold.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = a.Close() })
+	fid, err := a.WriteFile(ctx, &model.File{
+		Path: "fold.rb", Language: "ruby", Hash: "f", Symbols: 1, IndexedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return a, fid
+}
+
+func mustSym(t *testing.T, a *sqlite.Adapter, s *model.Symbol) int64 {
+	t.Helper()
+	id, err := a.WriteSymbol(context.Background(), s)
+	if err != nil {
+		t.Fatalf("WriteSymbol %s: %v", s.Name, err)
+	}
+	return id
+}
+
+func mustEdge(t *testing.T, a *sqlite.Adapter, e *model.Edge) {
+	t.Helper()
+	if _, err := a.WriteEdge(context.Background(), e); err != nil {
+		t.Fatalf("WriteEdge: %v", err)
+	}
+}
+
+// A class with no direct callers surfaces the callers of its methods, so it
+// no longer looks unused — while its own members are excluded as callers.
+func TestReadSymbolGraphFoldsMemberCallers(t *testing.T) {
+	a, fileID := newFoldAdapter(t)
+	ctx := context.Background()
+
+	classID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "Order", Qualified: "Order", Kind: model.KindClass, LineStart: 1, LineEnd: 50})
+	methodID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "process", Qualified: "Order#process", Kind: model.KindMethod, ParentID: &classID, LineStart: 5, LineEnd: 10})
+	siblingID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "validate", Qualified: "Order#validate", Kind: model.KindMethod, ParentID: &classID, LineStart: 12, LineEnd: 16})
+	callerID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "Run", Qualified: "Client.Run", Kind: model.KindFunction, LineStart: 20, LineEnd: 30})
+
+	mustEdge(t, a, &model.Edge{SourceID: &callerID, TargetID: methodID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 1.0})
+	mustEdge(t, a, &model.Edge{SourceID: &siblingID, TargetID: methodID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 1.0})
+
+	gr, err := a.ReadSymbolGraph(ctx, classID, 1, model.DirectionCallers, 0)
+	if err != nil {
+		t.Fatalf("ReadSymbolGraph: %v", err)
+	}
+	var gotCaller, gotSelf bool
+	for _, e := range gr.Root.Inbound {
+		switch e.Target.ID {
+		case callerID:
+			gotCaller = true
+		case classID, methodID, siblingID:
+			gotSelf = true
+		}
+	}
+	if !gotCaller {
+		t.Error("class graph should fold in the caller of its method")
+	}
+	if gotSelf {
+		t.Error("class graph must exclude the class's own members as callers")
+	}
+}
+
+// When a class already has direct callers, the precise answer is kept — method
+// callers are not folded in to dilute it.
+func TestReadSymbolGraphDirectCallersNotDiluted(t *testing.T) {
+	a, fileID := newFoldAdapter(t)
+	ctx := context.Background()
+
+	classID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "Acct", Qualified: "Acct", Kind: model.KindClass, LineStart: 1, LineEnd: 30})
+	methodID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "debit", Qualified: "Acct#debit", Kind: model.KindMethod, ParentID: &classID, LineStart: 3, LineEnd: 6})
+	directID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "Direct", Qualified: "Direct", Kind: model.KindFunction, LineStart: 10, LineEnd: 14})
+	indirectID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "Indirect", Qualified: "Indirect", Kind: model.KindFunction, LineStart: 16, LineEnd: 20})
+
+	mustEdge(t, a, &model.Edge{SourceID: &directID, TargetID: classID, Kind: model.EdgeReferences, FileID: fileID, Confidence: 1.0})
+	mustEdge(t, a, &model.Edge{SourceID: &indirectID, TargetID: methodID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 1.0})
+
+	gr, err := a.ReadSymbolGraph(ctx, classID, 1, model.DirectionCallers, 0)
+	if err != nil {
+		t.Fatalf("ReadSymbolGraph: %v", err)
+	}
+	var direct, indirect bool
+	for _, e := range gr.Root.Inbound {
+		if e.Target.ID == directID {
+			direct = true
+		}
+		if e.Target.ID == indirectID {
+			indirect = true
+		}
+	}
+	if !direct {
+		t.Error("direct caller missing")
+	}
+	if indirect {
+		t.Error("method-caller should not be folded when direct callers already exist")
+	}
+}
+
+// A non-container root (a method) never folds — its graph is exactly its own edges.
+func TestReadSymbolGraphMethodRootNotFolded(t *testing.T) {
+	a, fileID := newFoldAdapter(t)
+	ctx := context.Background()
+
+	classID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "Svc", Qualified: "Svc", Kind: model.KindClass, LineStart: 1, LineEnd: 20})
+	methodID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "run", Qualified: "Svc#run", Kind: model.KindMethod, ParentID: &classID, LineStart: 3, LineEnd: 6})
+
+	gr, err := a.ReadSymbolGraph(ctx, methodID, 1, model.DirectionCallers, 0)
+	if err != nil {
+		t.Fatalf("ReadSymbolGraph: %v", err)
+	}
+	if len(gr.Root.Inbound) != 0 {
+		t.Errorf("method root inbound = %d, want 0 (no folding for non-containers)", len(gr.Root.Inbound))
+	}
+}


### PR DESCRIPTION
## Problem
Sense's Ruby extractor only modeled method-call edges, so a class reached
through `Const.new`, `rescue Const`, `Const::CHILD`, or a bare constant
recorded no edge to the class itself. As a result, `sense_graph` reported
zero callers for referenced classes/value-objects/services, and the
dead-code detector flagged them (and exception classes) as dead. A second
defect compounded it: the resolver's bare-name fallback bound ambiguous
matches at a confidence high enough to inflate blast radius with false
callers (e.g. `count.zero?` resolving to an unrelated `zero`).

## Summary
Record constant/class references as first-class `references` edges, stop
ambiguous name-only matches from polluting impact analysis, and make the
graph and dead-code views consistent with the richer edge data.

## Changes
- **Extractor (`internal/extract/ruby`)**: emit `references` edges for
  constant and scope-resolution references in method *and* class bodies;
  register class/module names so `Const.new`/`rescue Const`/`Const::CHILD`
  resolve to the type. Cross-file targets emit surface text for the
  resolver to match (or drop). Nested-def and structural-DSL args
  (`include`/associations) are skipped to avoid double-counting; the LHS of
  a constant assignment is treated as a definition, not a reference. Bare
  core-Ruby methods on unknown receivers (`zero?`, `present?`, `to_s`,
  `call`, …) no longer emit calls edges.
- **Resolver (`internal/resolve`)**: ambiguous bare-name fallback matches
  (multiple same-named symbols) are stamped at a new
  `ConfidenceNameCollision` (0.3), below blast's traversal floor, so impact
  analysis ignores the guess while dead-code still counts it as alive.
- **Graph (`internal/sqlite`)**: a class/type with no real direct caller
  folds in the callers of its members, so a class used only through its
  methods no longer reports zero callers. Containers that already have a
  real caller, and the class's own members, are excluded.
- **Dead code (`internal/dead`)**: Ruby class/module/constant candidates
  are tiered `possibly_dead` only under a dynamic-autoload framework
  (Rails); plain-Ruby projects report them `dead`.

## Architecture Highlights
- Resolution quality is encoded in the existing confidence field rather
  than a new schema column — no migration, and blast's existing floor does
  the filtering. A cross-package invariant test guards
  `ConfidenceNameCollision < blast.defaultMinConfidence` so the two
  constants can't silently drift.

## Breaking Changes
⚠️ Adds a new `references` edge kind and many new edges; existing indexes
must be re-scanned to gain the improved graph/dead-code results. No schema
migration required (the index is rebuilt on scan).

## Test Plan
- [x] Ruby extractor: `Const.new`, `rescue`, `Const::CHILD`, `rescue_from`,
      include-no-double-emit, unknown-constant, superclass-not-a-reference,
      pkgBinding first-write-wins, core-noise drop (incl. literal receivers)
- [x] Resolver: ambiguous name-only match lands below blast's floor; single
      name match keeps its confidence
- [x] Graph: class with only method-callers folds them in; class with a
      direct caller is not diluted; method root never folds
- [x] Dead code: Ruby types `possibly_dead` under Rails, `dead` otherwise;
      non-Ruby unaffected
- [x] Per-file coverage >=90% on changed files
- [x] `go test ./...` passes
- [x] `make ci` green (build + test + lint)
- [x] sense binary builds cleanly
