### PR TITLE
fix(graph): aggregate class callees and floor low-confidence edges

### DIFF
--- a/internal/mcpio/graph.go
+++ b/internal/mcpio/graph.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/luuuc/sense/internal/extract"
 	"github.com/luuuc/sense/internal/model"
 )
 
@@ -14,6 +15,18 @@ const (
 	MaxGraphDepth = 3
 	MaxPerHop     = 200
 )
+
+// graphConfidenceFloor hides usage edges (calls / references) whose
+// resolution confidence is below blast's traversal floor. It tracks the same
+// constant the sqlite fold uses (extract.ConfidenceUnresolved == 0.5) so the
+// display floor and the fold floor move together if the ladder is retuned.
+// Below it live bare-name and basic-tier guesses — e.g. the 0.3 ERB i18n edges
+// that point at a Ruby method's own definition line, which read as real
+// dependencies in raw graph output and carry a misattributed snippet. blast
+// already filters them; sense_graph now matches. Structural edges
+// (inherits/composes/includes/imports) and tests are never confidence-floored
+// — they're syntactically explicit.
+const graphConfidenceFloor = extract.ConfidenceUnresolved
 
 // FileLookup resolves a sense_files row id to its path. Used by
 // BuildGraphResponse / BuildBlastResponse to hydrate edge endpoints.
@@ -59,7 +72,9 @@ func BuildGraphResponse(ctx context.Context, sc *model.SymbolContext, files File
 		},
 	}
 
-	resp.Edges = categorizeEdges(ctx, sc.Outbound, sc.Inbound, files, req.Direction, req.Snippets)
+	var hidden int
+	resp.Edges, hidden = categorizeEdges(ctx, sc.Outbound, sc.Inbound, files, req.Direction, req.Snippets)
+	resp.LowConfidenceHidden = hidden
 	resp.SnippetsTruncated = req.Snippets.Truncated(len(sc.Outbound) + len(sc.Inbound))
 
 	// Test-caller segmentation: split test callers out of CalledBy.
