### PR TITLE
feat(graph): add min_confidence to sense_graph; surface hidden callers

### DIFF
--- a/internal/mcpio/graph.go
+++ b/internal/mcpio/graph.go
@@ -87,6 +87,20 @@ const (
 // — they're syntactically explicit.
 const graphConfidenceFloor = extract.ConfidenceUnresolved
 
+// GraphConfidenceFloor is the exported default usage-edge floor for
+// sense_graph — the value min_confidence defaults to when the parameter is
+// absent. It mirrors graphConfidenceFloor so callers outside this package
+// (the MCP handler) resolve the same default the builder uses.
+const GraphConfidenceFloor = graphConfidenceFloor
+
+// MinGraphConfidence is the smallest positive floor the MCP handler clamps an
+// explicit min_confidence to. It keeps an explicit 0.0 ("show everything")
+// distinguishable from an unset field in BuildGraphRequest.edgeFloor, whose
+// zero-value guard resolves to the default floor. The lowest real usage-edge
+// confidence is 0.3 (name collision), so any floor at or below it surfaces
+// every stored caller.
+const MinGraphConfidence = 0.01
+
 // FileLookup resolves a sense_files row id to its path. Used by
 // BuildGraphResponse / BuildBlastResponse to hydrate edge endpoints.
 // A miss returns ("", false); the builder then renders `File` as
@@ -102,6 +116,22 @@ type BuildGraphRequest struct {
 	Direction      model.Direction // DirectionBoth, DirectionCallers, DirectionCallees; "" == both
 	SegmentCallers bool
 	Snippets       *SnippetReader
+	// MinConfidence is the floor below which usage edges (calls/references)
+	// are hidden and counted in LowConfidenceHidden. A zero value means
+	// "unset" and resolves to graphConfidenceFloor, so CLI and benchmark
+	// callers that leave it blank keep the default 0.5 floor. The MCP handler
+	// passes an explicit value (default 0.5, lowered via the min_confidence
+	// parameter to surface name-collision and other below-floor callers).
+	MinConfidence float64
+}
+
+// edgeFloor resolves the request's usage-edge confidence floor, treating a
+// zero/unset MinConfidence as the default graphConfidenceFloor.
+func (r BuildGraphRequest) edgeFloor() float64 {
+	if r.MinConfidence <= 0 {
+		return graphConfidenceFloor
+	}
+	return r.MinConfidence
 }
 
 // BuildGraphResponse assembles the wire-shape response from the
@@ -132,7 +162,7 @@ func BuildGraphResponse(ctx context.Context, sc *model.SymbolContext, files File
 	}
 
 	var hidden int
-	resp.Edges, hidden = categorizeEdges(ctx, sc.Outbound, sc.Inbound, files, req.Direction, req.Snippets)
+	resp.Edges, hidden = categorizeEdges(ctx, sc.Outbound, sc.Inbound, files, req.Direction, req.Snippets, req.edgeFloor())
 	resp.LowConfidenceHidden = hidden
 	resp.SnippetsTruncated = req.Snippets.Truncated(len(sc.Outbound) + len(sc.Inbound))
 
@@ -252,7 +282,7 @@ func BuildFullGraphResponse(ctx context.Context, gr *model.GraphResult, files Fi
 // BuildGraphLayer converts a model.HopEdges into a wire-format
 // GraphLayer for the given hop depth.
 func BuildGraphLayer(ctx context.Context, hop model.HopEdges, depth int, files FileLookup, req BuildGraphRequest) GraphLayer {
-	edges, _ := categorizeEdges(ctx, hop.Outbound, hop.Inbound, files, req.Direction, req.Snippets)
+	edges, _ := categorizeEdges(ctx, hop.Outbound, hop.Inbound, files, req.Direction, req.Snippets, req.edgeFloor())
 	return GraphLayer{
 		Depth: depth,
 		Edges: edges,
@@ -263,9 +293,11 @@ func BuildGraphLayer(ctx context.Context, hop model.HopEdges, depth int, files F
 // shape, dispatching each edge kind to the right bucket. Temporal edges
 // and test-caller segmentation are root-only concerns handled by
 // BuildGraphResponse on top of this. Usage edges (calls / references)
-// below graphConfidenceFloor are dropped and counted in the returned
-// hidden total so the caller can report them rather than silently omit.
-func categorizeEdges(ctx context.Context, outbound, inbound []model.EdgeRef, files FileLookup, direction model.Direction, snippets *SnippetReader) (GraphEdges, int) {
+// below floor are dropped and counted in the returned hidden total so the
+// caller can report them rather than silently omit. floor is the resolved
+// usage-edge confidence floor (graphConfidenceFloor by default; lower to
+// surface name-collision and other below-floor callers).
+func categorizeEdges(ctx context.Context, outbound, inbound []model.EdgeRef, files FileLookup, direction model.Direction, snippets *SnippetReader, floor float64) (GraphEdges, int) {
 	var edges GraphEdges
 	var hidden int
 
@@ -284,7 +316,7 @@ func categorizeEdges(ctx context.Context, outbound, inbound []model.EdgeRef, fil
 		for _, e := range outbound {
 			switch e.Edge.Kind {
 			case model.EdgeCalls, model.EdgeReferences:
-				if e.Edge.Confidence < graphConfidenceFloor {
+				if e.Edge.Confidence < floor {
 					hidden++
 					continue
 				}
@@ -343,7 +375,7 @@ func categorizeEdges(ctx context.Context, outbound, inbound []model.EdgeRef, fil
 		for _, e := range inbound {
 			switch e.Edge.Kind {
 			case model.EdgeCalls, model.EdgeReferences:
-				if e.Edge.Confidence < graphConfidenceFloor {
+				if e.Edge.Confidence < floor {
 					hidden++
 					continue
 				}

--- a/internal/mcpio/graph_test.go
+++ b/internal/mcpio/graph_test.go
@@ -870,6 +870,56 @@ func TestCategorizeEdgesInboundIncludesImportsTests(t *testing.T) {
 	}
 }
 
+func TestBuildGraphResponseMinConfidenceSurfacesHiddenCallers(t *testing.T) {
+	// A method whose name is defined in several classes resolves its
+	// implicit-receiver callers by bare-name fallback, stamped 0.3
+	// (ConfidenceNameCollision) — below the default display floor. The default
+	// request hides them and counts them in LowConfidenceHidden; a lowered
+	// MinConfidence surfaces the same edges so an empty list is never mistaken
+	// for "unused".
+	files := func(id int64) (string, bool) {
+		paths := map[int64]string{2: "app/controllers/posts_controller.rb"}
+		p, ok := paths[id]
+		return p, ok
+	}
+	newSC := func() *model.SymbolContext {
+		return &model.SymbolContext{
+			Symbol: model.Symbol{ID: 1, Name: "current_user", Qualified: "Authentication#current_user", Kind: model.KindMethod, FileID: 1, LineStart: 5},
+			File:   model.File{Path: "app/controllers/concerns/authentication.rb"},
+			Inbound: []model.EdgeRef{
+				{Edge: model.Edge{Kind: model.EdgeCalls, Confidence: 0.3, FileID: 2}, Target: model.Symbol{ID: 7, Qualified: "PostsController#show", FileID: 2, LineStart: 12}},
+			},
+		}
+	}
+
+	// Default floor (0.5): the 0.3 caller is hidden and counted.
+	def := BuildGraphResponse(context.Background(), newSC(), files, BuildGraphRequest{Direction: model.DirectionCallers})
+	if len(def.Edges.CalledBy) != 0 {
+		t.Fatalf("default floor: CalledBy = %d, want 0", len(def.Edges.CalledBy))
+	}
+	if def.LowConfidenceHidden != 1 {
+		t.Fatalf("default floor: LowConfidenceHidden = %d, want 1", def.LowConfidenceHidden)
+	}
+
+	// Lowered floor (0.3): the same caller is surfaced and no longer counted hidden.
+	low := BuildGraphResponse(context.Background(), newSC(), files, BuildGraphRequest{Direction: model.DirectionCallers, MinConfidence: 0.3})
+	if len(low.Edges.CalledBy) != 1 || low.Edges.CalledBy[0].Symbol != "PostsController#show" {
+		t.Fatalf("lowered floor: CalledBy = %+v, want [PostsController#show]", low.Edges.CalledBy)
+	}
+	if low.LowConfidenceHidden != 0 {
+		t.Errorf("lowered floor: LowConfidenceHidden = %d, want 0", low.LowConfidenceHidden)
+	}
+}
+
+func TestBuildGraphRequestEdgeFloorDefaults(t *testing.T) {
+	if got := (BuildGraphRequest{}).edgeFloor(); got != graphConfidenceFloor {
+		t.Errorf("unset MinConfidence: edgeFloor = %g, want default %g", got, graphConfidenceFloor)
+	}
+	if got := (BuildGraphRequest{MinConfidence: 0.3}).edgeFloor(); got != 0.3 {
+		t.Errorf("explicit MinConfidence: edgeFloor = %g, want 0.3", got)
+	}
+}
+
 func TestBuildGraphResponseInboundOnlyTemporal(t *testing.T) {
 	coChanges := 7
 	sc := &model.SymbolContext{

--- a/internal/mcpserver/handler_test.go
+++ b/internal/mcpserver/handler_test.go
@@ -407,6 +407,45 @@ func TestHandleGraph(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:    "min_confidence above 1 returns error",
+			args:    map[string]any{"symbol": "auth.Verify", "min_confidence": 1.5},
+			isError: true,
+			checkJSON: func(t *testing.T, text string) {
+				if !strings.Contains(text, "min_confidence must be between") {
+					t.Errorf("expected min_confidence range error, got %q", text)
+				}
+			},
+		},
+		{
+			name: "min_confidence within range is accepted",
+			args: map[string]any{"symbol": "auth.Verify", "direction": "callers", "min_confidence": 0.3},
+			checkJSON: func(t *testing.T, text string) {
+				var resp mcpio.GraphResponse
+				if err := json.Unmarshal([]byte(text), &resp); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if resp.Symbol.Name != "Verify" {
+					t.Errorf("symbol.name = %q, want Verify", resp.Symbol.Name)
+				}
+			},
+		},
+		{
+			// An explicit 0.0 ("show everything") is clamped to MinGraphConfidence
+			// so the builder's zero-means-default guard doesn't swallow it back to
+			// the 0.5 floor.
+			name: "min_confidence zero is clamped not defaulted",
+			args: map[string]any{"symbol": "auth.Verify", "direction": "callers", "min_confidence": 0.0},
+			checkJSON: func(t *testing.T, text string) {
+				var resp mcpio.GraphResponse
+				if err := json.Unmarshal([]byte(text), &resp); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if resp.Symbol.Name != "Verify" {
+					t.Errorf("symbol.name = %q, want Verify", resp.Symbol.Name)
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/mcpserver/hints_test.go
+++ b/internal/mcpserver/hints_test.go
@@ -73,6 +73,36 @@ func TestGraphHintsNoCallers(t *testing.T) {
 	}
 }
 
+func TestGraphHintsNoCallersButHiddenLowConfidence(t *testing.T) {
+	// An empty called_by with hidden low-confidence callers must steer the
+	// agent to lower the threshold, not imply the symbol is unused.
+	resp := mcpio.GraphResponse{
+		Symbol: mcpio.GraphSymbol{
+			Name:      "current_user",
+			Qualified: "Authentication#current_user",
+			File:      "app/controllers/concerns/authentication.rb",
+		},
+		Edges:               mcpio.GraphEdges{CalledBy: []mcpio.CallEdgeRef{}},
+		LowConfidenceHidden: 111,
+	}
+	hints := graphHints(resp, "callers")
+	if len(hints) == 0 {
+		t.Fatal("want a hint when low-confidence callers are hidden, got none")
+	}
+	if hints[0].Tool != "sense_graph" {
+		t.Errorf("tool = %q, want sense_graph", hints[0].Tool)
+	}
+	if hints[0].Args["min_confidence"] != 0.3 {
+		t.Errorf("args.min_confidence = %v, want 0.3", hints[0].Args["min_confidence"])
+	}
+	if hints[0].Args["direction"] != "callers" {
+		t.Errorf("args.direction = %v, want callers", hints[0].Args["direction"])
+	}
+	if hints[0].Args["symbol"] != "Authentication#current_user" {
+		t.Errorf("args.symbol = %v, want qualified name", hints[0].Args["symbol"])
+	}
+}
+
 func TestGraphHintsNoCallersTestFile(t *testing.T) {
 	resp := mcpio.GraphResponse{
 		Symbol: mcpio.GraphSymbol{

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -290,6 +290,13 @@ func graphTool() mcp.Tool {
 		mcp.WithNumber("context_lines",
 			mcp.Description("Lines of source context around each call site (default 2, 0 to suppress snippets)"),
 		),
+		mcp.WithNumber("min_confidence",
+			mcp.Description("Minimum edge confidence 0.0–1.0 for callers/callees (default 0.5). "+
+				"Lower it (e.g. 0.3) to surface low-confidence callers that the default floor hides — "+
+				"implicit-receiver calls to a method whose name is defined in multiple classes resolve by "+
+				"bare-name fallback and are stamped 0.3. When called_by is empty but low_confidence_hidden "+
+				"is non-zero, re-run with a lower min_confidence before concluding a symbol is unused."),
+		),
 	)
 }
 
@@ -402,10 +409,27 @@ func (h *handlers) handleGraph(ctx context.Context, req mcp.CallToolRequest) (*m
 	}
 
 	contextLines := req.GetInt("context_lines", mcpio.DefaultContextLines)
+
+	// min_confidence defaults to the display floor (0.5); a sentinel of -1
+	// lets us tell "absent" from an explicit 0.0. An explicit value is
+	// validated to [0,1] and clamped to a small positive epsilon so the
+	// builder's zero-means-default guard never swallows it.
+	minConfidence := mcpio.GraphConfidenceFloor
+	if v := req.GetFloat("min_confidence", -1); v >= 0 {
+		if v > 1 {
+			return mcp.NewToolResultError(fmt.Sprintf("sense_graph: min_confidence must be between 0.0 and 1.0 (got %g)", v)), nil
+		}
+		minConfidence = v
+		if minConfidence < mcpio.MinGraphConfidence {
+			minConfidence = mcpio.MinGraphConfidence
+		}
+	}
+
 	buildReq := mcpio.BuildGraphRequest{
 		Direction:      direction,
 		SegmentCallers: h.defaults.GraphSegmentCallers,
 		Snippets:       mcpio.NewSnippetReader(h.dir, contextLines),
+		MinConfidence:  minConfidence,
 	}
 	resp := mcpio.BuildFullGraphResponse(ctx, gr, lookup, buildReq)
 
@@ -608,13 +632,28 @@ func graphHints(resp mcpio.GraphResponse, direction model.Direction) []mcpio.Nex
 	if resp.TestCallerSummary != nil {
 		totalCallers += resp.TestCallerSummary.Count
 	}
-	if totalCallers >= 5 {
+	switch {
+	case totalCallers >= 5:
 		hints = append(hints, mcpio.NextStep{
 			Tool:   "sense_blast",
 			Args:   map[string]any{"symbol": resp.Symbol.Qualified},
 			Reason: fmt.Sprintf("%d callers found — check blast radius before changing this symbol", totalCallers),
 		})
-	} else if totalCallers == 0 && !isTestFile(resp.Symbol.File) {
+	case totalCallers == 0 && resp.LowConfidenceHidden > 0:
+		// Callers exist in the index but sit below the display floor — e.g.
+		// implicit-receiver calls to a method whose name is defined in several
+		// classes, stamped 0.3 by name-collision fallback. Surfacing the knob
+		// here stops an agent from reading the empty list as "unused".
+		args := map[string]any{"symbol": resp.Symbol.Qualified, "min_confidence": 0.3}
+		if direction == model.DirectionCallers {
+			args["direction"] = "callers"
+		}
+		hints = append(hints, mcpio.NextStep{
+			Tool:   "sense_graph",
+			Args:   args,
+			Reason: fmt.Sprintf("%d low-confidence callers hidden — re-run with min_confidence=0.3 to view before assuming this is unused", resp.LowConfidenceHidden),
+		})
+	case totalCallers == 0 && !isTestFile(resp.Symbol.File):
 		hints = append(hints, mcpio.NextStep{
 			Tool:   "sense_search",
 			Args:   map[string]any{"query": resp.Symbol.Name},


### PR DESCRIPTION
## Problem
`sense_graph` drops every usage edge below a fixed 0.5 display floor and offers no way to lower it. For a method whose name is defined in several classes (e.g. a Rails `current_user` resolved via implicit receiver), every caller resolves by bare-name fallback and is stamped 0.3 — below the floor. The result is an empty `called_by` paired with a "no callers found" hint, which reads as authoritative: an agent can conclude the symbol is unused or safe to change when 100+ real callers are sitting hidden in the index. `sense_blast` already exposes `min_confidence`, so the absence on `sense_graph` is also an inconsistency.

## Summary
Add a `min_confidence` parameter to `sense_graph` (default 0.5, mirroring `sense_blast`) and rewrite the empty-state hint so hidden callers steer the agent to re-run with a lower threshold instead of implying the symbol is unused.

## Changes
- **`sense_graph` tool** — new `min_confidence` param, validated to [0,1]; an explicit `0.0` is clamped to a small epsilon so "show everything" isn't swallowed back to the default floor.
- **Display layer** — floor threaded through `BuildGraphRequest.MinConfidence` / `edgeFloor()` into `categorizeEdges`, replacing the hardcoded constant. Purely display-layer; the low-confidence edges were already loaded, so no scan or SQL change.
- **Hints** — empty `called_by` with `low_confidence_hidden > 0` now emits a `sense_graph` next step pre-filled with `min_confidence=0.3` ("N low-confidence callers hidden — re-run before assuming this is unused") instead of "no callers found".
- **Tests** — floor surfacing, hint behavior, and param validation (range + zero-clamp).

## Architecture Highlights
- `MinConfidence` zero-value means "unset" and resolves to the default floor via `edgeFloor()`, so existing CLI/benchmark callers keep the 0.5 floor with no signature churn.
- Scope kept to the MCP tool (the AI consumer); the CLI `sense graph` retains its fixed floor, consistent with the existing CLI/MCP divergence.

## Test Plan
- [x] `sense_graph` callers on a name-collision method returns empty `called_by` + `low_confidence_hidden` + the lower-threshold hint
- [x] Same query with `min_confidence=0.3` surfaces the previously hidden callers (verified end-to-end: 111 callers surfaced)
- [x] `min_confidence` > 1 returns a validation error; `0.0` is accepted and clamped
- [x] `go test ./...` passes
- [x] `make ci` green (build + test + lint)
- [x] sense binary builds cleanly
