### PR TITLE
fix(dead): tier Ruby predicate methods as possibly-dead, add verify grep

### DIFF
--- a/internal/dead/dead.go
+++ b/internal/dead/dead.go
@@ -668,35 +668,29 @@ var serviceClassSuffixes = []string{
 	"Service", "Command", "Query", "Interactor", "Operation", "Job", "Worker",
 }
 
-// resultClassSuffixes name value-object conventions whose predicate methods
-// (success?/failure?/...) are read off a return value of an unknown static
-// type, so their call sites frequently don't resolve to the definition.
-var resultClassSuffixes = []string{"Result", "Response", "Outcome"}
-
-// resultPredicates are the predicate method names commonly defined on the
-// result/value objects above.
-var resultPredicates = map[string]bool{
-	"success?": true, "failure?": true, "error?": true,
-	"ok?": true, "valid?": true, "invalid?": true,
-}
-
 // isDynamicRubyMethod flags Ruby methods that follow a dynamic-dispatch
-// convention the static indexer routinely under-resolves: the service-object
-// `call` entry point, and predicate methods on result/value objects. With no
-// detected caller these would otherwise top-tier as "dead"; the convention
-// makes that confidence unwarranted, so they are reported possibly-dead.
+// convention the static indexer routinely under-resolves, so a zero-caller
+// result can't justify a hard "dead" verdict:
+//
+//   - Predicate methods (foo?) — almost always invoked on a duck-typed
+//     receiver (`if result.success?`, `raise if e.retriable?`) or implicitly
+//     on self (`return false unless retriable?`), paths the indexer frequently
+//     can't tie back to the definition. This covers result/value-object
+//     predicates whose inner Struct is flattened onto a *Service class, where
+//     the parent name carries no Result/Response suffix to key off.
+//   - The service-object `call` entry point — reached through `Klass.new.call`,
+//     a `.()` shorthand, or a duck-typed handler.
+//
+// They are reported possibly-dead rather than dead.
 func isDynamicRubyMethod(s Symbol) bool {
 	if s.Language != "ruby" || s.Kind != "method" {
 		return false
 	}
-	parent := rubyMethodParentName(s.Qualified)
-	switch {
-	case s.Name == "call" && hasAnySuffix(parent, serviceClassSuffixes):
-		return true
-	case resultPredicates[s.Name] && hasAnySuffix(parent, resultClassSuffixes):
+	if strings.HasSuffix(s.Name, "?") {
 		return true
 	}
-	return false
+	parent := rubyMethodParentName(s.Qualified)
+	return s.Name == "call" && hasAnySuffix(parent, serviceClassSuffixes)
 }
 
 // rubyMethodParentName returns the unqualified parent class/module name from

--- a/internal/dead/tiering_test.go
+++ b/internal/dead/tiering_test.go
@@ -33,10 +33,9 @@ func TestRubyDynamicTypesTieredUnderFramework(t *testing.T) {
 	}
 }
 
