### PR TITLE
fix(mcpio): surface view templates as source of inbound view edges

### DIFF
--- a/internal/mcpio/graph.go
+++ b/internal/mcpio/graph.go
@@ -347,13 +347,36 @@ func categorizeEdges(ctx context.Context, outbound, inbound []model.EdgeRef, fil
 					hidden++
 					continue
 				}
+				sym := qualifiedOrName(e.Target)
 				fp := fileRefOrNil(e.Target.FileID, files)
+				lineStart, lineEnd := e.Target.LineStart, e.Target.LineEnd
+				if e.Target.ID == 0 {
+					// The source didn't resolve to an indexed symbol, so the
+					// LEFT-joined source columns are empty. In practice this is a
+					// view-origin edge — a template (ERB data-controller /
+					// data-action / render / i18n) calling into the subject — but
+					// the branch fires for ANY unresolved-source calls/references
+					// edge. The edge's own file id always points at the true
+					// emitting file, so surface it (and the call-site line) instead
+					// of a blank {symbol:"", file:null} stub. Note this means
+					// Symbol may carry a file path rather than a qualified name for
+					// such callers.
+					if path, ok := files(e.Edge.FileID); ok {
+						sym = path
+						fp = fileRefOrNil(e.Edge.FileID, files)
+						// An unresolved target already carries zero lines; lift the
+						// edge's own call-site line when it has one.
+						if e.Edge.Line != nil {
+							lineStart, lineEnd = *e.Edge.Line, *e.Edge.Line
+						}
+					}
+				}
 				edges.CalledBy = append(edges.CalledBy, CallEdgeRef{
-					Symbol:     qualifiedOrName(e.Target),
+					Symbol:     sym,
 					File:       fp,
-					LineStart:  e.Target.LineStart,
-					LineEnd:    e.Target.LineEnd,
-					Ref:        FormatRefPtr(fp, e.Target.LineStart),
+					LineStart:  lineStart,
+					LineEnd:    lineEnd,
+					Ref:        FormatRefPtr(fp, lineStart),
 					Confidence: Confidence(e.Edge.Confidence),
 					CallSite:   readSnippet(e),
 				})

