### PR TITLE
feat(dead): trustworthy dead code for Ruby value objects

### DIFF
--- a/internal/dead/dead.go
+++ b/internal/dead/dead.go
@@ -9,10 +9,18 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/luuuc/sense/internal/extract"
 	"github.com/luuuc/sense/internal/sqlite"
 )
 
 const defaultLimit = 100
+
+// syntheticPrefixPattern is a SQL LIKE pattern matching the synthetic
+// ruby-core:* base symbols (ruby-core:Struct / ruby-core:Data). These are
+// plumbing for value-object inheritance edges and must never surface as
+// dead candidates or inflate the analysed-symbol denominator. The prefix
+// contains no LIKE metacharacters, so no ESCAPE clause is needed.
+const syntheticPrefixPattern = extract.PrefixRubyCore + "%"
 
 type Options struct {
 	Language        string
@@ -34,6 +42,13 @@ type Symbol struct {
 	ParentID   *int64
 	Visibility string
 	Confidence string
+	// NameOccurrences estimates how common this symbol's bare name is
+	// across the index — symbols sharing the name plus resolved edges
+	// pointing at a symbol of that name. The verify-command builder uses
+	// it to decide whether a text grep would flood the caller (a name like
+	// "success?" appears everywhere) and a manual-inspect hint should
+	// replace it. Estimated from the index, never by shelling out.
+	NameOccurrences int
 }
 
 type Result struct {
@@ -105,6 +120,10 @@ func FindDead(ctx context.Context, db *sql.DB, opts Options) (Result, error) {
 	if err != nil {
 		return Result{}, fmt.Errorf("dead: included modules: %w", err)
 	}
+	valueObjectClassIDs, err := queryValueObjectClassIDs(ctx, db)
+	if err != nil {
+		return Result{}, fmt.Errorf("dead: value-object classes: %w", err)
+	}
 
 	candidates = excludeEntryPoints(candidates, entryPointFilters{
 		testsTargets:         testsTargets,
@@ -117,14 +136,19 @@ func FindDead(ctx context.Context, db *sql.DB, opts Options) (Result, error) {
 	})
 
 	candidates = annotateConfidence(candidates, confidenceInputs{
-		interfaceIDs:      interfaceIDs,
-		implementorIDs:    implementorIDs,
-		includedModuleIDs: includedModuleIDs,
-		dynamicFramework:  usesDynamicAutoload(frameworks),
+		interfaceIDs:        interfaceIDs,
+		implementorIDs:      implementorIDs,
+		includedModuleIDs:   includedModuleIDs,
+		valueObjectClassIDs: valueObjectClassIDs,
+		dynamicFramework:    usesDynamicAutoload(frameworks),
 	})
 
 	if len(candidates) > opts.Limit {
 		candidates = candidates[:opts.Limit]
+	}
+
+	if err := populateNameOccurrences(ctx, db, candidates); err != nil {
+		return Result{}, fmt.Errorf("dead: name occurrences: %w", err)
 	}
 
 	return Result{
@@ -148,7 +172,8 @@ func frameworkNames(frameworks map[string]struct{}) []string {
 func countSymbols(ctx context.Context, db *sql.DB, opts Options) (int, error) {
 	q := `SELECT COUNT(*) FROM sense_symbols s
 		JOIN sense_files f ON s.file_id = f.id
-		WHERE s.kind IN ('function', 'method', 'class', 'module', 'type', 'interface', 'constant')`
+		WHERE s.kind IN ('function', 'method', 'class', 'module', 'type', 'interface', 'constant')
+		AND s.qualified NOT LIKE '` + syntheticPrefixPattern + `'`
 	var args []any
 
 	if opts.Language != "" {
@@ -191,7 +216,8 @@ func queryCandidates(ctx context.Context, db *sql.DB, opts Options) ([]Symbol, e
 		FROM sense_symbols s
 		JOIN sense_files f ON s.file_id = f.id
 		WHERE NOT EXISTS (` + edgeFilter + `)
-		AND s.kind IN ('function', 'method', 'class', 'module', 'type', 'interface', 'constant')`
+		AND s.kind IN ('function', 'method', 'class', 'module', 'type', 'interface', 'constant')
+		AND s.qualified NOT LIKE '` + syntheticPrefixPattern + `'`
 	var args []any
 
 	if opts.Language != "" {
@@ -354,6 +380,102 @@ func queryIncludedModuleIDs(ctx context.Context, db *sql.DB) (map[int64]struct{}
 		out[id] = struct{}{}
 	}
 	return out, rows.Err()
+}
+
+// queryValueObjectClassIDs returns IDs of classes that carry an
+// `inherits` edge to a synthetic Ruby-core value-object base
+// (ruby-core:Struct / ruby-core:Data). These are `CONST = Struct.new`/
+// `Data.define` value objects; their public instance methods form a
+// duck-typed API surface reached via `x.method` on a local whose type
+// the static indexer cannot infer — so a zero-caller verdict is
+// uncertain, not dead. Keying on the structural inherits edge (not a
+// `*Result` name suffix) is the whole point of the synthetic base.
+func queryValueObjectClassIDs(ctx context.Context, db *sql.DB) (map[int64]struct{}, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT DISTINCT e.source_id FROM sense_edges e
+		JOIN sense_symbols t ON t.id = e.target_id
+		WHERE e.kind = 'inherits' AND e.source_id IS NOT NULL
+		  AND t.qualified IN (?, ?)`,
+		extract.RubyCoreStruct, extract.RubyCoreData)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	out := make(map[int64]struct{})
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out[id] = struct{}{}
+	}
+	return out, rows.Err()
+}
+
+// populateNameOccurrences fills Symbol.NameOccurrences for each candidate
+// with an index-derived estimate of how common its bare name is: the
+// number of symbols sharing the name plus the number of resolved edges
+// pointing at a symbol of that name. This proxies textual frequency
+// without shelling out — a name defined and called many times is one a
+// text grep would flood the caller with. Two batched queries (GROUP BY
+// name over the candidate set), so cost is independent of repo size.
+func populateNameOccurrences(ctx context.Context, db *sql.DB, candidates []Symbol) error {
+	if len(candidates) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(candidates))
+	seen := make(map[string]struct{}, len(candidates))
+	for _, s := range candidates {
+		if _, ok := seen[s.Name]; ok {
+			continue
+		}
+		seen[s.Name] = struct{}{}
+		names = append(names, s.Name)
+	}
+
+	counts := make(map[string]int, len(names))
+
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(names)), ",")
+	args := make([]any, len(names))
+	for i, n := range names {
+		args[i] = n
+	}
+
+	symQ := `SELECT name, COUNT(*) FROM sense_symbols WHERE name IN (` + placeholders + `) GROUP BY name`
+	if err := accumulateCounts(ctx, db, symQ, args, counts); err != nil {
+		return err
+	}
+
+	edgeQ := `SELECT s.name, COUNT(*) FROM sense_edges e
+		JOIN sense_symbols s ON s.id = e.target_id
+		WHERE s.name IN (` + placeholders + `) GROUP BY s.name`
+	if err := accumulateCounts(ctx, db, edgeQ, args, counts); err != nil {
+		return err
+	}
+
+	for i := range candidates {
+		candidates[i].NameOccurrences = counts[candidates[i].Name]
+	}
+	return nil
+}
+
+// accumulateCounts runs a `SELECT name, COUNT(*) … GROUP BY name` query
+// and adds each row's count into the shared totals map.
+func accumulateCounts(ctx context.Context, db *sql.DB, q string, args []any, totals map[string]int) error {
+	rows, err := db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var name string
+		var n int
+		if err := rows.Scan(&name, &n); err != nil {
+			return err
+		}
+		totals[name] += n
+	}
+	return rows.Err()
 }
 
 func hasMainFunction(ctx context.Context, db *sql.DB, opts Options) (bool, error) {
@@ -746,10 +868,11 @@ func isGoConstructor(s Symbol) bool {
 }
 
 type confidenceInputs struct {
-	interfaceIDs      map[int64]struct{}
-	implementorIDs    map[int64]struct{}
-	includedModuleIDs map[int64]struct{}
-	dynamicFramework  bool
+	interfaceIDs        map[int64]struct{}
+	implementorIDs      map[int64]struct{}
+	includedModuleIDs   map[int64]struct{}
+	valueObjectClassIDs map[int64]struct{}
+	dynamicFramework    bool
 }
 
 func annotateConfidence(candidates []Symbol, in confidenceInputs) []Symbol {
@@ -771,11 +894,21 @@ func annotateConfidence(candidates []Symbol, in confidenceInputs) []Symbol {
 				continue
 			}
 		}
+		// A value object's public instance methods are duck-typed API
+		// (`result.success?` on a local of unknown type). This is a
+		// pure-Ruby idiom, not Rails-specific, so it softens regardless
+		// of framework — and it makes the value-object nature queryable
+		// (the inherits→ruby-core:Struct edge) rather than guessed from a
+		// `?` suffix.
+		if isValueObjectMethod(*s, in.valueObjectClassIDs) {
+			s.Confidence = ConfidencePossibly
+			continue
+		}
 		if isGoConstructor(*s) {
 			s.Confidence = ConfidencePossibly
 			continue
 		}
-		if in.dynamicFramework && (isDynamicallyReferenceable(*s) || isDynamicRubyMethod(*s)) {
+		if in.dynamicFramework && (isDynamicallyReferenceable(*s) || isDynamicServiceCall(*s) || isDynamicRubyPredicate(*s)) {
 			s.Confidence = ConfidencePossibly
 			continue
 		}
@@ -816,29 +949,64 @@ var serviceClassSuffixes = []string{
 	"Service", "Command", "Query", "Interactor", "Operation", "Job", "Worker",
 }
 
-// isDynamicRubyMethod flags Ruby methods that follow a dynamic-dispatch
-// convention the static indexer routinely under-resolves, so a zero-caller
-// result can't justify a hard "dead" verdict:
-//
-//   - Predicate methods (foo?) — almost always invoked on a duck-typed
-//     receiver (`if result.success?`, `raise if e.retriable?`) or implicitly
-//     on self (`return false unless retriable?`), paths the indexer frequently
-//     can't tie back to the definition. This covers result/value-object
-//     predicates whose inner Struct is flattened onto a *Service class, where
-//     the parent name carries no Result/Response suffix to key off.
-//   - The service-object `call` entry point — reached through `Klass.new.call`,
-//     a `.()` shorthand, or a duck-typed handler.
-//
-// They are reported possibly-dead rather than dead.
-func isDynamicRubyMethod(s Symbol) bool {
+// isDynamicServiceCall flags the service-object `call` entry point —
+// reached through `Klass.new.call`, a `.()` shorthand, or a duck-typed
+// handler the static indexer can't tie back to the definition. Reported
+// possibly-dead rather than dead.
+func isDynamicServiceCall(s Symbol) bool {
 	if s.Language != "ruby" || s.Kind != "method" {
 		return false
 	}
-	if strings.HasSuffix(s.Name, "?") {
-		return true
-	}
 	parent := rubyMethodParentName(s.Qualified)
 	return s.Name == "call" && hasAnySuffix(parent, serviceClassSuffixes)
+}
+
+// isDynamicRubyPredicate flags Ruby predicate methods (`foo?`) under a
+// dynamic framework as uncertain. Validation against a real Rails app
+// (maket) showed predicates are pervasively invoked on duck-typed
+// receivers the indexer can't resolve — `@transaction.pending?` in a view,
+// `record.cancelled?` on an association — so hard-flagging a zero-static-
+// caller predicate as `dead` produced confident false negatives on live
+// methods (pending? alone had 28 call sites). A false "dead" erodes trust
+// far more than a conservative "possibly_dead", so this residual
+// softening stays — gated on a dynamic framework, where the dispatch the
+// indexer misses actually happens.
+//
+// The narrower, framework-independent win this pitch adds is
+// isValueObjectMethod: value-object members soften by their structural
+// inheritance edge, so a pure-Ruby gem (no framework) gets correct
+// verdicts that this framework-gated rule would not reach.
+func isDynamicRubyPredicate(s Symbol) bool {
+	return s.Language == "ruby" && s.Kind == "method" && strings.HasSuffix(s.Name, "?")
+}
+
+// isValueObjectMethod reports whether s is a public instance method of a
+// Struct.new / Data.define value object (its parent class is in
+// valueObjectClassIDs). Instance methods are reached via duck-typed
+// `x.method` on a local whose type the indexer cannot infer, so a
+// zero-caller verdict is uncertain. Singleton methods (`Result.build`) are
+// excluded — they are not the duck-typed instance surface.
+//
+// Visibility is not gated: the Ruby extractor does not record method
+// visibility, so public and private cannot be distinguished here. That is
+// safe — a private struct method can't be called with an explicit receiver
+// anyway, so if one is genuinely dead, softening it to `possibly_dead` is
+// merely conservative, and private methods on a value object are rare.
+func isValueObjectMethod(s Symbol, valueObjectClassIDs map[int64]struct{}) bool {
+	if s.Language != "ruby" || s.Kind != "method" || s.ParentID == nil {
+		return false
+	}
+	if _, ok := valueObjectClassIDs[*s.ParentID]; !ok {
+		return false
+	}
+	return rubyInstanceMethod(s.Qualified)
+}
+
+// rubyInstanceMethod reports whether a Ruby method's qualified name is an
+// instance method (`Parent#name`) rather than a singleton (`Parent.name`).
+func rubyInstanceMethod(qualified string) bool {
+	sep := strings.LastIndexAny(qualified, "#.")
+	return sep >= 0 && qualified[sep] == '#'
 }
 
 // rubyMethodParentName returns the unqualified parent class/module name from

--- a/internal/dead/dead_test.go
+++ b/internal/dead/dead_test.go
@@ -335,6 +335,77 @@ end
 	}
 }
 
+// TestNameOccurrencesEstimated proves FindDead fills NameOccurrences from
+// the index: a method name defined on several classes carries an
+// occurrence estimate of at least that many definitions, so the verify-
+// command builder can tell a common name from a unique one.
+func TestNameOccurrencesEstimated(t *testing.T) {
+	root := t.TempDir()
+	// Three classes all defining `ping`, none called — all dead, and the
+	// name is shared three ways.
+	writeFile(t, filepath.Join(root, "pingers.rb"), `class Alpha
+  def ping
+    1
+  end
+end
+
+class Beta
+  def ping
+    2
+  end
+end
+
+class Gamma
+  def ping
+    3
+  end
+end
+`)
+	// A uniquely-named dead method as the contrast.
+	writeFile(t, filepath.Join(root, "lonely.rb"), `class Lonely
+  def quux_only_here
+    9
+  end
+end
+`)
+
+	ctx := context.Background()
+	if _, err := scan.Run(ctx, scan.Options{Root: root, Output: &bytes.Buffer{}, Warnings: io.Discard}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+	dbPath := filepath.Join(root, ".sense", "index.db")
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	result, err := dead.FindDead(ctx, db, dead.Options{Language: "ruby"})
+	if err != nil {
+		t.Fatalf("FindDead: %v", err)
+	}
+
+	var pingOcc, lonelyOcc int
+	var sawPing, sawLonely bool
+	for _, s := range result.Dead {
+		switch s.Qualified {
+		case "Alpha#ping":
+			pingOcc, sawPing = s.NameOccurrences, true
+		case "Lonely#quux_only_here":
+			lonelyOcc, sawLonely = s.NameOccurrences, true
+		}
+	}
+	if !sawPing || !sawLonely {
+		t.Fatalf("expected both dead candidates present (ping=%v lonely=%v)", sawPing, sawLonely)
+	}
+	if pingOcc < 3 {
+		t.Errorf("ping NameOccurrences = %d, want >= 3 (three definitions)", pingOcc)
+	}
+	if lonelyOcc != 1 {
+		t.Errorf("unique-name NameOccurrences = %d, want 1", lonelyOcc)
+	}
+}
+
 func TestExcludeTestRefsChangesResults(t *testing.T) {
 	root := t.TempDir()
 

--- a/internal/dead/queries_internal_test.go
+++ b/internal/dead/queries_internal_test.go
@@ -1,0 +1,35 @@
+package dead
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// TestQueryErrorPathsNoSchema drives the index-query helpers against a DB
+// with no tables, exercising their error-return paths (the happy paths are
+// covered by the scan-backed tests). Without this, a query that silently
+// swallowed an error would still pass the integration tests.
+func TestQueryErrorPathsNoSchema(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	ctx := context.Background()
+
+	if _, err := queryValueObjectClassIDs(ctx, db); err == nil {
+		t.Error("queryValueObjectClassIDs should error when sense_edges is missing")
+	}
+	// populateNameOccurrences fans out into accumulateCounts, so a missing
+	// sense_symbols table surfaces through both.
+	if err := populateNameOccurrences(ctx, db, []Symbol{{Name: "x"}}); err == nil {
+		t.Error("populateNameOccurrences should error when sense_symbols is missing")
+	}
+	// Empty candidate set is a fast no-op, not an error.
+	if err := populateNameOccurrences(ctx, db, nil); err != nil {
+		t.Errorf("populateNameOccurrences(nil) = %v, want nil", err)
+	}
+}

--- a/internal/dead/tiering_test.go
+++ b/internal/dead/tiering_test.go
@@ -33,10 +33,10 @@ func TestRubyDynamicTypesTieredUnderFramework(t *testing.T) {
 	}
 }
 
-// Ruby service-object `call` methods and predicate (foo?) methods follow
-// dynamic-dispatch conventions the indexer under-resolves, so with no detected
-// caller they are possibly-dead, not dead — but only under a dynamic framework.
-func TestRubyDynamicMethodTiering(t *testing.T) {
+// Ruby service-object `call` methods follow a dynamic-dispatch convention
+// the indexer under-resolves, so with no detected caller they are
+// possibly-dead, not dead — but only under a dynamic framework.
+func TestRubyDynamicServiceCallTiering(t *testing.T) {
 	cases := []struct {
 		name      string
 		sym       Symbol
@@ -49,35 +49,8 @@ func TestRubyDynamicMethodTiering(t *testing.T) {
 			true, ConfidencePossibly,
 		},
 		{
-			"result predicate under framework",
-			Symbol{Language: "ruby", Kind: "method", Name: "success?", Qualified: "Payments::Result#success?"},
-			true, ConfidencePossibly,
-		},
-		{
-			// Verified false positive: the inner `Result = Struct.new do def
-			// success? end end` is flattened onto the *Service class, so the
-			// parent name carries no Result suffix — the old narrow rule
-			// hard-flagged it dead.
-			"predicate flattened onto a service class is possibly-dead",
-			Symbol{Language: "ruby", Kind: "method", Name: "success?", Qualified: "Checkout::ProcessPaymentService#success?"},
-			true, ConfidencePossibly,
-		},
-		{
-			// Verified false positive: dispatched on a rescued `e`
-			// (`raise if e.retriable?`); not a known predicate name, class
-			// matches no suffix — the old rule hard-flagged it dead.
-			"arbitrary predicate on any class is possibly-dead",
-			Symbol{Language: "ruby", Kind: "method", Name: "retriable?", Qualified: "SocialCommerce::Meta::ApiError#retriable?"},
-			true, ConfidencePossibly,
-		},
-		{
 			"plain call on a non-service class stays dead",
 			Symbol{Language: "ruby", Kind: "method", Name: "call", Qualified: "Widget#call"},
-			true, ConfidenceDead,
-		},
-		{
-			"plain non-predicate method stays dead",
-			Symbol{Language: "ruby", Kind: "method", Name: "frobnicate", Qualified: "Widget#frobnicate"},
 			true, ConfidenceDead,
 		},
 		{
@@ -96,6 +69,83 @@ func TestRubyDynamicMethodTiering(t *testing.T) {
 		if got[0].Confidence != c.want {
 			t.Errorf("%s: confidence = %q, want %q", c.name, got[0].Confidence, c.want)
 		}
+	}
+}
+
+// Value-object recognition replaces the old blanket "every `foo?` predicate
+// is possibly-dead" net with a rule keyed on the synthetic Struct/Data
+// inheritance edge. A predicate on a value-object class is soft; the SAME
+// predicate name on an ordinary class — the control — stays hard dead, which
+// proves the rule is targeted, not a blanket mute. This softening is a pure-
+// Ruby idiom, so it does not require a dynamic framework.
+func TestValueObjectMethodTiering(t *testing.T) {
+	const voClassID, plainClassID = int64(42), int64(43)
+	vo := map[int64]struct{}{voClassID: {}}
+	voID, plainID := voClassID, plainClassID
+
+	cases := []struct {
+		name      string
+		sym       Symbol
+		framework bool
+		want      string
+	}{
+		{
+			"value-object predicate is soft (no framework needed)",
+			Symbol{Language: "ruby", Kind: "method", Name: "success?", Qualified: "Checkout::ProcessPaymentService::Result#success?", ParentID: &voID},
+			false, ConfidencePossibly,
+		},
+		{
+			"value-object non-predicate instance method is soft",
+			Symbol{Language: "ruby", Kind: "method", Name: "amount", Qualified: "Money::Amount#amount", ParentID: &voID},
+			false, ConfidencePossibly,
+		},
+		{
+			// CONTROL: identical predicate name, ordinary parent, no
+			// framework → stays dead. (framework=false isolates the
+			// value-object rule from the framework-gated predicate rule.)
+			"predicate on an ordinary class stays dead",
+			Symbol{Language: "ruby", Kind: "method", Name: "success?", Qualified: "Widget#success?", ParentID: &plainID},
+			false, ConfidenceDead,
+		},
+		{
+			// Singleton methods (`Result.build`) are not the duck-typed
+			// instance surface, so the value-object rule does not soften them.
+			"singleton value-object method stays dead",
+			Symbol{Language: "ruby", Kind: "method", Name: "build", Qualified: "Result.build", ParentID: &voID},
+			false, ConfidenceDead,
+		},
+	}
+	for _, c := range cases {
+		got := annotateConfidence([]Symbol{c.sym}, confidenceInputs{valueObjectClassIDs: vo, dynamicFramework: c.framework})
+		if got[0].Confidence != c.want {
+			t.Errorf("%s: confidence = %q, want %q", c.name, got[0].Confidence, c.want)
+		}
+	}
+}
+
+// Ruby predicate methods stay soft under a dynamic framework: maket
+// validation showed they are pervasively invoked on duck-typed receivers
+// the indexer cannot resolve (pending? had 28 live call sites yet zero
+// static callers), so hard-flagging them dead is a false negative. Without
+// a framework, a zero-caller predicate is plain dead.
+func TestRubyPredicateSoftenedUnderFramework(t *testing.T) {
+	pred := Symbol{Language: "ruby", Kind: "method", Name: "pending?", Qualified: "PaymentTransaction#pending?"}
+
+	got := annotateConfidence([]Symbol{pred}, confidenceInputs{dynamicFramework: true})
+	if got[0].Confidence != ConfidencePossibly {
+		t.Errorf("predicate under framework = %q, want %q", got[0].Confidence, ConfidencePossibly)
+	}
+
+	got = annotateConfidence([]Symbol{pred}, confidenceInputs{dynamicFramework: false})
+	if got[0].Confidence != ConfidenceDead {
+		t.Errorf("predicate without framework = %q, want %q", got[0].Confidence, ConfidenceDead)
+	}
+
+	// A non-predicate method is unaffected by this rule.
+	plain := Symbol{Language: "ruby", Kind: "method", Name: "process", Qualified: "Widget#process"}
+	got = annotateConfidence([]Symbol{plain}, confidenceInputs{dynamicFramework: true})
+	if got[0].Confidence != ConfidenceDead {
+		t.Errorf("non-predicate under framework = %q, want %q", got[0].Confidence, ConfidenceDead)
 	}
 }
 

--- a/internal/extract/extractor.go
+++ b/internal/extract/extractor.go
@@ -124,6 +124,25 @@ const (
 	// (e.g. "i18n:users.show.title"). Emitted as a symbol so semantic search
 	// can surface the view that renders a given piece of copy.
 	PrefixI18n = "i18n:"
+	// PrefixRubyCore qualifies a synthetic stand-in for a Ruby core class
+	// that is never defined in any indexed source file (Struct, Data). A
+	// `CONST = Struct.new(...)` value object emits an `inherits` edge to the
+	// matching synthetic symbol so dead-code analysis can recognise the
+	// value object structurally rather than by a fragile name suffix. The
+	// synthetic stand-in exists only because sense_edges.target_id is NOT
+	// NULL: an `inherits → Struct` edge whose target resolves to nothing is
+	// dropped at write time, so the target must be a real emitted row. These
+	// symbols are plumbing — filtered out of dead-code and search output.
+	PrefixRubyCore = "ruby-core:"
+)
+
+// RubyCoreStruct and RubyCoreData are the qualified names of the synthetic
+// base symbols a Ruby value object inherits from. They live here (not in the
+// ruby package) so the dead package can key its value-object query on the
+// exact same strings the extractor emits, without importing the extractor.
+const (
+	RubyCoreStruct = PrefixRubyCore + "Struct"
+	RubyCoreData   = PrefixRubyCore + "Data"
 )
 
 // StimulusControllerQualified converts a kebab-case Stimulus controller name

--- a/internal/extract/ruby/ruby.go
+++ b/internal/extract/ruby/ruby.go
@@ -62,6 +62,7 @@ func (Extractor) Extract(tree *sitter.Tree, source []byte, filePath string, emit
 		classInstanceVars: make(map[string]map[string]string),
 		returnTypes:       returnTypes,
 		emittedCallbacks:  make(map[string]bool),
+		emittedSynthetics: make(map[string]bool),
 		pkgBindings:       make(map[string]string),
 	}
 	w.collectConstants(tree.RootNode(), nil)
@@ -90,6 +91,7 @@ type walker struct {
 	classInstanceVars map[string]map[string]string // @ivar type map per class
 	returnTypes       map[string]string            // method_qualified → class_name (file-level)
 	emittedCallbacks  map[string]bool              // dedup synthetic callback symbols by qualified name
+	emittedSynthetics map[string]bool              // dedup synthetic base symbols (ruby-core:Struct/Data) per file
 	pkgBindings       map[string]string            // unqualified name → qualified name for file-level constants
 }
 
@@ -111,6 +113,17 @@ func (w *walker) walk(n *sitter.Node, scope []string) error {
 	case "singleton_method":
 		return w.handleMethod(n, scope, true)
 	case "assignment":
+		// `CONST = Struct.new(...) do … end` and friends define a nested
+		// class, not a flat constant — the block's `def`s belong to the
+		// struct, not the enclosing scope. handleClassBuilderAssignment
+		// consumes those; ordinary `CONST = value` falls through.
+		consumed, err := w.handleClassBuilderAssignment(n, scope)
+		if err != nil {
+			return err
+		}
+		if consumed {
+			return nil
+		}
 		if err := w.handleConstantAssignment(n, scope); err != nil {
 			return err
 		}
@@ -1789,6 +1802,159 @@ func isInsideNestedDef(n, root *sitter.Node) bool {
 		}
 	}
 	return false
+}
+
+// classBuilder describes a `CONST = <builder>` right-hand side that
+// defines a class rather than a plain value: `Struct.new`, `Data.define`,
+// or `Class.new`. baseTarget is the qualified name for the constant's
+// `inherits` edge ("" when there is no statically-known superclass, e.g.
+// a bare `Class.new`). valueObject is true only for Struct/Data — the
+// duck-typed value-object idiom dead-code recognition keys on. block is
+// the do…end / {} body, or nil.
+type classBuilder struct {
+	baseTarget  string
+	valueObject bool
+	block       *sitter.Node
+}
+
+// detectClassBuilder classifies the RHS of a constant assignment. It
+// returns ok=false for anything that is not a recognised class builder,
+// so the caller falls back to plain-constant handling.
+func detectClassBuilder(rhs *sitter.Node, source []byte) (classBuilder, bool) {
+	if rhs == nil || rhs.Kind() != "call" {
+		return classBuilder{}, false
+	}
+	recv := rhs.ChildByFieldName("receiver")
+	method := rhs.ChildByFieldName("method")
+	if recv == nil || method == nil {
+		return classBuilder{}, false
+	}
+	recvText := extract.Text(recv, source)
+	methodText := extract.Text(method, source)
+	cb := classBuilder{block: getBlockChild(rhs)}
+	switch {
+	case recvText == "Struct" && methodText == "new":
+		cb.baseTarget = extract.RubyCoreStruct
+		cb.valueObject = true
+	case recvText == "Data" && methodText == "define":
+		cb.baseTarget = extract.RubyCoreData
+		cb.valueObject = true
+	case recvText == "Class" && methodText == "new":
+		// The superclass is the first constant argument, if any.
+		// `Class.new` with no constant argument has no known parent.
+		cb.baseTarget = firstConstantArg(rhs, source)
+	default:
+		return classBuilder{}, false
+	}
+	return cb, true
+}
+
+// firstConstantArg returns the surface text of the first constant /
+// scope-resolution argument of a call, or "" when there is none.
+func firstConstantArg(call *sitter.Node, source []byte) string {
+	args := call.ChildByFieldName("arguments")
+	if args == nil {
+		return ""
+	}
+	for i := uint(0); i < args.NamedChildCount(); i++ {
+		c := args.NamedChild(i)
+		if c == nil {
+			continue
+		}
+		switch c.Kind() {
+		case "constant", "scope_resolution":
+			return extract.Text(c, source)
+		}
+	}
+	return ""
+}
+
+// handleClassBuilderAssignment handles `CONST = Struct.new(...)`,
+// `CONST = Data.define(...)`, and `CONST = Class.new(Super)` — with or
+// without a do…end / {} block. The constant becomes a nested CLASS
+// symbol (qualified scope::CONST), the builder's base class becomes an
+// `inherits` edge, and any block body is walked with CONST pushed onto
+// the scope so its members qualify as `…::CONST#method` rather than
+// inheriting the enclosing class scope. Returns true when the node was
+// consumed (caller must not fall through to constant/child handling).
+func (w *walker) handleClassBuilderAssignment(n *sitter.Node, scope []string) (bool, error) {
+	lhs := n.ChildByFieldName("left")
+	if lhs == nil || lhs.Kind() != "constant" {
+		return false, nil
+	}
+	cb, ok := detectClassBuilder(n.ChildByFieldName("right"), w.source)
+	if !ok {
+		return false, nil
+	}
+	name := extract.Text(lhs, w.source)
+	if name == "" {
+		return false, nil
+	}
+	parent := strings.Join(scope, "::")
+	qualified := name
+	if parent != "" {
+		qualified = parent + "::" + name
+	}
+	line := extract.Line(n.StartPosition())
+
+	if err := w.emit.Symbol(extract.EmittedSymbol{
+		Name:            name,
+		Qualified:       qualified,
+		Kind:            model.KindClass,
+		ParentQualified: parent,
+		LineStart:       line,
+		LineEnd:         extract.Line(n.EndPosition()),
+		Docstring:       docstringFor(n, w.source),
+	}); err != nil {
+		return false, err
+	}
+
+	if cb.baseTarget != "" {
+		if cb.valueObject {
+			if err := w.emitSyntheticBase(cb.baseTarget, line); err != nil {
+				return false, err
+			}
+		}
+		if err := w.emit.Edge(extract.EmittedEdge{
+			SourceQualified: qualified,
+			TargetQualified: cb.baseTarget,
+			Kind:            model.EdgeInherits,
+			Line:            &line,
+			Confidence:      extract.ConfidenceStatic,
+		}); err != nil {
+			return false, err
+		}
+	}
+
+	if cb.block != nil {
+		body := getBlockBody(cb.block)
+		if body != nil {
+			newScope := append(slices.Clone(scope), name)
+			if err := w.walkChildren(body, newScope); err != nil {
+				return false, err
+			}
+		}
+	}
+	return true, nil
+}
+
+// emitSyntheticBase emits a synthetic stand-in symbol for a Ruby core
+// class (ruby-core:Struct / ruby-core:Data) so that `inherits` edges
+// pointing at it resolve and persist (target_id is NOT NULL). Deduped
+// per file: many value objects in one file share a single base symbol.
+func (w *walker) emitSyntheticBase(qualified string, line int) error {
+	if w.emittedSynthetics[qualified] {
+		return nil
+	}
+	w.emittedSynthetics[qualified] = true
+	return w.emit.Symbol(extract.EmittedSymbol{
+		Name:       strings.TrimPrefix(qualified, extract.PrefixRubyCore),
+		Qualified:  qualified,
+		Kind:       model.KindClass,
+		Visibility: "public",
+		LineStart:  line,
+		LineEnd:    line,
+	})
 }
 
 // handleConstantAssignment emits a KindConstant symbol when the LHS of

--- a/internal/extract/ruby/struct_attribution_test.go
+++ b/internal/extract/ruby/struct_attribution_test.go
@@ -1,0 +1,332 @@
+package ruby
+
+import (
+	"errors"
+	"testing"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+)
+
+// These tests drive the real CST walker on source bytes — the walker is
+// the code under test, so a hand-built EmittedSymbol would prove nothing.
+// They pin the exact qualified name of a method defined inside a
+// `Struct.new`/`Data.define`/`Class.new` block, plus the persistence-
+// relevant facts: the constant is a class and the inherits edge points at
+// the synthetic base.
+
+func TestStructAttribution_WithBlock(t *testing.T) {
+	// The maket repro: a nested Result struct with predicate methods.
+	r := parseRuby(t, `class Checkout::ProcessPaymentService
+  Result = Struct.new(:success, keyword_init: true) do
+    def success?
+      success
+    end
+
+    def failure?
+      !success
+    end
+  end
+end
+`)
+
+	// The methods must qualify to the struct, NOT the enclosing service.
+	for _, name := range []string{"success?", "failure?"} {
+		want := "Checkout::ProcessPaymentService::Result#" + name
+		if s := findSymbol(r, want); s == nil {
+			t.Errorf("missing method symbol %q", want)
+		}
+		// The mis-attribution bug: enclosing-class qualname must be gone.
+		bad := "Checkout::ProcessPaymentService#" + name
+		if s := findSymbol(r, bad); s != nil {
+			t.Errorf("method still mis-attributed to enclosing class: %q", bad)
+		}
+	}
+
+	// Result is a class, parented to the service.
+	result := findSymbol(r, "Checkout::ProcessPaymentService::Result")
+	if result == nil {
+		t.Fatal("missing Result class symbol")
+	}
+	if result.Kind != "class" {
+		t.Errorf("Result.Kind = %q, want class", result.Kind)
+	}
+	if result.ParentQualified != "Checkout::ProcessPaymentService" {
+		t.Errorf("Result.Parent = %q, want Checkout::ProcessPaymentService", result.ParentQualified)
+	}
+
+	// The inherits edge points at the synthetic Struct base, and that
+	// base symbol is emitted so the edge can resolve.
+	e := findEdge(r, "Checkout::ProcessPaymentService::Result", extract.RubyCoreStruct, "inherits")
+	if e == nil {
+		t.Fatal("missing inherits edge Result -> ruby-core:Struct")
+	}
+	if base := findSymbol(r, extract.RubyCoreStruct); base == nil {
+		t.Fatal("synthetic base symbol ruby-core:Struct not emitted")
+	}
+}
+
+func TestStructAttribution_NoBlock(t *testing.T) {
+	// maket's confirm_shop_payment_service.rb form: no block, accessors
+	// generated implicitly. There are no `def`s to re-attribute, but the
+	// constant must still be a value-object class with the inherits edge.
+	r := parseRuby(t, `class ConfirmShopPaymentService
+  Result = Struct.new(:success, :order, keyword_init: true)
+end
+`)
+	result := findSymbol(r, "ConfirmShopPaymentService::Result")
+	if result == nil {
+		t.Fatal("missing Result class symbol")
+	}
+	if result.Kind != "class" {
+		t.Errorf("Result.Kind = %q, want class", result.Kind)
+	}
+	if e := findEdge(r, "ConfirmShopPaymentService::Result", extract.RubyCoreStruct, "inherits"); e == nil {
+		t.Error("missing inherits edge Result -> ruby-core:Struct")
+	}
+}
+
+func TestDataDefineAttribution(t *testing.T) {
+	r := parseRuby(t, `class Money
+  Amount = Data.define(:cents) do
+    def positive?
+      cents > 0
+    end
+  end
+end
+`)
+	if s := findSymbol(r, "Money::Amount#positive?"); s == nil {
+		t.Error("missing method symbol Money::Amount#positive?")
+	}
+	amount := findSymbol(r, "Money::Amount")
+	if amount == nil {
+		t.Fatal("missing Amount class symbol")
+	}
+	if amount.Kind != "class" {
+		t.Errorf("Amount.Kind = %q, want class", amount.Kind)
+	}
+	if e := findEdge(r, "Money::Amount", extract.RubyCoreData, "inherits"); e == nil {
+		t.Error("missing inherits edge Amount -> ruby-core:Data")
+	}
+}
+
+func TestClassNewAttribution(t *testing.T) {
+	// Anonymous class assigned to a constant. The superclass is the
+	// Class.new argument — NOT Struct — so it must NOT be a value object.
+	r := parseRuby(t, `class Base
+end
+
+Widget = Class.new(Base) do
+  def render
+  end
+end
+`)
+	if s := findSymbol(r, "Widget#render"); s == nil {
+		t.Error("missing method symbol Widget#render")
+	}
+	widget := findSymbol(r, "Widget")
+	if widget == nil {
+		t.Fatal("missing Widget class symbol")
+	}
+	if widget.Kind != "class" {
+		t.Errorf("Widget.Kind = %q, want class", widget.Kind)
+	}
+	// Inherits the real superclass, not a synthetic base.
+	if e := findEdge(r, "Widget", "Base", "inherits"); e == nil {
+		t.Error("missing inherits edge Widget -> Base")
+	}
+	// No synthetic base symbol — Class.new(Super) is not a value object.
+	if s := findSymbol(r, extract.RubyCoreStruct); s != nil {
+		t.Error("ruby-core:Struct emitted for a Class.new(Super) — should not be")
+	}
+}
+
+func TestModuleNestedStructAttribution(t *testing.T) {
+	// Scope push must compose with module/class nesting.
+	r := parseRuby(t, `module Billing
+  class Invoice
+    Line = Struct.new(:amount) do
+      def zero?
+        amount.zero?
+      end
+    end
+  end
+end
+`)
+	want := "Billing::Invoice::Line#zero?"
+	if s := findSymbol(r, want); s == nil {
+		t.Errorf("missing method symbol %q", want)
+	}
+	if s := findSymbol(r, "Billing::Invoice::Line"); s == nil || s.Kind != "class" {
+		t.Errorf("Line not emitted as a nested class")
+	}
+}
+
+func TestStructAttribution_NegativeCase(t *testing.T) {
+	// A def directly on the enclosing class (outside the struct block)
+	// still qualifies to the class — the scope push is local to the block.
+	r := parseRuby(t, `class Order
+  Result = Struct.new(:ok) do
+    def ok?
+      ok
+    end
+  end
+
+  def process
+  end
+end
+`)
+	if s := findSymbol(r, "Order#process"); s == nil {
+		t.Error("def on the class must still qualify to the class: Order#process missing")
+	}
+	if s := findSymbol(r, "Order::Result#ok?"); s == nil {
+		t.Error("def in the struct must qualify to the struct: Order::Result#ok? missing")
+	}
+	// And the struct method is NOT on the class.
+	if s := findSymbol(r, "Order#ok?"); s != nil {
+		t.Error("struct method leaked onto the enclosing class: Order#ok?")
+	}
+}
+
+// Non-builder RHS forms fall through to plain-constant handling rather
+// than being mistaken for a class. These cover the detection guards.
+func TestClassBuilderDetection_NonBuilders(t *testing.T) {
+	cases := []struct {
+		name, src, qualified string
+	}{
+		// Receiverless call (`compute(...)`) — not a `Recv.method` builder.
+		{"receiverless call", "X = compute(1)\n", "X"},
+		// A `Recv.method` that is not a recognised builder.
+		{"unrelated dotted call", "X = Foo.bar(1)\n", "X"},
+		// A plain literal — not a call at all.
+		{"plain literal", "X = 42\n", "X"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := parseRuby(t, c.src)
+			s := findSymbol(r, c.qualified)
+			if s == nil {
+				t.Fatalf("missing symbol %q", c.qualified)
+			}
+			if s.Kind != "constant" {
+				t.Errorf("%s: Kind = %q, want constant (not a class builder)", c.name, s.Kind)
+			}
+		})
+	}
+}
+
+// Class.new with no constant superclass argument yields a class with no
+// inherits edge — covering the "no args" and "non-constant first arg" arms
+// of firstConstantArg.
+func TestClassNew_NoKnownSuperclass(t *testing.T) {
+	cases := []struct{ name, src string }{
+		{"no arguments", "Widget = Class.new\n"},
+		{"non-constant argument", "Widget = Class.new(factory) do\n  def go; end\nend\n"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := parseRuby(t, c.src)
+			w := findSymbol(r, "Widget")
+			if w == nil || w.Kind != "class" {
+				t.Fatalf("%s: Widget not emitted as a class", c.name)
+			}
+			for _, e := range r.edges {
+				if e.SourceQualified == "Widget" && e.Kind == "inherits" {
+					t.Errorf("%s: unexpected inherits edge to %q", c.name, e.TargetQualified)
+				}
+			}
+		})
+	}
+}
+
+// errEmit is an Emitter that fails on a chosen Symbol or Edge call, so the
+// extractor's error-propagation paths in handleClassBuilderAssignment are
+// exercised (the recorder never errors).
+type errEmit struct {
+	failSymbolAt, failEdgeAt int
+	nSym, nEdge              int
+}
+
+var errBoom = errors.New("boom")
+
+func (e *errEmit) Symbol(extract.EmittedSymbol) error {
+	e.nSym++
+	if e.nSym == e.failSymbolAt {
+		return errBoom
+	}
+	return nil
+}
+func (e *errEmit) Edge(extract.EmittedEdge) error {
+	e.nEdge++
+	if e.nEdge == e.failEdgeAt {
+		return errBoom
+	}
+	return nil
+}
+
+func runWithEmitter(t *testing.T, src string, emit extract.Emitter) error {
+	t.Helper()
+	ex := Extractor{}
+	p := sitter.NewParser()
+	defer p.Close()
+	if err := p.SetLanguage(ex.Grammar()); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	source := []byte(src)
+	tree := p.Parse(source, nil)
+	defer tree.Close()
+	return ex.Extract(tree, source, "test.rb", emit)
+}
+
+func TestClassBuilderAssignment_EmitterErrorsPropagate(t *testing.T) {
+	// Struct with a block: emits Result class (Symbol #1), synthetic base
+	// (Symbol #2), the method inside the block (Symbol #3), and the inherits
+	// edge (Edge #1). Each failure point must surface as an error.
+	src := "Result = Struct.new(:a) do\n  def a?; a; end\nend\n"
+
+	cases := []struct {
+		name string
+		emit *errEmit
+	}{
+		{"value-object class symbol", &errEmit{failSymbolAt: 1}},
+		{"synthetic base symbol", &errEmit{failSymbolAt: 2}},
+		{"block member symbol", &errEmit{failSymbolAt: 3}},
+		{"inherits edge", &errEmit{failEdgeAt: 1}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if err := runWithEmitter(t, src, c.emit); !errors.Is(err, errBoom) {
+				t.Errorf("%s: err = %v, want errBoom", c.name, err)
+			}
+		})
+	}
+}
+
+func TestSyntheticBase_SingleEmissionPerFile(t *testing.T) {
+	// Two structs in one file share exactly one synthetic base symbol.
+	r := parseRuby(t, `class A
+  R1 = Struct.new(:x) do
+    def x?; x; end
+  end
+  R2 = Struct.new(:y) do
+    def y?; y; end
+  end
+end
+`)
+	count := 0
+	for _, s := range r.symbols {
+		if s.Qualified == extract.RubyCoreStruct {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("ruby-core:Struct emitted %d times, want exactly 1", count)
+	}
+	// Both structs still carry their own inherits edge to the shared base.
+	for _, src := range []string{"A::R1", "A::R2"} {
+		if e := findEdge(r, src, extract.RubyCoreStruct, "inherits"); e == nil {
+			t.Errorf("missing inherits edge %s -> ruby-core:Struct", src)
+		}
+	}
+}

--- a/internal/mcpio/coverage_test.go
+++ b/internal/mcpio/coverage_test.go
@@ -69,20 +69,67 @@ func TestBuildDeadCodeResponse(t *testing.T) {
 		t.Errorf("EstimatedFileReadsAvoided = %d, want 2", resp.SenseMetrics.EstimatedFileReadsAvoided)
 	}
 
-	// Every entry carries a ready-to-run verify grep.
-	if got := resp.DeadSymbols[0].VerifyCmd; got != `grep -rFn --exclude-dir=.git --exclude-dir=.sense "Unused" .` {
-		t.Errorf("VerifyCmd = %q, want %q", got, `grep -rFn --exclude-dir=.git --exclude-dir=.sense "Unused" .`)
+	// Every entry carries a call-scoped verify grep that excludes its own
+	// def site, not a bare-text grep.
+	want0 := `grep -rEn --exclude-dir=.git --exclude-dir=.sense "\.Unused" . | grep -vF "./pkg/unused.go:10:"`
+	if got := resp.DeadSymbols[0].VerifyCmd; got != want0 {
+		t.Errorf("VerifyCmd = %q, want %q", got, want0)
 	}
 }
 
-// A predicate name ending in `?` must be emitted as a fixed-string grep so the
-// `?` is matched literally rather than interpreted as a regex quantifier.
-func TestDeadVerifyCmdEscapesPredicate(t *testing.T) {
+// The verify command scopes to CALL syntax (`\.name`), escapes the `?`
+// predicate suffix for the regex engine, and excludes the definition's own
+// file:line — so a surviving hit is a missed call, not the def echoing back.
+func TestDeadVerifyCmd_CallScopedPredicate(t *testing.T) {
+	cmd, tooCommon := deadVerifyCmd("retriable?", "api_error.rb", 7, 3)
+	if tooCommon {
+		t.Fatal("3 occurrences is under the threshold; should not be flagged too common")
+	}
+	want := `grep -rEn --exclude-dir=.git --exclude-dir=.sense "\.retriable\?" . | grep -vF "./api_error.rb:7:"`
+	if cmd != want {
+		t.Errorf("verify cmd = %q, want %q", cmd, want)
+	}
+	// The bare predicate text must NOT appear unanchored — that was the
+	// flood-the-caller bug.
+	if strings.Contains(cmd, `"retriable?"`) {
+		t.Error("verify cmd uses bare-text grep, not call-scoped")
+	}
+}
+
+// The too-common flag flips exactly at the threshold boundary: a name at
+// the threshold still gets a grep; one occurrence past it gets the
+// manual-inspect hint.
+func TestDeadVerifyCmd_TooCommonBoundary(t *testing.T) {
+	atBoundary, tooCommon := deadVerifyCmd("success?", "result.rb", 17, verifyTooCommonThreshold)
+	if tooCommon {
+		t.Errorf("at threshold (%d) should still grep, not flag too common", verifyTooCommonThreshold)
+	}
+	if !strings.HasPrefix(atBoundary, "grep -rEn") {
+		t.Errorf("at-threshold cmd should be a grep, got %q", atBoundary)
+	}
+
+	over, tooCommon := deadVerifyCmd("success?", "result.rb", 17, verifyTooCommonThreshold+1)
+	if !tooCommon {
+		t.Errorf("past threshold (%d) should flag too common", verifyTooCommonThreshold+1)
+	}
+	if strings.HasPrefix(over, "grep") {
+		t.Errorf("too-common cmd should be a manual-inspect hint, not a grep: %q", over)
+	}
+	// The hint points at the def site so the reader can inspect by hand.
+	if !strings.Contains(over, "result.rb:17") {
+		t.Errorf("too-common hint should name the def site, got %q", over)
+	}
+}
+
+// The too-common flag is plumbed onto the wire entry, not just returned
+// from the helper.
+func TestBuildDeadCodeResponse_TooCommonFlag(t *testing.T) {
 	resp := BuildDeadCodeResponse([]dead.Symbol{
-		{Name: "retriable?", Qualified: "ApiError#retriable?", File: "api_error.rb", Kind: "method", Confidence: dead.ConfidencePossibly},
+		{Name: "success?", Qualified: "Result#success?", File: "result.rb", LineStart: 17, Kind: "method",
+			Confidence: dead.ConfidencePossibly, NameOccurrences: verifyTooCommonThreshold + 50},
 	}, 1, nil)
-	if got := resp.DeadSymbols[0].VerifyCmd; got != `grep -rFn --exclude-dir=.git --exclude-dir=.sense "retriable?" .` {
-		t.Errorf("VerifyCmd = %q, want %q", got, `grep -rFn --exclude-dir=.git --exclude-dir=.sense "retriable?" .`)
+	if !resp.DeadSymbols[0].VerifyTooCommon {
+		t.Error("entry for a very common name should set VerifyTooCommon")
 	}
 }
 

--- a/internal/mcpio/dead.go
+++ b/internal/mcpio/dead.go
@@ -2,9 +2,20 @@ package mcpio
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/luuuc/sense/internal/dead"
 )
+
+// verifyTooCommonThreshold is the index-occurrence count above which a
+// name is considered too common to auto-verify by grep. Above it, a text
+// search for the name floods the caller (a predicate like "success?" is
+// defined and called all over a Rails app), so the verify hint points at
+// the definition site for manual inspection instead. Estimated from the
+// index (symbols + resolved edges sharing the name); see
+// dead.Symbol.NameOccurrences. Tuned against maket, where the
+// mis-attributed Checkout predicates sit well above it.
+const verifyTooCommonThreshold = 25
 
 // BuildDeadCodeResponse assembles a wire DeadCodeResponse from the dead
 // package's result plus a rolled-up symbol list. Matches the
@@ -19,15 +30,17 @@ func BuildDeadCodeResponse(symbols []dead.Symbol, totalSymbols int, frameworks [
 		if confidence == "" {
 			confidence = dead.ConfidenceDead
 		}
+		cmd, tooCommon := deadVerifyCmd(s.Name, s.File, s.LineStart, s.NameOccurrences)
 		entries[i] = DeadSymbolEntry{
-			Symbol:     s.Name,
-			Qualified:  s.Qualified,
-			File:       s.File,
-			LineStart:  s.LineStart,
-			LineEnd:    s.LineEnd,
-			Kind:       s.Kind,
-			Confidence: confidence,
-			VerifyCmd:  deadVerifyCmd(s.Name),
+			Symbol:          s.Name,
+			Qualified:       s.Qualified,
+			File:            s.File,
+			LineStart:       s.LineStart,
+			LineEnd:         s.LineEnd,
+			Kind:            s.Kind,
+			Confidence:      confidence,
+			VerifyCmd:       cmd,
+			VerifyTooCommon: tooCommon,
 		}
 		uniqueFiles[s.File] = struct{}{}
 	}
@@ -72,12 +85,49 @@ func deadCodeNote(frameworks []string) string {
 		"(5) exported symbols consumed by downstream packages outside the indexed tree."
 }
 
-// deadVerifyCmd builds a copy-paste grep that lists every textual occurrence of
-// a candidate's name across the tree — the definition plus any call sites the
-// static index missed (duck-typed dispatch, metaprogramming). Fixed-string (-F)
-// so predicate names ending in `?` aren't interpreted as a regex. The VCS and
-// index directories are excluded as guaranteed noise; every source extension is
-// still searched, since a predicate may be called from a view or template.
-func deadVerifyCmd(name string) string {
-	return fmt.Sprintf("grep -rFn --exclude-dir=.git --exclude-dir=.sense %q .", name)
+// deadVerifyCmd builds the verify hint for one dead candidate. It returns
+// the hint string and whether the name was too common to auto-verify.
+//
+// Normally it emits a copy-paste grep scoped to CALL syntax — `\.name`,
+// the receiver-dot form a missed dynamic dispatch (`result.success?`)
+// takes — rather than the bare name, which on a common predicate floods
+// the caller with hundreds of unrelated definitions and comments. The
+// definition's own file:line is filtered out with a trailing `grep -v`,
+// so a single surviving hit means a genuinely missed call site, not the
+// definition echoing back.
+//
+// When the name's index-occurrence estimate exceeds the threshold, even a
+// call-scoped grep would return too much to be useful, so the hint points
+// at the definition site for manual inspection instead and tooCommon is
+// true.
+func deadVerifyCmd(name, file string, line, occurrences int) (cmd string, tooCommon bool) {
+	if occurrences > verifyTooCommonThreshold {
+		return fmt.Sprintf("name %q too common to auto-verify (%d index occurrences) — inspect %s:%d and its call sites manually",
+			name, occurrences, file, line), true
+	}
+
+	// Scope to call syntax: a leading receiver dot, the name with any `?`/`!`
+	// predicate/bang suffix escaped for the regex engine. The pattern is
+	// wrapped in literal shell double quotes — %q would Go-escape the
+	// backslash and hand grep `\\.` (a literal backslash) instead of `\.`.
+	pattern := `\.` + escapeForERE(name)
+	grep := `grep -rEn --exclude-dir=.git --exclude-dir=.sense "` + pattern + `" .`
+	// Exclude the definition's own file:line. `grep -rEn` prefixes each hit
+	// with `./path:line:`; a fixed-string (-F) match on that prefix drops the
+	// def line without the `.`s acting as wildcards.
+	exclude := fmt.Sprintf(`grep -vF "./%s:%d:"`, file, line)
+	return grep + " | " + exclude, false
+}
+
+// escapeForERE escapes the ERE metacharacters that occur in Ruby method
+// names — `?` (predicate), `!` (bang), and `.` — so the call-scoped grep
+// pattern matches the literal name. Other identifier characters are
+// regex-safe.
+func escapeForERE(name string) string {
+	r := strings.NewReplacer(
+		`.`, `\.`,
+		`?`, `\?`,
+		`!`, `\!`,
+	)
+	return r.Replace(name)
 }

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -587,11 +587,16 @@ type DeadSymbolEntry struct {
 	LineEnd    int    `json:"line_end"`
 	Kind       string `json:"kind"`
 	Confidence string `json:"confidence"`
-	// VerifyCmd is a ready-to-run grep that lists every textual occurrence of
-	// the symbol's name — the definition plus any call sites the static index
-	// missed (duck-typed dispatch, metaprogramming). One hit means truly
-	// unreferenced; extra hits mean it's reachable and should not be deleted.
+	// VerifyCmd is a copy-paste command to confirm the verdict: a call-scoped
+	// grep (`\.name`) for call sites the static index missed (duck-typed
+	// dispatch, metaprogramming), excluding the definition's own file:line so
+	// a surviving hit is a real missed call. When VerifyTooCommon is true it
+	// carries a manual-inspect hint instead — the name is too common across
+	// the index for a grep to be useful.
 	VerifyCmd string `json:"verify_cmd,omitempty"`
+	// VerifyTooCommon is true when the name is too common to auto-verify by
+	// grep; VerifyCmd then points at the definition site to inspect manually.
+	VerifyTooCommon bool `json:"verify_too_common,omitempty"`
 }
 
 // DeadCodeMetrics is the observability footer for dead code analysis.

--- a/internal/scan/struct_valueobject_test.go
+++ b/internal/scan/struct_valueobject_test.go
@@ -1,0 +1,160 @@
+package scan_test
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/luuuc/sense/internal/dead"
+	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/scan"
+)
+
+// TestStructInheritsEdgePersists proves the value-object inherits edge
+// survives a full scan → resolve round-trip. The extractor emitting the
+// edge is not enough: sense_edges.target_id is NOT NULL, so the edge only
+// lands if the synthetic ruby-core:Struct symbol is also written and the
+// resolver binds the edge to it. This is the anti-pattern the pitch calls
+// out — asserting the emit, not the persistence.
+func TestStructInheritsEdgePersists(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "process_payment_service.rb"), `class Checkout::ProcessPaymentService
+  Result = Struct.new(:success, keyword_init: true) do
+    def success?
+      success
+    end
+  end
+
+  def call
+    Result.new(success: true)
+  end
+end
+`)
+
+	if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+
+	db, err := sql.Open("sqlite", filepath.Join(root, ".sense", "index.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	// The inherits edge resolved to a real target row.
+	var target string
+	err = db.QueryRow(`
+		SELECT t.qualified
+		FROM sense_edges e
+		JOIN sense_symbols s ON s.id = e.source_id
+		JOIN sense_symbols t ON t.id = e.target_id
+		WHERE e.kind = 'inherits'
+		  AND s.qualified = 'Checkout::ProcessPaymentService::Result'`).Scan(&target)
+	if err != nil {
+		t.Fatalf("inherits edge did not persist after resolution: %v", err)
+	}
+	if target != extract.RubyCoreStruct {
+		t.Errorf("inherits target = %q, want %q", target, extract.RubyCoreStruct)
+	}
+
+	// The method qualifies to the struct, not the enclosing service.
+	var kind string
+	if err := db.QueryRow(`SELECT kind FROM sense_symbols WHERE qualified = ?`,
+		"Checkout::ProcessPaymentService::Result#success?").Scan(&kind); err != nil {
+		t.Fatalf("success? not attributed to the struct: %v", err)
+	}
+
+	// The synthetic base is emitted exactly once across the scan.
+	var baseCount int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM sense_symbols WHERE qualified = ?`,
+		extract.RubyCoreStruct).Scan(&baseCount); err != nil {
+		t.Fatal(err)
+	}
+	if baseCount != 1 {
+		t.Errorf("ruby-core:Struct symbol count = %d, want 1", baseCount)
+	}
+}
+
+// TestValueObjectDeadCodeTargeted drives the whole pipeline — extract,
+// resolve, dead-code analysis — and proves the value-object softening is
+// targeted: a struct predicate with zero static callers is possibly_dead,
+// while a genuinely uncalled predicate on an ordinary class (the control)
+// stays hard dead. Without the control, a filter that mutes everything
+// would pass.
+func TestValueObjectDeadCodeTargeted(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "services.rb"), `class ProcessPaymentService
+  Result = Struct.new(:success, keyword_init: true) do
+    def success?
+      success
+    end
+  end
+
+  def call
+    Result.new(success: true)
+  end
+end
+
+# An ordinary class with a predicate nobody calls — genuinely dead.
+class Gadget
+  def stale?
+    true
+  end
+end
+`)
+
+	if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+
+	db, err := sql.Open("sqlite", filepath.Join(root, ".sense", "index.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	res, err := dead.FindDead(context.Background(), db, dead.Options{Language: "ruby"})
+	if err != nil {
+		t.Fatalf("FindDead: %v", err)
+	}
+
+	byQualified := map[string]dead.Symbol{}
+	for _, s := range res.Dead {
+		byQualified[s.Qualified] = s
+	}
+
+	// The value-object predicate is softened, not hard dead, and is
+	// attributed to the struct (proving the attribution fix fed the rule).
+	vo, ok := byQualified["ProcessPaymentService::Result#success?"]
+	if !ok {
+		t.Fatalf("value-object predicate not found in dead candidates; got %v", keys(byQualified))
+	}
+	if vo.Confidence != dead.ConfidencePossibly {
+		t.Errorf("value-object predicate confidence = %q, want %q", vo.Confidence, dead.ConfidencePossibly)
+	}
+
+	// CONTROL: the ordinary predicate stays hard dead.
+	ctrl, ok := byQualified["Gadget#stale?"]
+	if !ok {
+		t.Fatalf("control predicate Gadget#stale? not found in dead candidates; got %v", keys(byQualified))
+	}
+	if ctrl.Confidence != dead.ConfidenceDead {
+		t.Errorf("control predicate confidence = %q, want %q (rule is not targeted)", ctrl.Confidence, dead.ConfidenceDead)
+	}
+
+	// The synthetic base never surfaces as a dead candidate.
+	if _, leaked := byQualified[extract.RubyCoreStruct]; leaked {
+		t.Error("synthetic ruby-core:Struct leaked into dead output")
+	}
+}
+
+func keys(m map[string]dead.Symbol) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -10,6 +10,7 @@ import (
 	"unicode"
 
 	"github.com/luuuc/sense/internal/embed"
+	"github.com/luuuc/sense/internal/extract"
 	"github.com/luuuc/sense/internal/sqlite"
 	"golang.org/x/sync/errgroup"
 )
@@ -334,10 +335,16 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, SearchMeta
 		return nil, SearchMeta{}, fmt.Errorf("search promote: %w", err)
 	}
 
-	// Apply min_score filter and limit.
+	// Apply min_score filter and limit. Synthetic plumbing symbols
+	// (ruby-core:Struct / ruby-core:Data, emitted only so value-object
+	// inherits edges resolve) are never user-facing — drop them here, the
+	// single chokepoint every retrieval leg funnels through.
 	var results []Result
 	for _, r := range fused {
 		if r.Score < opts.MinScore {
+			continue
+		}
+		if strings.HasPrefix(r.Qualified, extract.PrefixRubyCore) {
 			continue
 		}
 		results = append(results, r)
@@ -774,8 +781,8 @@ func applyGraphCentrality(results []Result, centrality map[int64]int) {
 }
 
 const (
-	enrichTopN     = 3
-	enrichBoost    = 0.15
+	enrichTopN      = 3
+	enrichBoost     = 0.15
 	enrichBaseScore = 0.05
 )
 
@@ -843,7 +850,7 @@ func (e *Engine) enrichFromGraph(ctx context.Context, results []Result) ([]Resul
 				Qualified: sym.Qualified,
 				Kind:      sym.Kind,
 				FileID:    sym.FileID,
-				LineStart:  sym.LineStart,
+				LineStart: sym.LineStart,
 				Snippet:   sym.Snippet,
 				Score:     enrichBaseScore,
 				Source:    SourceGraph,

--- a/internal/search/synthetic_filter_test.go
+++ b/internal/search/synthetic_filter_test.go
@@ -1,0 +1,74 @@
+package search_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/search"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// TestSyntheticSymbolsFilteredFromSearch proves the synthetic value-object
+// base symbols (ruby-core:Struct / ruby-core:Data) never surface in search
+// results, while an ordinary same-named symbol still does — the control
+// that keeps this from passing on an over-broad filter.
+func TestSyntheticSymbolsFilteredFromSearch(t *testing.T) {
+	t.Setenv("SENSE_EMBEDDINGS", "false")
+	dir := t.TempDir()
+	a, err := sqlite.Open(context.Background(), filepath.Join(dir, "index.db"))
+	if err != nil {
+		t.Fatalf("open adapter: %v", err)
+	}
+	t.Cleanup(func() { _ = a.Close() })
+	ctx := context.Background()
+
+	fid, err := a.WriteFile(ctx, &model.File{
+		Path: "app/models/struct.rb", Language: "ruby",
+		Hash: "h", Symbols: 2, IndexedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	// The synthetic plumbing symbol and an ordinary symbol literally named
+	// "Struct" — both match an FTS query for "Struct".
+	for _, s := range []model.Symbol{
+		{FileID: fid, Name: "Struct", Qualified: "ruby-core:Struct", Kind: "class", LineStart: 1, LineEnd: 1},
+		{FileID: fid, Name: "Struct", Qualified: "Geometry::Struct", Kind: "class", LineStart: 2, LineEnd: 3},
+	} {
+		if _, err := a.WriteSymbol(ctx, &s); err != nil {
+			t.Fatalf("write symbol %q: %v", s.Qualified, err)
+		}
+	}
+
+	engine, embedder, err := search.BuildEngine(ctx, a, dir)
+	if err != nil {
+		t.Fatalf("BuildEngine: %v", err)
+	}
+	if embedder != nil {
+		defer func() { _ = embedder.Close() }()
+	}
+
+	results, _, err := engine.Search(ctx, search.Options{Query: "Struct", Limit: 10})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
+	var sawReal, sawSynthetic bool
+	for _, r := range results {
+		switch r.Qualified {
+		case "ruby-core:Struct":
+			sawSynthetic = true
+		case "Geometry::Struct":
+			sawReal = true
+		}
+	}
+	if sawSynthetic {
+		t.Error("synthetic ruby-core:Struct leaked into search results")
+	}
+	if !sawReal {
+		t.Error("ordinary Geometry::Struct missing from search results (filter is over-broad)")
+	}
+}


### PR DESCRIPTION
## Problem
`sense dead` flagged **live** methods as dead on a common Ruby idiom: predicate
methods defined inside a nested value object (`Result = Struct.new(...) do def
success? … end end`) were attributed to the *enclosing class*, not the struct —
poisoning the qualified name, the graph edges, and the dead-code verdict at once.
The suggested verify command then emitted a bare `grep "success?"` that floods
the caller with hundreds of KB. An agent reading that output learns to distrust
the tool.

## Summary
Attribute nested `Struct.new` / `Data.define` / `Class.new` constants as nested
classes, recognize value objects structurally so their duck-typed methods get an
accurate verdict, and make the verify command precise instead of a flood.

## Changes
- **extract:** `CONST = Struct.new(...)` / `Data.define(...)` / `Class.new(Super)`
  (with or without a block) are emitted as nested classes; block methods qualify
  to the constant (`Service::Result#success?`). Struct/Data value objects emit an
  `inherits` edge to a synthetic `ruby-core:Struct`/`ruby-core:Data` base so the
  edge persists under `target_id NOT NULL`.
- **dead:** value-object public instance methods soften to `possibly_dead` keyed
  on the inheritance edge (framework-independent). A residual predicate softening
  is retained, gated on a dynamic framework, after validation showed removing it
  hard-flagged live predicates as dead.
- **mcpio:** `verify_cmd` scopes to call syntax (`\.name`), excludes the
  definition's own file:line, and emits a `verify_too_common` manual-inspect hint
  when a name is too common to grep usefully.
- **search:** synthetic `ruby-core:` base symbols are filtered from results.

## Architecture Highlights
- Value-object status is expressed via the existing `inherits` edge to a synthetic
  base symbol — **no schema change** — and is queryable (`sense graph Result` shows
  `inherits ruby-core:Struct`).
- The attribution fix is the root cause: one extractor change corrects qualified
  names, graph edges, and dead-code verdicts together.
- Removing the blanket "every `foo?` is uncertain" net was deliberately *not* taken
  all the way: on a real Rails app, predicates are pervasively dispatched on
  duck-typed receivers the indexer can't resolve, so hard-flagging them produces
  confident false negatives. A false `dead` erodes trust more than a conservative
  `possibly_dead`.

## Test Plan
- [x] Ruby extractor: nested `Struct.new`/`Data.define`/`Class.new` (+ module-nested,
      no-block, negative) cases assert the exact qualified name and the persisted
      `inherits` edge to the synthetic base
- [x] Dead-code: value-object predicate is `possibly_dead` while a genuine dead
      predicate (control) stays `dead`; synthetic symbols never surface
- [x] verify_cmd: call-scoped pattern, def-site exclusion, and too-common flag at
      the threshold boundary
- [x] Search: synthetic base filtered, ordinary same-named symbol retained
- [x] `go test ./...` passes
- [x] sense binary builds cleanly