### PR TITLE
feat(dead): Go language voice earns the dead verdict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to Sense.
 
 ## [Unreleased]
 
+### Added
+
+- Go is the second language whose symbols can earn the `dead` verdict. The Go
+  voice earns `dead` only for an unexported func / method / type with no caller,
+  no mention, and no invisible-reach idiom; everything else stays `possibly_dead`
+  with an exact reason: `go_init` (runtime-invoked package initializer),
+  `go_interface` (satisfies an indexed or stdlib interface — `String`, `Error`,
+  `MarshalJSON`, …), `go_cgo` (called from C via a `//export` directive),
+  `go_generated` (`*.pb.go` / `*_gen.go` / `*_generated.go`), `go_exported` (an
+  external package may use it), and `go_const` (an unexported const/var may anchor
+  an iota sequence). The Go extractor harvests its own mention set (the
+  per-language soundness gate), reflective dispatch targets
+  (`reflect.MethodByName` / `FieldByName`, struct-tag fields), and cgo `//export`
+  names. The verdict is validated against `staticcheck -checks U1000` as a
+  compiler-grade oracle (binding invariant: Sense `dead` for Go ⊆ U1000 — zero
+  false `dead` on the `gin` and `sense` benchmark repos). `testdata/` fixtures are
+  excluded from dead-code candidacy, matching the Go toolchain's universe.
+
 ### Breaking Changes
 
 - Dead-code analysis now emits honest verdicts. The `sense_graph dead_code=true`
@@ -12,8 +30,8 @@ All notable changes to Sense.
   safe to remove, each with a per-symbol `verify` grep) and `possibly_dead`
   groups (a hidden caller could exist, grouped by reason, each with a `verify`
   recipe). The two-value `confidence` field is removed. A symbol earns `dead`
-  only when a language voice can prove closed-world for its language; only Ruby
-  ships a voice, so all other stacks report `possibly_dead`. This makes a
+  only when a language voice can prove closed-world for its language; Ruby and Go
+  ship voices, so all other stacks report `possibly_dead`. This makes a
   confident-but-wrong `dead` impossible on unsupported stacks.
 
 ### Fixed

--- a/internal/cli/render_test.go
+++ b/internal/cli/render_test.go
@@ -835,8 +835,9 @@ func TestRunDeadHumanSuccess(t *testing.T) {
 		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
 	}
 	out := stdout.String()
-	// Seeded data is Go, which has no language voice, so the unreferenced
-	// symbols are possibly_dead (core_no_language_voice), never earned dead.
+	// Seeded data is Go, but this DB is hand-built and never scanned, so no Go
+	// mention harvest ran: the soundness gate fails closed (core_no_harvest),
+	// keeping the unreferenced symbols possibly_dead, never earned dead.
 	if !strings.Contains(out, "Possibly dead") {
 		t.Errorf("expected possibly-dead section, got:\n%s", out)
 	}

