### PR TITLE
fix(search): honest result provenance + blast tests_affected_count

### DIFF
--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -184,7 +184,7 @@ func buildSearchResponse(results []search.Result, pathByID map[int64]string, met
 			Score:      mcpio.SearchScore(r.Score),
 			Snippet:    r.Snippet,
 			References: r.References,
-			Source:     "structural",
+			Source:     r.Source,
 		}
 		if path != "" {
 			uniqueFiles[path] = struct{}{}

--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -229,6 +229,7 @@ func BuildDiffBlastResponse(ctx context.Context, ref string, results []blast.Res
 	}
 
 	resp.Risk = risk
+	resp.TestsAffectedCount = len(resp.AffectedTests)
 	resp.TotalAffected = len(resp.DirectCallers) + len(resp.IndirectCallers)
 	resp.AffectedSymbols = resp.TotalAffected
 	resp.GraphEdgesTraversed = totalEdges

--- a/internal/mcpio/blast_test.go
+++ b/internal/mcpio/blast_test.go
@@ -597,6 +597,36 @@ func TestBuildDiffBlastResponseAffectedSymbolsAndFiles(t *testing.T) {
 	}
 }
 
+// TestBuildDiffBlastResponseTestsAffectedCount pins that the diff path
+// populates tests_affected_count from the deduped affected_tests list —
+// it was silently left at 0 while the list held entries, contradicting
+// the data a consumer reads for safe-to-change decisions.
+func TestBuildDiffBlastResponseTestsAffectedCount(t *testing.T) {
+	results := []blast.Result{
+		{
+			Symbol:        model.Symbol{ID: 1, Qualified: "A"},
+			Risk:          blast.RiskLow,
+			AffectedTests: []string{"test/a_test.rb", "test/shared_test.rb"},
+		},
+		{
+			Symbol:        model.Symbol{ID: 2, Qualified: "B"},
+			Risk:          blast.RiskLow,
+			AffectedTests: []string{"test/b_test.rb", "test/shared_test.rb"},
+		},
+	}
+
+	resp := BuildDiffBlastResponse(context.Background(), "HEAD~1", results, noFiles, nil)
+
+	// shared_test.rb is deduped → 3 unique tests.
+	if len(resp.AffectedTests) != 3 {
+		t.Fatalf("AffectedTests = %d, want 3", len(resp.AffectedTests))
+	}
+	if resp.TestsAffectedCount != len(resp.AffectedTests) {
+		t.Errorf("TestsAffectedCount = %d, want %d (must match affected_tests)",
+			resp.TestsAffectedCount, len(resp.AffectedTests))
+	}
+}
+
 func TestBuildBlastResponseZeroEdges(t *testing.T) {
 	r := blast.Result{
 		Symbol:         model.Symbol{ID: 1, Qualified: "Isolated"},

--- a/internal/mcpio/marshal_test.go
+++ b/internal/mcpio/marshal_test.go
@@ -709,7 +709,7 @@ func TestMarshalGraphCompactDirectional(t *testing.T) {
 func searchFixture() SearchResponse {
 	return SearchResponse{
 		Results: []SearchResultEntry{
-			{Symbol: "User", File: "app/models/user.rb", Line: 1, Kind: "class", Score: 0.92, Snippet: "class User < ApplicationRecord", References: 12, Source: "structural"},
+			{Symbol: "User", File: "app/models/user.rb", Line: 1, Kind: "class", Score: 0.92, Snippet: "class User < ApplicationRecord", References: 12, Source: "hybrid"},
 		},
 		SearchMode:    "hybrid",
 		FusionWeights: FusionWeights{Keyword: 0.6, Vector: 0.4},

--- a/internal/mcpio/textresult.go
+++ b/internal/mcpio/textresult.go
@@ -2,6 +2,12 @@ package mcpio
 
 import "strconv"
 
+// SourceText labels a SearchResultEntry that came from the substring
+// text-fallback path rather than the keyword/vector retrieval legs. The
+// other Source values (keyword/vector/hybrid/graph) originate in the
+// search engine; "text" originates here, so it is named here.
+const SourceText = "text"
+
 // TextMatch holds the fields needed to convert a text fallback hit into
 // a SearchResultEntry. Defined here (rather than importing search.TextResult)
 // to keep mcpio free of upstream dependencies on the search package.
@@ -32,7 +38,7 @@ func ConvertTextResults(matches []TextMatch, structuralEntries []SearchResultEnt
 			Line:    m.Line,
 			Kind:    "text_match",
 			Snippet: m.Match,
-			Source:  "text",
+			Source:  SourceText,
 		})
 	}
 	return entries, len(entries) > 0

--- a/internal/mcpio/textresult_test.go
+++ b/internal/mcpio/textresult_test.go
@@ -24,7 +24,7 @@ func TestConvertTextResultsBasic(t *testing.T) {
 
 func TestConvertTextResultsDeduplicates(t *testing.T) {
 	existing := []SearchResultEntry{
-		{File: "schema.sql", Line: 1, Kind: "type", Source: "structural"},
+		{File: "schema.sql", Line: 1, Kind: "type", Source: "keyword"},
 	}
 	matches := []TextMatch{
 		{File: "schema.sql", Line: 1, Match: "CREATE TABLE users"},
@@ -44,7 +44,7 @@ func TestConvertTextResultsDeduplicates(t *testing.T) {
 
 func TestConvertTextResultsAllDuplicates(t *testing.T) {
 	existing := []SearchResultEntry{
-		{File: "a.go", Line: 10, Source: "structural"},
+		{File: "a.go", Line: 10, Source: "keyword"},
 	}
 	matches := []TextMatch{
 		{File: "a.go", Line: 10, Match: "something"},
@@ -70,7 +70,7 @@ func TestConvertTextResultsEmpty(t *testing.T) {
 
 func TestConvertTextResultsSameFileDifferentLine(t *testing.T) {
 	existing := []SearchResultEntry{
-		{File: "schema.sql", Line: 1, Source: "structural"},
+		{File: "schema.sql", Line: 1, Source: "keyword"},
 	}
 	matches := []TextMatch{
 		{File: "schema.sql", Line: 5, Match: "ALTER TABLE"},

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -520,6 +520,12 @@ type FusionWeights struct {
 }
 
 // SearchResultEntry is a single search hit in the wire response.
+//
+// Source reports which retrieval path surfaced the hit, so a consumer
+// can distinguish a keyword match from a semantic one. It is one of:
+// "keyword" (FTS5 leg only), "vector" (HNSW semantic leg only),
+// "hybrid" (both legs), "graph" (injected by graph enrichment — search
+// did not match it directly), or "text" (substring text-fallback path).
 type SearchResultEntry struct {
 	Symbol     string      `json:"symbol"`
 	File       string      `json:"file"`

--- a/internal/mcpserver/compaction_test.go
+++ b/internal/mcpserver/compaction_test.go
@@ -207,6 +207,43 @@ func TestHandleSearchStripsSnippets(t *testing.T) {
 	}
 }
 
+// TestHandleSearchSourceIsHonest pins the wire-layer contract: the
+// handler must emit the engine's real provenance, never the old
+// hardcoded "structural" placeholder. Guards against a future refactor
+// silently re-hardcoding the field.
+func TestHandleSearchSourceIsHonest(t *testing.T) {
+	ts := setupTestServer(t)
+	ctx := context.Background()
+
+	result, err := ts.handlers.handleSearch(ctx, toolReq(map[string]any{
+		"query": "Verify",
+		"limit": 10,
+	}))
+	if err != nil {
+		t.Fatalf("handleSearch: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("unexpected error: %s", resultText(t, result))
+	}
+
+	var resp mcpio.SearchResponse
+	if err := json.Unmarshal([]byte(resultText(t, result)), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Results) == 0 {
+		t.Fatal("expected results for seeded query")
+	}
+	honest := map[string]bool{"keyword": true, "vector": true, "hybrid": true, "graph": true, "text": true}
+	for _, r := range resp.Results {
+		if r.Source == "structural" {
+			t.Errorf("result %s still carries hardcoded 'structural' source", r.Symbol)
+		}
+		if !honest[r.Source] {
+			t.Errorf("result %s has unrecognized source %q", r.Symbol, r.Source)
+		}
+	}
+}
+
 func TestHandleSearchSessionDedup(t *testing.T) {
 	ts := setupTestServer(t)
 	h := ts.handlers

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -761,7 +761,7 @@ func (h *handlers) handleSearch(ctx context.Context, req mcp.CallToolRequest) (*
 			Score:      mcpio.SearchScore(r.Score),
 			Snippet:    r.Snippet,
 			References: r.References,
-			Source:     "structural",
+			Source:     r.Source,
 		}
 		h.seenMu.Lock()
 		if h.seenSymbols[r.SymbolID] {

--- a/internal/search/expand.go
+++ b/internal/search/expand.go
@@ -110,6 +110,7 @@ func mergeMultiQuery(queryResults [][]Result) []Result {
 			rrfScore := 1.0 / float64(rrfK+rank+1)
 			if e, ok := merged[r.SymbolID]; ok {
 				e.score += rrfScore
+				e.result.Source = mergeSource(e.result.Source, r.Source)
 			} else {
 				merged[r.SymbolID] = &entry{result: r, score: rrfScore}
 			}

--- a/internal/search/fusion_internal_test.go
+++ b/internal/search/fusion_internal_test.go
@@ -125,12 +125,113 @@ func TestFuseRRFBothSources(t *testing.T) {
 		t.Fatalf("fuseRRF returned %d, want 3", len(got))
 	}
 	scoreMap := map[int64]float64{}
+	srcMap := map[int64]string{}
 	for _, r := range got {
 		scoreMap[r.SymbolID] = r.Score
+		srcMap[r.SymbolID] = r.Source
 	}
 	// Symbol 1 appears in both sources, should have highest score
 	if scoreMap[1] <= scoreMap[2] || scoreMap[1] <= scoreMap[3] {
 		t.Errorf("shared symbol should have highest score: %v", scoreMap)
+	}
+	// Provenance must be honest: 1 from both legs, 2 keyword-only, 3 vector-only.
+	if srcMap[1] != SourceHybrid {
+		t.Errorf("symbol 1 source = %q, want %q", srcMap[1], SourceHybrid)
+	}
+	if srcMap[2] != SourceKeyword {
+		t.Errorf("symbol 2 source = %q, want %q", srcMap[2], SourceKeyword)
+	}
+	if srcMap[3] != SourceVector {
+		t.Errorf("symbol 3 source = %q, want %q", srcMap[3], SourceVector)
+	}
+}
+
+func TestFuseRRFKeywordOnlyTagsSource(t *testing.T) {
+	kw := []sqlite.SearchResult{{SymbolID: 1, Name: "a"}, {SymbolID: 2, Name: "b"}}
+	// vecWeight 0 means the vector leg is ignored entirely (keyword-only mode).
+	got := fuseRRF(kw, []VectorResult{{SymbolID: 1, Similarity: 0.9}}, 1.0, 0.0)
+	for _, r := range got {
+		if r.Source != SourceKeyword {
+			t.Errorf("symbol %d source = %q, want %q", r.SymbolID, r.Source, SourceKeyword)
+		}
+	}
+}
+
+func TestFuseRRFKeywordDuplicateAccumulates(t *testing.T) {
+	// A symbol appearing twice in the keyword list accumulates both RRF
+	// contributions and stays keyword-sourced.
+	kw := []sqlite.SearchResult{
+		{SymbolID: 1, Name: "dup"},
+		{SymbolID: 1, Name: "dup"},
+		{SymbolID: 2, Name: "other"},
+	}
+	got := fuseRRF(kw, nil, 1.0, 0.0)
+	var dup, other Result
+	for _, r := range got {
+		switch r.SymbolID {
+		case 1:
+			dup = r
+		case 2:
+			other = r
+		}
+	}
+	if dup.Source != SourceKeyword {
+		t.Errorf("dup source = %q, want %q", dup.Source, SourceKeyword)
+	}
+	if dup.Score <= other.Score {
+		t.Errorf("twice-listed symbol should outscore single: dup=%v other=%v", dup.Score, other.Score)
+	}
+}
+
+func TestSourceLabel(t *testing.T) {
+	cases := []struct {
+		kw, vec bool
+		want    string
+	}{
+		{true, false, SourceKeyword},
+		{false, true, SourceVector},
+		{true, true, SourceHybrid},
+		{false, false, SourceKeyword}, // defensive default
+	}
+	for _, c := range cases {
+		if got := sourceLabel(c.kw, c.vec); got != c.want {
+			t.Errorf("sourceLabel(%v, %v) = %q, want %q", c.kw, c.vec, got, c.want)
+		}
+	}
+}
+
+func TestMergeSource(t *testing.T) {
+	cases := []struct {
+		a, b, want string
+	}{
+		{SourceKeyword, SourceKeyword, SourceKeyword},
+		{SourceVector, SourceVector, SourceVector},
+		{SourceKeyword, SourceVector, SourceHybrid},
+		{SourceVector, SourceKeyword, SourceHybrid},
+		{"", SourceVector, SourceVector},
+		{SourceKeyword, "", SourceKeyword},
+		{SourceHybrid, SourceKeyword, SourceHybrid},
+	}
+	for _, c := range cases {
+		if got := mergeSource(c.a, c.b); got != c.want {
+			t.Errorf("mergeSource(%q, %q) = %q, want %q", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+func TestMergeMultiQueryCombinesSource(t *testing.T) {
+	// Symbol 1 is keyword-sourced in query A and vector-sourced in query B:
+	// the merged provenance must reflect both legs.
+	queryResults := [][]Result{
+		{{SymbolID: 1, Source: SourceKeyword}},
+		{{SymbolID: 1, Source: SourceVector}},
+	}
+	got := mergeMultiQuery(queryResults)
+	if len(got) != 1 {
+		t.Fatalf("mergeMultiQuery returned %d, want 1", len(got))
+	}
+	if got[0].Source != SourceHybrid {
+		t.Errorf("merged source = %q, want %q", got[0].Source, SourceHybrid)
 	}
 }
 

--- a/internal/search/internals_test.go
+++ b/internal/search/internals_test.go
@@ -126,6 +126,88 @@ func openTestDB(t *testing.T) *sqlite.Adapter {
 	return a
 }
 
+func TestEnrichFromGraphInjectsGraphSource(t *testing.T) {
+	ctx := context.Background()
+	a := openTestDB(t)
+
+	fid, err := a.WriteFile(ctx, &model.File{Path: "h.go", Language: "go", Hash: "h1", Symbols: 2, IndexedAt: time.Now()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	hub, err := a.WriteSymbol(ctx, &model.Symbol{FileID: fid, Name: "Hub", Qualified: "pkg.Hub", Kind: "function", LineStart: 1, LineEnd: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	callee, err := a.WriteSymbol(ctx, &model.Symbol{FileID: fid, Name: "Leaf", Qualified: "pkg.Leaf", Kind: "function", LineStart: 6, LineEnd: 9})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.WriteEdge(ctx, &model.Edge{SourceID: &hub, TargetID: callee, Kind: model.EdgeCalls, FileID: fid, Confidence: 1.0}); err != nil {
+		t.Fatal(err)
+	}
+
+	e := NewEngine(a, nil, nil)
+	// Only the hub is a search hit; the callee is absent and must be
+	// injected by graph enrichment with SourceGraph provenance.
+	results := []Result{{SymbolID: hub, Name: "Hub", Qualified: "pkg.Hub", Score: 1.0, Source: SourceKeyword}}
+	out, err := e.enrichFromGraph(ctx, results)
+	if err != nil {
+		t.Fatalf("enrichFromGraph: %v", err)
+	}
+	var found bool
+	for _, r := range out {
+		if r.SymbolID == callee {
+			found = true
+			if r.Source != SourceGraph {
+				t.Errorf("injected callee source = %q, want %q", r.Source, SourceGraph)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("expected callee to be injected by enrichment")
+	}
+}
+
+func TestSubstringFallbackEarlyReturn(t *testing.T) {
+	// At or above the threshold, keyword results are returned untouched
+	// without consulting the substring index.
+	e := NewEngine(nil, nil, nil)
+	kw := make([]sqlite.SearchResult, substringFallbackThreshold)
+	for i := range kw {
+		kw[i] = sqlite.SearchResult{SymbolID: int64(i + 1)}
+	}
+	got := e.substringFallback(context.Background(), kw, "anything", "", 10)
+	if len(got) != substringFallbackThreshold {
+		t.Errorf("len = %d, want %d (unchanged)", len(got), substringFallbackThreshold)
+	}
+}
+
+func TestSubstringFallbackMergesMatches(t *testing.T) {
+	ctx := context.Background()
+	a := openTestDB(t)
+	fid, err := a.WriteFile(ctx, &model.File{Path: "w.go", Language: "go", Hash: "h1", Symbols: 1, IndexedAt: time.Now()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sid, err := a.WriteSymbol(ctx, &model.Symbol{FileID: fid, Name: "ZebraWidget", Qualified: "pkg.ZebraWidget", Kind: "function", LineStart: 1, LineEnd: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e := NewEngine(a, nil, nil)
+	// Below threshold and empty → substring search supplies the match.
+	got := e.substringFallback(ctx, nil, "Zebra", "", 10)
+	var found bool
+	for _, r := range got {
+		if r.SymbolID == sid {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("substring fallback did not surface ZebraWidget; got %+v", got)
+	}
+}
+
 func TestPromoteParentsEmpty(t *testing.T) {
 	e := NewEngine(nil, nil, nil)
 	out, err := e.promoteParents(context.Background(), nil, 10)
@@ -194,8 +276,8 @@ func TestPromoteParentsPromotes(t *testing.T) {
 
 	e := NewEngine(a, nil, nil)
 	results := []Result{
-		{SymbolID: child1, Name: "Method1", Score: 0.9},
-		{SymbolID: child2, Name: "Method2", Score: 0.8},
+		{SymbolID: child1, Name: "Method1", Score: 0.9, Source: SourceVector},
+		{SymbolID: child2, Name: "Method2", Score: 0.8, Source: SourceKeyword},
 	}
 	out, err := e.promoteParents(ctx, results, 10)
 	if err != nil {
@@ -210,6 +292,11 @@ func TestPromoteParentsPromotes(t *testing.T) {
 	}
 	if out[0].Name != "MyClass" {
 		t.Errorf("expected name MyClass, got %q", out[0].Name)
+	}
+	// The promoted parent inherits the provenance of the highest-scoring
+	// child (Method1, vector-sourced) whose score it takes.
+	if out[0].Source != SourceVector {
+		t.Errorf("promoted parent source = %q, want %q", out[0].Source, SourceVector)
 	}
 }
 

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -20,6 +20,8 @@ type Reranker interface {
 }
 
 // Result is a single fused search hit with metadata from both backends.
+// Source records which retrieval leg surfaced the hit so consumers can
+// tell keyword matches from semantic ones — see the Source* constants.
 type Result struct {
 	SymbolID   int64
 	Name       string
@@ -30,6 +32,49 @@ type Result struct {
 	Snippet    string
 	Score      float64
 	References int
+	Source     string
+}
+
+// Source values for Result.Source. They report provenance — which
+// retrieval leg actually surfaced a hit — not where it finally ranked.
+// A hit found by both the keyword (FTS5) and vector (HNSW) legs is
+// SourceHybrid; one injected by graph enrichment is SourceGraph; the
+// substring text-fallback path sets "text" directly (see textresult.go).
+const (
+	SourceKeyword = "keyword"
+	SourceVector  = "vector"
+	SourceHybrid  = "hybrid"
+	SourceGraph   = "graph"
+)
+
+// sourceLabel maps the per-leg contribution flags to a Source value.
+// Keyword-only mode (no vector leg) always yields SourceKeyword because
+// vec is never set.
+func sourceLabel(kw, vec bool) string {
+	switch {
+	case kw && vec:
+		return SourceHybrid
+	case vec:
+		return SourceVector
+	default:
+		return SourceKeyword
+	}
+}
+
+// mergeSource combines the provenance of one symbol seen across multiple
+// sub-queries. Differing non-empty legs (keyword in one, vector in
+// another) mean both legs contributed somewhere, so the merge is hybrid.
+func mergeSource(a, b string) string {
+	switch {
+	case a == b:
+		return a
+	case a == "":
+		return b
+	case b == "":
+		return a
+	default:
+		return SourceHybrid
+	}
 }
 
 // Options controls search behavior.
@@ -331,6 +376,8 @@ func fuseRRF(keyword []sqlite.SearchResult, vector []VectorResult, kwWeight, vec
 	type entry struct {
 		result Result
 		score  float64
+		kw     bool
+		vec    bool
 	}
 	merged := make(map[int64]*entry)
 
@@ -339,6 +386,7 @@ func fuseRRF(keyword []sqlite.SearchResult, vector []VectorResult, kwWeight, vec
 		rrfScore := kwWeight / float64(rrfK+rank+1)
 		if e, ok := merged[id]; ok {
 			e.score += rrfScore
+			e.kw = true
 		} else {
 			merged[id] = &entry{
 				result: Result{
@@ -351,6 +399,7 @@ func fuseRRF(keyword []sqlite.SearchResult, vector []VectorResult, kwWeight, vec
 					Snippet:   kr.Snippet,
 				},
 				score: rrfScore,
+				kw:    true,
 			}
 		}
 	}
@@ -361,12 +410,14 @@ func fuseRRF(keyword []sqlite.SearchResult, vector []VectorResult, kwWeight, vec
 			rrfScore := vecWeight / float64(rrfK+rank+1)
 			if e, ok := merged[id]; ok {
 				e.score += rrfScore
+				e.vec = true
 			} else {
 				merged[id] = &entry{
 					result: Result{
 						SymbolID: vr.SymbolID,
 					},
 					score: rrfScore,
+					vec:   true,
 				}
 			}
 		}
@@ -375,6 +426,7 @@ func fuseRRF(keyword []sqlite.SearchResult, vector []VectorResult, kwWeight, vec
 	results := make([]Result, 0, len(merged))
 	for _, e := range merged {
 		e.result.Score = e.score
+		e.result.Source = sourceLabel(e.kw, e.vec)
 		results = append(results, e.result)
 	}
 	return results
@@ -661,6 +713,7 @@ func (e *Engine) enrichFromGraph(ctx context.Context, results []Result) ([]Resul
 				LineStart:  sym.LineStart,
 				Snippet:   sym.Snippet,
 				Score:     enrichBaseScore,
+				Source:    SourceGraph,
 			})
 		}
 	}
@@ -702,9 +755,10 @@ func (e *Engine) promoteParents(ctx context.Context, results []Result, limit int
 	}
 
 	type parentGroup struct {
-		info     sqlite.ParentInfo
-		children []int
-		maxScore float64
+		info      sqlite.ParentInfo
+		children  []int
+		maxScore  float64
+		maxSource string
 	}
 	groups := map[int64]*parentGroup{}
 	for i := range topK {
@@ -720,6 +774,7 @@ func (e *Engine) promoteParents(ctx context.Context, results []Result, limit int
 		g.children = append(g.children, i)
 		if results[i].Score > g.maxScore {
 			g.maxScore = results[i].Score
+			g.maxSource = results[i].Source
 		}
 	}
 
@@ -749,6 +804,7 @@ func (e *Engine) promoteParents(ctx context.Context, results []Result, limit int
 			LineStart: g.info.LineStart,
 			Snippet:   g.info.Snippet,
 			Score:     g.maxScore,
+			Source:    g.maxSource,
 		})
 	}
 

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -985,6 +985,18 @@ func TestGraphEnrichmentBoostsCallees(t *testing.T) {
 		t.Errorf("HandleRoute (callee of top result) score=%.4f should be > HTTPConfig score=%.4f",
 			handleRouteScore, httpConfigScore)
 	}
+
+	// Every result must carry honest provenance — never empty, never the
+	// old hardcoded "structural" placeholder.
+	valid := map[string]bool{
+		search.SourceKeyword: true, search.SourceVector: true,
+		search.SourceHybrid: true, search.SourceGraph: true,
+	}
+	for _, r := range results {
+		if !valid[r.Source] {
+			t.Errorf("result %s has invalid source %q", r.Qualified, r.Source)
+		}
+	}
 	t.Logf("enrichment result:")
 	for i, r := range results {
 		t.Logf("  %d. %s (score=%.4f)", i+1, r.Qualified, r.Score)


### PR DESCRIPTION
## Problem
Two output fields reported values disconnected from the underlying data, which is worse than reporting nothing — consumers and reviewers made decisions based on them.

- **`source` was a hardcoded literal.** Every search result carried `source: "structural"`, set at the wire layer regardless of which retrieval leg actually surfaced the hit. Anyone reading the field to judge whether the vector index was contributing concluded it never did — they were reading a constant. Measured on two real repos, the vector leg in fact wins frequently (e.g. 6/10 results vector-sourced on a Rails query); the signal that said otherwise was fake.
- **`tests_affected_count` was always 0 in diff blast.** `BuildDiffBlastResponse` listed affected test files but left the count at 0, contradicting the `affected_tests` array used for safe-to-change decisions.

## Summary
Make both fields tell the truth: search results report their real retrieval provenance, and diff blast sets the test count from the list it already builds.

## Changes
- **search:** add `Result.Source`, tracked through RRF fusion, multi-query merge, graph enrichment, and parent promotion. Values: `keyword` (FTS5 only), `vector` (HNSW only), `hybrid` (both), `graph` (injected by enrichment), `text` (substring fallback). Emitted by both the MCP server and CLI instead of the hardcoded string.
- **blast:** set `tests_affected_count` from the deduped `affected_tests` list in the diff path.
- **docs:** document the full `source` value set on the wire type; name the previously-bare `"text"` literal as a constant.

## Test Plan
- [x] Unit tests for `sourceLabel`, `mergeSource`, and provenance through fusion/merge/enrich/promote
- [x] Wire-layer test asserting the handler never emits `"structural"`
- [x] Diff-blast test asserting `tests_affected_count == len(affected_tests)` (incl. dedup)
- [x] Verified on a real Rails index: `source` now reports keyword/vector/hybrid; `tests_affected_count` matches `affected_tests` (65)
- [x] `make ci` passes (build + tests + lint, 0 issues)
- [x] Changed files ≥92% line coverage