@@ -177,18 +192,22 @@ func BuildFullGraphResponse(ctx context.Context, gr *model.GraphResult, files Fi
 // BuildGraphLayer converts a model.HopEdges into a wire-format
 // GraphLayer for the given hop depth.
 func BuildGraphLayer(ctx context.Context, hop model.HopEdges, depth int, files FileLookup, req BuildGraphRequest) GraphLayer {
+	edges, _ := categorizeEdges(ctx, hop.Outbound, hop.Inbound, files, req.Direction, req.Snippets)
 	return GraphLayer{
 		Depth: depth,
-		Edges: categorizeEdges(ctx, hop.Outbound, hop.Inbound, files, req.Direction, req.Snippets),
+		Edges: edges,
 	}
 }
 
 // categorizeEdges maps model edge refs into the wire-format GraphEdges
 // shape, dispatching each edge kind to the right bucket. Temporal edges
 // and test-caller segmentation are root-only concerns handled by
-// BuildGraphResponse on top of this.
-func categorizeEdges(ctx context.Context, outbound, inbound []model.EdgeRef, files FileLookup, direction model.Direction, snippets *SnippetReader) GraphEdges {
+// BuildGraphResponse on top of this. Usage edges (calls / references)
+// below graphConfidenceFloor are dropped and counted in the returned
+// hidden total so the caller can report them rather than silently omit.
+func categorizeEdges(ctx context.Context, outbound, inbound []model.EdgeRef, files FileLookup, direction model.Direction, snippets *SnippetReader) (GraphEdges, int) {
 	var edges GraphEdges
+	var hidden int
 
 	readSnippet := func(e model.EdgeRef) *CallSite {
 		if e.Edge.Line == nil {
@@ -205,6 +224,10 @@ func categorizeEdges(ctx context.Context, outbound, inbound []model.EdgeRef, fil
 		for _, e := range outbound {
 			switch e.Edge.Kind {
 			case model.EdgeCalls, model.EdgeReferences:
+				if e.Edge.Confidence < graphConfidenceFloor {
+					hidden++
+					continue
+				}
 				fp := fileRefOrNil(e.Target.FileID, files)
 				edges.Calls = append(edges.Calls, CallEdgeRef{
 					Symbol:     qualifiedOrName(e.Target),
@@ -260,6 +283,10 @@ func categorizeEdges(ctx context.Context, outbound, inbound []model.EdgeRef, fil
 		for _, e := range inbound {
 			switch e.Edge.Kind {
 			case model.EdgeCalls, model.EdgeReferences:
+				if e.Edge.Confidence < graphConfidenceFloor {
+					hidden++
+					continue
+				}
 				fp := fileRefOrNil(e.Target.FileID, files)
 				edges.CalledBy = append(edges.CalledBy, CallEdgeRef{
 					Symbol:     qualifiedOrName(e.Target),
@@ -333,7 +360,7 @@ func categorizeEdges(ctx context.Context, outbound, inbound []model.EdgeRef, fil
 		}
 	}
 
-	return edges
+	return edges, hidden
 }
 
 // qualifiedOrName prefers the qualified name but falls back to the

--- a/internal/mcpio/graph_test.go
+++ b/internal/mcpio/graph_test.go
@@ -1308,3 +1308,94 @@ func TestFullGraphResponseSharedSnippetBudget(t *testing.T) {
 		t.Error("SnippetsTruncated should be true when total edges exceed cap")
 	}
 }
+
+// Usage edges (calls / references) below the confidence floor are dropped from
+// the graph and tallied in LowConfidenceHidden — the 0.3 ERB/i18n noise the
+// real Rails index produced for Listing::Item#price_amount.
+func TestCategorizeEdgesHidesLowConfidenceUsageEdges(t *testing.T) {
+	files := func(int64) (string, bool) { return "", false }
+	sc := &model.SymbolContext{
+		Symbol: model.Symbol{Name: "price_amount", Qualified: "Listing::Item#price_amount", Kind: "method"},
+		File:   model.File{Path: "app/models/listing/item.rb"},
+		Outbound: []model.EdgeRef{
+			{Edge: model.Edge{Kind: model.EdgeCalls, Confidence: 0.7}, Target: model.Symbol{Qualified: "PriceValue#amount"}},
+			{Edge: model.Edge{Kind: model.EdgeCalls, Confidence: 0.3}, Target: model.Symbol{Qualified: "i18n:admin.help.articles.new.breadcrumbs.new"}},
+			{Edge: model.Edge{Kind: model.EdgeReferences, Confidence: 0.3}, Target: model.Symbol{Qualified: "i18n:account.wallet.currency"}},
+		},
+		Inbound: []model.EdgeRef{
+			{Edge: model.Edge{Kind: model.EdgeCalls, Confidence: 0.5}, Target: model.Symbol{Qualified: "Admin::ProductsController#generate_csv"}},
+			{Edge: model.Edge{Kind: model.EdgeCalls, Confidence: 0.3}, Target: model.Symbol{Qualified: "Noise#caller"}},
+		},
+	}
+
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{})
+
+	if len(resp.Edges.Calls) != 1 || resp.Edges.Calls[0].Symbol != "PriceValue#amount" {
+		t.Errorf("Calls = %v, want only PriceValue#amount (0.3 i18n edges floored)", resp.Edges.Calls)
+	}
+	if len(resp.Edges.CalledBy) != 1 || resp.Edges.CalledBy[0].Symbol != "Admin::ProductsController#generate_csv" {
+		t.Errorf("CalledBy = %v, want only the 0.5 caller (0.3 caller floored)", resp.Edges.CalledBy)
+	}
+	if resp.LowConfidenceHidden != 3 {
+		t.Errorf("LowConfidenceHidden = %d, want 3 (2 outbound + 1 inbound below floor)", resp.LowConfidenceHidden)
+	}
+}
+
+// The floor applies only to usage edges. Structural edges (inherits, composes,
+// includes, imports) are syntactically explicit and are never confidence-floored.
+func TestCategorizeEdgesDoesNotFloorStructuralEdges(t *testing.T) {
+	files := func(int64) (string, bool) { return "", false }
+	sc := &model.SymbolContext{
+		Symbol: model.Symbol{Name: "User", Qualified: "User", Kind: "class"},
+		File:   model.File{Path: "user.rb"},
+		Outbound: []model.EdgeRef{
+			{Edge: model.Edge{Kind: model.EdgeInherits, Confidence: 0.3}, Target: model.Symbol{Qualified: "Base"}},
+			{Edge: model.Edge{Kind: model.EdgeComposes, Confidence: 0.3}, Target: model.Symbol{Qualified: "Order"}},
+		},
+	}
+
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{})
+
+	if len(resp.Edges.Inherits) != 1 {
+		t.Errorf("Inherits = %v, want 1 (structural edges are not floored)", resp.Edges.Inherits)
+	}
+	if len(resp.Edges.Composes) != 1 {
+		t.Errorf("Composes = %v, want 1 (structural edges are not floored)", resp.Edges.Composes)
+	}
+	if resp.LowConfidenceHidden != 0 {
+		t.Errorf("LowConfidenceHidden = %d, want 0 (no usage edges below floor)", resp.LowConfidenceHidden)
+	}
+}
+
+// The floor is applied to every hop's edges, but LowConfidenceHidden tallies
+// the root only — deeper hops drop their below-floor edges without counting.
+func TestBuildFullGraphResponseFloorsLayersCountsRootOnly(t *testing.T) {
+	files := func(int64) (string, bool) { return "", false }
+	gr := &model.GraphResult{
+		Root: model.SymbolContext{
+			Symbol: model.Symbol{Name: "A", Qualified: "A", Kind: "method"},
+			File:   model.File{Path: "a.rb"},
+			Outbound: []model.EdgeRef{
+				{Edge: model.Edge{Kind: model.EdgeCalls, Confidence: 0.3}, Target: model.Symbol{Qualified: "rootNoise"}},
+			},
+		},
+		Layers: []model.HopEdges{
+			{Outbound: []model.EdgeRef{
+				{Edge: model.Edge{Kind: model.EdgeCalls, Confidence: 0.3}, Target: model.Symbol{Qualified: "layerNoise"}},
+				{Edge: model.Edge{Kind: model.EdgeCalls, Confidence: 0.9}, Target: model.Symbol{Qualified: "layerReal"}},
+			}},
+		},
+	}
+
+	resp := BuildFullGraphResponse(context.Background(), gr, files, BuildGraphRequest{})
+
+	if len(resp.Edges.Calls) != 0 {
+		t.Errorf("root Calls = %v, want 0 (0.3 floored)", resp.Edges.Calls)
+	}
+	if len(resp.Layers) != 1 || len(resp.Layers[0].Edges.Calls) != 1 || resp.Layers[0].Edges.Calls[0].Symbol != "layerReal" {
+		t.Errorf("layer Calls = %v, want only layerReal (0.3 floored)", resp.Layers)
+	}
+	if resp.LowConfidenceHidden != 1 {
+		t.Errorf("LowConfidenceHidden = %d, want 1 (root only, layer hides not counted)", resp.LowConfidenceHidden)
+	}
+}

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -103,6 +103,10 @@ type GraphResponse struct {
 	Truncated          bool               `json:"truncated,omitempty"`
 	SnippetsTruncated  bool               `json:"snippets_truncated,omitempty"`
 	TestCallerSummary  *TestCallerSummary `json:"test_caller_summary,omitempty"`
+	// LowConfidenceHidden counts usage edges dropped below graphConfidenceFloor
+	// for the root symbol only (not deeper layers), so a consumer knows the
+	// edge list was filtered rather than silently truncated.
+	LowConfidenceHidden int               `json:"low_confidence_hidden,omitempty"`
 	CoverageNote       string                 `json:"coverage_note,omitempty"`
 	VerifyHint         string                 `json:"verify_hint,omitempty"`
 	IndexCaveat        string                 `json:"index_caveat,omitempty"`

--- a/internal/sqlite/adapter.go
+++ b/internal/sqlite/adapter.go
@@ -594,6 +594,15 @@ func (a *Adapter) ReadSymbolGraph(ctx context.Context, id int64, depth int, dire
 			return nil, err
 		}
 	}
+	// Symmetric to foldMemberCallers: fold member callees into the container's
+	// outbound set so "what does this class call" reflects what its methods
+	// reach, instead of returning an empty list that reads as "depends on
+	// nothing".
+	if direction != model.DirectionCallers {
+		if err := a.foldMemberCallees(ctx, &result.Root); err != nil {
+			return nil, err
+		}
+	}
 	if depth <= 1 {
 		return result, nil
 	}
@@ -720,10 +729,12 @@ func isUsageEdge(k model.EdgeKind) bool {
 	return k == model.EdgeCalls || k == model.EdgeReferences
 }
 
-// hasUsageCaller reports whether edges contains at least one above-floor
-// usage edge — a real "someone calls/references this" signal, as opposed to
-// a structural edge or a low-confidence resolution guess.
-func hasUsageCaller(edges []model.EdgeRef) bool {
+// hasUsageEdge reports whether edges contains at least one above-floor
+// usage edge — a real call/reference signal, as opposed to a structural
+// edge or a low-confidence resolution guess. Used by both fold paths:
+// against Inbound it means "has a real caller", against Outbound it means
+// "has a real callee".
+func hasUsageEdge(edges []model.EdgeRef) bool {
 	for _, e := range edges {
 		if isUsageEdge(e.Edge.Kind) && e.Edge.Confidence >= extract.ConfidenceUnresolved {
 			return true
@@ -747,7 +758,7 @@ func (a *Adapter) foldMemberCallers(ctx context.Context, sc *model.SymbolContext
 	// blast found callers via the class's methods). A structural edge
 	// (inherits/composes) or a low-confidence name-collision guess is not a
 	// real caller, so those do not suppress enrichment.
-	if hasUsageCaller(sc.Inbound) {
+	if hasUsageEdge(sc.Inbound) {
 		return nil
 	}
 	childIDs, err := a.childSymbolIDs(ctx, sc.Symbol.ID)
@@ -789,6 +800,71 @@ func (a *Adapter) foldMemberCallers(ctx context.Context, sc *model.SymbolContext
 			}
 			seen[e.Target.ID] = struct{}{}
 			sc.Inbound = append(sc.Inbound, e)
+		}
+	}
+	return nil
+}
+
+// foldMemberCallees enriches a container symbol's outbound edges with the
+// callees of its own members. Without it, "what does PriceValue call" returns
+// only the edges the type itself names (usually none), so calls renders as
+// `[]` — read as "depends on nothing" when the class in fact reaches Money.new,
+// money.format, and friends through its methods. Calls back into the container
+// or its own siblings are excluded so internal method-to-method traffic doesn't
+// masquerade as an external dependency; results are deduped by target against
+// the existing outbound set and each other.
+func (a *Adapter) foldMemberCallees(ctx context.Context, sc *model.SymbolContext) error {
+	if !isContainerExpandKind(sc.Symbol.Kind) {
+		return nil
+	}
+	// Only enrich when the container has no real callee of its own — the
+	// "a class's dependencies look empty" case. A structural edge
+	// (inherits/composes) or a low-confidence guess is not a real callee, so
+	// those do not suppress enrichment.
+	if hasUsageEdge(sc.Outbound) {
+		return nil
+	}
+	childIDs, err := a.childSymbolIDs(ctx, sc.Symbol.ID)
+	if err != nil {
+		return err
+	}
+	if len(childIDs) == 0 {
+		return nil
+	}
+	exclude := make(map[int64]struct{}, len(childIDs)+1)
+	exclude[sc.Symbol.ID] = struct{}{}
+	for _, cid := range childIDs {
+		exclude[cid] = struct{}{}
+	}
+	seen := make(map[int64]struct{}, len(sc.Outbound))
+	for _, e := range sc.Outbound {
+		seen[e.Target.ID] = struct{}{}
+	}
+	for _, cid := range childIDs {
+		refs, err := a.loadEdges(ctx, cid, true)
+		if err != nil {
+			return err
+		}
+		for _, e := range refs {
+			if e.Target.ID == 0 || e.Edge.Kind == model.EdgeTemporal {
+				continue
+			}
+			// Don't fold low-confidence guesses (e.g. the 0.3 ERB/i18n
+			// edges) into the class's callees — that would re-admit exactly
+			// what blast and the graph confidence floor filter out.
+			if e.Edge.Confidence < extract.ConfidenceUnresolved {
+				continue
+			}
+			if _, skip := exclude[e.Target.ID]; skip {
+				continue
+			}
+			if _, dup := seen[e.Target.ID]; dup {
+				continue
+			}
+			// First member edge to a given target wins; the displayed
+			// confidence is first-seen (by edge id), not the max across members.
+			seen[e.Target.ID] = struct{}{}
+			sc.Outbound = append(sc.Outbound, e)
 		}
 	}
 	return nil

--- a/internal/sqlite/foldcallees_internal_test.go
+++ b/internal/sqlite/foldcallees_internal_test.go
@@ -1,0 +1,27 @@
+package sqlite
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/luuuc/sense/internal/model"
+)
+
+// foldMemberCallees surfaces a DB error from the child-symbol lookup rather
+// than swallowing it. Exercised against a closed adapter so the query fails.
+func TestFoldMemberCalleesChildQueryError(t *testing.T) {
+	ctx := context.Background()
+	a, err := Open(ctx, filepath.Join(t.TempDir(), "closed.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := a.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	sc := &model.SymbolContext{Symbol: model.Symbol{ID: 1, Kind: model.KindClass}}
+	if err := a.foldMemberCallees(ctx, sc); err == nil {
+		t.Fatal("foldMemberCallees on closed adapter: want error, got nil")
+	}
+}

--- a/internal/sqlite/foldcallees_test.go
+++ b/internal/sqlite/foldcallees_test.go
@@ -1,0 +1,190 @@
+package sqlite_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luuuc/sense/internal/model"
+)
+
+// A class with no callees of its own surfaces the callees of its methods, so
+// "what does this class call" no longer reads as an empty "depends on nothing"
+// — while its own members (self-calls, sibling calls) are excluded.
+func TestReadSymbolGraphFoldsMemberCallees(t *testing.T) {
+	a, fileID := newFoldAdapter(t)
+	ctx := context.Background()
+
+	classID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "Price", Qualified: "Price", Kind: model.KindClass, LineStart: 1, LineEnd: 50})
+	methodID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "formatted", Qualified: "Price#formatted", Kind: model.KindMethod, ParentID: &classID, LineStart: 5, LineEnd: 10})
+	siblingID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "amount", Qualified: "Price#amount", Kind: model.KindMethod, ParentID: &classID, LineStart: 12, LineEnd: 16})
+	depID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "format", Qualified: "I18n.format", Kind: model.KindFunction, LineStart: 20, LineEnd: 30})
+
+	// formatted -> I18n.format (external dependency, should fold up)
+	mustEdge(t, a, &model.Edge{SourceID: &methodID, TargetID: depID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 1.0})
+	// formatted -> amount (internal sibling call, must be excluded)
+	mustEdge(t, a, &model.Edge{SourceID: &methodID, TargetID: siblingID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 1.0})
+
+	gr, err := a.ReadSymbolGraph(ctx, classID, 1, model.DirectionCallees, 0)
+	if err != nil {
+		t.Fatalf("ReadSymbolGraph: %v", err)
+	}
+	var gotDep, gotSelf bool
+	for _, e := range gr.Root.Outbound {
+		switch e.Target.ID {
+		case depID:
+			gotDep = true
+		case classID, methodID, siblingID:
+			gotSelf = true
+		}
+	}
+	if !gotDep {
+		t.Error("class graph should fold in the callee of its method")
+	}
+	if gotSelf {
+		t.Error("class graph must exclude the class's own members as callees")
+	}
+}
+
+// When a class already names a callee directly, the precise answer is kept —
+// method callees are not folded in to dilute it.
+func TestReadSymbolGraphDirectCalleesNotDiluted(t *testing.T) {
+	a, fileID := newFoldAdapter(t)
+	ctx := context.Background()
+
+	classID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "Acct", Qualified: "Acct", Kind: model.KindClass, LineStart: 1, LineEnd: 30})
+	methodID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "debit", Qualified: "Acct#debit", Kind: model.KindMethod, ParentID: &classID, LineStart: 3, LineEnd: 6})
+	directID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "Direct", Qualified: "Direct", Kind: model.KindFunction, LineStart: 10, LineEnd: 14})
+	indirectID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "Indirect", Qualified: "Indirect", Kind: model.KindFunction, LineStart: 16, LineEnd: 20})
+
+	// Class itself references Direct (a real callee of its own).
+	mustEdge(t, a, &model.Edge{SourceID: &classID, TargetID: directID, Kind: model.EdgeReferences, FileID: fileID, Confidence: 1.0})
+	// Method debit calls Indirect — should NOT fold up since the class has a callee.
+	mustEdge(t, a, &model.Edge{SourceID: &methodID, TargetID: indirectID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 1.0})
+
+	gr, err := a.ReadSymbolGraph(ctx, classID, 1, model.DirectionCallees, 0)
+	if err != nil {
+		t.Fatalf("ReadSymbolGraph: %v", err)
+	}
+	var direct, indirect bool
+	for _, e := range gr.Root.Outbound {
+		if e.Target.ID == directID {
+			direct = true
+		}
+		if e.Target.ID == indirectID {
+			indirect = true
+		}
+	}
+	if !direct {
+		t.Error("direct callee missing")
+	}
+	if indirect {
+		t.Error("method-callee should not be folded when the class already names a callee")
+	}
+}
+
+// A non-container root (a method) never folds — its graph is exactly its own edges.
+func TestReadSymbolGraphMethodRootNotFoldedCallees(t *testing.T) {
+	a, fileID := newFoldAdapter(t)
+	ctx := context.Background()
+
+	classID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "Svc", Qualified: "Svc", Kind: model.KindClass, LineStart: 1, LineEnd: 20})
+	methodID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "run", Qualified: "Svc#run", Kind: model.KindMethod, ParentID: &classID, LineStart: 3, LineEnd: 6})
+
+	gr, err := a.ReadSymbolGraph(ctx, methodID, 1, model.DirectionCallees, 0)
+	if err != nil {
+		t.Fatalf("ReadSymbolGraph: %v", err)
+	}
+	if len(gr.Root.Outbound) != 0 {
+		t.Errorf("method root outbound = %d, want 0 (no folding for non-containers)", len(gr.Root.Outbound))
+	}
+}
+
+// A low-confidence member callee (below the 0.5 floor — e.g. a 0.3 ERB/i18n
+// guess) is not folded into the class's callees.
+func TestReadSymbolGraphMemberCalleesRespectConfidenceFloor(t *testing.T) {
+	a, fileID := newFoldAdapter(t)
+	ctx := context.Background()
+
+	classID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "Price", Qualified: "Price", Kind: model.KindClass, LineStart: 1, LineEnd: 50})
+	methodID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "formatted", Qualified: "Price#formatted", Kind: model.KindMethod, ParentID: &classID, LineStart: 5, LineEnd: 10})
+	noiseID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "i18n_key", Qualified: "i18n:some.key", Kind: model.KindFunction, LineStart: 20, LineEnd: 21})
+
+	// 0.3 == ConfidenceNameCollision, below the 0.5 fold floor.
+	mustEdge(t, a, &model.Edge{SourceID: &methodID, TargetID: noiseID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 0.3})
+
+	gr, err := a.ReadSymbolGraph(ctx, classID, 1, model.DirectionCallees, 0)
+	if err != nil {
+		t.Fatalf("ReadSymbolGraph: %v", err)
+	}
+	for _, e := range gr.Root.Outbound {
+		if e.Target.ID == noiseID {
+			t.Error("low-confidence member callee should not be folded into the class")
+		}
+	}
+}
+
+// A container with no members folds nothing — outbound stays empty.
+func TestReadSymbolGraphFoldsMemberCalleesNoChildren(t *testing.T) {
+	a, fileID := newFoldAdapter(t)
+	ctx := context.Background()
+
+	classID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "Empty", Qualified: "Empty", Kind: model.KindClass, LineStart: 1, LineEnd: 2})
+
+	gr, err := a.ReadSymbolGraph(ctx, classID, 1, model.DirectionCallees, 0)
+	if err != nil {
+		t.Fatalf("ReadSymbolGraph: %v", err)
+	}
+	if len(gr.Root.Outbound) != 0 {
+		t.Errorf("childless class outbound = %d, want 0", len(gr.Root.Outbound))
+	}
+}
+
+// The fold dedupes a callee reached from several methods, skips temporal
+// (co-change) member edges, and preserves the container's own structural
+// outbound edge (which doesn't suppress the fold since it isn't a usage edge).
+func TestReadSymbolGraphMemberCalleesDedupSkipsTemporalKeepsStructural(t *testing.T) {
+	a, fileID := newFoldAdapter(t)
+	ctx := context.Background()
+
+	classID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "Wallet", Qualified: "Wallet", Kind: model.KindClass, LineStart: 1, LineEnd: 60})
+	baseID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "Base", Qualified: "Base", Kind: model.KindClass, LineStart: 100, LineEnd: 110})
+	m1 := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "credit", Qualified: "Wallet#credit", Kind: model.KindMethod, ParentID: &classID, LineStart: 5, LineEnd: 9})
+	m2 := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "debit", Qualified: "Wallet#debit", Kind: model.KindMethod, ParentID: &classID, LineStart: 11, LineEnd: 15})
+	depID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "new", Qualified: "Money.new", Kind: model.KindFunction, LineStart: 200, LineEnd: 210})
+	tmpID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "CoChange", Qualified: "CoChange", Kind: model.KindFunction, LineStart: 300, LineEnd: 310})
+
+	// Class itself inherits Base — a structural (non-usage) edge that should
+	// survive and must not suppress the fold.
+	mustEdge(t, a, &model.Edge{SourceID: &classID, TargetID: baseID, Kind: model.EdgeInherits, FileID: fileID, Confidence: 1.0})
+	// Both methods reach Money.new — should fold up exactly once.
+	mustEdge(t, a, &model.Edge{SourceID: &m1, TargetID: depID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 1.0})
+	mustEdge(t, a, &model.Edge{SourceID: &m2, TargetID: depID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 1.0})
+	// A co-change edge on a member must be skipped, not folded as a callee.
+	mustEdge(t, a, &model.Edge{SourceID: &m1, TargetID: tmpID, Kind: model.EdgeTemporal, FileID: fileID, Confidence: 1.0})
+
+	gr, err := a.ReadSymbolGraph(ctx, classID, 1, model.DirectionCallees, 0)
+	if err != nil {
+		t.Fatalf("ReadSymbolGraph: %v", err)
+	}
+	var depCount, baseCount int
+	var sawTemporal bool
+	for _, e := range gr.Root.Outbound {
+		switch e.Target.ID {
+		case depID:
+			depCount++
+		case baseID:
+			baseCount++
+		case tmpID:
+			sawTemporal = true
+		}
+	}
+	if depCount != 1 {
+		t.Errorf("Money.new folded %d times, want 1 (deduped across methods)", depCount)
+	}
+	if baseCount != 1 {
+		t.Errorf("structural Base edge count = %d, want 1 (preserved)", baseCount)
+	}
+	if sawTemporal {
+		t.Error("temporal member edge should not be folded as a callee")
+	}
+}