-// Ruby service-object `call` methods and result-object predicates follow
-// dynamic-dispatch conventions the indexer under-resolves, so with no
-// detected caller they are possibly-dead, not dead — but only under a
-// dynamic framework, and only for the matching name/parent conventions.
+// Ruby service-object `call` methods and predicate (foo?) methods follow
+// dynamic-dispatch conventions the indexer under-resolves, so with no detected
+// caller they are possibly-dead, not dead — but only under a dynamic framework.
 func TestRubyDynamicMethodTiering(t *testing.T) {
 	cases := []struct {
 		name      string
@@ -55,13 +54,30 @@ func TestRubyDynamicMethodTiering(t *testing.T) {
 			true, ConfidencePossibly,
 		},
 		{
+			// Verified false positive: the inner `Result = Struct.new do def
+			// success? end end` is flattened onto the *Service class, so the
+			// parent name carries no Result suffix — the old narrow rule
+			// hard-flagged it dead.
+			"predicate flattened onto a service class is possibly-dead",
+			Symbol{Language: "ruby", Kind: "method", Name: "success?", Qualified: "Checkout::ProcessPaymentService#success?"},
+			true, ConfidencePossibly,
+		},
+		{
+			// Verified false positive: dispatched on a rescued `e`
+			// (`raise if e.retriable?`); not a known predicate name, class
+			// matches no suffix — the old rule hard-flagged it dead.
+			"arbitrary predicate on any class is possibly-dead",
+			Symbol{Language: "ruby", Kind: "method", Name: "retriable?", Qualified: "SocialCommerce::Meta::ApiError#retriable?"},
+			true, ConfidencePossibly,
+		},
+		{
 			"plain call on a non-service class stays dead",
 			Symbol{Language: "ruby", Kind: "method", Name: "call", Qualified: "Widget#call"},
 			true, ConfidenceDead,
 		},
 		{
-			"predicate on a non-result class stays dead",
-			Symbol{Language: "ruby", Kind: "method", Name: "success?", Qualified: "Widget#success?"},
+			"plain non-predicate method stays dead",
+			Symbol{Language: "ruby", Kind: "method", Name: "frobnicate", Qualified: "Widget#frobnicate"},
 			true, ConfidenceDead,
 		},
 		{

--- a/internal/mcpio/coverage_test.go
+++ b/internal/mcpio/coverage_test.go
@@ -67,6 +67,22 @@ func TestBuildDeadCodeResponse(t *testing.T) {
 	if resp.SenseMetrics.EstimatedFileReadsAvoided != 2 {
 		t.Errorf("EstimatedFileReadsAvoided = %d, want 2", resp.SenseMetrics.EstimatedFileReadsAvoided)
 	}
+
+	// Every entry carries a ready-to-run verify grep.
+	if got := resp.DeadSymbols[0].VerifyCmd; got != `grep -rFn --exclude-dir=.git --exclude-dir=.sense "Unused" .` {
+		t.Errorf("VerifyCmd = %q, want %q", got, `grep -rFn --exclude-dir=.git --exclude-dir=.sense "Unused" .`)
+	}
+}
+
+// A predicate name ending in `?` must be emitted as a fixed-string grep so the
+// `?` is matched literally rather than interpreted as a regex quantifier.
+func TestDeadVerifyCmdEscapesPredicate(t *testing.T) {
+	resp := BuildDeadCodeResponse([]dead.Symbol{
+		{Name: "retriable?", Qualified: "ApiError#retriable?", File: "api_error.rb", Kind: "method", Confidence: dead.ConfidencePossibly},
+	}, 1)
+	if got := resp.DeadSymbols[0].VerifyCmd; got != `grep -rFn --exclude-dir=.git --exclude-dir=.sense "retriable?" .` {
+		t.Errorf("VerifyCmd = %q, want %q", got, `grep -rFn --exclude-dir=.git --exclude-dir=.sense "retriable?" .`)
+	}
 }
 
 func TestBuildDeadCodeResponseEmpty(t *testing.T) {

--- a/internal/mcpio/dead.go
+++ b/internal/mcpio/dead.go
@@ -1,6 +1,10 @@
 package mcpio
 
-import "github.com/luuuc/sense/internal/dead"
+import (
+	"fmt"
+
+	"github.com/luuuc/sense/internal/dead"
+)
 
 // BuildDeadCodeResponse assembles a wire DeadCodeResponse from the dead
 // package's result plus a rolled-up symbol list. Matches the
@@ -22,6 +26,7 @@ func BuildDeadCodeResponse(symbols []dead.Symbol, totalSymbols int) DeadCodeResp
 			LineEnd:    s.LineEnd,
 			Kind:       s.Kind,
 			Confidence: confidence,
+			VerifyCmd:  deadVerifyCmd(s.Name),
 		}
 		uniqueFiles[s.File] = struct{}{}
 	}
@@ -43,4 +48,14 @@ func BuildDeadCodeResponse(symbols []dead.Symbol, totalSymbols int) DeadCodeResp
 			EstimatedTokensSaved:      filesAvoided * AvgTokensPerFile,
 		},
 	}
