### PR TITLE
fix(dead): treat framework apps as non-library to fix reason mislabel

### DIFF
--- a/internal/dead/arbiter.go
+++ b/internal/dead/arbiter.go
@@ -72,8 +72,11 @@ type Voice interface {
 type Facts struct {
 	// Frameworks is the set of detected frameworks (e.g. "Rails").
 	Frameworks map[string]struct{}
-	// IsLibrary is true when the project has no main entry point, so its
-	// public symbols may be consumed by code outside the indexed tree.
+	// IsLibrary is true when the tree has no application entry point — no main
+	// function AND no detected framework — so its public symbols may be an API
+	// surface consumed from outside. A framework application (Rails, etc.) has
+	// no main yet is not a library: its public methods are internal, so a
+	// detected framework makes IsLibrary false. See buildFacts.
 	IsLibrary bool
 	// DispatchNames is the set of literal names that appear as reflection /
 	// metaprogramming dispatch targets (send/public_send/__send__/

--- a/internal/dead/arbiter_test.go
+++ b/internal/dead/arbiter_test.go
@@ -151,6 +151,39 @@ func TestCoreVoiceReflectionBeatsExport(t *testing.T) {
 	}
 }
 
+// TestFrameworkAppMethodGetsLanguageReasonNotExportedAPI pins the behavior the
+// IsLibrary = !hasMain && len(frameworks)==0 fix exists for, through the real
+// voice stack rather than fakes. In a framework application IsLibrary is false,
+// so the core voice stays silent and an app-internal public Ruby method earns
+// the accurate ruby_public_method reason — not core_exported_api ("search
+// dependent projects"), which would mislead a triager. The contrast case (a
+// genuine library, IsLibrary=true) still surfaces core_exported_api, proving
+// the fix corrected the premise rather than the 50-vs-60 priority ladder: the
+// export reason only wins when its premise actually holds.
+func TestFrameworkAppMethodGetsLanguageReasonNotExportedAPI(t *testing.T) {
+	a := defaultArbiter()
+	// A public Ruby instance method with no dynamic-dispatch / mixin signal —
+	// the rubyVoice catch-all is ruby_public_method. Visibility must be public
+	// for the export gate to be a candidate at all, so the test proves the
+	// IsLibrary premise (not visibility) is what silences it.
+	method := Symbol{Name: "public_helper", Qualified: "Billing::Calculator#public_helper",
+		Kind: "method", Visibility: "public", Language: "ruby"}
+
+	// Framework app: IsLibrary false ⇒ core voice silent ⇒ ruby_public_method.
+	app := a.Decide([]Symbol{method}, Facts{IsLibrary: false})[0]
+	if app.Reason == nil || app.Reason.Code != ReasonRubyPublicMethod {
+		t.Errorf("framework-app method: reason = %+v, want %s", app.Reason, ReasonRubyPublicMethod)
+	}
+
+	// Genuine library: IsLibrary true ⇒ core voice raises the higher-priority
+	// export reason, which wins. Confirms the fix changed the premise, not the
+	// priority ordering.
+	lib := a.Decide([]Symbol{method}, Facts{IsLibrary: true})[0]
+	if lib.Reason == nil || lib.Reason.Code != ReasonExportedAPI {
+		t.Errorf("library method: reason = %+v, want %s", lib.Reason, ReasonExportedAPI)
+	}
+}
+
 func TestReasonCatalogLookup(t *testing.T) {
 	if reasonPriority(ReasonNoLanguageVoice) != 70 {
 		t.Errorf("no_language_voice priority = %d, want 70", reasonPriority(ReasonNoLanguageVoice))

--- a/internal/dead/dead.go
+++ b/internal/dead/dead.go
@@ -162,8 +162,13 @@ func buildFacts(ctx context.Context, db *sql.DB) (Facts, error) {
 	}
 
 	return Facts{
-		Frameworks:           frameworks,
-		IsLibrary:            !hasMain,
+		Frameworks: frameworks,
+		// A library is a tree with no application entry point whose public
+		// symbols may be consumed from outside. "No main" alone is not enough:
+		// a framework application (Rails, etc.) also has no main, yet its public
+		// methods are internal, not an exported API. A detected framework means
+		// the tree is an application, so it is not a library.
+		IsLibrary:            !hasMain && len(frameworks) == 0,
 		DispatchNames:        readDispatchNames(ctx, db),
 		MentionedNames:       readMentionedNames(ctx, db),
 		ValueObjectClassIDs:  valueObjectClassIDs,


### PR DESCRIPTION
## Problem
Dead-code analysis classified any project without a `main` entry point as a library, and the core voice then raised `core_exported_api` ("public API of a library, search dependent projects") on every public symbol. A framework application (Rails, etc.) has no `main` but is not a library: its public methods are internal. Because `core_exported_api` (priority 50) outranks the accurate `ruby_public_method` (priority 60), a triager looking at an app-internal method was told to go search nonexistent dependent projects.

## Summary
Gate the library determination on framework detection as well as `main` absence, so a detected framework marks the tree an application and its public symbols stop being treated as an exported API surface.

## Changes
- `internal/dead/dead.go`: `IsLibrary` is now `!hasMain && len(frameworks) == 0` (was `!hasMain`).
- `internal/dead/arbiter.go`: doc comment on `Facts.IsLibrary` records that a detected framework makes it false.
- `internal/dead/arbiter_test.go`: regression test through the real voice stack — a framework-app public Ruby method earns `ruby_public_method`, while a genuine library (IsLibrary true) still surfaces `core_exported_api`, pinning that the fix corrected the premise rather than the priority ordering.

## Architecture Highlights
- The fix is at the premise, not the tie-break: once `IsLibrary` is correct, the core voice never raises the export reason for app methods, so the 50-vs-60 priority interaction never comes into play.
- Known tradeoff: a genuine Rails engine (a gem shipped as a Rails component) also loses `core_exported_api` and gets `ruby_public_method`. The verdict stays `possibly_dead` and the hint stays safe, so no correctness regression.

## Test Plan
- [x] Framework present + public Ruby method gets reason `ruby_public_method`
- [x] Library (no framework, no main) + public symbol gets reason `core_exported_api`
- [x] `go test ./...` passes
- [x] sense binary builds cleanly