--- a/internal/mcpio/graph_test.go
+++ b/internal/mcpio/graph_test.go
@@ -3,6 +3,7 @@ package mcpio
 import (
 	"bytes"
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/luuuc/sense/internal/model"
@@ -161,6 +162,110 @@ func TestBuildGraphResponseComposesEdges(t *testing.T) {
 	}
 	if resp.Edges.Composes[0].File == nil {
 		t.Error("Composes[0].File = nil, want non-nil")
+	}
+}
+
+func TestBuildGraphResponseViewOriginInboundEdgeSurfacesTemplate(t *testing.T) {
+	// A Stimulus controller's inbound calls originate in ERB templates whose
+	// source is not a named symbol (source_id == 0), so the LEFT-joined source
+	// columns come back empty. The edge's own file id carries the template, so
+	// the caller must surface the template path instead of a blank
+	// {symbol:"", file:null} stub.
+	const erbFileID = 7
+	const tmpl = "app/views/marketplace/photo_upload/_form.html.erb"
+	files := func(id int64) (string, bool) {
+		if id == erbFileID {
+			return tmpl, true
+		}
+		return "", false
+	}
+	const callLine = 12
+	line := callLine
+	sc := &model.SymbolContext{
+		Symbol: model.Symbol{ID: 1, Name: "PhotoUploadController", Qualified: "Marketplace::PhotoUploadController", Kind: "class", FileID: 1},
+		File:   model.File{Path: "app/javascript/controllers/marketplace/photo_upload_controller.js"},
+		Inbound: []model.EdgeRef{
+			{
+				Edge:   model.Edge{Kind: model.EdgeCalls, Confidence: 0.9, FileID: erbFileID, Line: &line},
+				Target: model.Symbol{ID: 0}, // unresolved view source
+			},
+		},
+	}
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{Direction: model.DirectionCallers})
+	if len(resp.Edges.CalledBy) != 1 {
+		t.Fatalf("CalledBy = %d, want 1", len(resp.Edges.CalledBy))
+	}
+	got := resp.Edges.CalledBy[0]
+	if got.Symbol != tmpl {
+		t.Errorf("Symbol = %q, want template path %q", got.Symbol, tmpl)
+	}
+	if got.File == nil || *got.File != tmpl {
+		t.Errorf("File = %v, want %q", got.File, tmpl)
+	}
+	// The call-site line is half of "where is this used?" — it must be lifted
+	// from the edge onto the recovered ref, including the formatted Ref.
+	if got.LineStart != callLine || got.LineEnd != callLine {
+		t.Errorf("LineStart/LineEnd = %d/%d, want %d/%d", got.LineStart, got.LineEnd, callLine, callLine)
+	}
+	wantRef := tmpl + ":" + strconv.Itoa(callLine)
+	if got.Ref != wantRef {
+		t.Errorf("Ref = %q, want %q", got.Ref, wantRef)
+	}
+}
+
+func TestBuildGraphResponseViewOriginInboundEdgeWithoutLine(t *testing.T) {
+	// A view-origin edge whose call site carries no line (e.Edge.Line == nil)
+	// still recovers the template path; the line fields stay zero rather than
+	// inheriting stale values from the unresolved target.
+	const erbFileID = 7
+	const tmpl = "app/views/marketplace/photo_upload/_index.html.erb"
+	files := func(id int64) (string, bool) {
+		if id == erbFileID {
+			return tmpl, true
+		}
+		return "", false
+	}
+	sc := &model.SymbolContext{
+		Symbol: model.Symbol{ID: 1, Qualified: "Marketplace::PhotoUploadController", Kind: "class", FileID: 1},
+		File:   model.File{Path: "app/javascript/controllers/marketplace/photo_upload_controller.js"},
+		Inbound: []model.EdgeRef{
+			{
+				Edge:   model.Edge{Kind: model.EdgeCalls, Confidence: 0.9, FileID: erbFileID}, // Line nil
+				Target: model.Symbol{ID: 0},
+			},
+		},
+	}
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{Direction: model.DirectionCallers})
+	if len(resp.Edges.CalledBy) != 1 {
+		t.Fatalf("CalledBy = %d, want 1", len(resp.Edges.CalledBy))
+	}
+	got := resp.Edges.CalledBy[0]
+	if got.Symbol != tmpl || got.File == nil || *got.File != tmpl {
+		t.Errorf("want template path recovered, got symbol=%q file=%v", got.Symbol, got.File)
+	}
+	if got.LineStart != 0 || got.LineEnd != 0 {
+		t.Errorf("LineStart/LineEnd = %d/%d, want 0/0 (no call-site line)", got.LineStart, got.LineEnd)
+	}
+}
+
+func TestBuildGraphResponseUnresolvedInboundWithoutFileStaysBlank(t *testing.T) {
+	// Guard: when the source is unresolved AND the edge's file id is unknown,
+	// keep the prior (blank) behavior rather than crashing.
+	files := func(int64) (string, bool) { return "", false }
+	sc := &model.SymbolContext{
+		Symbol: model.Symbol{ID: 1, Qualified: "X", Kind: "class"},
+		File:   model.File{Path: "x.js"},
+		Inbound: []model.EdgeRef{
+			{Edge: model.Edge{Kind: model.EdgeCalls, Confidence: 0.9, FileID: 99}, Target: model.Symbol{ID: 0}},
+		},
+	}
+	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{Direction: model.DirectionCallers})
+	if len(resp.Edges.CalledBy) != 1 {
+		t.Fatalf("CalledBy = %d, want 1", len(resp.Edges.CalledBy))
+	}
+	if resp.Edges.CalledBy[0].Symbol != "" || resp.Edges.CalledBy[0].File != nil {
+		t.Errorf("want blank stub when no file to recover, got symbol=%q file=%v",
+			resp.Edges.CalledBy[0].Symbol, resp.Edges.CalledBy[0].File)
 	}
 }
 


### PR DESCRIPTION
## Problem
A graph query for a Stimulus controller (or any symbol reached from a view) listed its ERB callers as blank `{symbol:"", file:null}` stubs. The edges are real — the ERB extractor emits them with the template's file path as the source, which matches no symbol, so the edge persists with `source_id = 0`. On an inbound query the left-joined source columns then come back empty, making "who uses this Stimulus controller?" unanswerable without a grep fallback.

## Summary
When an inbound calls/references edge has no resolved source symbol, render it from the edge's own file id — surfacing the template path and the data-controller/data-action call-site line instead of a row of blanks.

## Changes
- `internal/mcpio/graph.go`: in the inbound calls/references branch, recover the source from `e.Edge.FileID` when `e.Target.ID == 0`, lifting the call-site line when present. Falls back to the prior blank behavior when the edge file id is unknown.
- `internal/mcpio/graph_test.go`: tests for the recover path (symbol, file, line, and ref), the no-call-site-line case, and the can't-recover (blank) fallback.

## Architecture Highlights
- Query-time only: no schema change and no re-scan required — the fix renders edges already present in the index.
- The branch fires for any unresolved-source calls/references edge, not only ERB, so the comment notes that `Symbol` may carry a file path rather than a qualified name for such callers. The edge's file id always points at the true emitting file, so the path is never wrong.

## Test Plan
- [x] Inbound view edge (source_id 0) surfaces template path + call-site line
- [x] View edge with no call-site line: path recovered, line fields zero
- [x] Unresolved source with unknown file id: prior blank behavior, no crash
- [x] `go test ./...` passes; sense binary builds cleanly
