### PR TITLE
feat(mcp): bound graph and blast responses to a token budget

### DIFF
--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -10,7 +10,70 @@ import (
 const (
 	tier1Cap         = 200
 	tier2ExamplesCap = 5
+	// blastTestExamplesCap bounds the affected-test sample kept when a
+	// response must be trimmed to fit a token budget. tests_affected_count
+	// still reports the true total.
+	blastTestExamplesCap = 10
 )
+
+// ApplyBlastBudget trims a blast response in least-relevant-first order
+// until its estimated token count fits within budget. Summary counts
+// (total_affected, tests_affected_count, references.count) are never
+// reduced — only the enumerated lists shrink — so the headline answer
+// stays truthful and reachable even when the body is capped. Any trim
+// sets Truncated. A non-positive budget disables trimming.
+//
+// Applied on the MCP path only — the token budget is an LLM-context
+// concern. The CLI emits the full (untrimmed) response for piping to
+// jq and friends, so the two surfaces can diverge by design.
+func ApplyBlastBudget(resp *BlastResponse, budget int) {
+	if budget <= 0 {
+		return
+	}
+	// 1. Affected-test sample: tests_affected_count carries the real total.
+	if estimateJSONTokens(resp) > budget && len(resp.AffectedTests) > blastTestExamplesCap {
+		resp.AffectedTests = resp.AffectedTests[:blastTestExamplesCap]
+		resp.Truncated = true
+	}
+	// 2. Call-site snippets are supporting detail; a caller's identity is
+	// the decision-relevant signal for "what breaks?". Shed snippets before
+	// dropping any caller, so more callers survive within the same budget.
+	if estimateJSONTokens(resp) > budget {
+		stripped := false
+		for i := range resp.DirectCallers {
+			if resp.DirectCallers[i].CallSite != nil {
+				resp.DirectCallers[i].CallSite = nil
+				stripped = true
+			}
+		}
+		if stripped {
+			resp.Truncated = true
+		}
+	}
+	// 3. Indirect callers are a weaker signal than direct callers.
+	for estimateJSONTokens(resp) > budget && len(resp.IndirectCallers) > 0 {
+		n := len(resp.IndirectCallers)
+		resp.IndirectCallers = resp.IndirectCallers[:n-trimStep(n)]
+		resp.Truncated = true
+	}
+	// 4. Direct callers last; keep at least one. total_affected still
+	// reports how many exist beyond what is shown.
+	for estimateJSONTokens(resp) > budget && len(resp.DirectCallers) > 1 {
+		n := len(resp.DirectCallers)
+		resp.DirectCallers = resp.DirectCallers[:n-trimStep(n-1)]
+		resp.Truncated = true
+	}
+}
+
+// trimStep returns how many trailing items to drop this iteration —
+// ~10% of what remains, at least 1 — so trimming a long list converges
+// in a handful of marshal passes instead of one pass per dropped item.
+func trimStep(n int) int {
+	if step := n / 10; step > 1 {
+		return step
+	}
+	return 1
+}
 
 // BuildBlastResponse assembles a wire BlastResponse from the blast
 // engine's Result plus a file-path lookup for caller symbols. Results

--- a/internal/mcpio/blast_test.go
+++ b/internal/mcpio/blast_test.go
@@ -627,6 +627,79 @@ func TestBuildDiffBlastResponseTestsAffectedCount(t *testing.T) {
 	}
 }
 
