### PR TITLE
feat(extract): promote ERB to Full tier (embedded Ruby + routes)

### DIFF
--- a/internal/blast/engine.go
+++ b/internal/blast/engine.go
@@ -171,6 +171,12 @@ type Result struct {
 
 	EdgesTraversed    int
 	SubjectHasCallees bool
+	// ViewReached is true when a view template (ERB) reaches the subject via a
+	// calls/references edge. Such edges have a NULL source_id (the source is a
+	// template, not a symbol), so they never appear in DirectCallers — the BFS
+	// only traverses symbol→symbol edges. ViewReached is the only place a
+	// view-helper or Stimulus-dispatched symbol's view reachability surfaces.
+	ViewReached bool
 
 	// Edge-kind groups: filtered views over the same nodes that appear
 	// in DirectCallers/IndirectCallers. A node appears in at most one
@@ -213,6 +219,7 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 	}
 
 	hasCallees := subjectHasCallees(ctx, db, symbolIDs)
+	viewReached := subjectViewReached(ctx, db, symbolIDs)
 
 	visited := map[int64]int{}
 	predecessor := map[int64]int64{}
@@ -510,6 +517,7 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 		TotalAffected:          totalAffectedCount,
 		EdgesTraversed:         edgesTraversed,
 		SubjectHasCallees:      hasCallees,
+		ViewReached:            viewReached,
 		DirectTemporalIDs:      directTemporalIDs,
 		DirectEdgeSites:        directEdgeSites,
 		AffectedSubclasses:     subclasses,
@@ -536,6 +544,26 @@ func subjectHasCallees(ctx context.Context, db *sql.DB, symbolIDs []int64) bool 
 	placeholders := strings.Repeat("?,", len(symbolIDs))
 	placeholders = placeholders[:len(placeholders)-1]
 	q := `SELECT 1 FROM sense_edges WHERE source_id IN (` + placeholders + `) AND kind = 'calls' LIMIT 1`
