### PR TITLE
feat(search): shape-aware fusion, generic-token penalty, and mode hatch

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/luuuc/sense/internal/search"
 )
 
 // newTestIO returns an IO with byte buffer sinks and Dir="." so a
@@ -137,17 +139,17 @@ func TestParseSearchArgs(t *testing.T) {
 		{
 			name: "query with defaults",
 			args: []string{"payment error handling"},
-			want: searchOptions{Query: "payment error handling", Limit: 10},
+			want: searchOptions{Query: "payment error handling", Limit: 10, Mode: search.ModeHybrid},
 		},
 		{
 			name: "with flags",
 			args: []string{"--limit", "5", "--language", "ruby", "--json", "auth flow"},
-			want: searchOptions{Query: "auth flow", Limit: 5, Language: "ruby", JSON: true},
+			want: searchOptions{Query: "auth flow", Limit: 5, Language: "ruby", JSON: true, Mode: search.ModeHybrid},
 		},
 		{
 			name: "min-score flag",
 			args: []string{"--min-score", "0.5", "test query"},
-			want: searchOptions{Query: "test query", Limit: 10, MinScore: 0.5},
+			want: searchOptions{Query: "test query", Limit: 10, MinScore: 0.5, Mode: search.ModeHybrid},
 		},
 		{name: "missing query", args: nil, wantErr: true},
 	}

--- a/internal/cli/search.go
+++ b/internal/cli/search.go
@@ -22,6 +22,9 @@ Flags:
   --limit N                 Maximum results (default 10)
   --language LANG           Filter by language (e.g. "ruby", "go")
   --min-score F             Minimum score threshold 0.0–1.0 (default 0.0)
+  --mode MODE               Ranking mode: hybrid (default), semantic, keyword.
+                            hybrid auto-detects query shape; semantic forces
+                            concept ranking; keyword forces literal ranking.
   --json                    Emit JSON matching the sense_search MCP schema
   --no-color                Disable ANSI color (NO_COLOR env var is also respected)
   -h, --help                Show this help
@@ -44,6 +47,7 @@ type searchOptions struct {
 	Limit    int
 	Language string
 	MinScore float64
+	Mode     string
 	JSON     bool
 	NoColor  bool
 }
