### PR TITLE
fix(resolve): gate the exact byQualified path; never bind production code to test symbols

### DIFF
--- a/internal/model/symbol.go
+++ b/internal/model/symbol.go
@@ -48,6 +48,11 @@ type SymbolRef struct {
 	// a Ruby call must not bind to a same-named JS symbol. Empty when the file
 	// language is unknown, in which case the gate is a no-op.
 	Language string
+	// Path is the symbol's file path (from sense_files). The resolver uses it to
+	// determine test-ness so a production-source calls/references edge cannot
+	// resolve into a test file (production never depends on test code). Empty
+	// when the file path is unknown, in which case that gate is a no-op.
+	Path string
 }
 
 // HydrateSymbolNullables copies the sql.NullXxx carriers scanned from

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -31,6 +31,11 @@ type Index struct {
 	// look up the source edge's language from req.SourceFileID without threading
 	// it through every Request. Built from the same SymbolRefs as the name maps.
 	fileLang map[int64]string
+	// fileIsTest maps a file id to whether its path is a test file, so the
+	// resolver can keep a production-source calls/references edge from binding to
+	// a coincidental same-named symbol that lives in a test file. Built from the
+	// same SymbolRefs; a file id absent from the map is treated as non-test.
+	fileIsTest map[int64]bool
 }
 
 // NewIndex builds an Index from the bulk SymbolRefs output. The input
