### PR TITLE
fix(resolve): gate unqualified fallback by language and namespace

### DIFF
--- a/internal/model/symbol.go
+++ b/internal/model/symbol.go
@@ -43,6 +43,11 @@ type SymbolRef struct {
 	// resolver's unqualified fallback filters candidates by dispatch kind
 	// so an instance call cannot bind to a same-named singleton method.
 	Receiver string
+	// Language is the symbol's file language (from sense_files). The resolver's
+	// unqualified fallback uses it to drop code-to-code cross-language matches —
+	// a Ruby call must not bind to a same-named JS symbol. Empty when the file
+	// language is unknown, in which case the gate is a no-op.
+	Language string
 }
 
 // HydrateSymbolNullables copies the sql.NullXxx carriers scanned from

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -27,6 +27,10 @@ import (
 type Index struct {
 	byQualified map[string][]model.SymbolRef
 	byName      map[string][]model.SymbolRef
+	// fileLang maps a file id to its language, so the unqualified fallback can
+	// look up the source edge's language from req.SourceFileID without threading
+	// it through every Request. Built from the same SymbolRefs as the name maps.
+	fileLang map[int64]string
 }
 
 // NewIndex builds an Index from the bulk SymbolRefs output. The input
@@ -36,11 +40,15 @@ func NewIndex(refs []model.SymbolRef) *Index {
 	ix := &Index{
 		byQualified: make(map[string][]model.SymbolRef, len(refs)),
 		byName:      make(map[string][]model.SymbolRef, len(refs)),
+		fileLang:    make(map[int64]string),
 	}
 	for _, r := range refs {
 		ix.byQualified[r.Qualified] = append(ix.byQualified[r.Qualified], r)
 		name := unqualifiedName(r.Qualified)
 		ix.byName[name] = append(ix.byName[name], r)
+		if r.Language != "" {
+			ix.fileLang[r.FileID] = r.Language
+		}
 	}
 	return ix
 }
@@ -95,9 +103,12 @@ const nameCollisionConfidence = extract.ConfidenceNameCollision
 //  2. Exact match via byQualified. Single hit ⇒ BaseConfidence.
 //     Multiple ⇒ same-file preferred, else lowest-id; confidence
 //     clamped to ambiguousConfidence.
-//  3. For calls and tests edges, fall back to unqualified-name match
-//     via byName. Same scope preference; confidence clamped to
-//     ambiguousConfidence.
+//  3. For calls, tests, and references edges, fall back to
+//     unqualified-name match via byName. Candidates in a different code
+//     language than the source are dropped (filterByLanguage); same
+//     scope preference applies; confidence is clamped to
+//     ambiguousConfidence, and a `::`-qualified target that matched only
+//     its leaf is demoted below blast's floor as a cross-namespace guess.
 //  4. No match ⇒ ok=false.
 func (ix *Index) Resolve(req Request) (Result, bool) {
 	target := rewriteReceiver(req.Target, req.SourceQualified, req.SourceParentQualified)
@@ -124,6 +135,7 @@ func (ix *Index) Resolve(req Request) (Result, bool) {
 				sep = ""
 			}
 			matches := ix.byName[name]
+			matches = filterByLanguage(matches, ix.fileLang[req.SourceFileID])
 			matches = filterByReceiver(matches, sep)
 			if len(matches) > 0 {
 				r := pickBest(matches, req.SourceFileID, req.BaseConfidence)
@@ -135,6 +147,15 @@ func (ix *Index) Resolve(req Request) (Result, bool) {
 					// weakest resolution — no receiver type disambiguates it. Drop
 					// it below blast's floor so impact analysis ignores the guess;
 					// it still counts for dead-code liveness.
+					r.Confidence = nameCollisionConfidence
+				}
+				if sep == "::" && r.Confidence > nameCollisionConfidence {
+					// A `::`-qualified target that missed exact lookup and matched
+					// only its trailing segment is a cross-namespace guess: the leaf
+					// bound but the namespace we couldn't verify was discarded
+					// (`Stripe::Checkout::Session` ⇒ a local `User::Session`). Demote
+					// below blast's floor even on a single match, so impact analysis
+					// ignores it while it still counts for dead-code liveness.
 					r.Confidence = nameCollisionConfidence
 				}
 				return r, true
@@ -309,4 +330,62 @@ func receiverForSeparator(sep string) string {
 		return extract.ReceiverSingleton
 	}
 	return ""
+}
+
+// filterByLanguage drops unqualified-fallback candidates that belong to a
+// different programming language than the source edge. A bare-name match
+// between two distinct code languages (a Ruby `application` call binding to a
+// JS Stimulus `application`) is a same-name coincidence, never a real call.
+//
+// Two carve-outs keep it from dropping legitimate edges:
+//
+//   - When the source is a view/template language (ERB, …) the gate is OFF.
+//     Templates legitimately dispatch into Ruby helpers and JS controllers by
+//     bare name through this very fallback, so their cross-language matches are
+//     real. (Synthetic-prefix view edges resolve via exact byQualified and never
+//     reach here; this carve-out covers the embedded-helper bare-name calls.)
+//   - An unknown language on the source (empty) or on a candidate is kept:
+//     without both languages the gate cannot prove a mismatch, so it stays a
+//     no-op (older indexes and unit tests that don't carry language are
+//     unaffected). The gate fails open: srcLang is "" when the source file
+//     contributed no symbol to fileLang (e.g. a file with zero indexed
+//     symbols), so a real edge is never silently dropped for lack of language.
+//
+// Unlike filterByReceiver, a language mismatch is a hard exclusion, not a
+// tie-break: if every candidate is cross-language the result is empty and the
+// edge drops to unresolved rather than binding to a coincidence. (filterBy
+// receiver, by contrast, returns its input untouched when filtering would
+// empty the set, because dispatch kind is a hint rather than a gate.)
+func filterByLanguage(matches []model.SymbolRef, srcLang string) []model.SymbolRef {
+	if srcLang == "" || isViewLanguage(srcLang) {
+		return matches
+	}
+	// Fast path: the overwhelmingly common case is every candidate sharing the
+	// source language, so scan first and return the input untouched rather than
+	// allocating a copy on every fallback in the hot resolve loop.
+	crossLang := false
+	for _, m := range matches {
+		if m.Language != "" && m.Language != srcLang {
+			crossLang = true
+			break
+		}
+	}
+	if !crossLang {
+		return matches
+	}
+	kept := make([]model.SymbolRef, 0, len(matches))
+	for _, m := range matches {
+		if m.Language == "" || m.Language == srcLang {
+			kept = append(kept, m)
+		}
+	}
+	return kept
+}
+
+// isViewLanguage reports whether a language is a view/template layer that
+// legitimately dispatches into other languages by bare name (so the
+// cross-language fallback gate must not apply to edges originating in it).
+// ERB is the only such language today; add others here as they gain extractors.
+func isViewLanguage(lang string) bool {
+	return lang == "erb"
 }

--- a/internal/resolve/resolver_test.go
+++ b/internal/resolve/resolver_test.go
@@ -481,3 +481,118 @@ func TestResolveImplicitSelfReachesInstanceConcernMethod(t *testing.T) {
 		t.Errorf("SymbolID = %d, want 1 (CurrencyContext#current_currency)", r.SymbolID)
 	}
 }
+
+func TestResolveDropsCodeToCodeCrossLanguageFallback(t *testing.T) {
+	// A Ruby file's bare `application` call must not bind to a JS symbol named
+	// `application` (the Stimulus entrypoint). Cross-language code-to-code
+	// bare-name matches are coincidences, so the edge drops to unresolved.
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "StripeClient#charge", FileID: 10, Language: "ruby"},
+		{ID: 2, Qualified: "application", FileID: 60, Language: "javascript"},
+	}
+	ix := resolve.NewIndex(rs)
+	// `Rails.application` misses exact lookup, so resolution falls back to the
+	// leaf `application`, whose only candidate is the JS symbol. The language
+	// gate must drop it (Ruby source, JS candidate) so the edge stays unresolved
+	// rather than becoming a cross-language phantom.
+	_, ok := ix.Resolve(resolve.Request{
+		Target:         "Rails.application",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   10, // ruby file
+		BaseConfidence: 1.0,
+	})
+	if ok {
+		t.Error("expected no resolution: a Ruby source must not bind a same-named JS symbol")
+	}
+}
+
+func TestResolveKeepsSameLanguageFallback(t *testing.T) {
+	// Ruby → Ruby bare-name fallback is the intended path and must survive the
+	// language gate, keeping the 0.8 ambiguous clamp.
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "A#caller", FileID: 10, Language: "ruby"},
+		{ID: 2, Qualified: "Helpers.format_money", FileID: 11, Language: "ruby"},
+	}
+	ix := resolve.NewIndex(rs)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "x.format_money",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   10,
+		BaseConfidence: 1.0,
+	})
+	if !ok || r.SymbolID != 2 {
+		t.Fatalf("expected ruby→ruby fallback to id 2, got id=%d ok=%v", r.SymbolID, ok)
+	}
+	if r.Confidence != 0.8 {
+		t.Errorf("Confidence = %v, want 0.8 (same-language `.` fallback not demoted)", r.Confidence)
+	}
+}
+
+func TestResolveViewSourceKeepsCrossLanguageHelperCall(t *testing.T) {
+	// An ERB template calling a Ruby helper (`current_user`) by bare name is a
+	// legitimate cross-language view edge. The gate is OFF for view-language
+	// sources, so it must still resolve. Symbol id 2 anchors the erb file's
+	// language so fileLang[50] == "erb".
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "ApplicationController#current_user", FileID: 11, Language: "ruby", Receiver: extract.ReceiverInstance},
+		{ID: 2, Qualified: "turbo-frame:cart", FileID: 50, Language: "erb"},
+	}
+	ix := resolve.NewIndex(rs)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "current_user",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   50, // erb template
+		BaseConfidence: 1.0,
+	})
+	if !ok || r.SymbolID != 1 {
+		t.Fatalf("expected erb→ruby helper edge to id 1, got id=%d ok=%v", r.SymbolID, ok)
+	}
+}
+
+func TestResolveViewSourceKeepsCrossLanguageStimulusCall(t *testing.T) {
+	// The headline case from the report: an ERB template referencing a Stimulus
+	// JS controller by bare name (data-controller="photo-upload"). The source is
+	// a view language, so the gate is OFF and the cross-language ERB→JS edge must
+	// survive. Symbol id 2 anchors the erb file's language so fileLang[50]=="erb".
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "PhotoUploadController", FileID: 60, Language: "javascript"},
+		{ID: 2, Qualified: "turbo-frame:cart", FileID: 50, Language: "erb"},
+	}
+	ix := resolve.NewIndex(rs)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "x.PhotoUploadController",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   50, // erb template
+		BaseConfidence: 1.0,
+	})
+	if !ok || r.SymbolID != 1 {
+		t.Fatalf("expected erb→js Stimulus edge to id 1, got id=%d ok=%v", r.SymbolID, ok)
+	}
+}
+
+func TestResolveCrossNamespaceColonColonDemotedBelowFloor(t *testing.T) {
+	// `Stripe::Checkout::Session` misses exact lookup; only its leaf `Session`
+	// matches an unrelated `User::Session`. Binding the leaf while discarding an
+	// unverified namespace is a guess, so it lands below blast's 0.5 floor even
+	// as a single match (it still counts for dead-code liveness).
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "StripeClient#charge", FileID: 10, Language: "ruby"},
+		{ID: 2, Qualified: "User::Session", FileID: 11, Language: "ruby"},
+	}
+	ix := resolve.NewIndex(rs)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "Stripe::Checkout::Session",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   10,
+		BaseConfidence: 1.0,
+	})
+	if !ok || r.SymbolID != 2 {
+		t.Fatalf("expected leaf fallback to id 2, got id=%d ok=%v", r.SymbolID, ok)
+	}
+	if r.Confidence >= 0.5 {
+		t.Errorf("Confidence = %v, want < 0.5 (cross-namespace :: guess below blast floor)", r.Confidence)
+	}
+	if r.Ambiguous {
+		t.Error("single match should not be flagged ambiguous")
+	}
+}