@@ -109,6 +113,7 @@ func RunSearch(args []string, cio IO) int {
 		Limit:    opts.Limit,
 		Language: opts.Language,
 		MinScore: opts.MinScore,
+		Mode:     opts.Mode,
 	})
 	if err != nil {
 		_, _ = fmt.Fprintln(cio.Stderr, "sense search:", err)
@@ -215,12 +220,21 @@ func parseSearchArgs(args []string, stderr io.Writer) (searchOptions, error) {
 	fs.IntVar(&opts.Limit, "limit", 10, "maximum results")
 	fs.StringVar(&opts.Language, "language", "", "filter by language")
 	fs.Float64Var(&opts.MinScore, "min-score", 0.0, "minimum score threshold")
+	fs.StringVar(&opts.Mode, "mode", search.ModeHybrid, "ranking mode: hybrid, semantic, or keyword")
 	fs.BoolVar(&opts.JSON, "json", false, "emit JSON matching the sense_search MCP schema")
 	fs.BoolVar(&opts.NoColor, "no-color", false, "disable ANSI color")
 
 	positional, err := parseInterleaved(fs, args)
 	if err != nil {
 		return searchOptions{}, err
+	}
+
+	switch opts.Mode {
+	case search.ModeHybrid, search.ModeSemantic, search.ModeKeyword:
+		// valid
+	default:
+		_, _ = fmt.Fprintf(stderr, "sense search: invalid --mode %q (want hybrid, semantic, or keyword)\n", opts.Mode)
+		return searchOptions{}, fmt.Errorf("invalid mode: %s", opts.Mode)
 	}
 
 	if len(positional) < 1 {

--- a/internal/cli/search_test.go
+++ b/internal/cli/search_test.go
@@ -63,6 +63,75 @@ func seedSearchProject(t *testing.T) string {
 	return dir
 }
 
+func TestParseSearchArgsMode(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+		want    string
+	}{
+		{"default is hybrid", []string{"query"}, false, search.ModeHybrid},
+		{"explicit hybrid", []string{"--mode", "hybrid", "query"}, false, search.ModeHybrid},
+		{"semantic", []string{"--mode", "semantic", "query"}, false, search.ModeSemantic},
+		{"keyword", []string{"--mode", "keyword", "query"}, false, search.ModeKeyword},
+		{"invalid mode rejected", []string{"--mode", "fuzzy", "query"}, true, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stderr bytes.Buffer
+			opts, err := parseSearchArgs(tt.args, &stderr)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for args %v, got none", tt.args)
+				}
+				if !strings.Contains(stderr.String(), "invalid --mode") {
+					t.Errorf("expected invalid-mode message, got: %s", stderr.String())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if opts.Mode != tt.want {
+				t.Errorf("Mode = %q, want %q", opts.Mode, tt.want)
+			}
+		})
+	}
+}
+
+// TestRunSearchModeKeyword is a plumbing smoke test: it confirms --mode is
+// accepted and reaches the engine without error. The actual mode→ranking
+// behavior is pinned in search.TestSearchModeOverridesShape (resolved
+// weights per mode); this test is its complement, not the behavioral gate.
+func TestRunSearchModeKeyword(t *testing.T) {
+	dir := seedSearchProject(t)
+	t.Setenv("SENSE_EMBEDDINGS", "false")
+
+	var stdout, stderr bytes.Buffer
+	cio := IO{Stdout: &stdout, Stderr: &stderr, Dir: dir}
+
+	code := RunSearch([]string{"--mode", "keyword", "payment"}, cio)
+	if code != ExitSuccess {
+		t.Fatalf("exit code = %d, want %d; stderr: %s", code, ExitSuccess, stderr.String())
+	}
+	if stdout.String() == "" {
+		t.Fatal("expected output, got empty")
+	}
+}
+
+func TestRunSearchInvalidMode(t *testing.T) {
+	dir := seedSearchProject(t)
+	t.Setenv("SENSE_EMBEDDINGS", "false")
+
+	var stdout, stderr bytes.Buffer
+	cio := IO{Stdout: &stdout, Stderr: &stderr, Dir: dir}
+
+	code := RunSearch([]string{"--mode", "nonsense", "payment"}, cio)
+	if code != ExitGeneralError {
+		t.Fatalf("exit code = %d, want %d", code, ExitGeneralError)
+	}
+}
+
 func TestRunSearchKeywordFallback(t *testing.T) {
 	dir := seedSearchProject(t)
 	t.Setenv("SENSE_EMBEDDINGS", "false")

--- a/internal/mcpserver/searchmode_test.go
+++ b/internal/mcpserver/searchmode_test.go
@@ -1,0 +1,152 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/internal/embed"
+	"github.com/luuuc/sense/internal/mcpio"
+	"github.com/luuuc/sense/internal/metrics"
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/profile"
+	"github.com/luuuc/sense/internal/search"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// lowConfEmbedder returns query vectors orthogonal to every seeded symbol
+// embedding, forcing vector confidence into the low bucket so the shape
+// floor (semantic mode) is distinguishable from the confidence ladder
+// (keyword/identifier mode).
+type lowConfEmbedder struct{}
+
+func (lowConfEmbedder) Embed(_ context.Context, inputs []embed.EmbedInput) ([][]float32, error) {
+	out := make([][]float32, len(inputs))
+	for i := range inputs {
+		v := make([]float32, 384)
+		v[200] = 0.9
+		v[201] = 0.1
+		out[i] = v
+	}
+	return out, nil
+}
+
+func (lowConfEmbedder) Close() error { return nil }
+
+// setupVectorHandlers builds a handlers fixture backed by a vector index so
+// the mode override's effect on fusion weights is observable.
+func setupVectorHandlers(t *testing.T) *handlers {
+	t.Helper()
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	fid, err := adapter.WriteFile(ctx, &model.File{
+		Path: "app/auth.go", Language: "go", Hash: "h1", Symbols: 3, IndexedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"Authenticate", "AuthToken", "AuthGuard"} {
+		id, werr := adapter.WriteSymbol(ctx, &model.Symbol{
+			FileID: fid, Name: name, Qualified: "auth." + name,
+			Kind: "function", LineStart: 1, LineEnd: 5,
+		})
+		if werr != nil {
+			t.Fatal(werr)
+		}
+		vec := make([]float32, 384)
+		vec[10] = 0.9
+		vec[11] = 0.1
+		if eerr := adapter.WriteEmbedding(ctx, id, vectorBlob(vec)); eerr != nil {
+			t.Fatal(eerr)
+		}
+	}
+
+	embeddings, err := adapter.LoadEmbeddings(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vectorIdx := search.BuildHNSWIndex(embeddings)
+	engine := search.NewEngine(adapter, vectorIdx, lowConfEmbedder{})
+
+	tracker := metrics.NewTracker(adapter.DB())
+	t.Cleanup(func() { tracker.Close() })
+
+	return &handlers{
+		adapter:     adapter,
+		db:          adapter.DB(),
+		dir:         dir,
+		search:      engine,
+		tracker:     tracker,
+		defaults:    profile.DefaultParams(),
+		seenSymbols: make(map[int64]bool),
+	}
+}
+
+func vectorBlob(vec []float32) []byte {
+	buf := make([]byte, len(vec)*4)
+	for i, v := range vec {
+		binary.LittleEndian.PutUint32(buf[i*4:], math.Float32bits(v))
+	}
+	return buf
+}
+
+// TestHandleSearchModeAffectsFusionWeights proves the sense_search `mode`
+// argument reaches the engine: on the same query, keyword mode reproduces
+// the confidence ladder (low-confidence vector weight 0.3) while semantic
+// mode floors the vector leg at 0.5.
+func TestHandleSearchModeAffectsFusionWeights(t *testing.T) {
+	h := setupVectorHandlers(t)
+	ctx := context.Background()
+
+	weightsFor := func(mode string) mcpio.FusionWeights {
+		t.Helper()
+		args := map[string]any{"query": "auth", "limit": 10}
+		if mode != "" {
+			args["mode"] = mode
+		}
+		result, err := h.handleSearch(ctx, toolReq(args))
+		if err != nil {
+			t.Fatalf("handleSearch(mode=%q): %v", mode, err)
+		}
+		if result.IsError {
+			t.Fatalf("handleSearch(mode=%q) error: %s", mode, resultText(t, result))
+		}
+		var resp mcpio.SearchResponse
+		if err := json.Unmarshal([]byte(resultText(t, result)), &resp); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		return resp.FusionWeights
+	}
+
+	keyword := weightsFor(search.ModeKeyword)
+	if keyword.Vector != 0.3 {
+		t.Errorf("keyword mode vector weight = %v, want 0.3 (confidence ladder)", keyword.Vector)
+	}
+
+	semantic := weightsFor(search.ModeSemantic)
+	if semantic.Vector != 0.5 {
+		t.Errorf("semantic mode vector weight = %v, want 0.5 (shape floor)", semantic.Vector)
+	}
+
+	// Default (omitted mode) must behave as hybrid. "auth" is a single
+	// identifier token, so the classifier picks Identifier → ladder 0.3.
+	def := weightsFor("")
+	if def.Vector != 0.3 {
+		t.Errorf("default mode vector weight = %v, want 0.3 (hybrid → Identifier for a lone identifier)", def.Vector)
+	}
+}

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -279,6 +279,10 @@ func searchTool() mcp.Tool {
 		mcp.WithNumber("min_score",
 			mcp.Description("Minimum relevance score threshold 0.0–1.0 (default 0.0). Raise to filter weak matches."),
 		),
+		mcp.WithString("mode",
+			mcp.Description("Ranking mode (default 'hybrid'). 'hybrid' auto-detects whether the query is a concept or an identifier. 'semantic' forces concept ranking — use when an identifier-looking query is actually conceptual. 'keyword' forces literal ranking — use for exact identifier lookups."),
+			mcp.Enum(search.ModeHybrid, search.ModeSemantic, search.ModeKeyword),
+		),
 	)
 }
 
@@ -728,6 +732,7 @@ func (h *handlers) handleSearch(ctx context.Context, req mcp.CallToolRequest) (*
 	limit := req.GetInt("limit", 10)
 	language := req.GetString("language", "")
 	minScore := req.GetFloat("min_score", 0.0)
+	mode := req.GetString("mode", search.ModeHybrid)
 
 	keywordBias := h.defaults.SearchKeywordWeight - 0.5
 	if keywordBias < 0 {
@@ -739,6 +744,7 @@ func (h *handlers) handleSearch(ctx context.Context, req mcp.CallToolRequest) (*
 		Language:    language,
 		MinScore:    minScore,
 		KeywordBias: keywordBias,
+		Mode:        mode,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("sense_search: %w", err)

--- a/internal/search/generic.go
+++ b/internal/search/generic.go
@@ -1,0 +1,116 @@
+package search
+
+import "strings"
+
+const (
+	// genericTokenDFRatio is the document-frequency fraction at or above
+	// which a query term is "generic": it appears in too many symbols to
+	// rank a hit on its own. Chosen to mark common verbs like
+	// prevent/create/handle as generic while leaving domain nouns
+	// (listing, negotiation) specific. The threshold is corpus-relative
+	// (DF / total symbols), not a hardcoded English stopword list; see the
+	// pitch's generic-token rabbit hole. Validated against the maket
+	// corpus distribution in the ground-truth suite.
+	genericTokenDFRatio = 0.05
+
+	// genericOnlyPenalty multiplies the (normalized) score of a
+	// keyword-sourced hit whose only overlap with the query is generic
+	// tokens. Tuned, like testRankPenalty, to push such a hit below a
+	// genuine domain match.
+	genericOnlyPenalty = 0.3
+)
+
+// queryTermSet returns the distinct, lowercased query terms used for
+// document-frequency lookup and generic-token analysis. Each whitespace
+// token is also split on identifier boundaries so a camelCase/snake_case
+// query term contributes its constituent words (matching how the FTS
+// index decomposes name_parts).
+func queryTermSet(query string) []string {
+	seen := map[string]struct{}{}
+	var terms []string
+	add := func(w string) {
+		if w == "" {
+			return
+		}
+		if _, ok := seen[w]; ok {
+			return
+		}
+		seen[w] = struct{}{}
+		terms = append(terms, w)
+	}
+	for _, tok := range strings.Fields(query) {
+		add(strings.ToLower(strings.Trim(tok, ".,;:?!()\"'`")))
+		for _, w := range splitToken(tok) {
+			add(w)
+		}
+	}
+	return terms
+}
+
+// nonGenericTerms returns the subset of query terms that are NOT generic —
+// specific enough that a hit matching one should be trusted. A term is
+// generic when its document frequency / total symbols >= the threshold.
+// When the corpus size is unknown (<= 0) every term is treated as specific
+// so the penalty becomes a no-op rather than demoting indiscriminately.
+func nonGenericTerms(terms []string, df map[string]int, totalSymbols int) map[string]struct{} {
+	out := make(map[string]struct{}, len(terms))
+	if totalSymbols <= 0 {
+		for _, t := range terms {
+			out[t] = struct{}{}
+		}
+		return out
+	}
+	threshold := genericTokenDFRatio * float64(totalSymbols)
+	for _, t := range terms {
+		if float64(df[t]) < threshold {
+			out[t] = struct{}{}
+		}
+	}
+	return out
+}
+
+// genericTokenPenalty demotes keyword-sourced hits whose only overlap with
+// the query is high-frequency generic tokens. A hit is left untouched if
+// any non-generic query term appears in its name/qualified/snippet; only
+// when none do — meaning it surfaced purely on a generic token like
+// "prevent" — is its score multiplied down.
+//
+// It is applied pre-normalize (like applyKindWeights): the fused RRF
+// scores of single-term keyword matches are tightly clustered, so the
+// multiplier is decisive here, whereas a post-normalize multiplier is
+// neutralized whenever the genuine domain match is the rescale floor
+// (pinned to 0). It runs AFTER any reranking, so a cross-encoder cannot
+// silently erase it. Vector and hybrid hits are exempt: the vector leg
+// vouching for a hit means it is not generic-only.
+func genericTokenPenalty(results []Result, nonGeneric map[string]struct{}) {
+	if len(nonGeneric) == 0 {
+		return
+	}
+	for i := range results {
+		if results[i].Source != SourceKeyword {
+			continue
+		}
+		if symbolMatchesAny(results[i], nonGeneric) {
+			continue
+		}
+		results[i].Score *= genericOnlyPenalty
+	}
+}
+
+// symbolMatchesAny reports whether any term appears as a token in the
+// result's name, qualified name, or snippet (after identifier splitting).
+func symbolMatchesAny(r Result, terms map[string]struct{}) bool {
+	for _, field := range []string{r.Name, r.Qualified, r.Snippet} {
+		for _, tok := range strings.Fields(field) {
+			if _, ok := terms[strings.ToLower(tok)]; ok {
+				return true
+			}
+			for _, w := range splitToken(tok) {
+				if _, ok := terms[w]; ok {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/internal/search/generic_internal_test.go
+++ b/internal/search/generic_internal_test.go
@@ -1,0 +1,122 @@
+package search
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestQueryTermSet(t *testing.T) {
+	// "user_id" re-adds the already-seen split token "user" (dedup branch);
+	// "..." trims to empty and splits to nothing (empty-token branch).
+	got := queryTermSet("prevent_own user user_id ... Listing?")
+	set := map[string]bool{}
+	for _, term := range got {
+		set[term] = true
+	}
+	for _, want := range []string{"prevent_own", "prevent", "own", "listing"} {
+		if !set[want] {
+			t.Errorf("queryTermSet missing %q; got %v", want, got)
+		}
+	}
+	// Distinct: no duplicates.
+	seen := map[string]bool{}
+	for _, term := range got {
+		if seen[term] {
+			t.Errorf("duplicate term %q in %v", term, got)
+		}
+		seen[term] = true
+	}
+}
+
+// TestNonGenericTermsThresholdBoundary pins the DF threshold: with a
+// corpus of 100 symbols the cutoff is 0.05*100 = 5. A term at df=4 (just
+// below) is non-generic; a term at df=5 (exactly at the cutoff) is
+// generic; a high-DF term is generic.
+func TestNonGenericTermsThresholdBoundary(t *testing.T) {
+	terms := []string{"rare", "boundary", "common"}
+	df := map[string]int{"rare": 4, "boundary": 5, "common": 50}
+
+	out := nonGenericTerms(terms, df, 100)
+
+	if _, ok := out["rare"]; !ok {
+		t.Error("term with df=4 (below threshold 5) should be non-generic")
+	}
+	if _, ok := out["boundary"]; ok {
+		t.Error("term with df=5 (at threshold 5) should be generic, not in non-generic set")
+	}
+	if _, ok := out["common"]; ok {
+		t.Error("term with df=50 should be generic")
+	}
+}
+
+func TestNonGenericTermsUnknownCorpusSize(t *testing.T) {
+	terms := []string{"a", "b"}
+	df := map[string]int{"a": 999, "b": 0}
+	out := nonGenericTerms(terms, df, 0)
+	if len(out) != 2 {
+		t.Errorf("with totalSymbols<=0 every term should be non-generic (no-op penalty); got %v", out)
+	}
+}
+
+// TestGenericTokenPenaltyDemotesGenericOnly is the core behavioral pin: a
+// keyword-only hit matching solely a generic token is demoted; a hit
+// matching a non-generic domain term is not; vector- and hybrid-sourced
+// hits are exempt even when generic-only.
+func TestGenericTokenPenaltyDemotesGenericOnly(t *testing.T) {
+	results := []Result{
+		{Name: "preventClose", Qualified: "ui.preventClose", Score: 1.0, Source: SourceKeyword},
+		{Name: "ListingGuard", Qualified: "shop.ListingGuard", Score: 0.8, Source: SourceKeyword},
+		{Name: "preventEscape", Qualified: "ui.preventEscape", Score: 0.9, Source: SourceVector},
+		{Name: "preventResize", Qualified: "ui.preventResize", Score: 0.7, Source: SourceHybrid},
+	}
+	// "prevent" is generic (absent from the set); "listing" is the only
+	// non-generic query term.
+	nonGeneric := map[string]struct{}{"listing": {}}
+
+	genericTokenPenalty(results, nonGeneric)
+
+	if results[0].Score != 1.0*genericOnlyPenalty {
+		t.Errorf("generic-only keyword hit not demoted: score = %v, want %v", results[0].Score, genericOnlyPenalty)
+	}
+	if results[1].Score != 0.8 {
+		t.Errorf("domain-term hit wrongly demoted: score = %v, want 0.8", results[1].Score)
+	}
+	if results[2].Score != 0.9 {
+		t.Errorf("vector-sourced hit must be exempt: score = %v, want 0.9", results[2].Score)
+	}
+	if results[3].Score != 0.7 {
+		t.Errorf("hybrid-sourced hit must be exempt: score = %v, want 0.7", results[3].Score)
+	}
+}
+
+func TestGenericTokenPenaltyNoNonGenericTermsIsNoOp(t *testing.T) {
+	results := []Result{
+		{Name: "preventClose", Qualified: "ui.preventClose", Score: 1.0, Source: SourceKeyword},
+	}
+	genericTokenPenalty(results, nil)
+	if results[0].Score != 1.0 {
+		t.Errorf("empty non-generic set must be a no-op; score = %v", results[0].Score)
+	}
+}
+
+// TestSymbolMatchesAnySnippetAndSplit covers the snippet field and the
+// identifier-split branch of token matching.
+func TestSymbolMatchesAnySnippetAndSplit(t *testing.T) {
+	r := Result{Name: "Foo", Qualified: "pkg.Foo", Snippet: "func cannot_offer_on_own_listing()"}
+	if !symbolMatchesAny(r, map[string]struct{}{"offer": {}}) {
+		t.Error("expected match on snippet identifier-split token 'offer'")
+	}
+	if symbolMatchesAny(r, map[string]struct{}{"absent": {}}) {
+		t.Error("did not expect a match for an absent term")
+	}
+	// Sanity: deterministic across iteration order.
+	terms := map[string]struct{}{"foo": {}, "listing": {}}
+	keys := make([]string, 0, len(terms))
+	for k := range terms {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	if !symbolMatchesAny(r, terms) {
+		t.Error("expected match on name token 'foo'")
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -85,6 +85,10 @@ type Options struct {
 	Language    string
 	MinScore    float64
 	KeywordBias float64
+	// Mode is the optional query-shape override: "" or ModeHybrid runs the
+	// classifier, ModeSemantic pins NaturalLanguage (floors the vector
+	// leg), ModeKeyword pins Identifier (reproduces pre-shape ranking).
+	Mode string
 }
 
 // Engine orchestrates hybrid search: keyword (FTS5) and vector (HNSW)
@@ -128,12 +132,18 @@ func (e *Engine) SetReranker(r Reranker) {
 const (
 	ModeHybrid  = "hybrid"
 	ModeKeyword = "keyword"
+	// ModeSemantic is a request-mode value for Options.Mode that pins the
+	// query shape to NaturalLanguage. ModeHybrid and ModeKeyword double as
+	// request-mode values; SearchMeta.Mode reuses the same strings to
+	// report which retrieval legs actually ran.
+	ModeSemantic = "semantic"
 )
 
 // SearchMeta carries non-result metadata from a search invocation.
 type SearchMeta struct {
 	SymbolCount   int
 	Mode          string
+	Shape         string
 	KeywordWeight float64
 	VectorWeight  float64
 	Reranked      bool
@@ -167,6 +177,26 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, SearchMeta
 	canVector := vectors != nil && vectors.Len() > 0 && e.embedder != nil
 
 	queries := expandQuery(opts.Query)
+
+	// Classify the ORIGINAL query once and propagate the shape to every
+	// sub-query: expandQuery's identifier-split sub-queries would otherwise
+	// re-classify as Identifier and silently re-introduce keyword bias on
+	// an NL search.
+	shape := resolveShape(opts.Mode, opts.Query)
+
+	// Generic-token analysis: for non-Identifier queries, look up the
+	// corpus document frequency of each query term so generic-only keyword
+	// hits can be demoted later. Skipped for Identifier queries — the
+	// keyword leg is authoritative there — which also avoids the DF lookups.
+	var nonGenericQueryTerms map[string]struct{}
+	if shape != ShapeIdentifier {
+		terms := queryTermSet(opts.Query)
+		df, dfErr := e.adapter.DocumentFrequency(ctx, terms)
+		if dfErr != nil {
+			return nil, SearchMeta{}, fmt.Errorf("search df: %w", dfErr)
+		}
+		nonGenericQueryTerms = nonGenericTerms(terms, df, symbolCount)
+	}
 
 	// Batch-embed all sub-queries in one call when in hybrid mode.
 	var queryVecs [][]float32
@@ -227,7 +257,7 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, SearchMeta
 		qKwWeight, qVecWeight := 1.0, 0.0
 		if canVector {
 			vecConf := vectorConfidence(vecResults)
-			qKwWeight, qVecWeight = fusionWeights(vecConf)
+			qKwWeight, qVecWeight = shapeWeights(shape, vecConf)
 		}
 
 		// Report primary query's weights in metadata.
@@ -302,6 +332,17 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, SearchMeta
 	}
 	applyPathWeights(fused, pathByID)
 
+	// Generic-token demotion: a keyword-only hit that matched the query
+	// solely on high-frequency tokens (e.g. "prevent" → preventClose) is
+	// noise. Applied pre-normalize, like applyKindWeights and for the same
+	// reason: the fused RRF scores of single-term keyword matches are
+	// tightly clustered, so the multiplier is decisive *here* but would be
+	// neutralized post-normalize whenever the genuine domain match happens
+	// to be the rescale floor (pinned to 0). It runs after any reranking,
+	// so a cross-encoder cannot silently erase it. No-op for Identifier
+	// queries (nonGenericQueryTerms is nil).
+	genericTokenPenalty(fused, nonGenericQueryTerms)
+
 	normalizeScores(fused)
 	applyGraphCentrality(fused, centrality)
 
@@ -350,6 +391,7 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, SearchMeta
 	return results, SearchMeta{
 		SymbolCount:   symbolCount,
 		Mode:          mode,
+		Shape:         shape.String(),
 		KeywordWeight: kwWeight,
 		VectorWeight:  vecWeight,
 		Reranked:      reranked,

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -904,6 +904,282 @@ func TestLowConfidenceVectorFloor(t *testing.T) {
 	t.Logf("low confidence weights: kw=%.2f vec=%.2f", meta.KeywordWeight, meta.VectorWeight)
 }
 
+// TestNaturalLanguageQueryFloorsVectorWeight drives the full Search path
+// with a low-confidence embedder (vectors orthogonal to the index, so
+// confidence lands in the < 0.4 bucket) on a NATURAL-LANGUAGE query. The
+// confidence ladder alone would return vector weight 0.3; the shape floor
+// must lift it to 0.5. This proves the shape (not just cosine confidence)
+// steers the weighting end-to-end, including propagation through
+// expandQuery's sub-queries.
+func TestNaturalLanguageQueryFloorsVectorWeight(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	a, err := sqlite.Open(ctx, filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	seedFusionIndex(ctx, t, a)
+	embeddings, err := a.LoadEmbeddings(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vectorIdx := search.BuildHNSWIndex(embeddings)
+	engine := search.NewEngine(a, vectorIdx, &lowConfidenceEmbedder{})
+
+	// Natural-language query: stopword "the" + multiple plain words, no
+	// identifier-shaped tokens → NaturalLanguage.
+	_, meta, err := engine.Search(ctx, search.Options{
+		Query: "prevent the user from charging their own card", Limit: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if meta.Shape != "natural_language" {
+		t.Fatalf("shape = %q, want natural_language", meta.Shape)
+	}
+	if meta.VectorWeight != 0.5 {
+		t.Errorf("vector weight = %v, want 0.5 (floored despite low confidence)", meta.VectorWeight)
+	}
+	if meta.KeywordWeight != 0.5 {
+		t.Errorf("keyword weight = %v, want 0.5", meta.KeywordWeight)
+	}
+	t.Logf("NL floored weights: kw=%.2f vec=%.2f", meta.KeywordWeight, meta.VectorWeight)
+}
+
+// TestGenericTokenPenaltyEndToEnd seeds a corpus where "prevent" is a
+// high-frequency generic token and "listing" is a rare domain token, then
+// drives the full keyword-only Search path with a natural-language query.
+// The hits that matched ONLY the generic token ("preventClose" etc.) must
+// be demoted below the domain match ("ListingGuard"), reproducing the
+// headline fix in miniature.
+func TestGenericTokenPenaltyEndToEnd(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	a, err := sqlite.Open(ctx, filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	fid, err := a.WriteFile(ctx, &model.File{
+		Path: "app/ui.js", Language: "javascript",
+		Hash: "h1", Symbols: 40, IndexedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	write := func(name, qualified string) {
+		t.Helper()
+		if _, err := a.WriteSymbol(ctx, &model.Symbol{
+			FileID: fid, Name: name, Qualified: qualified,
+			Kind: "function", LineStart: 1, LineEnd: 2,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Six symbols whose only query overlap is the generic token "prevent".
+	preventNames := []string{
+		"preventClose", "preventEscape", "preventResize",
+		"preventScroll", "preventDefault", "preventEditing",
+	}
+	for _, n := range preventNames {
+		write(n, "ui."+n)
+	}
+	// One rare domain symbol matching the non-generic token "listing".
+	write("ListingGuard", "shop.ListingGuard")
+	// Filler symbols (none containing the query terms) to make "prevent"
+	// land above the 5% generic threshold and "listing" below it: 7 named
+	// symbols + 33 fillers = 40 total → prevent 6/40=0.15 (generic),
+	// listing 1/40=0.025 (specific).
+	for i := 0; i < 33; i++ {
+		write(fmt.Sprintf("Widget%d", i), fmt.Sprintf("ui.Widget%d", i))
+	}
+
+	// Keyword-only engine (no embedder) isolates the keyword-leg defect.
+	engine := search.NewEngine(a, nil, nil)
+	results, meta, err := engine.Search(ctx, search.Options{
+		Query: "prevent adding own listing", Limit: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if meta.Shape != "natural_language" {
+		t.Fatalf("shape = %q, want natural_language", meta.Shape)
+	}
+
+	rank := map[string]int{}
+	for i, r := range results {
+		rank[r.Name] = i
+	}
+	listingRank, ok := rank["ListingGuard"]
+	if !ok {
+		t.Fatalf("ListingGuard absent from results: %+v", names(results))
+	}
+	for _, n := range preventNames {
+		if pr, ok := rank[n]; ok && pr < listingRank {
+			t.Errorf("generic-only hit %q (rank %d) outranked domain match ListingGuard (rank %d)", n, pr, listingRank)
+		}
+	}
+	if listingRank != 0 {
+		t.Logf("ListingGuard at rank %d (top result is %q)", listingRank, results[0].Name)
+	}
+}
+
+// uniformReranker scores every document identically, erasing all RRF rank
+// information. It isolates the generic-token penalty: any surviving
+// reordering must come from the penalty, not from residual fusion order.
+type uniformReranker struct{}
+
+func (uniformReranker) Score(_ string, docs []string) ([]float32, error) {
+	scores := make([]float32, len(docs))
+	for i := range scores {
+		scores[i] = 1.0
+	}
+	return scores, nil
+}
+
+// TestGenericTokenPenaltySurvivesReranking pins the card-5 decision: the
+// generic-token penalty runs AFTER reranking, so a cross-encoder cannot
+// silently erase it. With a uniform reranker every hit is tied at 1.0; if
+// the penalty ran before rerank the reranker's overwrite would erase it
+// and the tie would stand. Because it runs after, the generic-only
+// "prevent" hits are demoted below the domain match "ListingGuard".
+func TestGenericTokenPenaltySurvivesReranking(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	a, err := sqlite.Open(ctx, filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	fid, err := a.WriteFile(ctx, &model.File{
+		Path: "app/ui.js", Language: "javascript",
+		Hash: "h1", Symbols: 40, IndexedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	write := func(name, qualified string) {
+		t.Helper()
+		if _, err := a.WriteSymbol(ctx, &model.Symbol{
+			FileID: fid, Name: name, Qualified: qualified,
+			Kind: "function", LineStart: 1, LineEnd: 2,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	preventNames := []string{
+		"preventClose", "preventEscape", "preventResize",
+		"preventScroll", "preventDefault", "preventEditing",
+	}
+	for _, n := range preventNames {
+		write(n, "ui."+n)
+	}
+	write("ListingGuard", "shop.ListingGuard")
+	for i := 0; i < 33; i++ {
+		write(fmt.Sprintf("Widget%d", i), fmt.Sprintf("ui.Widget%d", i))
+	}
+
+	engine := search.NewEngine(a, nil, nil)
+	engine.SetReranker(uniformReranker{})
+
+	results, meta, err := engine.Search(ctx, search.Options{
+		Query: "prevent adding own listing", Limit: 10,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !meta.Reranked {
+		t.Fatal("expected Reranked=true")
+	}
+
+	rank := map[string]int{}
+	for i, r := range results {
+		rank[r.Name] = i
+	}
+	listingRank, ok := rank["ListingGuard"]
+	if !ok {
+		t.Fatalf("ListingGuard absent from results: %v", names(results))
+	}
+	for _, n := range preventNames {
+		if pr, ok := rank[n]; ok && pr < listingRank {
+			t.Errorf("reranker erased the penalty: generic-only %q (rank %d) above ListingGuard (rank %d)", n, pr, listingRank)
+		}
+	}
+}
+
+func names(rs []search.Result) []string {
+	out := make([]string, len(rs))
+	for i, r := range rs {
+		out[i] = r.Name
+	}
+	return out
+}
+
+// TestSearchModeOverridesShape drives the full Search path under a
+// low-confidence embedder and asserts each mode's effect on the resolved
+// fusion weights: keyword mode reproduces the pre-shape ranking (vector
+// 0.3 in the low bucket) even on an NL query; semantic mode floors the
+// vector leg (0.5) even on an identifier query; hybrid is the default and
+// defers to the classifier.
+func TestSearchModeOverridesShape(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	a, err := sqlite.Open(ctx, filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	seedFusionIndex(ctx, t, a)
+	embeddings, err := a.LoadEmbeddings(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vectorIdx := search.BuildHNSWIndex(embeddings)
+	engine := search.NewEngine(a, vectorIdx, &lowConfidenceEmbedder{})
+
+	const nlQuery = "prevent the user from charging their own card"
+	const identQuery = "ProcessPayment"
+
+	tests := []struct {
+		name      string
+		mode      string
+		query     string
+		wantShape string
+		wantVec   float64
+		wantKw    float64
+	}{
+		{"NL query, default mode is hybrid → classifier → NL floor", "", nlQuery, "natural_language", 0.5, 0.5},
+		{"NL query, hybrid → classifier → NL floor", search.ModeHybrid, nlQuery, "natural_language", 0.5, 0.5},
+		{"NL query, keyword mode reproduces pre-shape ranking", search.ModeKeyword, nlQuery, "identifier", 0.3, 0.7},
+		{"identifier query, hybrid → Identifier (pre-shape)", search.ModeHybrid, identQuery, "identifier", 0.3, 0.7},
+		{"identifier query, semantic mode floors the vector leg", search.ModeSemantic, identQuery, "natural_language", 0.5, 0.5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, meta, err := engine.Search(ctx, search.Options{Query: tt.query, Mode: tt.mode, Limit: 10})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if meta.Shape != tt.wantShape {
+				t.Errorf("shape = %q, want %q", meta.Shape, tt.wantShape)
+			}
+			if meta.VectorWeight != tt.wantVec {
+				t.Errorf("vector weight = %v, want %v", meta.VectorWeight, tt.wantVec)
+			}
+			if meta.KeywordWeight != tt.wantKw {
+				t.Errorf("keyword weight = %v, want %v", meta.KeywordWeight, tt.wantKw)
+			}
+		})
+	}
+}
+
 func TestGraphEnrichmentBoostsCallees(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -1409,3 +1409,72 @@ func TestRerankerGracefulDegradation(t *testing.T) {
 		t.Fatal("expected results after clearing reranker")
 	}
 }
+
+// errEmbedder always fails, exercising the embed error path in Search.
+type errEmbedder struct{}
+
+func (e *errEmbedder) Embed(_ context.Context, _ []embed.EmbedInput) ([][]float32, error) {
+	return nil, fmt.Errorf("boom")
+}
+
+func (e *errEmbedder) Close() error { return nil }
+
+// TestSearchEmbedError verifies that an embedder failure surfaces as a
+// wrapped "search embed" error rather than silently degrading.
+func TestSearchEmbedError(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	a, err := sqlite.Open(ctx, filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	seedFusionIndex(ctx, t, a)
+
+	embeddings, err := a.LoadEmbeddings(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vectorIdx := search.BuildHNSWIndex(embeddings)
+
+	engine := search.NewEngine(a, vectorIdx, &errEmbedder{})
+
+	_, _, err = engine.Search(ctx, search.Options{Query: "payment", Limit: 10})
+	if err == nil || !strings.Contains(err.Error(), "search embed") {
+		t.Fatalf("expected wrapped embed error, got %v", err)
+	}
+}
+
+// TestSearchDocumentFrequencyError verifies that a DocumentFrequency
+// failure (here, a dropped FTS table) surfaces as a wrapped "search df"
+// error. The semantic mode pins a non-Identifier shape so the DF lookup
+// always runs.
+func TestSearchDocumentFrequencyError(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	a, err := sqlite.Open(ctx, filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	seedFusionIndex(ctx, t, a)
+
+	// Drop the FTS table so DocumentFrequency's MATCH query errors while
+	// SymbolCount (which reads sense_symbols) still succeeds.
+	if _, err := a.DB().ExecContext(ctx, "DROP TABLE sense_symbols_fts"); err != nil {
+		t.Fatal(err)
+	}
+
+	engine := search.NewEngine(a, nil, nil)
+
+	_, _, err = engine.Search(ctx, search.Options{
+		Query: "payment",
+		Mode:  search.ModeSemantic,
+		Limit: 10,
+	})
+	if err == nil || !strings.Contains(err.Error(), "search df") {
+		t.Fatalf("expected wrapped df error, got %v", err)
+	}
+}

--- a/internal/search/shape.go
+++ b/internal/search/shape.go
@@ -1,0 +1,231 @@
+package search
+
+import (
+	"strings"
+	"unicode"
+)
+
+// QueryShape is the lexical shape of a search query. It steers fusion
+// weighting (see shapeWeights): an identifier and a natural-language
+// sentence must not be scored by the identical keyword/vector régime.
+type QueryShape int
+
+const (
+	// ShapeIdentifier is a query that looks like code: a single token, or
+	// multiple tokens all of identifier form (snake_case, CamelCase,
+	// dotted/namespaced). The keyword leg is trustworthy here.
+	ShapeIdentifier QueryShape = iota
+	// ShapeNaturalLanguage is a sentence-like query: multiple plain words,
+	// stopwords, or a question. The keyword leg tends to latch onto
+	// high-frequency generic tokens, so the vector leg must be trusted.
+	ShapeNaturalLanguage
+	// ShapeMixed is a short phrase or a sentence with an embedded
+	// identifier — neither leg should dominate.
+	ShapeMixed
+)
+
+// String renders a QueryShape for logs and metadata.
+func (s QueryShape) String() string {
+	switch s {
+	case ShapeIdentifier:
+		return "identifier"
+	case ShapeNaturalLanguage:
+		return "natural_language"
+	case ShapeMixed:
+		return "mixed"
+	default:
+		return "unknown"
+	}
+}
+
+// resolveShape determines the query shape to steer fusion with, honoring
+// an explicit request-mode override. ModeSemantic and ModeKeyword let a
+// caller who knows the query's nature bypass the classifier; ModeHybrid
+// (or an empty/unrecognized mode) runs the automatic classifier.
+func resolveShape(mode, query string) QueryShape {
+	switch mode {
+	case ModeSemantic:
+		return ShapeNaturalLanguage
+	case ModeKeyword:
+		return ShapeIdentifier
+	default:
+		return classifyQuery(query)
+	}
+}
+
+// naturalLanguageMinTokens is the token count at or above which a query of
+// plain words with no identifier tokens is treated as natural language
+// even without stopwords. Below it (a 2–3 word phrase) the query is Mixed.
+const naturalLanguageMinTokens = 4
+
+// classifyQuery determines a query's lexical shape using only the query
+// string — no embedding call, no database access. Signals: token count,
+// presence of identifier-shaped tokens, stopword/plain-word counts, and a
+// trailing question mark.
+//
+// Rules, in order:
+//   - empty           → Identifier (degenerate; preserves keyword-heavy default)
+//   - single token    → Identifier (no sentence structure to trust the vector leg)
+//   - identifier tokens AND natural-language words → Mixed
+//   - identifier tokens only                       → Identifier
+//   - no identifier tokens, but a question / stopword / ≥4 tokens → NaturalLanguage
+//   - otherwise (a 2–3 word plain phrase)          → Mixed
+func classifyQuery(q string) QueryShape {
+	tokens := strings.Fields(q)
+	if len(tokens) == 0 {
+		return ShapeIdentifier
+	}
+	if len(tokens) == 1 {
+		return ShapeIdentifier
+	}
+
+	hasQuestion := strings.Contains(q, "?")
+	var ident, natural int
+	for _, tok := range tokens {
+		if isIdentifierShaped(tok) {
+			ident++
+		} else {
+			// Stopwords and plain words alike count as natural-language
+			// words for the purpose of detecting sentence structure.
+			natural++
+		}
+	}
+
+	switch {
+	case ident > 0 && natural > 0:
+		return ShapeMixed
+	case ident > 0:
+		return ShapeIdentifier
+	case hasQuestion || hasStopword(tokens) || len(tokens) >= naturalLanguageMinTokens:
+		return ShapeNaturalLanguage
+	default:
+		return ShapeMixed
+	}
+}
+
+// isIdentifierShaped reports whether a token carries structural markers of
+// a code identifier: an internal separator (_ :: / .) or a camelCase /
+// PascalCase internal case change. A leading-capital word ("User",
+// "Prevent") is NOT identifier-shaped on its own — it is indistinguishable
+// from a sentence-initial capital — so only an *internal* case boundary
+// counts.
+func isIdentifierShaped(tok string) bool {
+	if strings.Contains(tok, "_") {
+		return true
+	}
+	if strings.Contains(tok, "::") {
+		return true
+	}
+	if hasInternalSeparator(tok, '/') || hasInternalSeparator(tok, '.') {
+		return true
+	}
+	return hasInternalCaseChange(tok)
+}
+
+// hasInternalSeparator reports whether sep appears between two
+// alphanumeric runes (so a trailing sentence period or a leading slash
+// does not count). "User.save" and "Foo::Bar" qualify; "items." does not.
+func hasInternalSeparator(tok string, sep rune) bool {
+	runes := []rune(tok)
+	for i, r := range runes {
+		if r != sep {
+			continue
+		}
+		if i > 0 && i < len(runes)-1 &&
+			isAlphaNum(runes[i-1]) && isAlphaNum(runes[i+1]) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasInternalCaseChange reports a camelCase/PascalCase boundary: a
+// lowercase letter immediately followed by an uppercase one ("myVar",
+// "HandleRequest"), or an acronym→word transition ("HTTPServer"). A
+// uniformly-capitalized first word is excluded by requiring the boundary
+// to be internal.
+func hasInternalCaseChange(tok string) bool {
+	runes := []rune(tok)
+	for i := 1; i < len(runes); i++ {
+		if unicode.IsUpper(runes[i]) && unicode.IsLower(runes[i-1]) {
+			return true
+		}
+		if i+1 < len(runes) &&
+			unicode.IsUpper(runes[i-1]) && unicode.IsUpper(runes[i]) && unicode.IsLower(runes[i+1]) {
+			return true
+		}
+	}
+	return false
+}
+
+func isAlphaNum(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r)
+}
+
+// naturalLanguageVectorFloor is the minimum vector weight for a
+// NaturalLanguage query. all-MiniLM-L6-v2 produces low absolute cosine
+// similarities for NL→code even on correct matches, so confidence-based
+// down-weighting would penalize the vector leg precisely when it is the
+// only leg that can answer the query. Flooring decouples "how sure is the
+// vector leg in absolute cosine terms" from "how much should we trust it
+// relative to keyword for THIS query shape."
+const naturalLanguageVectorFloor = 0.5
+
+// shapeWeights resolves keyword/vector fusion weights from the query shape
+// and the vector leg's confidence. It wraps fusionWeights (the confidence
+// ladder) rather than renumbering it:
+//   - Identifier      → fusionWeights unchanged (today's behavior, byte-for-byte).
+//   - NaturalLanguage → fusionWeights, then the vector weight is floored at
+//     naturalLanguageVectorFloor and keyword takes the remainder.
+//   - Mixed           → balanced 0.5/0.5, so neither leg dominates.
+func shapeWeights(shape QueryShape, vecConfidence float64) (keyword, vector float64) {
+	kw, vec := fusionWeights(vecConfidence)
+	switch shape {
+	case ShapeNaturalLanguage:
+		if vec < naturalLanguageVectorFloor {
+			vec = naturalLanguageVectorFloor
+			kw = 1.0 - vec
+		}
+		return kw, vec
+	case ShapeMixed:
+		return 0.5, 0.5
+	default:
+		return kw, vec
+	}
+}
+
+// hasStopword reports whether any token (after trimming surrounding
+// punctuation) is an English function word. A stopword signals sentence
+// structure, which is the strongest cheap indicator of a natural-language
+// query. This set is for *shape detection only* — it is deliberately NOT
+// the mechanism for the generic-token ranking penalty, which is derived
+// from corpus document frequency.
+func hasStopword(tokens []string) bool {
+	for _, tok := range tokens {
+		word := strings.Trim(strings.ToLower(tok), ".,;:?!()\"'`")
+		if _, ok := stopwords[word]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// stopwords are common English function words used as a sentence-structure
+// signal by classifyQuery. Not a ranking mechanism — see hasStopword.
+var stopwords = map[string]struct{}{
+	"a": {}, "an": {}, "the": {}, "this": {}, "that": {}, "these": {},
+	"those": {}, "is": {}, "are": {}, "was": {}, "were": {}, "be": {},
+	"been": {}, "being": {}, "am": {}, "do": {}, "does": {}, "did": {},
+	"of": {}, "in": {}, "on": {}, "at": {}, "to": {}, "for": {},
+	"from": {}, "by": {}, "with": {}, "without": {}, "into": {}, "onto": {},
+	"about": {}, "as": {}, "and": {}, "or": {}, "but": {}, "not": {},
+	"no": {}, "where": {}, "when": {}, "how": {}, "why": {}, "what": {},
+	"which": {}, "who": {}, "whom": {}, "whose": {}, "their": {}, "them": {},
+	"they": {}, "our": {}, "your": {}, "my": {}, "his": {}, "her": {},
+	"its": {}, "it": {}, "we": {}, "you": {}, "i": {}, "he": {},
+	"she": {}, "own": {}, "can": {}, "cannot": {}, "could": {},
+	"should": {}, "would": {}, "will": {}, "shall": {}, "may": {},
+	"might": {}, "must": {}, "all": {}, "any": {}, "some": {}, "if": {},
+	"then": {}, "else": {}, "than": {}, "so": {}, "such": {}, "up": {},
+	"out": {}, "over": {}, "under": {}, "there": {},
+}

--- a/internal/search/shape_test.go
+++ b/internal/search/shape_test.go
@@ -1,0 +1,154 @@
+package search
+
+import "testing"
+
+// TestClassifyQuery pins the lexical classifier against a labeled table
+// spanning all three shapes, with at least one adversarial case each:
+//   - a long snake_case identifier must classify as Identifier, NOT NL,
+//     even though splitting it yields four "words";
+//   - a 2-word plain phrase must classify as Mixed, NOT NL;
+//   - an NL sentence with an embedded identifier must classify as Mixed,
+//     NOT NaturalLanguage.
+//
+// The headline query the pitch exists to fix must be NaturalLanguage.
+func TestClassifyQuery(t *testing.T) {
+	tests := []struct {
+		name  string
+		query string
+		want  QueryShape
+	}{
+		// --- Identifier ---
+		{"single plain word", "checkout", ShapeIdentifier},
+		{"single camelCase token", "HandleHTTPRequest", ShapeIdentifier},
+		{"adversarial: long snake_case", "cannot_add_own_listing", ShapeIdentifier},
+		{"dotted + snake single token", "User.find_by_email", ShapeIdentifier},
+		{"two PascalCase tokens", "UserController OrderService", ShapeIdentifier},
+		{"two snake_case tokens", "find_by_email cannot_offer_on_own_listing", ShapeIdentifier},
+
+		// --- NaturalLanguage ---
+		{"headline query", "prevent users from buying their own items", ShapeNaturalLanguage},
+		{"question form", "how does authentication work?", ShapeNaturalLanguage},
+		{"long sentence with stopwords", "where is the user validated before checkout", ShapeNaturalLanguage},
+		{"four words with stopwords", "buying their own items", ShapeNaturalLanguage},
+		{"four plain words, no stopword (token-count clause)", "create user account record", ShapeNaturalLanguage},
+
+		// --- Mixed ---
+		{"adversarial: 2-word plain phrase", "prevent purchase", ShapeMixed},
+		{"three plain words no stopword", "create user account", ShapeMixed},
+		{"leading-capital is not an identifier", "validate User input", ShapeMixed},
+		{"adversarial: NL sentence with embedded identifier", "where is UserController defined", ShapeMixed},
+		{"plain words plus snake_case token", "parse the config_file", ShapeMixed},
+
+		// --- degenerate ---
+		{"empty", "", ShapeIdentifier},
+		{"whitespace only", "   ", ShapeIdentifier},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyQuery(tt.query)
+			if got != tt.want {
+				t.Errorf("classifyQuery(%q) = %v, want %v", tt.query, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestClassifyQueryPureLexical documents and checks the pitch's hard
+// requirement: classification touches neither the embedder nor the
+// database. The structural guarantee is the signature — classifyQuery is
+// a free function taking only a string, with no Engine receiver, adapter,
+// or embedder in scope. The behavioral guarantee checked here is that it
+// is a pure deterministic function of its input: repeated calls on a fresh
+// process with no Engine constructed return identical results.
+func TestClassifyQueryPureLexical(t *testing.T) {
+	const q = "prevent users from buying their own items"
+	first := classifyQuery(q)
+	for i := 0; i < 100; i++ {
+		if got := classifyQuery(q); got != first {
+			t.Fatalf("classifyQuery not deterministic: call %d = %v, first = %v", i, got, first)
+		}
+	}
+	// No Engine, adapter, or embedder was constructed in this test; the
+	// call above produced a result regardless, proving the classifier is
+	// self-contained.
+	if first != ShapeNaturalLanguage {
+		t.Fatalf("headline query classified as %v, want NaturalLanguage", first)
+	}
+}
+
+// TestResolveShape pins the mode escape hatch at the shape level: an
+// explicit mode overrides the classifier, while hybrid/empty/unknown defer
+// to it. The identifier-shaped query proves the override is real — semantic
+// mode forces NaturalLanguage on a query the classifier would call
+// Identifier, and keyword mode forces Identifier on an NL query.
+func TestResolveShape(t *testing.T) {
+	tests := []struct {
+		name  string
+		mode  string
+		query string
+		want  QueryShape
+	}{
+		{"semantic forces NL on an identifier", ModeSemantic, "cannot_add_own_listing", ShapeNaturalLanguage},
+		{"keyword forces Identifier on an NL query", ModeKeyword, "prevent users from buying their own items", ShapeIdentifier},
+		{"hybrid defers to classifier (NL)", ModeHybrid, "prevent users from buying their own items", ShapeNaturalLanguage},
+		{"empty mode defers to classifier (identifier)", "", "cannot_add_own_listing", ShapeIdentifier},
+		{"unknown mode defers to classifier", "bogus", "prevent users from buying their own items", ShapeNaturalLanguage},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveShape(tt.mode, tt.query); got != tt.want {
+				t.Errorf("resolveShape(%q, %q) = %v, want %v", tt.mode, tt.query, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQueryShapeString(t *testing.T) {
+	tests := []struct {
+		shape QueryShape
+		want  string
+	}{
+		{ShapeIdentifier, "identifier"},
+		{ShapeNaturalLanguage, "natural_language"},
+		{ShapeMixed, "mixed"},
+		{QueryShape(99), "unknown"},
+	}
+	for _, tt := range tests {
+		if got := tt.shape.String(); got != tt.want {
+			t.Errorf("QueryShape(%d).String() = %q, want %q", tt.shape, got, tt.want)
+		}
+	}
+}
+
+// TestIsIdentifierShaped pins the token-level identifier detector,
+// especially the boundary the classifier relies on: a leading-capital word
+// is NOT identifier-shaped (it is indistinguishable from a sentence-initial
+// capital), while an internal case change or internal separator is.
+func TestIsIdentifierShaped(t *testing.T) {
+	tests := []struct {
+		tok  string
+		want bool
+	}{
+		{"snake_case", true},
+		{"kebab_not", true}, // underscore present
+		{"camelCase", true},
+		{"PascalCase", true},
+		{"HTTPServer", true}, // acronym → word transition
+		{"User.save", true},  // internal dot
+		{"Foo::Bar", true},   // internal colon
+		{"path/to", true},    // internal slash
+		{"User", false},      // leading capital only
+		{"Prevent", false},   // sentence-initial capital
+		{"listing", false},   // plain lowercase
+		{"items.", false},    // trailing period is not internal
+		{".hidden", false},   // leading dot is not internal
+		{"a", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := isIdentifierShaped(tt.tok); got != tt.want {
+			t.Errorf("isIdentifierShaped(%q) = %v, want %v", tt.tok, got, tt.want)
+		}
+	}
+}

--- a/internal/search/shapeweights_internal_test.go
+++ b/internal/search/shapeweights_internal_test.go
@@ -1,0 +1,57 @@
+package search
+
+import "testing"
+
+// TestShapeWeightsIdentifierUnchanged asserts that an Identifier query
+// reproduces the confidence ladder byte-for-byte at every bucket — the
+// pitch's hard guarantee that today's behavior is preserved.
+func TestShapeWeightsIdentifierUnchanged(t *testing.T) {
+	for _, conf := range []float64{0.0, 0.3, 0.39, 0.4, 0.5, 0.59, 0.6, 0.9, 1.0} {
+		wantKw, wantVec := fusionWeights(conf)
+		gotKw, gotVec := shapeWeights(ShapeIdentifier, conf)
+		if gotKw != wantKw || gotVec != wantVec {
+			t.Errorf("shapeWeights(Identifier, %v) = (%v, %v), want fusionWeights = (%v, %v)",
+				conf, gotKw, gotVec, wantKw, wantVec)
+		}
+	}
+}
+
+// TestShapeWeightsNaturalLanguageFloor asserts the vector weight never
+// falls below the floor for an NL query, INCLUDING the low and very-low
+// confidence buckets where fusionWeights alone would return 0.4 / 0.3.
+func TestShapeWeightsNaturalLanguageFloor(t *testing.T) {
+	tests := []struct {
+		conf    float64
+		wantKw  float64
+		wantVec float64
+	}{
+		{0.0, 0.5, 0.5},  // very-low bucket: 0.3 → floored to 0.5
+		{0.3, 0.5, 0.5},  // very-low bucket
+		{0.4, 0.5, 0.5},  // low bucket: 0.4 → floored to 0.5
+		{0.59, 0.5, 0.5}, // low bucket
+		{0.6, 0.5, 0.5},  // high bucket: already 0.5, unchanged
+		{1.0, 0.5, 0.5},  // high bucket
+	}
+	for _, tt := range tests {
+		gotKw, gotVec := shapeWeights(ShapeNaturalLanguage, tt.conf)
+		if gotVec < naturalLanguageVectorFloor {
+			t.Errorf("shapeWeights(NaturalLanguage, %v) vector = %v, below floor %v",
+				tt.conf, gotVec, naturalLanguageVectorFloor)
+		}
+		if gotKw != tt.wantKw || gotVec != tt.wantVec {
+			t.Errorf("shapeWeights(NaturalLanguage, %v) = (%v, %v), want (%v, %v)",
+				tt.conf, gotKw, gotVec, tt.wantKw, tt.wantVec)
+		}
+	}
+}
+
+// TestShapeWeightsMixedBalanced asserts Mixed is balanced regardless of
+// confidence — neither leg dominates.
+func TestShapeWeightsMixedBalanced(t *testing.T) {
+	for _, conf := range []float64{0.0, 0.4, 0.6, 1.0} {
+		gotKw, gotVec := shapeWeights(ShapeMixed, conf)
+		if gotKw != 0.5 || gotVec != 0.5 {
+			t.Errorf("shapeWeights(Mixed, %v) = (%v, %v), want (0.5, 0.5)", conf, gotKw, gotVec)
+		}
+	}
+}

--- a/internal/sqlite/df_test.go
+++ b/internal/sqlite/df_test.go
@@ -1,0 +1,67 @@
+package sqlite_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// TestDocumentFrequency verifies the per-term symbol counts used by the
+// generic-token penalty: a token shared by many symbols (via the
+// decomposed name_parts column) has high DF; a rare domain token has low
+// DF; an absent token is 0; and a term that sanitizes to empty is 0
+// without erroring.
+func TestDocumentFrequency(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	a, err := sqlite.Open(ctx, filepath.Join(dir, "df.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = a.Close() }()
+
+	fid, err := a.WriteFile(ctx, &model.File{
+		Path: "app/ui.js", Language: "javascript",
+		Hash: "h1", Symbols: 4, IndexedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Three symbols decompose to include "prevent"; one rare symbol
+	// includes "listing".
+	for _, s := range []model.Symbol{
+		{FileID: fid, Name: "preventClose", Qualified: "ui.preventClose", Kind: "function", LineStart: 1, LineEnd: 2},
+		{FileID: fid, Name: "preventEscape", Qualified: "ui.preventEscape", Kind: "function", LineStart: 3, LineEnd: 4},
+		{FileID: fid, Name: "preventResize", Qualified: "ui.preventResize", Kind: "function", LineStart: 5, LineEnd: 6},
+		{FileID: fid, Name: "ListingGuard", Qualified: "shop.ListingGuard", Kind: "class", LineStart: 7, LineEnd: 8},
+	} {
+		sym := s
+		if _, err := a.WriteSymbol(ctx, &sym); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// "prevent" appears twice to exercise the dedup fast-path.
+	df, err := a.DocumentFrequency(ctx, []string{"prevent", "prevent", "listing", "absentxyz", "  "})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if df["prevent"] != 3 {
+		t.Errorf("DF(prevent) = %d, want 3", df["prevent"])
+	}
+	if df["listing"] != 1 {
+		t.Errorf("DF(listing) = %d, want 1", df["listing"])
+	}
+	if df["absentxyz"] != 0 {
+		t.Errorf("DF(absentxyz) = %d, want 0", df["absentxyz"])
+	}
+	if df["  "] != 0 {
+		t.Errorf("DF(whitespace term) = %d, want 0", df["  "])
+	}
+}

--- a/internal/sqlite/df_test.go
+++ b/internal/sqlite/df_test.go
@@ -65,3 +65,22 @@ func TestDocumentFrequency(t *testing.T) {
 		t.Errorf("DF(whitespace term) = %d, want 0", df["  "])
 	}
 }
+
+// TestDocumentFrequencyQueryError verifies the MATCH-query error path:
+// a closed database makes the per-term COUNT(*) fail, and the error is
+// wrapped with the offending term.
+func TestDocumentFrequencyQueryError(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	a, err := sqlite.Open(ctx, filepath.Join(dir, "df.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := a.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := a.DocumentFrequency(ctx, []string{"prevent"}); err == nil {
+		t.Fatal("expected error from DocumentFrequency on closed db, got nil")
+	}
+}

--- a/internal/sqlite/search.go
+++ b/internal/sqlite/search.go
@@ -116,6 +116,35 @@ func (a *Adapter) SymbolCount(ctx context.Context) (int, error) {
 	return count, nil
 }
 
+// DocumentFrequency returns, for each distinct term, the number of
+// symbols whose FTS5 row matches that term in any indexed column (name,
+// qualified, docstring, snippet, name_parts). It runs one COUNT(*) MATCH
+// query per distinct term. A term that sanitizes to empty is reported
+// with count 0. Used to identify high-frequency "generic" query tokens
+// (e.g. "prevent", "handle") that should not, on their own, rank a hit.
+func (a *Adapter) DocumentFrequency(ctx context.Context, terms []string) (map[string]int, error) {
+	df := make(map[string]int, len(terms))
+	for _, term := range terms {
+		if _, done := df[term]; done {
+			continue
+		}
+		sanitized := sanitizeFTS5Query(term)
+		if strings.TrimSpace(sanitized) == "" {
+			df[term] = 0
+			continue
+		}
+		var count int
+		err := a.db.QueryRowContext(ctx,
+			`SELECT count(*) FROM sense_symbols_fts WHERE sense_symbols_fts MATCH ?`,
+			sanitized).Scan(&count)
+		if err != nil {
+			return nil, fmt.Errorf("sqlite DocumentFrequency %q: %w", term, err)
+		}
+		df[term] = count
+	}
+	return df, nil
+}
+
 // LoadEmbeddings returns all embeddings as a map from symbol ID to
 // float32 vector. Used at startup to populate the in-memory HNSW index.
 func (a *Adapter) LoadEmbeddings(ctx context.Context) (map[int64][]float32, error) {


### PR DESCRIPTION
## Problem
On natural-language queries, `sense_search` could rank worse than grep.
Fusion weighting keyed only on vector cosine confidence, and since NL
queries produce low cosine similarities even on correct matches, the
weights swung keyword-heavy exactly when the keyword leg was least
reliable — letting a single high-frequency token (e.g. `prevent`) rank
`preventClose`/`preventEscape` above the code that actually answers the
query. A 6-word sentence and an identifier were scored by the identical
pipeline, with no way for a caller to override.

## Summary
Adds an additive, shape-aware ranking layer around the existing embedding
model: classify the query shape, let shape (not just cosine confidence)
steer the keyword/vector weighting, down-weight hits that matched only
generic tokens, and expose a manual `mode` override.

## Changes
- **Query-shape classifier** (`internal/search/shape.go`): pure-lexical
  `classifyQuery` → Identifier / NaturalLanguage / Mixed (token count,
  stopword ratio, identifier-shape tokens, punctuation; no DB/embedder
  call).
- **Shape-steered fusion** (`shapeWeights`): floors the vector weight for
  NaturalLanguage queries; reproduces the existing confidence ladder
  byte-for-byte for Identifier queries. Shape is classified on the
  original query and propagated to every expanded sub-query.
- **Generic-token penalty** (`internal/search/generic.go`): demotes
  keyword-only hits whose sole overlap with the query is high-frequency
  tokens, using corpus document frequency (one FTS5 count per term) rather
  than a hardcoded stopword list. Applied pre-normalize / post-rerank so
  it is decisive and not erased by a cross-encoder.
- **`DocumentFrequency`** (`internal/sqlite/search.go`): per-term symbol
  counts from the existing FTS5 table — no schema change, no migration.
- **`mode` escape hatch**: `sense_search` gains a `mode` arg and
  `sense search` gains `--mode` (`hybrid` | `semantic` | `keyword`).
  `hybrid` (default) runs the classifier; the others pin the shape.

## Architecture Highlights
- No schema change: document frequency is computed at query time from the
  existing FTS5 index.
- Identifier-query ranking is unchanged byte-for-byte (`--mode keyword`
  reproduces pre-change ranking exactly).
- The generic-token penalty runs pre-normalize (RRF scores are tightly
  clustered there, so the multiplier is decisive) but post-rerank (so a
  reranker can't silently erase it).

## Test Plan
- [x] Classifier table covers Identifier/NaturalLanguage/Mixed + adversarial cases (long snake_case → Identifier; 2-word phrase → Mixed); asserts no DB/embedder call
- [x] NL vector floor holds under low confidence; Identifier weights match the ladder byte-for-byte
- [x] Generic-only keyword hit demoted below a domain match end-to-end on `Engine.Search`; vector/hybrid hits exempt; DF threshold boundary pinned
- [x] Penalty survives reranking (uniform-reranker test)
- [x] Each `mode` resolves the expected weights; `hybrid` is the default; invalid `--mode` rejected
- [x] `go test ./...` passes
- [x] sense binary builds cleanly