### PR DESCRIPTION
## Why

PR A of 3 addressing real feedback from a Ruby/Rails project (maket). Two `sense_graph` trustworthiness issues:

1. **Class nodes returned `calls: []`** even when their methods clearly call things — an agent reads that as "depends on nothing". A trap.
2. **0.3-confidence ERB/i18n noise edges** leaked into `sense_graph` (with a snippet misattributed to the Ruby method's own definition line). `blast` already filters these by confidence; `sense_graph` did not.

## What

- **`foldMemberCallees`** (`internal/sqlite/adapter.go`) — mirrors the shipped `foldMemberCallers`: folds member callees into a container's outbound set, gated on the container having no real callee of its own, excluding internal self/sibling traffic, deduped by target. Renamed `hasUsageCaller`→`hasUsageEdge` since both fold paths now share it.
- **Confidence floor** (`internal/mcpio/graph.go`) — usage edges (calls/references) below `extract.ConfidenceUnresolved` (0.5, the same constant the fold uses) are dropped from the graph, with a root-scoped `low_confidence_hidden` count so the filtering is reported, not silent. Structural edges (inherits/composes/includes/imports) and tests are never floored.

## Verified on maket

- `PriceValue` (class) now shows its callees instead of `calls: []`.
- `Listing::Item#price_amount` hides its two 0.3 i18n edges (`low_confidence_hidden: 2`); the misattributed snippet goes with them; real edges (`PriceValue#amount`, `PriceValue`) survive.

## Known, out of scope

Class-callee aggregation faithfully surfaces **pre-existing bare-name resolution collisions** (e.g. `is_a?` resolving to a test class, `.format` to a controller). Each carries its confidence and the `index_caveat` fires. Fixing resolution itself is a separately-shaped resolver bet — not this PR. The empty list was a silent lie; a confidence-tagged list is the lesser evil.

## Tests / CI

`make ci` green (build + test + lint, 0 issues). New functions covered at ≥96%. Reviewed by the code-review council; both agreed follow-ups (single-source-of-truth on the floor constant; documenting the count's root scope) applied.