@@ -41,6 +46,7 @@ func NewIndex(refs []model.SymbolRef) *Index {
 		byQualified: make(map[string][]model.SymbolRef, len(refs)),
 		byName:      make(map[string][]model.SymbolRef, len(refs)),
 		fileLang:    make(map[int64]string),
+		fileIsTest:  make(map[int64]bool),
 	}
 	for _, r := range refs {
 		ix.byQualified[r.Qualified] = append(ix.byQualified[r.Qualified], r)
@@ -48,6 +54,9 @@ func NewIndex(refs []model.SymbolRef) *Index {
 		ix.byName[name] = append(ix.byName[name], r)
 		if r.Language != "" {
 			ix.fileLang[r.FileID] = r.Language
+		}
+		if r.Path != "" {
+			ix.fileIsTest[r.FileID] = isTestPath(r.Path)
 		}
 	}
 	return ix
@@ -102,11 +111,18 @@ const nameCollisionConfidence = extract.ConfidenceNameCollision
 //     when the source symbol has a parent qualified name.
 //  2. Exact match via byQualified. Single hit ⇒ BaseConfidence.
 //     Multiple ⇒ same-file preferred, else lowest-id; confidence
-//     clamped to ambiguousConfidence.
+//     clamped to ambiguousConfidence. For calls/tests/references the
+//     exact match is gated the same way the fallback is — a cross-language
+//     or production-into-test coincidence is dropped (synthetic cross-language
+//     targets like `partial:` are exempt). A bare target the extractor
+//     emitted at ConfidenceUnresolved (receiver unknown) skips the exact
+//     shortcut entirely: its byQualified hit would be a leaf coincidence, so
+//     it goes straight to the gated fallback.
 //  3. For calls, tests, and references edges, fall back to
 //     unqualified-name match via byName. Candidates in a different code
-//     language than the source are dropped (filterByLanguage); same
-//     scope preference applies; confidence is clamped to
+//     language than the source are dropped (filterByLanguage), test-file
+//     candidates are dropped for production sources (filterByTestDirection),
+//     same scope preference applies, confidence is clamped to
 //     ambiguousConfidence. A qualified target that matched only its leaf
 //     (the namespace or receiver type was discarded) is demoted below
 //     blast's floor as an unverified cross-scope guess unless the
@@ -114,12 +130,32 @@ const nameCollisionConfidence = extract.ConfidenceNameCollision
 //  4. No match ⇒ ok=false.
 func (ix *Index) Resolve(req Request) (Result, bool) {
 	target := rewriteReceiver(req.Target, req.SourceQualified, req.SourceParentQualified)
+	gatedKind := req.Kind == model.EdgeCalls || req.Kind == model.EdgeTests || req.Kind == model.EdgeReferences
 
-	if matches := ix.byQualified[target]; len(matches) > 0 {
-		return pickBest(matches, req.SourceFileID, req.BaseConfidence), true
+	// A bare target emitted at ConfidenceUnresolved means the extractor could
+	// not type the receiver, so the name is a leaf, not a qualified name. Any
+	// exact byQualified hit on it is a coincidence with a same-named symbol;
+	// skip the shortcut and let the gated fallback handle (and demote) it.
+	_, targetSep := unqualifiedNameSep(target)
+	bareGuess := targetSep == "" && req.BaseConfidence <= extract.ConfidenceUnresolved
+
+	if !bareGuess {
+		if matches := ix.byQualified[target]; len(matches) > 0 {
+			if gatedKind && !isSyntheticTarget(target) {
+				matches = filterByLanguage(matches, ix.fileLang[req.SourceFileID])
+				matches = filterByTestDirection(matches, ix.fileIsTest[req.SourceFileID], ix.fileIsTest)
+			}
+			if len(matches) > 0 {
+				return pickBest(matches, req.SourceFileID, req.BaseConfidence), true
+			}
+			// The qualified name matched only cross-language or test-only
+			// symbols: a coincidence, not a real edge. Drop it rather than
+			// leaf-fallback into more coincidences.
+			return Result{}, false
+		}
 	}
 
-	if req.Kind == model.EdgeCalls || req.Kind == model.EdgeTests || req.Kind == model.EdgeReferences {
+	if gatedKind {
 		// Unqualified fallback: find symbols whose trailing segment
 		// matches the target's trailing segment. Applies to bare
 		// targets ("say" ⇒ byName["say"]) as well as dotted targets
@@ -138,6 +174,7 @@ func (ix *Index) Resolve(req Request) (Result, bool) {
 			}
 			matches := ix.byName[name]
 			matches = filterByLanguage(matches, ix.fileLang[req.SourceFileID])
+			matches = filterByTestDirection(matches, ix.fileIsTest[req.SourceFileID], ix.fileIsTest)
 			matches, receiverContradicted := filterByReceiver(matches, sep)
 			if len(matches) > 0 {
 				r := pickBest(matches, req.SourceFileID, req.BaseConfidence)
@@ -435,4 +472,104 @@ func filterByLanguage(matches []model.SymbolRef, srcLang string) []model.SymbolR
 // ERB is the only such language today; add others here as they gain extractors.
 func isViewLanguage(lang string) bool {
 	return lang == "erb"
+}
+
+// filterByTestDirection drops candidates that live in a test file when the
+// source is production code. Production code never has a static calls or
+// references edge into a test file — test files define stubs, doubles, and
+// helpers that shadow real (often framework or gem) names, so a same-named
+// match there is a coincidence (a Ruby helper's `url_for` binding to a
+// `FiltersHelperTest#url_for`, a `count` call binding to a JS spec's `count`).
+//
+// The gate is one-directional: when the source itself is a test file it is a
+// no-op, because tests legitimately reference both production and test symbols.
+// A candidate whose file test-ness is unknown (path absent) is kept, so the
+// gate fails open. Like filterByLanguage and unlike filterByReceiver, this is a
+// hard exclusion: if every candidate is test-only the set empties and the edge
+// drops to unresolved rather than binding to a coincidence.
+func filterByTestDirection(matches []model.SymbolRef, sourceIsTest bool, fileIsTest map[int64]bool) []model.SymbolRef {
+	if sourceIsTest {
+		return matches
+	}
+	// Fast path: most candidates are production, so scan first and avoid
+	// allocating a copy unless a test candidate is actually present.
+	hasTest := false
+	for _, m := range matches {
+		if fileIsTest[m.FileID] {
+			hasTest = true
+			break
+		}
+	}
+	if !hasTest {
+		return matches
+	}
+	kept := make([]model.SymbolRef, 0, len(matches))
+	for _, m := range matches {
+		if !fileIsTest[m.FileID] {
+			kept = append(kept, m)
+		}
+	}
+	return kept
+}
+
+// isTestPath reports whether a file path is a test/spec file. It mirrors
+// mcpio.IsTestPath (kept as a small local copy to avoid a dependency from this
+// low-level package on the presentation layer); the conventions it encodes —
+// `test/`/`spec/` directories, `_test`/`_spec`/`.test.` infixes, a `test_`
+// prefix, and a `Test`/`Tests` filename suffix — are stable across the
+// supported languages.
+func isTestPath(path string) bool {
+	if strings.Contains(path, "_test.") ||
+		strings.Contains(path, ".test.") ||
+		strings.Contains(path, "_spec.") ||
+		strings.Contains(path, "/test/") ||
+		strings.Contains(path, "/tests/") ||
+		strings.Contains(path, "/testdata/") ||
+		strings.Contains(path, "/spec/") ||
+		strings.HasPrefix(path, "test/") ||
+		strings.HasPrefix(path, "tests/") ||
+		strings.HasPrefix(path, "spec/") {
+		return true
+	}
+	base := path
+	if i := strings.LastIndex(path, "/"); i >= 0 {
+		base = path[i+1:]
+	}
+	if strings.HasPrefix(base, "test_") {
+		return true
+	}
+	if dot := strings.LastIndex(base, "."); dot > 0 {
+		name := base[:dot]
+		if strings.HasSuffix(name, "Test") || strings.HasSuffix(name, "Tests") {
+			return true
+		}
+	}
+	return false
+}
+
+// syntheticTargetPrefixes are the qualified-name prefixes the extractors use
+// for intentional cross-language and framework edges (view partials, Turbo
+// channels/frames, importmap entries, i18n keys, route helpers, ruby-core
+// shims). A target carrying one of these is a designed cross-language link, not
+// a same-name coincidence, so the exact-path language gate must not touch it.
+var syntheticTargetPrefixes = []string{
+	extract.PrefixTurboChannel,
+	extract.PrefixTurboFrame,
+	extract.PrefixImportmap,
+	extract.PrefixPartial,
+	extract.PrefixI18n,
+	extract.PrefixRoute,
+	extract.PrefixRubyCore,
+}
+
+// isSyntheticTarget reports whether a target name is one of the synthetic
+// cross-language/framework qualified names that resolve by exact match and are
+// exempt from the cross-language gate.
+func isSyntheticTarget(target string) bool {
+	for _, p := range syntheticTargetPrefixes {
+		if strings.HasPrefix(target, p) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/resolve/resolver_internal_test.go
+++ b/internal/resolve/resolver_internal_test.go
@@ -62,6 +62,88 @@ func TestReceiverForSeparator(t *testing.T) {
 	}
 }
 
+func TestIsTestPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"app/models/user.rb", false},
+		{"app/services/attestation_service.rb", false}, // "test" substring, not a test file
+		{"test/models/user_test.rb", true},
+		{"spec/models/user_spec.rb", true},
+		{"app/foo_test.go", true},
+		{"src/components/Button.test.tsx", true},
+		{"lib/tests/helper.rb", true},
+		{"pkg/testdata/fixture.json", true},
+		{"test_helper.py", true}, // test_ prefix marks a Python test file
+		{"scripts/test_runner.py", true},
+		{"src/WidgetTest.java", true},
+		{"src/WidgetTests.cs", true},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := isTestPath(c.path); got != c.want {
+			t.Errorf("isTestPath(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}
+
+func TestIsSyntheticTarget(t *testing.T) {
+	cases := []struct {
+		target string
+		want   bool
+	}{
+		{"partial:users/profile", true},
+		{"turbo-channel:notifications", true},
+		{"turbo-frame:cart", true},
+		{"importmap:application", true},
+		{"i18n:account.title", true},
+		{"route:admin_users", true},
+		{"ruby-core:Kernel#puts", true},
+		{"User::Session", false},
+		{"count", false},
+		{"I18n.t", false},
+	}
+	for _, c := range cases {
+		if got := isSyntheticTarget(c.target); got != c.want {
+			t.Errorf("isSyntheticTarget(%q) = %v, want %v", c.target, got, c.want)
+		}
+	}
+}
+
+func TestFilterByTestDirection(t *testing.T) {
+	prod := model.SymbolRef{ID: 1, Qualified: "App::Worker", FileID: 10}
+	test := model.SymbolRef{ID: 2, Qualified: "WorkerTest", FileID: 20}
+	fileIsTest := map[int64]bool{10: false, 20: true}
+
+	t.Run("production source drops test candidates", func(t *testing.T) {
+		got := filterByTestDirection([]model.SymbolRef{prod, test}, false, fileIsTest)
+		if len(got) != 1 || got[0].ID != 1 {
+			t.Fatalf("got %+v, want only id 1 (production)", got)
+		}
+	})
+	t.Run("test source keeps everything", func(t *testing.T) {
+		got := filterByTestDirection([]model.SymbolRef{prod, test}, true, fileIsTest)
+		if len(got) != 2 {
+			t.Fatalf("got %d, want 2 (test source is exempt)", len(got))
+		}
+	})
+	t.Run("no test candidate returns input untouched", func(t *testing.T) {
+		in := []model.SymbolRef{prod, {ID: 3, Qualified: "App::Other", FileID: 11}}
+		got := filterByTestDirection(in, false, fileIsTest)
+		if len(got) != 2 {
+			t.Fatalf("got %d, want 2 (no test candidate to drop)", len(got))
+		}
+	})
+	t.Run("unknown file test-ness is kept (fail open)", func(t *testing.T) {
+		unknown := model.SymbolRef{ID: 4, Qualified: "Mystery", FileID: 99} // not in fileIsTest
+		got := filterByTestDirection([]model.SymbolRef{unknown}, false, fileIsTest)
+		if len(got) != 1 {
+			t.Fatalf("got %d, want 1 (unknown test-ness fails open)", len(got))
+		}
+	})
+}
+
 func TestFilterByReceiver(t *testing.T) {
 	instance := model.SymbolRef{ID: 1, Qualified: "Counter#zero", Receiver: extract.ReceiverInstance}
 	singleton := model.SymbolRef{ID: 2, Qualified: "Money.zero", Receiver: extract.ReceiverSingleton}

--- a/internal/resolve/resolver_test.go
+++ b/internal/resolve/resolver_test.go
@@ -163,6 +163,24 @@ func TestResolveReceiverRewriteHashRuby(t *testing.T) {
 	}
 }
 
+func TestResolveReceiverRewriteNoOpForNonSelfTarget(t *testing.T) {
+	ix := resolve.NewIndex(refs())
+	// The source has a parent, but the target is an ordinary qualified name,
+	// not a `self.`/`Self::` reference — the receiver rewrite must leave it
+	// untouched and exact resolution proceeds normally.
+	r, ok := ix.Resolve(resolve.Request{
+		Target:                "app.User.email",
+		Kind:                  model.EdgeCalls,
+		SourceFileID:          10,
+		SourceQualified:       "app.User.profile",
+		SourceParentQualified: "app.User",
+		BaseConfidence:        1.0,
+	})
+	if !ok || r.SymbolID != 2 {
+		t.Fatalf("expected unchanged target to resolve to id 2, got id=%d ok=%v", r.SymbolID, ok)
+	}
+}
+
 func TestResolveReceiverRewriteSkippedWithoutParent(t *testing.T) {
 	ix := resolve.NewIndex(refs())
 	// Top-level function has no parent — self rewrites must no-op.
@@ -669,6 +687,149 @@ func TestResolveViewSourceKeepsCrossLanguageStimulusCall(t *testing.T) {
 	})
 	if !ok || r.SymbolID != 1 {
 		t.Fatalf("expected erb→js Stimulus edge to id 1, got id=%d ok=%v", r.SymbolID, ok)
+	}
+}
+
+func TestResolveExactMatchDroppedWhenCrossLanguage(t *testing.T) {
+	// A Ruby production call to `I18n.t` exact-matches a JS test-helper symbol
+	// of the same qualified name. The exact byQualified path now applies the
+	// language gate too, so the cross-language coincidence is dropped rather
+	// than returned at full confidence — and it does not leaf-fall-back into a
+	// further coincidence.
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "LafricaClient#handle", FileID: 10, Language: "ruby", Path: "app/clients/lafrica_client.rb"},
+		{ID: 2, Qualified: "I18n.t", FileID: 60, Language: "javascript", Path: "test/system/support/i18n.js"},
+	}
+	ix := resolve.NewIndex(rs)
+	if _, ok := ix.Resolve(resolve.Request{
+		Target:         "I18n.t",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   10,
+		BaseConfidence: 1.0,
+	}); ok {
+		t.Error("expected no resolution: a Ruby source must not exact-bind a same-named JS symbol")
+	}
+}
+
+func TestResolveExactMatchKeepsSyntheticCrossLanguageTarget(t *testing.T) {
+	// A Ruby controller rendering a partial emits the synthetic `partial:` target
+	// that resolves to an ERB symbol. This cross-language edge is intentional, so
+	// the exact-path language gate must exempt synthetic-prefix targets.
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "OrdersController#show", FileID: 10, Language: "ruby", Path: "app/controllers/orders_controller.rb"},
+		{ID: 2, Qualified: "partial:orders/line_item", FileID: 50, Language: "erb", Path: "app/views/orders/_line_item.html.erb"},
+	}
+	ix := resolve.NewIndex(rs)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "partial:orders/line_item",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   10,
+		BaseConfidence: 1.0,
+	})
+	if !ok || r.SymbolID != 2 {
+		t.Fatalf("expected synthetic cross-language edge to id 2, got id=%d ok=%v", r.SymbolID, ok)
+	}
+}
+
+func TestResolveProductionDoesNotBindTestSymbol(t *testing.T) {
+	// A production helper's `url_for` (really ActionView's, unindexed) misses
+	// exact lookup and its only same-named candidate is a test helper method.
+	// Production code never has a real calls edge into a test file, so the edge
+	// drops to unresolved rather than binding the coincidence.
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "FiltersHelper#filter_url", FileID: 10, Language: "ruby", Path: "app/helpers/filters_helper.rb"},
+		{ID: 2, Qualified: "FiltersHelperTest#url_for", FileID: 20, Language: "ruby", Path: "test/helpers/filters_helper_test.rb", Receiver: extract.ReceiverInstance},
+	}
+	ix := resolve.NewIndex(rs)
+	if _, ok := ix.Resolve(resolve.Request{
+		Target:         "FiltersHelper#url_for",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   10,
+		BaseConfidence: extract.ConfidenceDynamic,
+	}); ok {
+		t.Error("expected no resolution: production code must not bind a test-file symbol")
+	}
+}
+
+func TestResolveProductionPrefersNonTestCandidate(t *testing.T) {
+	// When a production call has both a production and a test candidate of the
+	// same name, the test candidate is excluded and the production one wins.
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "Caller#act", FileID: 10, Language: "ruby", Path: "app/caller.rb"},
+		{ID: 2, Qualified: "Worker#process", FileID: 11, Language: "ruby", Path: "app/worker.rb", Receiver: extract.ReceiverInstance},
+		{ID: 3, Qualified: "FakeTest#process", FileID: 20, Language: "ruby", Path: "test/fake_test.rb", Receiver: extract.ReceiverInstance},
+	}
+	ix := resolve.NewIndex(rs)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "Unknown#process",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   10,
+		BaseConfidence: extract.ConfidenceDynamic,
+	})
+	if !ok || r.SymbolID != 2 {
+		t.Fatalf("expected production candidate id 2, got id=%d ok=%v", r.SymbolID, ok)
+	}
+}
+
+func TestResolveTestSourceKeepsTestCandidate(t *testing.T) {
+	// The gate is one-directional: a test-file source legitimately calls a test
+	// helper, so test candidates are kept when the source itself is a test file.
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "WidgetTest#setup", FileID: 20, Language: "ruby", Path: "test/models/widget_test.rb"},
+		{ID: 2, Qualified: "TestDataHelpers#build_widget", FileID: 21, Language: "ruby", Path: "test/support/test_data_helpers.rb", Receiver: extract.ReceiverInstance},
+	}
+	ix := resolve.NewIndex(rs)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "Unknown#build_widget",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   20,
+		BaseConfidence: extract.ConfidenceDynamic,
+	})
+	if !ok || r.SymbolID != 2 {
+		t.Fatalf("expected test->test resolution to id 2, got id=%d ok=%v", r.SymbolID, ok)
+	}
+}
+
+func TestResolveBareGuessRoutedThroughFallbackDemotes(t *testing.T) {
+	// A bare receiver-unknown call (`x.count`, emitted bare at ConfidenceUnresolved)
+	// coincidentally exact-matches a symbol qualified exactly `count`. The bare
+	// guess must skip the exact shortcut and go through the gated fallback, which
+	// demotes it below blast's floor rather than returning the exact match at 0.5.
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "Client#post", FileID: 10, Language: "ruby", Path: "app/client.rb"},
+		{ID: 2, Qualified: "count", FileID: 11, Language: "ruby", Path: "app/helpers.rb"},
+	}
+	ix := resolve.NewIndex(rs)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "count",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   10,
+		BaseConfidence: extract.ConfidenceUnresolved,
+	})
+	if !ok || r.SymbolID != 2 {
+		t.Fatalf("expected fallback resolution to id 2, got id=%d ok=%v", r.SymbolID, ok)
+	}
+	if r.Confidence >= 0.5 {
+		t.Errorf("Confidence = %v, want < 0.5 (bare guess routed through gated fallback)", r.Confidence)
+	}
+}
+
+func TestResolveBareGuessCrossLanguageDropped(t *testing.T) {
+	// The dominant real-world case: a Ruby production `x.count` (bare, receiver
+	// unknown) whose only same-named symbol is a JS spec constant. Routed through
+	// the fallback, the language gate drops it and the edge stays unresolved.
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "Client#post", FileID: 10, Language: "ruby", Path: "app/client.rb"},
+		{ID: 2, Qualified: "count", FileID: 60, Language: "javascript", Path: "test/system/specs/x.spec.js"},
+	}
+	ix := resolve.NewIndex(rs)
+	if _, ok := ix.Resolve(resolve.Request{
+		Target:         "count",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   10,
+		BaseConfidence: extract.ConfidenceUnresolved,
+	}); ok {
+		t.Error("expected no resolution: bare Ruby guess must not bind a JS spec constant")
 	}
 }
 

