### PR TITLE
fix(resolve,blast): demote unverified cross-scope guesses; seed diff-blast by changed line range

### DIFF
--- a/internal/cli/blast.go
+++ b/internal/cli/blast.go
@@ -98,7 +98,7 @@ func runBlastDiff(cio IO, opts blastOptions) int {
 	// RunGraph for the cancellation-deferred-to-01-05 rationale.
 	ctx := context.Background()
 
-	paths, err := GitDiffFiles(ctx, cio.Dir, opts.Diff)
+	hunks, err := GitDiffHunks(ctx, cio.Dir, opts.Diff)
 	if err != nil {
 		_, _ = fmt.Fprintln(cio.Stderr, "sense blast:", err)
 		return ExitGeneralError
@@ -110,7 +110,7 @@ func runBlastDiff(cio IO, opts blastOptions) int {
 	}
 	defer func() { _ = adapter.Close() }()
 
-	symbolIDs, err := SymbolsInFiles(ctx, adapter.DB(), paths)
+	symbolIDs, err := SymbolsInChangedLines(ctx, adapter.DB(), hunks)
 	if err != nil {
 		_, _ = fmt.Fprintln(cio.Stderr, "sense blast:", err)
 		return ExitGeneralError

--- a/internal/cli/blast_test.go
+++ b/internal/cli/blast_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,9 +21,9 @@ import (
 // richer caller graph so the direct/indirect/tests sections all
 // populate. Shape:
 //
-//   OrdersController#create → CheckoutService
-//   WebhookJob#process      → OrdersController#create   (indirect → CheckoutService)
-//   CheckoutServiceTest     → CheckoutService            (tests edge)
+//	OrdersController#create → CheckoutService
+//	WebhookJob#process      → OrdersController#create   (indirect → CheckoutService)
+//	CheckoutServiceTest     → CheckoutService            (tests edge)
 func seedBlastProject(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -280,10 +281,12 @@ func seedBlastGitProject(t *testing.T) (dir, pastRef string) {
 	}
 
 	run("init", "--quiet", "-b", "main")
-	// First commit: empty source file matching the indexed path so
-	// the working tree matches the file paths sense already knows.
+	// First commit: source files matching the indexed paths so the working
+	// tree matches the paths sense already knows. The CheckoutService file is
+	// padded past the indexed symbol's span (lines 12-85) so the second
+	// commit's edit lands *inside* that span — diff-blast now seeds by changed
+	// line range, not whole file, so the edit must overlap the symbol.
 	for _, rel := range []string{
-		"app/services/checkout_service.rb",
 		"app/controllers/orders_controller.rb",
 		"app/jobs/webhook_job.rb",
 		"test/services/checkout_service_test.rb",
@@ -296,19 +299,41 @@ func seedBlastGitProject(t *testing.T) (dir, pastRef string) {
 			t.Fatalf("write: %v", err)
 		}
 	}
+	checkout := filepath.Join(dir, "app/services/checkout_service.rb")
+	if err := os.MkdirAll(filepath.Dir(checkout), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	v1 := checkoutServiceBody("original")
+	if err := os.WriteFile(checkout, []byte(v1), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
 	run("add", ".")
 	run("commit", "--quiet", "-m", "v1")
 
-	// Second commit: edit the CheckoutService file so HEAD~1..HEAD
-	// shows it as changed.
-	changed := filepath.Join(dir, "app/services/checkout_service.rb")
-	if err := os.WriteFile(changed, []byte("# v2\n"), 0o644); err != nil {
+	// Second commit: edit a line within the CheckoutService span (12-85) so
+	// HEAD~1..HEAD shows the symbol's body as changed.
+	if err := os.WriteFile(checkout, []byte(checkoutServiceBody("edited")), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	run("add", changed)
+	run("add", checkout)
 	run("commit", "--quiet", "-m", "v2")
 
 	return dir, "HEAD~1"
+}
+
+// checkoutServiceBody builds a 90-line file whose body covers the indexed
+// CheckoutService span (lines 12-85). The marker is placed at line 40, well
+// inside the span, so editing it produces a hunk that overlaps the symbol.
+func checkoutServiceBody(marker string) string {
+	var b strings.Builder
+	for i := 1; i <= 90; i++ {
+		if i == 40 {
+			fmt.Fprintf(&b, "  # body %d (%s)\n", i, marker)
+			continue
+		}
+		fmt.Fprintf(&b, "  # body %d\n", i)
+	}
+	return b.String()
 }
 
 func TestRunBlastDiffHuman(t *testing.T) {
@@ -400,7 +425,7 @@ func TestRunBlastDiffEmptyWhenNoIndexedFiles(t *testing.T) {
 // git's complaint when the ref doesn't resolve. Uses the tempdir
 // from seedBlastProject which is not a git repo — so `git diff`
 // fails at the "not a git repository" level, exercising the
-// gitDiffFiles error path.
+// GitDiffHunks error path.
 func TestRunBlastDiffBadRefErrors(t *testing.T) {
 	dir := seedBlastProject(t)
 	var stdout, stderr bytes.Buffer

--- a/internal/cli/gitdiff.go
+++ b/internal/cli/gitdiff.go
@@ -6,31 +6,39 @@ import (
 	"database/sql"
 	"fmt"
 	"os/exec"
+	"sort"
+	"strconv"
 	"strings"
 )
 
-// gitDiffFiles runs `git diff --name-only <ref>` inside dir and
-// returns the paths it prints. One path per line, blanks skipped.
-// Errors fire for: not a git repo, bad ref, git exec failure — the
-// underlying stderr message is preserved so the CLI can surface
-// git's actual complaint ("bad revision 'foo'") instead of a
-// generic wrapper.
+// LineRange is an inclusive [Start, End] span of 1-based line numbers in a
+// file's post-diff (new) state.
+type LineRange struct {
+	Start int
+	End   int
+}
+
+// GitDiffHunks runs `git diff -U0 <ref>` inside dir and returns, per changed
+// file path, the line ranges that the diff touched in the file's new state.
+// Seeding a diff-blast from these ranges scopes it to the symbols that overlap
+// a change, rather than every symbol in a touched file — so a one-line edit to
+// a 400-symbol routes file no longer drags all 400 into the blast.
 //
-// The ref argument is passed as a positional arg to argv, not
-// through a shell — no quoting concerns, no injection surface.
-// `--end-of-options` precedes the ref so a ref starting with `-`
-// cannot be interpreted as a git option. Defence-in-depth against
-// an untrusted caller (future MCP server, git hook, CI job) passing
-// e.g. `--upload-pack=...` as a "ref." Available since git 2.24.
-func GitDiffFiles(ctx context.Context, dir, ref string) ([]string, error) {
-	// Pre-check git availability so a missing binary produces a
-	// clear "git not in PATH" error instead of an opaque
-	// exec.ErrNotFound wrapped in the generic git-diff message. A
-	// user on a system without git sees the cause, not the symptom.
+// Zero context (`-U0`) keeps each hunk tight to its edited lines. Paths are the
+// new-side (`+++ b/<path>`) names with the `b/` prefix stripped, matching the
+// repo-relative paths stored in sense_files. Pure deletions (`+++ /dev/null`)
+// contribute no ranges — the symbols are gone from the index anyway.
+//
+// The git invocation is hardened: git is located via LookPath for a clear
+// error, the ref is passed positionally after `--end-of-options` so a ref
+// starting with `-` cannot be read as an option (defence-in-depth against an
+// untrusted caller passing e.g. `--upload-pack=...`; available since git
+// 2.24), and git's own stderr is preserved on failure.
+func GitDiffHunks(ctx context.Context, dir, ref string) (map[string][]LineRange, error) {
 	if _, err := exec.LookPath("git"); err != nil {
 		return nil, fmt.Errorf("sense blast --diff requires git in PATH: %w", err)
 	}
-	cmd := exec.CommandContext(ctx, "git", "diff", "--name-only", "--end-of-options", ref)
+	cmd := exec.CommandContext(ctx, "git", "diff", "-U0", "--end-of-options", ref)
 	cmd.Dir = dir
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -42,27 +50,99 @@ func GitDiffFiles(ctx context.Context, dir, ref string) ([]string, error) {
 		}
 		return nil, fmt.Errorf("git diff %s: %s", ref, msg)
 	}
-	var paths []string
-	for _, line := range strings.Split(stdout.String(), "\n") {
-		if p := strings.TrimSpace(line); p != "" {
-			paths = append(paths, p)
-		}
-	}
-	return paths, nil
+	return parseDiffHunks(stdout.String()), nil
 }
 
-// symbolsInFiles returns symbol ids for every sense_symbols row
-// whose file's path is in paths. Unindexed paths (docs, YAML,
-// anything Sense has no extractor for) are silently absent from
-// the result — a diff that touches only Markdown produces an
-// empty blast, not an error.
+// parseDiffHunks turns unified-diff text (as produced by `git diff -U0`) into
+// the per-file changed line ranges. It tracks the current file from `+++`
+// header lines and reads each `@@ -a,b +c,d @@` hunk's new-side span.
+func parseDiffHunks(diff string) map[string][]LineRange {
+	hunks := make(map[string][]LineRange)
+	current := ""
+	for _, line := range strings.Split(diff, "\n") {
+		switch {
+		case strings.HasPrefix(line, "+++ "):
+			current = newFilePath(line)
+		case strings.HasPrefix(line, "@@ ") && current != "":
+			if r, ok := newSideRange(line); ok {
+				hunks[current] = append(hunks[current], r)
+			}
+		}
+	}
+	return hunks
+}
+
+// newFilePath extracts the repo-relative path from a `+++ b/<path>` header.
+// `+++ /dev/null` (a deletion) yields "" so its hunks are skipped — the file's
+// symbols no longer exist in the index. A leading `a/` or `b/` prefix is
+// stripped to match the paths stored in sense_files.
+func newFilePath(header string) string {
+	p := strings.TrimPrefix(header, "+++ ")
+	if p == "/dev/null" {
+		return ""
+	}
+	// Trailing tab-separated metadata (rare, e.g. timestamps) is dropped.
+	if i := strings.IndexByte(p, '\t'); i >= 0 {
+		p = p[:i]
+	}
+	p = strings.TrimPrefix(p, "b/")
+	p = strings.TrimPrefix(p, "a/")
+	return p
+}
+
+// newSideRange parses the new-side span from a hunk header
+// `@@ -oldStart,oldCount +newStart,newCount @@`. newCount defaults to 1 when
+// omitted. A pure deletion (newCount 0) is widened to the two lines bracketing
+// the gap so the enclosing symbol is still caught.
+func newSideRange(header string) (LineRange, bool) {
+	for _, field := range strings.Fields(header) {
+		if !strings.HasPrefix(field, "+") {
+			continue
+		}
+		spec := strings.TrimPrefix(field, "+")
+		startStr, countStr, hasCount := strings.Cut(spec, ",")
+		start, err := strconv.Atoi(startStr)
+		if err != nil {
+			return LineRange{}, false
+		}
+		count := 1
+		if hasCount {
+			count, err = strconv.Atoi(countStr)
+			if err != nil {
+				return LineRange{}, false
+			}
+		}
+		if start < 1 {
+			start = 1
+		}
+		if count == 0 {
+			// Deletion: the change sits between new-side lines start and start+1.
+			// Cover both so a removal inside a symbol still seeds that symbol.
+			return LineRange{Start: start, End: start + 1}, true
+		}
+		return LineRange{Start: start, End: start + count - 1}, true
+	}
+	return LineRange{}, false
+}
+
+// SymbolsInChangedLines returns the ids of symbols whose line span overlaps a
+// changed hunk range in their file. It is the line-granular seed selector for
+// diff-blast: only symbols touched by the diff are returned, not every symbol
+// in a touched file.
 //
-// The query chunks on SQLITE_MAX_VARIABLE_NUMBER (999) so a diff
-// covering hundreds of files stays in one pass of small queries.
-func SymbolsInFiles(ctx context.Context, db *sql.DB, paths []string) ([]int64, error) {
-	if len(paths) == 0 {
+// The query chunks paths on SQLITE_MAX_VARIABLE_NUMBER headroom (500). Overlap
+// is computed in Go against the per-file ranges; ids are returned ascending for
+// deterministic downstream ordering.
+func SymbolsInChangedLines(ctx context.Context, db *sql.DB, hunks map[string][]LineRange) ([]int64, error) {
+	if len(hunks) == 0 {
 		return nil, nil
 	}
+	paths := make([]string, 0, len(hunks))
+	for p := range hunks {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+
 	var ids []int64
 	const chunk = 500
 	for start := 0; start < len(paths); start += chunk {
@@ -73,26 +153,32 @@ func SymbolsInFiles(ctx context.Context, db *sql.DB, paths []string) ([]int64, e
 		batch := paths[start:end]
 		placeholders := strings.Repeat("?,", len(batch))
 		placeholders = placeholders[:len(placeholders)-1]
-		q := `SELECT s.id
+		q := `SELECT s.id, f.path, s.line_start, s.line_end
 		      FROM sense_symbols s
 		      JOIN sense_files   f ON f.id = s.file_id
-		      WHERE f.path IN (` + placeholders + `)
-		      ORDER BY s.id`
+		      WHERE f.path IN (` + placeholders + `)`
 		args := make([]any, len(batch))
 		for i, p := range batch {
 			args[i] = p
 		}
 		rows, err := db.QueryContext(ctx, q, args...)
 		if err != nil {
-			return nil, fmt.Errorf("symbols in files: %w", err)
+			return nil, fmt.Errorf("symbols in changed lines: %w", err)
 		}
 		for rows.Next() {
-			var id int64
-			if err := rows.Scan(&id); err != nil {
+			var (
+				id        int64
+				path      string
+				lineStart int
+				lineEnd   int
+			)
+			if err := rows.Scan(&id, &path, &lineStart, &lineEnd); err != nil {
 				_ = rows.Close()
-				return nil, fmt.Errorf("scan symbol id: %w", err)
+				return nil, fmt.Errorf("scan symbol row: %w", err)
 			}
-			ids = append(ids, id)
+			if overlapsAny(lineStart, lineEnd, hunks[path]) {
+				ids = append(ids, id)
+			}
 		}
 		if err := rows.Err(); err != nil {
 			_ = rows.Close()
@@ -100,5 +186,22 @@ func SymbolsInFiles(ctx context.Context, db *sql.DB, paths []string) ([]int64, e
 		}
 		_ = rows.Close()
 	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
 	return ids, nil
+}
+
+// overlapsAny reports whether the inclusive symbol span [symStart, symEnd]
+// intersects any of the changed line ranges. A symbol with an unknown end
+// (symEnd < symStart, e.g. a zero line_end) is treated as the single line
+// symStart so it can still match.
+func overlapsAny(symStart, symEnd int, ranges []LineRange) bool {
+	if symEnd < symStart {
+		symEnd = symStart
+	}
+	for _, r := range ranges {
+		if r.Start <= symEnd && symStart <= r.End {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/cli/gitdiff_test.go
+++ b/internal/cli/gitdiff_test.go
@@ -2,10 +2,15 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/sqlite"
 )
 
 func initGitRepo(t *testing.T) string {
@@ -38,40 +43,83 @@ func initGitRepo(t *testing.T) string {
 	return dir
 }
 
-func TestGitDiffFilesValidRef(t *testing.T) {
-	if _, err := exec.LookPath("git"); err != nil {
-		t.Skip("git not in PATH")
-	}
-	dir := initGitRepo(t)
-	paths, err := GitDiffFiles(context.Background(), dir, "HEAD~0")
-	if err != nil {
-		t.Fatalf("GitDiffFiles: %v", err)
-	}
-	if len(paths) != 0 {
-		t.Errorf("expected no diff for HEAD~0, got %v", paths)
+// commit stages everything in dir and records a commit with the given message.
+func commit(t *testing.T, dir, msg string) {
+	t.Helper()
+	for _, args := range [][]string{{"add", "."}, {"commit", "-m", msg}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %s (%v)", args, out, err)
+		}
 	}
 }
 
-func TestGitDiffFilesBadRefReturnsError(t *testing.T) {
+func TestGitDiffHunksValidRef(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not in PATH")
 	}
 	dir := initGitRepo(t)
-	_, err := GitDiffFiles(context.Background(), dir, "nonexistent-ref-abc123")
+	hunks, err := GitDiffHunks(context.Background(), dir, "HEAD~0")
+	if err != nil {
+		t.Fatalf("GitDiffHunks: %v", err)
+	}
+	if len(hunks) != 0 {
+		t.Errorf("expected no diff for HEAD~0, got %v", hunks)
+	}
+}
+
+func TestGitDiffHunksReportsChangedLines(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not in PATH")
+	}
+	dir := initGitRepo(t)
+	// Grow the file, then edit a single line, so the hunk is tight to the
+	// change rather than spanning the whole file.
+	body := "package main\n\nfunc A() {}\nfunc B() {}\nfunc C() {}\n"
+	if err := os.WriteFile(filepath.Join(dir, "hello.go"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	commit(t, dir, "grow file")
+	edited := "package main\n\nfunc A() {}\nfunc B2() {}\nfunc C() {}\n"
+	if err := os.WriteFile(filepath.Join(dir, "hello.go"), []byte(edited), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	hunks, err := GitDiffHunks(context.Background(), dir, "HEAD")
+	if err != nil {
+		t.Fatalf("GitDiffHunks: %v", err)
+	}
+	ranges, ok := hunks["hello.go"]
+	if !ok {
+		t.Fatalf("expected hello.go in hunks, got %v", hunks)
+	}
+	// Only line 4 changed; the range must not span the whole 5-line file.
+	if len(ranges) != 1 || ranges[0].Start != 4 || ranges[0].End != 4 {
+		t.Errorf("ranges = %v, want a single [4,4] span", ranges)
+	}
+}
+
+func TestGitDiffHunksBadRefReturnsError(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not in PATH")
+	}
+	dir := initGitRepo(t)
+	_, err := GitDiffHunks(context.Background(), dir, "nonexistent-ref-abc123")
 	if err == nil {
 		t.Fatal("expected error for bad ref")
 	}
 }
 
-func TestGitDiffFilesFlagInjectionBlocked(t *testing.T) {
+func TestGitDiffHunksFlagInjectionBlocked(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not in PATH")
 	}
 	dir := initGitRepo(t)
 
-	// These payloads would be dangerous without --end-of-options.
-	// With it, git interprets them as literal ref names (which don't
-	// exist) and returns an error — not a flag-injection side effect.
+	// These payloads would be dangerous without --end-of-options. With it, git
+	// interprets them as literal ref names (which don't exist) and errors —
+	// not a flag-injection side effect.
 	payloads := []string{
 		"--upload-pack=evil",
 		"--output=/tmp/evil",
@@ -81,7 +129,7 @@ func TestGitDiffFilesFlagInjectionBlocked(t *testing.T) {
 	}
 	for _, p := range payloads {
 		t.Run(p, func(t *testing.T) {
-			_, err := GitDiffFiles(context.Background(), dir, p)
+			_, err := GitDiffHunks(context.Background(), dir, p)
 			if err == nil {
 				t.Errorf("flag-like ref %q should error (bad revision), not be treated as a flag", p)
 			}
@@ -89,23 +137,274 @@ func TestGitDiffFilesFlagInjectionBlocked(t *testing.T) {
 	}
 }
 
-func TestGitDiffFilesNoGit(t *testing.T) {
-	// Set PATH to empty dir so git is not found
+func TestGitDiffHunksNoGit(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
-	_, err := GitDiffFiles(context.Background(), t.TempDir(), "HEAD")
+	_, err := GitDiffHunks(context.Background(), t.TempDir(), "HEAD")
 	if err == nil {
 		t.Error("expected error when git not on PATH")
 	}
 }
 
-func TestSymbolsInFilesEmpty(t *testing.T) {
+func TestParseDiffHunks(t *testing.T) {
+	cases := []struct {
+		name string
+		diff string
+		want map[string][]LineRange
+	}{
+		{
+			name: "single edit",
+			diff: "diff --git a/f.rb b/f.rb\n--- a/f.rb\n+++ b/f.rb\n@@ -4 +4 @@\n-old\n+new\n",
+			want: map[string][]LineRange{"f.rb": {{4, 4}}},
+		},
+		{
+			name: "multi-line addition with count",
+			diff: "+++ b/app/x.rb\n@@ -10,0 +11,3 @@\n+a\n+b\n+c\n",
+			want: map[string][]LineRange{"app/x.rb": {{11, 13}}},
+		},
+		{
+			name: "pure deletion widens to bracket the gap",
+			diff: "+++ b/app/x.rb\n@@ -5,3 +4,0 @@\n",
+			want: map[string][]LineRange{"app/x.rb": {{4, 5}}},
+		},
+		{
+			name: "two files, multiple hunks",
+			diff: "+++ b/a.rb\n@@ -1 +1 @@\n+++ b/b.rb\n@@ -2,2 +2,2 @@\n@@ -9 +9,0 @@\n",
+			want: map[string][]LineRange{
+				"a.rb": {{1, 1}},
+				"b.rb": {{2, 3}, {9, 10}},
+			},
+		},
+		{
+			name: "deletion target /dev/null contributes nothing",
+			diff: "+++ /dev/null\n@@ -1,5 +0,0 @@\n",
+			want: map[string][]LineRange{},
+		},
+		{
+			name: "new file added covers all its lines",
+			diff: "+++ b/new.rb\n@@ -0,0 +1,4 @@\n+l1\n+l2\n+l3\n+l4\n",
+			want: map[string][]LineRange{"new.rb": {{1, 4}}},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := parseDiffHunks(c.diff)
+			if len(got) != len(c.want) {
+				t.Fatalf("parseDiffHunks(%q) = %v, want %v", c.diff, got, c.want)
+			}
+			for path, wantRanges := range c.want {
+				gotRanges := got[path]
+				if len(gotRanges) != len(wantRanges) {
+					t.Fatalf("path %q ranges = %v, want %v", path, gotRanges, wantRanges)
+				}
+				for i := range wantRanges {
+					if gotRanges[i] != wantRanges[i] {
+						t.Errorf("path %q range %d = %v, want %v", path, i, gotRanges[i], wantRanges[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestNewFilePath(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"+++ b/app/x.rb", "app/x.rb"},
+		{"+++ a/app/x.rb", "app/x.rb"},
+		{"+++ app/x.rb", "app/x.rb"},       // no prefix (diff.noprefix)
+		{"+++ /dev/null", ""},              // deletion target
+		{"+++ b/x.rb\t2026-01-01", "x.rb"}, // trailing tab metadata dropped
+	}
+	for _, c := range cases {
+		if got := newFilePath(c.in); got != c.want {
+			t.Errorf("newFilePath(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestNewSideRange(t *testing.T) {
+	cases := []struct {
+		header string
+		want   LineRange
+		wantOK bool
+	}{
+		{"@@ -4 +4 @@", LineRange{4, 4}, true},         // count omitted defaults to 1
+		{"@@ -10,0 +11,3 @@", LineRange{11, 13}, true}, // explicit count
+		{"@@ -5,3 +4,0 @@", LineRange{4, 5}, true},     // deletion widens
+		{"@@ -1,2 +0,3 @@", LineRange{1, 3}, true},     // start < 1 clamps to 1, end follows
+		{"@@ -1 +x,2 @@", LineRange{}, false},          // non-numeric start
+		{"@@ -1 +5,y @@", LineRange{}, false},          // non-numeric count
+		{"@@ -1 @@", LineRange{}, false},               // no new-side field
+	}
+	for _, c := range cases {
+		got, ok := newSideRange(c.header)
+		if ok != c.wantOK || got != c.want {
+			t.Errorf("newSideRange(%q) = (%v, %v), want (%v, %v)", c.header, got, ok, c.want, c.wantOK)
+		}
+	}
+}
+
+func TestSymbolsInChangedLinesChunksManyPaths(t *testing.T) {
+	// More changed paths than the 500-path query chunk forces a second query
+	// iteration; the overlapping symbol must still be found across batches.
 	ctx := context.Background()
-	// Empty paths should return nil, nil immediately
-	ids, err := SymbolsInFiles(ctx, nil, []string{})
+	dir := t.TempDir()
+	adapter, err := sqlite.Open(ctx, filepath.Join(dir, "index.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	file := model.File{Path: "app/real.rb", Language: "ruby", Hash: "h", IndexedAt: time.Now()}
+	fid, err := adapter.WriteFile(ctx, &file)
+	if err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	sym := model.Symbol{FileID: fid, Name: "thing", Qualified: "Real#thing", Kind: "method", LineStart: 3, LineEnd: 7}
+	sid, err := adapter.WriteSymbol(ctx, &sym)
+	if err != nil {
+		t.Fatalf("WriteSymbol: %v", err)
+	}
+
+	hunks := map[string][]LineRange{"app/real.rb": {{4, 4}}}
+	for i := 0; i < 600; i++ {
+		hunks[fmt.Sprintf("app/bogus_%d.rb", i)] = []LineRange{{1, 1}}
+	}
+	got, err := SymbolsInChangedLines(ctx, adapter.DB(), hunks)
+	if err != nil {
+		t.Fatalf("SymbolsInChangedLines: %v", err)
+	}
+	if len(got) != 1 || got[0] != sid {
+		t.Fatalf("got %v, want only [%d] across %d chunked paths", got, sid, len(hunks))
+	}
+}
+
+func TestSymbolsInChangedLinesScanError(t *testing.T) {
+	// A row whose line_start is not an integer fails the scan and surfaces an
+	// error rather than being silently skipped. We corrupt the column directly
+	// (SQLite is dynamically typed) to drive the scan-error path.
+	ctx := context.Background()
+	dir := t.TempDir()
+	adapter, err := sqlite.Open(ctx, filepath.Join(dir, "index.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	file := model.File{Path: "app/x.rb", Language: "ruby", Hash: "h", IndexedAt: time.Now()}
+	fid, err := adapter.WriteFile(ctx, &file)
+	if err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	sym := model.Symbol{FileID: fid, Name: "m", Qualified: "X#m", Kind: "method", LineStart: 1, LineEnd: 9}
+	sid, err := adapter.WriteSymbol(ctx, &sym)
+	if err != nil {
+		t.Fatalf("WriteSymbol: %v", err)
+	}
+	if _, err := adapter.DB().ExecContext(ctx, "UPDATE sense_symbols SET line_start='not-an-int' WHERE id=?", sid); err != nil {
+		t.Fatalf("corrupt line_start: %v", err)
+	}
+
+	_, qerr := SymbolsInChangedLines(ctx, adapter.DB(), map[string][]LineRange{"app/x.rb": {{1, 1}}})
+	if qerr == nil {
+		t.Error("expected a scan error for a non-integer line_start")
+	}
+}
+
+func TestSymbolsInChangedLinesQueryError(t *testing.T) {
+	// A DB without the sense schema surfaces the query error rather than
+	// silently returning nothing.
+	db, err := sqlite.Open(context.Background(), filepath.Join(t.TempDir(), "empty.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	rawDB := db.DB()
+	_ = db.Close() // close so the query fails on a closed handle
+	_, qerr := SymbolsInChangedLines(context.Background(), rawDB, map[string][]LineRange{"x.rb": {{1, 1}}})
+	if qerr == nil {
+		t.Error("expected an error querying a closed database")
+	}
+}
+
+func TestOverlapsAny(t *testing.T) {
+	ranges := []LineRange{{10, 12}, {20, 20}}
+	cases := []struct {
+		symStart, symEnd int
+		want             bool
+	}{
+		{1, 5, false},   // before all ranges
+		{8, 10, true},   // touches a range's lower edge
+		{12, 30, true},  // spans both ranges
+		{13, 19, false}, // gap between ranges
+		{20, 20, true},  // exact single-line match
+		{20, 19, true},  // unknown end (symEnd < symStart) treated as [20,20]
+		{30, 40, false}, // after all ranges
+	}
+	for _, c := range cases {
+		if got := overlapsAny(c.symStart, c.symEnd, ranges); got != c.want {
+			t.Errorf("overlapsAny(%d,%d,%v) = %v, want %v", c.symStart, c.symEnd, ranges, got, c.want)
+		}
+	}
+}
+
+func TestSymbolsInChangedLinesEmpty(t *testing.T) {
+	ids, err := SymbolsInChangedLines(context.Background(), nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(ids) != 0 {
 		t.Errorf("expected empty ids, got %v", ids)
+	}
+}
+
+// TestSymbolsInChangedLinesSelectsOverlapping is the heart of the diff-blast
+// fix: a one-line change to a file with many symbols must seed only the
+// symbol whose span overlaps the change, not every symbol in the file.
+func TestSymbolsInChangedLinesSelectsOverlapping(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	adapter, err := sqlite.Open(ctx, filepath.Join(dir, "index.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	file := model.File{Path: "config/routes/admin_routes.rb", Language: "ruby", Hash: "h", IndexedAt: time.Now()}
+	fid, err := adapter.WriteFile(ctx, &file)
+	if err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	// Three route helpers at disjoint line spans, mimicking a hub file.
+	syms := []model.Symbol{
+		{FileID: fid, Name: "admin_users", Qualified: "route:admin_users", Kind: "method", LineStart: 1, LineEnd: 5},
+		{FileID: fid, Name: "admin_orders", Qualified: "route:admin_orders", Kind: "method", LineStart: 10, LineEnd: 14},
+		{FileID: fid, Name: "admin_reports", Qualified: "route:admin_reports", Kind: "method", LineStart: 20, LineEnd: 24},
+	}
+	ids := make([]int64, len(syms))
+	for i := range syms {
+		id, werr := adapter.WriteSymbol(ctx, &syms[i])
+		if werr != nil {
+			t.Fatalf("WriteSymbol: %v", werr)
+		}
+		ids[i] = id
+	}
+
+	// Two disjoint changes (lines 2 and 11) seed exactly the two helpers they
+	// fall inside — never the third at lines 20-24. Returned ids are ascending.
+	hunks := map[string][]LineRange{"config/routes/admin_routes.rb": {{2, 2}, {11, 11}}}
+	got, err := SymbolsInChangedLines(ctx, adapter.DB(), hunks)
+	if err != nil {
+		t.Fatalf("SymbolsInChangedLines: %v", err)
+	}
+	if len(got) != 2 || got[0] != ids[0] || got[1] != ids[1] {
+		t.Fatalf("got %v, want [%d %d] (the two overlapping helpers, not admin_reports)", got, ids[0], ids[1])
+	}
+
+	// A path Sense has no symbols for (a locale .yml, a migration) seeds nothing.
+	none, err := SymbolsInChangedLines(ctx, adapter.DB(), map[string][]LineRange{"config/locales/en.yml": {{1, 100}}})
+	if err != nil {
+		t.Fatalf("SymbolsInChangedLines (unindexed): %v", err)
+	}
+	if len(none) != 0 {
+		t.Errorf("expected no symbols for an unindexed path, got %v", none)
 	}
 }

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -1139,12 +1139,12 @@ func (h *handlers) blastSymbol(ctx context.Context, symbol string, opts blast.Op
 }
 
 func (h *handlers) blastDiff(ctx context.Context, ref string, opts blast.Options, snippets *mcpio.SnippetReader) (mcpio.BlastResponse, error) {
-	paths, err := cli.GitDiffFiles(ctx, h.dir, ref)
+	hunks, err := cli.GitDiffHunks(ctx, h.dir, ref)
 	if err != nil {
 		return mcpio.BlastResponse{}, fmt.Errorf("sense_blast: %w", err)
 	}
 
-	symbolIDs, err := cli.SymbolsInFiles(ctx, h.db, paths)
+	symbolIDs, err := cli.SymbolsInChangedLines(ctx, h.db, hunks)
 	if err != nil {
 		return mcpio.BlastResponse{}, fmt.Errorf("sense_blast: %w", err)
 	}

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -107,8 +107,10 @@ const nameCollisionConfidence = extract.ConfidenceNameCollision
 //     unqualified-name match via byName. Candidates in a different code
 //     language than the source are dropped (filterByLanguage); same
 //     scope preference applies; confidence is clamped to
-//     ambiguousConfidence, and a `::`-qualified target that matched only
-//     its leaf is demoted below blast's floor as a cross-namespace guess.
+//     ambiguousConfidence. A qualified target that matched only its leaf
+//     (the namespace or receiver type was discarded) is demoted below
+//     blast's floor as an unverified cross-scope guess unless the
+//     qualifier can be verified — see isUnverifiedCrossScope.
 //  4. No match ⇒ ok=false.
 func (ix *Index) Resolve(req Request) (Result, bool) {
 	target := rewriteReceiver(req.Target, req.SourceQualified, req.SourceParentQualified)
@@ -136,7 +138,7 @@ func (ix *Index) Resolve(req Request) (Result, bool) {
 			}
 			matches := ix.byName[name]
 			matches = filterByLanguage(matches, ix.fileLang[req.SourceFileID])
-			matches = filterByReceiver(matches, sep)
+			matches, receiverContradicted := filterByReceiver(matches, sep)
 			if len(matches) > 0 {
 				r := pickBest(matches, req.SourceFileID, req.BaseConfidence)
 				if r.Confidence > ambiguousConfidence {
@@ -149,13 +151,14 @@ func (ix *Index) Resolve(req Request) (Result, bool) {
 					// it still counts for dead-code liveness.
 					r.Confidence = nameCollisionConfidence
 				}
-				if sep == "::" && r.Confidence > nameCollisionConfidence {
-					// A `::`-qualified target that missed exact lookup and matched
-					// only its trailing segment is a cross-namespace guess: the leaf
-					// bound but the namespace we couldn't verify was discarded
-					// (`Stripe::Checkout::Session` ⇒ a local `User::Session`). Demote
-					// below blast's floor even on a single match, so impact analysis
-					// ignores it while it still counts for dead-code liveness.
+				if r.Confidence > nameCollisionConfidence &&
+					ix.isUnverifiedCrossScope(target, name, sep, req.SourceFileID, req.BaseConfidence, receiverContradicted) {
+					// The leaf bound but the qualifier (namespace or receiver type)
+					// could not be verified — a cross-scope guess such as
+					// `Stripe::StripeError#message` landing on a same-named test
+					// method. Demote below blast's floor even on a single match, so
+					// impact analysis ignores it while it still counts for dead-code
+					// liveness. See isUnverifiedCrossScope for the per-separator rule.
 					r.Confidence = nameCollisionConfidence
 				}
 				return r, true
@@ -164,6 +167,48 @@ func (ix *Index) Resolve(req Request) (Result, bool) {
 	}
 
 	return Result{}, false
+}
+
+// isUnverifiedCrossScope reports whether a successful unqualified-fallback
+// match is a cross-scope guess that resolution could not verify, and so must
+// be demoted below blast's floor. The fallback only runs after exact lookup
+// missed, so a qualified target (sep != "") here matched on its trailing leaf
+// alone — the qualifier (namespace or receiver type) was discarded.
+//
+//   - Bare target (sep ""): no qualifier to verify. A bare call the extractor
+//     emitted with confidence above ConfidenceUnresolved is trustworthy — a
+//     Go/Python top-level function (base 1.0) resolves legitimately by name. A
+//     bare call emitted *at* ConfidenceUnresolved means the extractor could not
+//     determine the receiver type at all (Ruby's `x.m` with unknown `x`), so
+//     binding the leaf to a coincidental same-named symbol is a guess.
+//   - "::" namespace: the full path already missed exact lookup, so the
+//     namespace cannot be confirmed to contain this leaf
+//     (`Stripe::Checkout::Session` landing on a local `User::Session`). Always
+//     a guess.
+//   - "#"/"." receiver dispatch: verifiable only if the receiver type itself
+//     is an indexed symbol — then an inherited or reopened method is plausible
+//     (`Child#m` resolving to `Parent#m`). An external or unknown receiver type
+//     (a gem class like `Stripe::StripeError`, a stdlib package) is a
+//     coincidence, as is a dispatch kind that contradicted every candidate.
+//
+// View-language sources are exempt from the receiver-dispatch check: templates
+// dispatch into helpers and controllers loosely by leaf name, mirroring
+// filterByLanguage's view carve-out.
+func (ix *Index) isUnverifiedCrossScope(target, leaf, sep string, srcFileID int64, baseConfidence float64, receiverContradicted bool) bool {
+	switch sep {
+	case "":
+		return baseConfidence <= extract.ConfidenceUnresolved
+	case "::":
+		return true
+	}
+	if isViewLanguage(ix.fileLang[srcFileID]) {
+		return false
+	}
+	if receiverContradicted {
+		return true
+	}
+	prefix := strings.TrimSuffix(target, sep+leaf)
+	return len(ix.byQualified[prefix]) == 0
 }
 
 // pickBest selects a winner among one or more candidates. A single
@@ -281,11 +326,13 @@ func unqualifiedNameSep(qualified string) (name, sep string) {
 // always kept, so resolution for languages that don't populate receiver is
 // unchanged. If filtering would remove every candidate, the original set is
 // returned rather than dropping the edge — the dispatch hint is a tie-break,
-// not a hard gate.
-func filterByReceiver(matches []model.SymbolRef, sep string) []model.SymbolRef {
+// not a hard gate — and the second return value reports that contradiction so
+// the caller can demote the result: an instance call that finds only singleton
+// candidates (or vice-versa) is a kind-mismatched guess, not a confident edge.
+func filterByReceiver(matches []model.SymbolRef, sep string) (kept []model.SymbolRef, contradicted bool) {
 	want := receiverForSeparator(sep)
 	if want == "" {
-		return matches
+		return matches, false
 	}
 	declared := false
 	for _, m := range matches {
@@ -295,18 +342,18 @@ func filterByReceiver(matches []model.SymbolRef, sep string) []model.SymbolRef {
 		}
 	}
 	if !declared {
-		return matches
+		return matches, false
 	}
-	kept := make([]model.SymbolRef, 0, len(matches))
+	kept = make([]model.SymbolRef, 0, len(matches))
 	for _, m := range matches {
 		if m.Receiver == "" || m.Receiver == want {
 			kept = append(kept, m)
 		}
 	}
 	if len(kept) == 0 {
-		return matches
+		return matches, true
 	}
-	return kept
+	return kept, false
 }
 
 // receiverForSeparator maps a call separator to the dispatch kind it implies:

--- a/internal/resolve/resolver_internal_test.go
+++ b/internal/resolve/resolver_internal_test.go
@@ -68,39 +68,55 @@ func TestFilterByReceiver(t *testing.T) {
 	bare := model.SymbolRef{ID: 3, Qualified: "zero"} // no receiver (e.g. another language)
 
 	t.Run("instance separator keeps instance and bare, drops singleton", func(t *testing.T) {
-		got := filterByReceiver([]model.SymbolRef{instance, singleton, bare}, "#")
+		got, contradicted := filterByReceiver([]model.SymbolRef{instance, singleton, bare}, "#")
 		if len(got) != 2 || got[0].ID != 1 || got[1].ID != 3 {
 			t.Fatalf("got %+v, want ids [1 3]", got)
 		}
+		if contradicted {
+			t.Error("contradicted = true, want false (instance candidate survives)")
+		}
 	})
 	t.Run("singleton separator keeps singleton and bare, drops instance", func(t *testing.T) {
-		got := filterByReceiver([]model.SymbolRef{instance, singleton, bare}, ".")
+		got, contradicted := filterByReceiver([]model.SymbolRef{instance, singleton, bare}, ".")
 		if len(got) != 2 || got[0].ID != 2 || got[1].ID != 3 {
 			t.Fatalf("got %+v, want ids [2 3]", got)
+		}
+		if contradicted {
+			t.Error("contradicted = true, want false (singleton candidate survives)")
 		}
 	})
 	t.Run("no receiver declared leaves candidates untouched", func(t *testing.T) {
 		in := []model.SymbolRef{bare, {ID: 4, Qualified: "pkg.zero"}}
-		got := filterByReceiver(in, "#")
+		got, contradicted := filterByReceiver(in, "#")
 		if len(got) != 2 {
 			t.Fatalf("got %d candidates, want 2", len(got))
+		}
+		if contradicted {
+			t.Error("contradicted = true, want false (no receiver declared)")
 		}
 	})
 	t.Run("non-dispatch separator is a no-op", func(t *testing.T) {
 		in := []model.SymbolRef{instance, singleton}
-		got := filterByReceiver(in, "::")
+		got, contradicted := filterByReceiver(in, "::")
 		if len(got) != 2 {
 			t.Fatalf("got %d candidates, want 2", len(got))
 		}
+		if contradicted {
+			t.Error("contradicted = true, want false (`::` carries no dispatch hint)")
+		}
 	})
-	t.Run("empty result falls back to original set", func(t *testing.T) {
+	t.Run("empty result falls back to original set and reports contradiction", func(t *testing.T) {
 		// All candidates are singletons but the call is an instance dispatch:
 		// filtering would empty the set, so the original is returned as a
-		// tie-break rather than dropping the edge.
+		// tie-break rather than dropping the edge — and the contradiction is
+		// reported so the resolver demotes the kind-mismatched bind.
 		in := []model.SymbolRef{singleton, {ID: 5, Qualified: "Other.zero", Receiver: extract.ReceiverSingleton}}
-		got := filterByReceiver(in, "#")
+		got, contradicted := filterByReceiver(in, "#")
 		if len(got) != 2 {
 			t.Fatalf("got %d candidates, want 2 (original set)", len(got))
+		}
+		if !contradicted {
+			t.Error("contradicted = false, want true (every candidate's kind disagreed)")
 		}
 	})
 }

--- a/internal/resolve/resolver_test.go
+++ b/internal/resolve/resolver_test.go
@@ -183,9 +183,11 @@ func TestResolveReceiverRewriteSkippedWithoutParent(t *testing.T) {
 
 func TestResolveUnqualifiedFallbackForCalls(t *testing.T) {
 	ix := resolve.NewIndex(refs())
-	// Bare `Sprintf` doesn't exist as a qualified name but `fmt.Sprintf`
-	// does, and its unqualified segment is `Sprintf`. The fallback
-	// fires for calls, with confidence clamped to 0.8.
+	// `whatever.Sprintf` misses exact lookup; only its leaf `Sprintf` matches
+	// `fmt.Sprintf`. The fallback fires for calls edges (the point of this
+	// test), but `whatever` is not an indexed receiver type, so binding the
+	// leaf is an unverified cross-scope guess: confidence lands below blast's
+	// floor while the edge still resolves for dead-code liveness.
 	r, ok := ix.Resolve(resolve.Request{
 		Target:         "whatever.Sprintf",
 		Kind:           model.EdgeCalls,
@@ -198,8 +200,8 @@ func TestResolveUnqualifiedFallbackForCalls(t *testing.T) {
 	if r.SymbolID != 9 {
 		t.Errorf("SymbolID = %d, want 9 (fmt.Sprintf)", r.SymbolID)
 	}
-	if r.Confidence != 0.8 {
-		t.Errorf("Confidence = %v, want 0.8", r.Confidence)
+	if r.Confidence >= 0.5 {
+		t.Errorf("Confidence = %v, want < 0.5 (unverified receiver prefix demoted)", r.Confidence)
 	}
 }
 
@@ -217,8 +219,8 @@ func TestResolveUnqualifiedFallbackForTests(t *testing.T) {
 	if r.SymbolID != 9 {
 		t.Errorf("SymbolID = %d, want 9 (fmt.Sprintf)", r.SymbolID)
 	}
-	if r.Confidence != 0.8 {
-		t.Errorf("Confidence = %v, want 0.8", r.Confidence)
+	if r.Confidence >= 0.5 {
+		t.Errorf("Confidence = %v, want < 0.5 (unverified receiver prefix demoted)", r.Confidence)
 	}
 }
 
@@ -506,25 +508,125 @@ func TestResolveDropsCodeToCodeCrossLanguageFallback(t *testing.T) {
 	}
 }
 
-func TestResolveKeepsSameLanguageFallback(t *testing.T) {
-	// Ruby → Ruby bare-name fallback is the intended path and must survive the
-	// language gate, keeping the 0.8 ambiguous clamp.
+func TestResolveKeepsFallbackWhenReceiverTypeIsIndexed(t *testing.T) {
+	// The inheritance case the demotion must NOT break: `Child#describe` misses
+	// exact lookup because `describe` is defined on its parent, but `Child` is
+	// an indexed type, so an inherited (or reopened) method is plausible. The
+	// leaf bind keeps the 0.8 ambiguous clamp rather than being demoted.
 	rs := []model.SymbolRef{
-		{ID: 1, Qualified: "A#caller", FileID: 10, Language: "ruby"},
-		{ID: 2, Qualified: "Helpers.format_money", FileID: 11, Language: "ruby"},
+		{ID: 1, Qualified: "Child", FileID: 10, Language: "ruby"},
+		{ID: 2, Qualified: "Parent#describe", FileID: 11, Language: "ruby", Receiver: extract.ReceiverInstance},
 	}
 	ix := resolve.NewIndex(rs)
 	r, ok := ix.Resolve(resolve.Request{
-		Target:         "x.format_money",
+		Target:         "Child#describe",
 		Kind:           model.EdgeCalls,
 		SourceFileID:   10,
 		BaseConfidence: 1.0,
 	})
 	if !ok || r.SymbolID != 2 {
-		t.Fatalf("expected ruby→ruby fallback to id 2, got id=%d ok=%v", r.SymbolID, ok)
+		t.Fatalf("expected fallback to id 2 (Parent#describe), got id=%d ok=%v", r.SymbolID, ok)
 	}
 	if r.Confidence != 0.8 {
-		t.Errorf("Confidence = %v, want 0.8 (same-language `.` fallback not demoted)", r.Confidence)
+		t.Errorf("Confidence = %v, want 0.8 (indexed receiver type — inherited method kept)", r.Confidence)
+	}
+}
+
+func TestResolveDemotesBareUnresolvedGuess(t *testing.T) {
+	// A Ruby call on an unknown receiver (`x.body`) is emitted bare at
+	// ConfidenceUnresolved. Its only same-named match is a coincidental test
+	// method. With no receiver type to verify, the bare guess must land below
+	// blast's floor — it still resolves for dead-code liveness.
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "Hub2Client#post", FileID: 10, Language: "ruby"},
+		{ID: 2, Qualified: "TranslationServiceTest.body", FileID: 20, Language: "ruby", Receiver: extract.ReceiverSingleton},
+	}
+	ix := resolve.NewIndex(rs)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "body",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   10,
+		BaseConfidence: extract.ConfidenceUnresolved,
+	})
+	if !ok || r.SymbolID != 2 {
+		t.Fatalf("expected bare fallback to id 2, got id=%d ok=%v", r.SymbolID, ok)
+	}
+	if r.Confidence >= 0.5 {
+		t.Errorf("Confidence = %v, want < 0.5 (bare unresolved guess demoted)", r.Confidence)
+	}
+}
+
+func TestResolveDemotesFallbackWhenReceiverTypeIsExternal(t *testing.T) {
+	// The headline residual bug: a rescue variable typed to an external gem
+	// class — `Stripe::StripeError#message` — misses exact lookup (the gem is
+	// not indexed) and its leaf `message` binds to a coincidental same-named
+	// test method. The receiver type is not indexed, so this is an unverified
+	// cross-type guess and must land below blast's floor while still resolving.
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "StripeClient#charge", FileID: 10, Language: "ruby"},
+		{ID: 2, Qualified: "TranslationServiceTest.message", FileID: 20, Language: "ruby", Receiver: extract.ReceiverSingleton},
+	}
+	ix := resolve.NewIndex(rs)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "Stripe::StripeError#message",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   10,
+		BaseConfidence: extract.ConfidenceDynamic,
+	})
+	if !ok || r.SymbolID != 2 {
+		t.Fatalf("expected leaf fallback to id 2, got id=%d ok=%v", r.SymbolID, ok)
+	}
+	if r.Confidence >= 0.5 {
+		t.Errorf("Confidence = %v, want < 0.5 (external receiver type — cross-type guess demoted)", r.Confidence)
+	}
+}
+
+func TestResolveDemotesReceiverKindContradiction(t *testing.T) {
+	// Even when the receiver type IS indexed, a dispatch-kind contradiction is
+	// evidence of a wrong bind: an instance call `Widget#size` whose only
+	// same-named candidate is a singleton method cannot be that method. It
+	// resolves (the set is kept as a tie-break) but is demoted below the floor.
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "Widget", FileID: 10, Language: "ruby"},
+		{ID: 2, Qualified: "Catalog.size", FileID: 11, Language: "ruby", Receiver: extract.ReceiverSingleton},
+	}
+	ix := resolve.NewIndex(rs)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "Widget#size",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   10,
+		BaseConfidence: 1.0,
+	})
+	if !ok || r.SymbolID != 2 {
+		t.Fatalf("expected fallback to id 2, got id=%d ok=%v", r.SymbolID, ok)
+	}
+	if r.Confidence >= 0.5 {
+		t.Errorf("Confidence = %v, want < 0.5 (instance call vs singleton-only candidate demoted)", r.Confidence)
+	}
+}
+
+func TestResolveViewSourceKeepsReceiverDispatchFallback(t *testing.T) {
+	// View templates dispatch into helpers loosely, so the receiver-dispatch
+	// demotion is off for view-language sources (mirroring the language gate's
+	// view carve-out). An ERB source's `helper.format` keeps base confidence
+	// even though `helper` is not an indexed type. Symbol id 2 anchors the erb
+	// file's language so fileLang[50] == "erb".
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "MoneyHelper.format", FileID: 11, Language: "ruby", Receiver: extract.ReceiverSingleton},
+		{ID: 2, Qualified: "turbo-frame:cart", FileID: 50, Language: "erb"},
+	}
+	ix := resolve.NewIndex(rs)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "helper.format",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   50,
+		BaseConfidence: 1.0,
+	})
+	if !ok || r.SymbolID != 1 {
+		t.Fatalf("expected erb→ruby fallback to id 1, got id=%d ok=%v", r.SymbolID, ok)
+	}
+	if r.Confidence != 0.8 {
+		t.Errorf("Confidence = %v, want 0.8 (view source exempt from receiver-dispatch demotion)", r.Confidence)
 	}
 }
 


### PR DESCRIPTION
## Problem
Two related defects undermined trust in `calls` edges and diff-blast on a real Rails codebase:

1. **Phantom calls edges.** The resolver's unqualified-name fallback granted caller-grade confidence to leaf-only matches whose qualifier could not be verified. An instance call on an external gem type (`Stripe::StripeError#message`) missed exact lookup and bound its bare leaf to a coincidental same-named *test* method at full 0.7; bare receiver-unknown calls (`x.body`) bound at 0.5; and a dispatch-kind contradiction (instance call, singleton-only candidate) failed open instead of demoting. These plausible-looking-but-wrong edges meant outbound `calls` could not be taken at face value.

2. **Over-broad diff-blast.** Seeding selected every symbol in any touched file, so a one-line edit to a routes file with hundreds of helpers seeded them all — inflating blast radius by an order of magnitude on hub-file commits.

## Summary
Make resolver confidence track *verifiability*, and seed diff-blast from changed line ranges instead of whole files.

## Changes
- **`internal/resolve`** — generalize the existing `::`-only cross-namespace demotion into one rule: a qualified target that resolves only by its leaf is demoted to `ConfidenceNameCollision` (below blast's floor, still counted for dead-code liveness) unless the qualifier is verifiable — the receiver type is an indexed symbol (so an inherited/reopened method is plausible) **and** the dispatch kind agrees. Bare targets keep base confidence only when the extractor was confident; a bare emit at `ConfidenceUnresolved` is a receiver-unknown guess and is demoted. `filterByReceiver` now reports when every candidate's kind contradicts the call so the resolver demotes rather than fails open.
- **`internal/cli` + `internal/mcpserver`** — replace file-granular `SymbolsInFiles` with `GitDiffHunks` (`git diff -U0`) + `SymbolsInChangedLines`, which seed only symbols whose line span overlaps a changed hunk. Wired into both the CLI and MCP diff paths; removed the now-unused file-granular helpers.

## Architecture Highlights
- Inheritance/reopening is preserved: an indexed receiver type keeps base confidence, so `Child#m` → `Parent#m` still resolves. Go/Python top-level bare calls (emitted at 1.0) are untouched.
- The git invocation keeps its hardening (`--end-of-options`, `LookPath`, preserved stderr). Pure deletions and `/dev/null` targets contribute no ranges.

## Verification (real Rails app)
- Production→test `calls` edges at confidence ≥0.5: **689 → 465** (the StripeClient phantoms are gone; the remainder are framework-inherited and exact test-stub matches that are out of scope for this fix).
- Diff-blast on a hub-file commit: **939 → 82** modified symbols.

## Test Plan
- [x] Resolver: external-type demotion, inherited-method preserved, receiver-kind contradiction, bare-unresolved demotion, view-source carve-out
- [x] gitdiff: hunk parsing (additions, deletions, multi-file, renames, `/dev/null`), overlap selection, chunk boundary, scan/query errors
- [x] Coverage ≥92% line & per-function on modified files (resolver.go 98.2%, gitdiff.go 96.6%)
- [x] `make ci` fully green (build, test, lint 0 issues)
- [x] sense binary builds cleanly