+func bigBlastResponse(direct, indirect, tests int) BlastResponse {
+	r := BlastResponse{
+		Symbol:             "Hub",
+		Risk:               "high",
+		TotalAffected:      direct + indirect,
+		AffectedSymbols:    direct + indirect,
+		TestsAffectedCount: tests,
+	}
+	for i := 0; i < direct; i++ {
+		r.DirectCallers = append(r.DirectCallers, BlastCaller{
+			Symbol: "pkg.Caller" + itoa(i), File: "app/models/caller" + itoa(i) + ".rb", LineStart: i,
+			CallSite: &CallSite{Line: i, Snippet: "some representative source line of code here"},
+		})
+	}
+	for i := 0; i < indirect; i++ {
+		r.IndirectCallers = append(r.IndirectCallers, BlastIndirect{Symbol: "pkg.Ind" + itoa(i), Via: "pkg.V", Hops: 2})
+	}
+	for i := 0; i < tests; i++ {
+		r.AffectedTests = append(r.AffectedTests, "test/thing"+itoa(i)+"_test.rb")
+	}
+	return r
+}
+
+func itoa(i int) string { return fmt.Sprintf("%d", i) }
+
+func TestApplyBlastBudgetNoopUnderBudget(t *testing.T) {
+	r := bigBlastResponse(5, 3, 2)
+	ApplyBlastBudget(&r, 1_000_000)
+	if r.Truncated || len(r.DirectCallers) != 5 || len(r.IndirectCallers) != 3 || len(r.AffectedTests) != 2 {
+		t.Errorf("under-budget response should be untouched: %+v", r)
+	}
+}
+
+func TestApplyBlastBudgetDisabledWhenNonPositive(t *testing.T) {
+	r := bigBlastResponse(200, 200, 200)
+	ApplyBlastBudget(&r, 0)
+	if r.Truncated || len(r.DirectCallers) != 200 {
+		t.Error("budget <= 0 must disable trimming")
+	}
+}
+
+func TestApplyBlastBudgetTrimsToFitPreservingCounts(t *testing.T) {
+	r := bigBlastResponse(400, 300, 120)
+	const budget = 1500
+	ApplyBlastBudget(&r, budget)
+
+	if got := estimateJSONTokens(&r); got > budget {
+		t.Errorf("after trim, tokens=%d still exceed budget=%d", got, budget)
+	}
+	if !r.Truncated {
+		t.Error("expected Truncated=true after trimming")
+	}
+	// Summary counts must survive untouched — the headline answer stays true.
+	if r.TotalAffected != 700 || r.TestsAffectedCount != 120 {
+		t.Errorf("counts must not shrink: TotalAffected=%d TestsAffectedCount=%d", r.TotalAffected, r.TestsAffectedCount)
+	}
+	if len(r.DirectCallers) < 1 {
+		t.Error("must keep at least one direct caller")
+	}
+	if len(r.AffectedTests) > blastTestExamplesCap {
+		t.Errorf("affected_tests sample = %d, want <= %d", len(r.AffectedTests), blastTestExamplesCap)
+	}
+}
+
+func TestTrimStep(t *testing.T) {
+	cases := map[int]int{1: 1, 5: 1, 9: 1, 10: 1, 20: 2, 100: 10}
+	for n, want := range cases {
+		if got := trimStep(n); got != want {
+			t.Errorf("trimStep(%d) = %d, want %d", n, got, want)
+		}
+	}
+}
+
 func TestBuildBlastResponseZeroEdges(t *testing.T) {
 	r := blast.Result{
 		Symbol:         model.Symbol{ID: 1, Qualified: "Isolated"},

--- a/internal/mcpio/graph.go
+++ b/internal/mcpio/graph.go
@@ -11,6 +11,65 @@ import (
 
 const testCallerCollapseThreshold = 20
 
+// ApplyGraphBudget trims a graph response until its estimated token count
+// fits within budget. It sheds the least-relevant content first — deeper
+// BFS layers, then the longest edge list one chunk at a time — keeping
+// the focal symbol and the highest-signal edges. Dropped edges are
+// counted in OmittedEdges and set Truncated, so the consumer knows the
+// view is partial. A non-positive budget disables trimming.
+//
+// Applied on the MCP path only, matching ApplyBlastBudget: the CLI emits
+// the full response for scripting, the MCP surface stays within context.
+func ApplyGraphBudget(resp *GraphResponse, budget int) {
+	if budget <= 0 {
+		return
+	}
+	// 1. Deeper layers are the weakest signal — drop whole hops first.
+	for estimateJSONTokens(resp) > budget && len(resp.Layers) > 0 {
+		dropped := countEdgeSymbols(resp.Layers[len(resp.Layers)-1].Edges)
+		resp.Layers = resp.Layers[:len(resp.Layers)-1]
+		resp.OmittedEdges += dropped
+		resp.Truncated = true
+	}
+	// 2. Trim the longest root edge list, a chunk at a time, until it fits.
+	for estimateJSONTokens(resp) > budget && trimLongestEdgeList(&resp.Edges, resp) {
+		resp.Truncated = true
+	}
+}
+
+// trimLongestEdgeList drops a chunk from whichever root edge slice is
+// longest, keeping at least one entry per kind so each relationship type
+// stays represented. Returns false when nothing more can be trimmed.
+func trimLongestEdgeList(e *GraphEdges, resp *GraphResponse) bool {
+	type slot struct {
+		n    int
+		drop func(int)
+	}
+	slots := []slot{
+		{len(e.CalledBy), func(k int) { e.CalledBy = e.CalledBy[:len(e.CalledBy)-k] }},
+		{len(e.Calls), func(k int) { e.Calls = e.Calls[:len(e.Calls)-k] }},
+		{len(e.Composes), func(k int) { e.Composes = e.Composes[:len(e.Composes)-k] }},
+		{len(e.Inherits), func(k int) { e.Inherits = e.Inherits[:len(e.Inherits)-k] }},
+		{len(e.Includes), func(k int) { e.Includes = e.Includes[:len(e.Includes)-k] }},
+		{len(e.Imports), func(k int) { e.Imports = e.Imports[:len(e.Imports)-k] }},
+		{len(e.Temporal), func(k int) { e.Temporal = e.Temporal[:len(e.Temporal)-k] }},
+		{len(e.Tests), func(k int) { e.Tests = e.Tests[:len(e.Tests)-k] }},
+	}
+	best := -1
+	for i, s := range slots {
+		if best == -1 || s.n > slots[best].n {
+			best = i
+		}
+	}
+	if best == -1 || slots[best].n <= 1 {
+		return false
+	}
+	drop := trimStep(slots[best].n - 1)
+	slots[best].drop(drop)
+	resp.OmittedEdges += drop
+	return true
+}
+
 const (
 	MaxGraphDepth = 3
 	MaxPerHop     = 200

--- a/internal/mcpio/graph_test.go
+++ b/internal/mcpio/graph_test.go
@@ -8,6 +8,114 @@ import (
 	"github.com/luuuc/sense/internal/model"
 )
 
+func bigGraphResponse(callers, layers int) GraphResponse {
+	r := GraphResponse{Symbol: GraphSymbol{Name: "Hub", Qualified: "pkg.Hub"}}
+	for i := 0; i < callers; i++ {
+		f := "app/models/caller" + itoa(i) + ".rb"
+		r.Edges.CalledBy = append(r.Edges.CalledBy, CallEdgeRef{
+			Symbol: "pkg.Caller" + itoa(i), File: &f, LineStart: i, Confidence: 1.0,
+			CallSite: &CallSite{Line: i, Snippet: "a representative line of calling source code"},
+		})
+	}
+	for d := 0; d < layers; d++ {
+		layer := GraphLayer{Depth: d + 2}
+		for i := 0; i < 20; i++ {
+			s := "pkg.L" + itoa(d) + "_" + itoa(i)
+			layer.Edges.CalledBy = append(layer.Edges.CalledBy, CallEdgeRef{Symbol: s, Confidence: 1.0})
+		}
+		r.Layers = append(r.Layers, layer)
+	}
+	return r
+}
+
+func TestApplyGraphBudgetNoopAndDisabled(t *testing.T) {
+	r := bigGraphResponse(3, 0)
+	ApplyGraphBudget(&r, 1_000_000)
+	if r.Truncated || r.OmittedEdges != 0 || len(r.Edges.CalledBy) != 3 {
+		t.Error("under-budget graph response should be untouched")
+	}
+	r2 := bigGraphResponse(200, 2)
+	ApplyGraphBudget(&r2, 0)
+	if r2.Truncated || len(r2.Edges.CalledBy) != 200 {
+		t.Error("budget <= 0 must disable trimming")
+	}
+}
+
+func TestApplyGraphBudgetDropsLayersFirst(t *testing.T) {
+	r := bigGraphResponse(15, 3)
+	const budget = 1200
+	ApplyGraphBudget(&r, budget)
+	if got := estimateJSONTokens(&r); got > budget {
+		t.Errorf("after trim tokens=%d exceed budget=%d", got, budget)
+	}
+	if !r.Truncated || r.OmittedEdges == 0 {
+		t.Errorf("expected Truncated + OmittedEdges>0, got Truncated=%v Omitted=%d", r.Truncated, r.OmittedEdges)
+	}
+	if len(r.Layers) == 3 {
+		t.Error("expected deeper layers to be dropped first")
+	}
+}
+
+func TestApplyGraphBudgetTrimsLongestEdgeList(t *testing.T) {
+	r := bigGraphResponse(400, 0)
+	const budget = 800
+	ApplyGraphBudget(&r, budget)
+	if got := estimateJSONTokens(&r); got > budget {
+		t.Errorf("after trim tokens=%d exceed budget=%d", got, budget)
+	}
+	if len(r.Edges.CalledBy) < 1 {
+		t.Error("must keep at least one edge per kind")
+	}
+	if r.OmittedEdges != 400-len(r.Edges.CalledBy) {
+		t.Errorf("OmittedEdges=%d should equal dropped=%d", r.OmittedEdges, 400-len(r.Edges.CalledBy))
+	}
+}
+
+func TestApplyGraphBudgetTrimsEveryEdgeKind(t *testing.T) {
+	// All eight edge kinds start equally long; a tiny budget forces the
+	// trimmer to cycle through and shrink each kind's slice in turn.
+	r := GraphResponse{Symbol: GraphSymbol{Name: "Hub", Qualified: "pkg.Hub"}}
+	const per = 12
+	for i := 0; i < per; i++ {
+		s := "pkg.S" + itoa(i)
+		r.Edges.CalledBy = append(r.Edges.CalledBy, CallEdgeRef{Symbol: s, Confidence: 1.0})
+		r.Edges.Calls = append(r.Edges.Calls, CallEdgeRef{Symbol: s, Confidence: 1.0})
+		r.Edges.Inherits = append(r.Edges.Inherits, InheritEdgeRef{Symbol: s})
+		r.Edges.Composes = append(r.Edges.Composes, ComposeEdgeRef{Symbol: s})
+		r.Edges.Includes = append(r.Edges.Includes, IncludeEdgeRef{Symbol: s})
+		r.Edges.Imports = append(r.Edges.Imports, ImportEdgeRef{Symbol: s})
+		r.Edges.Temporal = append(r.Edges.Temporal, TemporalEdgeRef{Symbol: s, Strength: 0.5})
+		r.Edges.Tests = append(r.Edges.Tests, TestEdgeRef{File: "test/" + s + "_test.rb", Confidence: 0.8})
+	}
+	// A budget below the one-entry-per-kind floor forces every kind to be
+	// trimmed down to its single representative, exercising each kind's
+	// drop path while proving no relationship type is dropped entirely.
+	ApplyGraphBudget(&r, 200)
+	kinds := []int{
+		len(r.Edges.CalledBy), len(r.Edges.Calls), len(r.Edges.Inherits), len(r.Edges.Composes),
+		len(r.Edges.Includes), len(r.Edges.Imports), len(r.Edges.Temporal), len(r.Edges.Tests),
+	}
+	for i, n := range kinds {
+		if n != 1 {
+			t.Errorf("edge kind %d trimmed to %d, want 1", i, n)
+		}
+	}
+	if !r.Truncated {
+		t.Error("expected Truncated=true")
+	}
+	if want := (per - 1) * 8; r.OmittedEdges != want {
+		t.Errorf("OmittedEdges = %d, want %d", r.OmittedEdges, want)
+	}
+}
+
+func TestTrimLongestEdgeListStopsWhenMinimal(t *testing.T) {
+	e := &GraphEdges{CalledBy: []CallEdgeRef{{Symbol: "a"}}, Calls: []CallEdgeRef{{Symbol: "b"}}}
+	resp := &GraphResponse{}
+	if trimLongestEdgeList(e, resp) {
+		t.Error("should return false when no list has more than one entry")
+	}
+}
+
 func TestBuildGraphResponseComposesEdges(t *testing.T) {
 	filePaths := map[int64]string{
 		1: "app/models/user.rb",

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -107,6 +107,11 @@ type GraphResponse struct {
 	// for the root symbol only (not deeper layers), so a consumer knows the
 	// edge list was filtered rather than silently truncated.
 	LowConfidenceHidden int               `json:"low_confidence_hidden,omitempty"`
+	// OmittedEdges counts edges dropped to keep the response within its
+	// token budget (distinct from low_confidence_hidden, which is a
+	// confidence filter). Non-zero means the edge lists are a partial,
+	// highest-signal view — narrow with a direction or a specific symbol.
+	OmittedEdges       int                    `json:"omitted_edges,omitempty"`
 	CoverageNote       string                 `json:"coverage_note,omitempty"`
 	VerifyHint         string                 `json:"verify_hint,omitempty"`
 	IndexCaveat        string                 `json:"index_caveat,omitempty"`

--- a/internal/mcpserver/helpers_test.go
+++ b/internal/mcpserver/helpers_test.go
@@ -967,6 +967,45 @@ func TestHandleBlastWithIncludeTests(t *testing.T) {
 	}
 }
 
+// TestHandleBlastAppliesTokenBudget locks the wiring: a tiny budget on
+// the handler must trim the response and flag it, while the summary
+// counts survive. Guards against the budget call being dropped.
+func TestHandleBlastAppliesTokenBudget(t *testing.T) {
+	ts := setupTestServer(t)
+	ts.handlers.defaults.BlastTokenBudget = 1 // force trimming
+	result, err := ts.handlers.handleBlast(context.Background(), toolReq(map[string]any{"symbol": "auth.Verify"}))
+	if err != nil {
+		t.Fatalf("handleBlast: %v", err)
+	}
+	var resp mcpio.BlastResponse
+	if err := json.Unmarshal([]byte(resultText(t, result)), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !resp.Truncated {
+		t.Error("expected truncated=true when budget forces trimming")
+	}
+	if resp.TotalAffected == 0 {
+		t.Error("total_affected must survive trimming")
+	}
+}
+
+// TestHandleGraphAppliesTokenBudget is the graph-side wiring lock.
+func TestHandleGraphAppliesTokenBudget(t *testing.T) {
+	ts := setupTestServer(t)
+	ts.handlers.defaults.GraphTokenBudget = 1 // force trimming
+	result, err := ts.handlers.handleGraph(context.Background(), toolReq(map[string]any{"symbol": "auth.Verify", "direction": "callers"}))
+	if err != nil {
+		t.Fatalf("handleGraph: %v", err)
+	}
+	var resp mcpio.GraphResponse
+	if err := json.Unmarshal([]byte(resultText(t, result)), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !resp.Truncated {
+		t.Error("expected truncated=true when budget forces trimming")
+	}
+}
+
 func TestHandleBlastWithMaxResults(t *testing.T) {
 	ts := setupTestServer(t)
 	ctx := context.Background()

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -477,6 +477,10 @@ func (h *handlers) handleGraph(ctx context.Context, req mcp.CallToolRequest) (*m
 	resp.Freshness = freshness
 	resp.NextSteps = graphHints(resp, direction)
 
+	// Keep hub responses within the MCP token budget — sheds deeper layers
+	// and trims the longest edge list, recording the count in OmittedEdges.
+	mcpio.ApplyGraphBudget(&resp, h.defaults.GraphTokenBudget)
+
 	out, err := mcpio.MarshalGraphCompactDirectional(resp, direction)
 	if err != nil {
 		return nil, fmt.Errorf("sense_graph: marshal: %w", err)
@@ -926,6 +930,11 @@ func (h *handlers) handleBlast(ctx context.Context, req mcp.CallToolRequest) (*m
 	freshness := computeFreshness(ctx, h.db, h.dir, false, h.watchState)
 	resp.Freshness = freshness
 	resp.NextSteps = blastHints(resp)
+
+	// Keep the response within the MCP token budget — trims enumerated
+	// lists while preserving the summary counts. Runs last so hints and
+	// metrics still reflect the full radius.
+	mcpio.ApplyBlastBudget(&resp, h.defaults.BlastTokenBudget)
 
 	out, err := mcpio.MarshalBlastCompact(resp)
 	if err != nil {

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -183,6 +183,8 @@ type Defaults struct {
 	BlastMaxHops           int
 	BlastMinConfidence     float64
 	BlastResultCap         int
+	BlastTokenBudget       int
+	GraphTokenBudget       int
 	GraphSegmentCallers    bool
 }
 
@@ -196,6 +198,8 @@ func DefaultParams() Defaults {
 		BlastMaxHops:           5,
 		BlastMinConfidence:     0.3,
 		BlastResultCap:         200,
+		BlastTokenBudget:       12000,
+		GraphTokenBudget:       12000,
 		GraphSegmentCallers:    false,
 	}
 }

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -52,6 +52,8 @@ func TestDefaultParams(t *testing.T) {
 		BlastMaxHops:           5,
 		BlastMinConfidence:     0.3,
 		BlastResultCap:         200,
+		BlastTokenBudget:       12000,
+		GraphTokenBudget:       12000,
 		GraphSegmentCallers:    false,
 	}
 	if d != want {


### PR DESCRIPTION
> Stacked on #99 (telemetry honesty). Review/merge that first; this targets its branch for a clean diff.

## Problem
Hub-symbol `sense_graph` queries (~96KB on a real Rails hub) and `sense_blast --diff` responses (~162KB, observed up to 337KB) overflowed the MCP single-result token limit and spilled to a file whose lines were too long to read — forcing char-range slicing. Meanwhile the actually-useful summary (risk, counts) was buried at the very end. Only `sense_conventions` had a token budget; `graph` and `blast` had none.

## Summary
Generalize the budget mechanism to graph and blast: trim least-relevant content first until the response fits, always preserving the summary counts and honestly flagging what was cut.

## Changes
- `ApplyBlastBudget`: trims in order — affected-test sample → call-site snippets → indirect callers → direct callers (keeps ≥1). `total_affected` / `tests_affected_count` are never reduced. Stripping snippets before dropping callers keeps more caller identities (the decision-relevant signal) per token.
- `ApplyGraphBudget`: sheds deeper BFS layers first, then trims the longest edge list a chunk at a time, keeping ≥1 entry per edge kind. Dropped edges are reported in a new `omitted_edges` field.
- Both set `truncated` and are applied on the **MCP path only** — the CLI emits full responses for `jq`/scripting.
- Budgets live in `Defaults` (12000 tokens), tunable per profile.

## Architecture Highlights
- Reuses the existing `estimateJSONTokens` estimator; chunked (10%) trimming converges in a handful of marshal passes rather than one per dropped item.
- Honesty model: a partial answer that reports the true totals + `truncated`/`omitted_edges` beats a complete answer that overflows and is discarded.

## Test Plan
- [x] Unit tests: no-op under budget, disabled at budget≤0, trim-to-fit, count preservation, per-edge-kind floor, all eight edge kinds, snippet-strip
- [x] Handler tests asserting the budget is actually wired (blast + graph)
- [x] Verified on a 10.7K-symbol Rails index via the MCP stdio path: diff blast 162KB→35KB, graph hub 96KB→34KB, both under budget, `truncated=true`, counts intact
- [x] `make ci` passes (build + tests + lint, 0 issues)
- [x] Changed files ≥92% line coverage; new budget functions 100%

## Known limitation
Trimming drops from the tail of lists not ordered by importance, so "which callers survived" is somewhat arbitrary. Confidence-ordered trimming is deferred until a real case shows tail-drop loses something that mattered.