--- a/internal/sqlite/adapter.go
+++ b/internal/sqlite/adapter.go
@@ -952,7 +952,7 @@ func (a *Adapter) Query(ctx context.Context, f index.Filter) ([]model.Symbol, er
 // sense_files so the resolver can gate cross-language bare-name matches; a
 // symbol whose file row is missing returns an empty language.
 func (a *Adapter) SymbolRefs(ctx context.Context) ([]model.SymbolRef, error) {
-	const q = `SELECT s.id, s.qualified, s.file_id, s.receiver, COALESCE(f.language, '')
+	const q = `SELECT s.id, s.qualified, s.file_id, s.receiver, COALESCE(f.language, ''), COALESCE(f.path, '')
 		FROM sense_symbols s
 		LEFT JOIN sense_files f ON f.id = s.file_id
 		ORDER BY s.id ASC`
@@ -965,7 +965,7 @@ func (a *Adapter) SymbolRefs(ctx context.Context) ([]model.SymbolRef, error) {
 	var refs []model.SymbolRef
 	for rows.Next() {
 		var r model.SymbolRef
-		if err := rows.Scan(&r.ID, &r.Qualified, &r.FileID, &r.Receiver, &r.Language); err != nil {
+		if err := rows.Scan(&r.ID, &r.Qualified, &r.FileID, &r.Receiver, &r.Language, &r.Path); err != nil {
 			return nil, fmt.Errorf("sqlite SymbolRefs scan: %w", err)
 		}
 		refs = append(refs, r)

--- a/internal/sqlite/coverage_test.go
+++ b/internal/sqlite/coverage_test.go
@@ -256,6 +256,61 @@ func TestSymbolRefsCarriesLanguage(t *testing.T) {
 	}
 }
 
+func TestSymbolRefsCarriesPath(t *testing.T) {
+	a := openTestDB(t)
+	ctx := context.Background()
+
+	app := seedFile(t, a, "app/models/user.rb", "ruby", "h1")
+	test := seedFile(t, a, "test/models/user_test.rb", "ruby", "h2")
+	seedSymbol(t, a, app, "User", "User", "class")
+	seedSymbol(t, a, test, "UserTest", "UserTest", "class")
+
+	refs, err := a.SymbolRefs(ctx)
+	if err != nil {
+		t.Fatalf("SymbolRefs: %v", err)
+	}
+	got := map[string]string{}
+	for _, r := range refs {
+		got[r.Qualified] = r.Path
+	}
+	if got["User"] != "app/models/user.rb" {
+		t.Errorf("User Path = %q, want app/models/user.rb (left-joined from sense_files)", got["User"])
+	}
+	if got["UserTest"] != "test/models/user_test.rb" {
+		t.Errorf("UserTest Path = %q, want test/models/user_test.rb", got["UserTest"])
+	}
+}
+
+func TestSymbolRefsScanError(t *testing.T) {
+	a := openTestDB(t)
+	ctx := context.Background()
+
+	fid := seedFile(t, a, "app/x.rb", "ruby", "h1")
+	sid := seedSymbol(t, a, fid, "X", "X", "class")
+	// Corrupt file_id to a non-integer so the row fails to scan into int64
+	// (SQLite is dynamically typed), exercising the scan-error path. The write
+	// is done on a pinned connection with FK enforcement off so the bad value
+	// lands; reads don't check FKs, so SymbolRefs still hits the scan failure.
+	// The connection is released before SymbolRefs — the adapter caps the pool
+	// at one connection, so holding it would deadlock the subsequent read.
+	conn, err := a.DB().Conn(ctx)
+	if err != nil {
+		t.Fatalf("Conn: %v", err)
+	}
+	if _, err := conn.ExecContext(ctx, "PRAGMA foreign_keys=OFF"); err != nil {
+		t.Fatalf("disable FK: %v", err)
+	}
+	if _, err := conn.ExecContext(ctx, "UPDATE sense_symbols SET file_id='not-an-int' WHERE id=?", sid); err != nil {
+		t.Fatalf("corrupt file_id: %v", err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("close conn: %v", err)
+	}
+	if _, err := a.SymbolRefs(ctx); err == nil {
+		t.Error("expected a scan error for a non-integer file_id")
+	}
+}
+
 func TestEdgesOfKind(t *testing.T) {
 	a := openTestDB(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Problem
Follow-up to #116. After that fix, a real Rails codebase still showed **603 production→test structural edges** (465 calls + 138 references) where production code resolved a call/reference to a symbol defined in a **test file**. Root cause: the resolver's gates (cross-language, receiver, cross-scope demotion) only ran on the **fallback** path. Targets that hit `byQualified` **exactly** skipped every gate, so:

- a bare Ruby call like `x.count` (emitted at `ConfidenceUnresolved`, receiver unknown) exact-matched a same-named JavaScript constant in a test spec and resolved at 0.5;
- a constant call like `I18n.t` exact-matched a JS test-helper `I18n.t` at 1.0.

**598 of the 603 were cross-language** (Ruby production → JS test specs); the other 5 were same-language (a helper's `url_for` binding to `FiltersHelperTest#url_for`, where the real method is framework-inherited and unindexed).

## Summary
Extend the gates the fallback already applies to the exact `byQualified` path, and add a one-directional production→test gate.

## Changes
- **Exact-path cross-language gate** — `calls`/`tests`/`references` exact matches now run through `filterByLanguage`, exempting intentional synthetic cross-language targets (`partial:`, `turbo-*`, `importmap:`, `i18n:`, `route:`, `ruby-core:`). When the exact name matches only gated-away coincidences, the edge drops to unresolved instead of leaf-falling-back into another coincidence.
- **Bare-guess routing** — a bare target emitted at `ConfidenceUnresolved` (receiver unknown) skips the exact shortcut and goes through the gated fallback, which demotes it below blast's floor rather than letting a leaf coincidence resolve at 0.5.
- **`filterByTestDirection`** — a production-source `calls`/`references` edge cannot resolve into a test file. Test files define stubs/helpers that shadow real (often framework) names, so a same-named match there is a coincidence. One-directional: test code still references both production and test symbols.
- **`SymbolRef.Path`** — carried through the existing `SymbolRefs` left-join so the resolver can determine per-file test-ness, mirroring how it already carries `Language`.

## Architecture / scope notes
- `isTestPath` is a small local copy of `mcpio.IsTestPath`. `resolve` is a low-level package and must not depend on the presentation layer, so the copy is deliberate; hoisting a shared predicate into a base package is a reasonable **follow-up**, intentionally out of scope here.
- Temporal production↔test co-change coupling is **legitimate** and left untouched — the gates apply only to structural `calls`/`tests`/`references` edges.

## Verification (real Rails app)
- production→test `calls`+`references` edges ≥0.5: **603 → 0**
- cross-language structural edges: **803 → 0**
- legit edges intact: production→production calls **6,773**, test→production edges **6,083**, temporal coupling preserved

## Test Plan
- [x] Resolver: cross-language exact-drop, synthetic-target exemption, production→test (exact + fallback), test-source exemption, bare-guess routing (demote + drop)
- [x] White-box: `isTestPath`, `isSyntheticTarget`, `filterByTestDirection`; adapter carries `Path`
- [x] Coverage ≥92% line & per-function on modified files (resolver.go 98.7%, all new functions 100%)
- [x] `make ci` fully green (build, test, lint 0 issues)
- [x] sense binary builds cleanly