### PR TITLE
feat(dead): stop flagging Rails/Hotwire entry points as dead

### DIFF
--- a/internal/cli/dead.go
+++ b/internal/cli/dead.go
@@ -72,7 +72,7 @@ func RunDead(args []string, cio IO) int {
 	rolled := dead.Rollup(result.Dead)
 
 	if opts.JSON {
-		resp := mcpio.BuildDeadCodeResponse(rolled, result.TotalSymbols)
+		resp := mcpio.BuildDeadCodeResponse(rolled, result.TotalSymbols, result.Frameworks)
 		out, merr := mcpio.MarshalDeadCode(resp)
 		if merr != nil {
 			_, _ = fmt.Fprintln(cio.Stderr, "sense dead:", merr)

--- a/internal/dead/dead.go
+++ b/internal/dead/dead.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 
 	"github.com/luuuc/sense/internal/sqlite"
@@ -38,6 +39,9 @@ type Symbol struct {
 type Result struct {
 	Dead         []Symbol
 	TotalSymbols int
+	// Frameworks are the detected project frameworks (e.g. "Rails"),
+	// used to tailor the blind-spot caveat to the right ecosystem.
+	Frameworks []string
 }
 
 func FindDead(ctx context.Context, db *sql.DB, opts Options) (Result, error) {
@@ -93,6 +97,15 @@ func FindDead(ctx context.Context, db *sql.DB, opts Options) (Result, error) {
 		return Result{}, fmt.Errorf("dead: interface implementors: %w", err)
 	}
 
+	controllerConcernIDs, err := queryControllerConcernModuleIDs(ctx, db)
+	if err != nil {
+		return Result{}, fmt.Errorf("dead: controller concern modules: %w", err)
+	}
+	includedModuleIDs, err := queryIncludedModuleIDs(ctx, db)
+	if err != nil {
+		return Result{}, fmt.Errorf("dead: included modules: %w", err)
+	}
+
 	candidates = excludeEntryPoints(candidates, entryPointFilters{
 		testsTargets:         testsTargets,
 		interfaceIDs:         interfaceIDs,
@@ -100,9 +113,15 @@ func FindDead(ctx context.Context, db *sql.DB, opts Options) (Result, error) {
 		isLibrary:            isLibrary,
 		interfaceMethodNames: interfaceMethodNames,
 		implementorIDs:       implementorIDs,
+		controllerConcernIDs: controllerConcernIDs,
 	})
 
-	candidates = annotateConfidence(candidates, interfaceIDs, implementorIDs, usesDynamicAutoload(frameworks))
+	candidates = annotateConfidence(candidates, confidenceInputs{
+		interfaceIDs:      interfaceIDs,
+		implementorIDs:    implementorIDs,
+		includedModuleIDs: includedModuleIDs,
+		dynamicFramework:  usesDynamicAutoload(frameworks),
+	})
 
 	if len(candidates) > opts.Limit {
 		candidates = candidates[:opts.Limit]
@@ -111,7 +130,19 @@ func FindDead(ctx context.Context, db *sql.DB, opts Options) (Result, error) {
 	return Result{
 		Dead:         candidates,
 		TotalSymbols: totalSymbols,
+		Frameworks:   frameworkNames(frameworks),
 	}, nil
+}
+
+// frameworkNames returns the detected framework names in sorted order
+// for stable output.
+func frameworkNames(frameworks map[string]struct{}) []string {
+	names := make([]string, 0, len(frameworks))
+	for n := range frameworks {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
 }
 
 func countSymbols(ctx context.Context, db *sql.DB, opts Options) (int, error) {
@@ -279,6 +310,52 @@ func queryInterfaceImplementors(ctx context.Context, db *sql.DB) (map[int64]stru
 	return out, rows.Err()
 }
 
+// queryControllerConcernModuleIDs returns IDs of modules included into a
+// class whose name ends in "Controller". Their instance methods become
+// routed controller actions (ActiveSupport::Concern mixed into a
+// controller), so they are framework entry points, not dead code.
+func queryControllerConcernModuleIDs(ctx context.Context, db *sql.DB) (map[int64]struct{}, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT DISTINCT e.target_id FROM sense_edges e
+		JOIN sense_symbols s ON s.id = e.source_id
+		WHERE e.kind = 'includes' AND e.target_id IS NOT NULL AND s.name LIKE '%Controller'`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	out := make(map[int64]struct{})
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out[id] = struct{}{}
+	}
+	return out, rows.Err()
+}
+
+// queryIncludedModuleIDs returns IDs of modules included anywhere (any
+// incoming includes edge). A method on such a module is reachable through
+// the including type, so a zero-caller verdict is uncertain rather than
+// dead.
+func queryIncludedModuleIDs(ctx context.Context, db *sql.DB) (map[int64]struct{}, error) {
+	rows, err := db.QueryContext(ctx,
+		`SELECT DISTINCT target_id FROM sense_edges WHERE kind = 'includes' AND target_id IS NOT NULL`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	out := make(map[int64]struct{})
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out[id] = struct{}{}
+	}
+	return out, rows.Err()
+}
+
 func hasMainFunction(ctx context.Context, db *sql.DB, opts Options) (bool, error) {
 	q := `SELECT 1 FROM sense_symbols s
 		JOIN sense_files f ON s.file_id = f.id
@@ -314,6 +391,9 @@ type entryPointFilters struct {
 	isLibrary            bool
 	interfaceMethodNames map[string]struct{}
 	implementorIDs       map[int64]struct{}
+	// controllerConcernIDs are module IDs included into a *Controller —
+	// their methods are routed actions. Populated only for Rails projects.
+	controllerConcernIDs map[int64]struct{}
 }
 
 func excludeEntryPoints(candidates []Symbol, filters entryPointFilters) []Symbol {
@@ -430,6 +510,14 @@ func isEntryPoint(s Symbol, f entryPointFilters) bool {
 	}
 	if isFrameworkHook(s, f.frameworks) {
 		return true
+	}
+	if isStimulusController(s) {
+		return true
+	}
+	if _, rails := f.frameworks["Rails"]; rails {
+		if isRailsControllerClass(s) || isRailsControllerAction(s, f.controllerConcernIDs) {
+			return true
+		}
 	}
 	if isInterfaceMethod(s, f.interfaceIDs) {
 		return true
@@ -559,6 +647,53 @@ func isFrameworkHook(s Symbol, frameworks map[string]struct{}) bool {
 	return false
 }
 
+// isRailsControllerClass reports whether s is a Rails controller class.
+// Controllers are instantiated and dispatched by the router, never by a
+// Ruby caller, so a zero-edge controller is an entry point, not dead.
+func isRailsControllerClass(s Symbol) bool {
+	return s.Language == "ruby" && s.Kind == "class" && strings.HasSuffix(s.Name, "Controller")
+}
+
+// isRailsControllerAction reports whether s is a public instance method
+// that the router can dispatch — defined directly on a *Controller, or
+// on a concern mixed into one.
+//
+// The visibility guard is currently inert: the Ruby extractor does not
+// populate Visibility, so every controller method passes it. That is the
+// intended trade — wrongly excluding an unused private helper is benign,
+// while flagging a routed action as dead would make a reader delete live
+// code. The guard stays so the policy is explicit and tightens for free
+// if visibility is ever indexed.
+func isRailsControllerAction(s Symbol, controllerConcernIDs map[int64]struct{}) bool {
+	if s.Language != "ruby" || s.Kind != "method" {
+		return false
+	}
+	if s.Visibility == "private" || s.Visibility == "protected" {
+		return false
+	}
+	if strings.HasSuffix(rubyMethodParentName(s.Qualified), "Controller") {
+		return true
+	}
+	if s.ParentID != nil {
+		_, ok := controllerConcernIDs[*s.ParentID]
+		return ok
+	}
+	return false
+}
+
+// isStimulusController reports whether s belongs to a Stimulus controller.
+// Stimulus dispatches lifecycle callbacks (connect/disconnect), action
+// methods, and target getters through the runtime and HTML data-*
+// attributes — none are static JS call edges. The *_controller.js
+// convention is the signal; no framework flag is required because the
+// filename is unambiguous.
+func isStimulusController(s Symbol) bool {
+	if s.Language != "javascript" && s.Language != "typescript" {
+		return false
+	}
+	return strings.HasSuffix(s.File, "_controller.js") || strings.HasSuffix(s.File, "_controller.ts")
+}
+
 func readFrameworks(ctx context.Context, db *sql.DB) map[string]struct{} {
 	out := map[string]struct{}{}
 	var raw string
@@ -610,15 +745,28 @@ func isGoConstructor(s Symbol) bool {
 	return s.Language == "go" && strings.HasPrefix(s.Name, "New") && s.Kind == "function"
 }
 
-func annotateConfidence(candidates []Symbol, interfaceIDs, implementorIDs map[int64]struct{}, dynamicFramework bool) []Symbol {
+type confidenceInputs struct {
+	interfaceIDs      map[int64]struct{}
+	implementorIDs    map[int64]struct{}
+	includedModuleIDs map[int64]struct{}
+	dynamicFramework  bool
+}
+
+func annotateConfidence(candidates []Symbol, in confidenceInputs) []Symbol {
 	for i := range candidates {
 		s := &candidates[i]
 		if s.ParentID != nil {
-			if _, ok := interfaceIDs[*s.ParentID]; ok {
+			if _, ok := in.interfaceIDs[*s.ParentID]; ok {
 				s.Confidence = ConfidencePossibly
 				continue
 			}
-			if _, ok := implementorIDs[*s.ParentID]; ok {
+			if _, ok := in.implementorIDs[*s.ParentID]; ok {
+				s.Confidence = ConfidencePossibly
+				continue
+			}
+			// A method on a module included somewhere is reachable through
+			// the including type, so a zero-caller verdict is uncertain.
+			if _, ok := in.includedModuleIDs[*s.ParentID]; ok {
 				s.Confidence = ConfidencePossibly
 				continue
 			}
@@ -627,7 +775,7 @@ func annotateConfidence(candidates []Symbol, interfaceIDs, implementorIDs map[in
 			s.Confidence = ConfidencePossibly
 			continue
 		}
-		if dynamicFramework && (isDynamicallyReferenceable(*s) || isDynamicRubyMethod(*s)) {
+		if in.dynamicFramework && (isDynamicallyReferenceable(*s) || isDynamicRubyMethod(*s)) {
 			s.Confidence = ConfidencePossibly
 			continue
 		}

--- a/internal/dead/framework_test.go
+++ b/internal/dead/framework_test.go
@@ -1,0 +1,237 @@
+package dead
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+func TestIsRailsControllerClass(t *testing.T) {
+	yes := Symbol{Language: "ruby", Kind: "class", Name: "OrdersController"}
+	if !isRailsControllerClass(yes) {
+		t.Error("a *Controller class should be a router entry point")
+	}
+	for _, s := range []Symbol{
+		{Language: "ruby", Kind: "class", Name: "OrderService"}, // not a controller
+		{Language: "ruby", Kind: "module", Name: "OrdersController"}, // module, not class
+		{Language: "go", Kind: "class", Name: "OrdersController"},  // not ruby
+	} {
+		if isRailsControllerClass(s) {
+			t.Errorf("isRailsControllerClass(%+v) = true, want false", s)
+		}
+	}
+}
+
+func TestIsRailsControllerAction(t *testing.T) {
+	concern := map[int64]struct{}{42: {}}
+	pidConcern := int64(42)
+	pidOther := int64(7)
+
+	// Direct action on a controller.
+	if !isRailsControllerAction(Symbol{Language: "ruby", Kind: "method", Qualified: "Account::OrdersController#create"}, nil) {
+		t.Error("public method on a *Controller should be a routed action")
+	}
+	// Action via a concern mixed into a controller.
+	if !isRailsControllerAction(Symbol{Language: "ruby", Kind: "method", Qualified: "Admin::Importable#index", ParentID: &pidConcern}, concern) {
+		t.Error("method on a controller-concern should be a routed action")
+	}
+	for _, s := range []Symbol{
+		{Language: "ruby", Kind: "method", Qualified: "OrderService#call"},                       // not a controller
+		{Language: "ruby", Kind: "method", Qualified: "X::OrdersController#secret", Visibility: "private"}, // private
+		{Language: "ruby", Kind: "class", Qualified: "X::OrdersController"},                       // not a method
+		{Language: "go", Kind: "method", Qualified: "X::OrdersController#create"},                 // not ruby
+		{Language: "ruby", Kind: "method", Qualified: "Helper#thing", ParentID: &pidOther},        // module not a controller concern
+	} {
+		if isRailsControllerAction(s, concern) {
+			t.Errorf("isRailsControllerAction(%+v) = true, want false", s)
+		}
+	}
+}
+
+func TestIsStimulusController(t *testing.T) {
+	for _, f := range []string{"app/javascript/controllers/modal_controller.js", "app/frontend/x_controller.ts"} {
+		if !isStimulusController(Symbol{Language: "javascript", File: f}) && !isStimulusController(Symbol{Language: "typescript", File: f}) {
+			t.Errorf("%s should be a Stimulus controller", f)
+		}
+	}
+	for _, s := range []Symbol{
+		{Language: "javascript", File: "app/javascript/util.js"}, // not a *_controller file
+		{Language: "ruby", File: "app/controllers/foo_controller.rb"}, // ruby, not js
+	} {
+		if isStimulusController(s) {
+			t.Errorf("isStimulusController(%+v) = true, want false", s)
+		}
+	}
+}
+
+func TestFrameworkNames(t *testing.T) {
+	got := frameworkNames(map[string]struct{}{"Rails": {}, "Sidekiq": {}})
+	if len(got) != 2 || got[0] != "Rails" || got[1] != "Sidekiq" {
+		t.Errorf("frameworkNames = %v, want [Rails Sidekiq] (sorted)", got)
+	}
+	if len(frameworkNames(nil)) != 0 {
+		t.Error("frameworkNames(nil) should be empty")
+	}
+}
+
+func TestAnnotateConfidenceIncludedModuleDowngrade(t *testing.T) {
+	pid := int64(99)
+	out := annotateConfidence(
+		[]Symbol{{Kind: "method", Name: "helper", ParentID: &pid}},
+		confidenceInputs{includedModuleIDs: map[int64]struct{}{99: {}}},
+	)
+	if out[0].Confidence != ConfidencePossibly {
+		t.Errorf("method on an included module should be possibly_dead, got %q", out[0].Confidence)
+	}
+}
+
+func TestIsTestSymbolAllForms(t *testing.T) {
+	for _, n := range []string{"TestX", "test_x", "BenchmarkX", "it", "describe", "specify"} {
+		if !isTestSymbol(Symbol{Name: n}) {
+			t.Errorf("isTestSymbol(%q) = false, want true", n)
+		}
+	}
+	if isTestSymbol(Symbol{Name: "Process"}) {
+		t.Error("isTestSymbol(\"Process\") = true, want false")
+	}
+}
+
+// TestQueryHelpersErrorOnClosedDB exercises the SQL error paths: with a
+// closed handle every query must surface the error rather than panic or
+// return a partial result.
+func TestQueryHelpersErrorOnClosedDB(t *testing.T) {
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(t.TempDir(), "index.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	db := a.DB()
+	_ = a.Close() // close so every subsequent query fails
+
+	checks := []func() error{
+		func() error { _, e := queryTestsTargets(ctx, db); return e },
+		func() error { _, e := queryInterfaceIDs(ctx, db); return e },
+		func() error { _, e := queryInterfaceMethodNames(ctx, db); return e },
+		func() error { _, e := queryInterfaceImplementors(ctx, db); return e },
+		func() error { _, e := queryControllerConcernModuleIDs(ctx, db); return e },
+		func() error { _, e := queryIncludedModuleIDs(ctx, db); return e },
+		func() error { _, e := countSymbols(ctx, db, Options{}); return e },
+		func() error { _, e := FindDead(ctx, db, Options{}); return e },
+	}
+	for i, fn := range checks {
+		if fn() == nil {
+			t.Errorf("check %d: expected error on closed DB, got nil", i)
+		}
+	}
+}
+
+// TestFindDeadControllerActionGatedOnRails proves the controller-action
+// exclusion is gated on the Rails framework flag: a *Controller method in
+// a project with no Rails detected is still analyzed as a normal symbol,
+// not blanket-excluded by its class name.
+func TestFindDeadControllerActionGatedOnRails(t *testing.T) {
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(t.TempDir(), "index.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = a.Close() })
+
+	fid, err := a.WriteFile(ctx, &model.File{Path: "lib/foo_controller.rb", Language: "ruby", Hash: "h", Symbols: 1, IndexedAt: time.Now()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cid, err := a.WriteSymbol(ctx, &model.Symbol{FileID: fid, Name: "FooController", Qualified: "FooController", Kind: "class", LineStart: 1, LineEnd: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.WriteSymbol(ctx, &model.Symbol{FileID: fid, Name: "orphan", Qualified: "FooController#orphan", Kind: "method", LineStart: 2, LineEnd: 2, ParentID: &cid}); err != nil {
+		t.Fatal(err)
+	}
+	// No sense_meta 'frameworks' row → not a Rails project.
+
+	result, err := FindDead(ctx, a.DB(), Options{})
+	if err != nil {
+		t.Fatalf("FindDead: %v", err)
+	}
+	var found bool
+	for _, s := range result.Dead {
+		if s.Qualified == "FooController#orphan" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("without Rails, a *Controller method must not be auto-excluded as a routed action")
+	}
+}
+
+// TestFindDeadRailsEntryPoints is the end-to-end check: routed controllers,
+// their concern actions, and Stimulus callbacks are not flagged, while a
+// genuinely unreferenced service method still is. It also exercises the
+// includes-edge queries.
+func TestFindDeadRailsEntryPoints(t *testing.T) {
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(t.TempDir(), "index.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = a.Close() })
+
+	mkFile := func(path, lang string) int64 {
+		id, err := a.WriteFile(ctx, &model.File{Path: path, Language: lang, Hash: path, Symbols: 1, IndexedAt: time.Now()})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return id
+	}
+	mkSym := func(fid int64, name, qual, kind string, parent *int64) int64 {
+		id, err := a.WriteSymbol(ctx, &model.Symbol{FileID: fid, Name: name, Qualified: qual, Kind: model.SymbolKind(kind), LineStart: 1, LineEnd: 3, ParentID: parent})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return id
+	}
+
+	ctrlFile := mkFile("app/controllers/orders_controller.rb", "ruby")
+	concernFile := mkFile("app/controllers/concerns/importable.rb", "ruby")
+	jsFile := mkFile("app/javascript/controllers/modal_controller.js", "javascript")
+	svcFile := mkFile("app/services/orphan_service.rb", "ruby")
+
+	ctrlID := mkSym(ctrlFile, "OrdersController", "OrdersController", "class", nil)
+	mkSym(ctrlFile, "create", "OrdersController#create", "method", &ctrlID)
+	concernID := mkSym(concernFile, "Importable", "Importable", "module", nil)
+	mkSym(concernFile, "index", "Importable#index", "method", &concernID)
+	mkSym(jsFile, "connect", "ModalController.connect", "method", nil)
+	svcID := mkSym(svcFile, "OrphanService", "OrphanService", "class", nil)
+	mkSym(svcFile, "perform", "OrphanService#perform", "method", &svcID)
+
+	// OrdersController includes Importable.
+	if _, err := a.WriteEdge(ctx, &model.Edge{SourceID: &ctrlID, TargetID: concernID, Kind: model.EdgeIncludes, FileID: ctrlFile, Confidence: 1.0}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := a.DB().ExecContext(ctx, `INSERT INTO sense_meta (key, value) VALUES ('frameworks', '["Rails"]')`); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := FindDead(ctx, a.DB(), Options{})
+	if err != nil {
+		t.Fatalf("FindDead: %v", err)
+	}
+
+	dead := map[string]bool{}
+	for _, s := range result.Dead {
+		dead[s.Qualified] = true
+	}
+	for _, live := range []string{"OrdersController", "OrdersController#create", "Importable#index", "ModalController.connect"} {
+		if dead[live] {
+			t.Errorf("%s was flagged dead but is a framework entry point", live)
+		}
+	}
+	if !dead["OrphanService#perform"] {
+		t.Error("genuinely unreferenced OrphanService#perform should still be flagged dead")
+	}
+}

--- a/internal/dead/tiering_test.go
+++ b/internal/dead/tiering_test.go
@@ -16,18 +16,18 @@ func TestRubyDynamicTypesTieredUnderFramework(t *testing.T) {
 		{"method", ConfidenceDead},
 	}
 	for _, c := range cases {
-		got := annotateConfidence([]Symbol{{Language: "ruby", Kind: c.kind, Name: "X"}}, nil, nil, true)
+		got := annotateConfidence([]Symbol{{Language: "ruby", Kind: c.kind, Name: "X"}}, confidenceInputs{dynamicFramework: true})
 		if got[0].Confidence != c.want {
 			t.Errorf("ruby %s (framework): confidence = %q, want %q", c.kind, got[0].Confidence, c.want)
 		}
 	}
 	// Without a dynamic framework, an unreferenced Ruby class is plain dead.
-	got := annotateConfidence([]Symbol{{Language: "ruby", Kind: "class", Name: "X"}}, nil, nil, false)
+	got := annotateConfidence([]Symbol{{Language: "ruby", Kind: "class", Name: "X"}}, confidenceInputs{dynamicFramework: false})
 	if got[0].Confidence != ConfidenceDead {
 		t.Errorf("ruby class (no framework): confidence = %q, want %q", got[0].Confidence, ConfidenceDead)
 	}
 	// Non-Ruby types are never tiered by this rule.
-	got = annotateConfidence([]Symbol{{Language: "python", Kind: "class", Name: "X"}}, nil, nil, true)
+	got = annotateConfidence([]Symbol{{Language: "python", Kind: "class", Name: "X"}}, confidenceInputs{dynamicFramework: true})
 	if got[0].Confidence != ConfidenceDead {
 		t.Errorf("python class: confidence = %q, want %q", got[0].Confidence, ConfidenceDead)
 	}
@@ -92,7 +92,7 @@ func TestRubyDynamicMethodTiering(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		got := annotateConfidence([]Symbol{c.sym}, nil, nil, c.framework)
+		got := annotateConfidence([]Symbol{c.sym}, confidenceInputs{dynamicFramework: c.framework})
 		if got[0].Confidence != c.want {
 			t.Errorf("%s: confidence = %q, want %q", c.name, got[0].Confidence, c.want)
 		}
@@ -114,7 +114,7 @@ func TestRubyMethodParentName(t *testing.T) {
 }
 
 func TestGoConstructorPossiblyDead(t *testing.T) {
-	got := annotateConfidence([]Symbol{{Language: "go", Kind: "function", Name: "NewThing"}}, nil, nil, false)
+	got := annotateConfidence([]Symbol{{Language: "go", Kind: "function", Name: "NewThing"}}, confidenceInputs{dynamicFramework: false})
 	if got[0].Confidence != ConfidencePossibly {
 		t.Errorf("go constructor confidence = %q, want %q", got[0].Confidence, ConfidencePossibly)
 	}
@@ -132,7 +132,7 @@ func TestInterfaceAndImplementorTiering(t *testing.T) {
 		{"implementor method", Symbol{Kind: "method", Name: "Do", ParentID: &pid20}},
 	}
 	for _, c := range cases {
-		got := annotateConfidence([]Symbol{c.sym}, interfaceIDs, implementorIDs, false)
+		got := annotateConfidence([]Symbol{c.sym}, confidenceInputs{interfaceIDs: interfaceIDs, implementorIDs: implementorIDs})
 		if got[0].Confidence != ConfidencePossibly {
 			t.Errorf("%s: confidence = %q, want %q", c.name, got[0].Confidence, ConfidencePossibly)
 		}

--- a/internal/mcpio/coverage_test.go
+++ b/internal/mcpio/coverage_test.go
@@ -3,6 +3,7 @@ package mcpio
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -46,7 +47,7 @@ func TestBuildDeadCodeResponse(t *testing.T) {
 		{Name: "NoConf", Qualified: "pkg.NoConf", File: "pkg/unused.go", LineStart: 30, LineEnd: 35, Kind: "method"},
 	}
 
-	resp := BuildDeadCodeResponse(symbols, 100)
+	resp := BuildDeadCodeResponse(symbols, 100, nil)
 
 	if resp.DeadCount != 3 {
 		t.Errorf("DeadCount = %d, want 3", resp.DeadCount)
@@ -79,14 +80,32 @@ func TestBuildDeadCodeResponse(t *testing.T) {
 func TestDeadVerifyCmdEscapesPredicate(t *testing.T) {
 	resp := BuildDeadCodeResponse([]dead.Symbol{
 		{Name: "retriable?", Qualified: "ApiError#retriable?", File: "api_error.rb", Kind: "method", Confidence: dead.ConfidencePossibly},
-	}, 1)
+	}, 1, nil)
 	if got := resp.DeadSymbols[0].VerifyCmd; got != `grep -rFn --exclude-dir=.git --exclude-dir=.sense "retriable?" .` {
 		t.Errorf("VerifyCmd = %q, want %q", got, `grep -rFn --exclude-dir=.git --exclude-dir=.sense "retriable?" .`)
 	}
 }
 
+func TestDeadCodeNoteIsFrameworkAware(t *testing.T) {
+	rails := deadCodeNote([]string{"Sidekiq", "Rails"})
+	if !strings.Contains(rails, "routing") || !strings.Contains(rails, "Concern") || !strings.Contains(rails, "Stimulus") {
+		t.Errorf("Rails note should cover routing/concerns/Stimulus, got: %s", rails)
+	}
+	if strings.Contains(rails, "ServiceLoader") || strings.Contains(rails, "blank identifier") {
+		t.Error("Rails note must not carry Go-specific blind spots")
+	}
+
+	generic := deadCodeNote(nil)
+	if !strings.Contains(generic, "ServiceLoader") {
+		t.Errorf("non-Rails note should be the generic blind-spot list, got: %s", generic)
+	}
+	if strings.Contains(generic, "routing — controller actions") {
+		t.Error("generic note must not carry Rails idioms")
+	}
+}
+
 func TestBuildDeadCodeResponseEmpty(t *testing.T) {
-	resp := BuildDeadCodeResponse(nil, 50)
+	resp := BuildDeadCodeResponse(nil, 50, nil)
 	if resp.DeadCount != 0 {
 		t.Errorf("DeadCount = %d, want 0", resp.DeadCount)
 	}

--- a/internal/mcpio/dead.go
+++ b/internal/mcpio/dead.go
@@ -9,8 +9,9 @@ import (
 // BuildDeadCodeResponse assembles a wire DeadCodeResponse from the dead
 // package's result plus a rolled-up symbol list. Matches the
 // BuildBlastResponse / BuildGraphResponse pattern — one builder per
-// response shape, shared between CLI and MCP server.
-func BuildDeadCodeResponse(symbols []dead.Symbol, totalSymbols int) DeadCodeResponse {
+// response shape, shared between CLI and MCP server. frameworks tailors
+// the blind-spot caveat to the project's ecosystem.
+func BuildDeadCodeResponse(symbols []dead.Symbol, totalSymbols int, frameworks []string) DeadCodeResponse {
 	entries := make([]DeadSymbolEntry, len(symbols))
 	uniqueFiles := map[string]struct{}{}
 	for i, s := range symbols {
@@ -36,18 +37,39 @@ func BuildDeadCodeResponse(symbols []dead.Symbol, totalSymbols int) DeadCodeResp
 		DeadSymbols:  entries,
 		TotalSymbols: totalSymbols,
 		DeadCount:    len(symbols),
-		Note: "Symbols with zero incoming edges. Verify each candidate against these indexer blind spots before deleting: " +
-			"(1) method-on-field dispatch (e.g. c.engine.X invoking a method through a struct field), " +
-			"(2) function-value passing (handlers stored as fields, passed as args, or set via init()), " +
-			"(3) runtime registration (DI containers, plugin registries, reflection-based loaders, ServiceLoader), " +
-			"(4) interface/trait satisfaction via blank identifier (var _ Iface = (*T)(nil)), and " +
-			"(5) exported symbols consumed by downstream packages outside the indexed tree.",
+		Note:         deadCodeNote(frameworks),
 		SenseMetrics: DeadCodeMetrics{
 			SymbolsAnalyzed:           totalSymbols,
 			EstimatedFileReadsAvoided: filesAvoided,
 			EstimatedTokensSaved:      filesAvoided * AvgTokensPerFile,
 		},
 	}
+}
+
+const deadNotePrefix = "Symbols with zero incoming edges. Verify each candidate against these indexer blind spots before deleting: "
+
+// deadCodeNote returns a blind-spot caveat tailored to the project's
+// ecosystem. A Go-flavored note (struct-field dispatch, ServiceLoader,
+// blank-identifier interface satisfaction) is noise on a Rails app and
+// omits the failure modes that actually occur there — so Rails projects
+// get Rails idioms instead.
+func deadCodeNote(frameworks []string) string {
+	for _, f := range frameworks {
+		if f == "Rails" {
+			return deadNotePrefix +
+				"(1) routing — controller actions are dispatched by config/routes, never called from Ruby; " +
+				"(2) view & Hotwire dispatch — methods reached from ERB or Stimulus data-controller/data-action/data-*-target attributes; " +
+				"(3) ActiveSupport::Concern mixins — methods defined in an included module become instance methods of the includer; " +
+				"(4) callbacks & metaprogramming — before_action/after_action by symbol, define_method, const_get/constantize, STI; and " +
+				"(5) framework lifecycle hooks invoked by Rails rather than application code."
+		}
+	}
+	return deadNotePrefix +
+		"(1) method-on-field dispatch (e.g. c.engine.X invoking a method through a struct field), " +
+		"(2) function-value passing (handlers stored as fields, passed as args, or set via init()), " +
+		"(3) runtime registration (DI containers, plugin registries, reflection-based loaders, ServiceLoader), " +
+		"(4) interface/trait satisfaction via blank identifier (var _ Iface = (*T)(nil)), and " +
+		"(5) exported symbols consumed by downstream packages outside the indexed tree."
 }
 
 // deadVerifyCmd builds a copy-paste grep that lists every textual occurrence of

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -682,7 +682,7 @@ func (h *handlers) handleDeadCode(ctx context.Context, req mcp.CallToolRequest) 
 	}
 
 	rolled := dead.Rollup(result.Dead)
-	resp := mcpio.BuildDeadCodeResponse(rolled, result.TotalSymbols)
+	resp := mcpio.BuildDeadCodeResponse(rolled, result.TotalSymbols, result.Frameworks)
 	resp.CoverageNote = "Static analysis — does not trace dynamic dispatch, decorator registration, or external API consumers"
 
 	h.tracker.Record("sense_graph", "dead_code",


### PR DESCRIPTION
> Stacked on #103 → #101 → #99. Review/merge those first; this targets #103's branch for a clean diff.

## Problem
Dead-code analysis flags symbols with zero static incoming edges. On a Rails/Hotwire app that misclassifies large categories of live code, because dispatch happens through routing, mixins, and HTML data-attributes — none of which are static call edges. In maket's `controllers` domain, **all 91 flagged symbols were live**: 63 Stimulus callbacks/targets, 17 routed controllers/actions, 10 concern methods. The accompanying caveat listed Go blind spots (ServiceLoader, blank-identifier interface satisfaction) — wrong ecosystem, so it didn't warn about the failure modes that actually occur on Rails.

## Summary
Teach the engine the Rails/Hotwire dispatch idioms so framework entry points aren't reported as dead, and make the caveat ecosystem-aware.

## Changes
- **Routed controllers/actions:** a `*Controller` class and its public instance methods are router entry points (Rails-gated).
- **Concern actions:** methods defined in a module `include`d into a controller are entry points too — found via the existing `includes` edge (source=includer, target=module), verified against real index data.
- **Included-module methods (general):** downgraded to `possibly_dead` — reachable through the including type, so a zero-caller verdict is uncertain, not dead.
- **Stimulus:** `*_controller.js` / `.ts` symbols are entry points (lifecycle callbacks, actions, targets are runtime/`data-*` dispatched). Path-based, no framework gate — the filename convention is unambiguous.
- **Caveat:** Rails projects get Rails idioms (routing, concerns, callbacks, view/Stimulus dispatch); other projects keep the generic blind-spot note.

## Results (maket, `dead --domain controllers`)
| | before | after |
|---|---|---|
| flagged | 91 | **1** |
| of which live (false positives) | 91 | 0 |

The 1 remaining is `WhatsappSignature.verify`, a `module_function` dispatch the call-resolver misses — a **different root cause** (call resolution, not framework dispatch), deliberately out of scope. Its `verify_cmd` grep surfaces the real call site.

## Test Plan
- [x] Pure-predicate unit tests (controller class/action incl. concern path, Stimulus, framework gate)
- [x] End-to-end `FindDead`: controller/concern/Stimulus survive, a real orphan is still flagged dead
- [x] Negative test: a `*Controller` method in a non-Rails project is **not** auto-excluded
- [x] Closed-DB error-path sweep over the query helpers
- [x] Framework-aware caveat test (Rails vs generic)
- [x] Verified Go repo unaffected (generic note, 87 dead); maket still finds 98 genuine dead
- [x] `make ci` passes; `dead.go` 92.8% line coverage

## Known limitation
`module_function` / `extend self` dispatch (`Module.method`) is not yet resolved to a call edge — a resolver gap, not addressed here.