+	args := make([]any, len(symbolIDs))
+	for i, id := range symbolIDs {
+		args[i] = id
+	}
+	var one int
+	return db.QueryRowContext(ctx, q, args...).Scan(&one) == nil
+}
+
+// subjectViewReached reports whether a view template (ERB) reaches any of the
+// subject symbols via a calls/references edge. These edges carry a NULL
+// source_id, so they are invisible to the symbol→symbol BFS; this direct
+// edge-table check is the only way the subject's view reachability surfaces.
+func subjectViewReached(ctx context.Context, db *sql.DB, symbolIDs []int64) bool {
+	placeholders := strings.Repeat("?,", len(symbolIDs))
+	placeholders = placeholders[:len(placeholders)-1]
+	q := `SELECT 1 FROM sense_edges e
+		JOIN sense_files f ON e.file_id = f.id
+		WHERE e.target_id IN (` + placeholders + `)
+		AND e.kind IN ('calls', 'references')
+		AND f.path LIKE '%.erb' LIMIT 1`
 	args := make([]any, len(symbolIDs))
 	for i, id := range symbolIDs {
 		args[i] = id

--- a/internal/cli/index.go
+++ b/internal/cli/index.go
@@ -67,17 +67,22 @@ func OpenIndex(ctx context.Context, dir string) (*sqlite.Adapter, error) {
 func CollectFileIDs(sc *model.SymbolContext) []int64 {
 	seen := map[int64]struct{}{sc.File.ID: {}}
 	ids := []int64{sc.File.ID}
-	for _, e := range sc.Outbound {
-		if _, ok := seen[e.Target.FileID]; !ok {
-			seen[e.Target.FileID] = struct{}{}
-			ids = append(ids, e.Target.FileID)
+	add := func(id int64) {
+		if _, ok := seen[id]; !ok {
+			seen[id] = struct{}{}
+			ids = append(ids, id)
 		}
 	}
+	for _, e := range sc.Outbound {
+		add(e.Target.FileID)
+		// The edge's own file — for an ERB view edge this is the template,
+		// distinct from the (absent, NULL-source) caller symbol's file. Needed
+		// so the file lookup can resolve it for view_edges and call-site snippets.
+		add(e.Edge.FileID)
+	}
 	for _, e := range sc.Inbound {
-		if _, ok := seen[e.Target.FileID]; !ok {
-			seen[e.Target.FileID] = struct{}{}
-			ids = append(ids, e.Target.FileID)
-		}
+		add(e.Target.FileID)
+		add(e.Edge.FileID)
 	}
 	return ids
 }
@@ -90,18 +95,20 @@ func CollectGraphFileIDs(gr *model.GraphResult) []int64 {
 	for _, id := range ids {
 		seen[id] = struct{}{}
 	}
+	add := func(id int64) {
+		if _, ok := seen[id]; !ok {
+			seen[id] = struct{}{}
+			ids = append(ids, id)
+		}
+	}
 	for _, layer := range gr.Layers {
 		for _, e := range layer.Outbound {
-			if _, ok := seen[e.Target.FileID]; !ok {
-				seen[e.Target.FileID] = struct{}{}
-				ids = append(ids, e.Target.FileID)
-			}
+			add(e.Target.FileID)
+			add(e.Edge.FileID)
 		}
 		for _, e := range layer.Inbound {
-			if _, ok := seen[e.Target.FileID]; !ok {
-				seen[e.Target.FileID] = struct{}{}
-				ids = append(ids, e.Target.FileID)
-			}
+			add(e.Target.FileID)
+			add(e.Edge.FileID)
 		}
 	}
 	return ids

--- a/internal/cli/index_test.go
+++ b/internal/cli/index_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -98,5 +99,69 @@ func TestOpenIndexNotRebuiltWhenCurrent(t *testing.T) {
 	}
 	if len(paths) != 1 {
 		t.Errorf("expected 1 file preserved, got %d", len(paths))
+	}
+}
+
+func TestLoadFilePaths(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.ExecContext(ctx, `CREATE TABLE sense_files (id INTEGER PRIMARY KEY, path TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Empty input short-circuits to an empty map without querying.
+	if got, err := LoadFilePaths(ctx, db, nil); err != nil || len(got) != 0 {
+		t.Fatalf("LoadFilePaths(nil) = %v, %v; want empty map, nil", got, err)
+	}
+
+	// Seed more than one chunk (chunk size is 500) so the batching loop runs
+	// for multiple iterations.
+	const n = 600
+	ids := make([]int64, n)
+	for i := 0; i < n; i++ {
+		id := int64(i + 1)
+		ids[i] = id
+		if _, err := db.ExecContext(ctx, `INSERT INTO sense_files (id, path) VALUES (?, ?)`, id, fmt.Sprintf("app/f%d.rb", id)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := LoadFilePaths(ctx, db, ids)
+	if err != nil {
+		t.Fatalf("LoadFilePaths: %v", err)
+	}
+	if len(got) != n {
+		t.Fatalf("got %d paths, want %d (multi-chunk)", len(got), n)
+	}
+	if got[1] != "app/f1.rb" || got[600] != "app/f600.rb" {
+		t.Errorf("path mismatch: [1]=%q [600]=%q", got[1], got[600])
+	}
+}
+
+func TestLoadFilePathsQueryError(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	// No sense_files table — the query fails and the error must propagate.
+	if _, err := LoadFilePaths(ctx, db, []int64{1, 2}); err == nil {
+		t.Fatal("expected an error when sense_files is missing")
+	}
+}
+
+func TestOpenIndexMissing(t *testing.T) {
+	// A directory with no .sense/index.db returns ErrIndexMissing.
+	_, err := OpenIndex(context.Background(), t.TempDir())
+	if !errors.Is(err, ErrIndexMissing) {
+		t.Fatalf("OpenIndex on empty dir = %v, want ErrIndexMissing", err)
+	}
+	// Empty dir defaults to "." — also missing an index here.
+	if _, err := OpenIndex(context.Background(), ""); !errors.Is(err, ErrIndexMissing) {
+		t.Fatalf("OpenIndex(\"\") = %v, want ErrIndexMissing", err)
 	}
 }

--- a/internal/dead/dead.go
+++ b/internal/dead/dead.go
@@ -22,6 +22,13 @@ const defaultLimit = 100
 // contains no LIKE metacharacters, so no ESCAPE clause is needed.
 const syntheticPrefixPattern = extract.PrefixRubyCore + "%"
 
+// routePrefixPattern matches the synthetic route:* helper symbols the route
+// DSL emits (route:orders_path → OrdersController#index). They are plumbing
+// for the view → route-helper → controller chain; a rarely-referenced one
+// (e.g. an `*_url` variant) has no incoming edge and would otherwise read as a
+// dead Ruby constant, so it is excluded from dead-code analysis like ruby-core.
+const routePrefixPattern = extract.PrefixRoute + "%"
+
 type Options struct {
 	Language        string
 	Domain          string
@@ -173,7 +180,8 @@ func countSymbols(ctx context.Context, db *sql.DB, opts Options) (int, error) {
 	q := `SELECT COUNT(*) FROM sense_symbols s
 		JOIN sense_files f ON s.file_id = f.id
 		WHERE s.kind IN ('function', 'method', 'class', 'module', 'type', 'interface', 'constant')
-		AND s.qualified NOT LIKE '` + syntheticPrefixPattern + `'`
+		AND s.qualified NOT LIKE '` + syntheticPrefixPattern + `'
+		AND s.qualified NOT LIKE '` + routePrefixPattern + `'`
 	var args []any
 
 	if opts.Language != "" {
@@ -217,7 +225,8 @@ func queryCandidates(ctx context.Context, db *sql.DB, opts Options) ([]Symbol, e
 		JOIN sense_files f ON s.file_id = f.id
 		WHERE NOT EXISTS (` + edgeFilter + `)
 		AND s.kind IN ('function', 'method', 'class', 'module', 'type', 'interface', 'constant')
-		AND s.qualified NOT LIKE '` + syntheticPrefixPattern + `'`
+		AND s.qualified NOT LIKE '` + syntheticPrefixPattern + `'
+		AND s.qualified NOT LIKE '` + routePrefixPattern + `'`
 	var args []any
 
 	if opts.Language != "" {

--- a/internal/dead/dead_test.go
+++ b/internal/dead/dead_test.go
@@ -1247,3 +1247,47 @@ func writeFile(t *testing.T, path, content string) {
 		t.Fatalf("write: %v", err)
 	}
 }
+
+// TestFindDeadExcludesRouteHelpers proves synthetic route:* helper symbols —
+// emitted by the route DSL and often unreferenced (e.g. the _url twins) — are
+// never reported as dead Ruby code, while an ordinary same-named app method
+// still is. Mirrors the ruby-core synthetic filter.
+func TestFindDeadExcludesRouteHelpers(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "config", "routes.rb"), `Rails.application.routes.draw do
+  resources :orders
+end
+`)
+	// An ordinary, uncalled method literally named orders_url — the control
+	// that proves the filter keys on the route: prefix, not the bare name.
+	writeFile(t, filepath.Join(root, "app", "models", "billing.rb"), `class Billing
+  def orders_url
+    "x"
+  end
+end
+`)
+
+	ctx := context.Background()
+	if _, err := scan.Run(ctx, scan.Options{Root: root, Output: &bytes.Buffer{}, Warnings: io.Discard}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(root, ".sense", "index.db"))
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	result, err := dead.FindDead(ctx, db, dead.Options{})
+	if err != nil {
+		t.Fatalf("FindDead: %v", err)
+	}
+	var sawRouteHelper bool
+	for _, s := range result.Dead {
+		if len(s.Qualified) >= 6 && s.Qualified[:6] == "route:" {
+			sawRouteHelper = true
+		}
+	}
+	if sawRouteHelper {
+		t.Error("a synthetic route:* helper leaked into dead-code output")
+	}
+}

--- a/internal/extract/erb/collection_test.go
+++ b/internal/extract/erb/collection_test.go
@@ -1,0 +1,119 @@
+package erb
+
+import (
+	"testing"
+
+	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/model"
+)
+
+func findEdgeKind(r *recorder, target string, kind model.EdgeKind) *extract.EmittedEdge {
+	for i := range r.edges {
+		if r.edges[i].TargetQualified == target && r.edges[i].Kind == kind {
+			return &r.edges[i]
+		}
+	}
+	return nil
+}
+
+func TestRenderCollection_PluralIvar(t *testing.T) {
+	r := extractERB(t, "<%= render @posts %>", "app/views/posts/index.html.erb")
+	e := findEdgeKind(r, extract.PrefixPartial+"posts/post", model.EdgeCalls)
+	if e == nil {
+		t.Fatalf("expected partial:posts/post edge, got %v", erbTargets(r))
+	}
+	if e.Line == nil || *e.Line != 1 {
+		t.Errorf("edge line = %v, want 1", e.Line)
+	}
+}
+
+func TestRenderCollection_KeywordAndCompoundName(t *testing.T) {
+	r := extractERB(t, "<%= render collection: @line_items %>", "v.erb")
+	if findEdgeKind(r, extract.PrefixPartial+"line_items/line_item", model.EdgeCalls) == nil {
+		t.Fatalf("expected partial:line_items/line_item edge, got %v", erbTargets(r))
+	}
+}
+
+func TestRenderCollection_SingularIvarSkipped(t *testing.T) {
+	// `render @post` (singular) would need pluralization to build the directory;
+	// guessing is a phantom, so no collection edge is emitted.
+	r := extractERB(t, "<%= render @post %>", "v.erb")
+	if findEdgeKind(r, extract.PrefixPartial+"post/post", model.EdgeCalls) != nil {
+		t.Errorf("singular ivar must not emit a guessed collection partial; got %v", erbTargets(r))
+	}
+}
+
+func TestRenderCollection_ExplicitPartialWins(t *testing.T) {
+	// An explicit partial: path is authoritative; the convention must not also
+	// guess posts/post from the collection ivar.
+	r := extractERB(t, `<%= render partial: "posts/card", collection: @posts %>`, "v.erb")
+	if findEdgeKind(r, extract.PrefixPartial+"posts/card", model.EdgeCalls) == nil {
+		t.Errorf("expected the explicit partial:posts/card edge, got %v", erbTargets(r))
+	}
+	if findEdgeKind(r, extract.PrefixPartial+"posts/post", model.EdgeCalls) != nil {
+		t.Errorf("convention must not override an explicit partial; got %v", erbTargets(r))
+	}
+}
+
+func TestFormModel_KeywordShape(t *testing.T) {
+	r := extractERB(t, `<%= form_with model: @order do |f| %>`, "app/views/orders/new.html.erb")
+	e := findEdgeKind(r, "Order", model.EdgeReferences)
+	if e == nil {
+		t.Fatalf("expected references edge to Order, got %v", erbTargets(r))
+	}
+	if e.Confidence != extract.ConfidenceConvention {
+		t.Errorf("form-model edge confidence = %v, want %v", e.Confidence, extract.ConfidenceConvention)
+	}
+}
+
+func TestFormModel_PositionalFormFor(t *testing.T) {
+	r := extractERB(t, `<%= form_for @user do |f| %>`, "v.erb")
+	if findEdgeKind(r, "User", model.EdgeReferences) == nil {
+		t.Fatalf("expected references edge to User, got %v", erbTargets(r))
+	}
+}
+
+func TestFormModel_NoModelNoEdge(t *testing.T) {
+	r := extractERB(t, `<%= form_with url: search_path do |f| %>`, "v.erb")
+	for _, e := range r.edges {
+		if e.Kind == model.EdgeReferences {
+			t.Errorf("a form with no model should emit no references edge, got %q", e.TargetQualified)
+		}
+	}
+}
+
+func TestFormModel_GatedOnFormContext(t *testing.T) {
+	// `model:` outside a form_with/form_for is not a form binding — no edge.
+	r := extractERB(t, `<%= some_helper model: @order %>`, "v.erb")
+	if findEdgeKind(r, "Order", model.EdgeReferences) != nil {
+		t.Errorf("model: outside a form must not emit a model edge; got %v", erbTargets(r))
+	}
+}
+
+func TestRenderCollectionEmitError(t *testing.T) {
+	err := (Extractor{}).ExtractRaw([]byte(`<%= render @posts %>`), "v.erb", &failEdgeEmitter{})
+	if err == nil {
+		t.Error("expected error from failing edge emitter on render-collection")
+	}
+}
+
+func TestFormModelEmitError(t *testing.T) {
+	err := (Extractor{}).ExtractRaw([]byte(`<%= form_with model: @order do |f| %>`), "v.erb", &failEdgeEmitter{})
+	if err == nil {
+		t.Error("expected error from failing edge emitter on form-model")
+	}
+}
+
+func TestFormModel_DedupSameModel(t *testing.T) {
+	// Both the positional and keyword shapes name the same model — emit once.
+	r := extractERB(t, `<%= form_for @order, model: @order do |f| %>`, "v.erb")
+	var count int
+	for _, e := range r.edges {
+		if e.TargetQualified == "Order" && e.Kind == model.EdgeReferences {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("Order references edge emitted %d times, want 1 (deduped)", count)
+	}
+}

--- a/internal/extract/erb/embedded_test.go
+++ b/internal/extract/erb/embedded_test.go
@@ -1,0 +1,188 @@
+package erb
+
+import (
+	"testing"
+
+	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/model"
+)
+
+func findERBEdge(r *recorder, target string) *extract.EmittedEdge {
+	for i := range r.edges {
+		if r.edges[i].TargetQualified == target && r.edges[i].Kind == model.EdgeCalls {
+			return &r.edges[i]
+		}
+	}
+	return nil
+}
+
+func erbTargets(r *recorder) []string {
+	out := make([]string, 0, len(r.edges))
+	for _, e := range r.edges {
+		out = append(out, e.TargetQualified)
+	}
+	return out
+}
+
+// The receiver chain and block body — invisible to the receiver-stripping
+// regex — now each emit a resolved call, at the ERB line they appear on.
+func TestEmbeddedRuby_ReceiverChainAndBlock(t *testing.T) {
+	r := extractERB(t, "<ul>\n<% @cart.items.each do |i| %>\n<li><%= i.listing.title %></li>\n<% end %>\n</ul>", "app/views/carts/show.html.erb")
+
+	cases := map[string]int{
+		"items":   2, // @cart.items, on line 2
+		"each":    2,
+		"listing": 3, // i.listing.title, on line 3
+		"title":   3,
+	}
+	for target, wantLine := range cases {
+		e := findERBEdge(r, target)
+		if e == nil {
+			t.Errorf("expected chain/block call %q to emit an edge; got %v", target, erbTargets(r))
+			continue
+		}
+		if e.SourceQualified != "app/views/carts/show.html.erb" {
+			t.Errorf("%q edge source = %q, want the ERB file path", target, e.SourceQualified)
+		}
+		if e.Line == nil || *e.Line != wantLine {
+			t.Errorf("%q edge line = %v, want %d", target, e.Line, wantLine)
+		}
+	}
+}
+
+// A receiver-position helper (`current_user`) is emitted by the regex pass
+// (the walker can't see it), while the method on it (`email`) is emitted by
+// the walker. Both survive.
+func TestEmbeddedRuby_ReceiverPositionHelperKept(t *testing.T) {
+	r := extractERB(t, `<%= current_user.email %>`, "v.erb")
+	if findERBEdge(r, "self.current_user") == nil {
+		t.Errorf("expected self.current_user (receiver-position helper), got %v", erbTargets(r))
+	}
+	if findERBEdge(r, "email") == nil {
+		t.Errorf("expected the email call on current_user, got %v", erbTargets(r))
+	}
+}
+
+// A receiverless call found by both passes collapses to a single edge, keeping
+// the higher-confidence (walker, 1.0) variant.
+func TestEmbeddedRuby_DedupsAcrossPasses(t *testing.T) {
+	r := extractERB(t, `<%= format_money(total) %>`, "v.erb")
+	var count int
+	for _, e := range r.edges {
+		if e.TargetQualified == "self.format_money" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("self.format_money emitted %d times, want 1 (deduped); edges=%v", count, erbTargets(r))
+	}
+	e := findERBEdge(r, "self.format_money")
+	if e.Confidence != extract.ConfidenceConvention {
+		t.Errorf("deduped edge confidence = %v, want the helper pass's %v (it runs first and claims the call)",
+			e.Confidence, extract.ConfidenceConvention)
+	}
+}
+
+// A split `<% if %> … <% end %>` conditional must not abort the scan, and the
+// predicate is still captured (by the regex pass, since the walker cannot
+// recover a dangling `if signed_in?` standalone).
+func TestEmbeddedRuby_SplitIfEndCaptured(t *testing.T) {
+	r := extractERB(t, "<% if signed_in? %>\n<p>hi</p>\n<% end %>", "v.erb")
+	if findERBEdge(r, "self.signed_in?") == nil {
+		t.Errorf("expected self.signed_in? from the split conditional, got %v", erbTargets(r))
+	}
+}
+
+// DSL helpers with a dedicated pass (render) do not also emit a bare
+// self.<helper> edge from the embedded walker.
+func TestEmbeddedRuby_DedicatedHelpersFiltered(t *testing.T) {
+	r := extractERB(t, `<%= render "shared/header" %>`, "app/views/pages/home.html.erb")
+	if findERBEdge(r, "self.render") != nil {
+		t.Errorf("render should not emit a bare self.render edge; got %v", erbTargets(r))
+	}
+	if findERBEdge(r, extract.PrefixPartial+"shared/header") == nil {
+		t.Errorf("expected the dedicated partial edge, got %v", erbTargets(r))
+	}
+}
+
+// A dangling `<% end %>` from a split block must not leak a `self.end` keyword
+// edge — the fragment walker mis-parses the bare keyword as a call, and the
+// dedup/skip layer drops it.
+func TestEmbeddedRuby_KeywordNotEmitted(t *testing.T) {
+	r := extractERB(t, "<% if signed_in? %>\n<p>hi</p>\n<% end %>", "v.erb")
+	for _, kw := range []string{"self.end", "self.if"} {
+		if findERBEdge(r, kw) != nil {
+			t.Errorf("keyword edge %q must not be emitted, got %v", kw, erbTargets(r))
+		}
+	}
+}
+
+func TestEmbeddedRubyCode(t *testing.T) {
+	cases := map[string]string{
+		"= current_user":  "current_user", // <%= output marker
+		" foo.bar ":       "foo.bar",       // <% plain
+		"- trimmed":       "trimmed",       // <%- whitespace-trim marker
+		"= -1":            "-1",            // unary minus after the output marker survives
+		" -1":             "-1",            // <% -1 %>: leading space means '-' is unary minus, not a marker
+		"":                "",
+		"   ":             "",
+		"current_user":    "current_user",
+	}
+	for in, want := range cases {
+		if got := embeddedRubyCode(in); got != want {
+			t.Errorf("embeddedRubyCode(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestEmbeddedRuby_EmptyTagNoParse(t *testing.T) {
+	// `<% %>` has no Ruby to parse — extractEmbeddedRuby short-circuits on the
+	// empty code, emitting nothing.
+	r := extractERB(t, `<% %>`, "v.erb")
+	if len(r.edges) != 0 {
+		t.Errorf("empty tag should emit no edges, got %v", erbTargets(r))
+	}
+}
+
+func TestDedupEmitter(t *testing.T) {
+	ln := 7
+	mk := func(target string) extract.EmittedEdge {
+		l := ln
+		return extract.EmittedEdge{SourceQualified: "v.erb", TargetQualified: target, Kind: model.EdgeCalls, Line: &l, Confidence: 0.9}
+	}
+
+	r := &recorder{}
+	d := dedupEmitter{inner: r, seen: map[string]bool{}}
+
+	// First occurrence emits; the exact-same call at the same line is dropped.
+	if err := d.Edge(mk("self.foo")); err != nil {
+		t.Fatal(err)
+	}
+	if err := d.Edge(mk("self.foo")); err != nil {
+		t.Fatal(err)
+	}
+	// A dedicated-helper self-call is dropped entirely.
+	if err := d.Edge(mk("self.render")); err != nil {
+		t.Fatal(err)
+	}
+	// A symbol passes straight through.
+	if err := d.Symbol(extract.EmittedSymbol{Qualified: "partial:x"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(r.edges) != 1 || r.edges[0].TargetQualified != "self.foo" {
+		t.Errorf("edges = %v, want exactly [self.foo]", erbTargets(r))
+	}
+	if len(r.symbols) != 1 || r.symbols[0].Qualified != "partial:x" {
+		t.Errorf("symbols = %v, want [partial:x]", r.symbols)
+	}
+}
+
+func TestEmbeddedRuby_CommentTagSkipped(t *testing.T) {
+	// `<%# ... %>` is a comment — extractTemplateRuby skips it before the
+	// embedded pass, so no edge is emitted for its contents.
+	r := extractERB(t, `<%# render "x"; current_user %>`, "v.erb")
+	if len(r.edges) != 0 {
+		t.Errorf("comment tag should emit no edges, got %v", erbTargets(r))
+	}
+}

--- a/internal/extract/erb/erb.go
+++ b/internal/extract/erb/erb.go
@@ -15,11 +15,13 @@ import (
 	"bytes"
 	"path"
 	"regexp"
+	"strconv"
 	"strings"
 
 	sitter "github.com/tree-sitter/go-tree-sitter"
 
 	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/extract/ruby"
 	"github.com/luuuc/sense/internal/model"
 )
 
@@ -36,7 +38,7 @@ func (Extractor) Extract(_ *sitter.Tree, source []byte, filePath string, emit ex
 }
 
 func (Extractor) ExtractRaw(source []byte, filePath string, emit extract.Emitter) error {
-	w := &walker{source: source, filePath: filePath, emit: emit}
+	w := &walker{source: source, filePath: filePath, emit: emit, embedSeen: map[string]bool{}}
 	return w.walk()
 }
 
@@ -109,6 +111,10 @@ type walker struct {
 	source   []byte
 	filePath string
 	emit     extract.Emitter
+	// embedSeen is the dedup key set shared by the two passes that parse a
+	// tag's embedded Ruby — the regex helper pass and the tree-sitter walker.
+	// A call both find collapses to one edge (see dedupEmitter).
+	embedSeen map[string]bool
 }
 
 func (w *walker) walk() error {
@@ -145,6 +151,38 @@ func (w *walker) walk() error {
 		}
 	}
 	return nil
+}
+
+// dedupEmitter wraps the real emitter for the two passes that parse a tag's
+// embedded Ruby — the regex helper pass and the tree-sitter fragment walker.
+// The two overlap on plain receiverless calls; dedupEmitter collapses a call
+// both find (keyed by target/kind/line — the source is always this file) so it
+// is emitted once. It also drops a `self.<name>` edge whose name is in
+// erbHelperSkip: a Ruby keyword the fragment walker mis-parsed as a bare call
+// in a split tag (`<% end %>` → `self.end`), or a helper that has a dedicated
+// cross-language pass (render → partial:, turbo_stream_from → turbo-channel:,
+// …). Symbols pass through untouched.
+type dedupEmitter struct {
+	inner extract.Emitter
+	seen  map[string]bool
+}
+
+func (d dedupEmitter) Symbol(s extract.EmittedSymbol) error { return d.inner.Symbol(s) }
+
+func (d dedupEmitter) Edge(e extract.EmittedEdge) error {
+	if name, ok := strings.CutPrefix(e.TargetQualified, "self."); ok && erbHelperSkip[name] {
+		return nil
+	}
+	line := 0
+	if e.Line != nil {
+		line = *e.Line
+	}
+	key := e.TargetQualified + "\x00" + string(e.Kind) + "\x00" + strconv.Itoa(line)
+	if d.seen[key] {
+		return nil
+	}
+	d.seen[key] = true
+	return d.inner.Edge(e)
 }
 
 func (w *walker) extractControllers(line string, lineNum int) error {
@@ -307,11 +345,53 @@ func (w *walker) extractTemplateRuby(line string, lineNum int) error {
 		if err := w.extractI18n(inner, lineNum); err != nil {
 			return err
 		}
+		// Helper pass first: it claims the bare receiverless calls (and
+		// receiver-position helpers the walker can't see) at convention
+		// confidence; the embedded walker then adds the calls the regex misses
+		// (chains, blocks, args), skipping anything the helper pass already
+		// recorded via the shared dedup set.
 		if err := w.extractHelperCalls(inner, lineNum); err != nil {
+			return err
+		}
+		if err := w.extractEmbeddedRuby(inner, lineNum); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// extractEmbeddedRuby parses the inner Ruby of one ERB tag with the Ruby
+// grammar itself, so receivers, method chains, and block bodies resolve —
+// `@cart.items.each { |i| i.listing.title }` emits its chain of calls, none of
+// which the receiver-stripping regex pass below can see. Edges are routed
+// through the dedup buffer, so the plain calls this and the regex pass both
+// find collapse to one; the regex pass survives only for the receiver-position
+// helpers (`current_user` in `current_user.email`) the walker doesn't emit.
+//
+// lineNum-1 is the line offset: the tag's content lives on ERB line lineNum,
+// so a fragment-line-1 call maps back to lineNum.
+func (w *walker) extractEmbeddedRuby(inner string, lineNum int) error {
+	code := embeddedRubyCode(inner)
+	if code == "" {
+		return nil
+	}
+	emit := dedupEmitter{inner: w.emit, seen: w.embedSeen}
+	return ruby.ExtractEmbeddedCalls([]byte(code), lineNum-1, w.filePath, emit)
+}
+
+// embeddedRubyCode strips a tag's ERB output/trim markers to leave parseable
+// Ruby. The leading `=` (output, `<%=`) or flush `-` (whitespace trim, `<%-`)
+// marker is dropped; a `-` that follows whitespace is a unary minus in code
+// (`<% -1 %>`), not a marker, so the check runs on the untrimmed input.
+func embeddedRubyCode(inner string) string {
+	s := inner
+	switch {
+	case strings.HasPrefix(s, "="):
+		s = s[1:]
+	case strings.HasPrefix(s, "-"):
+		s = s[1:]
+	}
+	return strings.TrimSpace(s)
 }
 
 // extractRender emits a calls edge to each rendered partial. The target is the
@@ -363,6 +443,7 @@ func (w *walker) extractI18n(inner string, lineNum int) error {
 // defined symbol, so unknown framework helpers fall away.
 func (w *walker) extractHelperCalls(inner string, lineNum int) error {
 	stripped := reRubyLiteral.ReplaceAllString(inner, " ")
+	emit := dedupEmitter{inner: w.emit, seen: w.embedSeen}
 	seen := map[string]bool{}
 	for _, m := range reHelperName.FindAllStringSubmatch(stripped, -1) {
 		name := m[1]
@@ -371,7 +452,7 @@ func (w *walker) extractHelperCalls(inner string, lineNum int) error {
 		}
 		seen[name] = true
 		ln := lineNum
-		if err := w.emit.Edge(extract.EmittedEdge{
+		if err := emit.Edge(extract.EmittedEdge{
 			SourceQualified: w.filePath,
 			TargetQualified: "self." + name,
 			Kind:            model.EdgeCalls,

--- a/internal/extract/erb/erb.go
+++ b/internal/extract/erb/erb.go
@@ -79,6 +79,22 @@ var (
 	// render(template: "x"). Captures the first partial-path string literal.
 	reRender = regexp.MustCompile(`\brender\b\s*\(?\s*(?:partial:|template:|layout:)?\s*["']([\w./-]+)["']`)
 
+	// render @posts / render collection: @posts / render(@posts) — an implicit
+	// collection render with no explicit partial. Captures the ivar name; the
+	// partial path is derived by Rails' to_partial_path convention.
+	reRenderCollection = regexp.MustCompile(`\brender\b\s*\(?\s*(?:collection:\s*)?@([a-z_][a-zA-Z0-9_]*)`)
+
+	// An explicit partial:/template: keyword means the render path is given
+	// literally (handled by reRender); the collection convention must not also
+	// guess a path from the ivar, which would be a phantom.
+	reRenderPartialKw = regexp.MustCompile(`\b(?:partial|template):`)
+
+	// form_with / form_for context, and the two shapes that name a model:
+	// `form_for @order` (positional) and `model: @order` (keyword).
+	reFormTag    = regexp.MustCompile(`\bform_(?:with|for)\b`)
+	reFormForArg = regexp.MustCompile(`\bform_for\s*\(?\s*@([a-z_][a-zA-Z0-9_]*)`)
+	reModelArg   = regexp.MustCompile(`\bmodel:\s*@([a-z_][a-zA-Z0-9_]*)`)
+
 	// t(".key") / t("a.b.c") / translate("...") / I18n.t("..."). Keys with
 	// interpolation (#{...}) are skipped — the literal isn't a stable key.
 	reI18n = regexp.MustCompile(`\b(?:I18n\.)?(?:t|translate)\b\s*\(?\s*["']([a-zA-Z0-9_.]+)["']`)
@@ -342,6 +358,12 @@ func (w *walker) extractTemplateRuby(line string, lineNum int) error {
 		if err := w.extractRender(inner, lineNum); err != nil {
 			return err
 		}
+		if err := w.extractRenderCollection(inner, lineNum); err != nil {
+			return err
+		}
+		if err := w.extractFormModel(inner, lineNum); err != nil {
+			return err
+		}
 		if err := w.extractI18n(inner, lineNum); err != nil {
 			return err
 		}
@@ -409,6 +431,79 @@ func (w *walker) extractRender(inner string, lineNum int) error {
 			Line:            &ln,
 			Confidence:      extract.ConfidenceConvention,
 		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// extractRenderCollection emits a calls edge for an implicit collection render
+// (`render @posts`, `render collection: @posts`) to the partial that Rails'
+// to_partial_path convention resolves it to: `posts/_post`, i.e. the render
+// path `posts/post`. The directory is the (plural) ivar name; the partial name
+// is its singular form. Only plural ivars are handled — a singular ivar
+// (`render @post`) would need pluralization to build the directory, and
+// guessing wrong is a phantom, so it is skipped. A render with an explicit
+// partial:/template: keyword is left to extractRender; the convention does not
+// override a literal path.
+func (w *walker) extractRenderCollection(inner string, lineNum int) error {
+	if reRenderPartialKw.MatchString(inner) {
+		return nil
+	}
+	for _, m := range reRenderCollection.FindAllStringSubmatch(inner, -1) {
+		ivar := m[1]
+		singular := ruby.Singularize(ivar)
+		if singular == ivar {
+			continue // singular ivar — cannot build the plural directory safely
+		}
+		ln := lineNum
+		if err := w.emit.Edge(extract.EmittedEdge{
+			SourceQualified: w.filePath,
+			TargetQualified: extract.PrefixPartial + ivar + "/" + singular,
+			Kind:            model.EdgeCalls,
+			Line:            &ln,
+			Confidence:      extract.ConfidenceConvention,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// extractFormModel emits a references edge from the view to the model a form
+// binds to: `form_with model: @order` / `form_for @order` → `Order`, by
+// classifying the ivar name. The edge resolves only if that model class is
+// indexed (unresolved edges are dropped at write time), so a form for a model
+// that does not exist emits nothing downstream. Both the positional
+// (`form_for @x`) and keyword (`model: @x`) shapes are covered; the keyword
+// scan is gated on form context so a stray `model:` elsewhere can't match.
+func (w *walker) extractFormModel(inner string, lineNum int) error {
+	if !reFormTag.MatchString(inner) {
+		return nil
+	}
+	seen := map[string]bool{}
+	emitModel := func(ivar string) error {
+		class := ruby.Classify(ivar) // never empty: the ivar regex guarantees a name
+		if seen[class] {
+			return nil
+		}
+		seen[class] = true
+		ln := lineNum
+		return w.emit.Edge(extract.EmittedEdge{
+			SourceQualified: w.filePath,
+			TargetQualified: class,
+			Kind:            model.EdgeReferences,
+			Line:            &ln,
+			Confidence:      extract.ConfidenceConvention,
+		})
+	}
+	for _, m := range reFormForArg.FindAllStringSubmatch(inner, -1) {
+		if err := emitModel(m[1]); err != nil {
+			return err
+		}
+	}
+	for _, m := range reModelArg.FindAllStringSubmatch(inner, -1) {
+		if err := emitModel(m[1]); err != nil {
 			return err
 		}
 	}

--- a/internal/extract/erb/erb.go
+++ b/internal/extract/erb/erb.go
@@ -121,6 +121,12 @@ var erbHelperSkip = map[string]bool{
 	"super": true, "render": true, "t": true, "translate": true,
 	// Turbo/Stimulus DSL helpers handled by the dedicated passes above.
 	"turbo_stream_from": true, "turbo_frame_tag": true,
+	// ActionView / ActionController context accessors. These are framework
+	// objects, never application methods, so a bare reference (request.path,
+	// params[:id]) must not emit a self-call that the resolver then binds to a
+	// coincidental same-named app symbol (e.g. a test fake's #request).
+	"request": true, "response": true, "params": true, "session": true,
+	"cookies": true, "flash": true, "controller": true,
 }
 
 type walker struct {

--- a/internal/extract/erb/erb.go
+++ b/internal/extract/erb/erb.go
@@ -186,8 +186,18 @@ type dedupEmitter struct {
 func (d dedupEmitter) Symbol(s extract.EmittedSymbol) error { return d.inner.Symbol(s) }
 
 func (d dedupEmitter) Edge(e extract.EmittedEdge) error {
-	if name, ok := strings.CutPrefix(e.TargetQualified, "self."); ok && erbHelperSkip[name] {
+	name, isSelf := strings.CutPrefix(e.TargetQualified, "self.")
+	if isSelf && erbHelperSkip[name] {
 		return nil
+	}
+	// A *_path / *_url reference is a Rails route helper: retarget it at the
+	// reserved route: symbol so it chains view → route-helper → controller and
+	// can never phantom-match an application method of the same name (e.g. a
+	// model's own verifications_path). Applies whether the walker emitted it as
+	// a receiverless self-call (self.orders_path) or a bare unresolved call.
+	if isRouteHelperName(name) {
+		e.TargetQualified = extract.PrefixRoute + name
+		e.Confidence = extract.ConfidenceConvention
 	}
 	line := 0
 	if e.Line != nil {
@@ -199,6 +209,22 @@ func (d dedupEmitter) Edge(e extract.EmittedEdge) error {
 	}
 	d.seen[key] = true
 	return d.inner.Edge(e)
+}
+
+// isRouteHelperName reports whether a target name is a bare Rails route-helper
+// identifier — an identifier ending in _path or _url with no receiver dot.
+// `orders_path` qualifies; `Money.orders_path` (a real method on a constant)
+// does not, so a genuine method call is never mistaken for a route helper.
+func isRouteHelperName(s string) bool {
+	if !strings.HasSuffix(s, "_path") && !strings.HasSuffix(s, "_url") {
+		return false
+	}
+	for _, r := range s {
+		if r != '_' && !(r >= 'a' && r <= 'z') && !(r >= 'A' && r <= 'Z') && !(r >= '0' && r <= '9') {
+			return false
+		}
+	}
+	return true
 }
 
 func (w *walker) extractControllers(line string, lineNum int) error {

--- a/internal/extract/erb/erb.go
+++ b/internal/extract/erb/erb.go
@@ -124,7 +124,9 @@ var erbHelperSkip = map[string]bool{
 	// ActionView / ActionController context accessors. These are framework
 	// objects, never application methods, so a bare reference (request.path,
 	// params[:id]) must not emit a self-call that the resolver then binds to a
-	// coincidental same-named app symbol (e.g. a test fake's #request).
+	// coincidental same-named app symbol (e.g. a test fake's #request). The
+	// receiver-unknown analogue for the Ruby fragment walker is
+	// coreNoiseMethods in internal/extract/ruby/ruby.go.
 	"request": true, "response": true, "params": true, "session": true,
 	"cookies": true, "flash": true, "controller": true,
 }

--- a/internal/extract/erb/erb.go
+++ b/internal/extract/erb/erb.go
@@ -220,7 +220,8 @@ func isRouteHelperName(s string) bool {
 		return false
 	}
 	for _, r := range s {
-		if r != '_' && !(r >= 'a' && r <= 'z') && !(r >= 'A' && r <= 'Z') && !(r >= '0' && r <= '9') {
+		valid := r == '_' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+		if !valid {
 			return false
 		}
 	}

--- a/internal/extract/erb/erb_test.go
+++ b/internal/extract/erb/erb_test.go
@@ -519,10 +519,15 @@ func TestExtractHelperCalls(t *testing.T) {
 	r := extractERB(t, `<p><%= current_currency %></p>
 <%= link_to "Edit profile", edit_user_path(user) %>`, "app/views/orders/show.html.erb")
 
-	for _, want := range []string{"self.current_currency", "self.link_to", "self.edit_user_path", "self.user"} {
+	// edit_user_path is a route helper → it targets the reserved route: symbol,
+	// not a bare self.edit_user_path that could phantom-match an app method.
+	for _, want := range []string{"self.current_currency", "self.link_to", "route:edit_user_path", "self.user"} {
 		if !r.hasEdgeTo(want) {
 			t.Errorf("missing helper-call edge %q", want)
 		}
+	}
+	if r.hasEdgeTo("self.edit_user_path") {
+		t.Error("a *_path reference must not emit a bare self.edit_user_path edge")
 	}
 	// Words inside string copy must not become calls.
 	for _, bad := range []string{"self.Edit", "self.profile", "self.edit"} {

--- a/internal/extract/erb/route_ref_test.go
+++ b/internal/extract/erb/route_ref_test.go
@@ -1,0 +1,66 @@
+package erb
+
+import (
+	"testing"
+
+	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/model"
+)
+
+// link_to / button_to route helpers retarget the reserved route: symbol so the
+// view → route-helper → controller chain connects.
+func TestRouteRef_LinkToTargetsRouteSymbol(t *testing.T) {
+	r := extractERB(t, `<%= link_to "Orders", orders_path %>`, "app/views/home/index.html.erb")
+	if findEdgeKind(r, "route:orders_path", model.EdgeCalls) == nil {
+		t.Errorf("expected edge to route:orders_path, got %v", erbTargets(r))
+	}
+	if findEdgeKind(r, "self.orders_path", model.EdgeCalls) != nil {
+		t.Error("must not emit a bare self.orders_path edge")
+	}
+}
+
+// The phantom guard: a *_path reference that happens to share a name with an
+// application method targets the route: symbol, never the bare app-method name.
+func TestRouteRef_PhantomGuard(t *testing.T) {
+	r := extractERB(t, `<%= button_to "Verify", verifications_path %>`, "app/views/sessions/new.html.erb")
+	if findEdgeKind(r, "route:verifications_path", model.EdgeCalls) == nil {
+		t.Errorf("expected edge to route:verifications_path, got %v", erbTargets(r))
+	}
+	// Neither a bare self.verifications_path nor an unqualified verifications_path
+	// (either of which could resolve to an unrelated app method).
+	if findEdgeKind(r, "self.verifications_path", model.EdgeCalls) != nil ||
+		findEdgeKind(r, "verifications_path", model.EdgeCalls) != nil {
+		t.Errorf("verifications_path must only target the route: symbol; got %v", erbTargets(r))
+	}
+}
+
+func TestRouteRef_UrlVariant(t *testing.T) {
+	r := extractERB(t, `<%= redirect_to order_url(@order) %>`, "v.erb")
+	if findEdgeKind(r, "route:order_url", model.EdgeCalls) == nil {
+		t.Errorf("expected edge to route:order_url, got %v", erbTargets(r))
+	}
+}
+
+// A method named *_path on an explicit constant receiver is a real method
+// call, not a route helper — it must not be rewritten to route:.
+func TestRouteRef_ConstantReceiverNotRewritten(t *testing.T) {
+	r := extractERB(t, `<%= Assets.image_path %>`, "v.erb")
+	if findEdgeKind(r, extract.PrefixRoute+"image_path", model.EdgeCalls) != nil {
+		t.Errorf("a constant-receiver .image_path must not become a route helper; got %v", erbTargets(r))
+	}
+}
+
+func TestIsRouteHelperName(t *testing.T) {
+	yes := []string{"orders_path", "edit_admin_order_url", "x_path", "a1_url"}
+	for _, s := range yes {
+		if !isRouteHelperName(s) {
+			t.Errorf("isRouteHelperName(%q) = false, want true", s)
+		}
+	}
+	no := []string{"orders", "path", "Money.orders_path", "order.path", "to_path_string", ""}
+	for _, s := range no {
+		if isRouteHelperName(s) {
+			t.Errorf("isRouteHelperName(%q) = true, want false", s)
+		}
+	}
+}

--- a/internal/extract/erb/route_ref_test.go
+++ b/internal/extract/erb/route_ref_test.go
@@ -64,3 +64,15 @@ func TestIsRouteHelperName(t *testing.T) {
 		}
 	}
 }
+
+// Framework context accessors (request/params/session/…) are never application
+// methods — a bare reference must not emit a self-call that the resolver then
+// binds to a coincidental same-named symbol (e.g. a test fake's #request).
+func TestFrameworkAccessorsNotEmitted(t *testing.T) {
+	r := extractERB(t, `<%= form_with url: request.path, method: :get %><%= params[:q] %>`, "v.erb")
+	for _, bad := range []string{"self.request", "self.params"} {
+		if findEdgeKind(r, bad, model.EdgeCalls) != nil {
+			t.Errorf("framework accessor %q must not be emitted, got %v", bad, erbTargets(r))
+		}
+	}
+}

--- a/internal/extract/extractor.go
+++ b/internal/extract/extractor.go
@@ -30,11 +30,17 @@ const (
 	TierFull     Tier = "full"
 )
 
+// ERB is Full, not Basic: it has a dedicated extractor doing cross-language
+// Stimulus/Turbo resolution AND parses the embedded Ruby of every <% %> tag
+// with the Ruby grammar (calls, chains, blocks, render-collection, form model,
+// and the view → route-helper → controller chain) — strictly more than the
+// Standard langspec languages.
 var languageTiers = map[string]Tier{
 	"ruby":       TierFull,
 	"go":         TierFull,
 	"typescript": TierFull,
 	"javascript": TierFull,
+	"erb":        TierFull,
 	"python":     TierStandard,
 	"java":       TierStandard,
 	"rust":       TierStandard,

--- a/internal/extract/extractor.go
+++ b/internal/extract/extractor.go
@@ -124,6 +124,15 @@ const (
 	// (e.g. "i18n:users.show.title"). Emitted as a symbol so semantic search
 	// can surface the view that renders a given piece of copy.
 	PrefixI18n = "i18n:"
+	// PrefixRoute qualifies a synthetic Rails route-helper symbol (e.g.
+	// "route:orders_path", "route:edit_order_url"). The route DSL emits one per
+	// generated path/url helper, with an edge to the controller action it
+	// routes to; a `*_path`/`*_url` reference in a view emits an edge to the
+	// prefixed name, so View → route:helper → Controller#action is a connected
+	// chain. The reserved prefix guarantees the view edge can never collide
+	// with a same-named application method (e.g. a model's own `foo_path`).
+	// These symbols are plumbing — filtered out of dead-code and search output.
+	PrefixRoute = "route:"
 	// PrefixRubyCore qualifies a synthetic stand-in for a Ruby core class
 	// that is never defined in any indexed source file (Struct, Data). A
 	// `CONST = Struct.new(...)` value object emits an `inherits` edge to the

--- a/internal/extract/extractor_test.go
+++ b/internal/extract/extractor_test.go
@@ -115,6 +115,7 @@ func TestLanguageTier(t *testing.T) {
 		{"python", "standard"},
 		{"javascript", "full"},
 		{"typescript", "full"},
+		{"erb", "full"},
 		{"rust", "standard"},
 		{"java", "standard"},
 		{"kotlin", "standard"},

--- a/internal/extract/ruby/embedded.go
+++ b/internal/extract/ruby/embedded.go
@@ -1,0 +1,113 @@
+package ruby
+
+import (
+	"bytes"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/grammars"
+)
+
+// ExtractEmbeddedCalls parses a Ruby source fragment and emits the calls edges
+// its expressions imply, each sourced from scopeQualified and shifted by
+// lineOffset so the edge's line number points at the original (e.g. ERB) line
+// rather than a line inside the synthetic fragment.
+//
+// It is the cross-package entry point the ERB extractor uses to understand the
+// embedded Ruby inside `<% %>` / `<%= %>` tags with the language's own grammar
+// instead of a receiver-stripping regex: receiverless calls resolve to
+// `self.<name>`, constant receivers to `Const.<name>`, and method chains and
+// blocks resolve by the same logic the whole-file walker uses
+// (`@cart.items.each { |i| i.listing.title }` emits the chain's calls, not a
+// single bare token).
+//
+// Parsing is tolerant by design. An embedded snippet is often not standalone-
+// valid Ruby — a `<% if x %> … <% end %>` conditional is split across tags, so
+// a single tag's content is a dangling `if x` or a dangling `end`. tree-sitter
+// still produces a best-effort tree with ERROR nodes; emission proceeds over
+// whatever resolved and a parse error never aborts the caller's file scan.
+//
+// No cross-tag local/instance-variable type map is available, so a chained
+// receiver whose type can't be inferred within the fragment emits the trailing
+// method name at unresolved confidence for the resolver's name fallback — the
+// same policy the whole-file walker applies to an unknown receiver.
+//
+// lineOffset is added to each emitted edge's (1-indexed) fragment line. For a
+// tag whose content lives on ERB line N, pass N-1 so a fragment-line-1 call
+// maps back to line N.
+func ExtractEmbeddedCalls(src []byte, lineOffset int, scopeQualified string, emit extract.Emitter) error {
+	// Empty / whitespace-only tags (`<% %>`, comment bodies the caller already
+	// stripped) carry no Ruby — skip the parse entirely. Templates have many
+	// of these, so the short-circuit is a real cost saving, not just a guard.
+	if len(bytes.TrimSpace(src)) == 0 {
+		return nil
+	}
+
+	parser := sitter.NewParser()
+	defer parser.Close()
+	if err := parser.SetLanguage(grammars.Ruby()); err != nil {
+		return err
+	}
+	tree := parser.Parse(src, nil)
+	if tree == nil {
+		// A nil tree (not merely a tree with ERROR nodes) means the parser
+		// could not produce anything usable. Skip rather than fail — a single
+		// unparseable tag must never abort the surrounding template scan.
+		return nil
+	}
+	defer tree.Close()
+
+	root := tree.RootNode()
+	w := &walker{
+		source:            src,
+		emit:              offsetEmitter{inner: emit, offset: lineOffset},
+		filePath:          scopeQualified,
+		classInstanceVars: make(map[string]map[string]string),
+		returnTypes:       map[string]string{},
+		emittedCallbacks:  make(map[string]bool),
+		emittedSynthetics: make(map[string]bool),
+		pkgBindings:       make(map[string]string),
+	}
+
+	localTypes := buildLocalTypeMap(root, src)
+
+	// Call nodes: emit each, but skip those nested inside a block — emitCall
+	// walks block bodies itself, so a top-level walk that also descended into
+	// blocks would double-emit the block's inner calls.
+	if err := extract.WalkNamedDescendants(root, "call", func(c *sitter.Node) error {
+		if isInsideBlock(c) {
+			return nil
+		}
+		return w.emitCall(c, scopeQualified, nil, localTypes, nil)
+	}); err != nil {
+		return err
+	}
+
+	// Bare receiverless calls (`current_user`, `render_widget`) parse as
+	// identifier nodes, not call nodes; emitBareIdentifierCalls picks them up.
+	return w.emitBareIdentifierCalls(root, scopeQualified, extract.ConfidenceDynamic, nil)
+}
+
+// offsetEmitter wraps an extract.Emitter, shifting every emitted edge's line
+// (and every emitted symbol's line span) by a fixed offset. It lets the
+// fragment walker run with the fragment's own 1-indexed line numbers while the
+// edges it produces report the original file's lines.
+type offsetEmitter struct {
+	inner  extract.Emitter
+	offset int
+}
+
+func (o offsetEmitter) Symbol(s extract.EmittedSymbol) error {
+	s.LineStart += o.offset
+	s.LineEnd += o.offset
+	return o.inner.Symbol(s)
+}
+
+func (o offsetEmitter) Edge(e extract.EmittedEdge) error {
+	if e.Line != nil {
+		shifted := *e.Line + o.offset
+		e.Line = &shifted
+	}
+	return o.inner.Edge(e)
+}

--- a/internal/extract/ruby/embedded_test.go
+++ b/internal/extract/ruby/embedded_test.go
@@ -1,0 +1,154 @@
+package ruby
+
+import (
+	"testing"
+
+	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/model"
+)
+
+// hasEmbeddedEdge reports whether a calls edge with the given source + target
+// was emitted, for terse presence assertions.
+func hasEmbeddedEdge(r *recorder, source, target string) bool {
+	return findEdge(r, source, target, string(model.EdgeCalls)) != nil
+}
+
+func TestExtractEmbeddedCalls_BareReceiverlessCall(t *testing.T) {
+	r := &recorder{}
+	// `<%= current_user %>` — a bare helper, no receiver.
+	if err := ExtractEmbeddedCalls([]byte(`current_user`), 0, "app/views/orders/show.html.erb", r); err != nil {
+		t.Fatalf("ExtractEmbeddedCalls: %v", err)
+	}
+	if !hasEmbeddedEdge(r, "app/views/orders/show.html.erb", "self.current_user") {
+		t.Fatalf("expected self.current_user edge, got %+v", r.edges)
+	}
+}
+
+func TestExtractEmbeddedCalls_ReceiverChainAndBlock(t *testing.T) {
+	r := &recorder{}
+	// `<% @cart.items.each do |i| i.listing.title end %>` — the chained calls
+	// and the block body that the receiver-stripping regex could never see.
+	frag := `@cart.items.each do |i| i.listing.title end`
+	if err := ExtractEmbeddedCalls([]byte(frag), 0, "v.erb", r); err != nil {
+		t.Fatalf("ExtractEmbeddedCalls: %v", err)
+	}
+	// The chain resolves to its trailing method names — not a single bare token,
+	// and not nothing (the regex baseline).
+	for _, want := range []string{"items", "each", "listing", "title"} {
+		if !hasEmbeddedEdge(r, "v.erb", want) {
+			t.Errorf("expected chain/block call %q to emit an edge; got %+v", want, edgeTargets(r))
+		}
+	}
+}
+
+func TestExtractEmbeddedCalls_ConstantReceiver(t *testing.T) {
+	r := &recorder{}
+	// `<%= Money.format(total) %>` — a constant receiver resolves exactly.
+	if err := ExtractEmbeddedCalls([]byte(`Money.format(total)`), 0, "v.erb", r); err != nil {
+		t.Fatalf("ExtractEmbeddedCalls: %v", err)
+	}
+	if !hasEmbeddedEdge(r, "v.erb", "Money.format") {
+		t.Fatalf("expected Money.format edge, got %+v", edgeTargets(r))
+	}
+}
+
+func TestExtractEmbeddedCalls_LineOffset(t *testing.T) {
+	r := &recorder{}
+	// A fragment whose content sits on ERB line 12: pass offset 11 so the
+	// fragment's line-1 call reports line 12.
+	if err := ExtractEmbeddedCalls([]byte(`current_user`), 11, "v.erb", r); err != nil {
+		t.Fatalf("ExtractEmbeddedCalls: %v", err)
+	}
+	e := findEdge(r, "v.erb", "self.current_user", string(model.EdgeCalls))
+	if e == nil {
+		t.Fatalf("expected self.current_user edge, got %+v", edgeTargets(r))
+	}
+	if e.Line == nil || *e.Line != 12 {
+		t.Fatalf("expected edge line 12 (offset 11 + fragment line 1), got %v", e.Line)
+	}
+}
+
+func TestExtractEmbeddedCalls_SplitFragmentsDoNotAbort(t *testing.T) {
+	// A `<% if … %> … <% end %>` conditional is split across tags. Each
+	// fragment alone is not standalone-valid Ruby; parsing must never error.
+	for _, frag := range []string{`if signed_in?`, `end`, `else`} {
+		r := &recorder{}
+		if err := ExtractEmbeddedCalls([]byte(frag), 0, "v.erb", r); err != nil {
+			t.Errorf("split fragment %q must not error, got: %v", frag, err)
+		}
+	}
+
+	// A dangling block opener — `<% @items.each do |item| %>` with the `end` in
+	// a later tag — recovers cleanly (only the `end` is MISSING), so emission
+	// surfaces what it can: the chained `items` and `each` calls.
+	r := &recorder{}
+	if err := ExtractEmbeddedCalls([]byte(`@items.each do |item|`), 0, "v.erb", r); err != nil {
+		t.Fatalf("dangling block opener must not error, got: %v", err)
+	}
+	if !hasEmbeddedEdge(r, "v.erb", "each") {
+		t.Errorf("expected the `each` call from the dangling block opener, got %+v", edgeTargets(r))
+	}
+}
+
+func TestExtractEmbeddedCalls_EmptyFragmentSkipped(t *testing.T) {
+	for _, frag := range []string{"", "   ", "\n\t "} {
+		r := &recorder{}
+		if err := ExtractEmbeddedCalls([]byte(frag), 0, "v.erb", r); err != nil {
+			t.Fatalf("empty fragment %q: %v", frag, err)
+		}
+		if len(r.edges) != 0 {
+			t.Errorf("empty fragment %q emitted %d edges, want 0", frag, len(r.edges))
+		}
+	}
+}
+
+func TestExtractEmbeddedCalls_EmitterErrorPropagates(t *testing.T) {
+	// A fragment with at least one call so the emitter is invoked; the failing
+	// emitter then forces the walk's error path to surface.
+	err := ExtractEmbeddedCalls([]byte(`Money.format(total)`), 0, "v.erb", &failAfterN{edgesLeft: 0})
+	if err == nil {
+		t.Fatal("expected the emitter error to propagate, got nil")
+	}
+}
+
+func TestOffsetEmitter(t *testing.T) {
+	r := &recorder{}
+	oe := offsetEmitter{inner: r, offset: 10}
+
+	// Symbol: both line endpoints shift.
+	if err := oe.Symbol(extract.EmittedSymbol{Qualified: "s", LineStart: 1, LineEnd: 3}); err != nil {
+		t.Fatalf("Symbol: %v", err)
+	}
+	if r.symbols[0].LineStart != 11 || r.symbols[0].LineEnd != 13 {
+		t.Errorf("symbol lines = %d..%d, want 11..13", r.symbols[0].LineStart, r.symbols[0].LineEnd)
+	}
+
+	// Edge with a line: shifts.
+	ln := 5
+	if err := oe.Edge(extract.EmittedEdge{TargetQualified: "t", Line: &ln}); err != nil {
+		t.Fatalf("Edge: %v", err)
+	}
+	if r.edges[0].Line == nil || *r.edges[0].Line != 15 {
+		t.Errorf("edge line = %v, want 15", r.edges[0].Line)
+	}
+	// The shift must not mutate the caller's original *int.
+	if ln != 5 {
+		t.Errorf("offsetEmitter mutated caller's line pointer: %d", ln)
+	}
+
+	// Edge with no line: passes through untouched.
+	if err := oe.Edge(extract.EmittedEdge{TargetQualified: "t2"}); err != nil {
+		t.Fatalf("Edge nil line: %v", err)
+	}
+	if r.edges[1].Line != nil {
+		t.Errorf("nil-line edge should stay nil, got %v", r.edges[1].Line)
+	}
+}
+
+func edgeTargets(r *recorder) []string {
+	out := make([]string, 0, len(r.edges))
+	for _, e := range r.edges {
+		out = append(out, e.TargetQualified)
+	}
+	return out
+}

--- a/internal/extract/ruby/inflect.go
+++ b/internal/extract/ruby/inflect.go
@@ -2,6 +2,16 @@ package ruby
 
 import "strings"
 
+// Singularize is the exported form of singularize for cross-package callers —
+// the ERB extractor's render-collection convention (`render @posts` →
+// `posts/post`). It applies the same minimal Rails suffix rules.
+func Singularize(s string) string { return singularize(s) }
+
+// Classify is the exported form of classify: a snake_case plural or singular
+// name to its PascalCase class name ("orders" → "Order"), used by the ERB
+// extractor's form-model convention (`form_with model: @order` → `Order`).
+func Classify(s string) string { return classify(s) }
+
 // classify converts a snake_case plural or singular symbol name to a
 // PascalCase class name: "line_items" → "LineItem", "user" → "User".
 // It singularizes first (for has_many / habtm), then PascalCases.

--- a/internal/extract/ruby/inflect_test.go
+++ b/internal/extract/ruby/inflect_test.go
@@ -53,3 +53,12 @@ func TestClassify(t *testing.T) {
 		}
 	}
 }
+
+func TestExportedInflectionWrappers(t *testing.T) {
+	if got := Singularize("orders"); got != "order" {
+		t.Errorf("Singularize(orders) = %q, want order", got)
+	}
+	if got := Classify("line_items"); got != "LineItem" {
+		t.Errorf("Classify(line_items) = %q, want LineItem", got)
+	}
+}

--- a/internal/extract/ruby/route_test.go
+++ b/internal/extract/ruby/route_test.go
@@ -1,0 +1,173 @@
+package ruby
+
+import (
+	"testing"
+
+	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/model"
+)
+
+func hasRouteSymbol(r *recorder, name string) *extract.EmittedSymbol {
+	return findSymbol(r, extract.PrefixRoute+name)
+}
+
+func hasRouteEdge(r *recorder, helper, action string) *extract.EmittedEdge {
+	return findEdge(r, extract.PrefixRoute+helper, action, string(model.EdgeCalls))
+}
+
+func TestRouteHelpers_PluralResources(t *testing.T) {
+	r := parseRuby(t, `resources :orders`)
+
+	// Every standard helper, both _path and _url, with the right action edge.
+	want := map[string]string{
+		"orders_path":     "OrdersController#index",
+		"order_path":      "OrdersController#show",
+		"new_order_path":  "OrdersController#new",
+		"edit_order_path": "OrdersController#edit",
+	}
+	for helper, action := range want {
+		if hasRouteSymbol(r, helper) == nil {
+			t.Errorf("missing route symbol %s", helper)
+		}
+		if hasRouteEdge(r, helper, action) == nil {
+			t.Errorf("missing edge %s → %s", helper, action)
+		}
+		// _url twin exists and routes to the same action.
+		url := helper[:len(helper)-len("_path")] + "_url"
+		if hasRouteSymbol(r, url) == nil {
+			t.Errorf("missing _url twin %s", url)
+		}
+		if hasRouteEdge(r, url, action) == nil {
+			t.Errorf("missing edge %s → %s", url, action)
+		}
+	}
+}
+
+func TestRouteHelpers_SingularResourceNoCollection(t *testing.T) {
+	r := parseRuby(t, `resource :profile`)
+
+	// Singular member + new/edit, controller is pluralized (ProfilesController).
+	if hasRouteEdge(r, "profile_path", "ProfilesController#show") == nil {
+		t.Error("missing profile_path → ProfilesController#show")
+	}
+	if hasRouteSymbol(r, "new_profile_path") == nil || hasRouteSymbol(r, "edit_profile_path") == nil {
+		t.Error("missing new_/edit_ profile helpers")
+	}
+	// No plural collection helper for a singular resource.
+	if hasRouteSymbol(r, "profiles_path") != nil {
+		t.Error("singular resource must not emit a plural collection helper")
+	}
+}
+
+func TestRouteHelpers_Namespaced(t *testing.T) {
+	r := parseRuby(t, "namespace :admin do\n  resources :orders\nend")
+
+	if hasRouteSymbol(r, "admin_orders_path") == nil {
+		t.Error("missing admin_orders_path")
+	}
+	if hasRouteEdge(r, "admin_orders_path", "Admin::OrdersController#index") == nil {
+		t.Error("missing admin_orders_path → Admin::OrdersController#index")
+	}
+	// new_/edit_ prefix the whole name: new_admin_order_path.
+	if hasRouteEdge(r, "new_admin_order_path", "Admin::OrdersController#new") == nil {
+		t.Error("missing new_admin_order_path → Admin::OrdersController#new")
+	}
+	// The un-namespaced form must not be emitted.
+	if hasRouteSymbol(r, "orders_path") != nil {
+		t.Error("namespaced resource must not also emit the bare orders_path")
+	}
+}
+
+func TestRouteHelpers_NestedResourceEmitsNoHelper(t *testing.T) {
+	r := parseRuby(t, "resources :orders do\n  resources :items\nend")
+
+	// The parent resource still gets its helpers.
+	if hasRouteSymbol(r, "orders_path") == nil {
+		t.Error("parent orders_path should still be emitted")
+	}
+	// The nested resource's helper name (order_items_path) can't be derived
+	// from the inner declaration — emit nothing rather than a wrong items_path.
+	if hasRouteSymbol(r, "items_path") != nil {
+		t.Error("nested resource must not emit a (wrong) items_path helper")
+	}
+	// But its controller edges are still tracked.
+	if findEdge(r, "routes", "ItemsController#index", string(model.EdgeCalls)) == nil {
+		t.Error("nested resource controller edge should still be emitted")
+	}
+}
+
+func TestRouteHelpers_VerbRouteWithAs(t *testing.T) {
+	r := parseRuby(t, `get "reports", to: "reports#index", as: :reports`)
+
+	if hasRouteEdge(r, "reports_path", "ReportsController#index") == nil {
+		t.Error("missing reports_path → ReportsController#index")
+	}
+	if hasRouteSymbol(r, "reports_url") == nil {
+		t.Error("missing reports_url twin")
+	}
+}
+
+func TestRouteHelpers_VerbRouteWithoutAsEmitsNoHelper(t *testing.T) {
+	r := parseRuby(t, `get "health", to: "health#show"`)
+
+	// The controller edge is emitted, but no route helper (un-nameable).
+	if findEdge(r, "routes", "HealthController#show", string(model.EdgeCalls)) == nil {
+		t.Error("verb route controller edge should be emitted")
+	}
+	for _, s := range r.symbols {
+		if len(s.Qualified) >= len(extract.PrefixRoute) && s.Qualified[:len(extract.PrefixRoute)] == extract.PrefixRoute {
+			t.Errorf("verb route without as: must emit no route helper, got %s", s.Qualified)
+		}
+	}
+}
+
+func TestRouteHelpers_SymbolDedupedPerFile(t *testing.T) {
+	// Two identical declarations must not emit duplicate symbols (UNIQUE
+	// (file_id, qualified) would otherwise conflict).
+	r := parseRuby(t, "resources :orders\nresources :orders")
+	var count int
+	for _, s := range r.symbols {
+		if s.Qualified == extract.PrefixRoute+"orders_path" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("route:orders_path symbol emitted %d times, want 1 (deduped)", count)
+	}
+}
+
+func TestRouteHelpers_SymbolEmitError(t *testing.T) {
+	// resources emits controller edges first (those succeed), then route-helper
+	// symbols — fail the first symbol to hit emitRouteHelper's symbol path.
+	err := parseWithEmitter(t, `resources :orders`, &failAfterN{symbolsLeft: 0, edgesLeft: 100})
+	if err == nil {
+		t.Error("expected error from failing symbol emitter on a route helper")
+	}
+}
+
+func TestRouteHelpers_EdgeEmitError(t *testing.T) {
+	// Allow the 7 RESTful controller edges, then fail the first route-helper
+	// edge so emitRouteHelper's edge path is exercised.
+	err := parseWithEmitter(t, `resources :orders`, &failAfterN{symbolsLeft: 100, edgesLeft: 7})
+	if err == nil {
+		t.Error("expected error from failing edge emitter on a route helper")
+	}
+}
+
+func TestRouteHelpers_AsString(t *testing.T) {
+	// `as: "foo"` (string form, not a symbol) names the helper too.
+	r := parseRuby(t, `get "reports", to: "reports#index", as: "summary"`)
+	if hasRouteEdge(r, "summary_path", "ReportsController#index") == nil {
+		t.Errorf("missing summary_path from string as:, got %v", r.symbols)
+	}
+}
+
+func TestRouteHelpers_VerbRouteNoTargetNoEmit(t *testing.T) {
+	// No `to:` → nothing to route to; emit nothing (covers the guard).
+	r := parseRuby(t, `get "health"`)
+	for _, s := range r.symbols {
+		if len(s.Qualified) >= len(extract.PrefixRoute) && s.Qualified[:len(extract.PrefixRoute)] == extract.PrefixRoute {
+			t.Errorf("verb route with no to: must emit no helper, got %s", s.Qualified)
+		}
+	}
+}

--- a/internal/extract/ruby/ruby.go
+++ b/internal/extract/ruby/ruby.go
@@ -83,16 +83,18 @@ var collectionMethods = map[string]bool{
 // ---- walker ----
 
 type walker struct {
-	source            []byte
-	emit              extract.Emitter
-	filePath          string
-	routeNS           []string                     // namespace stack for route files (e.g. ["Admin"])
-	testScope         []string                     // nested RSpec block descriptions for synthetic scope
-	classInstanceVars map[string]map[string]string // @ivar type map per class
-	returnTypes       map[string]string            // method_qualified → class_name (file-level)
-	emittedCallbacks  map[string]bool              // dedup synthetic callback symbols by qualified name
-	emittedSynthetics map[string]bool              // dedup synthetic base symbols (ruby-core:Struct/Data) per file
-	pkgBindings       map[string]string            // unqualified name → qualified name for file-level constants
+	source             []byte
+	emit               extract.Emitter
+	filePath           string
+	routeNS            []string                     // namespace stack for route files (e.g. ["Admin"])
+	routeNSRaw         []string                     // same stack in snake_case for route-helper names (e.g. ["admin"])
+	routeResourceDepth int                          // resource-block nesting depth; >0 means a nested resource (helper name not derivable confidently)
+	testScope          []string                     // nested RSpec block descriptions for synthetic scope
+	classInstanceVars  map[string]map[string]string // @ivar type map per class
+	returnTypes        map[string]string            // method_qualified → class_name (file-level)
+	emittedCallbacks   map[string]bool              // dedup synthetic callback symbols by qualified name
+	emittedSynthetics  map[string]bool              // dedup synthetic base symbols (ruby-core:Struct/Data) per file
+	pkgBindings        map[string]string            // unqualified name → qualified name for file-level constants
 }
 
 // walk visits node and its children under the given class/module scope.
@@ -2344,11 +2346,96 @@ func (w *walker) handleResources(n *sitter.Node, singular bool) error {
 		}
 	}
 
+	// Route-helper symbols (orders_path → OrdersController#index, …). Only for
+	// top-level / namespaced resources: a nested resource's helper name is
+	// prefixed by its parent's singular (order_items_path), which we can't
+	// reconstruct from the inner declaration alone, so we emit no helper rather
+	// than a wrong one. The controller edges above are still emitted for nested
+	// resources — only the helper naming is skipped.
+	if w.routeResourceDepth == 0 {
+		if err := w.emitResourceRouteHelpers(name, singular, controller, line); err != nil {
+			return err
+		}
+	}
+
 	// If the resource has a block, walk it for nested routes.
 	if block := n.ChildByFieldName("block"); block != nil {
+		w.routeResourceDepth++
+		defer func() { w.routeResourceDepth-- }()
 		return w.walkChildren(block, nil)
 	}
 	return nil
+}
+
+// routeHelper pairs a generated path/url helper base name (without the _path /
+// _url suffix) with the controller action it routes to.
+type routeHelper struct {
+	base   string
+	action string
+}
+
+// emitResourceRouteHelpers emits the synthetic route:* symbols and their
+// helper → controller#action edges for a resources/resource declaration. Each
+// base produces both a _path and a _url helper. The namespace (snake_case)
+// prefixes the resource segment; new_/edit_ prefix the whole helper, matching
+// Rails' generated names (new_admin_order_path).
+func (w *walker) emitResourceRouteHelpers(name string, singular bool, controller string, line int) error {
+	nsPrefix := ""
+	if len(w.routeNSRaw) > 0 {
+		nsPrefix = strings.Join(w.routeNSRaw, "_") + "_"
+	}
+
+	var sing string
+	if singular {
+		sing = name // `resource :profile` — name is already singular
+	} else {
+		sing = singularize(name)
+	}
+
+	helpers := []routeHelper{
+		{nsPrefix + sing, "show"}, // member
+		{"new_" + nsPrefix + sing, "new"},
+		{"edit_" + nsPrefix + sing, "edit"},
+	}
+	if !singular {
+		// Plural resources also generate a collection helper (orders_path).
+		helpers = append([]routeHelper{{nsPrefix + name, "index"}}, helpers...)
+	}
+
+	for _, h := range helpers {
+		for _, suffix := range [...]string{"_path", "_url"} {
+			if err := w.emitRouteHelper(h.base+suffix, controller+"#"+h.action, line); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// emitRouteHelper emits one synthetic route:* symbol (deduped per file) and an
+// edge from it to the controller action it routes to.
+func (w *walker) emitRouteHelper(helperName, actionTarget string, line int) error {
+	qualified := extract.PrefixRoute + helperName
+	if !w.emittedSynthetics[qualified] {
+		w.emittedSynthetics[qualified] = true
+		if err := w.emit.Symbol(extract.EmittedSymbol{
+			Name:       helperName,
+			Qualified:  qualified,
+			Kind:       model.KindConstant,
+			Visibility: "public",
+			LineStart:  line,
+			LineEnd:    line,
+		}); err != nil {
+			return err
+		}
+	}
+	return w.emit.Edge(extract.EmittedEdge{
+		SourceQualified: qualified,
+		TargetQualified: actionTarget,
+		Kind:            model.EdgeCalls,
+		Line:            &line,
+		Confidence:      extract.ConfidenceConvention,
+	})
 }
 
 // handleVerbRoute handles `get "/path", to: "controller#action"` style routes.
@@ -2372,13 +2459,54 @@ func (w *walker) handleVerbRoute(n *sitter.Node) error {
 	resolved := controller + "#" + parts[1]
 
 	line := extract.Line(n.StartPosition())
-	return w.emit.Edge(extract.EmittedEdge{
+	if err := w.emit.Edge(extract.EmittedEdge{
 		SourceQualified: "routes",
 		TargetQualified: resolved,
 		Kind:            model.EdgeCalls,
 		Line:            &line,
 		Confidence:      extract.ConfidenceConvention,
-	})
+	}); err != nil {
+		return err
+	}
+
+	// `as: :foo` names a route helper (foo_path / foo_url) pointing at the same
+	// action. Without `as:`, a verb route's helper name is derived from the
+	// path and is too irregular to reconstruct safely, so we emit none.
+	if as := keywordSymbolOrString(args, "as", w.source); as != "" {
+		nsPrefix := ""
+		if len(w.routeNSRaw) > 0 {
+			nsPrefix = strings.Join(w.routeNSRaw, "_") + "_"
+		}
+		for _, suffix := range [...]string{"_path", "_url"} {
+			if err := w.emitRouteHelper(nsPrefix+as+suffix, resolved, line); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// keywordSymbolOrString reads a keyword argument whose value is a simple symbol
+// (`as: :foo`) or a string (`as: "foo"`), returning the bare name. Unlike
+// findKeywordArg it accepts symbol values, which is the common form for `as:`.
+func keywordSymbolOrString(args *sitter.Node, key string, source []byte) string {
+	count := args.NamedChildCount()
+	for i := uint(0); i < count; i++ {
+		arg := args.NamedChild(i)
+		if arg == nil || arg.Kind() != "pair" {
+			continue
+		}
+		k := arg.ChildByFieldName("key")
+		v := arg.ChildByFieldName("value")
+		if k == nil || v == nil || extract.Text(k, source) != key {
+			continue
+		}
+		if v.Kind() == "simple_symbol" {
+			return strings.TrimPrefix(extract.Text(v, source), ":")
+		}
+		return extractStringValue(v, source)
+	}
+	return ""
 }
 
 // handleRouteNamespace processes `namespace :admin do ... end` by pushing
@@ -2392,10 +2520,15 @@ func (w *walker) handleRouteNamespace(n *sitter.Node) error {
 	if first == nil || first.Kind() != "simple_symbol" {
 		return nil
 	}
-	ns := pascalCase(strings.TrimPrefix(extract.Text(first, w.source), ":"))
+	raw := strings.TrimPrefix(extract.Text(first, w.source), ":")
+	ns := pascalCase(raw)
 
 	w.routeNS = append(w.routeNS, ns)
-	defer func() { w.routeNS = w.routeNS[:len(w.routeNS)-1] }()
+	w.routeNSRaw = append(w.routeNSRaw, raw)
+	defer func() {
+		w.routeNS = w.routeNS[:len(w.routeNS)-1]
+		w.routeNSRaw = w.routeNSRaw[:len(w.routeNSRaw)-1]
+	}()
 
 	if block := n.ChildByFieldName("block"); block != nil {
 		return w.walkChildren(block, nil)

--- a/internal/extract/ruby/ruby.go
+++ b/internal/extract/ruby/ruby.go
@@ -872,6 +872,11 @@ var coreNoiseMethods = map[string]bool{
 	"present?": true, "blank?": true, "nil?": true, "empty?": true,
 	"to_s": true, "to_i": true, "to_a": true, "to_h": true, "to_sym": true,
 	"freeze": true, "dup": true, "clone": true, "presence": true, "call": true,
+	// Object/reflection methods: a bare `x.is_a?` / `x.respond_to?` on an
+	// unknown receiver otherwise binds to a coincidental same-named app symbol
+	// (e.g. a test fake's `#is_a?`). Never a meaningful caller edge.
+	"is_a?": true, "kind_of?": true, "instance_of?": true, "respond_to?": true,
+	"frozen?": true, "itself": true, "inspect": true, "object_id": true,
 }
 
 // unresolvedCall is the emit decision for a call whose receiver type is

--- a/internal/extract/ruby/ruby.go
+++ b/internal/extract/ruby/ruby.go
@@ -1329,6 +1329,12 @@ var statementParents = map[string]bool{
 	"else":           true,
 	"begin":          true,
 	"ensure":         true,
+	// program is the root of a parsed fragment (ExtractEmbeddedCalls). Whole-
+	// file walks only ever pass a method/test body_statement to
+	// emitBareIdentifierCalls, never the program root, so listing it here is
+	// inert for file extraction and only catches top-level bare calls in an
+	// embedded `<% current_user %>` fragment.
+	"program": true,
 }
 
 // valueParents is the set of node kinds where a bare identifier sits in a

--- a/internal/extract/ruby/ruby.go
+++ b/internal/extract/ruby/ruby.go
@@ -866,7 +866,9 @@ func (w *walker) emitCallWithConfidence(n *sitter.Node, source string, scope []s
 // edge rather than let the resolver's unqualified fallback bind it to an
 // arbitrary same-named method elsewhere — e.g. `count.zero?` resolving
 // to a `Money.zero` singleton. A missing low-confidence edge is cheaper
-// than a false caller that inflates blast radius.
+// than a false caller that inflates blast radius. The ERB analogue, for
+// framework context accessors referenced bare in a template, is
+// erbHelperSkip in internal/extract/erb/erb.go.
 var coreNoiseMethods = map[string]bool{
 	"zero?": true, "positive?": true, "negative?": true, "nonzero?": true,
 	"present?": true, "blank?": true, "nil?": true, "empty?": true,
@@ -2419,6 +2421,12 @@ func (w *walker) emitResourceRouteHelpers(name string, singular bool, controller
 
 // emitRouteHelper emits one synthetic route:* symbol (deduped per file) and an
 // edge from it to the controller action it routes to.
+//
+// Note: like any symbol, a route:* symbol enters the resolver's by-name index,
+// so bare unqualified calls elsewhere in the routes file can fall back onto it,
+// giving it spurious sub-floor (<0.5) outgoing edges. Those are filtered from
+// graph/blast output at query time (the confidence floor); the one real,
+// convention-confidence edge is the controller-action edge emitted here.
 func (w *walker) emitRouteHelper(helperName, actionTarget string, line int) error {
 	qualified := extract.PrefixRoute + helperName
 	if !w.emittedSynthetics[qualified] {

--- a/internal/extract/testdata/ruby/metaprogramming.golden.json
+++ b/internal/extract/testdata/ruby/metaprogramming.golden.json
@@ -80,13 +80,6 @@
   ],
   "edges": [
     {
-      "source": "DynamicProxy#respond_to_missing?",
-      "target": "respond_to?",
-      "kind": "calls",
-      "line": 7,
-      "confidence": 0.5
-    },
-    {
       "source": "PluginLoader.load_all",
       "target": "PluginLoader::REGISTRY",
       "kind": "references",

--- a/internal/extract/testdata/ruby/rails_routes.golden.json
+++ b/internal/extract/testdata/ruby/rails_routes.golden.json
@@ -14,6 +14,246 @@
       "parent": "SomeService",
       "line_start": 19,
       "line_end": 21
+    },
+    {
+      "name": "admin_user_path",
+      "qualified": "route:admin_user_path",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 13,
+      "line_end": 13
+    },
+    {
+      "name": "admin_user_url",
+      "qualified": "route:admin_user_url",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 13,
+      "line_end": 13
+    },
+    {
+      "name": "admin_users_path",
+      "qualified": "route:admin_users_path",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 13,
+      "line_end": 13
+    },
+    {
+      "name": "admin_users_url",
+      "qualified": "route:admin_users_url",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 13,
+      "line_end": 13
+    },
+    {
+      "name": "edit_admin_user_path",
+      "qualified": "route:edit_admin_user_path",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 13,
+      "line_end": 13
+    },
+    {
+      "name": "edit_admin_user_url",
+      "qualified": "route:edit_admin_user_url",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 13,
+      "line_end": 13
+    },
+    {
+      "name": "edit_order_path",
+      "qualified": "route:edit_order_path",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 5,
+      "line_end": 5
+    },
+    {
+      "name": "edit_order_url",
+      "qualified": "route:edit_order_url",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 5,
+      "line_end": 5
+    },
+    {
+      "name": "edit_product_path",
+      "qualified": "route:edit_product_path",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 6,
+      "line_end": 6
+    },
+    {
+      "name": "edit_product_url",
+      "qualified": "route:edit_product_url",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 6,
+      "line_end": 6
+    },
+    {
+      "name": "edit_session_path",
+      "qualified": "route:edit_session_path",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 7,
+      "line_end": 7
+    },
+    {
+      "name": "edit_session_url",
+      "qualified": "route:edit_session_url",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 7,
+      "line_end": 7
+    },
+    {
+      "name": "new_admin_user_path",
+      "qualified": "route:new_admin_user_path",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 13,
+      "line_end": 13
+    },
+    {
+      "name": "new_admin_user_url",
+      "qualified": "route:new_admin_user_url",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 13,
+      "line_end": 13
+    },
+    {
+      "name": "new_order_path",
+      "qualified": "route:new_order_path",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 5,
+      "line_end": 5
+    },
+    {
+      "name": "new_order_url",
+      "qualified": "route:new_order_url",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 5,
+      "line_end": 5
+    },
+    {
+      "name": "new_product_path",
+      "qualified": "route:new_product_path",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 6,
+      "line_end": 6
+    },
+    {
+      "name": "new_product_url",
+      "qualified": "route:new_product_url",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 6,
+      "line_end": 6
+    },
+    {
+      "name": "new_session_path",
+      "qualified": "route:new_session_path",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 7,
+      "line_end": 7
+    },
+    {
+      "name": "new_session_url",
+      "qualified": "route:new_session_url",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 7,
+      "line_end": 7
+    },
+    {
+      "name": "order_path",
+      "qualified": "route:order_path",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 5,
+      "line_end": 5
+    },
+    {
+      "name": "order_url",
+      "qualified": "route:order_url",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 5,
+      "line_end": 5
+    },
+    {
+      "name": "orders_path",
+      "qualified": "route:orders_path",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 5,
+      "line_end": 5
+    },
+    {
+      "name": "orders_url",
+      "qualified": "route:orders_url",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 5,
+      "line_end": 5
+    },
+    {
+      "name": "product_path",
+      "qualified": "route:product_path",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 6,
+      "line_end": 6
+    },
+    {
+      "name": "product_url",
+      "qualified": "route:product_url",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 6,
+      "line_end": 6
+    },
+    {
+      "name": "products_path",
+      "qualified": "route:products_path",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 6,
+      "line_end": 6
+    },
+    {
+      "name": "products_url",
+      "qualified": "route:products_url",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 6,
+      "line_end": 6
+    },
+    {
+      "name": "session_path",
+      "qualified": "route:session_path",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 7,
+      "line_end": 7
+    },
+    {
+      "name": "session_url",
+      "qualified": "route:session_url",
+      "kind": "constant",
+      "visibility": "public",
+      "line_start": 7,
+      "line_end": 7
     }
   ],
   "edges": [
@@ -23,6 +263,216 @@
       "kind": "calls",
       "line": 20,
       "confidence": 1
+    },
+    {
+      "source": "route:admin_user_path",
+      "target": "Admin::UsersController#show",
+      "kind": "calls",
+      "line": 13,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:admin_user_url",
+      "target": "Admin::UsersController#show",
+      "kind": "calls",
+      "line": 13,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:admin_users_path",
+      "target": "Admin::UsersController#index",
+      "kind": "calls",
+      "line": 13,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:admin_users_url",
+      "target": "Admin::UsersController#index",
+      "kind": "calls",
+      "line": 13,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:edit_admin_user_path",
+      "target": "Admin::UsersController#edit",
+      "kind": "calls",
+      "line": 13,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:edit_admin_user_url",
+      "target": "Admin::UsersController#edit",
+      "kind": "calls",
+      "line": 13,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:edit_order_path",
+      "target": "OrdersController#edit",
+      "kind": "calls",
+      "line": 5,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:edit_order_url",
+      "target": "OrdersController#edit",
+      "kind": "calls",
+      "line": 5,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:edit_product_path",
+      "target": "ProductsController#edit",
+      "kind": "calls",
+      "line": 6,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:edit_product_url",
+      "target": "ProductsController#edit",
+      "kind": "calls",
+      "line": 6,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:edit_session_path",
+      "target": "SessionsController#edit",
+      "kind": "calls",
+      "line": 7,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:edit_session_url",
+      "target": "SessionsController#edit",
+      "kind": "calls",
+      "line": 7,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:new_admin_user_path",
+      "target": "Admin::UsersController#new",
+      "kind": "calls",
+      "line": 13,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:new_admin_user_url",
+      "target": "Admin::UsersController#new",
+      "kind": "calls",
+      "line": 13,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:new_order_path",
+      "target": "OrdersController#new",
+      "kind": "calls",
+      "line": 5,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:new_order_url",
+      "target": "OrdersController#new",
+      "kind": "calls",
+      "line": 5,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:new_product_path",
+      "target": "ProductsController#new",
+      "kind": "calls",
+      "line": 6,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:new_product_url",
+      "target": "ProductsController#new",
+      "kind": "calls",
+      "line": 6,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:new_session_path",
+      "target": "SessionsController#new",
+      "kind": "calls",
+      "line": 7,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:new_session_url",
+      "target": "SessionsController#new",
+      "kind": "calls",
+      "line": 7,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:order_path",
+      "target": "OrdersController#show",
+      "kind": "calls",
+      "line": 5,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:order_url",
+      "target": "OrdersController#show",
+      "kind": "calls",
+      "line": 5,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:orders_path",
+      "target": "OrdersController#index",
+      "kind": "calls",
+      "line": 5,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:orders_url",
+      "target": "OrdersController#index",
+      "kind": "calls",
+      "line": 5,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:product_path",
+      "target": "ProductsController#show",
+      "kind": "calls",
+      "line": 6,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:product_url",
+      "target": "ProductsController#show",
+      "kind": "calls",
+      "line": 6,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:products_path",
+      "target": "ProductsController#index",
+      "kind": "calls",
+      "line": 6,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:products_url",
+      "target": "ProductsController#index",
+      "kind": "calls",
+      "line": 6,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:session_path",
+      "target": "SessionsController#show",
+      "kind": "calls",
+      "line": 7,
+      "confidence": 0.9
+    },
+    {
+      "source": "route:session_url",
+      "target": "SessionsController#show",
+      "kind": "calls",
+      "line": 7,
+      "confidence": 0.9
     },
     {
       "source": "routes",

--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -204,6 +204,16 @@ func BuildBlastResponse(ctx context.Context, r blast.Result, files FileLookup, s
 
 	if subjectFile, ok := files(r.Symbol.FileID); ok {
 		resp.IndexCaveat = IndexCaveat(subjectFile)
+		// Compute view_edges from the raw direct callers (not resp.DirectCallers,
+		// which holds only the tier-1 slice) so a view edge counts regardless of
+		// the relevance tier it landed in.
+		callerFiles := make([]string, 0, len(r.DirectCallers))
+		for _, c := range r.DirectCallers {
+			if path, ok := files(c.FileID); ok {
+				callerFiles = append(callerFiles, path)
+			}
+		}
+		resp.ViewEdges = viewEdgesSignal(subjectFile, callerFiles)
 	}
 
 	uniqueFiles := countUniqueBlastFiles(resp)

--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -204,16 +204,11 @@ func BuildBlastResponse(ctx context.Context, r blast.Result, files FileLookup, s
 
 	if subjectFile, ok := files(r.Symbol.FileID); ok {
 		resp.IndexCaveat = IndexCaveat(subjectFile)
-		// Compute view_edges from the raw direct callers (not resp.DirectCallers,
-		// which holds only the tier-1 slice) so a view edge counts regardless of
-		// the relevance tier it landed in.
-		callerFiles := make([]string, 0, len(r.DirectCallers))
-		for _, c := range r.DirectCallers {
-			if path, ok := files(c.FileID); ok {
-				callerFiles = append(callerFiles, path)
-			}
-		}
-		resp.ViewEdges = viewEdgesSignal(subjectFile, callerFiles)
+		// view_edges comes from the engine's ViewReached flag, not from
+		// DirectCallers: a view edge has a NULL source_id, so the view never
+		// appears as a caller symbol — only the engine's direct edge-table
+		// check sees it.
+		resp.ViewEdges = viewEdgesSignal(subjectFile, r.ViewReached)
 	}
 
 	uniqueFiles := countUniqueBlastFiles(resp)

--- a/internal/mcpio/coverage_test.go
+++ b/internal/mcpio/coverage_test.go
@@ -135,8 +135,21 @@ func TestBuildDeadCodeResponse_TooCommonFlag(t *testing.T) {
 
 func TestDeadCodeNoteIsFrameworkAware(t *testing.T) {
 	rails := deadCodeNote([]string{"Sidekiq", "Rails"})
-	if !strings.Contains(rails, "routing") || !strings.Contains(rails, "Concern") || !strings.Contains(rails, "Stimulus") {
-		t.Errorf("Rails note should cover routing/concerns/Stimulus, got: %s", rails)
+	if !strings.Contains(rails, "routing") || !strings.Contains(rails, "Concern") {
+		t.Errorf("Rails note should cover routing/concerns, got: %s", rails)
+	}
+	// Honesty fix (pitch 25-12): view/Hotwire dispatch is NOT listed as an
+	// untracked blind spot — those edges are extracted and resolve. Assert the
+	// positive statement is present and the stale "dispatch is a blind spot"
+	// list-item phrasing is gone, both directions.
+	if !strings.Contains(rails, "NOT a blind spot") {
+		t.Errorf("Rails note must affirm view/Hotwire dispatch is tracked, got: %s", rails)
+	}
+	if !strings.Contains(rails, "view templates that produced no indexed edges") {
+		t.Errorf("Rails note must name the real residual blind spot (zero-edge view files), got: %s", rails)
+	}
+	if strings.Contains(rails, "dispatch — methods reached") {
+		t.Errorf("Rails note must not list view/Hotwire dispatch as a blind spot, got: %s", rails)
 	}
 	if strings.Contains(rails, "ServiceLoader") || strings.Contains(rails, "blank identifier") {
 		t.Error("Rails note must not carry Go-specific blind spots")

--- a/internal/mcpio/dead.go
+++ b/internal/mcpio/dead.go
@@ -71,10 +71,13 @@ func deadCodeNote(frameworks []string) string {
 		if f == "Rails" {
 			return deadNotePrefix +
 				"(1) routing — controller actions are dispatched by config/routes, never called from Ruby; " +
-				"(2) view & Hotwire dispatch — methods reached from ERB or Stimulus data-controller/data-action/data-*-target attributes; " +
-				"(3) ActiveSupport::Concern mixins — methods defined in an included module become instance methods of the includer; " +
-				"(4) callbacks & metaprogramming — before_action/after_action by symbol, define_method, const_get/constantize, STI; and " +
-				"(5) framework lifecycle hooks invoked by Rails rather than application code."
+				"(2) ActiveSupport::Concern mixins — methods defined in an included module become instance methods of the includer; " +
+				"(3) callbacks & metaprogramming — before_action/after_action by symbol, define_method, const_get/constantize, STI; " +
+				"(4) framework lifecycle hooks invoked by Rails rather than application code; and " +
+				"(5) view templates that produced no indexed edges — a pure-markup or otherwise unmodeled ERB file. " +
+				"View & Hotwire dispatch is NOT a blind spot: methods reached from ERB or Stimulus " +
+				"data-controller/data-action/data-*-target attributes, rendered partials, i18n keys, and embedded-Ruby " +
+				"helper/route calls ARE extracted and resolve, so a symbol reached only from a view is not dead."
 		}
 	}
 	return deadNotePrefix +

--- a/internal/mcpio/graph.go
+++ b/internal/mcpio/graph.go
@@ -206,7 +206,7 @@ func BuildGraphResponse(ctx context.Context, sc *model.SymbolContext, files File
 
 	resp.VerifyHint = graphVerifyHint(resp)
 	resp.IndexCaveat = graphIndexCaveat(resp)
-	resp.ViewEdges = graphViewEdges(resp)
+	resp.ViewEdges = viewEdgesSignal(sc.File.Path, anyViewTemplate(inboundEdgeFiles(sc.Inbound, files)))
 
 	symbolsReturned := len(resp.Edges.Calls) + len(resp.Edges.CalledBy) + len(testCallers) +
 		len(resp.Edges.Inherits) + len(resp.Edges.Composes) +
@@ -565,18 +565,23 @@ func graphIndexCaveat(resp GraphResponse) string {
 	return IndexCaveat(resp.Symbol.File)
 }
 
-// graphViewEdges derives the view_edges signal from the subject's defining
-// file and the files of its direct callers (called_by). Only depth-1 callers
-// count — view_edges is a "directly reached from a view" signal, not a
-// transitive one.
-func graphViewEdges(resp GraphResponse) string {
-	callerFiles := make([]string, 0, len(resp.Edges.CalledBy))
-	for _, c := range resp.Edges.CalledBy {
-		if c.File != nil {
-			callerFiles = append(callerFiles, *c.File)
+// inboundEdgeFiles returns the file each inbound usage edge was emitted from.
+// This is the edge's own file_id, NOT the caller symbol's file: a view edge
+// (ERB → Ruby/JS) is stored with source_id NULL — the source is a template,
+// not a symbol — so the caller-symbol file is absent, but the edge's file_id
+// is the ERB template. Checking the edge file is the only way view-reach
+// surfaces. Only usage edges (calls / references) count.
+func inboundEdgeFiles(inbound []model.EdgeRef, files FileLookup) []string {
+	out := make([]string, 0, len(inbound))
+	for _, e := range inbound {
+		if e.Edge.Kind != model.EdgeCalls && e.Edge.Kind != model.EdgeReferences {
+			continue
+		}
+		if p, ok := files(e.Edge.FileID); ok {
+			out = append(out, p)
 		}
 	}
-	return viewEdgesSignal(resp.Symbol.File, callerFiles)
+	return out
 }
 
 func graphVerifyHint(resp GraphResponse) string {

--- a/internal/mcpio/graph.go
+++ b/internal/mcpio/graph.go
@@ -206,6 +206,7 @@ func BuildGraphResponse(ctx context.Context, sc *model.SymbolContext, files File
 
 	resp.VerifyHint = graphVerifyHint(resp)
 	resp.IndexCaveat = graphIndexCaveat(resp)
+	resp.ViewEdges = graphViewEdges(resp)
 
 	symbolsReturned := len(resp.Edges.Calls) + len(resp.Edges.CalledBy) + len(testCallers) +
 		len(resp.Edges.Inherits) + len(resp.Edges.Composes) +
@@ -562,6 +563,20 @@ func graphIndexCaveat(resp GraphResponse) string {
 		return ""
 	}
 	return IndexCaveat(resp.Symbol.File)
+}
+
+// graphViewEdges derives the view_edges signal from the subject's defining
+// file and the files of its direct callers (called_by). Only depth-1 callers
+// count — view_edges is a "directly reached from a view" signal, not a
+// transitive one.
+func graphViewEdges(resp GraphResponse) string {
+	callerFiles := make([]string, 0, len(resp.Edges.CalledBy))
+	for _, c := range resp.Edges.CalledBy {
+		if c.File != nil {
+			callerFiles = append(callerFiles, *c.File)
+		}
+	}
+	return viewEdgesSignal(resp.Symbol.File, callerFiles)
 }
 
 func graphVerifyHint(resp GraphResponse) string {

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -115,6 +115,11 @@ type GraphResponse struct {
 	CoverageNote       string                 `json:"coverage_note,omitempty"`
 	VerifyHint         string                 `json:"verify_hint,omitempty"`
 	IndexCaveat        string                 `json:"index_caveat,omitempty"`
+	// ViewEdges is the per-subject view-reachability signal: "present" when a
+	// view template reaches this symbol, "none" when view-dispatch is a live
+	// question for it but no view edge exists, "" (omitted) otherwise. See
+	// viewedges.go for the full contract.
+	ViewEdges          string                 `json:"view_edges,omitempty"`
 	SenseMetrics       GraphMetrics           `json:"-"`
 	Freshness          *Freshness             `json:"freshness,omitempty"`
 	NextSteps          []NextStep             `json:"next_steps"`
@@ -309,6 +314,11 @@ type BlastResponse struct {
 
 	VerifyHint   string       `json:"verify_hint,omitempty"`
 	IndexCaveat  string       `json:"index_caveat,omitempty"`
+	// ViewEdges is the per-subject view-reachability signal: "present" when a
+	// view template reaches this symbol, "none" when view-dispatch is a live
+	// question for it but no view edge exists, "" (omitted) otherwise. See
+	// viewedges.go for the full contract.
+	ViewEdges    string       `json:"view_edges,omitempty"`
 	SenseMetrics BlastMetrics `json:"-"`
 	Freshness    *Freshness   `json:"freshness,omitempty"`
 	NextSteps    []NextStep   `json:"next_steps"`

--- a/internal/mcpio/viewedges.go
+++ b/internal/mcpio/viewedges.go
@@ -1,0 +1,68 @@
+package mcpio
+
+import "strings"
+
+// view_edges is the per-target honesty signal that replaces the old blanket
+// "view & Hotwire dispatch is a blind spot" hedge. Sense DOES extract and
+// resolve view-layer edges — ERB/Hotwire dispatch (data-controller /
+// data-action / data-*-target / data-*-outlet), render partials, i18n keys,
+// and embedded-Ruby helper/route calls — so a method reached only from a view
+// is not invisible. The signal reports that fact at the level of the queried
+// subject:
+//
+//   - "present" — at least one incoming edge originates in a view template.
+//     The subject IS reached from the view layer, and that edge is shown in
+//     the response.
+//   - "none" — the subject is one whose liveness is plausibly view-dispatched
+//     (a Rails controller/helper, or a Stimulus JS/TS controller) and no view
+//     edge reaches it. This is an affirmative "we looked and the view layer
+//     does not reach it," not a hedge.
+//   - "" (omitted) — the question is not salient for this subject (a model,
+//     service, or non-Ruby/JS symbol), so no claim is made either way.
+//
+// The distinction matters: "present" is reported for any subject a view
+// reaches, but "none" is scoped to subjects where view-dispatch is a live
+// question, so models, services, and Go code are not sprayed with a noisy
+// "view_edges": "none" on every response.
+const (
+	viewEdgesPresent = "present"
+	viewEdgesNone    = "none"
+)
+
+// isViewTemplate reports whether a file path is a view template — the source
+// side of a Hotwire/Stimulus or embedded-Ruby view edge.
+func isViewTemplate(file string) bool {
+	return strings.HasSuffix(file, ".erb")
+}
+
+// viewReachQuestionRelevant reports whether view-dispatch is a live question
+// for a subject defined in this file — i.e. whether a "none" answer carries
+// information. True for Rails controllers and helpers (often reached only via
+// routing or view rendering) and for Stimulus JS/TS controllers (reached only
+// via data-controller/data-action). False for models, services, libraries,
+// and everything else, where "no view edge" is the unremarkable default.
+func viewReachQuestionRelevant(file string) bool {
+	if strings.Contains(file, "app/controllers/") || strings.Contains(file, "app/helpers/") {
+		return true
+	}
+	if strings.Contains(file, "controllers/") &&
+		(strings.HasSuffix(file, ".js") || strings.HasSuffix(file, ".ts")) {
+		return true
+	}
+	return false
+}
+
+// viewEdgesSignal classifies a subject's view reachability from its defining
+// file and the files of its direct (depth-1) incoming callers. See the
+// view_edges doc comment for the three-way contract.
+func viewEdgesSignal(subjectFile string, callerFiles []string) string {
+	for _, f := range callerFiles {
+		if isViewTemplate(f) {
+			return viewEdgesPresent
+		}
+	}
+	if viewReachQuestionRelevant(subjectFile) {
+		return viewEdgesNone
+	}
+	return ""
+}

--- a/internal/mcpio/viewedges.go
+++ b/internal/mcpio/viewedges.go
@@ -52,17 +52,27 @@ func viewReachQuestionRelevant(file string) bool {
 	return false
 }
 
-// viewEdgesSignal classifies a subject's view reachability from its defining
-// file and the files of its direct (depth-1) incoming callers. See the
+// viewEdgesSignal classifies a subject's view reachability. present is whether
+// a view template reaches the subject directly (depth-1); subjectFile decides
+// whether a non-present answer is reported as "none" or omitted. See the
 // view_edges doc comment for the three-way contract.
-func viewEdgesSignal(subjectFile string, callerFiles []string) string {
-	for _, f := range callerFiles {
-		if isViewTemplate(f) {
-			return viewEdgesPresent
-		}
+func viewEdgesSignal(subjectFile string, present bool) string {
+	if present {
+		return viewEdgesPresent
 	}
 	if viewReachQuestionRelevant(subjectFile) {
 		return viewEdgesNone
 	}
 	return ""
+}
+
+// anyViewTemplate reports whether any of the given files is a view template —
+// the "present" input to viewEdgesSignal.
+func anyViewTemplate(files []string) bool {
+	for _, f := range files {
+		if isViewTemplate(f) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/mcpio/viewedges_test.go
+++ b/internal/mcpio/viewedges_test.go
@@ -13,139 +13,32 @@ func TestViewEdgesSignal(t *testing.T) {
 	tests := []struct {
 		name        string
 		subjectFile string
-		callerFiles []string
+		present     bool
 		want        string
 	}{
-		{
-			name:        "ruby helper reached from a view template is present",
-			subjectFile: "app/helpers/orders_helper.rb",
-			callerFiles: []string{"app/views/orders/show.html.erb"},
-			want:        viewEdgesPresent,
-		},
-		{
-			name:        "stimulus controller dispatched from erb is present",
-			subjectFile: "app/javascript/controllers/checkout_controller.js",
-			callerFiles: []string{"app/views/checkout/new.html.erb"},
-			want:        viewEdgesPresent,
-		},
-		{
-			name:        "present wins even for a non-view-adjacent subject",
-			subjectFile: "app/models/order.rb",
-			callerFiles: []string{"app/views/orders/_row.html.erb"},
-			want:        viewEdgesPresent,
-		},
-		{
-			name:        "controller with no view edge reports none",
-			subjectFile: "app/controllers/orders_controller.rb",
-			callerFiles: []string{"app/services/checkout_service.rb"},
-			want:        viewEdgesNone,
-		},
-		{
-			name:        "stimulus controller with no view edge reports none",
-			subjectFile: "app/javascript/controllers/cart_controller.ts",
-			callerFiles: nil,
-			want:        viewEdgesNone,
-		},
-		{
-			name:        "model with no view edge stays silent",
-			subjectFile: "app/models/order.rb",
-			callerFiles: []string{"app/services/checkout_service.rb"},
-			want:        "",
-		},
-		{
-			name:        "service with no view edge stays silent",
-			subjectFile: "app/services/checkout_service.rb",
-			callerFiles: nil,
-			want:        "",
-		},
-		{
-			name:        "go symbol is never view-relevant",
-			subjectFile: "internal/extract/ruby/ruby.go",
-			callerFiles: []string{"internal/scan/scan.go"},
-			want:        "",
-		},
+		{"present wins regardless of subject kind", "app/models/order.rb", true, viewEdgesPresent},
+		{"helper reached from view is present", "app/helpers/orders_helper.rb", true, viewEdgesPresent},
+		{"controller with no view edge reports none", "app/controllers/orders_controller.rb", false, viewEdgesNone},
+		{"stimulus controller with no view edge reports none", "app/javascript/controllers/cart_controller.ts", false, viewEdgesNone},
+		{"model with no view edge stays silent", "app/models/order.rb", false, ""},
+		{"service with no view edge stays silent", "app/services/checkout_service.rb", false, ""},
+		{"go symbol is never view-relevant", "internal/extract/ruby/ruby.go", false, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := viewEdgesSignal(tt.subjectFile, tt.callerFiles); got != tt.want {
-				t.Errorf("viewEdgesSignal(%q, %v) = %q, want %q",
-					tt.subjectFile, tt.callerFiles, got, tt.want)
+			if got := viewEdgesSignal(tt.subjectFile, tt.present); got != tt.want {
+				t.Errorf("viewEdgesSignal(%q, %v) = %q, want %q", tt.subjectFile, tt.present, got, tt.want)
 			}
 		})
 	}
 }
 
-// TestBuildGraphResponseViewEdges proves the graph builder reports view_edges
-// "present" when an ERB caller reaches the subject and "none" when a
-// view-relevant subject has no view edge.
-func TestBuildGraphResponseViewEdges(t *testing.T) {
-	filePaths := map[int64]string{
-		1: "app/controllers/orders_controller.rb",
-		2: "app/views/orders/index.html.erb",
-		3: "app/services/checkout_service.rb",
+func TestAnyViewTemplate(t *testing.T) {
+	if !anyViewTemplate([]string{"app/services/x.rb", "app/views/orders/show.html.erb"}) {
+		t.Error("expected an .erb file to count as a view template")
 	}
-	files := func(id int64) (string, bool) {
-		p, ok := filePaths[id]
-		return p, ok
-	}
-
-	present := &model.SymbolContext{
-		Symbol: model.Symbol{ID: 10, Name: "index", Qualified: "OrdersController#index", Kind: "method", FileID: 1},
-		File:   model.File{Path: "app/controllers/orders_controller.rb"},
-		Inbound: []model.EdgeRef{
-			{
-				Edge:   model.Edge{Kind: model.EdgeCalls, Confidence: extract.ConfidenceConvention},
-				Target: model.Symbol{Qualified: "app/views/orders/index.html.erb", FileID: 2},
-			},
-		},
-	}
-	if got := BuildGraphResponse(context.Background(), present, files, BuildGraphRequest{}).ViewEdges; got != viewEdgesPresent {
-		t.Errorf("ViewEdges = %q, want %q (controller reached from an ERB view)", got, viewEdgesPresent)
-	}
-
-	none := &model.SymbolContext{
-		Symbol: model.Symbol{ID: 11, Name: "create", Qualified: "OrdersController#create", Kind: "method", FileID: 1},
-		File:   model.File{Path: "app/controllers/orders_controller.rb"},
-		Inbound: []model.EdgeRef{
-			{
-				Edge:   model.Edge{Kind: model.EdgeCalls, Confidence: 1.0},
-				Target: model.Symbol{Qualified: "App::CheckoutService", FileID: 3},
-			},
-		},
-	}
-	if got := BuildGraphResponse(context.Background(), none, files, BuildGraphRequest{}).ViewEdges; got != viewEdgesNone {
-		t.Errorf("ViewEdges = %q, want %q (controller with no view edge)", got, viewEdgesNone)
-	}
-}
-
-// TestBuildBlastResponseViewEdges proves the blast builder reports view_edges
-// "present" when an ERB direct caller reaches the subject and "none" for a
-// view-relevant subject with no view edge.
-func TestBuildBlastResponseViewEdges(t *testing.T) {
-	filePaths := map[int64]string{
-		1: "app/controllers/orders_controller.rb",
-		2: "app/views/orders/index.html.erb",
-		3: "app/services/checkout_service.rb",
-	}
-	files := func(id int64) (string, bool) {
-		p, ok := filePaths[id]
-		return p, ok
-	}
-
-	present := blast.Result{
-		Symbol:        model.Symbol{ID: 10, Qualified: "OrdersController#index", FileID: 1},
-		DirectCallers: []model.Symbol{{ID: 20, Qualified: "app/views/orders/index.html.erb", FileID: 2}},
-	}
-	if got := BuildBlastResponse(context.Background(), present, files, nil).ViewEdges; got != viewEdgesPresent {
-		t.Errorf("ViewEdges = %q, want %q (controller reached from an ERB view)", got, viewEdgesPresent)
-	}
-
-	none := blast.Result{
-		Symbol:        model.Symbol{ID: 11, Qualified: "OrdersController#create", FileID: 1},
-		DirectCallers: []model.Symbol{{ID: 21, Qualified: "App::CheckoutService", FileID: 3}},
-	}
-	if got := BuildBlastResponse(context.Background(), none, files, nil).ViewEdges; got != viewEdgesNone {
-		t.Errorf("ViewEdges = %q, want %q (controller with no view edge)", got, viewEdgesNone)
+	if anyViewTemplate([]string{"app/services/x.rb", "config/routes.rb"}) {
+		t.Error("no .erb file should mean not view-reached")
 	}
 }
 
@@ -173,12 +66,81 @@ func TestViewReachQuestionRelevant(t *testing.T) {
 	irrelevant := []string{
 		"app/models/order.rb",
 		"app/services/checkout_service.rb",
-		"app/javascript/utils/format.js", // not a controller
+		"app/javascript/utils/format.js",
 		"internal/extract/ruby/ruby.go",
 	}
 	for _, f := range irrelevant {
 		if viewReachQuestionRelevant(f) {
 			t.Errorf("%q should not be view-reach relevant", f)
 		}
+	}
+}
+
+// TestBuildGraphResponseViewEdges proves the graph builder reads the inbound
+// edge's file_id (the ERB template), NOT the caller symbol's file — a view
+// edge has a NULL source, so the caller symbol is absent.
+func TestBuildGraphResponseViewEdges(t *testing.T) {
+	filePaths := map[int64]string{
+		1: "app/controllers/orders_controller.rb",
+		2: "app/views/orders/index.html.erb",
+		3: "app/services/checkout_service.rb",
+	}
+	files := func(id int64) (string, bool) {
+		p, ok := filePaths[id]
+		return p, ok
+	}
+
+	// A view edge: edge emitted from the ERB file (FileID 2), source symbol
+	// absent (the real shape — source_id is NULL for ERB edges).
+	present := &model.SymbolContext{
+		Symbol: model.Symbol{ID: 10, Qualified: "OrdersController#index", Kind: "method", FileID: 1},
+		File:   model.File{Path: "app/controllers/orders_controller.rb"},
+		Inbound: []model.EdgeRef{
+			{Edge: model.Edge{Kind: model.EdgeCalls, FileID: 2, Confidence: extract.ConfidenceConvention}},
+		},
+	}
+	if got := BuildGraphResponse(context.Background(), present, files, BuildGraphRequest{}).ViewEdges; got != viewEdgesPresent {
+		t.Errorf("ViewEdges = %q, want %q (controller reached from an ERB view)", got, viewEdgesPresent)
+	}
+
+	none := &model.SymbolContext{
+		Symbol: model.Symbol{ID: 11, Qualified: "OrdersController#create", Kind: "method", FileID: 1},
+		File:   model.File{Path: "app/controllers/orders_controller.rb"},
+		Inbound: []model.EdgeRef{
+			{
+				Edge:   model.Edge{Kind: model.EdgeCalls, FileID: 3, Confidence: 1.0},
+				Target: model.Symbol{Qualified: "App::CheckoutService", FileID: 3},
+			},
+		},
+	}
+	if got := BuildGraphResponse(context.Background(), none, files, BuildGraphRequest{}).ViewEdges; got != viewEdgesNone {
+		t.Errorf("ViewEdges = %q, want %q (controller with no view edge)", got, viewEdgesNone)
+	}
+}
+
+// TestBuildBlastResponseViewEdges proves the blast builder maps the engine's
+// ViewReached flag to the view_edges signal.
+func TestBuildBlastResponseViewEdges(t *testing.T) {
+	files := func(id int64) (string, bool) {
+		if id == 1 {
+			return "app/controllers/orders_controller.rb", true
+		}
+		return "", false
+	}
+
+	present := blast.Result{
+		Symbol:      model.Symbol{ID: 10, Qualified: "OrdersController#index", FileID: 1},
+		ViewReached: true,
+	}
+	if got := BuildBlastResponse(context.Background(), present, files, nil).ViewEdges; got != viewEdgesPresent {
+		t.Errorf("ViewEdges = %q, want %q (engine reported view-reached)", got, viewEdgesPresent)
+	}
+
+	none := blast.Result{
+		Symbol:      model.Symbol{ID: 11, Qualified: "OrdersController#create", FileID: 1},
+		ViewReached: false,
+	}
+	if got := BuildBlastResponse(context.Background(), none, files, nil).ViewEdges; got != viewEdgesNone {
+		t.Errorf("ViewEdges = %q, want %q (controller, not view-reached)", got, viewEdgesNone)
 	}
 }

--- a/internal/mcpio/viewedges_test.go
+++ b/internal/mcpio/viewedges_test.go
@@ -1,0 +1,184 @@
+package mcpio
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luuuc/sense/internal/blast"
+	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/model"
+)
+
+func TestViewEdgesSignal(t *testing.T) {
+	tests := []struct {
+		name        string
+		subjectFile string
+		callerFiles []string
+		want        string
+	}{
+		{
+			name:        "ruby helper reached from a view template is present",
+			subjectFile: "app/helpers/orders_helper.rb",
+			callerFiles: []string{"app/views/orders/show.html.erb"},
+			want:        viewEdgesPresent,
+		},
+		{
+			name:        "stimulus controller dispatched from erb is present",
+			subjectFile: "app/javascript/controllers/checkout_controller.js",
+			callerFiles: []string{"app/views/checkout/new.html.erb"},
+			want:        viewEdgesPresent,
+		},
+		{
+			name:        "present wins even for a non-view-adjacent subject",
+			subjectFile: "app/models/order.rb",
+			callerFiles: []string{"app/views/orders/_row.html.erb"},
+			want:        viewEdgesPresent,
+		},
+		{
+			name:        "controller with no view edge reports none",
+			subjectFile: "app/controllers/orders_controller.rb",
+			callerFiles: []string{"app/services/checkout_service.rb"},
+			want:        viewEdgesNone,
+		},
+		{
+			name:        "stimulus controller with no view edge reports none",
+			subjectFile: "app/javascript/controllers/cart_controller.ts",
+			callerFiles: nil,
+			want:        viewEdgesNone,
+		},
+		{
+			name:        "model with no view edge stays silent",
+			subjectFile: "app/models/order.rb",
+			callerFiles: []string{"app/services/checkout_service.rb"},
+			want:        "",
+		},
+		{
+			name:        "service with no view edge stays silent",
+			subjectFile: "app/services/checkout_service.rb",
+			callerFiles: nil,
+			want:        "",
+		},
+		{
+			name:        "go symbol is never view-relevant",
+			subjectFile: "internal/extract/ruby/ruby.go",
+			callerFiles: []string{"internal/scan/scan.go"},
+			want:        "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := viewEdgesSignal(tt.subjectFile, tt.callerFiles); got != tt.want {
+				t.Errorf("viewEdgesSignal(%q, %v) = %q, want %q",
+					tt.subjectFile, tt.callerFiles, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildGraphResponseViewEdges proves the graph builder reports view_edges
+// "present" when an ERB caller reaches the subject and "none" when a
+// view-relevant subject has no view edge.
+func TestBuildGraphResponseViewEdges(t *testing.T) {
+	filePaths := map[int64]string{
+		1: "app/controllers/orders_controller.rb",
+		2: "app/views/orders/index.html.erb",
+		3: "app/services/checkout_service.rb",
+	}
+	files := func(id int64) (string, bool) {
+		p, ok := filePaths[id]
+		return p, ok
+	}
+
+	present := &model.SymbolContext{
+		Symbol: model.Symbol{ID: 10, Name: "index", Qualified: "OrdersController#index", Kind: "method", FileID: 1},
+		File:   model.File{Path: "app/controllers/orders_controller.rb"},
+		Inbound: []model.EdgeRef{
+			{
+				Edge:   model.Edge{Kind: model.EdgeCalls, Confidence: extract.ConfidenceConvention},
+				Target: model.Symbol{Qualified: "app/views/orders/index.html.erb", FileID: 2},
+			},
+		},
+	}
+	if got := BuildGraphResponse(context.Background(), present, files, BuildGraphRequest{}).ViewEdges; got != viewEdgesPresent {
+		t.Errorf("ViewEdges = %q, want %q (controller reached from an ERB view)", got, viewEdgesPresent)
+	}
+
+	none := &model.SymbolContext{
+		Symbol: model.Symbol{ID: 11, Name: "create", Qualified: "OrdersController#create", Kind: "method", FileID: 1},
+		File:   model.File{Path: "app/controllers/orders_controller.rb"},
+		Inbound: []model.EdgeRef{
+			{
+				Edge:   model.Edge{Kind: model.EdgeCalls, Confidence: 1.0},
+				Target: model.Symbol{Qualified: "App::CheckoutService", FileID: 3},
+			},
+		},
+	}
+	if got := BuildGraphResponse(context.Background(), none, files, BuildGraphRequest{}).ViewEdges; got != viewEdgesNone {
+		t.Errorf("ViewEdges = %q, want %q (controller with no view edge)", got, viewEdgesNone)
+	}
+}
+
+// TestBuildBlastResponseViewEdges proves the blast builder reports view_edges
+// "present" when an ERB direct caller reaches the subject and "none" for a
+// view-relevant subject with no view edge.
+func TestBuildBlastResponseViewEdges(t *testing.T) {
+	filePaths := map[int64]string{
+		1: "app/controllers/orders_controller.rb",
+		2: "app/views/orders/index.html.erb",
+		3: "app/services/checkout_service.rb",
+	}
+	files := func(id int64) (string, bool) {
+		p, ok := filePaths[id]
+		return p, ok
+	}
+
+	present := blast.Result{
+		Symbol:        model.Symbol{ID: 10, Qualified: "OrdersController#index", FileID: 1},
+		DirectCallers: []model.Symbol{{ID: 20, Qualified: "app/views/orders/index.html.erb", FileID: 2}},
+	}
+	if got := BuildBlastResponse(context.Background(), present, files, nil).ViewEdges; got != viewEdgesPresent {
+		t.Errorf("ViewEdges = %q, want %q (controller reached from an ERB view)", got, viewEdgesPresent)
+	}
+
+	none := blast.Result{
+		Symbol:        model.Symbol{ID: 11, Qualified: "OrdersController#create", FileID: 1},
+		DirectCallers: []model.Symbol{{ID: 21, Qualified: "App::CheckoutService", FileID: 3}},
+	}
+	if got := BuildBlastResponse(context.Background(), none, files, nil).ViewEdges; got != viewEdgesNone {
+		t.Errorf("ViewEdges = %q, want %q (controller with no view edge)", got, viewEdgesNone)
+	}
+}
+
+func TestIsViewTemplate(t *testing.T) {
+	if !isViewTemplate("app/views/orders/show.html.erb") {
+		t.Error(".erb file should be a view template")
+	}
+	if isViewTemplate("app/models/order.rb") {
+		t.Error(".rb file is not a view template")
+	}
+}
+
+func TestViewReachQuestionRelevant(t *testing.T) {
+	relevant := []string{
+		"app/controllers/orders_controller.rb",
+		"app/helpers/orders_helper.rb",
+		"app/javascript/controllers/cart_controller.js",
+		"app/javascript/controllers/cart_controller.ts",
+	}
+	for _, f := range relevant {
+		if !viewReachQuestionRelevant(f) {
+			t.Errorf("%q should be view-reach relevant", f)
+		}
+	}
+	irrelevant := []string{
+		"app/models/order.rb",
+		"app/services/checkout_service.rb",
+		"app/javascript/utils/format.js", // not a controller
+		"internal/extract/ruby/ruby.go",
+	}
+	for _, f := range irrelevant {
+		if viewReachQuestionRelevant(f) {
+			t.Errorf("%q should not be view-reach relevant", f)
+		}
+	}
+}

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -344,7 +344,8 @@ func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, SearchMeta
 		if r.Score < opts.MinScore {
 			continue
 		}
-		if strings.HasPrefix(r.Qualified, extract.PrefixRubyCore) {
+		if strings.HasPrefix(r.Qualified, extract.PrefixRubyCore) ||
+			strings.HasPrefix(r.Qualified, extract.PrefixRoute) {
 			continue
 		}
 		results = append(results, r)

--- a/internal/search/synthetic_filter_test.go
+++ b/internal/search/synthetic_filter_test.go
@@ -72,3 +72,60 @@ func TestSyntheticSymbolsFilteredFromSearch(t *testing.T) {
 		t.Error("ordinary Geometry::Struct missing from search results (filter is over-broad)")
 	}
 }
+
+// TestRouteSymbolsFilteredFromSearch proves synthetic route:* helper symbols
+// never surface in search, while an ordinary same-named app method does.
+func TestRouteSymbolsFilteredFromSearch(t *testing.T) {
+	t.Setenv("SENSE_EMBEDDINGS", "false")
+	dir := t.TempDir()
+	a, err := sqlite.Open(context.Background(), filepath.Join(dir, "index.db"))
+	if err != nil {
+		t.Fatalf("open adapter: %v", err)
+	}
+	t.Cleanup(func() { _ = a.Close() })
+	ctx := context.Background()
+
+	fid, err := a.WriteFile(ctx, &model.File{
+		Path: "config/routes.rb", Language: "ruby",
+		Hash: "h", Symbols: 2, IndexedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	for _, s := range []model.Symbol{
+		{FileID: fid, Name: "orders_path", Qualified: "route:orders_path", Kind: "constant", LineStart: 1, LineEnd: 1},
+		{FileID: fid, Name: "orders_path", Qualified: "Billing#orders_path", Kind: "method", LineStart: 2, LineEnd: 3},
+	} {
+		if _, err := a.WriteSymbol(ctx, &s); err != nil {
+			t.Fatalf("write symbol %q: %v", s.Qualified, err)
+		}
+	}
+
+	engine, embedder, err := search.BuildEngine(ctx, a, dir)
+	if err != nil {
+		t.Fatalf("BuildEngine: %v", err)
+	}
+	if embedder != nil {
+		defer func() { _ = embedder.Close() }()
+	}
+
+	results, _, err := engine.Search(ctx, search.Options{Query: "orders_path", Limit: 10})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	var sawReal, sawSynthetic bool
+	for _, r := range results {
+		switch r.Qualified {
+		case "route:orders_path":
+			sawSynthetic = true
+		case "Billing#orders_path":
+			sawReal = true
+		}
+	}
+	if sawSynthetic {
+		t.Error("synthetic route:orders_path leaked into search results")
+	}
+	if !sawReal {
+		t.Error("ordinary Billing#orders_path missing from search results (filter is over-broad)")
+	}
+}


### PR DESCRIPTION
## Problem
ERB/Hotwire templates were registered as Basic tier, and the dead-code caveat told agents that "view & Hotwire dispatch" was an untracked blind spot — even though Stimulus/Turbo edges were already extracted and resolving. That caveat made agents distrust real edges, the inverse failure. Meanwhile the embedded Ruby inside `<% %>` tags was only regex-scanned, so receiver chains, blocks, and the view→route→controller chain were invisible, and `*_path` references could phantom-match an unrelated app method of the same name.

## Summary
Promote ERB to Full tier: parse the embedded Ruby of every tag with the Ruby grammar, emit Rails route-helper symbols so `link_to … orders_path` resolves through to its controller action, and tell the truth about what views reach.

## Changes
- **Embedded Ruby** — `ruby.ExtractEmbeddedCalls` parses each `<% %>`/`<%= %>` tag with tree-sitter-ruby (receivers, method chains, block bodies), tolerant of split `if`/`end` fragments. The ERB extractor funnels both this and the regex helper pass through a dedup layer.
- **render-collection / form-model** — `render @posts` → `partial:posts/post` (to_partial_path convention); `form_with model: @order` → `references` → the model class.
- **Route helpers** — the route DSL emits synthetic `route:NAME_path` / `route:NAME_url` symbols edged to the controller action they route to (namespaced / singular / `as:` forms; nested resources emit none rather than a wrong name). A `*_path`/`*_url` view reference retargets the reserved `route:` symbol, so it can never phantom-match an app method.
- **Honesty signals** — the Rails dead-code note no longer lists view/Hotwire dispatch as a blind spot and names the real residual (zero-edge view files); `sense_graph`/`sense_blast` gain a per-subject `view_edges: present|none`.
- **Noise filtering** — framework context accessors (`request`, `params`, …) and core Object/reflection methods (`is_a?`, `respond_to?`, …) no longer emit bare self-calls that the resolver binds to coincidental same-named symbols.
- **Tier** — ERB flipped Basic → Full in the language-tier map.

## Architecture Highlights
- `view_edges` is computed from the **edge's** `file_id` (the ERB template), not the caller symbol's file: ERB edges store `source_id = NULL`, so a caller-symbol check can never see them (blast uses a direct engine query; graph's file lookup now resolves edge files, which also fixes ERB call-site snippet resolution).
- The reserved `route:` prefix makes the whole view→route→controller chain fall out of existing name resolution — no new edge kind, no schema change — and is filtered from dead-code and search output like the other synthetics.

## Test Plan
- [x] Embedded-Ruby chain/block calls resolve to their targets at the correct ERB line; split `<% if %>…<% end %>` fragments don't abort the scan
- [x] `link_to … orders_path` reaches its controller action via a `route:` symbol; a `*_path` app method (e.g. `verifications_path`) is not hit
- [x] Route-helper naming: resources / resource / namespace / `as:` / un-nameable cases; `route:` symbols absent from dead/search
- [x] `view_edges` is `present` for a view-reached symbol, `none`/omitted otherwise, on both graph and blast
- [x] Dead-code caveat no longer claims Hotwire dispatch is untracked
- [x] `make ci` passes (build + `go test ./...` + lint)
- [x] sense binary builds cleanly