### PR TITLE
feat(extract/ruby): resolve calls on rescue-bound exception variables

### DIFF
--- a/internal/extract/ruby/ruby.go
+++ b/internal/extract/ruby/ruby.go
@@ -678,6 +678,7 @@ func (w *walker) handleMethod(n *sitter.Node, scope []string, singleton bool) er
 	// edge is an accurate record of what was written.
 	body := n.ChildByFieldName("body")
 	localTypes := buildLocalTypeMap(body, w.source)
+	w.addRescueBindings(body, localTypes)
 	ivarTypes := w.classInstanceVars[strings.Join(scope, "::")]
 	if err := extract.WalkNamedDescendants(body, "call", func(c *sitter.Node) error {
 		if isInsideBlock(c) {
@@ -1046,6 +1047,96 @@ func buildLocalTypeMap(body *sitter.Node, source []byte) map[string]string {
 		})
 	}
 	return types
+}
+
+// addRescueBindings records the type of each `rescue ExceptionType => var`
+// clause in the method body into localTypes, so a call on the bound variable
+// (`raise if e.retriable?`) resolves to ExceptionType#method instead of the
+// resolver's bare-name fallback, which would otherwise bind it to an arbitrary
+// same-named method on an unrelated class.
+//
+// Only single-type rescues with an identifier variable are recorded:
+// `rescue A, B => e` leaves the variable's type ambiguous, and a bare
+// `rescue => e` has no type. An existing entry (e.g. an explicit
+// `X = Class.new`) is never overwritten. The map is method-wide rather than
+// rescue-scoped, so two rescues binding the same name to different types are
+// last-write-wins — rare, and a missed/loose bind only costs one weak edge.
+func (w *walker) addRescueBindings(body *sitter.Node, localTypes map[string]string) {
+	if body == nil {
+		return
+	}
+	_ = extract.WalkNamedDescendants(body, "rescue", func(r *sitter.Node) error {
+		typ := w.singleRescueType(r)
+		if typ == "" {
+			return nil
+		}
+		varName := rescueVariableName(r, w.source)
+		if varName == "" {
+			return nil
+		}
+		if _, exists := localTypes[varName]; !exists {
+			localTypes[varName] = typ
+		}
+		return nil
+	})
+}
+
+// singleRescueType returns the fully-qualified exception type of a rescue
+// clause when it names exactly one constant/scope_resolution, resolving the
+// trailing segment through pkgBindings so `rescue ApiError` inside its own
+// namespace still yields the qualified name. Returns "" for multi-type or
+// typeless rescues.
+func (w *walker) singleRescueType(rescueNode *sitter.Node) string {
+	var exceptions *sitter.Node
+	for i := uint(0); i < rescueNode.NamedChildCount(); i++ {
+		if c := rescueNode.NamedChild(i); c.Kind() == "exceptions" {
+			exceptions = c
+			break
+		}
+	}
+	if exceptions == nil || exceptions.NamedChildCount() != 1 {
+		return ""
+	}
+	typeNode := exceptions.NamedChild(0)
+	switch typeNode.Kind() {
+	case "constant", "scope_resolution":
+	default:
+		return ""
+	}
+	text := strings.TrimSpace(extract.Text(typeNode, w.source))
+	if text == "" {
+		return ""
+	}
+	if q, ok := w.pkgBindings[lastConstSegment(text)]; ok {
+		return q
+	}
+	return text
+}
+
+// rescueVariableName returns the identifier bound by a rescue clause's
+// `=> var`, or "" when the binding is absent or not a simple identifier.
+func rescueVariableName(rescueNode *sitter.Node, source []byte) string {
+	for i := uint(0); i < rescueNode.NamedChildCount(); i++ {
+		c := rescueNode.NamedChild(i)
+		if c.Kind() != "exception_variable" {
+			continue
+		}
+		for j := uint(0); j < c.NamedChildCount(); j++ {
+			if v := c.NamedChild(j); v.Kind() == "identifier" {
+				return extract.Text(v, source)
+			}
+		}
+	}
+	return ""
+}
+
+// lastConstSegment returns the trailing `::`-separated segment of a constant
+// reference: "SocialCommerce::Meta::ApiError" → "ApiError", "ApiError" → "ApiError".
+func lastConstSegment(name string) string {
+	if i := strings.LastIndex(name, "::"); i >= 0 {
+		return name[i+len("::"):]
+	}
+	return name
 }
 
 // buildInstanceVarTypeMap scans a class body for `initialize` methods and