+}
+
+// deadVerifyCmd builds a copy-paste grep that lists every textual occurrence of
+// a candidate's name across the tree — the definition plus any call sites the
+// static index missed (duck-typed dispatch, metaprogramming). Fixed-string (-F)
+// so predicate names ending in `?` aren't interpreted as a regex. The VCS and
+// index directories are excluded as guaranteed noise; every source extension is
+// still searched, since a predicate may be called from a view or template.
+func deadVerifyCmd(name string) string {
+	return fmt.Sprintf("grep -rFn --exclude-dir=.git --exclude-dir=.sense %q .", name)
 }

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -572,6 +572,11 @@ type DeadSymbolEntry struct {
 	LineEnd    int    `json:"line_end"`
 	Kind       string `json:"kind"`
 	Confidence string `json:"confidence"`
+	// VerifyCmd is a ready-to-run grep that lists every textual occurrence of
+	// the symbol's name — the definition plus any call sites the static index
+	// missed (duck-typed dispatch, metaprogramming). One hit means truly
+	// unreferenced; extra hits mean it's reachable and should not be deleted.
+	VerifyCmd string `json:"verify_cmd,omitempty"`
 }
 
 // DeadCodeMetrics is the observability footer for dead code analysis.


### PR DESCRIPTION
## Why

PR B of 3 addressing real feedback from a Ruby/Rails project (maket). Two `dead_code` issues that erode trust — a wrong "dead" verdict is the worst output the tool can give:

1. **False positives on duck-typed predicates.** `Checkout::ProcessPaymentService#success?` and `SocialCommerce::Meta::ApiError#retriable?` were flagged `dead` despite having real call sites. Verified: `success?` lives on an inner `Result = Struct.new do … end` that the extractor flattens onto the *Service class (so its parent name carries no `Result` suffix), and `retriable?` is dispatched on a rescued `e`. The old rule only spared predicates whose parent ended in `Result`/`Response`/`Outcome`.
2. **No self-serve way to verify a candidate**, even though the response's own Note says "verify each candidate".

## What

- **Broadened tiering** (`internal/dead/dead.go`): any zero-caller Ruby `?` predicate method is now `possibly_dead`, not `dead` — predicates are dispatched on duck-typed receivers or implicit self, which the static index routinely under-resolves. This replaces the hand-maintained `resultPredicates` allowlist + `resultClassSuffixes` with the structural fact (ends in `?`), deleting more code than it adds.
- **`verify_cmd` per candidate** (`internal/mcpio/dead.go`, `types.go`): a ready-to-run fixed-string grep (`-F`, so `?` isn't a regex) listing every textual occurrence of the name, with `.git`/`.sense` excluded as guaranteed noise (all source extensions still searched — a predicate may be called from a view). One hit = truly unreferenced; extra hits = reachable.

## Verified on maket

- Both false positives are now `possibly_dead`; all 16 zero-caller Ruby `?` predicates tier uniformly (none left as hard `dead`).
- Running the emitted `grep -rFn --exclude-dir=.git --exclude-dir=.sense "retriable?" .` surfaces the two `raise if e.retriable?` call sites **and** the `return false unless retriable?` implicit-self call the index missed — proving the loop closes.

## Known follow-up (out of scope)

Predicate tiering inherits the existing **dynamic-framework gate**, so a non-Rails Ruby project still hard-flags predicates `dead`. The rationale (duck-typing) is plain-Ruby, but decoupling the gate widens blast radius beyond the reported case. Deliberately deferred. `!`-methods also left untiered (no evidence yet).

## Tests / CI

`make ci` green (build + test + lint, 0 issues). New/changed functions at 100%. Council-reviewed; the one agreed change (exclude VCS/index dirs from the grep, evidence-backed) applied.