### PR TITLE
feat(search): rank implementations above their tests

### DIFF
--- a/internal/search/fusion_internal_test.go
+++ b/internal/search/fusion_internal_test.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"math"
 	"sort"
 	"testing"
 
@@ -180,6 +181,87 @@ func TestFuseRRFKeywordDuplicateAccumulates(t *testing.T) {
 	}
 	if dup.Score <= other.Score {
 		t.Errorf("twice-listed symbol should outscore single: dup=%v other=%v", dup.Score, other.Score)
+	}
+}
+
+func TestQueryTargetsTests(t *testing.T) {
+	yes := []string{"test for the parser", "spec coverage", "mock server", "unit Test", "test_helpers setup"}
+	// Whole-word matching: these contain test/spec/mock as substrings but
+	// are not about tests.
+	no := []string{"build the scanner", "how does auth work", "payment flow",
+		"latest changes", "specification format", "inspect the request", "hammock config"}
+	for _, q := range yes {
+		if !queryTargetsTests(q) {
+			t.Errorf("queryTargetsTests(%q) = false, want true", q)
+		}
+	}
+	for _, q := range no {
+		if queryTargetsTests(q) {
+			t.Errorf("queryTargetsTests(%q) = true, want false", q)
+		}
+	}
+}
+
+func TestIsTestSymbol(t *testing.T) {
+	for _, n := range []string{"TestParse", "MockClient", "FakeDB", "StubServer"} {
+		if !isTestSymbol(n) {
+			t.Errorf("isTestSymbol(%q) = false, want true", n)
+		}
+	}
+	for _, n := range []string{"Parse", "FindUser", "Authenticator"} {
+		if isTestSymbol(n) {
+			t.Errorf("isTestSymbol(%q) = true, want false", n)
+		}
+	}
+}
+
+func TestIsTestPath(t *testing.T) {
+	for _, p := range []string{"internal/dead/dead_test.go", "spec/models/user_spec.rb", "test/foo.rb", "app/__tests__/x.js", "internal/scan/testdata/x.go"} {
+		if !isTestPath(p) {
+			t.Errorf("isTestPath(%q) = false, want true", p)
+		}
+	}
+	for _, p := range []string{"app/models/user.rb", "internal/dead/dead.go", ""} {
+		if isTestPath(p) {
+			t.Errorf("isTestPath(%q) = true, want false", p)
+		}
+	}
+}
+
+func TestApplyTestDemotion(t *testing.T) {
+	paths := map[int64]string{1: "internal/dead/dead.go", 2: "internal/dead/dead_test.go", 3: "internal/x/y.go"}
+	mk := func() []Result {
+		return []Result{
+			{SymbolID: 1, Name: "FindDead", FileID: 1, Score: 0.6},  // impl
+			{SymbolID: 2, Name: "TestFindDead", FileID: 2, Score: 1.0}, // test by path+name
+			{SymbolID: 3, Name: "MockThing", FileID: 3, Score: 0.9},  // test by name only
+		}
+	}
+
+	near := func(a, b float64) bool { return math.Abs(a-b) < 1e-9 }
+
+	// Non-test query: tests demoted, impl untouched.
+	r := mk()
+	applyTestDemotion(r, paths, "find dead code")
+	if r[0].Score != 0.6 {
+		t.Errorf("impl score changed: %v", r[0].Score)
+	}
+	if !near(r[1].Score, 1.0*testRankPenalty) {
+		t.Errorf("test-by-path score = %v, want %v", r[1].Score, testRankPenalty)
+	}
+	if !near(r[2].Score, 0.9*testRankPenalty) {
+		t.Errorf("mock-by-name score = %v, want %v", r[2].Score, 0.9*testRankPenalty)
+	}
+	// After demotion the implementation outranks both tests.
+	if r[0].Score <= r[1].Score || r[0].Score <= r[2].Score {
+		t.Error("implementation should outrank tests after demotion")
+	}
+
+	// Test-oriented query: no demotion at all.
+	r2 := mk()
+	applyTestDemotion(r2, paths, "test for dead code")
+	if r2[1].Score != 1.0 || r2[2].Score != 0.9 {
+		t.Error("test-oriented query must not demote test results")
 	}
 }
 

--- a/internal/search/internals_test.go
+++ b/internal/search/internals_test.go
@@ -208,6 +208,48 @@ func TestSubstringFallbackMergesMatches(t *testing.T) {
 	}
 }
 