--- a/internal/extract/ruby/ruby_test.go
+++ b/internal/extract/ruby/ruby_test.go
@@ -4038,3 +4038,150 @@ end
 		t.Error("bare Account should resolve to first-registered Admin::Account")
 	}
 }
+
+// A rescue clause binds its exception variable's type, so a call on that
+// variable resolves to ExceptionType#method instead of a bare-name guess.
+func TestRescueBindingResolvesNamespacedException(t *testing.T) {
+	r := parseRuby(t, `module SocialCommerce
+  module Meta
+    class ApiError < StandardError
+      def retriable?
+        true
+      end
+    end
+  end
+end
+
+class BatchSyncJob
+  def perform
+    do_work
+  rescue SocialCommerce::Meta::ApiError => e
+    raise if e.retriable?
+  end
+end
+`)
+	if findEdge(r, "BatchSyncJob#perform", "SocialCommerce::Meta::ApiError#retriable?", "calls") == nil {
+		t.Errorf("expected rescue var resolved to SocialCommerce::Meta::ApiError#retriable?; edges: %v", edgeTargetsFrom(r, "BatchSyncJob#perform"))
+	}
+	if findEdge(r, "BatchSyncJob#perform", "retriable?", "calls") != nil {
+		t.Error("should not also emit a bare-name retriable? fallback once the type is known")
+	}
+}
+
+// A bare exception constant resolves to its qualified name through pkgBindings.
+func TestRescueBindingResolvesViaPkgBindings(t *testing.T) {
+	r := parseRuby(t, `module SocialCommerce
+  module Meta
+    class ApiError < StandardError
+      def retriable?
+        true
+      end
+    end
+
+    class CatalogSyncService
+      def call
+        do_work
+      rescue ApiError => e
+        raise if e.retriable?
+      end
+    end
+  end
+end
+`)
+	want := "SocialCommerce::Meta::ApiError#retriable?"
+	if findEdge(r, "SocialCommerce::Meta::CatalogSyncService#call", want, "calls") == nil {
+		t.Errorf("expected bare ApiError resolved via pkgBindings to %s; edges: %v",
+			want, edgeTargetsFrom(r, "SocialCommerce::Meta::CatalogSyncService#call"))
+	}
+}
+
+// A multi-type rescue leaves the variable ambiguous — no typed edge is emitted;
+// the bare-name fallback is used instead.
+func TestRescueBindingSkipsMultiType(t *testing.T) {
+	r := parseRuby(t, `class Worker
+  def run
+    do_work
+  rescue FooError, BarError => e
+    raise if e.retriable?
+  end
+end
+`)
+	if findEdge(r, "Worker#run", "FooError#retriable?", "calls") != nil ||
+		findEdge(r, "Worker#run", "BarError#retriable?", "calls") != nil {
+		t.Error("multi-type rescue must not bind the variable to either type")
+	}
+	if findEdge(r, "Worker#run", "retriable?", "calls") == nil {
+		t.Error("expected bare-name fallback edge for an ambiguous rescue variable")
+	}
+}
+
+// A typeless rescue (`rescue => e`) has no type to bind.
+func TestRescueBindingSkipsTypeless(t *testing.T) {
+	r := parseRuby(t, `class Worker
+  def run
+    do_work
+  rescue => e
+    raise if e.retriable?
+  end
+end
+`)
+	if findEdge(r, "Worker#run", "retriable?", "calls") == nil {
+		t.Error("typeless rescue should fall back to the bare method name")
+	}
+}
+
+// An explicit assignment type takes precedence over a same-named rescue binding.
+func TestRescueBindingDoesNotOverrideAssignment(t *testing.T) {
+	r := parseRuby(t, `class Helper
+  def retriable?
+    false
+  end
+end
+
+class FooError < StandardError
+  def retriable?
+    true
+  end
+end
+
+class Worker
+  def run
+    e = Helper.new
+    e.retriable?
+  rescue FooError => e
+    e.retriable?
+  end
+end
+`)
+	if findEdge(r, "Worker#run", "Helper#retriable?", "calls") == nil {
+		t.Error("explicit e = Helper.new should keep precedence for the variable type")
+	}
+}
+
+// edgeTargetsFrom lists the calls-edge targets emitted from a given source, for
+// test failure diagnostics.
+func edgeTargetsFrom(r *recorder, source string) []string {
+	var out []string
+	for _, e := range r.edges {
+		if e.SourceQualified == source && e.Kind == "calls" {
+			out = append(out, e.TargetQualified)
+		}
+	}
+	return out
+}
+
+// A rescue that names a type but binds no variable (`rescue FooError`) records
+// nothing and does not panic.
+func TestRescueBindingNoVariable(t *testing.T) {
+	r := parseRuby(t, `class Worker
+  def run
+    do_work
+  rescue FooError
+    cleanup
+  end
+end
+`)
+	if findEdge(r, "Worker#run", "FooError#retriable?", "calls") != nil {
+		t.Error("a rescue without a variable binding should not produce a typed call edge")
+	}
+}


