### PR TITLE
feat(dead): per-language soundness gate for the dead verdict

### DIFF
--- a/internal/dead/arbiter.go
+++ b/internal/dead/arbiter.go
@@ -78,19 +78,31 @@ type Facts struct {
 	// no main yet is not a library: its public methods are internal, so a
 	// detected framework makes IsLibrary false. See buildFacts.
 	IsLibrary bool
-	// DispatchNames is the set of literal names that appear as reflection /
-	// metaprogramming dispatch targets (send/public_send/__send__/
-	// define_method/respond_to?/method/const_get/constantize). A symbol
-	// whose name is in this set could be invoked dynamically. Populated from
-	// sense_meta at scan time (see the Ruby visibility card).
-	DispatchNames map[string]struct{}
-	// MentionedNames is the broad set of every bare name the code mentions —
-	// every identifier/symbol token except definition names. It drives the
-	// arbiter's soundness gate: a candidate earns `dead` only when its name is
-	// absent from this set (mentioned nowhere a hidden caller could be) AND the
-	// set is non-empty (proving the harvest ran). This makes `dead` sound even
-	// where the resolver could not bind every call. Populated from sense_meta.
-	MentionedNames map[string]struct{}
+	// DispatchNames maps a language to the set of literal names that appear as
+	// reflection / metaprogramming dispatch targets in THAT language
+	// (Ruby send/public_send/__send__/define_method/respond_to?/method/
+	// const_get/constantize; other voices bring their own idioms). A symbol
+	// whose name is in its own language's set could be invoked dynamically. The
+	// set is keyed by language so one language's reflection literals never keep
+	// another language's symbol open-world. Populated from sense_meta at scan
+	// time (see the Ruby visibility card).
+	DispatchNames map[string]map[string]struct{}
+	// MentionedNames maps a language to the broad set of every bare name THAT
+	// language's code mentions — every identifier/symbol token except definition
+	// names. It drives the arbiter's soundness gate: a candidate earns `dead`
+	// only when its name is absent from its own language's set (mentioned
+	// nowhere a hidden caller could be) AND that set is non-empty. Keying by
+	// language is the soundness primitive: a symbol may earn `dead` only against
+	// mentions harvested from its OWN language, never off another's. Populated
+	// from sense_meta.
+	MentionedNames map[string]map[string]struct{}
+	// HarvestedLangs is the set of languages whose mention harvest actually ran
+	// for this index. The soundness gate refuses `dead` for a symbol whose
+	// language is absent here (reason core_no_harvest): a missing harvest cannot
+	// prove a name unmentioned, so it fails closed rather than earn `dead` off
+	// another language's mentions. This makes the gate's per-language scope
+	// explicit instead of resting on a coincidentally-empty global set.
+	HarvestedLangs map[string]struct{}
 	// InterfaceIDs are symbol IDs of interfaces; a method whose parent is one
 	// is part of a contract and reachable through any implementor.
 	InterfaceIDs map[int64]struct{}
@@ -188,20 +200,25 @@ func (a *Arbiter) decideOne(s Symbol, f Facts) Finding {
 	// be. A live-but-unbindable call still left a textual mention, which keeps
 	// the symbol open-world instead of falsely dead.
 	//
-	// An empty mention set fails closed: it means the harvest was unavailable
-	// (a pre-feature index or corrupt meta), so the gate cannot prove the name
-	// is unmentioned and stays honest. The gate assumes the mention harvest ran
-	// over the same tree the candidates came from — its soundness depends on
-	// that coupling, so a partial-tree harvest must not be trusted here.
+	// The gate is PER-LANGUAGE: a symbol is proven against the mentions
+	// harvested from its OWN language, never off another's. The set is keyed by
+	// s.Language and gated twice, both failing closed toward caution:
 	//
-	// NOTE (per-language scope): the mention set is project-GLOBAL, not
-	// per-language. With only the Ruby voice registered this is correct, because
-	// every name that could reach a Ruby symbol is harvested from Ruby files. A
-	// future language voice (Go/TS/…) MUST ship its own mention harvest before
-	// its symbols may earn `dead` here — otherwise it would earn `dead` off
-	// another language's mentions. TestSoundnessGateIsRubyOnlyToday pins this.
-	_, mentioned := f.MentionedNames[s.Name]
-	if len(f.MentionedNames) == 0 || mentioned {
+	//   1. HarvestedLangs miss → the symbol's language never harvested mentions,
+	//      so there is nothing to prove against. Refuse `dead` (core_no_harvest).
+	//      This is the invariant that makes proliferating voices safe: a future
+	//      voice that registers without shipping its own harvest earns
+	//      core_no_harvest, not `dead` off another language's mentions.
+	//   2. Empty set or name present → the gate cannot prove the name unmentioned
+	//      (an unavailable harvest, or a real unbound mention). Refuse `dead`
+	//      (core_name_mentioned). The gate assumes the harvest ran over the same
+	//      tree the candidates came from; a partial-tree harvest is not trusted.
+	set := f.MentionedNames[s.Language]
+	if _, harvested := f.HarvestedLangs[s.Language]; !harvested {
+		r := newReason(ReasonNoHarvest)
+		return Finding{Symbol: s, Verdict: VerdictPossiblyDead, Reason: &r}
+	}
+	if _, mentioned := set[s.Name]; len(set) == 0 || mentioned {
 		r := newReason(ReasonNameMentioned)
 		return Finding{Symbol: s, Verdict: VerdictPossiblyDead, Reason: &r}
 	}

--- a/internal/dead/arbiter_test.go
+++ b/internal/dead/arbiter_test.go
@@ -23,6 +23,26 @@ func sym(name, lang string) Symbol {
 	return Symbol{Name: name, Qualified: name, Language: lang, Kind: "method"}
 }
 
+// langNames builds a language-keyed name set {lang: {names...}}, the shape of
+// Facts.MentionedNames and Facts.DispatchNames after the per-language gate.
+func langNames(lang string, names ...string) map[string]map[string]struct{} {
+	set := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		set[n] = struct{}{}
+	}
+	return map[string]map[string]struct{}{lang: set}
+}
+
+// harvested builds a Facts.HarvestedLangs set for the given languages — the
+// languages whose mention harvest ran, the precondition for earning `dead`.
+func harvested(langs ...string) map[string]struct{} {
+	out := make(map[string]struct{}, len(langs))
+	for _, l := range langs {
+		out[l] = struct{}{}
+	}
+	return out
+}
+
 // TestArbiterTwoSidedGate is the control the coverage gate demands: with a
 // language voice registered, a symbol no voice flags earns `dead`, AND a
 // symbol the voice flags stays `possibly_dead`. The gate is two-sided, not a
@@ -31,9 +51,9 @@ func TestArbiterTwoSidedGate(t *testing.T) {
 	voice := fakeVoice{lang: "ruby", code: ReasonReflection, raiseFor: map[string]struct{}{"flagged": {}}}
 	a := NewArbiter(voice)
 
-	// A non-empty mention set that does NOT contain "clean" lets the soundness
-	// gate prove "clean" is mentioned nowhere a hidden caller could be.
-	f := Facts{MentionedNames: map[string]struct{}{"flagged": {}}}
+	// A non-empty Ruby mention set that does NOT contain "clean" lets the
+	// soundness gate prove "clean" is mentioned nowhere a hidden caller could be.
+	f := Facts{MentionedNames: langNames("ruby", "flagged"), HarvestedLangs: harvested("ruby")}
 	got := a.Decide([]Symbol{sym("flagged", "ruby"), sym("clean", "ruby")}, f)
 
 	if got[0].Verdict != VerdictPossiblyDead {
@@ -112,7 +132,7 @@ func TestArbiterTieBreakFirstRegistered(t *testing.T) {
 }
 
 func TestCoreVoiceReflectionGate(t *testing.T) {
-	f := Facts{DispatchNames: map[string]struct{}{"process": {}}}
+	f := Facts{DispatchNames: langNames("ruby", "process")}
 	r := coreVoice{}.Inspect(Symbol{Name: "process", Kind: "method", Language: "ruby"}, f)
 	if r == nil || r.Code != ReasonReflection {
 		t.Errorf("reflection gate: got %+v, want %q", r, ReasonReflection)
@@ -141,10 +161,29 @@ func TestCoreVoiceExportGate(t *testing.T) {
 	}
 }
 
+// TestCoreVoiceReflectionGateIsPerLanguage proves the dispatch gate keys by
+// language in lockstep with the soundness gate: a Ruby reflection literal must
+// not keep a Go symbol of the same name open-world. Without per-language keying
+// one language's `send :foo` would mute another language's `foo`, re-opening
+// the cross-language hole on the reflection side.
+func TestCoreVoiceReflectionGateIsPerLanguage(t *testing.T) {
+	f := Facts{DispatchNames: langNames("ruby", "process")}
+	// Same name, different language → the Ruby dispatch set must not match.
+	goSym := Symbol{Name: "process", Kind: "method", Language: "go"}
+	if r := (coreVoice{}).Inspect(goSym, f); r != nil {
+		t.Errorf("Go symbol matched a Ruby dispatch name: %+v, want nil (per-language)", r)
+	}
+	// The Ruby symbol of the same name IS matched.
+	rubySymbol := Symbol{Name: "process", Kind: "method", Language: "ruby"}
+	if r := (coreVoice{}).Inspect(rubySymbol, f); r == nil || r.Code != ReasonReflection {
+		t.Errorf("Ruby symbol reflection gate = %+v, want %q", r, ReasonReflection)
+	}
+}
+
 func TestCoreVoiceReflectionBeatsExport(t *testing.T) {
 	// A symbol that is both a dispatch target and public-in-a-library raises
 	// reflection (the gate checked first / more specific).
-	f := Facts{IsLibrary: true, DispatchNames: map[string]struct{}{"Charge": {}}}
+	f := Facts{IsLibrary: true, DispatchNames: langNames("go", "Charge")}
 	pub := Symbol{Name: "Charge", Kind: "function", Visibility: "public", Language: "go"}
 	if r := (coreVoice{}).Inspect(pub, f); r == nil || r.Code != ReasonReflection {
 		t.Errorf("got %+v, want reflection to win", r)

--- a/internal/dead/dead.go
+++ b/internal/dead/dead.go
@@ -168,9 +168,14 @@ func buildFacts(ctx context.Context, db *sql.DB) (Facts, error) {
 		// a framework application (Rails, etc.) also has no main, yet its public
 		// methods are internal, not an exported API. A detected framework means
 		// the tree is an application, so it is not a library.
-		IsLibrary:            !hasMain && len(frameworks) == 0,
-		DispatchNames:        readDispatchNames(ctx, db),
-		MentionedNames:       readMentionedNames(ctx, db),
+		IsLibrary:      !hasMain && len(frameworks) == 0,
+		DispatchNames:  readDispatchNames(ctx, db),
+		MentionedNames: readMentionedNames(ctx, db),
+		// HarvestedLangs comes from its own meta key, not the mention keyset, so a
+		// language that harvested an empty set (present here, absent from
+		// MentionedNames) is still allowed to earn `dead` against its empty set —
+		// distinct from a language that never harvested (absent here → fail closed).
+		HarvestedLangs:       readHarvestedLangs(ctx, db),
 		ValueObjectClassIDs:  valueObjectClassIDs,
 		IncludedModuleIDs:    includedModuleIDs,
 		ControllerConcernIDs: controllerConcernIDs,
@@ -705,45 +710,90 @@ func readFrameworks(ctx context.Context, db *sql.DB) map[string]struct{} {
 	return out
 }
 
-// readDispatchNames returns the project-wide set of reflective dispatch-target
-// names persisted to sense_meta by the scan layer (send/const_get/define_method
-// literals, constantize receivers). A symbol whose name is in this set could be
-// invoked dynamically, so the core voice keeps it open-world. A missing or
-// corrupt value yields an empty set — degrading to recall loss, never a crash
-// or a false `dead`.
-func readDispatchNames(ctx context.Context, db *sql.DB) map[string]struct{} {
-	return readNameSetMeta(ctx, db, "dispatch_names")
+// readDispatchNames returns the per-language sets of reflective dispatch-target
+// names persisted to sense_meta by the scan layer under per-language keys
+// (dispatch_names:<lang>). A symbol whose name is in its own language's set
+// could be invoked dynamically, so the core voice keeps it open-world. A
+// missing or corrupt value yields an empty map — degrading to recall loss,
+// never a crash or a false `dead`.
+func readDispatchNames(ctx context.Context, db *sql.DB) map[string]map[string]struct{} {
+	return readNameSetMetaByLang(ctx, db, "dispatch_names")
 }
 
-// readMentionedNames returns the project-wide broad mention set persisted to
-// sense_meta by the scan layer (every identifier/symbol token except definition
-// names). The arbiter's soundness gate earns `dead` only when a candidate's
-// name is absent from a NON-EMPTY mention set — mentioned nowhere a hidden
-// caller could be. An absent or corrupt value yields an empty set, which the
-// gate treats as "harvest unavailable, cannot prove closed-world" and blocks
-// `dead` entirely (fail-closed toward caution). This is the opposite default
-// from dispatch_names: there an empty set only loses recall, here it would
-// re-admit false `dead`, so the gate refuses rather than risk the lie.
-func readMentionedNames(ctx context.Context, db *sql.DB) map[string]struct{} {
-	return readNameSetMeta(ctx, db, "mentioned_names")
+// readMentionedNames returns the per-language broad mention sets persisted to
+// sense_meta by the scan layer under per-language keys (mentioned_names:<lang>,
+// every identifier/symbol token except definition names). The arbiter's
+// soundness gate earns `dead` only when a candidate's name is absent from a
+// NON-EMPTY set FOR ITS OWN LANGUAGE — mentioned nowhere a hidden caller could
+// be. A language with no key never harvested, which the gate treats as
+// "cannot prove closed-world" and blocks `dead` (core_no_harvest, fail-closed).
+// A pre-feature index carries only the legacy union key `mentioned_names` (no
+// language suffix); it does not match the per-language prefix, so every language
+// reads as un-harvested and the whole index degrades to possibly_dead — never a
+// false `dead` off stale union data.
+func readMentionedNames(ctx context.Context, db *sql.DB) map[string]map[string]struct{} {
+	return readNameSetMetaByLang(ctx, db, "mentioned_names")
 }
 
-// readNameSetMeta reads a JSON string-array sense_meta value into a set,
-// treating an absent or corrupt value as empty.
-func readNameSetMeta(ctx context.Context, db *sql.DB, key string) map[string]struct{} {
+// readNameSetMetaByLang reads every per-language sense_meta key with the given
+// prefix (e.g. mentioned_names:ruby, mentioned_names:go) into a language-keyed
+// map of name sets. A GLOB match on `prefix:*` discovers the languages present;
+// the legacy union key (the bare prefix, no `:lang`) does not match and is
+// ignored, so a pre-feature index reads as no-languages-harvested (fail-closed).
+// An absent or corrupt value for any one language yields an empty set for it,
+// self-healing on the next scan.
+// readHarvestedLangs returns the set of languages whose mention harvest ran,
+// persisted to the harvested_langs sense_meta key by the scan layer. The
+// soundness gate refuses `dead` for a symbol whose language is absent here. A
+// pre-feature index has no such key (the harvest predates it), so every language
+// reads as un-harvested and the index degrades to possibly_dead — the safe
+// direction. An absent or corrupt value yields an empty set.
+func readHarvestedLangs(ctx context.Context, db *sql.DB) map[string]struct{} {
 	out := map[string]struct{}{}
 	var raw string
-	err := db.QueryRowContext(ctx, `SELECT value FROM sense_meta WHERE key = ?`, key).Scan(&raw)
+	err := db.QueryRowContext(ctx, `SELECT value FROM sense_meta WHERE key = ?`, "harvested_langs").Scan(&raw)
 	if err != nil || raw == "" {
 		return out
 	}
-	var names []string
-	if err := json.Unmarshal([]byte(raw), &names); err != nil {
-		log.Printf("dead: corrupt %s meta: %v", key, err)
+	var langs []string
+	if err := json.Unmarshal([]byte(raw), &langs); err != nil {
+		log.Printf("dead: corrupt harvested_langs meta: %v", err)
 		return out
 	}
-	for _, n := range names {
-		out[n] = struct{}{}
+	for _, l := range langs {
+		out[l] = struct{}{}
+	}
+	return out
+}
+
+func readNameSetMetaByLang(ctx context.Context, db *sql.DB, prefix string) map[string]map[string]struct{} {
+	out := map[string]map[string]struct{}{}
+	rows, err := db.QueryContext(ctx,
+		`SELECT key, value FROM sense_meta WHERE key GLOB ?`, prefix+":*")
+	if err != nil {
+		return out
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var key, raw string
+		if err := rows.Scan(&key, &raw); err != nil {
+			continue
+		}
+		lang := strings.TrimPrefix(key, prefix+":")
+		if lang == "" {
+			continue
+		}
+		set := map[string]struct{}{}
+		var names []string
+		if raw != "" {
+			if err := json.Unmarshal([]byte(raw), &names); err != nil {
+				log.Printf("dead: corrupt %s meta: %v", key, err)
+			}
+		}
+		for _, n := range names {
+			set[n] = struct{}{}
+		}
+		out[lang] = set
 	}
 	return out
 }

--- a/internal/dead/dead_test.go
+++ b/internal/dead/dead_test.go
@@ -1307,6 +1307,100 @@ func verdictByQualified(r dead.Result) map[string]dead.Verdict {
 	return m
 }
 
+// TestFindDeadLegacyMetaFailsClosed is the legacy-meta control: a pre-feature
+// index that carries only the old union `mentioned_names` key (no per-language
+// suffix) must degrade to all-possibly_dead, never a false `dead`. The
+// per-language reader globs `mentioned_names:*`, so the legacy key is invisible,
+// every language reads as un-harvested, and the soundness gate fails closed with
+// core_no_harvest — the safe direction. Pins the migration rabbit hole.
+func TestFindDeadLegacyMetaFailsClosed(t *testing.T) {
+	// Scan the smoke fixture, which pins one genuinely-dead Ruby private
+	// (LineItem#orphaned_private) earning `dead` under per-language meta.
+	root := smokeRoot(t)
+	senseDir := t.TempDir()
+	ctx := context.Background()
+	if _, err := scan.Run(ctx, scan.Options{Root: root, Sense: senseDir, Output: &bytes.Buffer{}, Warnings: io.Discard}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+	dbPath := filepath.Join(senseDir, "index.db")
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	// Baseline: with per-language meta the orphan earns `dead`, proving the
+	// fixture is a real `dead` for the downgrade to then take away.
+	base, err := dead.FindDead(ctx, db, dead.Options{})
+	if err != nil {
+		t.Fatalf("FindDead baseline: %v", err)
+	}
+	if !deadHasSuffix(base, "#orphaned_private") {
+		t.Fatalf("baseline: orphaned_private should earn dead under per-language meta")
+	}
+
+	// Downgrade the index to a pre-feature shape: drop the per-language keys and
+	// write the bare union key carrying the same names.
+	legacyMentions, _ := adapter.ReadMeta(ctx, "mentioned_names:ruby")
+	if legacyMentions == "" {
+		t.Fatal("expected mentioned_names:ruby present before downgrade")
+	}
+	if err := adapter.DeleteMeta(ctx, "mentioned_names:ruby"); err != nil {
+		t.Fatalf("delete mention key: %v", err)
+	}
+	_ = adapter.DeleteMeta(ctx, "dispatch_names:ruby")
+	// A pre-feature index predates the harvest entirely — it has no
+	// harvested_langs key either, so drop it to model the legacy shape faithfully.
+	if err := adapter.DeleteMeta(ctx, "harvested_langs"); err != nil {
+		t.Fatalf("delete harvested_langs: %v", err)
+	}
+	if err := adapter.WriteMeta(ctx, "mentioned_names", legacyMentions); err != nil {
+		t.Fatalf("write legacy union key: %v", err)
+	}
+
+	// After downgrade: nothing earns `dead`, and the orphan fails closed with
+	// core_no_harvest (its language reads as un-harvested).
+	got, err := dead.FindDead(ctx, db, dead.Options{})
+	if err != nil {
+		t.Fatalf("FindDead legacy: %v", err)
+	}
+	for _, f := range got.Findings {
+		if f.Verdict == dead.VerdictDead {
+			t.Errorf("%s earned dead off a legacy union index, want possibly_dead", f.Symbol.Qualified)
+		}
+	}
+	if code := reasonCodeForSuffix(got, "#orphaned_private"); code != dead.ReasonNoHarvest {
+		t.Errorf("orphaned_private reason = %q, want %q (fail-closed)", code, dead.ReasonNoHarvest)
+	}
+}
+
+// deadHasSuffix reports whether any earned-`dead` finding's qualified name ends
+// with suffix.
+func deadHasSuffix(r dead.Result, suffix string) bool {
+	for _, f := range r.Findings {
+		if f.Verdict == dead.VerdictDead && endsWith(f.Symbol.Qualified, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+// reasonCodeForSuffix returns the reason code of the first finding whose
+// qualified name ends with suffix, or "" if none (or the finding has no reason).
+func reasonCodeForSuffix(r dead.Result, suffix string) string {
+	for _, f := range r.Findings {
+		if endsWith(f.Symbol.Qualified, suffix) && f.Reason != nil {
+			return f.Reason.Code
+		}
+	}
+	return ""
+}
+
 // TestFindDeadExcludesRouteHelpers proves synthetic route:* helper symbols —
 // emitted by the route DSL and often unreferenced (e.g. the _url twins) — are
 // never reported as dead Ruby code, while an ordinary same-named app method

--- a/internal/dead/queries_internal_test.go
+++ b/internal/dead/queries_internal_test.go
@@ -65,6 +65,18 @@ func TestQueryErrorPathsNoSchema(t *testing.T) {
 	if _, err := buildFacts(ctx, db); err == nil {
 		t.Error("buildFacts should error without schema")
 	}
+	// The per-language meta readers swallow a query error (here, the missing
+	// sense_meta table) and return an empty map rather than crashing — a missing
+	// harvest signal fails closed, never fatal.
+	if got := readDispatchNames(ctx, db); len(got) != 0 {
+		t.Errorf("readDispatchNames without schema = %v, want empty", got)
+	}
+	if got := readMentionedNames(ctx, db); len(got) != 0 {
+		t.Errorf("readMentionedNames without schema = %v, want empty", got)
+	}
+	if got := readHarvestedLangs(ctx, db); len(got) != 0 {
+		t.Errorf("readHarvestedLangs without schema = %v, want empty", got)
+	}
 	if _, err := FindDead(ctx, db, Options{}); err == nil {
 		t.Error("FindDead should error without schema")
 	}
@@ -113,26 +125,62 @@ func TestReadFrameworksMeta(t *testing.T) {
 	}
 }
 
-// TestReadDispatchNamesMeta covers the missing-row, empty-value, corrupt-JSON,
-// and valid branches of readDispatchNames.
+// TestReadHarvestedLangsMeta covers the missing-row, corrupt-JSON, and valid
+// branches of readHarvestedLangs against a real sense_meta table.
+func TestReadHarvestedLangsMeta(t *testing.T) {
+	db := memDB(t)
+	ctx := context.Background()
+	mustExec(t, db, `CREATE TABLE sense_meta(key TEXT PRIMARY KEY, value TEXT)`)
+
+	if got := readHarvestedLangs(ctx, db); len(got) != 0 {
+		t.Errorf("readHarvestedLangs (missing) = %v, want empty", got)
+	}
+	mustExec(t, db, `INSERT INTO sense_meta(key, value) VALUES('harvested_langs', '{bad')`)
+	if got := readHarvestedLangs(ctx, db); len(got) != 0 {
+		t.Errorf("readHarvestedLangs (corrupt) = %v, want empty", got)
+	}
+	mustExec(t, db, `UPDATE sense_meta SET value='["ruby","go"]' WHERE key='harvested_langs'`)
+	got := readHarvestedLangs(ctx, db)
+	if _, ok := got["ruby"]; !ok {
+		t.Error("readHarvestedLangs (valid) should contain ruby")
+	}
+	if _, ok := got["go"]; !ok {
+		t.Error("readHarvestedLangs (valid) should contain go")
+	}
+}
+
+// TestReadDispatchNamesMeta covers the per-language reader's branches: missing,
+// a legacy union key (ignored), a corrupt per-language value (self-heals to an
+// empty set), and a valid per-language value parsed under its language.
 func TestReadDispatchNamesMeta(t *testing.T) {
 	db := memDB(t)
 	ctx := context.Background()
 	mustExec(t, db, `CREATE TABLE sense_meta(key TEXT PRIMARY KEY, value TEXT)`)
 
+	// Missing → empty.
 	if got := readDispatchNames(ctx, db); len(got) != 0 {
 		t.Errorf("readDispatchNames (missing) = %v, want empty", got)
 	}
-	mustExec(t, db, `INSERT INTO sense_meta(key, value) VALUES('dispatch_names', '')`)
+	// A legacy union key (no language suffix) does not match the per-language
+	// GLOB, so it is ignored — a pre-feature index harvests no languages.
+	mustExec(t, db, `INSERT INTO sense_meta(key, value) VALUES('dispatch_names', '["legacy"]')`)
 	if got := readDispatchNames(ctx, db); len(got) != 0 {
-		t.Errorf("readDispatchNames (empty) = %v, want empty", got)
+		t.Errorf("readDispatchNames (legacy union key) = %v, want empty (ignored)", got)
 	}
-	mustExec(t, db, `UPDATE sense_meta SET value='{bad' WHERE key='dispatch_names'`)
-	if got := readDispatchNames(ctx, db); len(got) != 0 {
-		t.Errorf("readDispatchNames (corrupt) = %v, want empty", got)
+	// Corrupt per-language value → that language is present with an empty set.
+	mustExec(t, db, `INSERT INTO sense_meta(key, value) VALUES('dispatch_names:ruby', '{bad')`)
+	if got := readDispatchNames(ctx, db); len(got) != 1 || got["ruby"] == nil || len(got["ruby"]) != 0 {
+		t.Errorf("readDispatchNames (corrupt ruby) = %v, want ruby present-but-empty", got)
 	}
-	mustExec(t, db, `UPDATE sense_meta SET value='["process","perform"]' WHERE key='dispatch_names'`)
-	if _, ok := readDispatchNames(ctx, db)["process"]; !ok {
-		t.Error("readDispatchNames (valid) should contain process")
+	// Valid per-language value → names parsed under the language.
+	mustExec(t, db, `UPDATE sense_meta SET value='["process","perform"]' WHERE key='dispatch_names:ruby'`)
+	if _, ok := readDispatchNames(ctx, db)["ruby"]["process"]; !ok {
+		t.Error("readDispatchNames (valid) should contain ruby/process")
+	}
+	// An empty language suffix (the bare prefix plus a colon) is skipped — it
+	// names no language, so it can never mark a harvest.
+	mustExec(t, db, `INSERT INTO sense_meta(key, value) VALUES('dispatch_names:', '["x"]')`)
+	if _, ok := readDispatchNames(ctx, db)[""]; ok {
+		t.Error("readDispatchNames must skip an empty language suffix")
 	}
 }

--- a/internal/dead/reasons.go
+++ b/internal/dead/reasons.go
@@ -25,6 +25,15 @@ const (
 	// was unavailable. Either way closed-world is not proven, so it stays
 	// open-world. This is what makes `dead` sound against an incomplete resolver.
 	ReasonNameMentioned = "core_name_mentioned"
+	// ReasonNoHarvest is the per-language soundness-gate reason: a language
+	// voice for the symbol's language is registered (so it cleared the
+	// no-language-voice gate), but that language never harvested its own
+	// mention set, so the gate has no project-wide names to prove the symbol
+	// unmentioned. It fails closed — `dead` off another language's mentions is
+	// exactly the cross-language lie the per-language gate exists to refuse.
+	// Dormant for any language that harvests (Ruby always does); it is the
+	// guard a future voice trips until it ships its own harvest.
+	ReasonNoHarvest = "core_no_harvest"
 
 	// Ruby-voice reason codes (voice_ruby.go owns their catalog specs).
 	ReasonRubyValueObject  = "ruby_value_object"
@@ -88,6 +97,15 @@ var reasonCatalog = map[string]reasonSpec{
 		priority: 15,
 		hint:     "name appears in a call or symbol position Sense could not bind to this definition; grep for it before removing",
 		verify:   "These names are mentioned somewhere Sense could not resolve to a caller (an inherited bare call, a `**splat`, a chain receiver, or a `validate :sym`/`delegate`-style symbol argument). For each, grep the repo for its bare name and as a `:symbol` before removing.",
+	},
+	// Harvest unavailable for this language: Sense has a voice for the stack but
+	// no project-wide mention set to reason against, so it cannot prove the
+	// symbol unreachable. Sorts at the bottom with the other soundness-gate
+	// reason — least likely to be safely removable.
+	ReasonNoHarvest: {
+		priority: 15,
+		hint:     "Sense has not harvested this language's names, so it cannot prove the symbol unreachable; confirm callers manually before removing",
+		verify:   "Sense registered a voice for this language but harvested no project-wide names for it, so the soundness gate cannot prove these symbols unmentioned. For each, grep the repo for its bare name and as a string/symbol literal before removing.",
 	},
 }
 

--- a/internal/dead/voice_core.go
+++ b/internal/dead/voice_core.go
@@ -18,7 +18,11 @@ func (coreVoice) Lang() string { return "" }
 // Inspect raises the reflection gate first (the more specific, more
 // likely-live signal), then the export gate.
 func (coreVoice) Inspect(s Symbol, f Facts) *Reason {
-	if _, ok := f.DispatchNames[s.Name]; ok {
+	// The dispatch set is keyed by language: a name is reflection-reachable only
+	// if it appears as a dispatch target in its OWN language. Keying here in
+	// lockstep with the arbiter's soundness gate keeps both per-language, so a
+	// Ruby `send :foo` never keeps a Go `foo` open-world (or vice versa).
+	if _, ok := f.DispatchNames[s.Language][s.Name]; ok {
 		r := newReason(ReasonReflection)
 		return &r
 	}

--- a/internal/dead/voice_rails_test.go
+++ b/internal/dead/voice_rails_test.go
@@ -98,9 +98,9 @@ func TestArbiterEarnedDeadForPrivate(t *testing.T) {
 	priv := rubySym("orphan", "Report#orphan", "method", "private", id(1))
 	pub := rubySym("render", "Report#render", "method", "public", id(1))
 
-	// The soundness gate needs a non-empty mention set that does not contain
+	// The soundness gate needs a non-empty Ruby mention set that does not contain
 	// "orphan" to prove the private method is mentioned nowhere a caller could be.
-	f := Facts{MentionedNames: map[string]struct{}{"render": {}}}
+	f := Facts{MentionedNames: langNames("ruby", "render"), HarvestedLangs: harvested("ruby")}
 	got := a.Decide([]Symbol{priv, pub}, f)
 	if got[0].Verdict != VerdictDead {
 		t.Errorf("private orphan verdict = %q, want dead", got[0].Verdict)
@@ -116,7 +116,7 @@ func TestArbiterEarnedDeadForPrivate(t *testing.T) {
 func TestArbiterReflectionKeepsPrivateAlive(t *testing.T) {
 	a := NewArbiter(coreVoice{}, rubyVoice{}, railsVoice{})
 	priv := rubySym("handler", "Dispatcher#handler", "method", "private", id(1))
-	f := Facts{DispatchNames: map[string]struct{}{"handler": {}}}
+	f := Facts{DispatchNames: langNames("ruby", "handler")}
 
 	got := a.Decide([]Symbol{priv}, f)
 	if got[0].Verdict != VerdictPossiblyDead {
@@ -140,10 +140,10 @@ func TestSoundnessGateMentionedNameStaysPossiblyDead(t *testing.T) {
 
 	// The name is mentioned (as a `validate :sym` symbol arg the resolver did
 	// not bind to a caller edge), so the gate keeps it open-world.
-	f := Facts{MentionedNames: map[string]struct{}{
-		"amount_meets_minimum_threshold": {},
-		"other":                          {},
-	}}
+	f := Facts{
+		MentionedNames: langNames("ruby", "amount_meets_minimum_threshold", "other"),
+		HarvestedLangs: harvested("ruby"),
+	}
 	got := a.Decide([]Symbol{priv}, f)
 	if got[0].Verdict != VerdictPossiblyDead {
 		t.Fatalf("mentioned private verdict = %q, want possibly_dead", got[0].Verdict)
@@ -153,24 +153,38 @@ func TestSoundnessGateMentionedNameStaysPossiblyDead(t *testing.T) {
 	}
 }
 
-// TestSoundnessGateIsRubyOnlyToday is the per-language tripwire. The mention set
-// is project-GLOBAL, but only Ruby has both a voice and a mention harvest today,
-// so only Ruby symbols may earn `dead`. A non-Ruby symbol must NOT earn `dead`
-// off the global (Ruby-derived) mention set, even when its name is absent from
-// that set. This assertion fails the day a second language voice is registered
-// without its own mention harvest — at which point that voice's symbols would
-// start earning `dead` here off another language's mentions, forcing the
-// harvest question. See decideOne's per-language NOTE.
-func TestSoundnessGateIsRubyOnlyToday(t *testing.T) {
-	a := defaultArbiter()
-	goSym := sym("UnusedGoFunc", "go")
-	// Populated mention set that does NOT contain the Go symbol's name.
-	f := Facts{MentionedNames: map[string]struct{}{"some_ruby_name": {}}}
+// TestSoundnessGateIsPerLanguage is the cross-language soundness control: the
+// invariant 25-15 exists to guarantee. With a Ruby voice AND a Go voice both
+// registered but only Ruby's mention harvest run, a private Ruby method earns
+// `dead` while a Go symbol of the SAME NAME stays possibly_dead with
+// core_no_harvest. This proves a future language voice can never earn `dead`
+// off another language's mentions: it must ship its own harvest (register in
+// HarvestedLangs) first. The Go voice is registered precisely so the Go symbol
+// clears the no-language-voice gate and actually reaches the soundness gate —
+// the exact scenario the per-language keying must make safe.
+func TestSoundnessGateIsPerLanguage(t *testing.T) {
+	goVoice := fakeVoice{lang: "go"} // stand-in for a future voice; raises nothing
+	a := NewArbiter(coreVoice{}, rubyVoice{}, goVoice)
 
-	got := a.Decide([]Symbol{goSym}, f)
-	if got[0].Verdict != VerdictPossiblyDead {
-		t.Fatalf("non-Ruby symbol earned %q off the global mention set — a new "+
-			"language voice needs its own mention harvest before earning dead", got[0].Verdict)
+	rubyPriv := rubySym("orphan", "Report#orphan", "method", "private", id(1))
+	goSym := sym("orphan", "go") // same bare name, different language
+
+	// Only Ruby harvested; its set does not contain "orphan".
+	f := Facts{
+		MentionedNames: langNames("ruby", "unrelated"),
+		HarvestedLangs: harvested("ruby"),
+	}
+	got := a.Decide([]Symbol{rubyPriv, goSym}, f)
+
+	if got[0].Verdict != VerdictDead {
+		t.Fatalf("ruby private verdict = %q, want dead (own harvest, name absent)", got[0].Verdict)
+	}
+	if got[1].Verdict != VerdictPossiblyDead {
+		t.Fatalf("go symbol earned %q off Ruby mentions — a new voice must harvest "+
+			"its own names before earning dead", got[1].Verdict)
+	}
+	if got[1].Reason == nil || got[1].Reason.Code != ReasonNoHarvest {
+		t.Errorf("go symbol reason = %+v, want %q", got[1].Reason, ReasonNoHarvest)
 	}
 }
 
@@ -184,7 +198,7 @@ func TestSoundnessGateDemotesNameCollision(t *testing.T) {
 	priv := rubySym("process", "Worker#process", "method", "private", id(1))
 	// `process` is mentioned elsewhere (an unrelated local/call). The gate cannot
 	// tell it apart from Worker#process, so it stays cautious.
-	f := Facts{MentionedNames: map[string]struct{}{"process": {}, "other": {}}}
+	f := Facts{MentionedNames: langNames("ruby", "process", "other"), HarvestedLangs: harvested("ruby")}
 
 	got := a.Decide([]Symbol{priv}, f)
 	if got[0].Verdict != VerdictPossiblyDead {
@@ -195,17 +209,37 @@ func TestSoundnessGateDemotesNameCollision(t *testing.T) {
 	}
 }
 
-// TestSoundnessGateEmptySetFailsClosed proves the fail-closed default: when the
-// mention harvest is unavailable (an empty set — a pre-feature index or corrupt
-// meta), the gate cannot prove the name is unmentioned, so it refuses `dead`
-// rather than risk re-admitting a false one.
-func TestSoundnessGateEmptySetFailsClosed(t *testing.T) {
+// TestSoundnessGateNoHarvestFailsClosed proves the fail-closed default for an
+// unavailable harvest: when the symbol's language never harvested mentions (a
+// pre-feature index, corrupt meta, or a voice that did not ship its harvest),
+// the gate has no set to prove the name unmentioned, so it refuses `dead` with
+// core_no_harvest rather than risk re-admitting a false one.
+func TestSoundnessGateNoHarvestFailsClosed(t *testing.T) {
 	a := NewArbiter(coreVoice{}, rubyVoice{}, railsVoice{})
 	priv := rubySym("orphan", "Report#orphan", "method", "private", id(1))
 
-	got := a.Decide([]Symbol{priv}, Facts{}) // no MentionedNames
+	got := a.Decide([]Symbol{priv}, Facts{}) // no harvest for ruby
 	if got[0].Verdict != VerdictPossiblyDead {
-		t.Fatalf("empty-mention-set verdict = %q, want possibly_dead (fail-closed)", got[0].Verdict)
+		t.Fatalf("no-harvest verdict = %q, want possibly_dead (fail-closed)", got[0].Verdict)
+	}
+	if got[0].Reason == nil || got[0].Reason.Code != ReasonNoHarvest {
+		t.Errorf("reason = %+v, want %q", got[0].Reason, ReasonNoHarvest)
+	}
+}
+
+// TestSoundnessGateHarvestedEmptySetFailsClosed proves the second fail-closed
+// branch: the language DID harvest (it is in HarvestedLangs) but produced an
+// empty set, so the gate still cannot prove the name unmentioned and refuses
+// `dead` with core_name_mentioned. Harvest-ran and set-non-empty are distinct
+// preconditions; both must hold to earn `dead`.
+func TestSoundnessGateHarvestedEmptySetFailsClosed(t *testing.T) {
+	a := NewArbiter(coreVoice{}, rubyVoice{}, railsVoice{})
+	priv := rubySym("orphan", "Report#orphan", "method", "private", id(1))
+
+	f := Facts{HarvestedLangs: harvested("ruby")} // harvested, but empty mention set
+	got := a.Decide([]Symbol{priv}, f)
+	if got[0].Verdict != VerdictPossiblyDead {
+		t.Fatalf("harvested-empty verdict = %q, want possibly_dead (fail-closed)", got[0].Verdict)
 	}
 	if got[0].Reason == nil || got[0].Reason.Code != ReasonNameMentioned {
 		t.Errorf("reason = %+v, want %q", got[0].Reason, ReasonNameMentioned)

--- a/internal/extract/extractor.go
+++ b/internal/extract/extractor.go
@@ -278,6 +278,19 @@ type MentionEmitter interface {
 	MentionName(name string) error
 }
 
+// MentionHarvester marks an Extractor whose Extract streams the broad mention
+// set (via MentionEmitter) for every file it processes. The scan records such a
+// language as harvested even on a scan that yields zero mentions for it, so the
+// dead-code soundness gate can tell "harvested, nothing mentioned" (which may
+// still earn `dead`) apart from "this language never harvested" (which must NOT
+// — it would be `dead` off another language's mentions). An extractor opts in by
+// implementing HarvestsMentions; returning false is the same as not
+// implementing it. This is a STATIC capability, independent of how many names a
+// given scan happens to produce, which is exactly why the two facts can differ.
+type MentionHarvester interface {
+	HarvestsMentions() bool
+}
+
 // Extractor walks a parsed tree and emits symbols + edges for one language.
 // Implementations are stateless — the same instance handles every file in
 // that language. Any per-file state lives on the call stack.

--- a/internal/extract/mention.go
+++ b/internal/extract/mention.go
@@ -1,0 +1,60 @@
+package extract
+
+import (
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+// MentionWalkSpec parameterizes the shared mention harvest for one grammar. The
+// harvest itself — visit every identifier / name-literal node, skip the one
+// that is a definition's own name, collect the rest — is language-agnostic; only
+// the node kinds and the definition-name test differ per grammar. A voice's
+// extractor supplies those here so it opts into the soundness harvest with a few
+// lines rather than re-implementing the tree-walk.
+type MentionWalkSpec struct {
+	// NameOf maps a tree-sitter node kind to the function that reads the bare
+	// name off a node of that kind (e.g. Ruby "identifier" → Text, and
+	// "simple_symbol" → strip the leading colon). A node whose kind is absent
+	// from the map is never visited, so the spec is also the allow-list of which
+	// kinds carry a mention. At least one kind must be supplied or the harvest is
+	// empty.
+	NameOf map[string]func(*sitter.Node, []byte) string
+	// SkipDefinitionName reports whether a node is a definition's OWN name (the
+	// `foo` token in Ruby `def foo`). Such a node must NOT count as a mention —
+	// otherwise a method would cancel its own `dead` candidacy and no symbol
+	// could ever earn `dead`, muting the verdict (safe but useless). It is
+	// per-grammar because "what is a definition node" differs by language. A nil
+	// predicate skips nothing. It is applied to every visited node regardless of
+	// kind; a kind that can never be a definition name simply never matches.
+	SkipDefinitionName func(*sitter.Node) bool
+}
+
+// HarvestMentions walks root and returns the deduplicated set of bare names it
+// mentions anywhere EXCEPT a definition's own name, per the grammar-specific
+// spec. It is the shared core of the dead-code soundness harvest: a candidate
+// earns `dead` only when its name is absent from this set, so the set must be
+// the broad superset of every position a hidden caller could leave a textual
+// trace (a bare call, a chain receiver, a `**splat` arg, a `:symbol` literal).
+// Names are deduplicated; order is unspecified (the caller streams them into a
+// set). An empty harvest returns nil so callers can cheaply test for "nothing".
+func HarvestMentions(root *sitter.Node, source []byte, spec MentionWalkSpec) []string {
+	seen := map[string]struct{}{}
+	for kind, nameOf := range spec.NameOf {
+		_ = WalkNamedDescendants(root, kind, func(n *sitter.Node) error {
+			if spec.SkipDefinitionName != nil && spec.SkipDefinitionName(n) {
+				return nil
+			}
+			if name := nameOf(n, source); name != "" {
+				seen[name] = struct{}{}
+			}
+			return nil
+		})
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(seen))
+	for n := range seen {
+		out = append(out, n)
+	}
+	return out
+}

--- a/internal/extract/mention_test.go
+++ b/internal/extract/mention_test.go
@@ -1,0 +1,112 @@
+package extract_test
+
+import (
+	"strings"
+	"testing"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/grammars"
+)
+
+// parseRuby parses raw Ruby bytes and returns the root node, cleaning up the
+// parser and tree when the test ends. The walker is grammar-agnostic; Ruby is
+// just a convenient real grammar to drive it on raw bytes.
+func parseRuby(t *testing.T, src string) *sitter.Node {
+	t.Helper()
+	p := sitter.NewParser()
+	t.Cleanup(p.Close)
+	if err := p.SetLanguage(grammars.Ruby()); err != nil {
+		t.Fatalf("set language: %v", err)
+	}
+	tree := p.Parse([]byte(src), nil)
+	t.Cleanup(tree.Close)
+	return tree.RootNode()
+}
+
+// isMethodDefName reports whether n is the `name` token of a Ruby method def —
+// a stand-in for the per-grammar definition-name test a spec supplies.
+func isMethodDefName(n *sitter.Node) bool {
+	parent := n.Parent()
+	if parent == nil {
+		return false
+	}
+	if parent.Kind() != "method" && parent.Kind() != "singleton_method" {
+		return false
+	}
+	name := parent.ChildByFieldName("name")
+	return name != nil && name.Equals(*n)
+}
+
+func stripColon(n *sitter.Node, src []byte) string {
+	return strings.TrimPrefix(extract.Text(n, src), ":")
+}
+
+func toSet(names []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		out[n] = struct{}{}
+	}
+	return out
+}
+
+// TestHarvestMentions drives the shared walker on raw bytes: every identifier
+// and symbol literal is collected except a definition's own name, across the
+// call-position forms a resolver can fail to bind (a macro symbol arg, a bare
+// call, a chain receiver).
+func TestHarvestMentions(t *testing.T) {
+	src := "class Form\n" +
+		"  validate :amount_ok\n" + // symbol arg to an unrecognized macro
+		"  def run\n" +
+		"    helper_call\n" + // bare call
+		"    obj.chain_recv\n" + // chain receiver
+		"  end\n" +
+		"  def lonely; end\n" + // defined, mentioned nowhere else
+		"end\n"
+	root := parseRuby(t, src)
+
+	got := extract.HarvestMentions(root, []byte(src), extract.MentionWalkSpec{
+		NameOf: map[string]func(*sitter.Node, []byte) string{
+			"identifier":    extract.Text,
+			"simple_symbol": stripColon,
+		},
+		SkipDefinitionName: isMethodDefName,
+	})
+	set := toSet(got)
+
+	for _, want := range []string{"amount_ok", "helper_call", "chain_recv", "obj"} {
+		if _, ok := set[want]; !ok {
+			t.Errorf("HarvestMentions missing %q (got %v)", want, got)
+		}
+	}
+	// A method's own name is excluded, so a method mentioned nowhere else is
+	// absent — otherwise no method could ever earn `dead`.
+	for _, defName := range []string{"lonely", "run"} {
+		if _, ok := set[defName]; ok {
+			t.Errorf("definition name %q must be excluded (got %v)", defName, got)
+		}
+	}
+}
+
+// TestHarvestMentionsRespectsSpecParameters proves the seam is parameterized,
+// not hardcoded to Ruby: dropping SkipDefinitionName lets a definition name
+// through, and an empty NameOf visits nothing. A future voice relies on exactly
+// this — its own node kinds and definition test, not Ruby's.
+func TestHarvestMentionsRespectsSpecParameters(t *testing.T) {
+	src := "def only_def; end\n"
+	root := parseRuby(t, src)
+
+	// No skip predicate → the definition name now appears as a "mention".
+	withDefs := toSet(extract.HarvestMentions(root, []byte(src), extract.MentionWalkSpec{
+		NameOf: map[string]func(*sitter.Node, []byte) string{"identifier": extract.Text},
+	}))
+	if _, ok := withDefs["only_def"]; !ok {
+		t.Errorf("with no SkipDefinitionName, 'only_def' should appear (got %v)", withDefs)
+	}
+
+	// Empty NameOf → no kind is visited, so the harvest is nil.
+	if got := extract.HarvestMentions(root, []byte(src), extract.MentionWalkSpec{}); got != nil {
+		t.Errorf("empty spec should harvest nothing, got %v", got)
+	}
+}

--- a/internal/extract/ruby/ruby.go
+++ b/internal/extract/ruby/ruby.go
@@ -53,6 +53,12 @@ func (Extractor) Language() string          { return "ruby" }
 func (Extractor) Extensions() []string      { return []string{".rb", ".rake", ".gemspec"} }
 func (Extractor) Tier() extract.Tier        { return extract.TierBasic }
 
+// HarvestsMentions reports that the Ruby extractor streams the broad mention set
+// (see Extract's MentionEmitter block), so the scan records `ruby` as harvested
+// even on a scan that yields zero mentions — the dead-code soundness gate then
+// treats a Ruby symbol as proven-against-an-empty-set, not never-harvested.
+func (Extractor) HarvestsMentions() bool { return true }
+
 func (Extractor) Extract(tree *sitter.Tree, source []byte, filePath string, emit extract.Emitter) error {
 	returnTypes := buildFileReturnTypeMap(tree.RootNode(), source)
 	w := &walker{

--- a/internal/extract/ruby/ruby_test.go
+++ b/internal/extract/ruby/ruby_test.go
@@ -762,6 +762,11 @@ func TestExtractorMetadata(t *testing.T) {
 	if ex.Grammar() == nil {
 		t.Error("Grammar() returned nil")
 	}
+	// Ruby opts into the mention harvest, so the scan records `ruby` as
+	// harvested and its private methods may earn `dead`.
+	if !ex.HarvestsMentions() {
+		t.Error("HarvestsMentions() = false, want true (Ruby streams the mention set)")
+	}
 }
 
 func TestPascalCase(t *testing.T) {

--- a/internal/extract/ruby/visibility.go
+++ b/internal/extract/ruby/visibility.go
@@ -188,31 +188,21 @@ func collectDispatchNames(root *sitter.Node, source []byte) []string {
 // "grep the name; only the definition matches", and it makes the `dead`
 // verdict sound independent of whether the resolver could bind every call.
 // Definition names are excluded so a method is not cancelled by its own `def`.
+//
+// The tree-walk itself is the language-agnostic extract.HarvestMentions; Ruby
+// supplies only its grammar specifics — that an `identifier` carries its text
+// and a `simple_symbol` carries its name minus the leading colon, and that the
+// name token of a `def`/`def self.` is the one position to exclude. A future
+// voice harvests by passing its own kinds and definition test to the same
+// helper.
 func collectMentionedNames(root *sitter.Node, source []byte) []string {
-	seen := map[string]struct{}{}
-	_ = extract.WalkNamedDescendants(root, "identifier", func(id *sitter.Node) error {
-		if isDefinitionName(id) {
-			return nil
-		}
-		if name := extract.Text(id, source); name != "" {
-			seen[name] = struct{}{}
-		}
-		return nil
+	return extract.HarvestMentions(root, source, extract.MentionWalkSpec{
+		NameOf: map[string]func(*sitter.Node, []byte) string{
+			"identifier":    extract.Text,
+			"simple_symbol": symbolOrStringName,
+		},
+		SkipDefinitionName: isDefinitionName,
 	})
-	_ = extract.WalkNamedDescendants(root, "simple_symbol", func(s *sitter.Node) error {
-		if name := symbolOrStringName(s, source); name != "" {
-			seen[name] = struct{}{}
-		}
-		return nil
-	})
-	if len(seen) == 0 {
-		return nil
-	}
-	out := make([]string, 0, len(seen))
-	for n := range seen {
-		out = append(out, n)
-	}
-	return out
 }
 
 // isDefinitionName reports whether id is the `name` field of a method or

--- a/internal/scan/dispatch.go
+++ b/internal/scan/dispatch.go
@@ -20,24 +20,33 @@ func warnMetaWrite(warn io.Writer, label string, err error) {
 	}
 }
 
-// dispatchNamesMetaKey is the sense_meta key holding the project-wide set of
-// reflective dispatch-target names (send/const_get/define_method literals,
-// constantize receivers) as a JSON string array. The dead-code arbiter reads
-// it so a symbol whose name appears here stays open-world (possibly_dead)
-// rather than being falsely called dead.
+// dispatchNamesMetaKey is the prefix for the per-language sense_meta keys
+// holding each language's reflective dispatch-target names (send/const_get/
+// define_method literals, constantize receivers) as a JSON string array. The
+// actual key is `dispatch_names:<lang>` (see dispatchNamesKey): a symbol whose
+// name appears in its OWN language's set stays open-world (possibly_dead)
+// rather than being falsely called dead. Keying by language keeps one
+// language's reflection literals from muting another's symbol.
 const dispatchNamesMetaKey = "dispatch_names"
 
-// writeDispatchNames persists the dispatch-name set gathered during the walk,
-// unioning with the existing set (see writeNameSet for the union rationale).
-func writeDispatchNames(ctx context.Context, idx *sqlite.Adapter, collected map[string]struct{}) error {
-	return writeNameSet(ctx, idx, dispatchNamesMetaKey, collected)
+// dispatchNamesKey is the per-language sense_meta key for a language's dispatch
+// set (e.g. `dispatch_names:ruby`). The dead-code reader discovers languages by
+// globbing `dispatch_names:*`, so a legacy union key (the bare prefix) is never
+// matched and a pre-feature index reads as no-languages-harvested.
+func dispatchNamesKey(lang string) string { return dispatchNamesMetaKey + ":" + lang }
+
+// writeDispatchNames persists one language's dispatch-name set gathered during
+// the walk, unioning with the existing set (see writeNameSet for the rationale).
+func writeDispatchNames(ctx context.Context, idx *sqlite.Adapter, lang string, collected map[string]struct{}) error {
+	return writeNameSet(ctx, idx, dispatchNamesKey(lang), collected)
 }
 
-// readDispatchNames returns the persisted dispatch-name set, or an empty set
-// when the key is absent. A corrupt value is treated as empty rather than
-// fatal — a missing reflection signal degrades to recall loss, never a crash.
-func readDispatchNames(ctx context.Context, idx *sqlite.Adapter) (map[string]struct{}, error) {
-	return readNameSet(ctx, idx, dispatchNamesMetaKey)
+// readDispatchNames returns one language's persisted dispatch-name set, or an
+// empty set when the key is absent. A corrupt value is treated as empty rather
+// than fatal — a missing reflection signal degrades to recall loss, never a
+// crash.
+func readDispatchNames(ctx context.Context, idx *sqlite.Adapter, lang string) (map[string]struct{}, error) {
+	return readNameSet(ctx, idx, dispatchNamesKey(lang))
 }
 
 // mentionedNamesMetaKey is the sense_meta key holding the project-wide broad
@@ -57,10 +66,49 @@ func readDispatchNames(ctx context.Context, idx *sqlite.Adapter) (map[string]str
 // therefore refreshes on a full rescan; the set self-heals removed names then.
 const mentionedNamesMetaKey = "mentioned_names"
 
-// writeMentionedNames persists the broad mention set, unioning with the
-// existing set (see writeNameSet for the union rationale).
-func writeMentionedNames(ctx context.Context, idx *sqlite.Adapter, collected map[string]struct{}) error {
-	return writeNameSet(ctx, idx, mentionedNamesMetaKey, collected)
+// mentionedNamesKey is the per-language sense_meta key for a language's mention
+// set (e.g. `mentioned_names:ruby`). The dead-code soundness gate earns `dead`
+// for a symbol only against the mentions harvested from its OWN language, and
+// derives "this language harvested" from the presence of its key — so a
+// language with no key (a pre-feature index's legacy union key does not match
+// the `mentioned_names:*` glob) fails closed to possibly_dead.
+func mentionedNamesKey(lang string) string { return mentionedNamesMetaKey + ":" + lang }
+
+// writeMentionedNames persists one language's broad mention set, unioning with
+// the existing set (see writeNameSet for the union rationale).
+func writeMentionedNames(ctx context.Context, idx *sqlite.Adapter, lang string, collected map[string]struct{}) error {
+	return writeNameSet(ctx, idx, mentionedNamesKey(lang), collected)
+}
+
+// harvestedLangsMetaKey is the sense_meta key holding the set of languages
+// whose mention harvest RAN for this index, as a JSON string array. The
+// dead-code soundness gate reads it: a symbol whose language is absent earns
+// core_no_harvest (fail closed), so this set — not the mere presence of a
+// mention key — is the explicit record that a language's harvest happened. A
+// language harvests even when a scan yields zero mentions for it, so this set
+// can legitimately contain a language that has no mentioned_names:<lang> key.
+const harvestedLangsMetaKey = "harvested_langs"
+
+// writeHarvestedLangs persists the set of languages whose harvest ran, unioning
+// with the existing set (same self-heals-on-rebuild rationale as the name sets:
+// a language whose files were all removed lingers here until a full rebuild,
+// which only ever keeps a symbol open-world, never falsely `dead`).
+func writeHarvestedLangs(ctx context.Context, idx *sqlite.Adapter, collected map[string]struct{}) error {
+	return writeNameSet(ctx, idx, harvestedLangsMetaKey, collected)
+}
+
+// addNamesByLang unions names into byLang[lang], creating the language's set on
+// first use. Both per-language name accumulators (dispatch, mention) share it so
+// the handler keeps each language's names apart for per-language meta writes.
+func addNamesByLang(byLang map[string]map[string]struct{}, lang string, names []string) {
+	set := byLang[lang]
+	if set == nil {
+		set = map[string]struct{}{}
+		byLang[lang] = set
+	}
+	for _, n := range names {
+		set[n] = struct{}{}
+	}
 }
 
 // writeNameSet persists a name set to a sense_meta key, UNIONing with the
@@ -97,12 +145,12 @@ func writeNameSet(ctx context.Context, idx *sqlite.Adapter, key string, collecte
 	return idx.WriteMeta(ctx, key, string(b))
 }
 
-// readMentionedNames returns the persisted mention set, or an empty set when
-// the key is absent. A corrupt value is treated as empty — a missing mention
-// signal degrades to recall loss (a would-be `dead` stays open-world), never a
-// crash or a false `dead`.
-func readMentionedNames(ctx context.Context, idx *sqlite.Adapter) (map[string]struct{}, error) {
-	return readNameSet(ctx, idx, mentionedNamesMetaKey)
+// readMentionedNames returns one language's persisted mention set, or an empty
+// set when the key is absent. A corrupt value is treated as empty — a missing
+// mention signal degrades to recall loss (a would-be `dead` stays open-world),
+// never a crash or a false `dead`.
+func readMentionedNames(ctx context.Context, idx *sqlite.Adapter, lang string) (map[string]struct{}, error) {
+	return readNameSet(ctx, idx, mentionedNamesKey(lang))
 }
 
 // readNameSet reads a JSON string-array sense_meta value into a set, treating

--- a/internal/scan/dispatch_test.go
+++ b/internal/scan/dispatch_test.go
@@ -29,10 +29,10 @@ func TestWriteReadDispatchNamesRoundTrip(t *testing.T) {
 	ctx := context.Background()
 	a := openTempAdapter(t)
 
-	if err := writeDispatchNames(ctx, a, map[string]struct{}{"foo": {}, "bar": {}}); err != nil {
+	if err := writeDispatchNames(ctx, a, "ruby", map[string]struct{}{"foo": {}, "bar": {}}); err != nil {
 		t.Fatalf("writeDispatchNames: %v", err)
 	}
-	got, err := readDispatchNames(ctx, a)
+	got, err := readDispatchNames(ctx, a, "ruby")
 	if err != nil {
 		t.Fatalf("readDispatchNames: %v", err)
 	}
@@ -41,6 +41,19 @@ func TestWriteReadDispatchNamesRoundTrip(t *testing.T) {
 			t.Errorf("dispatch set missing %q: %v", want, got)
 		}
 	}
+	// The set is persisted under the per-language key, not the bare union key,
+	// so the dead-code reader's glob discovers the language and a legacy index
+	// (bare key only) fails closed.
+	if raw, _ := a.ReadMeta(ctx, "dispatch_names:ruby"); raw == "" {
+		t.Error("expected dispatch_names:ruby key to be written")
+	}
+	if raw, _ := a.ReadMeta(ctx, dispatchNamesMetaKey); raw != "" {
+		t.Errorf("bare union key must not be written, got %q", raw)
+	}
+	// A different language's set is independent.
+	if other, _ := readDispatchNames(ctx, a, "go"); len(other) != 0 {
+		t.Errorf("go dispatch set should be empty, got %v", other)
+	}
 }
 
 func TestWriteDispatchNamesUnionsWithExisting(t *testing.T) {
@@ -48,14 +61,14 @@ func TestWriteDispatchNamesUnionsWithExisting(t *testing.T) {
 	a := openTempAdapter(t)
 
 	// First scan persists {foo}.
-	if err := writeDispatchNames(ctx, a, map[string]struct{}{"foo": {}}); err != nil {
+	if err := writeDispatchNames(ctx, a, "ruby", map[string]struct{}{"foo": {}}); err != nil {
 		t.Fatalf("write 1: %v", err)
 	}
 	// Incremental scan only re-walks a file contributing {bar}; foo must survive.
-	if err := writeDispatchNames(ctx, a, map[string]struct{}{"bar": {}}); err != nil {
+	if err := writeDispatchNames(ctx, a, "ruby", map[string]struct{}{"bar": {}}); err != nil {
 		t.Fatalf("write 2: %v", err)
 	}
-	got, err := readDispatchNames(ctx, a)
+	got, err := readDispatchNames(ctx, a, "ruby")
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
@@ -71,15 +84,15 @@ func TestWriteDispatchNamesEmptyNoKey(t *testing.T) {
 	a := openTempAdapter(t)
 
 	// Empty collected + nothing persisted → key stays absent.
-	if err := writeDispatchNames(ctx, a, nil); err != nil {
+	if err := writeDispatchNames(ctx, a, "ruby", nil); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	raw, err := a.ReadMeta(ctx, dispatchNamesMetaKey)
+	raw, err := a.ReadMeta(ctx, dispatchNamesKey("ruby"))
 	if err != nil {
 		t.Fatalf("ReadMeta: %v", err)
 	}
 	if raw != "" {
-		t.Errorf("expected no dispatch_names key, got %q", raw)
+		t.Errorf("expected no dispatch_names:ruby key, got %q", raw)
 	}
 }
 
@@ -112,10 +125,10 @@ func TestWriteReadMentionedNamesRoundTrip(t *testing.T) {
 	ctx := context.Background()
 	a := openTempAdapter(t)
 
-	if err := writeMentionedNames(ctx, a, map[string]struct{}{"foo": {}, "bar": {}}); err != nil {
+	if err := writeMentionedNames(ctx, a, "ruby", map[string]struct{}{"foo": {}, "bar": {}}); err != nil {
 		t.Fatalf("writeMentionedNames: %v", err)
 	}
-	got, err := readMentionedNames(ctx, a)
+	got, err := readMentionedNames(ctx, a, "ruby")
 	if err != nil {
 		t.Fatalf("readMentionedNames: %v", err)
 	}
@@ -124,19 +137,25 @@ func TestWriteReadMentionedNamesRoundTrip(t *testing.T) {
 			t.Errorf("mention set missing %q: %v", want, got)
 		}
 	}
+	if raw, _ := a.ReadMeta(ctx, "mentioned_names:ruby"); raw == "" {
+		t.Error("expected mentioned_names:ruby key to be written")
+	}
+	if raw, _ := a.ReadMeta(ctx, mentionedNamesMetaKey); raw != "" {
+		t.Errorf("bare union key must not be written, got %q", raw)
+	}
 }
 
 func TestWriteMentionedNamesUnionsWithExisting(t *testing.T) {
 	ctx := context.Background()
 	a := openTempAdapter(t)
 
-	if err := writeMentionedNames(ctx, a, map[string]struct{}{"foo": {}}); err != nil {
+	if err := writeMentionedNames(ctx, a, "ruby", map[string]struct{}{"foo": {}}); err != nil {
 		t.Fatalf("write 1: %v", err)
 	}
-	if err := writeMentionedNames(ctx, a, map[string]struct{}{"bar": {}}); err != nil {
+	if err := writeMentionedNames(ctx, a, "ruby", map[string]struct{}{"bar": {}}); err != nil {
 		t.Fatalf("write 2: %v", err)
 	}
-	got, err := readMentionedNames(ctx, a)
+	got, err := readMentionedNames(ctx, a, "ruby")
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
@@ -151,15 +170,15 @@ func TestWriteMentionedNamesEmptyNoKey(t *testing.T) {
 	ctx := context.Background()
 	a := openTempAdapter(t)
 
-	if err := writeMentionedNames(ctx, a, nil); err != nil {
+	if err := writeMentionedNames(ctx, a, "ruby", nil); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	raw, err := a.ReadMeta(ctx, mentionedNamesMetaKey)
+	raw, err := a.ReadMeta(ctx, mentionedNamesKey("ruby"))
 	if err != nil {
 		t.Fatalf("ReadMeta: %v", err)
 	}
 	if raw != "" {
-		t.Errorf("expected no mentioned_names key, got %q", raw)
+		t.Errorf("expected no mentioned_names:ruby key, got %q", raw)
 	}
 }
 
@@ -167,10 +186,10 @@ func TestReadDispatchNamesCorruptIsEmpty(t *testing.T) {
 	ctx := context.Background()
 	a := openTempAdapter(t)
 
-	if err := a.WriteMeta(ctx, dispatchNamesMetaKey, "{not valid json"); err != nil {
+	if err := a.WriteMeta(ctx, dispatchNamesKey("ruby"), "{not valid json"); err != nil {
 		t.Fatalf("seed corrupt: %v", err)
 	}
-	got, err := readDispatchNames(ctx, a)
+	got, err := readDispatchNames(ctx, a, "ruby")
 	if err != nil {
 		t.Fatalf("readDispatchNames: %v", err)
 	}
@@ -187,13 +206,105 @@ func TestDispatchNamesAdapterErrors(t *testing.T) {
 	a := openTempAdapter(t)
 	_ = a.Close() // force every subsequent query to error
 
-	if _, err := readDispatchNames(ctx, a); err == nil {
+	if _, err := readDispatchNames(ctx, a, "ruby"); err == nil {
 		t.Error("readDispatchNames should surface a closed-adapter error")
 	}
 	// writeDispatchNames reads the existing set first, so the closed adapter
 	// makes it error before any write.
-	if err := writeDispatchNames(ctx, a, map[string]struct{}{"foo": {}}); err == nil {
+	if err := writeDispatchNames(ctx, a, "ruby", map[string]struct{}{"foo": {}}); err == nil {
 		t.Error("writeDispatchNames should surface the existing-read error")
+	}
+}
+
+// TestScanWritesHarvestedLangs proves the harvested-langs capability gate
+// end to end: a Ruby file marks `ruby` harvested (its extractor is a
+// MentionHarvester), while a Go file in the same scan does NOT mark `go` — Go
+// harvests no mentions, so its symbols must fail closed rather than earn `dead`
+// off an absent set. This is what lets HarvestedLangs diverge from the mention
+// keyset for a real, non-harvesting language.
+func TestScanWritesHarvestedLangs(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	senseDir := filepath.Join(root, ".sense")
+
+	if err := os.WriteFile(filepath.Join(root, "thing.rb"),
+		[]byte("class Thing\n  def go\n    helper\n  end\nend\n"), 0o644); err != nil {
+		t.Fatalf("write ruby: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "main.go"),
+		[]byte("package main\n\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatalf("write go: %v", err)
+	}
+
+	if _, err := Run(ctx, Options{Root: root, Sense: senseDir, Output: &bytes.Buffer{}, Warnings: io.Discard}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+
+	a, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatalf("open index: %v", err)
+	}
+	t.Cleanup(func() { _ = a.Close() })
+
+	got, err := readNameSet(ctx, a, harvestedLangsMetaKey)
+	if err != nil {
+		t.Fatalf("read harvested_langs: %v", err)
+	}
+	if _, ok := got["ruby"]; !ok {
+		t.Errorf("expected ruby in harvested_langs, got %v", got)
+	}
+	if _, ok := got["go"]; ok {
+		t.Errorf("go harvests no mentions; must be absent from harvested_langs, got %v", got)
+	}
+}
+
+// TestScanDeletesLegacyUnionKeys proves the in-place-upgrade cleanup: a scan
+// removes the stale bare `mentioned_names`/`dispatch_names` union keys a
+// pre-feature index left behind, while the per-language keys survive.
+func TestScanDeletesLegacyUnionKeys(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	senseDir := filepath.Join(root, ".sense")
+	if err := os.WriteFile(filepath.Join(root, "thing.rb"),
+		[]byte("class Thing\n  def go\n    helper\n  end\nend\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := Run(ctx, Options{Root: root, Sense: senseDir, Output: &bytes.Buffer{}, Warnings: io.Discard}); err != nil {
+		t.Fatalf("scan 1: %v", err)
+	}
+
+	// Simulate a pre-feature index leaving bare union keys behind.
+	a, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := a.WriteMeta(ctx, mentionedNamesMetaKey, `["legacy"]`); err != nil {
+		t.Fatalf("seed mentioned: %v", err)
+	}
+	if err := a.WriteMeta(ctx, dispatchNamesMetaKey, `["legacy"]`); err != nil {
+		t.Fatalf("seed dispatch: %v", err)
+	}
+	_ = a.Close()
+
+	// A subsequent scan removes the stale bare keys.
+	if _, err := Run(ctx, Options{Root: root, Sense: senseDir, Output: &bytes.Buffer{}, Warnings: io.Discard}); err != nil {
+		t.Fatalf("scan 2: %v", err)
+	}
+
+	a2, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	t.Cleanup(func() { _ = a2.Close() })
+	if raw, _ := a2.ReadMeta(ctx, mentionedNamesMetaKey); raw != "" {
+		t.Errorf("legacy mentioned_names should be deleted, got %q", raw)
+	}
+	if raw, _ := a2.ReadMeta(ctx, dispatchNamesMetaKey); raw != "" {
+		t.Errorf("legacy dispatch_names should be deleted, got %q", raw)
+	}
+	// The per-language key survives the cleanup.
+	if raw, _ := a2.ReadMeta(ctx, mentionedNamesKey("ruby")); raw == "" {
+		t.Error("per-language mentioned_names:ruby should remain")
 	}
 }
 
@@ -229,11 +340,11 @@ func TestScanWritesDispatchNames(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = a.Close() })
 
-	got, err := readDispatchNames(ctx, a)
+	got, err := readDispatchNames(ctx, a, "ruby")
 	if err != nil {
 		t.Fatalf("readDispatchNames: %v", err)
 	}
 	if _, ok := got["hidden_handler"]; !ok {
-		t.Errorf("expected 'hidden_handler' in dispatch_names meta, got %v", got)
+		t.Errorf("expected 'hidden_handler' in dispatch_names:ruby meta, got %v", got)
 	}
 }

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -224,8 +224,21 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 		_ = idx.DeleteMeta(ctx, "frameworks")
 	}
 
-	warnMetaWrite(warn, "dispatch-names", writeDispatchNames(ctx, idx, h.dispatchNames))
-	warnMetaWrite(warn, "mentioned-names", writeMentionedNames(ctx, idx, h.mentionedNames))
+	// Each language is an independent sense_meta key, so map-iteration order is
+	// irrelevant — no write depends on another.
+	for lang, set := range h.dispatchNames {
+		warnMetaWrite(warn, "dispatch-names:"+lang, writeDispatchNames(ctx, idx, lang, set))
+	}
+	for lang, set := range h.mentionedNames {
+		warnMetaWrite(warn, "mentioned-names:"+lang, writeMentionedNames(ctx, idx, lang, set))
+	}
+	warnMetaWrite(warn, "harvested-langs", writeHarvestedLangs(ctx, idx, h.harvestedLangs))
+	// A pre-feature index carried single bare union keys (no language suffix).
+	// The per-language reader globs `*:<lang>` and ignores them, but delete them
+	// on every full scan so an in-place upgrade leaves no stale meta to mislead a
+	// human inspecting sense_meta. Idempotent: absent keys are a no-op.
+	_ = idx.DeleteMeta(ctx, dispatchNamesMetaKey)
+	_ = idx.DeleteMeta(ctx, mentionedNamesMetaKey)
 
 	t0 = time.Now()
 	if err := h.removeStaleFiles(); err != nil {
@@ -490,22 +503,32 @@ type harness struct {
 	// entries can be detected and removed after the walk.
 	seenPaths map[string]bool
 
-	// dispatchNames accumulates the project-wide set of reflective
-	// dispatch-target names streamed by extractors during the walk. Written
-	// to sense_meta after the walk so the dead-code arbiter can keep a
-	// reflectively-reachable symbol open-world. Only populated for changed
-	// files this scan; merged with the persisted set so an unchanged file's
-	// names are not lost on an incremental scan.
-	dispatchNames map[string]struct{}
+	// dispatchNames accumulates each language's set of reflective
+	// dispatch-target names streamed by extractors during the walk, keyed by
+	// language. Written to per-language sense_meta keys after the walk so the
+	// dead-code arbiter keeps a reflectively-reachable symbol open-world only
+	// against its OWN language's literals. Only populated for changed files this
+	// scan; merged with the persisted per-language set so an unchanged file's
+	// names are not lost.
+	dispatchNames map[string]map[string]struct{}
 
-	// mentionedNames accumulates the project-wide broad set of bare names the
-	// code mentions (every identifier/symbol token except definition names),
-	// streamed by extractors during the walk. Written to sense_meta after the
-	// walk so the dead-code arbiter's soundness gate can earn `dead` only when
-	// a symbol's name is mentioned nowhere a hidden caller could be. Merged
-	// with the persisted set so an unchanged file's mentions survive an
-	// incremental scan.
-	mentionedNames map[string]struct{}
+	// mentionedNames accumulates each language's broad set of bare names that
+	// language's code mentions (every identifier/symbol token except definition
+	// names), keyed by language. Written to per-language sense_meta keys after
+	// the walk so the dead-code arbiter's soundness gate earns `dead` for a
+	// symbol only when its name is mentioned nowhere in its OWN language a hidden
+	// caller could be. Merged with the persisted per-language set so an unchanged
+	// file's mentions survive.
+	mentionedNames map[string]map[string]struct{}
+
+	// harvestedLangs is the set of languages whose mention harvest RAN this
+	// scan — every indexed file whose extractor is an extract.MentionHarvester
+	// marks its language here, regardless of how many names it produced. Written
+	// to the harvested_langs sense_meta key so the dead-code gate can refuse
+	// `dead` for a language that never harvested while still allowing it for a
+	// language that harvested an empty set. Distinct from the mentionedNames
+	// keyset precisely so the two can differ.
+	harvestedLangs map[string]struct{}
 
 	// changedFileIDs collects file IDs that were re-indexed this scan
 	// (new or hash-changed). Used by pass 3 to scope embedding work.
@@ -572,6 +595,22 @@ func int64Ptr(v int64) *int64 {
 func (h *harness) addWarning(kind warningKind, format string, args ...any) {
 	h.collector.add(kind, fmt.Sprintf(format, args...))
 	h.progress.incWarnings()
+}
+
+// markHarvested records ex's language as one whose mention harvest ran, when ex
+// is an extract.MentionHarvester. Called for every indexed file (fresh or
+// cached) so the harvested_langs set reflects the index, not just this scan's
+// freshly-parsed files. A non-harvesting extractor (no MentionHarvester) is a
+// no-op, so its language stays absent and its symbols fail closed.
+func (h *harness) markHarvested(ex extract.Extractor) {
+	mh, ok := ex.(extract.MentionHarvester)
+	if !ok || !mh.HarvestsMentions() {
+		return
+	}
+	if h.harvestedLangs == nil {
+		h.harvestedLangs = map[string]struct{}{}
+	}
+	h.harvestedLangs[ex.Language()] = struct{}{}
 }
 
 type walkEntry struct {
@@ -684,23 +723,29 @@ func (h *harness) walkTree(root string) error {
 					h.indexedFiles = append(h.indexedFiles, indexedFile{
 						ID: cached.ID, Path: rel, Language: ex.Language(),
 					})
+					// A cached file is still indexed, so its language's harvest
+					// is still represented in this index.
+					h.markHarvested(ex)
 				}
 			}
 			continue
 		}
+		h.markHarvested(ex)
 
-		for _, name := range fr.DispatchNames {
+		// Partition both name sets by the file's language: the dead-code gates
+		// reason per-language, so a Ruby file's mentions must never land in
+		// another language's set.
+		if len(fr.DispatchNames) > 0 {
 			if h.dispatchNames == nil {
-				h.dispatchNames = map[string]struct{}{}
+				h.dispatchNames = map[string]map[string]struct{}{}
 			}
-			h.dispatchNames[name] = struct{}{}
+			addNamesByLang(h.dispatchNames, fr.Language, fr.DispatchNames)
 		}
-
-		for _, name := range fr.MentionedNames {
+		if len(fr.MentionedNames) > 0 {
 			if h.mentionedNames == nil {
-				h.mentionedNames = map[string]struct{}{}
+				h.mentionedNames = map[string]map[string]struct{}{}
 			}
-			h.mentionedNames[name] = struct{}{}
+			addNamesByLang(h.mentionedNames, fr.Language, fr.MentionedNames)
 		}
 
 		batch = append(batch, fr)


### PR DESCRIPTION
## Problem

The dead-code `dead` verdict is sound only because two project-wide fact sets — the broad mention set (the soundness gate) and the reflection dispatch set — are gathered from Ruby files alone, and Ruby is the only registered language voice. Both sets were stored as single global keys and consulted globally. The instant a second language voice registers (Go, TS, …) without its own mention harvest, a symbol of that language with zero edges would hit the soundness gate, find its name absent from the Ruby-derived set, and earn a false `dead` — the exact lie the honest-verdicts work was built to kill. The global set also bleeds the other way: a non-Ruby name that coincidentally matches a Ruby dispatch literal gets mislabeled reflection-reachable.

## Summary

Key every soundness fact by language, so a symbol earns `dead` only against mentions harvested from its own language and is reflection-gated only by its own language's dispatch literals. A language must ship its own harvest before any of its symbols can earn `dead`.

## Changes

**Arbiter (`internal/dead`)**
- `Facts.MentionedNames` / `DispatchNames` become language-keyed maps; add `HarvestedLangs`.
- `decideOne`'s soundness gate keys on `s.Language` with two fail-closed branches: a `HarvestedLangs` miss → new reason `core_no_harvest`; an empty-or-mentioned set → `core_name_mentioned`.
- `coreVoice`'s reflection gate keys by language in lockstep.
- Readers load per-language `sense_meta` keys via GLOB; a legacy union key is ignored (fail-closed).

**Scan storage (`internal/scan`)**
- Writes per-language keys `mentioned_names:<lang>` / `dispatch_names:<lang>`, partitioned by file language.
- Writes a `harvested_langs` key driven by a static `extract.MentionHarvester` capability, so a language that harvested an empty set is distinct from one that never harvested.
- Deletes stale bare union keys on scan so an in-place upgrade leaves no leftover meta.

**Shared walker (`internal/extract`)**
- New `extract.HarvestMentions` + `MentionWalkSpec`: the language-agnostic identifier/name-literal harvest, parameterized per grammar. Ruby delegates to it with byte-identical output — the seam a future voice opts into.

## Architecture Highlights

- **Fail-closed everywhere.** An un-harvested language, an empty set, or a pre-feature index all degrade to `possibly_dead`, never a false `dead`. More languages can only add caution.
- **`HarvestedLangs` carries its own source of truth** (the `harvested_langs` key), not a derived view of the mention keyset, so harvested-but-empty and never-harvested are genuinely distinguishable.

## Test Plan

- [x] Cross-language soundness control: a Ruby private earns `dead` while a same-named symbol of a voiced-but-un-harvested language stays `possibly_dead` (`core_no_harvest`).
- [x] Legacy-meta control: an index carrying only the old union keys yields all-`possibly_dead`.
- [x] Scan capability gate: a Ruby file marks `ruby` harvested; a Go file does not mark `go`.
- [x] Shared walker drives byte-identical Ruby output; parameterization proven (no skip predicate → definition names appear).
- [x] Ruby benchmark regression: dead set and reasons unchanged on a Ruby-only repo (precision 1.00) and a Ruby+JS repo (only non-Ruby reflection reasons refine, no verdict changes).
- [x] `go test ./...` passes; `make ci` green; per-file coverage floor met.
- [x] sense binary builds cleanly.