### PR TITLE
fix(metrics): persist lifetime metrics write-through on each query

### DIFF
--- a/internal/metrics/tracker.go
+++ b/internal/metrics/tracker.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"log"
 	"sync"
 	"sync/atomic"
@@ -39,6 +40,11 @@ type Tracker struct {
 		textFallbackFired int64
 	}
 
+	// flushMu serializes the DB transaction in flush so that the write-through
+	// flush triggered by each Record never contends with another Record's
+	// flush (or the background ticker) on the single SQLite writer.
+	flushMu sync.Mutex
+
 	stop chan struct{}
 	done chan struct{}
 }
@@ -61,7 +67,12 @@ func NewTrackerWithInterval(db *sql.DB, interval time.Duration) *Tracker {
 	return t
 }
 
-// Record adds a query's estimates to both session and lifetime counters.
+// Record adds a query's estimates to both session and lifetime counters, then
+// flushes the lifetime delta to SQLite write-through. Persisting on every query
+// (rather than only on the 30s ticker or a graceful Close) keeps the durable
+// lifetime totals accurate even when the MCP server process is restarted on
+// reconnect/compaction or killed without a clean shutdown — the churn that also
+// resets the in-memory session counters.
 func (t *Tracker) Record(tool, args string, fileReadsAvoided, tokensSaved int, textFallback bool) {
 	t.session.queries.Add(1)
 	t.session.fileReadsAvoided.Add(int64(fileReadsAvoided))
@@ -86,6 +97,11 @@ func (t *Tracker) Record(tool, args string, fileReadsAvoided, tokensSaved int, t
 		t.topQuery.tokensSaved = tokensSaved
 	}
 	t.topQuery.mu.Unlock()
+
+	// Write-through. A transient failure (e.g. the DB briefly locked) leaves
+	// the delta in the in-memory buffer; the background ticker and Close retry
+	// it, so no increment is dropped.
+	t.flush()
 }
 
 // Session returns current session counters.