### PR DESCRIPTION
## Why

The deferred root-cause bet from the maket assessment: Ruby duck-typed dispatch. A `rescue SomeError => e` clause states `e`'s type explicitly, but the extractor never recorded it — so a later `raise if e.retriable?` fell through to the resolver's bare-name fallback and bound to an **arbitrary same-named method** on an unrelated class. The real method (`SocialCommerce::Meta::ApiError#retriable?`) was left with **zero callers** (flagged dead), while the collision target was inflated.

Unlike PR #92 (which *re-tiered* the symptom to `possibly_dead`), this fixes the **cause**: the right edge is produced.

## What

`internal/extract/ruby/ruby.go` — `handleMethod` now augments the method's local type map with each single-type `rescue` binding (`addRescueBindings`):
- Reuses `pkgBindings`, so both `rescue ApiError => e` (same namespace) and `rescue Mod::ApiError => e` resolve to the qualified type.
- Calls on the bound variable then resolve to `ExceptionType#method` via the existing local-variable path (confidence 0.7).
- **Conservative on ambiguity:** multi-type (`rescue A, B => e`) and typeless (`rescue => e`) clauses are left unbound (bare-name fallback as before); an explicit `X = Class.new` keeps precedence over a same-named rescue variable.

Node navigation is by tree-sitter node kind (`exceptions`, `exception_variable`), confirmed against a dumped parse tree.

## Verified on maket (full re-scan)

`SocialCommerce::Meta::ApiError#retriable?`:
- **Before:** `called_by: []`, listed `possibly_dead`.
- **After:** two real callers — `BatchSyncJob#sync_batch` (`batch_sync_job.rb:29`), `CatalogSyncService#call` (`catalog_sync_service.rb:10`) — `sense_blast` reports 2 direct / 3 total affected; no longer in the dead list.

(maket's index was backed up and restored — this binary is an unsigned local build and this PR isn't merged.)

## Scope — still deferred

This fixes the **rescue-variable** case only. The other assessment false positive — `result = service.call; result.success?` — remains deferred: it needs return-type-through-variable inference **plus** reconciling the inner `Result = Struct.new do … end` that the extractor flattens onto the enclosing `*Service` class (so even return-type inference would yield `Result#success?`, not the flattened `ProcessPaymentService#success?`). That's a larger, riskier change.

**Note:** takes effect only after a **full re-scan** — incremental scans skip unchanged caller files.

## Tests / CI

`make ci` green (build + test + lint, 0 issues). Six new tests pin every branch (namespaced/pkgBindings resolve, multi-type skip, typeless skip, assignment precedence, no-variable); new functions at ~90–100%, `ruby.go` 92.4% statements. Council-reviewed.