--- a/internal/sqlite/adapter.go
+++ b/internal/sqlite/adapter.go
@@ -942,16 +942,20 @@ func (a *Adapter) Query(ctx context.Context, f index.Filter) ([]model.Symbol, er
 	return out, nil
 }
 
-// SymbolRefs returns every symbol's (id, qualified, file_id) ordered
-// by ascending id. It exists so resolution passes that build an
-// in-memory qualified-name index can avoid hydrating Snippet /
-// Docstring / Visibility fields that they immediately discard — about
-// a 5× reduction in bytes loaded on a real-sized repo. The ascending
-// id guarantee lets callers build multi-value maps without a
-// follow-up sort: the first id under each key is deterministically
-// the earliest written.
+// SymbolRefs returns every symbol's (id, qualified, file_id, receiver,
+// language) ordered by ascending id. It exists so resolution passes that build
+// an in-memory qualified-name index can avoid hydrating Snippet / Docstring /
+// Visibility fields that they immediately discard — about a 5× reduction in
+// bytes loaded on a real-sized repo. The ascending id guarantee lets callers
+// build multi-value maps without a follow-up sort: the first id under each key
+// is deterministically the earliest written. The language is left-joined from
+// sense_files so the resolver can gate cross-language bare-name matches; a
+// symbol whose file row is missing returns an empty language.
 func (a *Adapter) SymbolRefs(ctx context.Context) ([]model.SymbolRef, error) {
-	const q = `SELECT id, qualified, file_id, receiver FROM sense_symbols ORDER BY id ASC`
+	const q = `SELECT s.id, s.qualified, s.file_id, s.receiver, COALESCE(f.language, '')
+		FROM sense_symbols s
+		LEFT JOIN sense_files f ON f.id = s.file_id
+		ORDER BY s.id ASC`
 	rows, err := a.db.QueryContext(ctx, q)
 	if err != nil {
 		return nil, fmt.Errorf("sqlite SymbolRefs: %w", err)
@@ -961,7 +965,7 @@ func (a *Adapter) SymbolRefs(ctx context.Context) ([]model.SymbolRef, error) {
 	var refs []model.SymbolRef
 	for rows.Next() {
 		var r model.SymbolRef
-		if err := rows.Scan(&r.ID, &r.Qualified, &r.FileID, &r.Receiver); err != nil {
+		if err := rows.Scan(&r.ID, &r.Qualified, &r.FileID, &r.Receiver, &r.Language); err != nil {
 			return nil, fmt.Errorf("sqlite SymbolRefs scan: %w", err)
 		}
 		refs = append(refs, r)

--- a/internal/sqlite/coverage_test.go
+++ b/internal/sqlite/coverage_test.go
@@ -231,6 +231,31 @@ func TestSymbolRefsCarriesReceiver(t *testing.T) {
 	}
 }
 
+func TestSymbolRefsCarriesLanguage(t *testing.T) {
+	a := openTestDB(t)
+	ctx := context.Background()
+
+	rb := seedFile(t, a, "app/models/user.rb", "ruby", "h1")
+	js := seedFile(t, a, "app/javascript/controllers/application.js", "javascript", "h2")
+	seedSymbol(t, a, rb, "User", "User", "class")
+	seedSymbol(t, a, js, "application", "application", "constant")
+
+	refs, err := a.SymbolRefs(ctx)
+	if err != nil {
+		t.Fatalf("SymbolRefs: %v", err)
+	}
+	got := map[string]string{}
+	for _, r := range refs {
+		got[r.Qualified] = r.Language
+	}
+	if got["User"] != "ruby" {
+		t.Errorf("User Language = %q, want ruby (left-joined from sense_files)", got["User"])
+	}
+	if got["application"] != "javascript" {
+		t.Errorf("application Language = %q, want javascript", got["application"])
+	}
+}
+
 func TestEdgesOfKind(t *testing.T) {
 	a := openTestDB(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Problem
The resolver's unqualified-name fallback matched a target's trailing segment against any same-named symbol, ignoring both language and namespace. On a mixed-language app this manufactured phantom graph and blast edges: a Ruby `Rails.application` call bound to the JavaScript Stimulus `application` constant, and `Stripe::Checkout::Session` bound to a local `User::Session`. Both surfaced as confidence-0.8 "callers," polluting impact analysis and caller queries.

## Summary
Add two gates to the bare-name fallback only (exact-qualified resolution is untouched): drop candidates whose code language differs from the source edge, and demote a `::`-qualified target that matched only its leaf below blast's traversal floor.

## Changes
- `internal/model/symbol.go`: `SymbolRef` gains a `Language` field.
- `internal/sqlite/adapter.go`: `SymbolRefs` left-joins `sense_files.language` so the resolver can see each symbol's language in one query.
- `internal/resolve/resolver.go`:
  - `filterByLanguage` drops cross-language bare-name candidates, with a fast path that avoids allocating when every candidate is same-language.
  - View/template source languages (ERB) are exempt — templates legitimately dispatch into Ruby helpers and JS controllers by bare name through this path.
  - A `::`-qualified target that bound only its leaf is demoted to the name-collision confidence (below blast's 0.5 floor) even on a single match; it still counts for dead-code liveness.
- Tests cover: cross-language drop, same-language keep, ERB to Ruby helper survives, ERB to JS Stimulus survives, `::` cross-namespace demotion, and `SymbolRefs` language plumbing.

## Architecture Highlights
- Language is looked up per source file via a `fileLang` map built in `NewIndex`, so neither `resolve.Request` nor the scan harness changed.
- The language gate fails open: an unknown source or candidate language is kept, so it degrades to prior behavior rather than dropping a real edge.
- Legitimate cross-language view edges (ERB to Stimulus/importmap/i18n) carry synthetic qualified names and resolve via exact match, never this fallback, so a bare-name match between two code languages is always a coincidence.

## Test Plan
- [x] Ruby source + same-named JS candidate resolves to nothing (no phantom)
- [x] Ruby to Ruby bare-name fallback still resolves at 0.8
- [x] ERB to Ruby helper and ERB to JS Stimulus edges survive the gate
- [x] `::` target matching only its leaf resolves below the 0.5 blast floor
- [x] `go test ./...` passes; sense binary builds cleanly
- [x] Note: this is a scan-time fix — it takes effect after a re-scan (`sense scan`), not against a stale index