@@ -149,6 +165,9 @@ func (t *Tracker) flushLoop() {
 }
 
 func (t *Tracker) flush() {
+	t.flushMu.Lock()
+	defer t.flushMu.Unlock()
+
 	t.lifetime.mu.Lock()
 	q := t.lifetime.queries
 	f := t.lifetime.fileReadsAvoided
@@ -164,31 +183,52 @@ func (t *Tracker) flush() {
 		return
 	}
 
+	if err := t.persist(q, f, ts, tf); err != nil {
+		log.Printf("sense metrics: flush: %v", err)
+		// Return the delta to the buffer so the next flush (write-through,
+		// ticker, or Close) retries it — a transient DB lock never drops counts.
+		t.lifetime.mu.Lock()
+		t.lifetime.queries += q
+		t.lifetime.fileReadsAvoided += f
+		t.lifetime.tokensSaved += ts
+		t.lifetime.textFallbackFired += tf
+		t.lifetime.mu.Unlock()
+	}
+}
+
+// persist upserts the lifetime deltas into sense_metrics in a single
+// transaction, rolling back (and returning the error) if any statement fails so
+// the caller can re-buffer the whole delta. Zero deltas are skipped.
+func (t *Tracker) persist(q, f, ts, tf int64) error {
 	ctx := context.Background()
 	const upsert = `INSERT INTO sense_metrics (key, value) VALUES (?, ?)
 		ON CONFLICT(key) DO UPDATE SET value = value + excluded.value`
 	tx, err := t.db.BeginTx(ctx, nil)
 	if err != nil {
-		log.Printf("sense metrics: flush begin tx: %v", err)
-		return
+		return fmt.Errorf("begin tx: %w", err)
 	}
-	if _, err := tx.ExecContext(ctx, upsert, "lifetime_queries", q); err != nil {
-		log.Printf("sense metrics: flush queries: %v", err)
+	deltas := []struct {
+		key string
+		val int64
+	}{
+		{"lifetime_queries", q},
+		{"lifetime_file_reads_avoided", f},
+		{"lifetime_tokens_saved", ts},
+		{"lifetime_text_fallback_fired", tf},
 	}
-	if _, err := tx.ExecContext(ctx, upsert, "lifetime_file_reads_avoided", f); err != nil {
-		log.Printf("sense metrics: flush file_reads_avoided: %v", err)
-	}
-	if _, err := tx.ExecContext(ctx, upsert, "lifetime_tokens_saved", ts); err != nil {
-		log.Printf("sense metrics: flush tokens_saved: %v", err)
-	}
-	if tf > 0 {
-		if _, err := tx.ExecContext(ctx, upsert, "lifetime_text_fallback_fired", tf); err != nil {
-			log.Printf("sense metrics: flush text_fallback_fired: %v", err)
+	for _, d := range deltas {
+		if d.val == 0 {
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, upsert, d.key, d.val); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("upsert %s: %w", d.key, err)
 		}
 	}
 	if err := tx.Commit(); err != nil {
-		log.Printf("sense metrics: flush commit: %v", err)
+		return fmt.Errorf("commit: %w", err)
 	}
+	return nil
 }
 
 func (t *Tracker) loadPersisted(ctx context.Context) LifetimeCounters {

--- a/internal/metrics/tracker_test.go
+++ b/internal/metrics/tracker_test.go
@@ -160,3 +160,49 @@ func TestTrackerLifetimeAccumulates(t *testing.T) {
 	}
 	tr2.Close()
 }
+
+// Write-through: a recorded query is persisted to SQLite immediately, without
+// waiting for the 30s ticker or a graceful Close — so an abrupt restart can't
+// drop it.
+func TestTrackerWriteThroughPersistsWithoutClose(t *testing.T) {
+	db := openTestDB(t)
+	tr := NewTracker(db)
+	defer tr.Close()
+
+	tr.Record("sense_search", "auth", 5, 4000, false)
+
+	var val int
+	if err := db.QueryRow(`SELECT value FROM sense_metrics WHERE key = 'lifetime_queries'`).Scan(&val); err != nil {
+		t.Fatalf("expected lifetime_queries persisted without Close: %v", err)
+	}
+	if val != 1 {
+		t.Errorf("persisted queries = %d, want 1 (write-through)", val)
+	}
+}
+
+// A flush that fails (here: the table is missing) must not drop the delta — it
+// is returned to the buffer and persisted by a later flush once the DB recovers.
+func TestTrackerFlushFailureRetainsDelta(t *testing.T) {
+	db := openTestDB(t)
+	tr := NewTracker(db)
+
+	// Break the write path so the write-through flush in Record fails.
+	if _, err := db.Exec(`DROP TABLE sense_metrics`); err != nil {
+		t.Fatal(err)
+	}
+	tr.Record("sense_search", "auth", 5, 4000, false)
+
+	// Recover the DB and flush again — the retained delta must land now.
+	if _, err := db.Exec(`CREATE TABLE sense_metrics (key TEXT PRIMARY KEY, value INTEGER NOT NULL)`); err != nil {
+		t.Fatal(err)
+	}
+	tr.Close()
+
+	var val int
+	if err := db.QueryRow(`SELECT value FROM sense_metrics WHERE key = 'lifetime_queries'`).Scan(&val); err != nil {
+		t.Fatalf("retained delta should persist after recovery: %v", err)
+	}
+	if val != 1 {
+		t.Errorf("persisted queries = %d, want 1 (delta retained across failed flush)", val)
+	}
+}


### PR DESCRIPTION
## Why

PR C of 3, from the maket assessment item *"session metrics never incremented (queries: 0)… tokens saved can't be trusted for retrospectives."*

**On investigation, the session counter is not broken.** It increments correctly with sequential calls (verified on maket: `session.queries → 1` after a search). It only resets when the MCP server **process restarts** — reconnect, `/compact` (maket has a `PreCompact` hook), or per-subagent processes (maket has a `SubagentStart` hook). That's inherent to in-memory state; there is no honest way to make `session` survive a process restart.

The real, fixable defect is the **durable `lifetime` total**: it buffered in memory for up to 30s and only persisted on a graceful `Close()`, so the exact churn that resets `session` (reconnect/kill) also silently dropped the tail of `lifetime` — the number retrospectives actually rely on.

## What

`internal/metrics/tracker.go`:
- **`Record` is now write-through** — it flushes the lifetime delta to SQLite on every query, not just on the 30s ticker or graceful `Close()`.
- **`flush` serialized by a dedicated `flushMu`** so the per-query flush never contends with the ticker or a concurrent query on SQLite's single writer.
- **DB write extracted into `persist`** — fail-fast with rollback, returning the error. On failure the delta is **returned to the buffer** so the next flush (next Record, ticker, or Close) retries it: a transient DB lock never drops a count. This also fixes a latent bug where the old `flush` logged per-statement errors but still committed a **possibly-partial** transaction.

## Verified on maket

Server **SIGKILLed mid-session** (no graceful shutdown, no `Close`) after one search: `lifetime_queries` advanced **11 → 12**. The pre-change binary, killed the same way, kept it at 11. Durability holds under the abrupt termination that motivated the report.

## Note

This does **not** make `session` survive server restarts — that is per-process by design. `lifetime` is the durable retrospective figure; `session` is "this server process". So a post-restart `session: 0` is expected, not a regression.

## Tests / CI

`make ci` green (build + test + lint, 0 issues), `-race` clean. New tests pin write-through-without-Close and the no-drop retry path; package coverage 94.9%. Council-reviewed; synchronous write-through chosen over an async signal (simplest durable guarantee, negligible cost at this QPS).