--- a/internal/dead/arbiter.go
+++ b/internal/dead/arbiter.go
@@ -96,6 +96,12 @@ type Facts struct {
 	// mentions harvested from its OWN language, never off another's. Populated
 	// from sense_meta.
 	MentionedNames map[string]map[string]struct{}
+	// CgoExportNames is the set of Go function names marked with a cgo `//export`
+	// directive. Such a function is called from C with no Go caller edge, so the
+	// Go voice keeps it open-world (go_cgo) rather than letting it earn `dead` off
+	// its absent caller. Flat, not per-language: cgo is Go-only. Populated from the
+	// cgo_exports sense_meta key; an absent key yields an empty set (no cgo known).
+	CgoExportNames map[string]struct{}
 	// HarvestedLangs is the set of languages whose mention harvest actually ran
 	// for this index. The soundness gate refuses `dead` for a symbol whose
 	// language is absent here (reason core_no_harvest): a missing harvest cannot

--- a/internal/dead/dead.go
+++ b/internal/dead/dead.go
@@ -135,7 +135,7 @@ func FindDead(ctx context.Context, db *sql.DB, opts Options) (Result, error) {
 // core voice plus the Ruby and Rails language voices. Adding a language voice
 // (Go, TS, Python) is a one-line change here once it exists.
 func defaultArbiter() *Arbiter {
-	return NewArbiter(coreVoice{}, rubyVoice{}, railsVoice{})
+	return NewArbiter(coreVoice{}, rubyVoice{}, railsVoice{}, goVoice{})
 }
 
 // buildFacts gathers the project-wide index facts the voices consume. It is
@@ -160,6 +160,10 @@ func buildFacts(ctx context.Context, db *sql.DB) (Facts, error) {
 	if err != nil {
 		return Facts{}, fmt.Errorf("dead: controller concern modules: %w", err)
 	}
+	interfaceMethodNames, err := queryInterfaceMethodNames(ctx, db)
+	if err != nil {
+		return Facts{}, fmt.Errorf("dead: interface method names: %w", err)
+	}
 
 	return Facts{
 		Frameworks: frameworks,
@@ -176,9 +180,11 @@ func buildFacts(ctx context.Context, db *sql.DB) (Facts, error) {
 		// MentionedNames) is still allowed to earn `dead` against its empty set —
 		// distinct from a language that never harvested (absent here → fail closed).
 		HarvestedLangs:       readHarvestedLangs(ctx, db),
+		CgoExportNames:       readCgoExportNames(ctx, db),
 		ValueObjectClassIDs:  valueObjectClassIDs,
 		IncludedModuleIDs:    includedModuleIDs,
 		ControllerConcernIDs: controllerConcernIDs,
+		InterfaceMethodNames: interfaceMethodNames,
 	}, nil
 }
 
@@ -321,6 +327,33 @@ func queryControllerConcernModuleIDs(ctx context.Context, db *sql.DB) (map[int64
 			return nil, err
 		}
 		out[id] = struct{}{}
+	}
+	return out, rows.Err()
+}
+
+// queryInterfaceMethodNames returns the set of method names declared on any
+// interface (a method symbol whose parent's kind is 'interface'). The Go voice
+// reads it: a concrete method sharing a name with an interface method may be
+// reached only through the interface, where the static graph shows zero direct
+// callers, so it stays open-world (go_interface) rather than earning `dead`. Go
+// interface satisfaction is structural (no `implements` keyword), so name match
+// is the soundest signal the index carries without recomputing satisfaction.
+func queryInterfaceMethodNames(ctx context.Context, db *sql.DB) (map[string]struct{}, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT DISTINCT s.name FROM sense_symbols s
+		JOIN sense_symbols p ON p.id = s.parent_id
+		WHERE s.kind = 'method' AND p.kind = 'interface'`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	out := make(map[string]struct{})
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		out[name] = struct{}{}
 	}
 	return out, rows.Err()
 }
@@ -624,15 +657,27 @@ func isInTestFile(s Symbol) bool {
 		strings.Contains(s.File, "/tests/") ||
 		strings.Contains(s.File, "/spec/") ||
 		strings.Contains(s.File, "/__tests__/") ||
+		// `testdata/` is a fixture directory the Go toolchain (go build/vet,
+		// staticcheck) ignores by convention; the same convention is common across
+		// ecosystems. Symbols there are test fixtures, not live code, so an
+		// unreferenced one is expected, not removable — excluding it keeps Sense's
+		// `dead` set aligned with the toolchain's universe and free of fixture noise.
+		strings.Contains(s.File, "/testdata/") ||
+		strings.HasPrefix(s.File, "testdata/") ||
 		strings.HasSuffix(s.File, ".spec.ts") ||
 		strings.HasSuffix(s.File, ".spec.js") ||
 		strings.HasSuffix(s.File, ".test.ts") ||
 		strings.HasSuffix(s.File, ".test.js")
 }
 
+// isConstructor reports whether s is an instance constructor invoked implicitly
+// by object creation (Ruby `initialize`, Python `__init__`, JS `constructor`),
+// which the resolver rarely ties to an explicit call. Go's `func init()` is NOT
+// here: it is a runtime-invoked package initializer, not a constructor, and the
+// Go voice owns it (go_init) so it surfaces as possibly_dead with an accurate
+// "runtime-invoked, never remove" hint rather than being silently excluded.
 func isConstructor(s Symbol) bool {
-	return s.Name == "initialize" || s.Name == "__init__" || s.Name == "constructor" ||
-		s.Name == "init" || s.Name == "Init"
+	return s.Name == "initialize" || s.Name == "__init__" || s.Name == "constructor"
 }
 
 var frameworkHooks = map[string]struct{}{
@@ -749,19 +794,35 @@ func readMentionedNames(ctx context.Context, db *sql.DB) map[string]map[string]s
 // reads as un-harvested and the index degrades to possibly_dead — the safe
 // direction. An absent or corrupt value yields an empty set.
 func readHarvestedLangs(ctx context.Context, db *sql.DB) map[string]struct{} {
+	return readStringSetMeta(ctx, db, "harvested_langs")
+}
+
+// readCgoExportNames returns the set of Go function names marked with a cgo
+// `//export` directive, persisted to the cgo_exports sense_meta key by the scan
+// layer. The Go voice keeps a name in this set open-world (go_cgo): it is called
+// from C, never by an indexed Go caller. A missing or corrupt key yields an empty
+// set — degrading to a possible false `dead` for a cgo export only until the next
+// full scan, never a crash.
+func readCgoExportNames(ctx context.Context, db *sql.DB) map[string]struct{} {
+	return readStringSetMeta(ctx, db, "cgo_exports")
+}
+
+// readStringSetMeta reads a JSON string-array sense_meta value into a set,
+// treating an absent or corrupt value as empty.
+func readStringSetMeta(ctx context.Context, db *sql.DB, key string) map[string]struct{} {
 	out := map[string]struct{}{}
 	var raw string
-	err := db.QueryRowContext(ctx, `SELECT value FROM sense_meta WHERE key = ?`, "harvested_langs").Scan(&raw)
+	err := db.QueryRowContext(ctx, `SELECT value FROM sense_meta WHERE key = ?`, key).Scan(&raw)
 	if err != nil || raw == "" {
 		return out
 	}
-	var langs []string
-	if err := json.Unmarshal([]byte(raw), &langs); err != nil {
-		log.Printf("dead: corrupt harvested_langs meta: %v", err)
+	var names []string
+	if err := json.Unmarshal([]byte(raw), &names); err != nil {
+		log.Printf("dead: corrupt %s meta: %v", key, err)
 		return out
 	}
-	for _, l := range langs {
-		out[l] = struct{}{}
+	for _, n := range names {
+		out[n] = struct{}{}
 	}
 	return out
 }

--- a/internal/dead/dead_test.go
+++ b/internal/dead/dead_test.go
@@ -626,18 +626,17 @@ func standaloneUnused() {}
 
 	verdict := verdictByQualified(result)
 
-	// Go has no language voice yet, so every Go symbol the arbiter reports is
-	// possibly_dead (core_no_language_voice) — never a confident dead. This is
-	// the safety invariant: an unsupported stack can't produce a false dead.
-	if v, ok := verdict["svc.standaloneUnused"]; ok {
-		if v != dead.VerdictPossiblyDead {
-			t.Errorf("standaloneUnused verdict = %q, want %q (Go has no language voice)", v, dead.VerdictPossiblyDead)
-		}
+	// The Go voice is registered, so the two sides diverge. An unexported func
+	// with no caller and no mention is genuinely dead (the airtight Go verdict).
+	if v, ok := verdict["svc.standaloneUnused"]; !ok {
+		t.Error("standaloneUnused should be reported")
+	} else if v != dead.VerdictDead {
+		t.Errorf("standaloneUnused verdict = %q, want %q (unexported, zero-edge, unmentioned)", v, dead.VerdictDead)
 	}
-	if v, ok := verdict["svc.MyHandler.Handle"]; ok {
-		if v != dead.VerdictPossiblyDead {
-			t.Errorf("MyHandler.Handle verdict = %q, want %q", v, dead.VerdictPossiblyDead)
-		}
+	// A method whose name matches an interface method stays possibly_dead: it may
+	// be invoked through the interface, where the static graph shows no caller.
+	if v, ok := verdict["svc.MyHandler.Handle"]; ok && v != dead.VerdictPossiblyDead {
+		t.Errorf("MyHandler.Handle verdict = %q, want %q (satisfies Handler)", v, dead.VerdictPossiblyDead)
 	}
 }
 
@@ -894,12 +893,13 @@ func TestDeadCodeExcludesDunderMethods(t *testing.T) {
 }
 
 // TestLibraryPublicAPIIsPossiblyDead pins the polarity inversion (pitch 25-13
-// decisions #1 and #6): a library's exported API is no longer silently
-// excluded. It surfaces as possibly_dead with the core_exported_api reason —
-// an external consumer Sense cannot see may exist — and, because Go has no
-// language voice, it can never earn the `dead` verdict. The honest contract
-// reports the fact (zero indexed references) and the reason, rather than
-// dropping the symbol and pretending it was reachable.
+// decisions #1 and #6) AND the Go voice's library rule (25-16): a library's
+// exported API is no longer silently excluded — it surfaces as possibly_dead
+// with the core_exported_api reason, because an external consumer Sense cannot
+// see may exist, and never earns `dead`. An UNEXPORTED library helper, by
+// contrast, has no external reach (staticcheck U1000 flags it) so it does earn
+// `dead`. The two sides together prove the voice is targeted, not a blanket
+// softener.
 func TestLibraryPublicAPIIsPossiblyDead(t *testing.T) {
 	root := t.TempDir()
 
@@ -945,13 +945,10 @@ func (p PublicType) privateMethod() {}
 	byQualified := map[string]dead.Finding{}
 	for _, f := range result.Findings {
 		byQualified[f.Symbol.Qualified] = f
-		// Nothing in a Go library can earn `dead`: Go has no language voice.
-		if f.Verdict == dead.VerdictDead {
-			t.Errorf("%q earned `dead` in a Go library; Go has no language voice so every symbol must stay possibly_dead", f.Symbol.Qualified)
-		}
 	}
 
-	// The exported API is reported (not excluded) and carries core_exported_api.
+	// The exported API is reported (not excluded), carries core_exported_api, and
+	// never earns `dead` — an external consumer may exist.
 	for _, name := range []string{"lib.PublicFunc", "lib.PublicType"} {
 		f, ok := byQualified[name]
 		if !ok {
@@ -964,6 +961,16 @@ func (p PublicType) privateMethod() {}
 		if f.Reason == nil || f.Reason.Code != dead.ReasonExportedAPI {
 			t.Errorf("%q reason = %v, want %q", name, f.Reason, dead.ReasonExportedAPI)
 		}
+	}
+
+	// An unexported library helper has no external reach, so it earns `dead`.
+	// (PublicType.privateMethod is collapsed under its still-reported parent type
+	// by Rollup, so the top-level privateFunc is the clean unexported probe.)
+	f, ok := byQualified["lib.privateFunc"]
+	if !ok {
+		t.Error("lib.privateFunc should be reported")
+	} else if f.Verdict != dead.VerdictDead {
+		t.Errorf("lib.privateFunc verdict = %q, want %q (unexported, no caller, no mention)", f.Verdict, dead.VerdictDead)
 	}
 }
 

--- a/internal/dead/eval/staticcheck.go
+++ b/internal/dead/eval/staticcheck.go
@@ -1,0 +1,182 @@
+package eval
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/luuuc/sense/internal/dead"
+	"github.com/luuuc/sense/internal/scan"
+)
+
+// The staticcheck oracle is the Go voice's compiler-grade trust gate. `staticcheck
+// -checks U1000` flags exactly Sense's earned-`dead` class — unused UNEXPORTED
+// funcs / methods / types — but with the full type system and build-tag knowledge
+// Sense lacks. So the binding invariant is a SUBSET, not equality:
+//
+//	Sense `dead` (Go) ⊆ staticcheck U1000
+//
+// A Sense `dead` symbol that staticcheck does NOT flag is a false `dead` and
+// fails the gate (precision is the only unforgivable error, per 25-13). The
+// reverse — staticcheck flags more than Sense — is acceptable lost recall, since
+// Sense fails closed on anything it cannot prove (an unbound mention, an
+// un-harvested language, a const/var, an interface name).
+
+// goSymRef identifies a Go symbol by repo-relative file and bare name. It is the
+// join key between Sense's `dead` set and staticcheck's U1000 findings — keyed on
+// name+file rather than line/column so the two tools' slightly different position
+// reporting (Sense: declaration start; staticcheck: the name token) never causes a
+// spurious mismatch.
+type goSymRef struct {
+	File string
+	Name string
+}
+
+// U1000Set is the set of symbols staticcheck flags as unused (U1000).
+type U1000Set map[goSymRef]struct{}
+
+// GoDead is one symbol Sense earns the `dead` verdict for, carrying the fields
+// needed to join against the oracle and to report a violation legibly.
+type GoDead struct {
+	Qualified string
+	File      string
+	Name      string
+}
+
+// staticcheckU1000Re matches one U1000 finding line, e.g.
+//
+//	internal/foo/bar.go:12:6: func unusedHelper is unused (U1000)
+//	internal/foo/bar.go:20:1: func (*T).deadMethod is unused (U1000)
+//	types.go:5:6: type unusedType is unused (U1000)
+//
+// Group 1 is the file path; group 2 is the (possibly receiver-qualified) symbol
+// name, normalised to its bare last segment by bareGoName.
+var staticcheckU1000Re = regexp.MustCompile(`^(.+\.go):\d+:\d+:\s+(?:func|type|const|var|field)\s+(\S+)\s+is unused \(U1000\)`)
+
+// ParseStaticcheckU1000 parses `staticcheck -checks U1000` output into the set of
+// flagged (file, bare-name) symbols. Lines that are not U1000 findings are
+// ignored, so the parser tolerates the build/warning noise staticcheck mixes in.
+func ParseStaticcheckU1000(output string) U1000Set {
+	set := U1000Set{}
+	for _, line := range strings.Split(output, "\n") {
+		m := staticcheckU1000Re.FindStringSubmatch(strings.TrimSpace(line))
+		if m == nil {
+			continue
+		}
+		set[goSymRef{File: normalizeRel(m[1]), Name: bareGoName(m[2])}] = struct{}{}
+	}
+	return set
+}
+
+// bareGoName strips a method's receiver qualifier so the name matches Sense's
+// bare symbol name: `(*T).deadMethod` / `(T).deadMethod` → `deadMethod`; a plain
+// `unusedHelper` is returned unchanged.
+func bareGoName(name string) string {
+	if i := strings.LastIndex(name, "."); i >= 0 {
+		return name[i+1:]
+	}
+	return name
+}
+
+// normalizeRel canonicalises a repo-relative path for joining: forward slashes,
+// no leading `./`.
+func normalizeRel(path string) string {
+	return strings.TrimPrefix(filepath.ToSlash(path), "./")
+}
+
+// ErrStaticcheckUnavailable is returned by RunStaticcheckU1000 when the
+// staticcheck binary cannot be launched, so callers can skip rather than fail.
+var ErrStaticcheckUnavailable = fmt.Errorf("staticcheck unavailable")
+
+// runStaticcheck launches `staticcheck -checks U1000 ./...` in repoRoot and
+// returns its combined output. It is a package var so tests can inject canned
+// output and error shapes deterministically, without depending on the binary.
+var runStaticcheck = func(ctx context.Context, repoRoot string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "staticcheck", "-checks", "U1000", "./...")
+	cmd.Dir = repoRoot
+	return cmd.CombinedOutput()
+}
+
+// RunStaticcheckU1000 runs staticcheck in repoRoot and returns the parsed U1000
+// set. staticcheck exits non-zero precisely when it reports findings, so an
+// ExitError with parseable output is success; only a failure to launch the
+// binary (e.g. not installed) is fatal. The caller is expected to skip when
+// ErrStaticcheckUnavailable is returned.
+func RunStaticcheckU1000(ctx context.Context, repoRoot string) (U1000Set, error) {
+	out, err := runStaticcheck(ctx, repoRoot)
+	if err != nil {
+		// An ExitError means staticcheck ran and found issues (or build errors in
+		// the target) — its stdout still carries the U1000 findings. Anything else
+		// is a launch failure (binary missing), which is fatal.
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			return nil, fmt.Errorf("%w: %v", ErrStaticcheckUnavailable, err)
+		}
+	}
+	return ParseStaticcheckU1000(string(out)), nil
+}
+
+// GoDeadSymbols scans repoRoot with Sense and returns the Go symbols it earns the
+// `dead` verdict for — the left side of the subset gate.
+func GoDeadSymbols(ctx context.Context, repoRoot, senseDir string) ([]GoDead, error) {
+	if _, err := scan.Run(ctx, scan.Options{
+		Root:     repoRoot,
+		Sense:    senseDir,
+		Output:   &bytes.Buffer{},
+		Warnings: io.Discard,
+	}); err != nil {
+		return nil, fmt.Errorf("scan %s: %w", repoRoot, err)
+	}
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		return nil, fmt.Errorf("open index: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	res, err := dead.FindDead(ctx, db, dead.Options{Language: "go", Limit: 1000000})
+	if err != nil {
+		return nil, fmt.Errorf("find dead: %w", err)
+	}
+	var out []GoDead
+	for _, f := range res.Findings {
+		if f.Verdict != dead.VerdictDead {
+			continue
+		}
+		out = append(out, GoDead{
+			Qualified: f.Symbol.Qualified,
+			File:      normalizeRel(f.Symbol.File),
+			Name:      f.Symbol.Name,
+		})
+	}
+	return out, nil
+}
+
+// GoFalseDeads returns the Sense `dead` Go symbols absent from the staticcheck
+// U1000 set — the gate violations. An empty result is the only passing state: it
+// means every symbol Sense called `dead` is one staticcheck independently agrees
+// is unused. Order is stable for legible reporting.
+func GoFalseDeads(senseDead []GoDead, oracle U1000Set) []GoDead {
+	var out []GoDead
+	for _, d := range senseDead {
+		if _, ok := oracle[goSymRef{File: d.File, Name: d.Name}]; !ok {
+			out = append(out, d)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].File != out[j].File {
+			return out[i].File < out[j].File
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}

--- a/internal/dead/eval/staticcheck_test.go
+++ b/internal/dead/eval/staticcheck_test.go
@@ -1,0 +1,242 @@
+package eval
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseStaticcheckU1000(t *testing.T) {
+	out := `internal/foo/bar.go:12:6: func unusedHelper is unused (U1000)
+./internal/foo/bar.go:20:1: func (*T).deadMethod is unused (U1000)
+types.go:5:6: type unusedType is unused (U1000)
+some/file.go:1:1: this is not a U1000 line
+const.go:3:7: const deadConst is unused (U1000)`
+	set := ParseStaticcheckU1000(out)
+
+	want := []goSymRef{
+		{File: "internal/foo/bar.go", Name: "unusedHelper"},
+		{File: "internal/foo/bar.go", Name: "deadMethod"}, // receiver stripped + leading ./ normalized
+		{File: "types.go", Name: "unusedType"},
+		{File: "const.go", Name: "deadConst"},
+	}
+	if len(set) != len(want) {
+		t.Fatalf("parsed %d entries, want %d: %v", len(set), len(want), set)
+	}
+	for _, w := range want {
+		if _, ok := set[w]; !ok {
+			t.Errorf("missing %v in parsed set %v", w, set)
+		}
+	}
+}
+
+func TestBareGoName(t *testing.T) {
+	cases := map[string]string{
+		"unusedHelper":    "unusedHelper",
+		"(*T).deadMethod": "deadMethod",
+		"(T).method":      "method",
+	}
+	for in, want := range cases {
+		if got := bareGoName(in); got != want {
+			t.Errorf("bareGoName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestGoFalseDeadsSubsetPasses: every Sense `dead` is in the oracle → no
+// violation (the passing state).
+func TestGoFalseDeadsSubsetPasses(t *testing.T) {
+	oracle := U1000Set{
+		{File: "a.go", Name: "x"}: {},
+		{File: "a.go", Name: "y"}: {},
+	}
+	senseDead := []GoDead{
+		{Qualified: "pkg.x", File: "a.go", Name: "x"},
+	}
+	if fd := GoFalseDeads(senseDead, oracle); len(fd) != 0 {
+		t.Errorf("expected zero false dead, got %v", fd)
+	}
+}
+
+// TestGoFalseDeadsPlantedLiveMethodFails is the coverage-gate requirement: a
+// planted false `dead` (a live interface method Sense wrongly called dead, absent
+// from staticcheck's U1000 set) MUST be reported, proving the gate detects the
+// only unforgivable error rather than rubber-stamping.
+func TestGoFalseDeadsPlantedLiveMethodFails(t *testing.T) {
+	oracle := U1000Set{
+		{File: "a.go", Name: "reallyDead"}: {},
+	}
+	senseDead := []GoDead{
+		{Qualified: "pkg.reallyDead", File: "a.go", Name: "reallyDead"}, // legitimate
+		{Qualified: "pkg.T.Handle", File: "b.go", Name: "Handle"},       // planted false dead
+	}
+	fd := GoFalseDeads(senseDead, oracle)
+	if len(fd) != 1 {
+		t.Fatalf("expected exactly one false dead (the planted live method), got %v", fd)
+	}
+	if fd[0].Qualified != "pkg.T.Handle" {
+		t.Errorf("false dead = %q, want pkg.T.Handle", fd[0].Qualified)
+	}
+}
+
+const sampleU1000 = "pkg/a.go:3:6: func deadHelper is unused (U1000)\n"
+
+// TestRunStaticcheckU1000Success: a clean run (nil error) parses the findings.
+func TestRunStaticcheckU1000Success(t *testing.T) {
+	restore := runStaticcheck
+	defer func() { runStaticcheck = restore }()
+	runStaticcheck = func(context.Context, string) ([]byte, error) {
+		return []byte(sampleU1000), nil
+	}
+	set, err := RunStaticcheckU1000(context.Background(), "ignored")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := set[goSymRef{File: "pkg/a.go", Name: "deadHelper"}]; !ok {
+		t.Errorf("expected deadHelper in set, got %v", set)
+	}
+}
+
+// TestRunStaticcheckU1000FindingsExit: staticcheck exits non-zero when it has
+// findings (an *exec.ExitError); the output must still be parsed, not treated as
+// a launch failure.
+func TestRunStaticcheckU1000FindingsExit(t *testing.T) {
+	restore := runStaticcheck
+	defer func() { runStaticcheck = restore }()
+	runStaticcheck = func(context.Context, string) ([]byte, error) {
+		return []byte(sampleU1000), &exec.ExitError{}
+	}
+	set, err := RunStaticcheckU1000(context.Background(), "ignored")
+	if err != nil {
+		t.Fatalf("ExitError must not be fatal: %v", err)
+	}
+	if len(set) != 1 {
+		t.Errorf("expected findings parsed despite non-zero exit, got %v", set)
+	}
+}
+
+// TestRunStaticcheckU1000LaunchFailure: a non-ExitError (binary missing) maps to
+// ErrStaticcheckUnavailable so callers can skip.
+func TestRunStaticcheckU1000LaunchFailure(t *testing.T) {
+	restore := runStaticcheck
+	defer func() { runStaticcheck = restore }()
+	runStaticcheck = func(context.Context, string) ([]byte, error) {
+		return nil, errors.New("exec: \"staticcheck\": executable file not found in $PATH")
+	}
+	_, err := RunStaticcheckU1000(context.Background(), "ignored")
+	if !errors.Is(err, ErrStaticcheckUnavailable) {
+		t.Errorf("expected ErrStaticcheckUnavailable, got %v", err)
+	}
+}
+
+// TestGoFalseDeadsSortOrder exercises both arms of the violation sort: across
+// files and within one file.
+func TestGoFalseDeadsSortOrder(t *testing.T) {
+	oracle := U1000Set{}
+	senseDead := []GoDead{
+		{Qualified: "p.zeta", File: "b.go", Name: "zeta"},
+		{Qualified: "p.alpha", File: "a.go", Name: "alpha"},
+		{Qualified: "p.beta", File: "a.go", Name: "beta"},
+	}
+	fd := GoFalseDeads(senseDead, oracle)
+	got := []string{fd[0].Name, fd[1].Name, fd[2].Name}
+	want := []string{"alpha", "beta", "zeta"} // a.go:alpha, a.go:beta, b.go:zeta
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("sort order = %v, want %v", got, want)
+			break
+		}
+	}
+}
+
+// TestGoDeadSymbolsScanError covers the scan-failure path: a root that cannot be
+// scanned surfaces an error rather than an empty set.
+func TestGoDeadSymbolsScanError(t *testing.T) {
+	_, err := GoDeadSymbols(context.Background(), filepath.Join(t.TempDir(), "does-not-exist"), filepath.Join(t.TempDir(), ".sense"))
+	if err == nil {
+		t.Error("expected an error scanning a missing root")
+	}
+}
+
+// TestGoDeadSymbols scans a tiny Go module and confirms GoDeadSymbols returns the
+// genuinely-dead unexported helper and nothing live. No staticcheck needed.
+func TestGoDeadSymbols(t *testing.T) {
+	root := t.TempDir()
+	if err := Materialize(root, map[string]string{
+		"go.mod": "module oracletest\n\ngo 1.21\n",
+		"main.go": `package main
+
+func main() { used() }
+
+func used() {}
+
+func deadHelper() {}
+`,
+	}); err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	got, err := GoDeadSymbols(context.Background(), root, filepath.Join(root, ".sense"))
+	if err != nil {
+		t.Fatalf("GoDeadSymbols: %v", err)
+	}
+	names := map[string]bool{}
+	for _, d := range got {
+		names[d.Name] = true
+	}
+	if !names["deadHelper"] {
+		t.Errorf("deadHelper should be earned dead; got %v", got)
+	}
+	if names["used"] || names["main"] {
+		t.Errorf("live/entry symbols must not be dead; got %v", got)
+	}
+}
+
+// TestStaticcheckOracleEndToEnd runs the full gate against a real staticcheck
+// when it is installed, asserting Sense's `dead` set is a subset (zero false
+// dead). It skips cleanly when staticcheck is unavailable so CI without the
+// binary stays green; the binding repo-level run lives in the benchmark card.
+func TestStaticcheckOracleEndToEnd(t *testing.T) {
+	root := t.TempDir()
+	if err := Materialize(root, map[string]string{
+		"go.mod": "module oracletest\n\ngo 1.21\n",
+		"lib.go": `package oracletest
+
+type Runner interface{ Run() }
+
+type Worker struct{}
+
+// Run satisfies Runner; it is reached through the interface, so Sense must NOT
+// call it dead even though no direct caller exists.
+func (Worker) Run() {}
+
+// deadHelper is genuinely unused — both Sense and staticcheck must agree.
+func deadHelper() {}
+
+func Use() Runner { return Worker{} }
+`,
+	}); err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	ctx := context.Background()
+
+	oracle, err := RunStaticcheckU1000(ctx, root)
+	if errors.Is(err, ErrStaticcheckUnavailable) {
+		t.Skip("staticcheck not installed; skipping the live oracle check")
+	}
+	if err != nil {
+		t.Fatalf("RunStaticcheckU1000: %v", err)
+	}
+
+	senseDead, err := GoDeadSymbols(ctx, root, filepath.Join(root, ".sense"))
+	if err != nil {
+		t.Fatalf("GoDeadSymbols: %v", err)
+	}
+
+	falseDead := GoFalseDeads(senseDead, oracle)
+	t.Logf("Sense dead=%d, staticcheck U1000=%d, false dead=%d", len(senseDead), len(oracle), len(falseDead))
+	if len(falseDead) != 0 {
+		t.Errorf("false-dead-count = %d, want 0; violations: %v", len(falseDead), falseDead)
+	}
+}

--- a/internal/dead/golden_test.go
+++ b/internal/dead/golden_test.go
@@ -153,8 +153,9 @@ func TestDeadCodeGolden(t *testing.T) {
 }
 
 // TestDeadCLIIntegration is the two-sided-gate proof on a real scanned
-// fixture: the genuinely-dead Ruby private earns `dead`; the value-object
-// predicates and every Go symbol (no Go voice) stay `possibly_dead`; and no
+// fixture: a genuinely-dead Ruby private AND an unexported Go helper earn
+// `dead`; the value-object predicates, an `init`, an interface method, and every
+// exported Go symbol stay `possibly_dead` with the exact reason; and no
 // known-live symbol is reported at all.
 func TestDeadCLIIntegration(t *testing.T) {
 	g := smokeGolden(t)
@@ -190,10 +191,23 @@ func TestDeadCLIIntegration(t *testing.T) {
 		}
 	}
 
-	// SAFETY INVARIANT: every Go symbol reported is possibly_dead (no Go voice).
+	// EARNED dead (Go): the unexported, zero-edge, unmentioned helper.
+	if verdict["smoke.reconcileLedger"] != "dead" {
+		t.Errorf("smoke.reconcileLedger verdict = %q, want dead (unexported, no caller, no mention)", verdict["smoke.reconcileLedger"])
+	}
+	// POSSIBLY_DEAD (Go), exact reason: init is runtime-invoked; an interface
+	// method is reachable through any implementor.
+	if v, r := verdict["smoke.init"], reason["smoke.init"]; v != "possibly_dead" || r != "go_init" {
+		t.Errorf("smoke.init = (%q, %q), want (possibly_dead, go_init)", v, r)
+	}
+	if v, r := verdict["smoke.Notifier.Notify"], reason["smoke.Notifier.Notify"]; v != "possibly_dead" || r != "go_interface" {
+		t.Errorf("smoke.Notifier.Notify = (%q, %q), want (possibly_dead, go_interface)", v, r)
+	}
+	// SAFETY INVARIANT: no EXPORTED Go symbol earns dead — staticcheck U1000
+	// flags only unexported symbols, so an exported one must stay possibly_dead.
 	for _, e := range g.Findings {
-		if hasSuffix(e.File, ".go") && e.Verdict == "dead" {
-			t.Errorf("%s (Go) was flagged dead, but Go has no language voice — must be possibly_dead", e.Qualified)
+		if hasSuffix(e.File, ".go") && e.Verdict == "dead" && startsUpper(lastSegment(e.Qualified)) {
+			t.Errorf("%s (exported Go) was flagged dead; exported symbols must stay possibly_dead", e.Qualified)
 		}
 	}
 
@@ -218,6 +232,21 @@ func TestDeadCLIIntegration(t *testing.T) {
 }
 
 func endsWith(s, suffix string) bool { return hasSuffix(s, suffix) }
+
+// lastSegment returns the final dot-separated segment of a qualified name
+// (smoke.PaymentGateway.Refund → Refund), the symbol's own name.
+func lastSegment(qualified string) string {
+	for i := len(qualified) - 1; i >= 0; i-- {
+		if qualified[i] == '.' {
+			return qualified[i+1:]
+		}
+	}
+	return qualified
+}
+
+// startsUpper reports whether s begins with an ASCII uppercase letter — Go's
+// exported-visibility rule.
+func startsUpper(s string) bool { return s != "" && s[0] >= 'A' && s[0] <= 'Z' }
 
 func hasSuffix(s, suffix string) bool {
 	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix

--- a/internal/dead/predicates_internal_test.go
+++ b/internal/dead/predicates_internal_test.go
@@ -27,6 +27,27 @@ func TestIsTestSymbolBranches(t *testing.T) {
 	}
 }
 
+// TestIsInTestFileBranches covers each non-production path form, including the
+// Go-toolchain `testdata/` fixture convention, plus a production control.
+func TestIsInTestFileBranches(t *testing.T) {
+	cases := map[string]bool{
+		"foo_test.go":                          true,
+		"app/test/helper.rb":                   true,
+		"src/tests/util.ts":                    true,
+		"app/spec/models/order_spec.rb":        true,
+		"internal/extract/testdata/go/x.go":    true, // testdata/ fixture dir
+		"testdata/fixtures/main.go":            true, // testdata/ at root
+		"components/__tests__/button.test.tsx": true,
+		"widget.spec.ts":                       true,
+		"internal/dead/dead.go":                false, // production source
+	}
+	for file, want := range cases {
+		if got := isInTestFile(Symbol{File: file}); got != want {
+			t.Errorf("isInTestFile(%q) = %v, want %v", file, got, want)
+		}
+	}
+}
+
 // TestRubyMethodParentNameBranches covers the no-separator, dotted, hashed,
 // and namespaced forms.
 func TestRubyMethodParentNameBranches(t *testing.T) {
@@ -143,13 +164,17 @@ func TestEntryPointPredicates(t *testing.T) {
 	if isMainFunction(Symbol{Name: "run"}) {
 		t.Error("run is not main")
 	}
-	for _, n := range []string{"initialize", "__init__", "constructor", "init", "Init"} {
+	for _, n := range []string{"initialize", "__init__", "constructor"} {
 		if !isConstructor(Symbol{Name: n}) {
 			t.Errorf("%q should be a constructor", n)
 		}
 	}
-	if isConstructor(Symbol{Name: "build"}) {
-		t.Error("build is not a constructor")
+	// Go's init/Init are NOT constructors: the Go voice owns init (go_init) so it
+	// surfaces as possibly_dead rather than being excluded as an entry point.
+	for _, n := range []string{"init", "Init", "build"} {
+		if isConstructor(Symbol{Name: n}) {
+			t.Errorf("%q should not be a constructor", n)
+		}
 	}
 	if !hasAnySuffix("PaymentService", serviceClassSuffixes) {
 		t.Error("PaymentService should match a service suffix")

--- a/internal/dead/reasons.go
+++ b/internal/dead/reasons.go
@@ -48,6 +48,14 @@ const (
 	ReasonRailsRouting  = "rails_routing"
 	ReasonRailsCallback = "rails_callback"
 	ReasonRailsConcern  = "rails_concern"
+
+	// Go-voice reason codes (voice_go.go owns their catalog specs).
+	ReasonGoInit      = "go_init"
+	ReasonGoInterface = "go_interface"
+	ReasonGoCgo       = "go_cgo"
+	ReasonGoGenerated = "go_generated"
+	ReasonGoConst     = "go_const"
+	ReasonGoExported  = "go_exported"
 )
 
 // reasonSpec is the static metadata for a reason code: a removability
@@ -84,11 +92,14 @@ var reasonCatalog = map[string]reasonSpec{
 		verify:   "Public API of a library — callers may live outside this repo. Search dependent projects and the rest of this tree for each name before removing.",
 	},
 	// Reflection target: the name is dispatched dynamically somewhere, so it
-	// is likely live — sort near the bottom.
+	// is likely live — sort near the bottom. The hint is language-neutral: each
+	// language's dispatch set is harvested from its own reflection idioms (Ruby
+	// send/const_get, Go reflect.MethodByName/struct tags, …), so the recipe names
+	// the general shape rather than one language's keywords.
 	ReasonReflection: {
 		priority: 30,
-		hint:     "name is a dynamic dispatch target (send/const_get/define_method); grep for it as a symbol/string before removing",
-		verify:   "These names appear as dynamic-dispatch targets. For each, grep for it as a string/symbol literal (send/public_send/const_get/define_method arguments) before removing.",
+		hint:     "name is a dynamic/reflective dispatch target; grep for it as a string literal before removing",
+		verify:   "These names appear as reflective dispatch targets (e.g. a reflection call's string argument or a struct-tag key). For each, grep the repo for it as a string literal before removing.",
 	},
 	// Name mentioned where the resolver could not bind it: very likely a real
 	// (just unresolved) caller, so this sorts near the bottom — least likely

--- a/internal/dead/voice_go.go
+++ b/internal/dead/voice_go.go
@@ -1,0 +1,173 @@
+package dead
+
+import "strings"
+
+// goVoice is the Go language voice. Go is the first statically-typed, compiled
+// language Sense reasons about, so its `dead` verdict can be made nearly
+// airtight: visibility is structural (capitalized == exported), and an
+// unexported symbol with no caller, no mention, and no invisible-reach idiom is
+// exactly what `staticcheck U1000` flags as unused. The voice re-expresses Go's
+// invisible-reach idioms as open-world reasons; like every voice it can only
+// raise a hand (push → possibly_dead), never vote for `dead`.
+//
+// The earned-`dead` candidate is narrow and structural: an UNEXPORTED func /
+// method / type with zero incoming edges, whose name is absent from the Go
+// mention set (the arbiter's soundness gate) and which this voice cannot tie to
+// init / interface satisfaction / cgo / generated code. Everything else raises a
+// hand. In particular every EXPORTED symbol stays open-world — `staticcheck
+// U1000` only flags unexported symbols, so letting an exported one earn `dead`
+// would break the binding "Sense `dead` ⊆ U1000" gate (an exported symbol may be
+// used by another package Sense never indexed).
+type goVoice struct{}
+
+func (goVoice) Lang() string { return "go" }
+
+// Inspect returns the most-specific (most-likely-live) reason a hidden caller
+// could exist for s, or nil when s is an unexported func/method/type with no
+// invisible-reach idiom — the only shape that may fall through to `dead`. Checks
+// are ordered most-live-first so the returned reason carries the most useful
+// hint; the arbiter independently picks the lowest-priority reason across voices.
+func (goVoice) Inspect(s Symbol, f Facts) *Reason {
+	// init() is run by the Go runtime at package load, never by a caller. (It is
+	// also filtered upstream as an entry point; this is defense in depth so the
+	// voice's contract holds regardless of the candidate pipeline.)
+	if isGoInit(s) {
+		return reasonPtr(ReasonGoInit)
+	}
+	// A method satisfying an interface is reachable through any implementor, where
+	// the static graph shows zero direct callers. Go satisfaction is structural,
+	// so name match against indexed interface methods (plus a stdlib magic-method
+	// table) is the soundest signal without recomputing satisfaction.
+	if isGoInterfaceMethod(s, f) {
+		return reasonPtr(ReasonGoInterface)
+	}
+	// A cgo `//export`ed function is called from C; no Go caller edge exists.
+	if _, ok := f.CgoExportNames[s.Name]; ok {
+		return reasonPtr(ReasonGoCgo)
+	}
+	// A symbol in a generated file is produced by a tool; it should be regenerated
+	// from its source, not hand-deleted, and may be referenced only by other
+	// generated code outside this scan's view.
+	if isGoGeneratedFile(s.File) {
+		return reasonPtr(ReasonGoGenerated)
+	}
+	// Exported symbols never earn `dead`: U1000 flags only unexported symbols, so
+	// an exported one may have an external consumer Sense never indexed. A library
+	// is handled by the core voice (core_exported_api); otherwise raise go_exported.
+	if s.Visibility == "public" {
+		if f.IsLibrary && isPublicAPISymbol(s) {
+			return nil
+		}
+		return reasonPtr(ReasonGoExported)
+	}
+	// Unexported from here. Constants and package-level variables (both KindConstant
+	// in the Go extractor) stay open-world: an unused iota anchor is load-bearing
+	// for its sequence yet looks unreferenced, and a var may be mutated/read through
+	// a path the resolver cannot bind. Only func/method/type may fall through.
+	switch s.Kind {
+	case "function", "method", "type", "class", "interface":
+		return nil
+	default:
+		return reasonPtr(ReasonGoConst)
+	}
+}
+
+// isGoInit reports whether s is a package init function (`func init()`).
+func isGoInit(s Symbol) bool {
+	return s.Kind == "function" && s.Name == "init"
+}
+
+// isGoInterfaceMethod reports whether s is a method whose name is declared on an
+// interface in this index, or is a well-known stdlib interface method. Either
+// way the method may be invoked through the interface, where the static graph
+// shows no direct caller, so it must stay open-world.
+func isGoInterfaceMethod(s Symbol, f Facts) bool {
+	if s.Kind != "method" {
+		return false
+	}
+	if _, ok := f.InterfaceMethodNames[s.Name]; ok {
+		return true
+	}
+	_, magic := goMagicMethods[s.Name]
+	return magic
+}
+
+// goMagicMethods are method names the Go runtime / standard library invokes
+// through interfaces that are NOT in Sense's index (fmt.Stringer, error,
+// json.Marshaler, io.Reader/Writer/Closer, sort.Interface, …). A method with one
+// of these names is reached by the stdlib, never by an indexed caller, so it
+// stays open-world. Signature is not checked — a name match over-approximates
+// toward caution (recall loss at worst), which is the safe direction.
+//
+// Every name here is exported (stdlib interfaces have exported methods), and only
+// UNEXPORTED methods can earn `dead`, so this table never changes a verdict — an
+// exported method is already `possibly_dead`. Its job is hint accuracy: it upgrades
+// such a method's reason from go_exported to the more precise go_interface.
+var goMagicMethods = map[string]struct{}{
+	"String": {}, "GoString": {}, "Error": {}, "Format": {},
+	"MarshalJSON": {}, "UnmarshalJSON": {},
+	"MarshalText": {}, "UnmarshalText": {},
+	"MarshalBinary": {}, "UnmarshalBinary": {},
+	"Read": {}, "Write": {}, "Close": {},
+	"Scan": {}, "Value": {},
+	"Len": {}, "Less": {}, "Swap": {},
+	"Unwrap": {}, "Is": {}, "As": {},
+	"ServeHTTP": {},
+}
+
+// goGeneratedSuffixes name files emitted by code generators. A symbol in such a
+// file should be regenerated, not hand-deleted. Filename-based detection is a
+// conservative subset of the canonical `// Code generated … DO NOT EDIT.` header
+// (which needs file content the voice does not carry); it covers the common
+// tools (protoc → *.pb.go, `go:generate` → *_gen.go / *_generated.go).
+var goGeneratedSuffixes = []string{".pb.go", "_gen.go", "_generated.go"}
+
+// isGoGeneratedFile reports whether path looks generator-produced.
+func isGoGeneratedFile(path string) bool {
+	for _, suf := range goGeneratedSuffixes {
+		if strings.HasSuffix(path, suf) {
+			return true
+		}
+	}
+	// k8s-style `zz_generated.*.go`.
+	base := path
+	if i := strings.LastIndexByte(base, '/'); i >= 0 {
+		base = base[i+1:]
+	}
+	return strings.HasPrefix(base, "zz_generated")
+}
+
+func init() {
+	registerReasons(map[string]reasonSpec{
+		ReasonGoInit: {
+			priority: 20,
+			hint:     "Go init() is run by the runtime at package load, not by a caller; never remove it as dead",
+			verify:   "`func init()` is invoked by the Go runtime when the package loads. It has no caller by design; do not remove it.",
+		},
+		ReasonGoInterface: {
+			priority: 30,
+			hint:     "method satisfies an interface (named on an interface, or a stdlib interface like fmt.Stringer/error/json.Marshaler); it may be called through the interface — confirm no implementor is used before removing",
+			verify:   "This method shares a name with an interface method, so it may be invoked through the interface (where Sense sees no direct caller). Check whether the receiver type is stored in an interface variable anywhere before removing.",
+		},
+		ReasonGoCgo: {
+			priority: 30,
+			hint:     "function is cgo `//export`ed and called from C; no Go caller exists — remove only if the C side no longer uses it",
+			verify:   "This function is exported to C via a cgo `//export` directive and has no Go caller by design. Check the C code that calls it before removing.",
+		},
+		ReasonGoGenerated: {
+			priority: 40,
+			hint:     "symbol lives in a generated file (*.pb.go / *_gen.go / *_generated.go); regenerate from its source rather than hand-deleting",
+			verify:   "This symbol is in a generated file. Change the generator input and regenerate rather than editing it directly; it may also be referenced by other generated code outside this scan.",
+		},
+		ReasonGoConst: {
+			priority: 45,
+			hint:     "Go constant or package-level variable; it may anchor an iota sequence or be referenced through a path Sense cannot bind — confirm before removing",
+			verify:   "Go constants/vars can be load-bearing iota anchors or referenced indirectly. For each, grep for its name across the package (including iota groups and struct tags) before removing.",
+		},
+		ReasonGoExported: {
+			priority: 50,
+			hint:     "exported Go symbol with no caller in this repo; another package may use it (staticcheck flags only unexported symbols) — search dependents before removing",
+			verify:   "Exported Go symbols can be used by packages outside this repo. For each, search dependent modules and the rest of this tree for the qualified name before removing.",
+		},
+	})
+}

--- a/internal/dead/voice_go_test.go
+++ b/internal/dead/voice_go_test.go
@@ -1,0 +1,106 @@
+package dead
+
+import "testing"
+
+func goSym(name, qualified, kind, visibility, file string) Symbol {
+	return Symbol{
+		Name:       name,
+		Qualified:  qualified,
+		Kind:       kind,
+		Language:   "go",
+		Visibility: visibility,
+		File:       file,
+	}
+}
+
+func TestGoVoiceInit(t *testing.T) {
+	v := goVoice{}
+	// init() is runtime-invoked: always raises go_init, never earns dead.
+	assertReason(t, v, goSym("init", "pkg.init", "function", "private", "pkg.go"), Facts{}, ReasonGoInit)
+	// A capitalized Init is an ordinary function, not the runtime initializer.
+	assertReason(t, v, goSym("Init", "pkg.Init", "function", "public", "pkg.go"), Facts{IsLibrary: false}, ReasonGoExported)
+}
+
+func TestGoVoiceInterfaceByDeclaredName(t *testing.T) {
+	v := goVoice{}
+	f := Facts{InterfaceMethodNames: map[string]struct{}{"Handle": {}}}
+	// A method whose name is declared on some interface stays open-world.
+	assertReason(t, v, goSym("Handle", "pkg.T.Handle", "method", "private", "t.go"), f, ReasonGoInterface)
+	// A package function of the same name is NOT an interface method.
+	assertReason(t, v, goSym("Handle", "pkg.Handle", "function", "private", "t.go"), f, "")
+}
+
+func TestGoVoiceInterfaceByMagicMethod(t *testing.T) {
+	v := goVoice{}
+	// Stdlib interface methods (not in the index) are recognised by name.
+	for _, name := range []string{"String", "Error", "MarshalJSON", "ServeHTTP", "Read"} {
+		assertReason(t, v, goSym(name, "pkg.T."+name, "method", "private", "t.go"), Facts{}, ReasonGoInterface)
+	}
+	// A non-magic unexported method falls through to silent.
+	assertReason(t, v, goSym("frobnicate", "pkg.T.frobnicate", "method", "private", "t.go"), Facts{}, "")
+}
+
+func TestGoVoiceCgo(t *testing.T) {
+	v := goVoice{}
+	f := Facts{CgoExportNames: map[string]struct{}{"goCallback": {}}}
+	assertReason(t, v, goSym("goCallback", "pkg.goCallback", "function", "private", "cgo.go"), f, ReasonGoCgo)
+	// A function not in the cgo set is unaffected.
+	assertReason(t, v, goSym("plain", "pkg.plain", "function", "private", "cgo.go"), f, "")
+}
+
+func TestGoVoiceGenerated(t *testing.T) {
+	v := goVoice{}
+	for _, file := range []string{"api.pb.go", "schema_gen.go", "model_generated.go", "k8s/zz_generated.deepcopy.go"} {
+		assertReason(t, v, goSym("helper", "pkg.helper", "function", "private", file), Facts{}, ReasonGoGenerated)
+	}
+	// A hand-written file is not generated.
+	assertReason(t, v, goSym("helper", "pkg.helper", "function", "private", "service.go"), Facts{}, "")
+}
+
+func TestGoVoiceExported(t *testing.T) {
+	v := goVoice{}
+	// Exported symbol in a binary (not a library) → go_exported, never dead.
+	assertReason(t, v, goSym("Handler", "pkg.Handler", "function", "public", "h.go"), Facts{IsLibrary: false}, ReasonGoExported)
+	assertReason(t, v, goSym("Config", "pkg.Config", "class", "public", "c.go"), Facts{IsLibrary: false}, ReasonGoExported)
+	// Exported callable/type in a LIBRARY → silent here; the core voice raises
+	// core_exported_api instead (proven by the arbiter-level test below).
+	assertReason(t, v, goSym("PublicFn", "pkg.PublicFn", "function", "public", "l.go"), Facts{IsLibrary: true}, "")
+	// An exported CONSTANT in a library is not a callable/type API surface, so the
+	// core voice would not claim it; the Go voice keeps it open-world (go_exported).
+	assertReason(t, v, goSym("MaxSize", "pkg.MaxSize", "constant", "public", "l.go"), Facts{IsLibrary: true}, ReasonGoExported)
+}
+
+func TestGoVoiceUnexportedConst(t *testing.T) {
+	v := goVoice{}
+	// Unexported const/var (KindConstant) stays open-world: iota-anchor / dynamic
+	// reference risk means it must not earn dead.
+	assertReason(t, v, goSym("threshold", "pkg.threshold", "constant", "private", "c.go"), Facts{}, ReasonGoConst)
+}
+
+func TestGoVoiceSilentUnexportedFuncMethodType(t *testing.T) {
+	v := goVoice{}
+	// The only shapes that may fall through to dead: unexported func/method/type/
+	// class/interface with no invisible-reach idiom.
+	assertReason(t, v, goSym("helper", "pkg.helper", "function", "private", "s.go"), Facts{}, "")
+	assertReason(t, v, goSym("compute", "pkg.T.compute", "method", "private", "s.go"), Facts{}, "")
+	assertReason(t, v, goSym("widget", "pkg.widget", "type", "private", "s.go"), Facts{}, "")
+	assertReason(t, v, goSym("box", "pkg.box", "class", "private", "s.go"), Facts{}, "")
+	assertReason(t, v, goSym("reader", "pkg.reader", "interface", "private", "s.go"), Facts{}, "")
+}
+
+func TestGoVoiceLang(t *testing.T) {
+	if (goVoice{}).Lang() != "go" {
+		t.Errorf("goVoice.Lang() = %q, want go", (goVoice{}).Lang())
+	}
+}
+
+// TestGoVoiceReasonPriorityOrder pins the most-live-first ordering: when a symbol
+// matches several signals, the more-likely-live reason is returned.
+func TestGoVoiceReasonPriorityOrder(t *testing.T) {
+	v := goVoice{}
+	// init in a generated file → go_init wins over go_generated.
+	assertReason(t, v, goSym("init", "pkg.init", "function", "private", "x_gen.go"), Facts{}, ReasonGoInit)
+	// An exported method matching an interface name → go_interface wins over go_exported.
+	f := Facts{InterfaceMethodNames: map[string]struct{}{"Handle": {}}}
+	assertReason(t, v, goSym("Handle", "pkg.T.Handle", "method", "public", "t.go"), f, ReasonGoInterface)
+}

--- a/internal/extract/extractor.go
+++ b/internal/extract/extractor.go
@@ -262,6 +262,19 @@ type DispatchEmitter interface {
 	DispatchName(name string) error
 }
 
+// CgoExportEmitter is an optional Emitter extension for streaming the names a
+// Go file marks with a cgo `//export <name>` directive. Such a function is
+// called from C and has no Go caller edge, so it would otherwise look dead. The
+// names feed a project-wide set in sense_meta so the dead-code Go voice keeps a
+// cgo-exported symbol open-world (reason go_cgo) instead of falsely calling it
+// dead. Distinct from DispatchEmitter because its verify recipe differs — the
+// caller lives in C, not in a reflective string literal. An extractor probes for
+// this interface with a type assertion; an Emitter that does not implement it
+// simply receives no cgo names. Returning an error aborts extraction.
+type CgoExportEmitter interface {
+	CgoExportName(name string) error
+}
+
 // MentionEmitter is an optional Emitter extension for streaming every bare
 // name a file *mentions* — every identifier or symbol-literal token that
 // appears in any position other than a definition's own name. Unlike

--- a/internal/extract/golang/golang.go
+++ b/internal/extract/golang/golang.go
@@ -17,7 +17,7 @@
 //   - func at package scope → KindFunction  (no receiver)
 //   - func with receiver    → KindMethod
 //   - const NAME = …        → KindConstant  (any case; Go has no
-//                             all-caps convention)
+//     all-caps convention)
 //
 // Calls edges:
 //   - Function / method bodies are walked for call_expression nodes.
@@ -56,12 +56,15 @@ func (Extractor) Tier() extract.Tier        { return extract.TierBasic }
 
 func (Extractor) Extract(tree *sitter.Tree, source []byte, _ string, emit extract.Emitter) error {
 	w := &walker{
-		source: source,
-		emit:   emit,
-		pkg:    packageName(tree.RootNode(), source),
+		source:      source,
+		emit:        emit,
+		pkg:         packageName(tree.RootNode(), source),
 		pkgBindings: map[string]string{},
 	}
-	return w.walkTopLevel(tree.RootNode())
+	if err := w.walkTopLevel(tree.RootNode()); err != nil {
+		return err
+	}
+	return emitHarvest(tree.RootNode(), source, emit)
 }
 
 func init() { extract.Register(Extractor{}) }
@@ -69,8 +72,8 @@ func init() { extract.Register(Extractor{}) }
 // ---- walker ----
 
 type walker struct {
-	source []byte
-	emit   extract.Emitter
+	source      []byte
+	emit        extract.Emitter
 	pkg         string            // package name, used to prefix every qualified name
 	pkgBindings map[string]string // unqualified name → qualified name for package-level consts and vars
 }
@@ -190,7 +193,10 @@ func (w *walker) emitConstSpec(spec *sitter.Node, doc string) error {
 			continue
 		}
 		name := extract.Text(c, w.source)
-		if name == "" {
+		// `const _ = …` is a blank declaration, not a named symbol; never emit it
+		// (it would otherwise read as a zero-edge dead candidate the Go voice can't
+		// vouch for, yet `staticcheck` never flags a blank).
+		if name == "" || name == "_" {
 			continue
 		}
 		if err := w.emit.Symbol(extract.EmittedSymbol{
@@ -224,7 +230,9 @@ func (w *walker) handleVarDeclaration(n *sitter.Node) error {
 				continue
 			}
 			name := extract.Text(c, w.source)
-			if name == "" {
+			// `var _ = …` (and the common `var _ Iface = (*T)(nil)` assertion) is a
+			// blank declaration, not a named symbol; never emit it.
+			if name == "" || name == "_" {
 				continue
 			}
 			if err := w.emit.Symbol(extract.EmittedSymbol{

--- a/internal/extract/golang/harvest.go
+++ b/internal/extract/golang/harvest.go
@@ -1,0 +1,255 @@
+package golang
+
+import (
+	"strings"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+)
+
+// HarvestsMentions reports that the Go extractor streams the broad mention set
+// (see emitHarvest), so the scan records `go` as harvested even on a scan that
+// yields zero mentions — the dead-code soundness gate then treats a Go symbol as
+// proven-against-an-empty-set, not never-harvested. Without this opt-in, every
+// Go symbol would fail closed at the per-language soundness gate (core_no_harvest)
+// and no Go symbol could ever earn `dead`.
+func (Extractor) HarvestsMentions() bool { return true }
+
+// emitHarvest streams the file's reflective dispatch-target names, cgo `//export`
+// names, and broad mention set to the emitter when it accepts them. The dispatch
+// set feeds the core voice's reflection gate (a name reached via
+// reflect.MethodByName / FieldByName, or a tagged struct field, can be invoked
+// invisibly); the cgo set feeds the Go voice's go_cgo reason; the mention set
+// feeds the arbiter's soundness gate (a symbol earns `dead` only when its bare
+// name is mentioned nowhere a hidden caller could be). All three are gathered in
+// ONE tree walk; each emit is best-effort — an Emitter that implements neither
+// extension simply receives no names.
+func emitHarvest(root *sitter.Node, source []byte, emit extract.Emitter) error {
+	h := collectGoHarvest(root, source)
+	if de, ok := emit.(extract.DispatchEmitter); ok {
+		for name := range h.dispatch {
+			if err := de.DispatchName(name); err != nil {
+				return err
+			}
+		}
+	}
+	if ce, ok := emit.(extract.CgoExportEmitter); ok {
+		for name := range h.cgoExports {
+			if err := ce.CgoExportName(name); err != nil {
+				return err
+			}
+		}
+	}
+	if me, ok := emit.(extract.MentionEmitter); ok {
+		for name := range h.mentions {
+			if err := me.MentionName(name); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// goHarvest accumulates the three name sets the Go dead-code analysis needs,
+// gathered in a single tree walk:
+//   - mentions: every identifier / type-identifier / field-identifier token
+//     EXCEPT a definition's own name — the broad superset feeding the arbiter's
+//     soundness gate (a candidate earns `dead` only when its name is absent here,
+//     i.e. mentioned nowhere a hidden caller could be).
+//   - dispatch: names reached by reflection — the string argument to a
+//     `.MethodByName(...)` / `.FieldByName(...)` call, and the Go name of every
+//     tagged struct field (json/gorm/… reach the field by reflection).
+//   - cgoExports: function names marked with a cgo `//export <name>` directive,
+//     called from C with no Go caller.
+type goHarvest struct {
+	mentions   map[string]struct{}
+	dispatch   map[string]struct{}
+	cgoExports map[string]struct{}
+}
+
+// collectGoHarvest walks every named node ONCE and routes it to the right set.
+// A single pass replaces the dozen kind-filtered traversals the three separate
+// harvests would otherwise each make. Scan is not a hot path, but one walk is
+// both faster and the clearer statement of intent: look at every node, decide
+// what it contributes.
+func collectGoHarvest(root *sitter.Node, source []byte) goHarvest {
+	h := goHarvest{
+		mentions:   map[string]struct{}{},
+		dispatch:   map[string]struct{}{},
+		cgoExports: map[string]struct{}{},
+	}
+	walkNamed(root, func(n *sitter.Node) {
+		switch n.Kind() {
+		case "call_expression":
+			h.addReflectDispatch(n, source)
+		case "field_declaration":
+			h.addTaggedFields(n, source)
+		case "comment":
+			h.addCgoExport(n, source)
+		case "identifier", "type_identifier", "field_identifier":
+			if !isGoDefinitionName(n) {
+				if name := extract.Text(n, source); name != "" {
+					h.mentions[name] = struct{}{}
+				}
+			}
+		}
+	})
+	return h
+}
+
+// walkNamed invokes visit on every named descendant of n (not n itself), once,
+// depth-first — the single-pass, all-kinds counterpart to the kind-filtered
+// extract.WalkNamedDescendants.
+func walkNamed(n *sitter.Node, visit func(*sitter.Node)) {
+	if n == nil {
+		return
+	}
+	count := n.NamedChildCount()
+	for i := uint(0); i < count; i++ {
+		child := n.NamedChild(i)
+		if child == nil {
+			continue
+		}
+		visit(child)
+		walkNamed(child, visit)
+	}
+}
+
+// isGoDefinitionName reports whether n is a definition's OWN name token: the
+// `name` field of a func / method / type declaration, or a declared identifier
+// in a const / var spec. The mention harvest skips these so a symbol is never
+// cancelled by its own definition (which would mute `dead` entirely). Checking
+// the parent at visit time replaces a precomputed ID set, keeping the harvest a
+// single pass. Interface method declarations (`method_elem`) are deliberately
+// NOT matched: leaving an interface method's name in the mention set keeps a
+// same-named concrete implementor open-world even when the resolver never drew
+// the implicit satisfaction edge.
+func isGoDefinitionName(n *sitter.Node) bool {
+	p := n.Parent()
+	if p == nil {
+		return false
+	}
+	switch p.Kind() {
+	case "function_declaration", "method_declaration", "type_spec", "type_alias":
+		name := p.ChildByFieldName("name")
+		return name != nil && name.Id() == n.Id()
+	case "const_spec", "var_spec":
+		// Names are the spec's direct `identifier` children; the type is a
+		// type_identifier and the value is nested under an expression_list, so
+		// neither is mistaken for a name.
+		return n.Kind() == "identifier"
+	}
+	return false
+}
+
+// addReflectDispatch records the string argument of a `.MethodByName(...)` /
+// `.FieldByName(...)` call as a reflection-reached name.
+func (h goHarvest) addReflectDispatch(call *sitter.Node, source []byte) {
+	fn := call.ChildByFieldName("function")
+	if fn == nil || fn.Kind() != "selector_expression" {
+		return
+	}
+	field := fn.ChildByFieldName("field")
+	if field == nil || !reflectDispatchMethods[extract.Text(field, source)] {
+		return
+	}
+	if name := firstStringArg(call, source); name != "" {
+		h.dispatch[name] = struct{}{}
+	}
+}
+
+// addTaggedFields records the Go name of every field in a tagged struct field
+// declaration as reflection-reachable. Forward-looking: Tier-Basic does not yet
+// emit struct fields as symbols, so they cannot be dead candidates today, but
+// keying them now keeps the gate sound the moment fields are indexed.
+func (h goHarvest) addTaggedFields(fd *sitter.Node, source []byte) {
+	if !hasStructTag(fd) {
+		return
+	}
+	for i := uint(0); i < fd.NamedChildCount(); i++ {
+		c := fd.NamedChild(i)
+		if c != nil && c.Kind() == "field_identifier" {
+			if name := extract.Text(c, source); name != "" {
+				h.dispatch[name] = struct{}{}
+			}
+		}
+	}
+}
+
+// addCgoExport records the function name of a cgo `//export <name>` directive.
+func (h goHarvest) addCgoExport(c *sitter.Node, source []byte) {
+	rest, ok := strings.CutPrefix(extract.Text(c, source), cgoExportPrefix)
+	if !ok || rest == "" || !isSpace(rest[0]) {
+		// Require whitespace after the directive so `//exported` (a normal
+		// comment) is not mistaken for `//export ed`.
+		return
+	}
+	if fields := strings.Fields(rest); len(fields) > 0 {
+		h.cgoExports[fields[0]] = struct{}{}
+	}
+}
+
+// cgoExportPrefix is the cgo directive that makes a Go function callable from C:
+// `//export Name`. The directive is a line comment whose text begins exactly
+// with `//export` followed by the exported Go function name.
+const cgoExportPrefix = "//export"
+
+// isSpace reports whether b is an ASCII space or tab — the separator cgo allows
+// between the `//export` directive and the function name.
+func isSpace(b byte) bool { return b == ' ' || b == '\t' }
+
+// reflectDispatchMethods are the reflect (and reflect.Value) methods whose first
+// string argument names a symbol reached dynamically: reflect.Value.MethodByName
+// invokes a method by name, FieldByName reads a field by name. A symbol whose
+// name appears as one of these literals could be reached invisibly, so the core
+// voice keeps it open-world.
+var reflectDispatchMethods = map[string]bool{
+	"MethodByName": true,
+	"FieldByName":  true,
+}
+
+// firstStringArg returns the content of a call's first argument when it is a
+// string literal, else "". Used to read the symbol name out of
+// `MethodByName("Foo")` / `FieldByName("Foo")`.
+func firstStringArg(call *sitter.Node, source []byte) string {
+	args := call.ChildByFieldName("arguments")
+	if args == nil || args.NamedChildCount() == 0 {
+		return ""
+	}
+	return stringLiteralContent(args.NamedChild(0), source)
+}
+
+// stringLiteralContent returns the inner text of an interpreted or raw string
+// literal (without the surrounding quotes/backticks), or "" for any other node
+// or an empty literal.
+func stringLiteralContent(n *sitter.Node, source []byte) string {
+	if n == nil {
+		return ""
+	}
+	switch n.Kind() {
+	case "interpreted_string_literal", "raw_string_literal":
+		for i := uint(0); i < n.NamedChildCount(); i++ {
+			c := n.NamedChild(i)
+			if c == nil {
+				continue
+			}
+			if c.Kind() == "interpreted_string_literal_content" || c.Kind() == "raw_string_literal_content" {
+				return extract.Text(c, source)
+			}
+		}
+	}
+	return ""
+}
+
+// hasStructTag reports whether a field_declaration carries a tag — a trailing
+// string literal after the field type (`Name string ` + "`json:\"name\"`" + `).
+func hasStructTag(fd *sitter.Node) bool {
+	for i := uint(0); i < fd.NamedChildCount(); i++ {
+		c := fd.NamedChild(i)
+		if c != nil && (c.Kind() == "raw_string_literal" || c.Kind() == "interpreted_string_literal") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/extract/golang/harvest_test.go
+++ b/internal/extract/golang/harvest_test.go
@@ -1,0 +1,450 @@
+package golang
+
+import (
+	"errors"
+	"sort"
+	"testing"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+)
+
+// captureEmitter records emitted symbols plus the streamed dispatch, mention,
+// and cgo-export names. It implements extract.Emitter, DispatchEmitter,
+// MentionEmitter, and CgoExportEmitter so a single Extract call exercises symbol
+// extraction and every harvest together.
+type captureEmitter struct {
+	symbols    []extract.EmittedSymbol
+	edges      []extract.EmittedEdge
+	dispatch   []string
+	mentions   []string
+	cgoExports []string
+}
+
+func (c *captureEmitter) Symbol(s extract.EmittedSymbol) error {
+	c.symbols = append(c.symbols, s)
+	return nil
+}
+func (c *captureEmitter) Edge(e extract.EmittedEdge) error { c.edges = append(c.edges, e); return nil }
+func (c *captureEmitter) DispatchName(name string) error {
+	c.dispatch = append(c.dispatch, name)
+	return nil
+}
+func (c *captureEmitter) MentionName(name string) error {
+	c.mentions = append(c.mentions, name)
+	return nil
+}
+func (c *captureEmitter) CgoExportName(name string) error {
+	c.cgoExports = append(c.cgoExports, name)
+	return nil
+}
+
+func has(names []string, want string) bool {
+	for _, n := range names {
+		if n == want {
+			return true
+		}
+	}
+	return false
+}
+
+// harvest parses Go source and runs the extractor into a fresh captureEmitter.
+func harvest(t *testing.T, src string) *captureEmitter {
+	t.Helper()
+	ex := Extractor{}
+	p := sitter.NewParser()
+	defer p.Close()
+	if err := p.SetLanguage(ex.Grammar()); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	source := []byte(src)
+	tree := p.Parse(source, nil)
+	if tree == nil {
+		t.Fatal("Parse returned nil tree")
+	}
+	defer tree.Close()
+	c := &captureEmitter{}
+	if err := ex.Extract(tree, source, "test.go", c); err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return c
+}
+
+func TestHarvestsMentionsTrue(t *testing.T) {
+	if !(Extractor{}).HarvestsMentions() {
+		t.Error("HarvestsMentions() = false, want true (Go streams the mention set)")
+	}
+}
+
+func TestMentionsCaptureUses(t *testing.T) {
+	c := harvest(t, `package p
+
+type T struct{}
+
+func (t *T) Run() {}
+
+func use() {
+	var x T
+	x.Run()
+	helper()
+}
+
+func helper() {}
+`)
+	// A call target, a selector method name, and a type reference are all
+	// mentions a hidden caller could leave.
+	for _, want := range []string{"helper", "Run", "T"} {
+		if !has(c.mentions, want) {
+			t.Errorf("mention %q missing; got %v", want, c.mentions)
+		}
+	}
+}
+
+func TestMentionsExcludeDefinitionNames(t *testing.T) {
+	// `lonely` is defined and never referenced: its only occurrence is the
+	// definition's own name, which the harvest skips. So it must NOT appear in
+	// the mention set — that absence is what lets the arbiter earn it `dead`.
+	c := harvest(t, `package p
+
+func lonely() {}
+`)
+	if has(c.mentions, "lonely") {
+		t.Errorf("definition name %q leaked into mentions: %v", "lonely", c.mentions)
+	}
+}
+
+func TestMentionsExcludeConstAndVarNames(t *testing.T) {
+	c := harvest(t, `package p
+
+const onlyConst = 1
+
+var onlyVar int
+`)
+	for _, name := range []string{"onlyConst", "onlyVar"} {
+		if has(c.mentions, name) {
+			t.Errorf("declaration name %q leaked into mentions: %v", name, c.mentions)
+		}
+	}
+}
+
+func TestMentionsIncludeInterfaceMethodName(t *testing.T) {
+	// An interface method declaration is deliberately left in the mention set so
+	// a concrete implementor of the same name stays open-world even when the
+	// resolver never drew the implicit satisfaction edge.
+	c := harvest(t, `package p
+
+type Runner interface {
+	Execute()
+}
+`)
+	if !has(c.mentions, "Execute") {
+		t.Errorf("interface method %q missing from mentions: %v", "Execute", c.mentions)
+	}
+}
+
+func TestDispatchMethodByName(t *testing.T) {
+	c := harvest(t, `package p
+
+func use(v reflectValue) {
+	v.MethodByName("Run")
+}
+`)
+	if !has(c.dispatch, "Run") {
+		t.Errorf("MethodByName arg %q missing from dispatch: %v", "Run", c.dispatch)
+	}
+}
+
+func TestDispatchFieldByName(t *testing.T) {
+	c := harvest(t, `package p
+
+func use(v reflectValue) {
+	v.FieldByName("Name")
+}
+`)
+	if !has(c.dispatch, "Name") {
+		t.Errorf("FieldByName arg %q missing from dispatch: %v", "Name", c.dispatch)
+	}
+}
+
+func TestDispatchRawStringArg(t *testing.T) {
+	c := harvest(t, "package p\n\nfunc use(v reflectValue) {\n\tv.MethodByName(`Raw`)\n}\n")
+	if !has(c.dispatch, "Raw") {
+		t.Errorf("raw-string MethodByName arg %q missing from dispatch: %v", "Raw", c.dispatch)
+	}
+}
+
+func TestDispatchStructTagFieldName(t *testing.T) {
+	c := harvest(t, "package p\n\ntype T struct {\n\tName string `json:\"name\"`\n\tPlain int\n}\n")
+	if !has(c.dispatch, "Name") {
+		t.Errorf("tagged field %q missing from dispatch: %v", "Name", c.dispatch)
+	}
+	if has(c.dispatch, "Plain") {
+		t.Errorf("untagged field %q must not enter dispatch: %v", "Plain", c.dispatch)
+	}
+}
+
+func TestDispatchEmptyWhenNone(t *testing.T) {
+	c := harvest(t, `package p
+
+func use() {
+	plain()
+}
+
+func plain() {}
+`)
+	if len(c.dispatch) != 0 {
+		t.Errorf("dispatch should be empty with no reflection/tags; got %v", c.dispatch)
+	}
+}
+
+func TestDispatchNonStringArgIgnored(t *testing.T) {
+	// A non-literal first argument (a variable) names nothing statically, so it
+	// must not enter the dispatch set.
+	c := harvest(t, `package p
+
+func use(v reflectValue, m string) {
+	v.MethodByName(m)
+	v.FieldByName()
+}
+`)
+	if len(c.dispatch) != 0 {
+		t.Errorf("non-literal/empty MethodByName args must not enter dispatch; got %v", c.dispatch)
+	}
+}
+
+func TestDispatchNonSelectorCallIgnored(t *testing.T) {
+	// A bare call named MethodByName (not a selector) is not a reflect call.
+	c := harvest(t, `package p
+
+func use() {
+	MethodByName("Run")
+}
+`)
+	if has(c.dispatch, "Run") {
+		t.Errorf("bare MethodByName call must not enter dispatch; got %v", c.dispatch)
+	}
+}
+
+// plainEmitter implements only extract.Emitter, proving the harvest is
+// best-effort: extraction still succeeds when the Emitter accepts no names.
+type plainEmitter struct{ symbols int }
+
+func (p *plainEmitter) Symbol(extract.EmittedSymbol) error { p.symbols++; return nil }
+func (p *plainEmitter) Edge(extract.EmittedEdge) error     { return nil }
+
+func TestHarvestOptionalEmitter(t *testing.T) {
+	ex := Extractor{}
+	p := sitter.NewParser()
+	defer p.Close()
+	if err := p.SetLanguage(ex.Grammar()); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	src := []byte("package p\n\nfunc use(v reflectValue) { v.MethodByName(\"Run\"); helper() }\n\nfunc helper() {}\n")
+	tree := p.Parse(src, nil)
+	defer tree.Close()
+	pe := &plainEmitter{}
+	if err := ex.Extract(tree, src, "test.go", pe); err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if pe.symbols == 0 {
+		t.Error("expected symbols emitted even without Dispatch/Mention emitter")
+	}
+}
+
+// failEmitter fails the chosen harvest stream so emit-error propagation is
+// exercised on both branches.
+type failEmitter struct {
+	failDispatch bool
+	failMention  bool
+	failCgo      bool
+}
+
+var errEmit = errors.New("emit failed")
+
+func (failEmitter) Symbol(extract.EmittedSymbol) error { return nil }
+func (failEmitter) Edge(extract.EmittedEdge) error     { return nil }
+func (f failEmitter) DispatchName(string) error {
+	if f.failDispatch {
+		return errEmit
+	}
+	return nil
+}
+func (f failEmitter) MentionName(string) error {
+	if f.failMention {
+		return errEmit
+	}
+	return nil
+}
+func (f failEmitter) CgoExportName(string) error {
+	if f.failCgo {
+		return errEmit
+	}
+	return nil
+}
+
+func extractInto(t *testing.T, src string, emit extract.Emitter) error {
+	t.Helper()
+	ex := Extractor{}
+	p := sitter.NewParser()
+	defer p.Close()
+	if err := p.SetLanguage(ex.Grammar()); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	source := []byte(src)
+	tree := p.Parse(source, nil)
+	defer tree.Close()
+	return ex.Extract(tree, source, "test.go", emit)
+}
+
+func TestDispatchEmitErrorPropagates(t *testing.T) {
+	err := extractInto(t, `package p
+
+func use(v reflectValue) { v.MethodByName("Run") }
+`, failEmitter{failDispatch: true})
+	if !errors.Is(err, errEmit) {
+		t.Errorf("DispatchName emit error not propagated; got %v", err)
+	}
+}
+
+func TestCgoEmitErrorPropagates(t *testing.T) {
+	err := extractInto(t, `package p
+
+//export GoCallback
+func GoCallback() {}
+`, failEmitter{failCgo: true})
+	if !errors.Is(err, errEmit) {
+		t.Errorf("CgoExportName emit error not propagated; got %v", err)
+	}
+}
+
+func TestMentionEmitErrorPropagates(t *testing.T) {
+	err := extractInto(t, `package p
+
+func use() { helper() }
+
+func helper() {}
+`, failEmitter{failMention: true})
+	if !errors.Is(err, errEmit) {
+		t.Errorf("MentionName emit error not propagated; got %v", err)
+	}
+}
+
+func TestCollectMentionedNamesDedup(t *testing.T) {
+	// `helper` is called twice but harvested once.
+	names := collectMentionedNamesFor(t, `package p
+
+func use() {
+	helper()
+	helper()
+}
+
+func helper() {}
+`)
+	count := 0
+	for _, n := range names {
+		if n == "helper" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("helper appears %d times in mentions, want 1 (deduped): %v", count, names)
+	}
+}
+
+func TestDispatchEmptyStringArgIgnored(t *testing.T) {
+	// An empty string literal names nothing: the literal node has no content
+	// child, so stringLiteralContent returns "" and nothing enters dispatch.
+	c := harvest(t, `package p
+
+func use(v reflectValue) {
+	v.MethodByName("")
+}
+`)
+	if len(c.dispatch) != 0 {
+		t.Errorf("empty MethodByName arg must not enter dispatch; got %v", c.dispatch)
+	}
+}
+
+func TestCgoExportCaptured(t *testing.T) {
+	c := harvest(t, `package p
+
+//export GoCallback
+func GoCallback() {}
+
+//export goHelper
+func goHelper() {}
+`)
+	for _, want := range []string{"GoCallback", "goHelper"} {
+		if !has(c.cgoExports, want) {
+			t.Errorf("cgo export %q missing; got %v", want, c.cgoExports)
+		}
+	}
+}
+
+func TestCgoExportIgnoresNonDirectives(t *testing.T) {
+	c := harvest(t, `package p
+
+// exported is just prose, not a directive
+//exporter typo, no space
+//export
+func helper() {}
+`)
+	if len(c.cgoExports) != 0 {
+		t.Errorf("non-directive comments must not enter cgo exports; got %v", c.cgoExports)
+	}
+}
+
+func TestCgoExportTabSeparator(t *testing.T) {
+	c := harvest(t, "package p\n\n//export\tTabbed\nfunc Tabbed() {}\n")
+	if !has(c.cgoExports, "Tabbed") {
+		t.Errorf("tab-separated //export name missing; got %v", c.cgoExports)
+	}
+}
+
+func TestStringLiteralContentNil(t *testing.T) {
+	if got := stringLiteralContent(nil, nil); got != "" {
+		t.Errorf("stringLiteralContent(nil) = %q, want \"\"", got)
+	}
+}
+
+func TestWalkNamedNil(t *testing.T) {
+	// A nil root is a no-op, not a panic.
+	walkNamed(nil, func(*sitter.Node) { t.Fatal("visit called on nil tree") })
+}
+
+func TestIsGoDefinitionNameRoot(t *testing.T) {
+	// The root node has no parent, so it is never a definition name.
+	ex := Extractor{}
+	p := sitter.NewParser()
+	defer p.Close()
+	if err := p.SetLanguage(ex.Grammar()); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	src := []byte("package p\n")
+	tree := p.Parse(src, nil)
+	defer tree.Close()
+	if isGoDefinitionName(tree.RootNode()) {
+		t.Error("root node should not be a definition name")
+	}
+}
+
+func collectMentionedNamesFor(t *testing.T, src string) []string {
+	t.Helper()
+	ex := Extractor{}
+	p := sitter.NewParser()
+	defer p.Close()
+	if err := p.SetLanguage(ex.Grammar()); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	source := []byte(src)
+	tree := p.Parse(source, nil)
+	defer tree.Close()
+	mentions := collectGoHarvest(tree.RootNode(), source).mentions
+	out := make([]string, 0, len(mentions))
+	for n := range mentions {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/mcpserver/handler_test.go
+++ b/internal/mcpserver/handler_test.go
@@ -783,11 +783,12 @@ func TestHandleDeadCode(t *testing.T) {
 				if err := json.Unmarshal([]byte(text), &resp); err != nil {
 					t.Fatalf("unmarshal: %v", err)
 				}
-				// Seeded data is Go, which has no language voice, so every
-				// unreferenced symbol is possibly_dead (core_no_language_voice),
-				// never an earned dead — the honest default on an unsupported stack.
+				// Seeded data is Go, but this DB is hand-built and never scanned, so
+				// no Go mention harvest ran. The per-language soundness gate fails
+				// closed (core_no_harvest), keeping every unreferenced symbol
+				// possibly_dead — never an earned dead off an absent harvest.
 				if resp.DeadCount != 0 {
-					t.Errorf("Go has no language voice; expected 0 earned dead, got %d", resp.DeadCount)
+					t.Errorf("no Go mention harvest in seeded data; expected 0 earned dead, got %d", resp.DeadCount)
 				}
 				if resp.PossiblyDeadCount == 0 {
 					t.Error("expected possibly_dead symbols (model.Order has zero incoming edges)")

--- a/internal/scan/dispatch.go
+++ b/internal/scan/dispatch.go
@@ -97,6 +97,22 @@ func writeHarvestedLangs(ctx context.Context, idx *sqlite.Adapter, collected map
 	return writeNameSet(ctx, idx, harvestedLangsMetaKey, collected)
 }
 
+// cgoExportsMetaKey is the sense_meta key holding the project-wide set of Go
+// function names marked with a cgo `//export` directive, as a JSON string array.
+// The dead-code Go voice reads it: a function whose name appears here is called
+// from C with no Go caller, so it stays open-world (go_cgo) rather than earning
+// `dead`. Flat, not per-language — cgo is Go-only. A pre-feature index has no
+// such key, which reads as an empty set (no cgo functions known), the safe
+// direction: a real cgo export then degrades to a possible false `dead` only
+// until the next full scan harvests it, never a crash.
+const cgoExportsMetaKey = "cgo_exports"
+
+// writeCgoExports persists the project-wide cgo-export set, unioning with the
+// existing set (same self-heals-on-rebuild rationale as the other name sets).
+func writeCgoExports(ctx context.Context, idx *sqlite.Adapter, collected map[string]struct{}) error {
+	return writeNameSet(ctx, idx, cgoExportsMetaKey, collected)
+}
+
 // addNamesByLang unions names into byLang[lang], creating the language's set on
 // first use. Both per-language name accumulators (dispatch, mention) share it so
 // the handler keeps each language's names apart for per-language meta writes.

--- a/internal/scan/dispatch_test.go
+++ b/internal/scan/dispatch_test.go
@@ -217,11 +217,11 @@ func TestDispatchNamesAdapterErrors(t *testing.T) {
 }
 
 // TestScanWritesHarvestedLangs proves the harvested-langs capability gate
-// end to end: a Ruby file marks `ruby` harvested (its extractor is a
-// MentionHarvester), while a Go file in the same scan does NOT mark `go` — Go
-// harvests no mentions, so its symbols must fail closed rather than earn `dead`
-// off an absent set. This is what lets HarvestedLangs diverge from the mention
-// keyset for a real, non-harvesting language.
+// end to end: Ruby and Go files mark their languages harvested (both extractors
+// are MentionHarvesters), while a Python file in the same scan does NOT mark
+// `python` — Python harvests no mentions, so its symbols must fail closed rather
+// than earn `dead` off an absent set. This is what lets HarvestedLangs diverge
+// from the mention keyset for a real, non-harvesting language.
 func TestScanWritesHarvestedLangs(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()
@@ -234,6 +234,10 @@ func TestScanWritesHarvestedLangs(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, "main.go"),
 		[]byte("package main\n\nfunc main() {}\n"), 0o644); err != nil {
 		t.Fatalf("write go: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "thing.py"),
+		[]byte("def helper():\n    pass\n"), 0o644); err != nil {
+		t.Fatalf("write python: %v", err)
 	}
 
 	if _, err := Run(ctx, Options{Root: root, Sense: senseDir, Output: &bytes.Buffer{}, Warnings: io.Discard}); err != nil {
@@ -250,11 +254,46 @@ func TestScanWritesHarvestedLangs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read harvested_langs: %v", err)
 	}
-	if _, ok := got["ruby"]; !ok {
-		t.Errorf("expected ruby in harvested_langs, got %v", got)
+	for _, lang := range []string{"ruby", "go"} {
+		if _, ok := got[lang]; !ok {
+			t.Errorf("expected %s in harvested_langs, got %v", lang, got)
+		}
 	}
-	if _, ok := got["go"]; ok {
-		t.Errorf("go harvests no mentions; must be absent from harvested_langs, got %v", got)
+	if _, ok := got["python"]; ok {
+		t.Errorf("python harvests no mentions; must be absent from harvested_langs, got %v", got)
+	}
+}
+
+// TestScanWritesCgoExports proves the cgo-export harvest flows end to end: a Go
+// file with a `//export` directive lands its function name in the cgo_exports
+// sense_meta key, where the dead-code Go voice reads it to keep the function
+// open-world (it is called from C, never by a Go caller).
+func TestScanWritesCgoExports(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	senseDir := filepath.Join(root, ".sense")
+
+	if err := os.WriteFile(filepath.Join(root, "bridge.go"),
+		[]byte("package main\n\n//export GoCallback\nfunc GoCallback() {}\n\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatalf("write go: %v", err)
+	}
+
+	if _, err := Run(ctx, Options{Root: root, Sense: senseDir, Output: &bytes.Buffer{}, Warnings: io.Discard}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+
+	a, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatalf("open index: %v", err)
+	}
+	t.Cleanup(func() { _ = a.Close() })
+
+	got, err := readNameSet(ctx, a, cgoExportsMetaKey)
+	if err != nil {
+		t.Fatalf("read cgo_exports: %v", err)
+	}
+	if _, ok := got["GoCallback"]; !ok {
+		t.Errorf("expected GoCallback in cgo_exports, got %v", got)
 	}
 }
 

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -233,6 +233,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 		warnMetaWrite(warn, "mentioned-names:"+lang, writeMentionedNames(ctx, idx, lang, set))
 	}
 	warnMetaWrite(warn, "harvested-langs", writeHarvestedLangs(ctx, idx, h.harvestedLangs))
+	warnMetaWrite(warn, "cgo-exports", writeCgoExports(ctx, idx, h.cgoExports))
 	// A pre-feature index carried single bare union keys (no language suffix).
 	// The per-language reader globs `*:<lang>` and ignores them, but delete them
 	// on every full scan so an in-place upgrade leaves no stale meta to mislead a
@@ -521,6 +522,14 @@ type harness struct {
 	// file's mentions survive.
 	mentionedNames map[string]map[string]struct{}
 
+	// cgoExports is the project-wide set of Go function names marked with a cgo
+	// `//export` directive. Written to the cgo_exports sense_meta key so the
+	// dead-code Go voice keeps a C-callable function open-world (go_cgo) rather
+	// than earning it `dead` off its absent Go caller. Flat (not per-language):
+	// cgo is Go-only. Only populated for changed files this scan; merged with the
+	// persisted set so an unchanged file's exports are not lost.
+	cgoExports map[string]struct{}
+
 	// harvestedLangs is the set of languages whose mention harvest RAN this
 	// scan — every indexed file whose extractor is an extract.MentionHarvester
 	// marks its language here, regardless of how many names it produced. Written
@@ -747,6 +756,14 @@ func (h *harness) walkTree(root string) error {
 			}
 			addNamesByLang(h.mentionedNames, fr.Language, fr.MentionedNames)
 		}
+		if len(fr.CgoExports) > 0 {
+			if h.cgoExports == nil {
+				h.cgoExports = map[string]struct{}{}
+			}
+			for _, n := range fr.CgoExports {
+				h.cgoExports[n] = struct{}{}
+			}
+		}
 
 		batch = append(batch, fr)
 		if len(batch) >= batchSize {
@@ -822,6 +839,7 @@ type fileResult struct {
 	Edges          []extract.EmittedEdge
 	DispatchNames  []string
 	MentionedNames []string
+	CgoExports     []string
 }
 
 // 100 files per SQLite transaction amortizes BEGIN/COMMIT overhead (~10x
@@ -939,6 +957,7 @@ func parseFileCore(po parseOpts, path, rel string, skip func(hash string) bool) 
 		Edges:          collected.edges,
 		DispatchNames:  collected.dispatchNames,
 		MentionedNames: collected.mentionedNames,
+		CgoExports:     collected.cgoExports,
 	}
 }
 
@@ -1272,6 +1291,7 @@ type collector struct {
 	edges          []extract.EmittedEdge
 	dispatchNames  []string
 	mentionedNames []string
+	cgoExports     []string
 }
 
 func (c *collector) Symbol(s extract.EmittedSymbol) error {
@@ -1296,6 +1316,15 @@ func (c *collector) DispatchName(name string) error {
 // caller could be.
 func (c *collector) MentionName(name string) error {
 	c.mentionedNames = append(c.mentionedNames, name)
+	return nil
+}
+
+// CgoExportName implements extract.CgoExportEmitter: an extractor streams every
+// name marked with a cgo `//export` directive. The project-wide set feeds the
+// dead-code Go voice so a function called only from C stays open-world (go_cgo)
+// instead of being falsely called dead.
+func (c *collector) CgoExportName(name string) error {
+	c.cgoExports = append(c.cgoExports, name)
 	return nil
 }
 

--- a/testdata/smoke/dead-golden.json
+++ b/testdata/smoke/dead-golden.json
@@ -46,7 +46,7 @@
       "kind": "method",
       "file": "service.go",
       "verdict": "possibly_dead",
-      "reason": "core_exported_api"
+      "reason": "go_interface"
     },
     {
       "qualified": "smoke.PaymentGateway.Refund",
@@ -61,9 +61,22 @@
       "file": "checkout.go",
       "verdict": "possibly_dead",
       "reason": "core_exported_api"
+    },
+    {
+      "qualified": "smoke.init",
+      "kind": "function",
+      "file": "ledger.go",
+      "verdict": "possibly_dead",
+      "reason": "go_init"
+    },
+    {
+      "qualified": "smoke.reconcileLedger",
+      "kind": "function",
+      "file": "ledger.go",
+      "verdict": "dead"
     }
   ],
-  "total_symbols": 32,
-  "dead_count": 1,
-  "possibly_dead_count": 8
+  "total_symbols": 34,
+  "dead_count": 2,
+  "possibly_dead_count": 9
 }

--- a/testdata/smoke/ledger.go
+++ b/testdata/smoke/ledger.go
@@ -1,0 +1,11 @@
+package smoke
+
+// reconcileLedger is unexported, has no caller, and its name is mentioned
+// nowhere else — the genuinely-dead shape the Go voice earns `dead` for.
+func reconcileLedger() {}
+
+// init is run by the Go runtime at package load, not by a caller. The Go voice
+// keeps it possibly_dead (go_init); it must never earn `dead`.
+func init() {
+	_ = 1
+}


### PR DESCRIPTION
## Problem

Every Go symbol Sense reported was `possibly_dead` with reason `core_no_language_voice` — the honest default for any stack with no registered voice. That surrenders the one language where a `dead` verdict can be made airtight: Go is statically typed and compiled, its visibility is structural (capitalized = exported), and the toolchain already ships an oracle for exactly this class (`staticcheck`'s `U1000`, unused unexported symbols). An agent asking "what is safe to delete in this Go package?" deserved a precise answer, not a wall of `possibly_dead`.

## Summary

Add a Go language voice so Go becomes the second language whose symbols can earn the `dead` verdict, with the verdict validated against `staticcheck U1000` as a compiler-grade oracle.

## Changes

**Harvest seam (`internal/extract`, `internal/scan`)**
- The Go extractor harvests, in a single tree walk per file, its broad mention set (the per-language soundness gate), reflective dispatch targets (`reflect.MethodByName` / `FieldByName` args, tagged struct-field names), and cgo `//export` names.
- New `extract.CgoExportEmitter`; the scan persists `//export` names to a flat `cgo_exports` meta key.
- Blank declarations (`const _`, `var _`) are no longer emitted as symbols (a blank is never an unused-symbol finding).

**Go voice (`internal/dead`)**
- `goVoice` earns `dead` only for an unexported func/method/type with no caller, no mention, and no invisible-reach idiom. Everything else stays `possibly_dead` with an exact reason: `go_init`, `go_interface` (indexed + stdlib interface methods), `go_cgo`, `go_generated`, `go_exported`, `go_const`.
- `Facts.InterfaceMethodNames` and `Facts.CgoExportNames` are populated; the shared `core_reflection` hint is now language-neutral.
- `init`/`Init` are no longer treated as constructors — the voice owns `init` (`go_init`) so it surfaces with an accurate "runtime-invoked" hint.
- `testdata/` fixtures are excluded from candidacy, matching the Go toolchain's universe so fixtures are never reported as removable.

**staticcheck oracle (`internal/dead/eval`)**
- A runner that scans a repo, runs `staticcheck -checks U1000`, and asserts Sense's `dead` set is a subset (zero false `dead`). Matches on (file, bare-name) to survive line/column drift; injects its command runner so all exit shapes test without the binary installed.

## Breaking Changes

⚠️ Dead-code output now reports Go symbols with Go-specific reasons and can mark Go symbols `dead`. Previously every Go symbol was `possibly_dead` / `core_no_language_voice`. No wire-schema change.

## Test Plan

- [x] Two-sided gate proven end to end (golden): an unexported helper earns `dead`; an `init` and an interface method stay `possibly_dead` with exact reasons.
- [x] Per-reason unit tests for every `go_*` code; planted false-`dead` is detected by the oracle gate.
- [x] Binding gate on real repos (gin, sense): zero false `dead`, validated against `staticcheck U1000` (sense: 2 dead, 100% recall; gin: 0).
- [x] `go test ./...` passes; `make ci` green (0 lint issues).
- [x] sense binary builds cleanly.
