### PR TITLE
feat(graph): sharpen Ruby/Rails graph, dead-code, and ERB indexing

### DIFF
--- a/internal/dead/dead.go
+++ b/internal/dead/dead.go
@@ -627,7 +627,7 @@ func annotateConfidence(candidates []Symbol, interfaceIDs, implementorIDs map[in
 			s.Confidence = ConfidencePossibly
 			continue
 		}
-		if dynamicFramework && isDynamicallyReferenceable(*s) {
+		if dynamicFramework && (isDynamicallyReferenceable(*s) || isDynamicRubyMethod(*s)) {
 			s.Confidence = ConfidencePossibly
 			continue
 		}
@@ -656,6 +656,70 @@ func isDynamicallyReferenceable(s Symbol) bool {
 	switch s.Kind {
 	case "class", "module", "constant":
 		return true
+	}
+	return false
+}
+
+// serviceClassSuffixes name the command-object conventions whose entry
+// point is a polymorphic `call` — invoked through `Klass.new.call`, a
+// `.()` shorthand, or a duck-typed handler the static indexer often can't
+// tie back to the definition.
+var serviceClassSuffixes = []string{
+	"Service", "Command", "Query", "Interactor", "Operation", "Job", "Worker",
+}
+
+// resultClassSuffixes name value-object conventions whose predicate methods
+// (success?/failure?/...) are read off a return value of an unknown static
+// type, so their call sites frequently don't resolve to the definition.
+var resultClassSuffixes = []string{"Result", "Response", "Outcome"}
+
+// resultPredicates are the predicate method names commonly defined on the
+// result/value objects above.
+var resultPredicates = map[string]bool{
+	"success?": true, "failure?": true, "error?": true,
+	"ok?": true, "valid?": true, "invalid?": true,
+}
+
+// isDynamicRubyMethod flags Ruby methods that follow a dynamic-dispatch
+// convention the static indexer routinely under-resolves: the service-object
+// `call` entry point, and predicate methods on result/value objects. With no
+// detected caller these would otherwise top-tier as "dead"; the convention
+// makes that confidence unwarranted, so they are reported possibly-dead.
+func isDynamicRubyMethod(s Symbol) bool {
+	if s.Language != "ruby" || s.Kind != "method" {
+		return false
+	}
+	parent := rubyMethodParentName(s.Qualified)
+	switch {
+	case s.Name == "call" && hasAnySuffix(parent, serviceClassSuffixes):
+		return true
+	case resultPredicates[s.Name] && hasAnySuffix(parent, resultClassSuffixes):
+		return true
+	}
+	return false
+}
+
+// rubyMethodParentName returns the unqualified parent class/module name from
+// a Ruby method's qualified name: "Checkout::ProcessPaymentService#call" →
+// "ProcessPaymentService", "A.b" → "A". Returns "" when there is no
+// receiver separator (top-level def).
+func rubyMethodParentName(qualified string) string {
+	sep := strings.LastIndexAny(qualified, "#.")
+	if sep < 0 {
+		return ""
+	}
+	parent := qualified[:sep]
+	if i := strings.LastIndex(parent, "::"); i >= 0 {
+		parent = parent[i+len("::"):]
+	}
+	return parent
+}
+
+func hasAnySuffix(s string, suffixes []string) bool {
+	for _, suf := range suffixes {
+		if strings.HasSuffix(s, suf) {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/dead/tiering_test.go
+++ b/internal/dead/tiering_test.go
@@ -33,6 +33,70 @@ func TestRubyDynamicTypesTieredUnderFramework(t *testing.T) {
 	}
 }
 
+// Ruby service-object `call` methods and result-object predicates follow
+// dynamic-dispatch conventions the indexer under-resolves, so with no
+// detected caller they are possibly-dead, not dead — but only under a
+// dynamic framework, and only for the matching name/parent conventions.
+func TestRubyDynamicMethodTiering(t *testing.T) {
+	cases := []struct {
+		name      string
+		sym       Symbol
+		framework bool
+		want      string
+	}{
+		{
+			"service call under framework",
+			Symbol{Language: "ruby", Kind: "method", Name: "call", Qualified: "Checkout::ProcessPaymentService#call"},
+			true, ConfidencePossibly,
+		},
+		{
+			"result predicate under framework",
+			Symbol{Language: "ruby", Kind: "method", Name: "success?", Qualified: "Payments::Result#success?"},
+			true, ConfidencePossibly,
+		},
+		{
+			"plain call on a non-service class stays dead",
+			Symbol{Language: "ruby", Kind: "method", Name: "call", Qualified: "Widget#call"},
+			true, ConfidenceDead,
+		},
+		{
+			"predicate on a non-result class stays dead",
+			Symbol{Language: "ruby", Kind: "method", Name: "success?", Qualified: "Widget#success?"},
+			true, ConfidenceDead,
+		},
+		{
+			"service call without a dynamic framework stays dead",
+			Symbol{Language: "ruby", Kind: "method", Name: "call", Qualified: "Checkout::ProcessPaymentService#call"},
+			false, ConfidenceDead,
+		},
+		{
+			"non-ruby call is untouched",
+			Symbol{Language: "go", Kind: "method", Name: "call", Qualified: "FooService#call"},
+			true, ConfidenceDead,
+		},
+	}
+	for _, c := range cases {
+		got := annotateConfidence([]Symbol{c.sym}, nil, nil, c.framework)
+		if got[0].Confidence != c.want {
+			t.Errorf("%s: confidence = %q, want %q", c.name, got[0].Confidence, c.want)
+		}
+	}
+}
+
+func TestRubyMethodParentName(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Checkout::ProcessPaymentService#call", "ProcessPaymentService"},
+		{"A.b", "A"},
+		{"Foo::Bar.baz", "Bar"},
+		{"top_level", ""},
+	}
+	for _, c := range cases {
+		if got := rubyMethodParentName(c.in); got != c.want {
+			t.Errorf("rubyMethodParentName(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
 func TestGoConstructorPossiblyDead(t *testing.T) {
 	got := annotateConfidence([]Symbol{{Language: "go", Kind: "function", Name: "NewThing"}}, nil, nil, false)
 	if got[0].Confidence != ConfidencePossibly {

--- a/internal/extract/erb/erb.go
+++ b/internal/extract/erb/erb.go
@@ -13,6 +13,7 @@ package erb
 
 import (
 	"bytes"
+	"path"
 	"regexp"
 	"strings"
 
@@ -57,16 +58,52 @@ var (
 	reDataOutlet = regexp.MustCompile(`data-([a-z0-9-]+)-outlet="([^"]+)"`)
 
 	// <turbo-frame id="name"> or turbo_frame_tag "name"
-	reTurboFrameTag = regexp.MustCompile(`<turbo-frame[^>]+id="([^"]+)"`)
+	reTurboFrameTag    = regexp.MustCompile(`<turbo-frame[^>]+id="([^"]+)"`)
 	reTurboFrameHelper = regexp.MustCompile(`turbo_frame_tag\s+["']([^"']+)["']`)
 
 	// <turbo-stream-from> or turbo_stream_from
-	reTurboStreamFrom = regexp.MustCompile(`<turbo-stream-from[^>]+signed-stream-name="([^"]+)"`)
+	reTurboStreamFrom   = regexp.MustCompile(`<turbo-stream-from[^>]+signed-stream-name="([^"]+)"`)
 	reTurboStreamHelper = regexp.MustCompile(`turbo_stream_from\s+[@:]?([a-zA-Z0-9_.]+)`)
 
 	// Individual action parsing: event->controller#method
 	reStimulusAction = regexp.MustCompile(`(?:([a-z]+)->)?([a-z0-9-]+(?:--[a-z0-9-]+)*)#([a-zA-Z0-9_]+)`)
+
+	// ERB tag inner Ruby: <% ... %>, <%= ... %>, with optional trim markers.
+	// Non-greedy so multiple tags on one line are captured separately. A
+	// leading '#' marks a comment tag, which extractTemplateRuby skips.
+	reErbTag = regexp.MustCompile(`<%([=#]?[-]?.*?)[-]?%>`)
+
+	// render "users/profile" / render partial: "users/profile" /
+	// render(template: "x"). Captures the first partial-path string literal.
+	reRender = regexp.MustCompile(`\brender\b\s*\(?\s*(?:partial:|template:|layout:)?\s*["']([\w./-]+)["']`)
+
+	// t(".key") / t("a.b.c") / translate("...") / I18n.t("..."). Keys with
+	// interpolation (#{...}) are skipped — the literal isn't a stable key.
+	reI18n = regexp.MustCompile(`\b(?:I18n\.)?(?:t|translate)\b\s*\(?\s*["']([a-zA-Z0-9_.]+)["']`)
+
+	// A method-call identifier in stripped tag content: a lowercase-leading
+	// name not preceded by '.', '@', ':' or '$' (so receivers, ivars, and
+	// symbols are excluded), optionally ending in '?'/'!'.
+	reHelperName = regexp.MustCompile(`(?:^|[^.@:$\w])([a-z_][a-zA-Z0-9_]*[!?]?)`)
+
+	// String / symbol literals stripped before helper-name scanning so words
+	// inside copy ("edit profile") aren't mistaken for method calls.
+	reRubyLiteral = regexp.MustCompile(`"[^"]*"|'[^']*'|:[a-zA-Z_][a-zA-Z0-9_]*`)
 )
+
+// erbHelperSkip holds Ruby keywords and the helpers handled by dedicated
+// passes (render / t / translate) so they aren't re-emitted as bare calls.
+var erbHelperSkip = map[string]bool{
+	"if": true, "unless": true, "while": true, "until": true, "for": true,
+	"in": true, "do": true, "end": true, "then": true, "else": true,
+	"elsif": true, "case": true, "when": true, "begin": true, "rescue": true,
+	"ensure": true, "def": true, "class": true, "module": true, "nil": true,
+	"true": true, "false": true, "self": true, "and": true, "or": true,
+	"not": true, "return": true, "yield": true, "break": true, "next": true,
+	"super": true, "render": true, "t": true, "translate": true,
+	// Turbo/Stimulus DSL helpers handled by the dedicated passes above.
+	"turbo_stream_from": true, "turbo_frame_tag": true,
+}
 
 type walker struct {
 	source   []byte
@@ -75,6 +112,10 @@ type walker struct {
 }
 
 func (w *walker) walk() error {
+	if err := w.emitPartialSymbol(); err != nil {
+		return err
+	}
+
 	lines := bytes.Split(w.source, []byte("\n"))
 
 	for i, rawLine := range lines {
@@ -97,6 +138,9 @@ func (w *walker) walk() error {
 			return err
 		}
 		if err := w.extractTurboStreams(line, lineNum); err != nil {
+			return err
+		}
+		if err := w.extractTemplateRuby(line, lineNum); err != nil {
 			return err
 		}
 	}
@@ -246,3 +290,176 @@ func (w *walker) extractTurboStreams(line string, lineNum int) error {
 	return nil
 }
 
+// extractTemplateRuby pulls Ruby-level references out of the embedded code in
+// each ERB tag on a line: rendered partials, i18n keys, and bare helper
+// calls. These open up the view layer to graph queries ("who renders this
+// partial", "which view uses this i18n key", "where is this helper used")
+// that the Stimulus/Turbo passes don't cover.
+func (w *walker) extractTemplateRuby(line string, lineNum int) error {
+	for _, tag := range reErbTag.FindAllStringSubmatch(line, -1) {
+		inner := tag[1]
+		if strings.HasPrefix(strings.TrimSpace(inner), "#") {
+			continue // comment tag
+		}
+		if err := w.extractRender(inner, lineNum); err != nil {
+			return err
+		}
+		if err := w.extractI18n(inner, lineNum); err != nil {
+			return err
+		}
+		if err := w.extractHelperCalls(inner, lineNum); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// extractRender emits a calls edge to each rendered partial. The target is the
+// partial's render path: absolute when the literal contains a slash, otherwise
+// resolved against the rendering view's directory (Rails' relative-partial
+// rule). The matching partial file emits a symbol with the same qualified name
+// via emitPartialSymbol, so the edge resolves.
+func (w *walker) extractRender(inner string, lineNum int) error {
+	for _, m := range reRender.FindAllStringSubmatch(inner, -1) {
+		ln := lineNum
+		if err := w.emit.Edge(extract.EmittedEdge{
+			SourceQualified: w.filePath,
+			TargetQualified: partialRenderTarget(m[1], w.filePath),
+			Kind:            model.EdgeCalls,
+			Line:            &ln,
+			Confidence:      extract.ConfidenceConvention,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// extractI18n emits a symbol for each translation key a view references, so
+// semantic search can surface the view behind a given piece of copy. Relative
+// keys (".title") are expanded against the view's lazy-lookup scope.
+func (w *walker) extractI18n(inner string, lineNum int) error {
+	for _, m := range reI18n.FindAllStringSubmatch(inner, -1) {
+		key := i18nKey(m[1], w.filePath)
+		if err := w.emit.Symbol(extract.EmittedSymbol{
+			Name:       key,
+			Qualified:  extract.PrefixI18n + key,
+			Kind:       model.KindConstant,
+			Visibility: "public",
+			LineStart:  lineNum,
+			LineEnd:    lineNum,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// extractHelperCalls emits a self-call edge for each bare, receiverless method
+// call in a tag — the view-helper / controller-concern methods (current_user,
+// current_currency, link_to, …) that the resolver binds back to their
+// definition. String and symbol literals are stripped first so words inside
+// copy aren't mistaken for calls; the resolver drops any name that matches no
+// defined symbol, so unknown framework helpers fall away.
+func (w *walker) extractHelperCalls(inner string, lineNum int) error {
+	stripped := reRubyLiteral.ReplaceAllString(inner, " ")
+	seen := map[string]bool{}
+	for _, m := range reHelperName.FindAllStringSubmatch(stripped, -1) {
+		name := m[1]
+		if erbHelperSkip[name] || seen[name] {
+			continue
+		}
+		seen[name] = true
+		ln := lineNum
+		if err := w.emit.Edge(extract.EmittedEdge{
+			SourceQualified: w.filePath,
+			TargetQualified: "self." + name,
+			Kind:            model.EdgeCalls,
+			Line:            &ln,
+			Confidence:      extract.ConfidenceConvention,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// emitPartialSymbol emits a symbol for a partial template (basename starting
+// with "_") qualified by its render path, so `render`-edge targets resolve to
+// it. Non-partial templates emit nothing here.
+func (w *walker) emitPartialSymbol() error {
+	name := partialSelfPath(w.filePath)
+	if name == "" {
+		return nil
+	}
+	return w.emit.Symbol(extract.EmittedSymbol{
+		Name:       path.Base(name),
+		Qualified:  extract.PrefixPartial + name,
+		Kind:       model.KindConstant,
+		Visibility: "public",
+		LineStart:  1,
+		LineEnd:    1,
+	})
+}
+
+// viewDir returns the directory of a view file relative to the views root:
+// "app/views/users/show.html.erb" → "users". Empty when no "views/" segment
+// is present (the render path can't be anchored).
+func viewDir(filePath string) string {
+	dir := path.Dir(filePath)
+	if i := strings.LastIndex(dir, "views/"); i >= 0 {
+		return dir[i+len("views/"):]
+	}
+	return ""
+}
+
+// templateBaseName returns a view file's logical name: the basename with the
+// leading "_" (partials) and all extensions stripped. "_profile.html.erb" →
+// "profile".
+func templateBaseName(filePath string) string {
+	base := strings.TrimPrefix(path.Base(filePath), "_")
+	if i := strings.IndexByte(base, '.'); i >= 0 {
+		base = base[:i]
+	}
+	return base
+}
+
+// partialSelfPath returns the render path of a partial file, or "" when the
+// file is not a partial. "app/views/users/_profile.html.erb" → "users/profile".
+func partialSelfPath(filePath string) string {
+	if !strings.HasPrefix(path.Base(filePath), "_") {
+		return ""
+	}
+	name := templateBaseName(filePath)
+	if dir := viewDir(filePath); dir != "" {
+		return dir + "/" + name
+	}
+	return name
+}
+
+// partialRenderTarget builds the qualified render target for a `render`
+// argument. A path with a slash is absolute; a bare name is resolved against
+// the rendering view's directory, matching Rails' relative-partial lookup.
+func partialRenderTarget(arg, filePath string) string {
+	if strings.Contains(arg, "/") {
+		return extract.PrefixPartial + arg
+	}
+	if dir := viewDir(filePath); dir != "" {
+		return extract.PrefixPartial + dir + "/" + arg
+	}
+	return extract.PrefixPartial + arg
+}
+
+// i18nKey expands a lazy-lookup key (leading ".") against the view's scope —
+// "app/views/users/show.html.erb" with ".title" → "users.show.title" — and
+// returns absolute keys unchanged.
+func i18nKey(raw, filePath string) string {
+	if !strings.HasPrefix(raw, ".") {
+		return raw
+	}
+	scope := templateBaseName(filePath)
+	if dir := viewDir(filePath); dir != "" {
+		scope = strings.ReplaceAll(dir, "/", ".") + "." + scope
+	}
+	return scope + raw
+}

--- a/internal/extract/erb/erb_test.go
+++ b/internal/extract/erb/erb_test.go
@@ -485,3 +485,153 @@ func TestMultipleActionsOnElement(t *testing.T) {
 		t.Fatalf("expected at least 2 action edges, got %d", len(r.edges))
 	}
 }
+
+// --- template Ruby extraction (helpers, partials, i18n) ---
+
+func (r *recorder) hasEdgeTo(target string) bool {
+	for _, e := range r.edges {
+		if e.TargetQualified == target {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *recorder) hasSymbol(qualified string) bool {
+	for _, s := range r.symbols {
+		if s.Qualified == qualified {
+			return true
+		}
+	}
+	return false
+}
+
+func extractERB(t *testing.T, src, path string) *recorder {
+	t.Helper()
+	r := &recorder{}
+	if err := (Extractor{}).ExtractRaw([]byte(src), path, r); err != nil {
+		t.Fatalf("ExtractRaw: %v", err)
+	}
+	return r
+}
+
+func TestExtractHelperCalls(t *testing.T) {
+	r := extractERB(t, `<p><%= current_currency %></p>
+<%= link_to "Edit profile", edit_user_path(user) %>`, "app/views/orders/show.html.erb")
+
+	for _, want := range []string{"self.current_currency", "self.link_to", "self.edit_user_path", "self.user"} {
+		if !r.hasEdgeTo(want) {
+			t.Errorf("missing helper-call edge %q", want)
+		}
+	}
+	// Words inside string copy must not become calls.
+	for _, bad := range []string{"self.Edit", "self.profile", "self.edit"} {
+		if r.hasEdgeTo(bad) {
+			t.Errorf("string-literal word wrongly emitted as call: %q", bad)
+		}
+	}
+}
+
+func TestExtractRenderPartial(t *testing.T) {
+	r := extractERB(t, `<%= render "shared/header" %>
+<%= render partial: "form" %>`, "app/views/users/show.html.erb")
+
+	if !r.hasEdgeTo("partial:shared/header") {
+		t.Error("missing absolute partial render edge partial:shared/header")
+	}
+	// Bare "form" resolves relative to the rendering view's directory (users).
+	if !r.hasEdgeTo("partial:users/form") {
+		t.Error("missing relative partial render edge partial:users/form")
+	}
+}
+
+func TestEmitPartialSymbol(t *testing.T) {
+	r := extractERB(t, `<div>just markup</div>`, "app/views/users/_profile.html.erb")
+	if !r.hasSymbol("partial:users/profile") {
+		t.Error("partial file should emit symbol partial:users/profile")
+	}
+
+	// A non-partial template emits no partial symbol.
+	r2 := extractERB(t, `<div>page</div>`, "app/views/users/show.html.erb")
+	if r2.hasSymbol("partial:users/show") {
+		t.Error("non-partial template must not emit a partial symbol")
+	}
+}
+
+func TestExtractI18nKeys(t *testing.T) {
+	r := extractERB(t, `<h1><%= t(".title") %></h1>
+<p><%= t("shared.footer.copyright") %></p>
+<span><%= I18n.t("users.greeting") %></span>`, "app/views/users/show.html.erb")
+
+	for _, want := range []string{
+		"i18n:users.show.title",     // lazy key expanded against the view scope
+		"i18n:shared.footer.copyright",
+		"i18n:users.greeting",
+	} {
+		if !r.hasSymbol(want) {
+			t.Errorf("missing i18n symbol %q", want)
+		}
+	}
+}
+
+func TestErbCommentTagSkipped(t *testing.T) {
+	r := extractERB(t, `<%# render "shared/header" and t(".title") %>`, "app/views/users/show.html.erb")
+	if len(r.edges) != 0 || len(r.symbols) != 0 {
+		t.Errorf("comment tag should emit nothing, got %d edges %d symbols", len(r.edges), len(r.symbols))
+	}
+}
+
+// failingEmitter returns an error on the Nth Symbol or Edge call so error
+// propagation paths are exercised.
+type failingEmitter struct {
+	failSymbolOn int
+	failEdgeOn   int
+	syms, edges  int
+}
+
+func (f *failingEmitter) Symbol(extract.EmittedSymbol) error {
+	f.syms++
+	if f.syms == f.failSymbolOn {
+		return errBoom
+	}
+	return nil
+}
+func (f *failingEmitter) Edge(extract.EmittedEdge) error {
+	f.edges++
+	if f.edges == f.failEdgeOn {
+		return errBoom
+	}
+	return nil
+}
+
+var errBoom = errBoomType("boom")
+
+type errBoomType string
+
+func (e errBoomType) Error() string { return string(e) }
+
+func TestExtractTemplateRubyPathsOutsideViewsRoot(t *testing.T) {
+	// A template not under a views/ root: render targets and partial symbols
+	// fall back to bare names with no directory anchor.
+	r := extractERB(t, `<%= render "menu" %>`, "components/_menu.erb")
+	if !r.hasEdgeTo("partial:menu") {
+		t.Error("bare render outside views/ should target partial:menu")
+	}
+	if !r.hasSymbol("partial:menu") {
+		t.Error("partial outside views/ should emit symbol partial:menu")
+	}
+}
+
+func TestExtractErrorPropagation(t *testing.T) {
+	src := `<%= render "shared/header" %>
+<%= t(".title") %>
+<%= current_user %>`
+	// Symbol emission failure (partial self-symbol / i18n key) propagates.
+	if err := (Extractor{}).ExtractRaw([]byte(src), "app/views/users/_show.html.erb", &failingEmitter{failSymbolOn: 1}); err == nil {
+		t.Error("expected symbol emit error to propagate")
+	}
+	// Edge emission failure (render / helper call) propagates.
+	if err := (Extractor{}).ExtractRaw([]byte(src), "app/views/users/show.html.erb", &failingEmitter{failEdgeOn: 1}); err == nil {
+		t.Error("expected edge emit error to propagate")
+	}
+}

--- a/internal/extract/extractor.go
+++ b/internal/extract/extractor.go
@@ -99,6 +99,16 @@ const (
 	ConfidenceNameCollision = 0.3
 )
 
+// Receiver kinds for EmittedSymbol.Receiver / Symbol.Receiver. They record
+// a method's dispatch kind for languages that distinguish them (Ruby
+// instance `Class#m` vs singleton `Class.m`). Empty means "no distinction"
+// — non-methods and languages that don't carry it. The resolver uses these
+// to keep an instance call from binding to a same-named singleton method.
+const (
+	ReceiverInstance  = "instance"
+	ReceiverSingleton = "singleton"
+)
+
 // Synthetic qualified-name prefixes for cross-language resolution.
 // Edges targeting these names connect symbols across language boundaries
 // (e.g., ERB template → JS controller via Turbo channel name matching).
@@ -106,6 +116,14 @@ const (
 	PrefixTurboChannel = "turbo-channel:"
 	PrefixTurboFrame   = "turbo-frame:"
 	PrefixImportmap    = "importmap:"
+	// PrefixPartial qualifies a Rails view partial by its render path
+	// (e.g. "partial:users/profile"). The partial file emits a symbol with
+	// this prefix; `render "users/profile"` emits a matching calls edge.
+	PrefixPartial = "partial:"
+	// PrefixI18n qualifies a translation key referenced from a view
+	// (e.g. "i18n:users.show.title"). Emitted as a symbol so semantic search
+	// can surface the view that renders a given piece of copy.
+	PrefixI18n = "i18n:"
 )
 
 // StimulusControllerQualified converts a kebab-case Stimulus controller name
@@ -157,10 +175,15 @@ func kebabToPascal(s string) string {
 // Tier-Basic — a method's class always lives in the same file as the
 // method.
 type EmittedSymbol struct {
-	Name            string
-	Qualified       string
-	Kind            model.SymbolKind
-	Visibility      string
+	Name       string
+	Qualified  string
+	Kind       model.SymbolKind
+	Visibility string
+	// Receiver is a method's dispatch kind ("instance" / "singleton") for
+	// languages that distinguish them; empty otherwise. Persisted to
+	// sense_symbols.receiver and used by the resolver to keep instance and
+	// singleton methods of the same name from cross-binding.
+	Receiver        string
 	ParentQualified string
 	LineStart       int
 	LineEnd         int

--- a/internal/extract/ruby/ruby.go
+++ b/internal/extract/ruby/ruby.go
@@ -365,8 +365,8 @@ func (w *walker) walkTestBody(body *sitter.Node, scope []string, source string) 
 	}); err != nil {
 		return err
 	}
-	// Emit edges for bare identifiers in statement position.
-	return w.emitBareIdentifierCalls(body, source, extract.ConfidenceTests)
+	// Emit edges for bare identifiers in statement and value positions.
+	return w.emitBareIdentifierCalls(body, source, extract.ConfidenceTests, nil)
 }
 
 // isInsideNestedTestBlock returns true if n sits inside a test DSL call
@@ -645,20 +645,25 @@ func (w *walker) handleMethod(n *sitter.Node, scope []string, singleton bool) er
 	}
 
 	parent := strings.Join(scope, "::")
-	var qualified string
+	var qualified, receiver string
 	switch {
 	case parent == "":
+		// Top-level def: attaches to Object at runtime; no class-vs-instance
+		// dispatch distinction to record.
 		qualified = name
 	case singleton:
 		qualified = parent + "." + name
+		receiver = extract.ReceiverSingleton
 	default:
 		qualified = parent + "#" + name
+		receiver = extract.ReceiverInstance
 	}
 
 	if err := w.emit.Symbol(extract.EmittedSymbol{
 		Name:            name,
 		Qualified:       qualified,
 		Kind:            model.KindMethod,
+		Receiver:        receiver,
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
@@ -682,7 +687,7 @@ func (w *walker) handleMethod(n *sitter.Node, scope []string, singleton bool) er
 	}); err != nil {
 		return err
 	}
-	if err := w.emitBareIdentifierCalls(body, qualified, extract.ConfidenceDynamic); err != nil {
+	if err := w.emitBareIdentifierCalls(body, qualified, extract.ConfidenceDynamic, methodParamNames(n, w.source)); err != nil {
 		return err
 	}
 	return w.collectConstRefs(body, qualified, false)
@@ -1222,23 +1227,74 @@ var statementParents = map[string]bool{
 	"ensure":         true,
 }
 
-// emitBareIdentifierCalls walks a method body for identifier nodes in
-// statement position (direct children of body_statement, then, else,
-// begin, ensure). Tree-sitter-ruby parses bare receiverless method
-// calls without parentheses as identifier nodes rather than call
-// nodes; we emit them as `self.name` so the resolver rewrites them to
-// the enclosing class (e.g. `self.validate` → `Order#validate`).
-func (w *walker) emitBareIdentifierCalls(body *sitter.Node, sourceQualified string, confidence float64) error {
+// valueParents is the set of node kinds where a bare identifier sits in a
+// value position — a method argument, string interpolation, conditional,
+// or the right-hand side of an assignment. A receiverless identifier here is
+// a method send (e.g. a controller-concern helper like `current_currency`
+// used inside `redirect_to foo(current_currency)`), not a definition or a
+// call receiver. We emit those as `self.name` so the resolver can bind them
+// to the included-concern method; a name that resolves to no symbol is
+// dropped, and an ambiguous one is clamped below the blast floor. Locals and
+// parameters are filtered out before this set is consulted.
+var valueParents = map[string]bool{
+	"argument_list":   true,
+	"interpolation":   true,
+	"pair":            true,
+	"array":           true,
+	"binary":          true,
+	"unary":           true,
+	"return":          true,
+	"if":              true,
+	"unless":          true,
+	"while":           true,
+	"until":           true,
+	"elsif":           true,
+	"case":            true,
+	"when":            true,
+	"if_modifier":     true, // `render :ok if current_country`
+	"unless_modifier": true,
+	"while_modifier":  true,
+	"until_modifier":  true,
+	// Assignment RHS — `@currency = current_currency`, `@user ||= current_user`.
+	// isAssignmentTarget excludes the left-hand-side identifier.
+	"assignment":          true,
+	"operator_assignment": true,
+}
+
+// emitBareIdentifierCalls walks a method body for identifier nodes that are
+// bare (receiverless, parenless) method calls. Tree-sitter-ruby parses these
+// as identifier nodes rather than call nodes; we emit them as `self.name` so
+// the resolver rewrites them to the enclosing class or an included concern
+// (e.g. `validate` → `Order#validate`, `current_currency` →
+// `CurrencyContext#current_currency`).
+//
+// Statement-position identifiers (direct children of body_statement, then,
+// else, begin, ensure) are always emitted. Value-position identifiers
+// (arguments, interpolations, conditionals, assignment RHS) are emitted only
+// when the name is not a known local variable or parameter — the signal that
+// distinguishes a method send from a variable reference. params carries the
+// enclosing definition's parameter names; body-local assignments and block
+// parameters are discovered here.
+func (w *walker) emitBareIdentifierCalls(body *sitter.Node, sourceQualified string, confidence float64, params map[string]bool) error {
+	locals := collectLocalNames(body, w.source, params)
 	return extract.WalkNamedDescendants(body, "identifier", func(ident *sitter.Node) error {
 		if w.isInsideNestedTestBlock(ident, body) {
 			return nil
 		}
 		parent := ident.Parent()
-		if parent == nil || !statementParents[parent.Kind()] {
+		if parent == nil {
 			return nil
 		}
 		name := extract.Text(ident, w.source)
 		if name == "" {
+			return nil
+		}
+		switch {
+		case statementParents[parent.Kind()]:
+			// always a bare call in statement position
+		case valueParents[parent.Kind()] && !locals[name] && !isAssignmentTarget(parent, ident):
+			// a value-position send that isn't a local/parameter
+		default:
 			return nil
 		}
 		line := extract.Line(ident.StartPosition())
@@ -1250,6 +1306,83 @@ func (w *walker) emitBareIdentifierCalls(body *sitter.Node, sourceQualified stri
 			Confidence:      confidence,
 		})
 	})
+}
+
+// isAssignmentTarget reports whether ident is the left-hand side of its
+// parent assignment — `x` in `x = current_currency`, which is a variable
+// being defined, not a method send. Right-hand-side identifiers fall through
+// and are treated as value-position sends.
+func isAssignmentTarget(parent, ident *sitter.Node) bool {
+	switch parent.Kind() {
+	case "assignment", "operator_assignment":
+		left := parent.ChildByFieldName("left")
+		return left != nil && left.Equals(*ident)
+	}
+	return false
+}
+
+// addIdentifierNames records every identifier name in n's subtree (including
+// n itself when it is an identifier) into set. WalkNamedDescendants only
+// visits children, so a simple `x = ...` target — where the left node is the
+// identifier itself — needs the explicit self check.
+func addIdentifierNames(n *sitter.Node, source []byte, set map[string]bool) {
+	if n == nil {
+		return
+	}
+	if n.Kind() == "identifier" {
+		if name := extract.Text(n, source); name != "" {
+			set[name] = true
+		}
+	}
+	_ = extract.WalkNamedDescendants(n, "identifier", func(id *sitter.Node) error {
+		if name := extract.Text(id, source); name != "" {
+			set[name] = true
+		}
+		return nil
+	})
+}
+
+// methodParamNames returns the parameter names of a method/singleton_method
+// node so they can be excluded from value-position send detection. It collects
+// every identifier under the parameters node, which over-approximates across
+// optional/keyword/splat/block parameter shapes — a safe bias, since the only
+// effect of an extra name is suppressing one would-be self-call edge.
+func methodParamNames(method *sitter.Node, source []byte) map[string]bool {
+	names := map[string]bool{}
+	if method == nil {
+		return names
+	}
+	addIdentifierNames(method.ChildByFieldName("parameters"), source, names)
+	return names
+}
+
+// collectLocalNames returns the set of names that are local variables or
+// parameters within body: the seed (enclosing parameters), assignment targets,
+// and block parameters. A name in this set is a variable reference, not a
+// method send, so value-position emission skips it.
+func collectLocalNames(body *sitter.Node, source []byte, seed map[string]bool) map[string]bool {
+	locals := map[string]bool{}
+	for k := range seed {
+		locals[k] = true
+	}
+	if body == nil {
+		return locals
+	}
+	for _, kind := range []string{"assignment", "operator_assignment"} {
+		_ = extract.WalkNamedDescendants(body, kind, func(n *sitter.Node) error {
+			// `x = ...` (identifier) and `a, b = ...` (left_assignment_list)
+			// both reduce to their identifier names. Attribute writes like
+			// `obj.attr = ...` add their receiver too — harmless, it just
+			// suppresses one would-be self-call.
+			addIdentifierNames(n.ChildByFieldName("left"), source, locals)
+			return nil
+		})
+	}
+	_ = extract.WalkNamedDescendants(body, "block_parameters", func(n *sitter.Node) error {
+		addIdentifierNames(n, source, locals)
+		return nil
+	})
+	return locals
 }
 
 // literalSendTarget extracts the target name from `send(:name)` /

--- a/internal/extract/ruby/ruby_test.go
+++ b/internal/extract/ruby/ruby_test.go
@@ -365,8 +365,13 @@ func TestSendNonLiteralSkipped(t *testing.T) {
   end
 end
 `)
+	// send() with a non-literal argument must not fabricate an edge to a
+	// guessed send target. The argument `method_name` is itself a
+	// receiverless call (no local binding ⇒ a method send in Ruby), so a
+	// `self.method_name` edge is expected; nothing else may be emitted.
 	for _, e := range r.edges {
-		if string(e.Kind) == "calls" && e.SourceQualified == "Service#invoke" {
+		if string(e.Kind) == "calls" && e.SourceQualified == "Service#invoke" &&
+			e.TargetQualified != "self.method_name" {
 			t.Errorf("unexpected calls edge from send with non-literal arg: %v", e.TargetQualified)
 		}
 	}
@@ -1486,9 +1491,13 @@ class Service
   end
 end
 `)
+	// The send target stays unresolved, but `callback` has no local binding,
+	// so it is itself a receiverless call — `self.callback` is expected and is
+	// the only edge allowed.
 	for _, e := range r.edges {
-		if e.SourceQualified == "Service#process" && string(e.Kind) == "calls" {
-			t.Error("should not emit calls edge when variable assignment cannot be traced")
+		if e.SourceQualified == "Service#process" && string(e.Kind) == "calls" &&
+			e.TargetQualified != "self.callback" {
+			t.Errorf("unexpected calls edge: %v", e.TargetQualified)
 		}
 	}
 }
@@ -3851,6 +3860,119 @@ end
 	}
 	if findEdge(r, "Order#process", "archive", "calls") == nil {
 		t.Error("non-noise method on a literal receiver should still emit a fallback edge")
+	}
+}
+
+func TestBareHelperCallInValuePositionRuby(t *testing.T) {
+	// Helpers (often injected via an included concern) are called bare and
+	// parenless in value positions — as arguments, in interpolations, in
+	// conditions, on the RHS of an assignment. Each must emit a self-call so
+	// the resolver can bind it to the concern method, while genuine locals
+	// and parameters are not mistaken for sends.
+	r := parseRuby(t, `class CheckoutController
+  def show(quantity)
+    total = quantity * 2
+    redirect_to path(currency: current_currency)
+    flash[:notice] = "in #{current_locale}"
+    render :ok if current_country
+    @sum = total
+    @cur = current_currency
+  end
+end
+`)
+	wantCalls := []string{"current_currency", "current_locale", "current_country"}
+	for _, name := range wantCalls {
+		if findEdge(r, "CheckoutController#show", "self."+name, "calls") == nil {
+			t.Errorf("missing self.%s call edge for value-position helper", name)
+		}
+	}
+	// `total` is a local and `quantity` a parameter — neither is a send.
+	for _, local := range []string{"total", "quantity"} {
+		if findEdge(r, "CheckoutController#show", "self."+local, "calls") != nil {
+			t.Errorf("local/parameter %q wrongly emitted as a call", local)
+		}
+	}
+}
+
+func TestBareHelperCallInAssignmentRHSRuby(t *testing.T) {
+	// Assignment and operator-assignment RHS are the canonical place a concern
+	// helper is captured (`@currency = current_currency`, memoised
+	// `@user ||= current_user`). The assignment target itself is not a send.
+	r := parseRuby(t, `class OrdersController
+  def show
+    @currency = current_currency
+    @user ||= current_user
+  end
+end
+`)
+	for _, name := range []string{"current_currency", "current_user"} {
+		if findEdge(r, "OrdersController#show", "self."+name, "calls") == nil {
+			t.Errorf("missing assignment-RHS helper call self.%s", name)
+		}
+	}
+}
+
+func TestTwoStepNamespacedNewCallResolvesRuby(t *testing.T) {
+	// `service = Klass.new; service.call(...)` on a namespaced constant must
+	// emit a resolved calls edge so the service-object entry point isn't
+	// reported dead. Regression guard for the dead-code false-positive case.
+	r := parseRuby(t, `module Checkout
+  class ProcessPaymentService
+    def call(order)
+      true
+    end
+  end
+end
+
+class PaymentCallbacksController
+  def create
+    service = Checkout::ProcessPaymentService.new
+    service.call(order)
+  end
+end
+`)
+	e := findEdge(r, "PaymentCallbacksController#create", "Checkout::ProcessPaymentService#call", "calls")
+	if e == nil {
+		t.Fatal("expected calls edge to Checkout::ProcessPaymentService#call")
+	}
+	if e.Confidence < 0.5 {
+		t.Errorf("edge confidence = %v, want >= 0.5 so dead-code counts it as a caller", e.Confidence)
+	}
+}
+
+func TestMethodReceiverKindRuby(t *testing.T) {
+	// Instance methods carry receiver=instance, singletons receiver=singleton,
+	// top-level defs carry none — feeding the resolver's dispatch-kind
+	// disambiguation.
+	r := parseRuby(t, `class PriceValue
+  def self.zero
+    new(0)
+  end
+
+  def zero?
+    amount == 0
+  end
+end
+
+def top_level_helper
+  1
+end
+`)
+	cases := []struct {
+		qualified, want string
+	}{
+		{"PriceValue.zero", extract.ReceiverSingleton},
+		{"PriceValue#zero?", extract.ReceiverInstance},
+		{"top_level_helper", ""},
+	}
+	for _, c := range cases {
+		s := findSymbol(r, c.qualified)
+		if s == nil {
+			t.Fatalf("missing symbol %q", c.qualified)
+		}
+		if s.Receiver != c.want {
+			t.Errorf("%q Receiver = %q, want %q", c.qualified, s.Receiver, c.want)
+		}
 	}
 }
 

--- a/internal/extract/testdata/ruby/dynamic_dispatch.golden.json
+++ b/internal/extract/testdata/ruby/dynamic_dispatch.golden.json
@@ -52,6 +52,13 @@
       "kind": "calls",
       "line": 3,
       "confidence": 0.7
+    },
+    {
+      "source": "Dispatcher#dynamic",
+      "target": "self.other",
+      "kind": "calls",
+      "line": 6,
+      "confidence": 0.7
     }
   ]
 }

--- a/internal/extract/testdata/ruby/dynamic_dispatch_variable.golden.json
+++ b/internal/extract/testdata/ruby/dynamic_dispatch_variable.golden.json
@@ -58,6 +58,13 @@
   ],
   "edges": [
     {
+      "source": "Service#no_assignment",
+      "target": "self.callback",
+      "kind": "calls",
+      "line": 28,
+      "confidence": 0.7
+    },
+    {
       "source": "Service#public_send_callback",
       "target": "process",
       "kind": "calls",

--- a/internal/extract/testdata/ruby/rspec_test_blocks.golden.json
+++ b/internal/extract/testdata/ruby/rspec_test_blocks.golden.json
@@ -2,6 +2,20 @@
   "symbols": [],
   "edges": [
     {
+      "source": "#it_works_standalone",
+      "target": "self.be_ok",
+      "kind": "calls",
+      "line": 14,
+      "confidence": 0.8
+    },
+    {
+      "source": "#it_works_standalone",
+      "target": "self.process_data",
+      "kind": "calls",
+      "line": 13,
+      "confidence": 0.8
+    },
+    {
       "source": "CategoryTest",
       "target": "Category",
       "kind": "tests",
@@ -86,6 +100,13 @@
       "confidence": 0.8
     },
     {
+      "source": "Post##it_publishes",
+      "target": "self.author",
+      "kind": "calls",
+      "line": 50,
+      "confidence": 0.8
+    },
+    {
       "source": "PostTest",
       "target": "Post",
       "kind": "tests",
@@ -102,6 +123,34 @@
     {
       "source": "TopicCreator##create##it_creates_a_valid_topic",
       "target": "TopicCreator.create",
+      "kind": "calls",
+      "line": 5,
+      "confidence": 0.8
+    },
+    {
+      "source": "TopicCreator##create##it_creates_a_valid_topic",
+      "target": "self.attrs",
+      "kind": "calls",
+      "line": 5,
+      "confidence": 0.8
+    },
+    {
+      "source": "TopicCreator##create##it_creates_a_valid_topic",
+      "target": "self.be_valid",
+      "kind": "calls",
+      "line": 6,
+      "confidence": 0.8
+    },
+    {
+      "source": "TopicCreator##create##it_creates_a_valid_topic",
+      "target": "self.guardian",
+      "kind": "calls",
+      "line": 5,
+      "confidence": 0.8
+    },
+    {
+      "source": "TopicCreator##create##it_creates_a_valid_topic",
+      "target": "self.user",
       "kind": "calls",
       "line": 5,
       "confidence": 0.8

--- a/internal/model/symbol.go
+++ b/internal/model/symbol.go
@@ -17,6 +17,11 @@ type Symbol struct {
 	Qualified  string
 	Kind       SymbolKind
 	Visibility string
+	// Receiver is a method's dispatch kind for languages that distinguish
+	// them: "instance" or "singleton". Empty for non-methods and languages
+	// that don't carry the distinction. See the resolver's unqualified
+	// fallback, which uses it to avoid instance/singleton mis-binding.
+	Receiver   string
 	ParentID   *int64
 	LineStart  int // 1-indexed; 0 means unknown (emitted as omitted via json:",omitempty" on wire types)
 	LineEnd    int // 1-indexed; 0 means unknown (emitted as omitted via json:",omitempty" on wire types)
@@ -34,6 +39,10 @@ type SymbolRef struct {
 	ID        int64
 	Qualified string
 	FileID    int64
+	// Receiver mirrors Symbol.Receiver ("instance"/"singleton"/""): the
+	// resolver's unqualified fallback filters candidates by dispatch kind
+	// so an instance call cannot bind to a same-named singleton method.
+	Receiver string
 }
 
 // HydrateSymbolNullables copies the sql.NullXxx carriers scanned from

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -114,8 +114,18 @@ func (ix *Index) Resolve(req Request) (Result, bool) {
 		// byName["Sprintf"]). byQualified and byName are different
 		// indexes, so looking up the same key in both is not
 		// duplicate work.
-		if name := unqualifiedName(target); name != "" {
-			if matches := ix.byName[name]; len(matches) > 0 {
+		if name, sep := unqualifiedNameSep(target); name != "" {
+			// A target still carrying a `self.`/`Self::` prefix here means
+			// rewriteReceiver had no parent to bind it to (e.g. a template
+			// file-level call). Its trailing `.` is the sentinel separator,
+			// not a class-method dispatch, so the dispatch kind is unknown and
+			// receiver filtering must not narrow on it.
+			if strings.HasPrefix(target, "self.") || strings.HasPrefix(target, "Self::") {
+				sep = ""
+			}
+			matches := ix.byName[name]
+			matches = filterByReceiver(matches, sep)
+			if len(matches) > 0 {
 				r := pickBest(matches, req.SourceFileID, req.BaseConfidence)
 				if r.Confidence > ambiguousConfidence {
 					r.Confidence = ambiguousConfidence
@@ -215,6 +225,16 @@ func separator(sourceQualified, parentQualified string) string {
 // using `.`, `#`, or `::` as separators. When no separator is
 // present, the original string is returned (it's already bare).
 func unqualifiedName(qualified string) string {
+	name, _ := unqualifiedNameSep(qualified)
+	return name
+}
+
+// unqualifiedNameSep returns the trailing segment of a qualified name and
+// the separator that precedes it (`.`, `#`, `::`, or "" when the name is
+// already bare). The separator carries the call's dispatch kind for Ruby —
+// `#` is an instance call, `.` is a class/singleton call — which
+// filterByReceiver uses to disambiguate same-named candidates.
+func unqualifiedNameSep(qualified string) (name, sep string) {
 	best := -1
 	bestSep := ""
 	for _, s := range []string{"::", "#", "."} {
@@ -224,7 +244,69 @@ func unqualifiedName(qualified string) string {
 		}
 	}
 	if best < 0 {
-		return qualified
+		return qualified, ""
 	}
-	return qualified[best+len(bestSep):]
+	return qualified[best+len(bestSep):], bestSep
+}
+
+// filterByReceiver narrows unqualified-fallback candidates to those whose
+// dispatch kind matches the call separator, so an instance call (`X#m`)
+// cannot bind to a same-named singleton method (`Y.m`) and vice-versa.
+//
+// It only acts when (a) the separator maps to a receiver kind (`#` ⇒
+// instance, `.` ⇒ singleton) and (b) at least one candidate declares a
+// receiver — i.e. a Ruby method carrying the distinction. Candidates with
+// an empty receiver (non-methods, other languages, top-level defs) are
+// always kept, so resolution for languages that don't populate receiver is
+// unchanged. If filtering would remove every candidate, the original set is
+// returned rather than dropping the edge — the dispatch hint is a tie-break,
+// not a hard gate.
+func filterByReceiver(matches []model.SymbolRef, sep string) []model.SymbolRef {
+	want := receiverForSeparator(sep)
+	if want == "" {
+		return matches
+	}
+	declared := false
+	for _, m := range matches {
+		if m.Receiver != "" {
+			declared = true
+			break
+		}
+	}
+	if !declared {
+		return matches
+	}
+	kept := make([]model.SymbolRef, 0, len(matches))
+	for _, m := range matches {
+		if m.Receiver == "" || m.Receiver == want {
+			kept = append(kept, m)
+		}
+	}
+	if len(kept) == 0 {
+		return matches
+	}
+	return kept
+}
+
+// receiverForSeparator maps a call separator to the dispatch kind it implies:
+// `#` ⇒ instance, `.` ⇒ singleton/class. `::` (namespace) and "" (bare,
+// receiver unknown) carry no dispatch hint.
+//
+// IMPORTANT: this encodes *Ruby* dispatch semantics, where `.` is a
+// singleton/class call and `#` an instance call. It is safe for other
+// languages today only because Ruby is the sole extractor that populates
+// SymbolRef.Receiver — filterByReceiver no-ops when no candidate declares a
+// receiver, so a Go/Python `pkg.fn` target (also separated by `.`) is never
+// narrowed. If another language begins populating Receiver, it must share this
+// `.`=singleton / `#`=instance convention, or filterByReceiver must be gated
+// by language — otherwise a `.`-dispatched instance call in that language
+// would be wrongly filtered against same-named singletons.
+func receiverForSeparator(sep string) string {
+	switch sep {
+	case "#":
+		return extract.ReceiverInstance
+	case ".":
+		return extract.ReceiverSingleton
+	}
+	return ""
 }

--- a/internal/resolve/resolver_internal_test.go
+++ b/internal/resolve/resolver_internal_test.go
@@ -1,6 +1,11 @@
 package resolve
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/model"
+)
 
 // TestUnqualifiedName is the direct-access white-box test for the
 // separator-stripping helper. Lives in the internal package because
@@ -22,4 +27,80 @@ func TestUnqualifiedName(t *testing.T) {
 			t.Errorf("unqualifiedName(%q) = %q, want %q", c.in, got, c.want)
 		}
 	}
+}
+
+func TestUnqualifiedNameSep(t *testing.T) {
+	cases := []struct {
+		in, wantName, wantSep string
+	}{
+		{"foo", "foo", ""},
+		{"a.b", "b", "."},
+		{"A::B::c", "c", "::"},
+		{"Greeter#greet", "greet", "#"},
+		{"A::B.c", "c", "."}, // rightmost separator wins when mixed
+	}
+	for _, c := range cases {
+		name, sep := unqualifiedNameSep(c.in)
+		if name != c.wantName || sep != c.wantSep {
+			t.Errorf("unqualifiedNameSep(%q) = (%q, %q), want (%q, %q)",
+				c.in, name, sep, c.wantName, c.wantSep)
+		}
+	}
+}
+
+func TestReceiverForSeparator(t *testing.T) {
+	cases := []struct{ sep, want string }{
+		{"#", extract.ReceiverInstance},
+		{".", extract.ReceiverSingleton},
+		{"::", ""},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := receiverForSeparator(c.sep); got != c.want {
+			t.Errorf("receiverForSeparator(%q) = %q, want %q", c.sep, got, c.want)
+		}
+	}
+}
+
+func TestFilterByReceiver(t *testing.T) {
+	instance := model.SymbolRef{ID: 1, Qualified: "Counter#zero", Receiver: extract.ReceiverInstance}
+	singleton := model.SymbolRef{ID: 2, Qualified: "Money.zero", Receiver: extract.ReceiverSingleton}
+	bare := model.SymbolRef{ID: 3, Qualified: "zero"} // no receiver (e.g. another language)
+
+	t.Run("instance separator keeps instance and bare, drops singleton", func(t *testing.T) {
+		got := filterByReceiver([]model.SymbolRef{instance, singleton, bare}, "#")
+		if len(got) != 2 || got[0].ID != 1 || got[1].ID != 3 {
+			t.Fatalf("got %+v, want ids [1 3]", got)
+		}
+	})
+	t.Run("singleton separator keeps singleton and bare, drops instance", func(t *testing.T) {
+		got := filterByReceiver([]model.SymbolRef{instance, singleton, bare}, ".")
+		if len(got) != 2 || got[0].ID != 2 || got[1].ID != 3 {
+			t.Fatalf("got %+v, want ids [2 3]", got)
+		}
+	})
+	t.Run("no receiver declared leaves candidates untouched", func(t *testing.T) {
+		in := []model.SymbolRef{bare, {ID: 4, Qualified: "pkg.zero"}}
+		got := filterByReceiver(in, "#")
+		if len(got) != 2 {
+			t.Fatalf("got %d candidates, want 2", len(got))
+		}
+	})
+	t.Run("non-dispatch separator is a no-op", func(t *testing.T) {
+		in := []model.SymbolRef{instance, singleton}
+		got := filterByReceiver(in, "::")
+		if len(got) != 2 {
+			t.Fatalf("got %d candidates, want 2", len(got))
+		}
+	})
+	t.Run("empty result falls back to original set", func(t *testing.T) {
+		// All candidates are singletons but the call is an instance dispatch:
+		// filtering would empty the set, so the original is returned as a
+		// tie-break rather than dropping the edge.
+		in := []model.SymbolRef{singleton, {ID: 5, Qualified: "Other.zero", Receiver: extract.ReceiverSingleton}}
+		got := filterByReceiver(in, "#")
+		if len(got) != 2 {
+			t.Fatalf("got %d candidates, want 2 (original set)", len(got))
+		}
+	})
 }

--- a/internal/resolve/resolver_test.go
+++ b/internal/resolve/resolver_test.go
@@ -3,6 +3,7 @@ package resolve_test
 import (
 	"testing"
 
+	"github.com/luuuc/sense/internal/extract"
 	"github.com/luuuc/sense/internal/model"
 	"github.com/luuuc/sense/internal/resolve"
 )
@@ -404,5 +405,79 @@ func TestResolveSingleNameOnlyKeepsConfidence(t *testing.T) {
 	}
 	if r.Confidence != 0.8 {
 		t.Errorf("Confidence = %v, want 0.8 (single name-only clamp)", r.Confidence)
+	}
+}
+
+// receiverRefs models the headline collision: a class/singleton method and a
+// same-named instance method. Their qualified names differ by separator, so
+// they share a bare-name bucket and the unqualified fallback must use the
+// call's dispatch kind to pick the right one.
+func receiverRefs() []model.SymbolRef {
+	return []model.SymbolRef{
+		{ID: 1, Qualified: "PriceValue.zero", FileID: 10, Receiver: extract.ReceiverSingleton},
+		{ID: 2, Qualified: "Counter#zero", FileID: 11, Receiver: extract.ReceiverInstance},
+	}
+}
+
+func TestResolveInstanceCallDoesNotBindSingleton(t *testing.T) {
+	ix := resolve.NewIndex(receiverRefs())
+	// Instance dispatch: `something#zero` whose class guess missed. The
+	// fallback must land on the instance method, never the PriceValue
+	// singleton — the bug that attributed `.zero?`-style calls to PriceValue.
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "Counter#zero",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   99,
+		BaseConfidence: 1.0,
+	})
+	if !ok {
+		t.Fatal("expected resolution")
+	}
+	if r.SymbolID != 2 {
+		t.Errorf("SymbolID = %d, want 2 (Counter#zero instance method)", r.SymbolID)
+	}
+	if r.Ambiguous {
+		t.Error("dispatch kind uniquely disambiguates — should not be ambiguous")
+	}
+}
+
+func TestResolveSingletonCallDoesNotBindInstance(t *testing.T) {
+	ix := resolve.NewIndex(receiverRefs())
+	// Class dispatch on a constant whose qualified form missed: must land on
+	// the singleton, not the same-named instance method.
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "Other.zero",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   99,
+		BaseConfidence: 1.0,
+	})
+	if !ok {
+		t.Fatal("expected resolution")
+	}
+	if r.SymbolID != 1 {
+		t.Errorf("SymbolID = %d, want 1 (PriceValue.zero singleton)", r.SymbolID)
+	}
+}
+
+func TestResolveImplicitSelfReachesInstanceConcernMethod(t *testing.T) {
+	// A template/file-level `self.current_currency` (no source parent to
+	// rewrite against) must still resolve to an instance concern method. The
+	// `self.` sentinel's trailing `.` must not be mistaken for singleton
+	// dispatch and filter the instance candidate out.
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "CurrencyContext#current_currency", FileID: 11, Receiver: extract.ReceiverInstance},
+	}
+	ix := resolve.NewIndex(rs)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "self.current_currency",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   50, // a view file, no parent class
+		BaseConfidence: extract.ConfidenceConvention,
+	})
+	if !ok {
+		t.Fatal("expected resolution to the concern method")
+	}
+	if r.SymbolID != 1 {
+		t.Errorf("SymbolID = %d, want 1 (CurrencyContext#current_currency)", r.SymbolID)
 	}
 }

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -1011,6 +1011,7 @@ func (h *harness) writeFileInner(fr *fileResult) (int, error) {
 			Qualified:  s.Qualified,
 			Kind:       s.Kind,
 			Visibility: s.Visibility,
+			Receiver:   s.Receiver,
 			ParentID:   parentID,
 			LineStart:  s.LineStart,
 			LineEnd:    s.LineEnd,

--- a/internal/sqlite/adapter.go
+++ b/internal/sqlite/adapter.go
@@ -30,7 +30,7 @@ var schemaFTSSQL string
 // Bump when schema.sql changes incompatibly — a mismatch triggers
 // auto-rebuild (drop all tables, fresh schema, full scan). Never set
 // before a scan completes successfully; see StampSchemaVersion.
-const SchemaVersion = 4
+const SchemaVersion = 5
 
 // maxOpenConns is the connection-pool size Open applies. InTx relies on
 // this being 1 — its raw BEGIN/COMMIT approach shares a transaction
@@ -372,13 +372,14 @@ func (a *Adapter) WriteFile(ctx context.Context, f *model.File) (int64, error) {
 func (a *Adapter) WriteSymbol(ctx context.Context, s *model.Symbol) (int64, error) {
 	const q = `
 		INSERT INTO sense_symbols
-			(file_id, name, qualified, kind, visibility, parent_id,
+			(file_id, name, qualified, kind, visibility, receiver, parent_id,
 			 line_start, line_end, docstring, complexity, snippet, name_parts)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(file_id, qualified) DO UPDATE SET
 			name       = excluded.name,
 			kind       = excluded.kind,
 			visibility = excluded.visibility,
+			receiver   = excluded.receiver,
 			parent_id  = excluded.parent_id,
 			line_start = excluded.line_start,
 			line_end   = excluded.line_end,
@@ -391,7 +392,7 @@ func (a *Adapter) WriteSymbol(ctx context.Context, s *model.Symbol) (int64, erro
 	nameParts := symbolNameParts(s.Name, s.Qualified)
 	var id int64
 	err := a.db.QueryRowContext(ctx, q,
-		s.FileID, s.Name, s.Qualified, string(s.Kind), s.Visibility,
+		s.FileID, s.Name, s.Qualified, string(s.Kind), s.Visibility, s.Receiver,
 		nullableInt64(s.ParentID), s.LineStart, s.LineEnd,
 		s.Docstring, nullableInt(s.Complexity), s.Snippet, nameParts,
 	).Scan(&id)
@@ -453,13 +454,14 @@ func (a *Adapter) WriteEdge(ctx context.Context, e *model.Edge) (int64, error) {
 func (a *Adapter) PrepareSymbolStmt(ctx context.Context) (*sql.Stmt, error) {
 	const q = `
 		INSERT INTO sense_symbols
-			(file_id, name, qualified, kind, visibility, parent_id,
+			(file_id, name, qualified, kind, visibility, receiver, parent_id,
 			 line_start, line_end, docstring, complexity, snippet, name_parts)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(file_id, qualified) DO UPDATE SET
 			name       = excluded.name,
 			kind       = excluded.kind,
 			visibility = excluded.visibility,
+			receiver   = excluded.receiver,
 			parent_id  = excluded.parent_id,
 			line_start = excluded.line_start,
 			line_end   = excluded.line_end,
@@ -476,7 +478,7 @@ func ExecSymbolStmt(ctx context.Context, stmt *sql.Stmt, s *model.Symbol) (int64
 	nameParts := symbolNameParts(s.Name, s.Qualified)
 	var id int64
 	err := stmt.QueryRowContext(ctx,
-		s.FileID, s.Name, s.Qualified, string(s.Kind), s.Visibility,
+		s.FileID, s.Name, s.Qualified, string(s.Kind), s.Visibility, s.Receiver,
 		nullableInt64(s.ParentID), s.LineStart, s.LineEnd,
 		s.Docstring, nullableInt(s.Complexity), s.Snippet, nameParts,
 	).Scan(&id)
@@ -873,7 +875,7 @@ func (a *Adapter) Query(ctx context.Context, f index.Filter) ([]model.Symbol, er
 // follow-up sort: the first id under each key is deterministically
 // the earliest written.
 func (a *Adapter) SymbolRefs(ctx context.Context) ([]model.SymbolRef, error) {
-	const q = `SELECT id, qualified, file_id FROM sense_symbols ORDER BY id ASC`
+	const q = `SELECT id, qualified, file_id, receiver FROM sense_symbols ORDER BY id ASC`
 	rows, err := a.db.QueryContext(ctx, q)
 	if err != nil {
 		return nil, fmt.Errorf("sqlite SymbolRefs: %w", err)
@@ -883,7 +885,7 @@ func (a *Adapter) SymbolRefs(ctx context.Context) ([]model.SymbolRef, error) {
 	var refs []model.SymbolRef
 	for rows.Next() {
 		var r model.SymbolRef
-		if err := rows.Scan(&r.ID, &r.Qualified, &r.FileID); err != nil {
+		if err := rows.Scan(&r.ID, &r.Qualified, &r.FileID, &r.Receiver); err != nil {
 			return nil, fmt.Errorf("sqlite SymbolRefs scan: %w", err)
 		}
 		refs = append(refs, r)

--- a/internal/sqlite/coverage_test.go
+++ b/internal/sqlite/coverage_test.go
@@ -197,6 +197,40 @@ func TestSymbolRefs(t *testing.T) {
 	}
 }
 
+func TestSymbolRefsCarriesReceiver(t *testing.T) {
+	a := openTestDB(t)
+	ctx := context.Background()
+
+	fid := seedFile(t, a, "price.rb", "ruby", "h1")
+	if _, err := a.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid, Name: "zero", Qualified: "PriceValue.zero",
+		Kind: model.KindMethod, Receiver: "singleton", LineStart: 1, LineEnd: 3,
+	}); err != nil {
+		t.Fatalf("WriteSymbol singleton: %v", err)
+	}
+	if _, err := a.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid, Name: "zero?", Qualified: "PriceValue#zero?",
+		Kind: model.KindMethod, Receiver: "instance", LineStart: 5, LineEnd: 7,
+	}); err != nil {
+		t.Fatalf("WriteSymbol instance: %v", err)
+	}
+
+	refs, err := a.SymbolRefs(ctx)
+	if err != nil {
+		t.Fatalf("SymbolRefs: %v", err)
+	}
+	got := map[string]string{}
+	for _, r := range refs {
+		got[r.Qualified] = r.Receiver
+	}
+	if got["PriceValue.zero"] != "singleton" {
+		t.Errorf("PriceValue.zero Receiver = %q, want singleton", got["PriceValue.zero"])
+	}
+	if got["PriceValue#zero?"] != "instance" {
+		t.Errorf("PriceValue#zero? Receiver = %q, want instance", got["PriceValue#zero?"])
+	}
+}
+
 func TestEdgesOfKind(t *testing.T) {
 	a := openTestDB(t)
 	ctx := context.Background()

--- a/internal/sqlite/schema.sql
+++ b/internal/sqlite/schema.sql
@@ -22,6 +22,13 @@ CREATE TABLE IF NOT EXISTS sense_symbols (
     qualified   TEXT    NOT NULL,
     kind        TEXT    NOT NULL,
     visibility  TEXT    DEFAULT 'public',
+    -- receiver records a method's dispatch kind for languages that
+    -- distinguish them: 'instance' (Ruby Class#m) or 'singleton'
+    -- (Ruby Class.m / def self.m). Empty for non-methods and for
+    -- languages that don't carry the distinction. Used by the resolver
+    -- to keep an instance call from binding to a same-named singleton
+    -- method (and vice-versa) in the unqualified-name fallback.
+    receiver    TEXT    NOT NULL DEFAULT '',
     parent_id   INTEGER REFERENCES sense_symbols(id),
     line_start  INTEGER NOT NULL,
     line_end    INTEGER NOT NULL,


### PR DESCRIPTION
## Problem
On Rails codebases, Sense's graph/blast caller analysis and dead-code detector
couldn't be trusted without grep verification. Three Ruby idioms were blind
spots: same-named instance/singleton methods collided in resolution (an
instance call could bind to an unrelated `Klass.method` singleton); concern/
helper methods called bare in expression position produced no caller edges
(showing 0 callers for ubiquitous helpers); and ERB templates were near-blind
(422 view files yielded a handful of symbols, so "who renders this partial / uses
this i18n key / calls this helper" was unanswerable). The dead-code detector
also top-tiered Ruby service-object and result-object methods as "dead".

## Summary
Adds dispatch-kind awareness to resolution, broadens Ruby call-edge emission to
value positions, indexes ERB references, and makes dead-code tiering Ruby-aware —
so graph, blast, and dead-code become trustworthy on Rails without grep checks.

## Changes
- **Dispatch disambiguation:** new `sense_symbols.receiver` column
  (`instance`/`singleton`), populated by the Ruby extractor; the resolver's
  unqualified-name fallback filters candidates by dispatch kind so an instance
  call can't bind to a same-named singleton (and vice-versa).
- **Concern/helper edges:** receiverless helper calls in value positions
  (arguments, interpolations, conditionals, assignment RHS) now emit caller
  edges, gated by a local-variable/parameter exclusion set.
- **ERB indexing:** rendered partials, i18n keys (lazy `.key` expanded to view
  scope), and bare helper calls are extracted from `.erb` templates.
- **Ruby-aware dead-code:** service `call` methods (`*Service`/`*Command`/…) and
  result predicates (`success?`/`failure?`/… on `*Result`/`*Response`/`*Outcome`)
  downgrade from `dead` to `possibly_dead` under a dynamic framework.

## Architecture Highlights
- **Emit-broad, resolve-narrow:** the extractor speculates on bare calls; the
  resolver drops any target matching no real symbol and clamps ambiguous matches
  below the blast floor — so speculative edges never pollute the final index.
- **Tiering only softens:** dead-code heuristics can downgrade `dead`→`possibly_dead`
  but never hide genuinely dead code.
- `receiver` is Ruby-only today; `receiverForSeparator` documents that any future
  language populating it must share `#`=instance / `.`=singleton semantics.

## Breaking Changes
⚠️ Schema version bumps 4→5. Existing indexes auto-rebuild on the next `sense scan`
(no manual migration); the rebuild is transparent and one-time.

## Test Plan
- [x] An instance call does not resolve to a same-named singleton method, and vice-versa
- [x] Concern helper used in expression position (e.g. `current_currency`) gets a caller edge; locals/params do not
- [x] ERB `render`, `t(".key")`, and `<%= helper %>` produce edges/symbols; relative partials/keys resolve to view scope
- [x] Service `.call` and `Result#success?` report `possibly_dead`, not `dead`
- [x] `go test ./...` passes and `make ci` is green
- [x] sense binary builds cleanly