+func TestSearchRanksImplementationAboveItsTest(t *testing.T) {
+	ctx := context.Background()
+	a := openTestDB(t)
+
+	implFile, err := a.WriteFile(ctx, &model.File{Path: "internal/parse/parse.go", Language: "go", Hash: "h1", Symbols: 1, IndexedAt: time.Now()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	testFile, err := a.WriteFile(ctx, &model.File{Path: "internal/parse/parse_test.go", Language: "go", Hash: "h2", Symbols: 1, IndexedAt: time.Now()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.WriteSymbol(ctx, &model.Symbol{FileID: implFile, Name: "ParseConfig", Qualified: "parse.ParseConfig", Kind: "function", LineStart: 1, LineEnd: 5, Snippet: "func ParseConfig(path string) (*Config, error)"}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.WriteSymbol(ctx, &model.Symbol{FileID: testFile, Name: "TestParseConfig", Qualified: "parse_test.TestParseConfig", Kind: "function", LineStart: 1, LineEnd: 5, Snippet: "func TestParseConfig(t *testing.T)"}); err != nil {
+		t.Fatal(err)
+	}
+
+	e := NewEngine(a, nil, nil)
+	results, _, err := e.Search(ctx, Options{Query: "parse config", Limit: 10})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
+	implPos, testPos := -1, -1
+	for i, r := range results {
+		switch r.Name {
+		case "ParseConfig":
+			implPos = i
+		case "TestParseConfig":
+			testPos = i
+		}
+	}
+	if implPos == -1 {
+		t.Fatal("implementation ParseConfig not in results")
+	}
+	if testPos != -1 && implPos > testPos {
+		t.Errorf("implementation ranked %d, below its test at %d — demotion failed", implPos, testPos)
+	}
+}
+
 func TestPromoteParentsEmpty(t *testing.T) {
 	e := NewEngine(nil, nil, nil)
 	out, err := e.promoteParents(context.Background(), nil, 10)

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"unicode"
 
 	"github.com/luuuc/sense/internal/embed"
 	"github.com/luuuc/sense/internal/sqlite"
@@ -304,6 +305,14 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, SearchMeta
 	normalizeScores(fused)
 	applyGraphCentrality(fused, centrality)
 
+	// Decisive test demotion, applied last so it survives the [0,1]
+	// rescale above. Test symbols match a query's tokens more densely
+	// than the implementation they exercise (TestParseConfig vs Parse),
+	// so a pre-normalize penalty is out-voted by the raw keyword gap;
+	// here every score is bounded, so the penalty reliably ranks the
+	// implementation above its tests. Skipped for test-oriented queries.
+	applyTestDemotion(fused, pathByID, opts.Query)
+
 	// Sort by final score descending.
 	sort.Slice(fused, func(i, j int) bool {
 		return fused[i].Score > fused[j].Score
@@ -503,6 +512,15 @@ const (
 
 var testNamePrefixes = []string{"Test", "Mock", "Fake", "Stub"}
 
+// applyKindWeights demotes modules (namespaces, rarely the search target)
+// and applies a pre-normalization test-name penalty. This pre-norm pass
+// is NOT redundant with applyTestDemotion (which runs post-norm): it
+// keeps a verbatim-matching test from becoming the normalize-max, since
+// normalizeScores pins the lowest score to 0 and the multiplicative
+// centrality boost cannot lift a 0 — so without it an implementation
+// that is the weakest keyword match gets stuck at the bottom. The two
+// passes are complementary: this one shapes which symbol anchors the
+// rescale; applyTestDemotion is the decisive reorder afterward.
 func applyKindWeights(results []Result) {
 	for i := range results {
 		if results[i].Kind == "module" {
@@ -602,6 +620,88 @@ func applyPathWeights(results []Result, pathByID map[int64]string) {
 			}
 		}
 	}
+}
+
+// testRankPenalty multiplies the final, normalized score of a test or
+// mock symbol. Tuned so an implementation of even modest relevance
+// (normalized ~0.3) outranks a test that matched the query verbatim
+// (normalized 1.0 → 0.2 after the penalty).
+const testRankPenalty = 0.2
+
+// testFilePathSegments identifies test/spec/mock paths across languages.
+var testFilePathSegments = []string{
+	"_test.", "_spec.", ".test.", ".spec.",
+	"/test/", "/tests/", "/spec/", "/specs/",
+	"/mock/", "/mocks/", "/__tests__/", "/testdata/",
+}
+
+var testFilePathPrefixes = []string{"test/", "spec/"}
+
+// applyTestDemotion multiplies test/mock symbols' scores by
+// testRankPenalty as the final ranking step, so implementations outrank
+// the tests that exercise them. It is a no-op when the query is itself
+// about tests (e.g. "test for the parser", "spec coverage"), where the
+// caller genuinely wants test code surfaced.
+func applyTestDemotion(results []Result, pathByID map[int64]string, query string) {
+	if queryTargetsTests(query) {
+		return
+	}
+	for i := range results {
+		if isTestSymbol(results[i].Name) || isTestPath(pathByID[results[i].FileID]) {
+			results[i].Score *= testRankPenalty
+		}
+	}
+}
+
+// testQueryWords are whole-word signals that the caller wants test code.
+var testQueryWords = map[string]struct{}{
+	"test": {}, "tests": {}, "testing": {},
+	"spec": {}, "specs": {}, "mock": {}, "mocks": {}, "mocked": {},
+}
+
+// queryTargetsTests reports whether the query is explicitly about test
+// code, in which case test results should not be demoted. It matches on
+// whole words so "latest", "specification", and "inspect" do not count
+// as test queries.
+func queryTargetsTests(query string) bool {
+	for _, tok := range strings.FieldsFunc(strings.ToLower(query), func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	}) {
+		if _, ok := testQueryWords[tok]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// isTestSymbol reports whether a symbol name signals test/mock code.
+func isTestSymbol(name string) bool {
+	for _, prefix := range testNamePrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// isTestPath reports whether a file path is a test/spec/mock file.
+// Mirrors mcpio.IsTestPath; kept separate because search cannot import
+// the mcpio marshalling layer. Keep the two in sync if patterns change.
+func isTestPath(path string) bool {
+	if path == "" {
+		return false
+	}
+	for _, p := range testFilePathPrefixes {
+		if strings.HasPrefix(path, p) {
+			return true
+		}
+	}
+	for _, seg := range testFilePathSegments {
+		if strings.Contains(path, seg) {
+			return true
+		}
+	}
+	return false
 }
 
 const vectorConfidenceTopK = 3


### PR DESCRIPTION
> Stacked on #101 → #99. Review/merge those first; this targets #101's branch for a clean diff.

## Problem
For code-understanding queries, test functions crowded out the implementation they exercise. On a test-dense Go repo, **6 of 12** realistic natural-language queries returned *no implementation at all* in the top 10 (e.g. "how is dead code detected" returned 10 `TestDeadCode…` functions; `FindDead` was nowhere). Root cause: test names match a query's tokens more densely than the code under test (`TestParseConfig` matches "parse config" better than `ParseConfig`), and the existing test demotion ran *before* `normalizeScores` — the min-max rescale washed the penalty out, so the raw keyword gap won.

## Summary
Demote test/mock symbols as the **final** ranking step, after normalization and centrality, where bounded scores make a fixed penalty reliably rank the implementation above its tests.

## Changes
- `applyTestDemotion`: 0.2 penalty on test/mock symbols (by name or path), applied post-normalize/centrality, just before the final sort.
- Skipped when the query targets tests — matched on **whole words** (`test`/`spec`/`mock`) via a tokenizer, so "latest", "specification", "inspect", "hammock" are not mistaken for test queries.
- Kept and documented the pre-normalization name penalty: it is *not* redundant — it stops a verbatim-matching test from becoming the normalize anchor, which (since normalize pins the lowest score to 0 and centrality is multiplicative) would otherwise pin a weak-matching implementation to zero. The two passes are complementary.

## Results (24-query benchmark, both repos)
| Metric | Go repo | Rails (maket) |
|---|---|---|
| queries with no impl in top 10 | 6/12 → **0/12** | 0/12 → 0/12 |
| #1 result is a test | 7/12 → **0/12** | 2/12 → **0/12** |
| first-implementation rank | ~50 → **1.0** | 1.5 → **1.0** |

## Test Plan
- [x] Unit tests: penalty math, whole-word guard (incl. "latest"/"specification" false-positive cases), path/name predicates
- [x] Engine-level test: implementation outranks its test after `Search()` for a plain query
- [x] Regression guard: pre-existing `TestSearchDemotesTestSymbols` (the 2-result normalize-anchor case) still passes
- [x] `make ci` passes (build + tests + lint, 0 issues); search.go ≥92% line coverage

## Note on behavior
Test results still appear, just below implementations; explicit test queries are unaffected by design. This intentionally relies on the honest `source` field from #99 — the earlier "vector never wins" concern was a labeling artifact, so this PR does not touch fusion weights.