### PR TITLE
feat(dead): add Rust dead-code voice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to Sense.
 
 ### Added
 
+- Rust is the third language whose symbols can earn the `dead` verdict. The Rust
+  voice earns `dead` only for a non-`pub` fn / method / type / struct / enum /
+  trait with no caller, no mention, and no invisible-reach idiom; everything else
+  stays `possibly_dead` with an exact reason: `rust_trait_impl` (a method in an
+  `impl Trait for Type` block, or named on an indexed/std trait like `Display` /
+  `Iterator` / serde's `Deserializer`), `rust_derive` (a `#[derive(...)]`-synthesized
+  method name like `clone` / `fmt` / `eq` / `serialize`), `rust_ffi` (a
+  `#[no_mangle]` / `#[export_name]` function called from C), `rust_used` (a
+  `#[no_mangle]` / `#[used]` static kept alive by the linker), `rust_test` (a
+  `#[test]` / `#[bench]` or `#[cfg(test)]` item, including scoped `#[tokio::test]`),
+  `rust_allow_dead` (an `#[allow(dead_code)]` / `#[allow(unused)]` item the author
+  intentionally retained), `rust_module` (rustc lints items inside a module, never
+  the `mod`), and `rust_pub` (another crate may use it). The Rust extractor harvests
+  its own mention set (the per-language soundness gate), `Any::downcast` dispatch
+  targets, FFI / `#[used]` exports, test symbols, `impl Trait for` method names, and
+  `#[allow(dead_code)]` markers. The verdict is validated against `cargo check`
+  `dead_code` as a compiler-grade oracle (binding invariant: Sense `dead` for Rust
+  ⊆ cargo `dead_code` — zero false `dead` on the `axum` benchmark repo).
+
 - Go is the second language whose symbols can earn the `dead` verdict. The Go
   voice earns `dead` only for an unexported func / method / type with no caller,
   no mention, and no invisible-reach idiom; everything else stays `possibly_dead`

--- a/internal/dead/arbiter.go
+++ b/internal/dead/arbiter.go
@@ -102,6 +102,34 @@ type Facts struct {
 	// its absent caller. Flat, not per-language: cgo is Go-only. Populated from the
 	// cgo_exports sense_meta key; an absent key yields an empty set (no cgo known).
 	CgoExportNames map[string]struct{}
+	// RustExportNames is the set of Rust function/static names whose reachability
+	// the edge graph cannot see: `#[no_mangle]` / `#[export_name]` functions
+	// (called across the FFI boundary) and `#[no_mangle]` / `#[used]` statics
+	// (kept alive by the linker). The Rust voice keeps such a name open-world
+	// (rust_ffi for a function, rust_used for a static). Flat, not per-language —
+	// these are Rust-only attributes. Populated from the rust_exports sense_meta
+	// key; an absent key yields an empty set.
+	RustExportNames map[string]struct{}
+	// RustTestSymbolNames is the set of Rust test-only symbol names (`#[test]` /
+	// `#[bench]`, or nested under a `#[cfg(test)]` module). The Rust voice keeps
+	// them open-world (rust_test): the test harness invokes them and `cargo build`
+	// does not compile them, so a zero-edge verdict would be a false `dead`.
+	// Populated from the rust_test_symbols sense_meta key.
+	RustTestSymbolNames map[string]struct{}
+	// RustTraitImplMethodNames is the set of method names defined in `impl Trait
+	// for Type` blocks. The Rust voice keeps such a method open-world
+	// (rust_trait_impl): it satisfies a trait and is reached through a trait object
+	// or generic bound, where the static graph shows no direct caller. This is the
+	// sound, name-independent trait-impl signal — it covers external traits (serde's
+	// Deserializer, std::io::Write, …) the voice's static table cannot enumerate.
+	// Populated from the rust_trait_impl_methods sense_meta key.
+	RustTraitImplMethodNames map[string]struct{}
+	// RustAllowDeadNames is the set of Rust item names annotated
+	// `#[allow(dead_code)]` / `#[allow(unused)]`. The Rust voice keeps such a name
+	// open-world (rust_allow_dead): the author deliberately suppressed the lint, so
+	// rustc never warns it and it is absent from the cargo oracle. Populated from
+	// the rust_allow_dead sense_meta key.
+	RustAllowDeadNames map[string]struct{}
 	// HarvestedLangs is the set of languages whose mention harvest actually ran
 	// for this index. The soundness gate refuses `dead` for a symbol whose
 	// language is absent here (reason core_no_harvest): a missing harvest cannot

--- a/internal/dead/arbiter_test.go
+++ b/internal/dead/arbiter_test.go
@@ -223,6 +223,46 @@ func TestFrameworkAppMethodGetsLanguageReasonNotExportedAPI(t *testing.T) {
 	}
 }
 
+// TestRustArbiterTwoSidedGate is the Rust two-sided control on the real voice
+// stack: a non-`pub`, unmentioned Rust function earns `dead`, while a trait-impl
+// method, a `pub` library function (core_exported_api, not rust_pub), and a
+// `#[no_mangle]` export all stay possibly_dead with the exact reason. It proves
+// the Rust voice composes with the core voice and the per-language soundness gate.
+func TestRustArbiterTwoSidedGate(t *testing.T) {
+	a := defaultArbiter()
+	f := Facts{
+		IsLibrary:            true,
+		HarvestedLangs:       harvested("rust"),
+		MentionedNames:       langNames("rust", "process", "public_api", "ffi_entry"),
+		InterfaceMethodNames: map[string]struct{}{"process": {}},
+		RustExportNames:      map[string]struct{}{"ffi_entry": {}},
+	}
+
+	dead := Symbol{Name: "orphan", Qualified: "m::orphan", Kind: "function", Visibility: "private", Language: "rust"}
+	trait := Symbol{Name: "process", Qualified: "m::Money::process", Kind: "method", Visibility: "private", Language: "rust"}
+	pub := Symbol{Name: "public_api", Qualified: "m::public_api", Kind: "function", Visibility: "public", Language: "rust"}
+	ffi := Symbol{Name: "ffi_entry", Qualified: "m::ffi_entry", Kind: "function", Visibility: "public", Language: "rust"}
+
+	got := a.Decide([]Symbol{dead, trait, pub, ffi}, f)
+
+	// orphan: non-pub, unmentioned, no idiom → earns dead.
+	if got[0].Verdict != VerdictDead {
+		t.Errorf("orphan: verdict = %q (reason %+v), want dead", got[0].Verdict, got[0].Reason)
+	}
+	// process: trait method name → rust_trait_impl, possibly_dead.
+	if got[1].Verdict != VerdictPossiblyDead || got[1].Reason == nil || got[1].Reason.Code != ReasonRustTraitImpl {
+		t.Errorf("process: got (%q, %+v), want (possibly_dead, rust_trait_impl)", got[1].Verdict, got[1].Reason)
+	}
+	// public_api: pub callable in a library → core_exported_api wins over rust_pub.
+	if got[2].Reason == nil || got[2].Reason.Code != ReasonExportedAPI {
+		t.Errorf("public_api: reason = %+v, want core_exported_api", got[2].Reason)
+	}
+	// ffi_entry: #[no_mangle] export → rust_ffi (wins over the pub gate).
+	if got[3].Reason == nil || got[3].Reason.Code != ReasonRustFFI {
+		t.Errorf("ffi_entry: reason = %+v, want rust_ffi", got[3].Reason)
+	}
+}
+
 func TestReasonCatalogLookup(t *testing.T) {
 	if reasonPriority(ReasonNoLanguageVoice) != 70 {
 		t.Errorf("no_language_voice priority = %d, want 70", reasonPriority(ReasonNoLanguageVoice))

--- a/internal/dead/dead.go
+++ b/internal/dead/dead.go
@@ -135,7 +135,7 @@ func FindDead(ctx context.Context, db *sql.DB, opts Options) (Result, error) {
 // core voice plus the Ruby and Rails language voices. Adding a language voice
 // (Go, TS, Python) is a one-line change here once it exists.
 func defaultArbiter() *Arbiter {
-	return NewArbiter(coreVoice{}, rubyVoice{}, railsVoice{}, goVoice{})
+	return NewArbiter(coreVoice{}, rubyVoice{}, railsVoice{}, goVoice{}, rustVoice{})
 }
 
 // buildFacts gathers the project-wide index facts the voices consume. It is
@@ -181,6 +181,10 @@ func buildFacts(ctx context.Context, db *sql.DB) (Facts, error) {
 		// distinct from a language that never harvested (absent here → fail closed).
 		HarvestedLangs:       readHarvestedLangs(ctx, db),
 		CgoExportNames:       readCgoExportNames(ctx, db),
+		RustExportNames:          readRustExportNames(ctx, db),
+		RustTestSymbolNames:      readRustTestSymbolNames(ctx, db),
+		RustTraitImplMethodNames: readRustTraitImplMethodNames(ctx, db),
+		RustAllowDeadNames:       readRustAllowDeadNames(ctx, db),
 		ValueObjectClassIDs:  valueObjectClassIDs,
 		IncludedModuleIDs:    includedModuleIDs,
 		ControllerConcernIDs: controllerConcernIDs,
@@ -805,6 +809,40 @@ func readHarvestedLangs(ctx context.Context, db *sql.DB) map[string]struct{} {
 // full scan, never a crash.
 func readCgoExportNames(ctx context.Context, db *sql.DB) map[string]struct{} {
 	return readStringSetMeta(ctx, db, "cgo_exports")
+}
+
+// readRustExportNames returns the set of Rust function/static names whose
+// reachability the edge graph cannot see (`#[no_mangle]` / `#[export_name]`
+// functions, `#[no_mangle]` / `#[used]` statics), persisted to the rust_exports
+// sense_meta key by the scan layer. The Rust voice keeps such a name open-world
+// (rust_ffi / rust_used). A missing or corrupt key yields an empty set — degrading
+// to a possible false `dead` only until the next full scan, never a crash.
+func readRustExportNames(ctx context.Context, db *sql.DB) map[string]struct{} {
+	return readStringSetMeta(ctx, db, "rust_exports")
+}
+
+// readRustTestSymbolNames returns the set of Rust test-only symbol names
+// (`#[test]` / `#[bench]`, or nested under `#[cfg(test)]`), persisted to the
+// rust_test_symbols sense_meta key by the scan layer. The Rust voice keeps them
+// open-world (rust_test). A missing or corrupt key yields an empty set.
+func readRustTestSymbolNames(ctx context.Context, db *sql.DB) map[string]struct{} {
+	return readStringSetMeta(ctx, db, "rust_test_symbols")
+}
+
+// readRustTraitImplMethodNames returns the set of method names defined in
+// `impl Trait for Type` blocks, persisted to the rust_trait_impl_methods
+// sense_meta key by the scan layer. The Rust voice keeps such a name open-world
+// (rust_trait_impl). A missing or corrupt key yields an empty set.
+func readRustTraitImplMethodNames(ctx context.Context, db *sql.DB) map[string]struct{} {
+	return readStringSetMeta(ctx, db, "rust_trait_impl_methods")
+}
+
+// readRustAllowDeadNames returns the set of Rust item names annotated
+// `#[allow(dead_code)]` / `#[allow(unused)]`, persisted to the rust_allow_dead
+// sense_meta key by the scan layer. The Rust voice keeps such a name open-world
+// (rust_allow_dead). A missing or corrupt key yields an empty set.
+func readRustAllowDeadNames(ctx context.Context, db *sql.DB) map[string]struct{} {
+	return readStringSetMeta(ctx, db, "rust_allow_dead")
 }
 
 // readStringSetMeta reads a JSON string-array sense_meta value into a set,

--- a/internal/dead/eval/cargo.go
+++ b/internal/dead/eval/cargo.go
@@ -1,0 +1,215 @@
+package eval
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/luuuc/sense/internal/dead"
+	"github.com/luuuc/sense/internal/scan"
+)
+
+// The cargo oracle is the Rust voice's compiler-grade trust gate. rustc's
+// `dead_code` lint flags exactly Sense's earned-`dead` class — unused non-`pub`
+// items — but with the full type system, trait resolution, and macro expansion
+// Sense lacks. So the binding invariant is a SUBSET, not equality:
+//
+//	Sense `dead` (Rust) ⊆ cargo `dead_code`
+//
+// A Sense `dead` symbol that cargo does NOT flag is a false `dead` and fails the
+// gate (precision is the only unforgivable error, per 25-13). The reverse — cargo
+// flags more than Sense — is acceptable lost recall, since Sense fails closed on
+// anything it cannot prove (an unbound mention, an un-harvested language, a `pub`
+// item, a trait/derive/FFI/test idiom).
+
+// rustSymRef identifies a Rust symbol by repo-relative file and bare name — the
+// join key between Sense's `dead` set and cargo's dead_code findings. Keyed on
+// name+file rather than line/column so the two tools' slightly different position
+// reporting never causes a spurious mismatch.
+type rustSymRef struct {
+	File string
+	Name string
+}
+
+// DeadCodeSet is the set of symbols cargo flags as dead (the dead_code lint).
+type DeadCodeSet map[rustSymRef]struct{}
+
+// RustDead is one symbol Sense earns the `dead` verdict for, carrying the fields
+// needed to join against the oracle and to report a violation legibly.
+type RustDead struct {
+	Qualified string
+	File      string
+	Name      string
+}
+
+// deadCodeNameRe pulls the backtick-quoted identifier(s) out of a rustc dead_code
+// message, e.g. "function `foo` is never used", "associated function `new` is
+// never used", "struct `Bar` is never constructed". A grouped message ("methods
+// `a` and `b` are never used") yields each name; all share the diagnostic's file.
+var deadCodeNameRe = regexp.MustCompile("`([A-Za-z_][A-Za-z0-9_]*)`")
+
+// cargoMessage is the minimal shape of one `--message-format=json` line: cargo
+// wraps each rustc diagnostic as {"reason":"compiler-message","message":{…}}. We
+// read only the dead_code diagnostics' message text and primary span file.
+type cargoMessage struct {
+	Reason  string `json:"reason"`
+	Message *struct {
+		Message string `json:"message"`
+		Code    *struct {
+			Code string `json:"code"`
+		} `json:"code"`
+		Spans []struct {
+			FileName  string `json:"file_name"`
+			IsPrimary bool   `json:"is_primary"`
+		} `json:"spans"`
+	} `json:"message"`
+}
+
+// ParseCargoDeadCode parses `cargo check --message-format=json` output into the
+// set of flagged (file, bare-name) symbols. Non-JSON lines and non-dead_code
+// diagnostics are ignored, so the parser tolerates the build/progress noise cargo
+// interleaves on the same stream.
+func ParseCargoDeadCode(output string) DeadCodeSet {
+	set := DeadCodeSet{}
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || line[0] != '{' {
+			continue
+		}
+		var m cargoMessage
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			continue
+		}
+		if m.Reason != "compiler-message" || m.Message == nil {
+			continue
+		}
+		if m.Message.Code == nil || m.Message.Code.Code != "dead_code" {
+			continue
+		}
+		file := primarySpanFile(m)
+		if file == "" {
+			continue
+		}
+		for _, nm := range deadCodeNameRe.FindAllStringSubmatch(m.Message.Message, -1) {
+			set[rustSymRef{File: normalizeRel(file), Name: nm[1]}] = struct{}{}
+		}
+	}
+	return set
+}
+
+// primarySpanFile returns the file of the diagnostic's primary span, falling back
+// to the first span when none is marked primary.
+func primarySpanFile(m cargoMessage) string {
+	if m.Message == nil || len(m.Message.Spans) == 0 {
+		return ""
+	}
+	for _, s := range m.Message.Spans {
+		if s.IsPrimary {
+			return s.FileName
+		}
+	}
+	return m.Message.Spans[0].FileName
+}
+
+// ErrCargoUnavailable is returned by RunCargoDeadCode when the cargo binary cannot
+// be launched, so callers can skip rather than fail.
+var ErrCargoUnavailable = fmt.Errorf("cargo unavailable")
+
+// runCargo launches `cargo check --message-format=json` in repoRoot and returns
+// its combined output. It is a package var so tests can inject canned output and
+// error shapes deterministically, without depending on the toolchain. `check`
+// (not `build`) is enough for the dead_code lint and far faster.
+var runCargo = func(ctx context.Context, repoRoot string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "cargo", "check", "--message-format=json")
+	cmd.Dir = repoRoot
+	return cmd.CombinedOutput()
+}
+
+// RunCargoDeadCode runs cargo in repoRoot and returns the parsed dead_code set.
+// cargo exits non-zero on a compile error but still streams the diagnostics it
+// produced, so an ExitError with parseable output is success; only a failure to
+// launch the binary (e.g. not installed) is fatal. The caller is expected to skip
+// when ErrCargoUnavailable is returned.
+//
+// FRESHNESS: cargo only emits diagnostics for crates it (re)compiles. On an
+// already-built target an up-to-date `cargo check` recompiles nothing and returns
+// an EMPTY set — which reads as "no dead code" but means "nothing rebuilt". A
+// caller validating a real repo must force a fresh build first (`cargo clean`, a
+// throwaway `CARGO_TARGET_DIR`, or touching the workspace sources). The temp-crate
+// callers in this package are always fresh, so they need no such step.
+func RunCargoDeadCode(ctx context.Context, repoRoot string) (DeadCodeSet, error) {
+	out, err := runCargo(ctx, repoRoot)
+	if err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			return nil, fmt.Errorf("%w: %v", ErrCargoUnavailable, err)
+		}
+	}
+	return ParseCargoDeadCode(string(out)), nil
+}
+
+// RustDeadSymbols scans repoRoot with Sense and returns the Rust symbols it earns
+// the `dead` verdict for — the left side of the subset gate.
+func RustDeadSymbols(ctx context.Context, repoRoot, senseDir string) ([]RustDead, error) {
+	if _, err := scan.Run(ctx, scan.Options{
+		Root:     repoRoot,
+		Sense:    senseDir,
+		Output:   &bytes.Buffer{},
+		Warnings: io.Discard,
+	}); err != nil {
+		return nil, fmt.Errorf("scan %s: %w", repoRoot, err)
+	}
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		return nil, fmt.Errorf("open index: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	res, err := dead.FindDead(ctx, db, dead.Options{Language: "rust", Limit: 1000000})
+	if err != nil {
+		return nil, fmt.Errorf("find dead: %w", err)
+	}
+	var out []RustDead
+	for _, f := range res.Findings {
+		if f.Verdict != dead.VerdictDead {
+			continue
+		}
+		out = append(out, RustDead{
+			Qualified: f.Symbol.Qualified,
+			File:      normalizeRel(f.Symbol.File),
+			Name:      f.Symbol.Name,
+		})
+	}
+	return out, nil
+}
+
+// RustFalseDeads returns the Sense `dead` Rust symbols absent from the cargo
+// dead_code set — the gate violations. An empty result is the only passing state:
+// every symbol Sense called `dead` is one cargo independently agrees is unused.
+// Order is stable for legible reporting.
+func RustFalseDeads(senseDead []RustDead, oracle DeadCodeSet) []RustDead {
+	var out []RustDead
+	for _, d := range senseDead {
+		if _, ok := oracle[rustSymRef{File: d.File, Name: d.Name}]; !ok {
+			out = append(out, d)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].File != out[j].File {
+			return out[i].File < out[j].File
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}

--- a/internal/dead/eval/cargo_test.go
+++ b/internal/dead/eval/cargo_test.go
@@ -1,0 +1,272 @@
+package eval
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseCargoDeadCode(t *testing.T) {
+	out := `{"reason":"compiler-artifact","package_id":"x"}
+{"reason":"compiler-message","message":{"message":"function ` + "`dead_helper`" + ` is never used","code":{"code":"dead_code"},"level":"warning","spans":[{"file_name":"src/lib.rs","is_primary":true}]}}
+{"reason":"compiler-message","message":{"message":"method ` + "`compute`" + ` is never used","code":{"code":"dead_code"},"level":"warning","spans":[{"file_name":"./src/money.rs","is_primary":true}]}}
+{"reason":"compiler-message","message":{"message":"struct ` + "`Unused`" + ` is never constructed","code":{"code":"dead_code"},"level":"warning","spans":[{"file_name":"src/lib.rs","is_primary":true}]}}
+{"reason":"compiler-message","message":{"message":"unused variable: ` + "`x`" + `","code":{"code":"unused_variables"},"level":"warning","spans":[{"file_name":"src/lib.rs","is_primary":true}]}}
+not json at all`
+	set := ParseCargoDeadCode(out)
+
+	want := []rustSymRef{
+		{File: "src/lib.rs", Name: "dead_helper"},
+		{File: "src/money.rs", Name: "compute"}, // leading ./ normalized
+		{File: "src/lib.rs", Name: "Unused"},
+	}
+	if len(set) != len(want) {
+		t.Fatalf("parsed %d entries, want %d: %v", len(set), len(want), set)
+	}
+	for _, w := range want {
+		if _, ok := set[w]; !ok {
+			t.Errorf("missing %v in parsed set %v", w, set)
+		}
+	}
+	// The unused_variables diagnostic must NOT be in the dead_code set.
+	if _, ok := set[rustSymRef{File: "src/lib.rs", Name: "x"}]; ok {
+		t.Error("unused_variables diagnostic must not be parsed as dead_code")
+	}
+}
+
+func TestParseCargoDeadCodeGroupedNames(t *testing.T) {
+	// A grouped dead_code message names several items; each shares the file.
+	out := `{"reason":"compiler-message","message":{"message":"methods ` + "`a`" + ` and ` + "`b`" + ` are never used","code":{"code":"dead_code"},"level":"warning","spans":[{"file_name":"src/lib.rs","is_primary":true}]}}`
+	set := ParseCargoDeadCode(out)
+	for _, name := range []string{"a", "b"} {
+		if _, ok := set[rustSymRef{File: "src/lib.rs", Name: name}]; !ok {
+			t.Errorf("grouped name %q missing from %v", name, set)
+		}
+	}
+}
+
+func TestParseCargoDeadCodeEdgeCases(t *testing.T) {
+	// A line that starts like JSON but is malformed (unmarshal error), a dead_code
+	// diagnostic with no primary span (fallback to the first span), and one with no
+	// spans at all (skipped). Only the no-primary one yields a parsed entry.
+	out := `{ this is not valid json
+{"reason":"compiler-message","message":{"message":"struct ` + "`Lonely`" + ` is never constructed","code":{"code":"dead_code"},"level":"warning","spans":[{"file_name":"src/only.rs","is_primary":false}]}}
+{"reason":"compiler-message","message":{"message":"function ` + "`nospan`" + ` is never used","code":{"code":"dead_code"},"level":"warning","spans":[]}}
+{"reason":"compiler-message","message":{"message":"a note with no code","level":"warning","spans":[{"file_name":"src/x.rs","is_primary":true}]}}`
+	set := ParseCargoDeadCode(out)
+	if _, ok := set[rustSymRef{File: "src/only.rs", Name: "Lonely"}]; !ok {
+		t.Errorf("no-primary span should fall back to the first span; got %v", set)
+	}
+	if _, ok := set[rustSymRef{File: "", Name: "nospan"}]; ok {
+		t.Error("a diagnostic with no spans must be skipped, not keyed on an empty file")
+	}
+	if len(set) != 1 {
+		t.Errorf("expected exactly the one parseable entry, got %v", set)
+	}
+}
+
+// TestRustFalseDeadsSubsetPasses: every Sense `dead` is in the oracle → no
+// violation (the passing state).
+func TestRustFalseDeadsSubsetPasses(t *testing.T) {
+	oracle := DeadCodeSet{
+		{File: "a.rs", Name: "x"}: {},
+		{File: "a.rs", Name: "y"}: {},
+	}
+	senseDead := []RustDead{
+		{Qualified: "m::x", File: "a.rs", Name: "x"},
+	}
+	if fd := RustFalseDeads(senseDead, oracle); len(fd) != 0 {
+		t.Errorf("expected zero false dead, got %v", fd)
+	}
+}
+
+// TestRustFalseDeadsPlantedLiveMethodFails is the coverage-gate requirement: a
+// planted false `dead` (a live trait method Sense wrongly called dead, absent from
+// cargo's dead_code set) MUST be reported, proving the gate detects the only
+// unforgivable error rather than rubber-stamping.
+func TestRustFalseDeadsPlantedLiveMethodFails(t *testing.T) {
+	oracle := DeadCodeSet{
+		{File: "a.rs", Name: "really_dead"}: {},
+	}
+	senseDead := []RustDead{
+		{Qualified: "m::really_dead", File: "a.rs", Name: "really_dead"}, // legitimate
+		{Qualified: "m::Worker::run", File: "b.rs", Name: "run"},         // planted false dead
+	}
+	fd := RustFalseDeads(senseDead, oracle)
+	if len(fd) != 1 {
+		t.Fatalf("expected exactly one false dead (the planted live method), got %v", fd)
+	}
+	if fd[0].Qualified != "m::Worker::run" {
+		t.Errorf("false dead = %q, want m::Worker::run", fd[0].Qualified)
+	}
+}
+
+const sampleCargoDeadCode = `{"reason":"compiler-message","message":{"message":"function ` + "`dead_helper`" + ` is never used","code":{"code":"dead_code"},"level":"warning","spans":[{"file_name":"src/lib.rs","is_primary":true}]}}` + "\n"
+
+// TestRunCargoDeadCodeSuccess: a clean run (nil error) parses the findings.
+func TestRunCargoDeadCodeSuccess(t *testing.T) {
+	restore := runCargo
+	defer func() { runCargo = restore }()
+	runCargo = func(context.Context, string) ([]byte, error) {
+		return []byte(sampleCargoDeadCode), nil
+	}
+	set, err := RunCargoDeadCode(context.Background(), "ignored")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := set[rustSymRef{File: "src/lib.rs", Name: "dead_helper"}]; !ok {
+		t.Errorf("expected dead_helper in set, got %v", set)
+	}
+}
+
+// TestRunCargoDeadCodeFindingsExit: cargo exits non-zero on a compile error but
+// still streams diagnostics; the output must be parsed, not treated as a launch
+// failure.
+func TestRunCargoDeadCodeFindingsExit(t *testing.T) {
+	restore := runCargo
+	defer func() { runCargo = restore }()
+	runCargo = func(context.Context, string) ([]byte, error) {
+		return []byte(sampleCargoDeadCode), &exec.ExitError{}
+	}
+	set, err := RunCargoDeadCode(context.Background(), "ignored")
+	if err != nil {
+		t.Fatalf("ExitError must not be fatal: %v", err)
+	}
+	if len(set) != 1 {
+		t.Errorf("expected findings parsed despite non-zero exit, got %v", set)
+	}
+}
+
+// TestRunCargoDeadCodeLaunchFailure: a non-ExitError (binary missing) maps to
+// ErrCargoUnavailable so callers can skip.
+func TestRunCargoDeadCodeLaunchFailure(t *testing.T) {
+	restore := runCargo
+	defer func() { runCargo = restore }()
+	runCargo = func(context.Context, string) ([]byte, error) {
+		return nil, errors.New("exec: \"cargo\": executable file not found in $PATH")
+	}
+	_, err := RunCargoDeadCode(context.Background(), "ignored")
+	if !errors.Is(err, ErrCargoUnavailable) {
+		t.Errorf("expected ErrCargoUnavailable, got %v", err)
+	}
+}
+
+// TestRustFalseDeadsSortOrder exercises both arms of the violation sort: across
+// files and within one file.
+func TestRustFalseDeadsSortOrder(t *testing.T) {
+	oracle := DeadCodeSet{}
+	senseDead := []RustDead{
+		{Qualified: "p::zeta", File: "b.rs", Name: "zeta"},
+		{Qualified: "p::alpha", File: "a.rs", Name: "alpha"},
+		{Qualified: "p::beta", File: "a.rs", Name: "beta"},
+	}
+	fd := RustFalseDeads(senseDead, oracle)
+	got := []string{fd[0].Name, fd[1].Name, fd[2].Name}
+	want := []string{"alpha", "beta", "zeta"} // a.rs:alpha, a.rs:beta, b.rs:zeta
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("sort order = %v, want %v", got, want)
+			break
+		}
+	}
+}
+
+// TestRustDeadSymbolsScanError covers the scan-failure path: a root that cannot be
+// scanned surfaces an error rather than an empty set.
+func TestRustDeadSymbolsScanError(t *testing.T) {
+	_, err := RustDeadSymbols(context.Background(), filepath.Join(t.TempDir(), "does-not-exist"), filepath.Join(t.TempDir(), ".sense"))
+	if err == nil {
+		t.Error("expected an error scanning a missing root")
+	}
+}
+
+// TestRustDeadSymbols scans a tiny Rust crate and confirms RustDeadSymbols returns
+// the genuinely-dead non-pub helper and nothing live. No cargo needed.
+func TestRustDeadSymbols(t *testing.T) {
+	root := t.TempDir()
+	if err := Materialize(root, map[string]string{
+		"src/lib.rs": `pub fn entry() { live(); }
+
+fn live() {}
+
+fn dead_helper() {}
+`,
+	}); err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	got, err := RustDeadSymbols(context.Background(), root, filepath.Join(root, ".sense"))
+	if err != nil {
+		t.Fatalf("RustDeadSymbols: %v", err)
+	}
+	names := map[string]bool{}
+	for _, d := range got {
+		names[d.Name] = true
+	}
+	if !names["dead_helper"] {
+		t.Errorf("dead_helper should be earned dead; got %v", got)
+	}
+	if names["live"] || names["entry"] {
+		t.Errorf("live/exported symbols must not be dead; got %v", got)
+	}
+}
+
+// TestCargoOracleEndToEnd runs the full gate against a real cargo when it is
+// installed, asserting Sense's `dead` set is a subset (zero false dead). It skips
+// cleanly when cargo is unavailable so CI without the toolchain stays green; the
+// binding repo-level run lives in the benchmark card.
+func TestCargoOracleEndToEnd(t *testing.T) {
+	root := t.TempDir()
+	if err := Materialize(root, map[string]string{
+		"Cargo.toml": `[package]
+name = "oracletest"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "src/lib.rs"
+`,
+		"src/lib.rs": `pub trait Runner {
+    fn run(&self);
+}
+
+struct Worker;
+
+impl Runner for Worker {
+    // run satisfies Runner; it is reached through the trait, so Sense must NOT
+    // call it dead even though no direct caller exists. cargo does not warn it.
+    fn run(&self) {}
+}
+
+// dead_helper is genuinely unused — both Sense and cargo must agree.
+fn dead_helper() {}
+
+pub fn make() -> impl Runner {
+    Worker
+}
+`,
+	}); err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	ctx := context.Background()
+
+	oracle, err := RunCargoDeadCode(ctx, root)
+	if errors.Is(err, ErrCargoUnavailable) {
+		t.Skip("cargo not installed; skipping the live oracle check")
+	}
+	if err != nil {
+		t.Fatalf("RunCargoDeadCode: %v", err)
+	}
+
+	senseDead, err := RustDeadSymbols(ctx, root, filepath.Join(root, ".sense"))
+	if err != nil {
+		t.Fatalf("RustDeadSymbols: %v", err)
+	}
+
+	falseDead := RustFalseDeads(senseDead, oracle)
+	t.Logf("Sense dead=%d, cargo dead_code=%d, false dead=%d", len(senseDead), len(oracle), len(falseDead))
+	if len(falseDead) != 0 {
+		t.Errorf("false-dead-count = %d, want 0; violations: %v", len(falseDead), falseDead)
+	}
+}

--- a/internal/dead/golden_test.go
+++ b/internal/dead/golden_test.go
@@ -211,6 +211,27 @@ func TestDeadCLIIntegration(t *testing.T) {
 		}
 	}
 
+	// EARNED dead (Rust): the non-`pub`, zero-edge, unmentioned function.
+	if verdict["orphaned_rust"] != "dead" {
+		t.Errorf("orphaned_rust verdict = %q, want dead (non-pub, no caller, no mention)", verdict["orphaned_rust"])
+	}
+	// POSSIBLY_DEAD (Rust), exact reason: a trait-impl method is reached through the
+	// trait; a derive-named method is reached through a synthesized impl. Both would
+	// otherwise be `dead` (Money::clone is unmentioned), so this is the two-sided proof.
+	if v, r := verdict["Robot::greet"], reason["Robot::greet"]; v != "possibly_dead" || r != "rust_trait_impl" {
+		t.Errorf("Robot::greet = (%q, %q), want (possibly_dead, rust_trait_impl)", v, r)
+	}
+	if v, r := verdict["Money::clone"], reason["Money::clone"]; v != "possibly_dead" || r != "rust_derive" {
+		t.Errorf("Money::clone = (%q, %q), want (possibly_dead, rust_derive)", v, r)
+	}
+	// SAFETY INVARIANT: no `pub` Rust symbol earns dead — rustc's dead_code lint
+	// flags only non-`pub` items, so a `pub` one must stay possibly_dead.
+	for _, e := range g.Findings {
+		if hasSuffix(e.File, ".rs") && e.Verdict == "dead" && (e.Qualified == "Registry" || e.Qualified == "Greeter") {
+			t.Errorf("%s (pub Rust) was flagged dead; pub items must stay possibly_dead", e.Qualified)
+		}
+	}
+
 	// Known-live symbols must not be reported at all.
 	for q := range verdict {
 		for _, live := range []string{

--- a/internal/dead/reasons.go
+++ b/internal/dead/reasons.go
@@ -56,6 +56,16 @@ const (
 	ReasonGoGenerated = "go_generated"
 	ReasonGoConst     = "go_const"
 	ReasonGoExported  = "go_exported"
+
+	// Rust-voice reason codes (voice_rust.go owns their catalog specs).
+	ReasonRustTraitImpl = "rust_trait_impl"
+	ReasonRustDerive    = "rust_derive"
+	ReasonRustFFI       = "rust_ffi"
+	ReasonRustUsed      = "rust_used"
+	ReasonRustTest      = "rust_test"
+	ReasonRustPub       = "rust_pub"
+	ReasonRustModule    = "rust_module"
+	ReasonRustAllowDead = "rust_allow_dead"
 )
 
 // reasonSpec is the static metadata for a reason code: a removability

--- a/internal/dead/voice_rust.go
+++ b/internal/dead/voice_rust.go
@@ -1,0 +1,159 @@
+package dead
+
+// rustVoice is the Rust language voice. Rust is an even more airtight `dead`
+// candidate than Go: privacy is enforced at module granularity (`pub` vs
+// private-by-default), the borrow checker forces every path to be explicit, and
+// rustc's own `dead_code` lint flags exactly this class — an unused non-`pub`
+// item. The voice re-expresses Rust's invisible-reach idioms (trait dispatch,
+// derives, FFI, linker-kept statics, tests) as open-world reasons; like every
+// voice it can only raise a hand (push → possibly_dead), never vote for `dead`.
+//
+// The earned-`dead` candidate is narrow and structural: a NON-`pub` fn / method /
+// type / struct / enum / trait with zero incoming edges, whose name is absent
+// from the Rust mention set (the arbiter's soundness gate) and which this voice
+// cannot tie to a trait impl / derive / FFI export / linker `#[used]` / test.
+// Every `pub` symbol stays open-world — rustc's dead_code lint never flags a
+// `pub` item (it may be used by another crate Sense never indexed), so letting
+// one earn `dead` would break the binding "Sense `dead` ⊆ cargo `dead_code`" gate.
+type rustVoice struct{}
+
+func (rustVoice) Lang() string { return "rust" }
+
+// Inspect returns the most-specific (most-likely-live) reason a hidden caller
+// could exist for s, or nil when s is a non-`pub` fn/method/type with no
+// invisible-reach idiom — the only shape that may fall through to `dead`. Checks
+// are ordered most-live-first so the returned reason carries the most useful
+// hint; the arbiter independently picks the lowest-priority reason across voices.
+func (rustVoice) Inspect(s Symbol, f Facts) *Reason {
+	// Intentionally retained: the author annotated `#[allow(dead_code)]` /
+	// `#[allow(unused)]`, so rustc suppresses the lint and the symbol is never in
+	// the cargo oracle. Respect that intent — never call it dead.
+	if _, ok := f.RustAllowDeadNames[s.Name]; ok {
+		return reasonPtr(ReasonRustAllowDead)
+	}
+	// Test-only: a `#[test]` / `#[bench]` item, or one nested under a
+	// `#[cfg(test)]` module, is invoked by the test harness and is not even
+	// compiled by `cargo build`, so no indexed caller exists by design.
+	if _, ok := f.RustTestSymbolNames[s.Name]; ok {
+		return reasonPtr(ReasonRustTest)
+	}
+	// FFI export / linker-kept: a `#[no_mangle]` / `#[export_name]` function is
+	// called from C; a `#[no_mangle]` / `#[used]` static is kept alive by the
+	// linker. Either way no Rust caller edge exists. The set carries both kinds;
+	// a static (KindConstant) is rust_used, a function is rust_ffi.
+	if _, ok := f.RustExportNames[s.Name]; ok {
+		if s.Kind == "constant" {
+			return reasonPtr(ReasonRustUsed)
+		}
+		return reasonPtr(ReasonRustFFI)
+	}
+	// A method that implements a trait method is reachable through a trait object
+	// or a generic bound, where the static graph shows zero direct callers. The
+	// soundest signal is structural: the method is defined in an `impl Trait for
+	// Type` block (RustTraitImplMethodNames, harvested at scan time) — this covers
+	// every external trait (serde's Deserializer, std::io::Write, …) without
+	// enumerating them. A method named on an in-index trait is the second signal.
+	if s.Kind == "method" {
+		if _, ok := f.RustTraitImplMethodNames[s.Name]; ok {
+			return reasonPtr(ReasonRustTraitImpl)
+		}
+		if _, ok := f.InterfaceMethodNames[s.Name]; ok {
+			return reasonPtr(ReasonRustTraitImpl)
+		}
+		// A `#[derive(...)]` synthesizes a trait impl with no source-level caller;
+		// a method sharing a std derivable-trait method name (clone / fmt / eq /
+		// cmp / hash / default / serialize / …) is reached the same invisible way.
+		if rustDerivableTraitMethods[s.Name] {
+			return reasonPtr(ReasonRustDerive)
+		}
+	}
+	// A Rust `mod` is a namespace; rustc's dead_code lint flags the unused items
+	// within a module, never the module itself, so a module can never be in the
+	// cargo oracle — it must never earn `dead`. (A module whose every child is dead
+	// is already collapsed away by Rollup; one that survives here is a namespace
+	// whose contents are reached invisibly, e.g. a `macros` module.)
+	if s.Kind == "module" {
+		return reasonPtr(ReasonRustModule)
+	}
+	// `pub` items never earn `dead`: rustc's dead_code lint flags only non-`pub`
+	// items, so a `pub` one may have a consumer in another crate Sense never
+	// indexed. A library's public callable/type API is handled by the core voice
+	// (core_exported_api); otherwise raise rust_pub. Note `pub(crate)` / `pub(in
+	// path)` are "private" to the extractor (the crate is Rust's export boundary),
+	// so they correctly fall through — rustc warns an unused crate-private item.
+	if s.Visibility == "public" {
+		if f.IsLibrary && isPublicAPISymbol(s) {
+			return nil
+		}
+		return reasonPtr(ReasonRustPub)
+	}
+	// Non-`pub` from here. Unlike Go (an unused iota anchor is load-bearing), a
+	// private Rust const / static is an ordinary `dead` candidate — rustc warns
+	// unused ones — so it falls through with everything else.
+	return nil
+}
+
+// rustDerivableTraitMethods are the method names the standard `#[derive(...)]`
+// traits synthesize. A `#[derive(Clone)]` / `#[derive(Serialize)]` impl has no
+// source-level caller, so a method of one of these names is reached invisibly and
+// must stay open-world (rust_derive). serde's Serialize/Deserialize are included:
+// `#[derive(Serialize)]` is ubiquitous in real Rust and the derive flood is the
+// primary precision risk the pitch calls out. Name match over-approximates toward
+// caution (recall loss at worst), the safe direction — exactly the Go magic-method
+// table's bet. Checked only for methods, so a free function of the same name is
+// unaffected.
+var rustDerivableTraitMethods = map[string]bool{
+	"clone": true, "clone_from": true, // Clone
+	"fmt":                              true, // Debug
+	"eq":  true, "ne": true,                 // PartialEq
+	"partial_cmp": true, "lt": true, "le": true, "gt": true, "ge": true, // PartialOrd
+	"cmp":  true,                            // Ord
+	"hash": true,                            // Hash
+	"default":     true,                     // Default
+	"serialize":   true, "deserialize": true, // serde
+}
+
+func init() {
+	registerReasons(map[string]reasonSpec{
+		ReasonRustAllowDead: {
+			priority: 40,
+			hint:     "item is annotated `#[allow(dead_code)]`/`#[allow(unused)]`; the author intentionally retained it and rustc suppresses the warning — remove the annotation first if you believe it is truly unused",
+			verify:   "This item carries `#[allow(dead_code)]` (or `#[allow(unused)]`), so the author deliberately kept it and rustc does not warn it. Remove the annotation and rebuild to confirm it is genuinely unused before deleting.",
+		},
+		ReasonRustModule: {
+			priority: 25,
+			hint:     "Rust module (namespace); rustc's dead_code lint flags unused items inside a module, never the module itself — inspect its contents rather than removing the `mod`",
+			verify:   "This is a Rust module. rustc never reports a module as dead (only the unused items within it), and its contents may be reached invisibly (e.g. macros). Inspect the items inside before removing the `mod`.",
+		},
+		ReasonRustTest: {
+			priority: 20,
+			hint:     "Rust test item (`#[test]`/`#[bench]`, or under a `#[cfg(test)]` module); run by the test harness and not compiled by `cargo build` — never remove it as dead",
+			verify:   "This symbol is test-only: invoked by the test harness, and `cargo build` does not compile it. Remove it only if you are removing the test it belongs to.",
+		},
+		ReasonRustFFI: {
+			priority: 30,
+			hint:     "function is exported across the FFI boundary (`#[no_mangle]`/`#[export_name]`) and called from C; no Rust caller exists — remove only if the C side no longer uses it",
+			verify:   "This function is exported to C (`#[no_mangle]` / `#[export_name]`) and has no Rust caller by design. Check the C / FFI code that calls it before removing.",
+		},
+		ReasonRustUsed: {
+			priority: 30,
+			hint:     "static is kept alive by the linker (`#[used]`/`#[no_mangle]`); it has no Rust reader by design — do not remove it",
+			verify:   "This static is retained by the linker (`#[used]` / `#[no_mangle]`), often for a linker section or the C ABI. It has no Rust reader by design; confirm the consumer before removing.",
+		},
+		ReasonRustTraitImpl: {
+			priority: 30,
+			hint:     "method implements a trait method (named on an in-index trait, or a std trait like Display/Drop/Iterator/From); it may be called through a trait object or generic bound — confirm no implementor is used before removing",
+			verify:   "This method shares a name with a trait method, so it may be invoked through a trait object or a generic bound (where Sense sees no direct caller). Check whether the type is used behind its trait anywhere before removing.",
+		},
+		ReasonRustDerive: {
+			priority: 35,
+			hint:     "method shares a name with a std derivable-trait method (`#[derive(Clone)]`/`Debug`/`PartialEq`/`Serialize`/…); a derived impl is reached with no source caller — confirm the type is unused before removing",
+			verify:   "This method shares a name with a derivable trait's method (Clone/Debug/PartialEq/Hash/Default/serde …). A `#[derive(...)]` impl is reached by code generated at compile time, not a source caller. Confirm the type is genuinely unused before removing.",
+		},
+		ReasonRustPub: {
+			priority: 50,
+			hint:     "`pub` Rust item with no caller in this crate; another crate may use it (rustc flags only non-`pub` items) — search dependents before removing",
+			verify:   "`pub` Rust items can be used by other crates. For each, search dependent crates and the rest of this tree for the path before removing.",
+		},
+	})
+}

--- a/internal/dead/voice_rust_test.go
+++ b/internal/dead/voice_rust_test.go
@@ -1,0 +1,144 @@
+package dead
+
+import "testing"
+
+func rustSym(name, qualified, kind, visibility, file string) Symbol {
+	return Symbol{
+		Name:       name,
+		Qualified:  qualified,
+		Kind:       kind,
+		Language:   "rust",
+		Visibility: visibility,
+		File:       file,
+	}
+}
+
+func TestRustVoiceLang(t *testing.T) {
+	if (rustVoice{}).Lang() != "rust" {
+		t.Errorf("rustVoice.Lang() = %q, want rust", (rustVoice{}).Lang())
+	}
+}
+
+func TestRustVoiceTest(t *testing.T) {
+	v := rustVoice{}
+	f := Facts{RustTestSymbolNames: map[string]struct{}{"it_works": {}}}
+	// A test symbol is harness-invoked, never an indexed caller.
+	assertReason(t, v, rustSym("it_works", "m::tests::it_works", "function", "private", "lib.rs"), f, ReasonRustTest)
+	// A function not in the test set is unaffected.
+	assertReason(t, v, rustSym("plain", "m::plain", "function", "private", "lib.rs"), f, "")
+}
+
+func TestRustVoiceFFI(t *testing.T) {
+	v := rustVoice{}
+	f := Facts{RustExportNames: map[string]struct{}{"ffi_entry": {}, "KEEP": {}}}
+	// A `#[no_mangle]` function is called from C → rust_ffi.
+	assertReason(t, v, rustSym("ffi_entry", "m::ffi_entry", "function", "public", "ffi.rs"), f, ReasonRustFFI)
+	// A `#[used]`/`#[no_mangle]` static (KindConstant) → rust_used.
+	assertReason(t, v, rustSym("KEEP", "m::KEEP", "constant", "private", "ffi.rs"), f, ReasonRustUsed)
+	// A function not in the export set is unaffected.
+	assertReason(t, v, rustSym("plain", "m::plain", "function", "private", "ffi.rs"), f, "")
+}
+
+func TestRustVoiceTraitImplByDeclaredName(t *testing.T) {
+	v := rustVoice{}
+	f := Facts{InterfaceMethodNames: map[string]struct{}{"process": {}}}
+	// A method whose name is declared on an in-index trait stays open-world.
+	assertReason(t, v, rustSym("process", "m::Money::process", "method", "private", "m.rs"), f, ReasonRustTraitImpl)
+	// A free function of the same name is NOT a trait-impl method.
+	assertReason(t, v, rustSym("process", "m::process", "function", "private", "m.rs"), f, "")
+}
+
+func TestRustVoiceStdTraitMethodNeedsImplBlockSignal(t *testing.T) {
+	v := rustVoice{}
+	// Hand-written std-trait methods (Display/Drop/Iterator/From …) are recognised
+	// structurally via the harvested `impl Trait for` set, not a static name table.
+	f := Facts{RustTraitImplMethodNames: map[string]struct{}{"drop": {}, "next": {}, "from": {}}}
+	for _, name := range []string{"drop", "next", "from"} {
+		assertReason(t, v, rustSym(name, "m::T::"+name, "method", "private", "m.rs"), f, ReasonRustTraitImpl)
+	}
+	// Without the impl-block signal, an inherent method of the same name is NOT
+	// assumed to be a trait impl — it falls through (rustc would warn it if dead).
+	assertReason(t, v, rustSym("deref", "m::T::deref", "method", "private", "m.rs"), Facts{}, "")
+	// A non-trait private method also falls through to silent.
+	assertReason(t, v, rustSym("frobnicate", "m::T::frobnicate", "method", "private", "m.rs"), Facts{}, "")
+}
+
+func TestRustVoiceTraitImplByImplBlock(t *testing.T) {
+	v := rustVoice{}
+	// A method defined in an `impl Trait for Type` block (harvested at scan time)
+	// stays open-world even when its name is in no table and no in-index trait —
+	// the sound signal for external traits like serde's Deserializer.
+	f := Facts{RustTraitImplMethodNames: map[string]struct{}{"deserialize_any": {}}}
+	assertReason(t, v, rustSym("deserialize_any", "m::De::deserialize_any", "method", "private", "de.rs"), f, ReasonRustTraitImpl)
+	// A free function of that name is not a method, so it is unaffected.
+	assertReason(t, v, rustSym("deserialize_any", "m::deserialize_any", "function", "private", "de.rs"), f, "")
+}
+
+func TestRustVoiceAllowDead(t *testing.T) {
+	v := rustVoice{}
+	f := Facts{RustAllowDeadNames: map[string]struct{}{"kept": {}}}
+	// An #[allow(dead_code)] item is intentionally retained → never dead.
+	assertReason(t, v, rustSym("kept", "m::kept", "function", "private", "m.rs"), f, ReasonRustAllowDead)
+	// It wins even over the non-pub silent path that would otherwise earn dead.
+	assertReason(t, v, rustSym("other", "m::other", "function", "private", "m.rs"), f, "")
+}
+
+func TestRustVoiceModule(t *testing.T) {
+	v := rustVoice{}
+	// rustc never lints a module as dead, so a surviving module stays possibly_dead.
+	assertReason(t, v, rustSym("macros", "crate::macros", "module", "private", "lib.rs"), Facts{}, ReasonRustModule)
+	assertReason(t, v, rustSym("api", "crate::api", "module", "public", "lib.rs"), Facts{}, ReasonRustModule)
+}
+
+func TestRustVoiceDerive(t *testing.T) {
+	v := rustVoice{}
+	// Std derivable-trait method names → rust_derive (a `#[derive(...)]` impl is
+	// reached with no source caller). Proves derives do not flood the dead set.
+	for _, name := range []string{"clone", "fmt", "eq", "cmp", "hash", "default", "serialize", "deserialize"} {
+		assertReason(t, v, rustSym(name, "m::T::"+name, "method", "private", "m.rs"), Facts{}, ReasonRustDerive)
+	}
+	// An in-index trait declaration of a derivable name is labelled the more
+	// precise rust_trait_impl, not rust_derive.
+	f := Facts{InterfaceMethodNames: map[string]struct{}{"clone": {}}}
+	assertReason(t, v, rustSym("clone", "m::T::clone", "method", "private", "m.rs"), f, ReasonRustTraitImpl)
+	// A free function named like a derivable method is unaffected (only methods).
+	assertReason(t, v, rustSym("clone", "m::clone", "function", "private", "m.rs"), Facts{}, "")
+}
+
+func TestRustVoicePub(t *testing.T) {
+	v := rustVoice{}
+	// `pub` symbol in a binary (not a library) → rust_pub, never dead.
+	assertReason(t, v, rustSym("handler", "m::handler", "function", "public", "m.rs"), Facts{IsLibrary: false}, ReasonRustPub)
+	assertReason(t, v, rustSym("Config", "m::Config", "class", "public", "m.rs"), Facts{IsLibrary: false}, ReasonRustPub)
+	// `pub` callable/type in a LIBRARY → silent here; the core voice raises
+	// core_exported_api instead (proven by the arbiter-level test below).
+	assertReason(t, v, rustSym("public_api", "m::public_api", "function", "public", "lib.rs"), Facts{IsLibrary: true}, "")
+	// A `pub` trait (interface) is not in isPublicAPISymbol, so the Rust voice keeps
+	// it open-world (rust_pub) even in a library.
+	assertReason(t, v, rustSym("Greeter", "m::Greeter", "interface", "public", "lib.rs"), Facts{IsLibrary: true}, ReasonRustPub)
+}
+
+func TestRustVoiceSilentNonPub(t *testing.T) {
+	v := rustVoice{}
+	// The only shapes that may fall through to dead: non-`pub` fn / method / type /
+	// struct / enum / trait / const with no invisible-reach idiom. Unlike Go, a
+	// private const is an ordinary candidate (no iota anchor), so it stays silent.
+	assertReason(t, v, rustSym("helper", "m::helper", "function", "private", "m.rs"), Facts{}, "")
+	assertReason(t, v, rustSym("compute", "m::T::compute", "method", "private", "m.rs"), Facts{}, "")
+	assertReason(t, v, rustSym("Widget", "m::Widget", "class", "private", "m.rs"), Facts{}, "")
+	assertReason(t, v, rustSym("Alias", "m::Alias", "type", "private", "m.rs"), Facts{}, "")
+	assertReason(t, v, rustSym("Secret", "m::Secret", "interface", "private", "m.rs"), Facts{}, "")
+	assertReason(t, v, rustSym("THRESHOLD", "m::THRESHOLD", "constant", "private", "m.rs"), Facts{}, "")
+}
+
+// TestRustVoiceReasonPriorityOrder pins the most-live-first ordering: when a
+// symbol matches several signals, the more-likely-live reason is returned.
+func TestRustVoiceReasonPriorityOrder(t *testing.T) {
+	v := rustVoice{}
+	// A `#[no_mangle]` pub function → rust_ffi wins over rust_pub.
+	f := Facts{RustExportNames: map[string]struct{}{"ffi_entry": {}}}
+	assertReason(t, v, rustSym("ffi_entry", "m::ffi_entry", "function", "public", "ffi.rs"), f, ReasonRustFFI)
+	// A pub method implementing a trait → rust_trait_impl wins over rust_pub.
+	f2 := Facts{InterfaceMethodNames: map[string]struct{}{"process": {}}}
+	assertReason(t, v, rustSym("process", "m::T::process", "method", "public", "m.rs"), f2, ReasonRustTraitImpl)
+}

--- a/internal/extract/extractor.go
+++ b/internal/extract/extractor.go
@@ -275,6 +275,39 @@ type CgoExportEmitter interface {
 	CgoExportName(name string) error
 }
 
+// RustHarvestEmitter is an optional Emitter extension for streaming the Rust
+// attribute facts the dead-code Rust voice reads — names whose reachability the
+// edge graph cannot see because the caller lives outside indexed Rust:
+//
+//   - RustExportName: a function marked `#[no_mangle]` / `#[export_name = …]`
+//     (called across the FFI boundary from C) or a `#[no_mangle]` / `#[used]`
+//     static (kept alive by the linker). No Rust caller edge exists, so the voice
+//     keeps it open-world (rust_ffi for a function, rust_used for a static).
+//   - RustTestSymbol: an item marked `#[test]` / `#[bench]` (including scoped
+//     `#[tokio::test]`) or nested under a `#[cfg(test)]` module. The test harness
+//     invokes it, never an indexed caller, and `cargo build` does not even compile
+//     it, so the voice keeps it open-world (rust_test).
+//   - RustTraitImplMethod: a method defined in an `impl Trait for Type` block. It
+//     satisfies a trait and is reached through a trait object or generic bound,
+//     so the voice keeps it open-world (rust_trait_impl). This is the sound,
+//     name-independent signal that covers external traits (serde, std::io) the
+//     magic table cannot enumerate.
+//   - RustAllowDeadName: an item annotated `#[allow(dead_code)]` / `#[allow(unused)]`.
+//     The author deliberately suppressed the lint, so rustc never warns it and it
+//     is absent from the cargo oracle; the voice keeps it open-world
+//     (rust_allow_dead).
+//
+// The name sets feed flat (not per-language) sense_meta keys — these concepts are
+// Rust-only, like cgo is Go-only — that the Rust voice reads. An extractor probes
+// for this interface with a type assertion; an Emitter that does not implement it
+// simply receives no names. Returning an error aborts extraction.
+type RustHarvestEmitter interface {
+	RustExportName(name string) error
+	RustTestSymbol(name string) error
+	RustTraitImplMethod(name string) error
+	RustAllowDeadName(name string) error
+}
+
 // MentionEmitter is an optional Emitter extension for streaming every bare
 // name a file *mentions* — every identifier or symbol-literal token that
 // appears in any position other than a definition's own name. Unlike

--- a/internal/extract/rust/harvest.go
+++ b/internal/extract/rust/harvest.go
@@ -1,0 +1,381 @@
+package rust
+
+import (
+	"strings"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+)
+
+// HarvestsMentions reports that the Rust extractor streams the broad mention set
+// (see emitHarvest), so the scan records `rust` as harvested even on a scan that
+// yields zero mentions — the dead-code soundness gate then treats a Rust symbol
+// as proven-against-an-empty-set, not never-harvested. Without this opt-in, every
+// Rust symbol would fail closed at the per-language soundness gate
+// (core_no_harvest) and no Rust symbol could ever earn `dead`.
+func (Extractor) HarvestsMentions() bool { return true }
+
+// emitHarvest streams the file's broad mention set, reflective dispatch targets,
+// FFI/`#[used]` export names, and test-symbol names to the emitter when it accepts
+// them. The mention set feeds the arbiter's soundness gate (a symbol earns `dead`
+// only when its bare name is mentioned nowhere a hidden caller could be); the
+// dispatch set feeds the core voice's reflection gate (a type named only in an
+// `Any::downcast::<T>()` turbofish is reached dynamically); the export and test
+// sets feed the Rust voice's rust_ffi / rust_used / rust_test reasons. All four
+// are gathered in one tree walk; each emit is best-effort — an Emitter that
+// implements neither extension simply receives no names.
+func emitHarvest(root *sitter.Node, source []byte, emit extract.Emitter) error {
+	h := collectRustHarvest(root, source)
+	if de, ok := emit.(extract.DispatchEmitter); ok {
+		for name := range h.dispatch {
+			if err := de.DispatchName(name); err != nil {
+				return err
+			}
+		}
+	}
+	if me, ok := emit.(extract.MentionEmitter); ok {
+		for name := range h.mentions {
+			if err := me.MentionName(name); err != nil {
+				return err
+			}
+		}
+	}
+	if re, ok := emit.(extract.RustHarvestEmitter); ok {
+		for name := range h.exports {
+			if err := re.RustExportName(name); err != nil {
+				return err
+			}
+		}
+		for name := range h.testSymbols {
+			if err := re.RustTestSymbol(name); err != nil {
+				return err
+			}
+		}
+		for name := range h.traitImplMethods {
+			if err := re.RustTraitImplMethod(name); err != nil {
+				return err
+			}
+		}
+		for name := range h.allowDead {
+			if err := re.RustAllowDeadName(name); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// rustHarvest accumulates the name sets the Rust dead-code analysis needs:
+//   - mentions: every identifier / type / field token EXCEPT a definition's own
+//     name — the broad superset feeding the soundness gate.
+//   - dispatch: type names reached via `Any::downcast::<T>()` — the only common
+//     Rust idiom that names a type the static graph cannot see.
+//   - exports: function names marked `#[no_mangle]` / `#[export_name]` and static
+//     names marked `#[no_mangle]` / `#[used]`, called/kept-alive with no Rust
+//     caller (rust_ffi for functions, rust_used for statics).
+//   - testSymbols: names of items marked `#[test]` / `#[bench]` or nested under a
+//     `#[cfg(test)]` module, invoked only by the test harness (rust_test).
+//   - traitImplMethods: names of methods defined in an `impl Trait for Type`
+//     block. Such a method satisfies a trait and is reached through a trait object
+//     or generic bound, where the static graph shows no direct caller — the sound,
+//     name-independent trait-impl signal (it sees serde's `deserialize_*`, `Write`'s
+//     `flush`, and any other external trait the magic table cannot enumerate).
+//   - allowDead: names of items annotated `#[allow(dead_code)]` / `#[allow(unused)]`.
+//     The author deliberately suppressed the lint, so rustc never warns them and
+//     they are absent from the cargo oracle (rust_allow_dead).
+type rustHarvest struct {
+	mentions         map[string]struct{}
+	dispatch         map[string]struct{}
+	exports          map[string]struct{}
+	testSymbols      map[string]struct{}
+	traitImplMethods map[string]struct{}
+	allowDead        map[string]struct{}
+}
+
+// collectRustHarvest gathers every name set in two passes: the shared,
+// grammar-parameterised mention walk (HarvestMentions), and an attribute-aware
+// recursive walk that tracks `#[cfg(test)]` scope to route export and test names.
+// Scan is not a hot path, so two clear passes beat one entangled one.
+func collectRustHarvest(root *sitter.Node, source []byte) rustHarvest {
+	h := rustHarvest{
+		mentions:         map[string]struct{}{},
+		dispatch:         map[string]struct{}{},
+		exports:          map[string]struct{}{},
+		testSymbols:      map[string]struct{}{},
+		traitImplMethods: map[string]struct{}{},
+		allowDead:        map[string]struct{}{},
+	}
+	for _, name := range extract.HarvestMentions(root, source, mentionWalkSpec()) {
+		h.mentions[name] = struct{}{}
+	}
+	h.walkAttrs(root, false, source)
+	h.collectDispatch(root, source)
+	h.collectTraitImplMethods(root, source)
+	return h
+}
+
+// collectTraitImplMethods records the name of every method defined in an
+// `impl Trait for Type` block (an impl_item carrying a `trait` field). Such a
+// method satisfies the trait and is reached through it, never by a direct caller
+// the static graph can see. This is the sound, name-independent backstop for the
+// trait-impl reason: it covers external traits (serde's Deserializer, std's Write,
+// Iterator, …) the magic table cannot enumerate.
+func (h rustHarvest) collectTraitImplMethods(root *sitter.Node, source []byte) {
+	_ = extract.WalkNamedDescendants(root, "impl_item", func(impl *sitter.Node) error {
+		if impl.ChildByFieldName("trait") == nil {
+			return nil
+		}
+		body := impl.ChildByFieldName("body")
+		if body == nil {
+			return nil
+		}
+		for i := uint(0); i < body.NamedChildCount(); i++ {
+			child := body.NamedChild(i)
+			if child == nil || child.Kind() != "function_item" {
+				continue
+			}
+			if name := extract.Text(child.ChildByFieldName("name"), source); name != "" {
+				h.traitImplMethods[name] = struct{}{}
+			}
+		}
+		return nil
+	})
+}
+
+// mentionWalkSpec is Rust's grammar parameterisation of the shared mention
+// harvest: identifiers, type identifiers, and field identifiers carry a mention,
+// and a definition's own name token is excluded so a symbol is never cancelled by
+// its own declaration. Trait method signatures (function_signature_item) are
+// deliberately NOT excluded: leaving a declared trait method's name in the
+// mention set keeps a same-named concrete impl open-world even when the resolver
+// never drew the satisfaction edge — the trait-impl soundness backstop.
+func mentionWalkSpec() extract.MentionWalkSpec {
+	return extract.MentionWalkSpec{
+		NameOf: map[string]func(*sitter.Node, []byte) string{
+			"identifier":                 extract.Text,
+			"type_identifier":            extract.Text,
+			"field_identifier":           extract.Text,
+			"shorthand_field_identifier": extract.Text,
+		},
+		SkipDefinitionName: isRustDefinitionName,
+	}
+}
+
+// isRustDefinitionName reports whether n is the `name` field of a concrete
+// definition (function / struct / enum / trait / type-alias / const / static /
+// mod). Those tokens are excluded from the mention set. function_signature_item
+// (a trait method declaration) is intentionally absent — see mentionWalkSpec.
+func isRustDefinitionName(n *sitter.Node) bool {
+	p := n.Parent()
+	if p == nil {
+		return false
+	}
+	switch p.Kind() {
+	case "function_item", "struct_item", "enum_item", "trait_item",
+		"type_item", "const_item", "static_item", "mod_item":
+		name := p.ChildByFieldName("name")
+		return name != nil && name.Id() == n.Id()
+	}
+	return false
+}
+
+// walkAttrs recurses the tree tracking whether the current node is inside a
+// `#[cfg(test)]` module, routing each definition's name to the export or test set
+// per its attributes. inTest is sticky: every descendant of a `#[cfg(test)]`
+// module is a test symbol regardless of its own attributes.
+func (h rustHarvest) walkAttrs(n *sitter.Node, inTest bool, source []byte) {
+	count := n.NamedChildCount()
+	for i := uint(0); i < count; i++ {
+		child := n.NamedChild(i)
+		if child == nil {
+			continue
+		}
+		childInTest := inTest || hasCfgTest(child, source)
+		switch child.Kind() {
+		case "function_item":
+			h.classifyFunction(child, childInTest, source)
+		case "static_item", "const_item":
+			h.classifyStatic(child, childInTest, source)
+		case "struct_item", "enum_item", "trait_item", "type_item":
+			if childInTest {
+				h.recordName(child, h.testSymbols, source)
+			}
+		}
+		// An item the author annotated `#[allow(dead_code)]` is intentionally
+		// retained; rustc suppresses the lint, so it never reaches the cargo oracle.
+		if isDefinitionKind(child.Kind()) && hasAllowDead(child, source) {
+			h.recordName(child, h.allowDead, source)
+		}
+		h.walkAttrs(child, childInTest, source)
+	}
+}
+
+// classifyFunction routes a function definition to the test set (inside
+// `#[cfg(test)]`, or marked `#[test]` / `#[bench]`) or the export set (marked
+// `#[no_mangle]` / `#[export_name]`). Test classification wins: a `#[no_mangle]`
+// function inside a test module is still test-only.
+func (h rustHarvest) classifyFunction(fn *sitter.Node, inTest bool, source []byte) {
+	if inTest || hasAttr(fn, source, "test", "bench") {
+		h.recordName(fn, h.testSymbols, source)
+		return
+	}
+	if hasAttr(fn, source, "no_mangle", "export_name") {
+		h.recordName(fn, h.exports, source)
+	}
+}
+
+// classifyStatic routes a static / const to the test set (inside `#[cfg(test)]`)
+// or the export set (marked `#[no_mangle]` / `#[export_name]` / `#[used]`, kept
+// alive by the linker with no Rust reader).
+func (h rustHarvest) classifyStatic(s *sitter.Node, inTest bool, source []byte) {
+	if inTest {
+		h.recordName(s, h.testSymbols, source)
+		return
+	}
+	if hasAttr(s, source, "no_mangle", "export_name", "used") {
+		h.recordName(s, h.exports, source)
+	}
+}
+
+// recordName adds a definition node's bare name to set.
+func (h rustHarvest) recordName(n *sitter.Node, set map[string]struct{}, source []byte) {
+	if name := extract.Text(n.ChildByFieldName("name"), source); name != "" {
+		set[name] = struct{}{}
+	}
+}
+
+// collectDispatch records the type argument of every `.downcast::<T>()` /
+// `downcast_ref::<T>()` / `downcast_mut::<T>()` call as a reflection-reached type
+// name — the one common Rust idiom (`std::any::Any`) that names a type the static
+// graph cannot tie back to a caller.
+func (h rustHarvest) collectDispatch(root *sitter.Node, source []byte) {
+	_ = extract.WalkNamedDescendants(root, "generic_function", func(g *sitter.Node) error {
+		fn := g.ChildByFieldName("function")
+		if !isDowncastCallee(fn, source) {
+			return nil
+		}
+		args := g.ChildByFieldName("type_arguments")
+		if args == nil {
+			return nil
+		}
+		for i := uint(0); i < args.NamedChildCount(); i++ {
+			if name := unwrapTypeName(args.NamedChild(i), source); name != "" {
+				h.dispatch[name] = struct{}{}
+			}
+		}
+		return nil
+	})
+}
+
+// isDowncastCallee reports whether fn is the callee of an `Any` downcast — a bare
+// `downcast` path or a `x.downcast_ref` field access.
+func isDowncastCallee(fn *sitter.Node, source []byte) bool {
+	if fn == nil {
+		return false
+	}
+	switch fn.Kind() {
+	case "identifier":
+		return downcastMethods[extract.Text(fn, source)]
+	case "field_expression":
+		return downcastMethods[extract.Text(fn.ChildByFieldName("field"), source)]
+	}
+	return false
+}
+
+// downcastMethods are the std `Any` downcast methods whose turbofish type
+// argument names a dynamically-reached type.
+var downcastMethods = map[string]bool{
+	"downcast": true, "downcast_ref": true, "downcast_mut": true,
+}
+
+// hasAttr reports whether any attribute immediately preceding n names one of the
+// given attribute names, matching on the path's LAST segment so a scoped test
+// attribute like `#[tokio::test]` / `#[async_std::test]` matches "test" just as a
+// bare `#[test]` does.
+func hasAttr(n *sitter.Node, source []byte, names ...string) bool {
+	found := false
+	forEachPrecedingAttr(n, func(attr *sitter.Node) {
+		name := attrLastSegment(attr, source)
+		for _, want := range names {
+			if name == want {
+				found = true
+			}
+		}
+	})
+	return found
+}
+
+// attrLastSegment returns the last `::`-separated segment of an attribute's path,
+// so `#[tokio::test]` → "test" and a bare `#[no_mangle]` → "no_mangle".
+func attrLastSegment(attr *sitter.Node, source []byte) string {
+	text := extract.Text(attr.NamedChild(0), source)
+	if i := strings.LastIndex(text, "::"); i >= 0 {
+		return text[i+len("::"):]
+	}
+	return text
+}
+
+// isDefinitionKind reports whether a node kind is a Rust definition that can
+// carry a name and become a dead-code candidate.
+func isDefinitionKind(kind string) bool {
+	switch kind {
+	case "function_item", "static_item", "const_item",
+		"struct_item", "enum_item", "trait_item", "type_item", "mod_item":
+		return true
+	}
+	return false
+}
+
+// hasAllowDead reports whether n carries an `#[allow(dead_code)]` or
+// `#[allow(unused)]` attribute (including grouped `#[allow(dead_code, …)]`): an
+// `allow` attribute whose token tree mentions `dead_code` or `unused`.
+func hasAllowDead(n *sitter.Node, source []byte) bool {
+	found := false
+	forEachPrecedingAttr(n, func(attr *sitter.Node) {
+		if attrLastSegment(attr, source) != "allow" {
+			return
+		}
+		_ = extract.WalkNamedDescendants(attr, "identifier", func(id *sitter.Node) error {
+			switch extract.Text(id, source) {
+			case "dead_code", "unused":
+				found = true
+			}
+			return nil
+		})
+	})
+	return found
+}
+
+// hasCfgTest reports whether n carries a `#[cfg(test)]` attribute (including
+// `#[cfg(all(test, …))]`): a `cfg` attribute whose token tree mentions `test`.
+func hasCfgTest(n *sitter.Node, source []byte) bool {
+	found := false
+	forEachPrecedingAttr(n, func(attr *sitter.Node) {
+		if extract.Text(attr.NamedChild(0), source) != "cfg" {
+			return
+		}
+		_ = extract.WalkNamedDescendants(attr, "identifier", func(id *sitter.Node) error {
+			if extract.Text(id, source) == "test" {
+				found = true
+			}
+			return nil
+		})
+	})
+	return found
+}
+
+// forEachPrecedingAttr calls fn for the `attribute` node of every `attribute_item`
+// sibling immediately preceding n. Rust attaches outer attributes as prior
+// siblings, so the scan stops at the first non-attribute sibling.
+func forEachPrecedingAttr(n *sitter.Node, fn func(attr *sitter.Node)) {
+	for sib := n.PrevNamedSibling(); sib != nil; sib = sib.PrevNamedSibling() {
+		if sib.Kind() != "attribute_item" {
+			break
+		}
+		inner := sib.NamedChild(0)
+		if inner != nil && inner.Kind() == "attribute" {
+			fn(inner)
+		}
+	}
+}

--- a/internal/extract/rust/harvest_test.go
+++ b/internal/extract/rust/harvest_test.go
@@ -1,0 +1,415 @@
+package rust
+
+import (
+	"errors"
+	"testing"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+)
+
+// captureEmitter records emitted symbols plus the streamed dispatch, mention,
+// export, and test-symbol names. It implements extract.Emitter, DispatchEmitter,
+// MentionEmitter, and RustHarvestEmitter so a single Extract call exercises symbol
+// extraction and every harvest together.
+type captureEmitter struct {
+	symbols      []extract.EmittedSymbol
+	edges        []extract.EmittedEdge
+	dispatch     []string
+	mentions     []string
+	exports      []string
+	testSymbols  []string
+	traitMethods []string
+	allowDead    []string
+}
+
+func (c *captureEmitter) Symbol(s extract.EmittedSymbol) error {
+	c.symbols = append(c.symbols, s)
+	return nil
+}
+func (c *captureEmitter) Edge(e extract.EmittedEdge) error { c.edges = append(c.edges, e); return nil }
+func (c *captureEmitter) DispatchName(name string) error {
+	c.dispatch = append(c.dispatch, name)
+	return nil
+}
+func (c *captureEmitter) MentionName(name string) error {
+	c.mentions = append(c.mentions, name)
+	return nil
+}
+func (c *captureEmitter) RustExportName(name string) error {
+	c.exports = append(c.exports, name)
+	return nil
+}
+func (c *captureEmitter) RustTestSymbol(name string) error {
+	c.testSymbols = append(c.testSymbols, name)
+	return nil
+}
+func (c *captureEmitter) RustTraitImplMethod(name string) error {
+	c.traitMethods = append(c.traitMethods, name)
+	return nil
+}
+func (c *captureEmitter) RustAllowDeadName(name string) error {
+	c.allowDead = append(c.allowDead, name)
+	return nil
+}
+
+func has(names []string, want string) bool {
+	for _, n := range names {
+		if n == want {
+			return true
+		}
+	}
+	return false
+}
+
+// harvest parses Rust source and runs the extractor into a fresh captureEmitter.
+func harvest(t *testing.T, src string) *captureEmitter {
+	t.Helper()
+	ex := Extractor{}
+	p := sitter.NewParser()
+	defer p.Close()
+	if err := p.SetLanguage(ex.Grammar()); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	source := []byte(src)
+	tree := p.Parse(source, nil)
+	if tree == nil {
+		t.Fatal("Parse returned nil tree")
+	}
+	defer tree.Close()
+	c := &captureEmitter{}
+	if err := ex.Extract(tree, source, "test.rs", c); err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return c
+}
+
+func TestHarvestsMentionsTrue(t *testing.T) {
+	if !(Extractor{}).HarvestsMentions() {
+		t.Error("HarvestsMentions() = false, want true (Rust streams the mention set)")
+	}
+}
+
+func TestMentionsCaptureUses(t *testing.T) {
+	c := harvest(t, `
+struct Widget;
+
+impl Widget {
+    fn run(&self) {}
+}
+
+fn use_it() {
+    let w = Widget;
+    w.run();
+    helper();
+}
+
+fn helper() {}
+`)
+	// A type reference, a method-call field name, and a bare call target are all
+	// mentioned; the project-global set proves them reachable.
+	for _, want := range []string{"Widget", "run", "helper"} {
+		if !has(c.mentions, want) {
+			t.Errorf("mention %q not captured; got %v", want, c.mentions)
+		}
+	}
+}
+
+func TestMentionsExcludeDefinitionNames(t *testing.T) {
+	// A definition that is never referenced must NOT mention its own name —
+	// otherwise it could never earn `dead`.
+	c := harvest(t, `
+fn orphan() {}
+
+struct Lonely;
+`)
+	if has(c.mentions, "orphan") {
+		t.Errorf("orphan (its own definition name) must not be a mention; got %v", c.mentions)
+	}
+	if has(c.mentions, "Lonely") {
+		t.Errorf("Lonely (its own definition name) must not be a mention; got %v", c.mentions)
+	}
+}
+
+func TestMentionsRetainTraitMethodDeclaration(t *testing.T) {
+	// A trait method DECLARATION's name stays in the mention set so a same-named
+	// concrete impl is kept open-world even when satisfaction was not resolved.
+	c := harvest(t, `
+trait Greeter {
+    fn greet(&self);
+}
+`)
+	if !has(c.mentions, "greet") {
+		t.Errorf("trait method declaration name 'greet' must remain a mention; got %v", c.mentions)
+	}
+}
+
+func TestDispatchCapturesDowncast(t *testing.T) {
+	c := harvest(t, `
+use std::any::Any;
+
+fn inspect(value: &dyn Any) {
+    if let Some(w) = value.downcast_ref::<Widget>() {
+        let _ = w;
+    }
+}
+
+struct Widget;
+`)
+	if !has(c.dispatch, "Widget") {
+		t.Errorf("downcast_ref::<Widget> should record Widget as a dispatch target; got %v", c.dispatch)
+	}
+}
+
+func TestExportsCaptureFFIFunction(t *testing.T) {
+	c := harvest(t, `
+#[no_mangle]
+pub extern "C" fn ffi_entry() {}
+
+#[export_name = "renamed"]
+fn exported() {}
+
+fn ordinary() {}
+`)
+	for _, want := range []string{"ffi_entry", "exported"} {
+		if !has(c.exports, want) {
+			t.Errorf("export %q not captured; got %v", want, c.exports)
+		}
+	}
+	if has(c.exports, "ordinary") {
+		t.Errorf("ordinary function must not be an export; got %v", c.exports)
+	}
+}
+
+func TestExportsCaptureUsedStatic(t *testing.T) {
+	c := harvest(t, `
+#[used]
+static KEEP: u8 = 0;
+
+#[no_mangle]
+static EXPORTED: u8 = 1;
+
+static PLAIN: u8 = 2;
+`)
+	for _, want := range []string{"KEEP", "EXPORTED"} {
+		if !has(c.exports, want) {
+			t.Errorf("static export %q not captured; got %v", want, c.exports)
+		}
+	}
+	if has(c.exports, "PLAIN") {
+		t.Errorf("plain static must not be an export; got %v", c.exports)
+	}
+}
+
+func TestTestSymbolsCaptureTestAttribute(t *testing.T) {
+	c := harvest(t, `
+#[test]
+fn it_works() {}
+
+#[tokio::test]
+async fn async_works() {}
+
+fn plain() {}
+`)
+	for _, want := range []string{"it_works", "async_works"} {
+		if !has(c.testSymbols, want) {
+			t.Errorf("#[test]/#[tokio::test] function %q should be a test symbol; got %v", want, c.testSymbols)
+		}
+	}
+	if has(c.testSymbols, "plain") {
+		t.Errorf("plain function must not be a test symbol; got %v", c.testSymbols)
+	}
+}
+
+func TestAllowDeadCaptured(t *testing.T) {
+	// Items annotated #[allow(dead_code)] / #[allow(unused)] are intentionally
+	// retained; an unannotated item is not.
+	c := harvest(t, `
+#[allow(dead_code)]
+fn kept_fn() {}
+
+#[allow(unused)]
+struct KeptStruct;
+
+#[allow(dead_code, clippy::all)]
+const KEPT_CONST: u8 = 0;
+
+fn plain_fn() {}
+`)
+	for _, want := range []string{"kept_fn", "KeptStruct", "KEPT_CONST"} {
+		if !has(c.allowDead, want) {
+			t.Errorf("#[allow(dead_code)] item %q should be captured; got %v", want, c.allowDead)
+		}
+	}
+	if has(c.allowDead, "plain_fn") {
+		t.Errorf("unannotated function must not be in the allow-dead set; got %v", c.allowDead)
+	}
+}
+
+func TestTraitImplMethodsCaptured(t *testing.T) {
+	// Methods in an `impl Trait for Type` block are trait-impl methods regardless of
+	// the trait's origin; an inherent `impl Type` method is not.
+	c := harvest(t, `
+trait Greeter {
+    fn greet(&self);
+}
+
+struct Robot;
+
+impl Greeter for Robot {
+    fn greet(&self) {}
+}
+
+impl Robot {
+    fn inherent_only(&self) {}
+}
+`)
+	if !has(c.traitMethods, "greet") {
+		t.Errorf("trait-impl method 'greet' should be captured; got %v", c.traitMethods)
+	}
+	if has(c.traitMethods, "inherent_only") {
+		t.Errorf("inherent method 'inherent_only' must not be a trait-impl method; got %v", c.traitMethods)
+	}
+}
+
+func TestTestSymbolsCaptureCfgTestTypesAndStatics(t *testing.T) {
+	// Every kind of definition nested under #[cfg(test)] is test-only, including
+	// statics and type definitions, not just functions.
+	c := harvest(t, `
+#[cfg(test)]
+mod tests {
+    static FIXTURE_DATA: u8 = 0;
+
+    struct Helper;
+
+    enum Mode { A, B }
+}
+`)
+	for _, want := range []string{"FIXTURE_DATA", "Helper", "Mode"} {
+		if !has(c.testSymbols, want) {
+			t.Errorf("symbol %q under #[cfg(test)] should be a test symbol; got %v", want, c.testSymbols)
+		}
+	}
+}
+
+func TestDispatchIgnoresNonDowncastGenerics(t *testing.T) {
+	// Generic calls that are not Any downcasts contribute no dispatch names — only
+	// the downcast family names a type the static graph cannot see.
+	c := harvest(t, `
+fn run() {
+    let _ = identity::<u8>(0);
+    let _: Vec<u8> = it.collect::<Vec<u8>>();
+    let _ = Foo::bar::<u8>();
+}
+`)
+	if len(c.dispatch) != 0 {
+		t.Errorf("non-downcast generic calls must not record dispatch names; got %v", c.dispatch)
+	}
+}
+
+// errEmitter returns the configured error from whichever harvest method matches
+// failOn, exercising emitHarvest's error-propagation paths.
+type errEmitter struct {
+	captureEmitter
+	failOn string
+	err    error
+}
+
+func (e *errEmitter) DispatchName(name string) error {
+	if e.failOn == "dispatch" {
+		return e.err
+	}
+	return e.captureEmitter.DispatchName(name)
+}
+func (e *errEmitter) MentionName(name string) error {
+	if e.failOn == "mention" {
+		return e.err
+	}
+	return e.captureEmitter.MentionName(name)
+}
+func (e *errEmitter) RustExportName(name string) error {
+	if e.failOn == "export" {
+		return e.err
+	}
+	return e.captureEmitter.RustExportName(name)
+}
+func (e *errEmitter) RustTestSymbol(name string) error {
+	if e.failOn == "test" {
+		return e.err
+	}
+	return e.captureEmitter.RustTestSymbol(name)
+}
+func (e *errEmitter) RustTraitImplMethod(name string) error {
+	if e.failOn == "traitimpl" {
+		return e.err
+	}
+	return e.captureEmitter.RustTraitImplMethod(name)
+}
+func (e *errEmitter) RustAllowDeadName(name string) error {
+	if e.failOn == "allowdead" {
+		return e.err
+	}
+	return e.captureEmitter.RustAllowDeadName(name)
+}
+
+func TestEmitHarvestPropagatesEmitterErrors(t *testing.T) {
+	src := `
+#[no_mangle]
+fn ffi_entry() {}
+
+#[test]
+fn it_works() {
+    let _ = v.downcast_ref::<Widget>();
+}
+
+struct Widget;
+
+trait T { fn m(&self); }
+impl T for Widget { fn m(&self) {} }
+
+#[allow(dead_code)]
+fn kept() {}
+`
+	ex := Extractor{}
+	p := sitter.NewParser()
+	defer p.Close()
+	if err := p.SetLanguage(ex.Grammar()); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	source := []byte(src)
+	tree := p.Parse(source, nil)
+	if tree == nil {
+		t.Fatal("Parse returned nil tree")
+	}
+	defer tree.Close()
+
+	boom := errors.New("boom")
+	for _, failOn := range []string{"dispatch", "mention", "export", "test", "traitimpl", "allowdead"} {
+		e := &errEmitter{failOn: failOn, err: boom}
+		if err := ex.Extract(tree, source, "test.rs", e); !errors.Is(err, boom) {
+			t.Errorf("failOn %q: Extract error = %v, want boom", failOn, err)
+		}
+	}
+}
+
+func TestTestSymbolsCaptureCfgTestModule(t *testing.T) {
+	c := harvest(t, `
+#[cfg(test)]
+mod tests {
+    fn fixture() {}
+
+    fn another_helper() {}
+}
+
+fn production() {}
+`)
+	for _, want := range []string{"fixture", "another_helper"} {
+		if !has(c.testSymbols, want) {
+			t.Errorf("symbol %q under #[cfg(test)] should be a test symbol; got %v", want, c.testSymbols)
+		}
+	}
+	if has(c.testSymbols, "production") {
+		t.Errorf("production function must not be a test symbol; got %v", c.testSymbols)
+	}
+}

--- a/internal/extract/rust/rust.go
+++ b/internal/extract/rust/rust.go
@@ -64,7 +64,10 @@ func (Extractor) Extract(tree *sitter.Tree, source []byte, _ string, emit extrac
 		typeTraits:   map[string][]string{},
 	}
 	w.preCollect(tree.RootNode(), nil)
-	return w.walk(tree.RootNode(), nil)
+	if err := w.walk(tree.RootNode(), nil); err != nil {
+		return err
+	}
+	return emitHarvest(tree.RootNode(), source, emit)
 }
 
 func init() { extract.Register(Extractor{}) }

--- a/internal/scan/dispatch.go
+++ b/internal/scan/dispatch.go
@@ -113,6 +113,62 @@ func writeCgoExports(ctx context.Context, idx *sqlite.Adapter, collected map[str
 	return writeNameSet(ctx, idx, cgoExportsMetaKey, collected)
 }
 
+// rustExportsMetaKey is the sense_meta key holding the project-wide set of Rust
+// function/static names whose reachability the edge graph cannot see: functions
+// marked `#[no_mangle]` / `#[export_name]` (called across the FFI boundary) and
+// statics marked `#[no_mangle]` / `#[used]` (kept alive by the linker). The Rust
+// voice reads it (rust_ffi for a function, rust_used for a static) so such a
+// symbol stays open-world rather than earning `dead` off its absent caller. Flat,
+// not per-language — these are Rust-only attributes, like cgo is Go-only.
+const rustExportsMetaKey = "rust_exports"
+
+// writeRustExports persists the project-wide Rust export/`#[used]` set, unioning
+// with the existing set (same self-heals-on-rebuild rationale as the other sets).
+func writeRustExports(ctx context.Context, idx *sqlite.Adapter, collected map[string]struct{}) error {
+	return writeNameSet(ctx, idx, rustExportsMetaKey, collected)
+}
+
+// rustTestSymbolsMetaKey is the sense_meta key holding the project-wide set of
+// Rust symbol names that are test-only: items marked `#[test]` / `#[bench]` or
+// nested under a `#[cfg(test)]` module. The test harness invokes them and
+// `cargo build` does not compile them, so the Rust voice keeps them open-world
+// (rust_test) rather than earning `dead` off an absent caller. Flat, like the
+// other Rust set.
+const rustTestSymbolsMetaKey = "rust_test_symbols"
+
+// writeRustTestSymbols persists the project-wide Rust test-symbol set, unioning
+// with the existing set (same self-heals-on-rebuild rationale as the other sets).
+func writeRustTestSymbols(ctx context.Context, idx *sqlite.Adapter, collected map[string]struct{}) error {
+	return writeNameSet(ctx, idx, rustTestSymbolsMetaKey, collected)
+}
+
+// rustTraitImplMethodsMetaKey is the sense_meta key holding the project-wide set
+// of method names defined in `impl Trait for Type` blocks. The Rust voice reads
+// it: such a method satisfies a trait and is reached through it, so it stays
+// open-world (rust_trait_impl) rather than earning `dead` off an absent caller.
+// This is the sound trait-impl signal that covers external traits (serde, std::io)
+// the voice's static method-name table cannot enumerate.
+const rustTraitImplMethodsMetaKey = "rust_trait_impl_methods"
+
+// writeRustTraitImplMethods persists the project-wide Rust trait-impl method set,
+// unioning with the existing set (same self-heals-on-rebuild rationale as above).
+func writeRustTraitImplMethods(ctx context.Context, idx *sqlite.Adapter, collected map[string]struct{}) error {
+	return writeNameSet(ctx, idx, rustTraitImplMethodsMetaKey, collected)
+}
+
+// rustAllowDeadMetaKey is the sense_meta key holding the project-wide set of Rust
+// item names annotated `#[allow(dead_code)]` / `#[allow(unused)]`. The Rust voice
+// reads it: the author deliberately suppressed the lint, so rustc never warns the
+// item and it is absent from the cargo oracle — the voice keeps it open-world
+// (rust_allow_dead) rather than calling it dead.
+const rustAllowDeadMetaKey = "rust_allow_dead"
+
+// writeRustAllowDead persists the project-wide Rust `#[allow(dead_code)]` set,
+// unioning with the existing set (same self-heals-on-rebuild rationale as above).
+func writeRustAllowDead(ctx context.Context, idx *sqlite.Adapter, collected map[string]struct{}) error {
+	return writeNameSet(ctx, idx, rustAllowDeadMetaKey, collected)
+}
+
 // addNamesByLang unions names into byLang[lang], creating the language's set on
 // first use. Both per-language name accumulators (dispatch, mention) share it so
 // the handler keeps each language's names apart for per-language meta writes.

--- a/internal/scan/dispatch_test.go
+++ b/internal/scan/dispatch_test.go
@@ -297,6 +297,75 @@ func TestScanWritesCgoExports(t *testing.T) {
 	}
 }
 
+// TestScanWritesRustHarvest proves the Rust attribute harvest flows end to end
+// through the scan collector and aggregation: a single Rust file carrying every
+// attribute shape lands each name in its sense_meta key, where the dead-code Rust
+// voice reads it. It exercises all four RustHarvestEmitter collector paths in one
+// scan.
+func TestScanWritesRustHarvest(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	senseDir := filepath.Join(root, ".sense")
+
+	src := `#[no_mangle]
+pub extern "C" fn ffi_entry() {}
+
+#[used]
+static KEEP: u8 = 0;
+
+#[allow(dead_code)]
+fn intentionally_kept() {}
+
+#[cfg(test)]
+mod tests {
+    #[tokio::test]
+    async fn async_case() {}
+}
+
+trait Greeter {
+    fn greet(&self);
+}
+
+struct Robot;
+
+impl Greeter for Robot {
+    fn greet(&self) {}
+}
+`
+	if err := os.WriteFile(filepath.Join(root, "lib.rs"), []byte(src), 0o644); err != nil {
+		t.Fatalf("write rust: %v", err)
+	}
+
+	if _, err := Run(ctx, Options{Root: root, Sense: senseDir, Output: &bytes.Buffer{}, Warnings: io.Discard}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+
+	a, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatalf("open index: %v", err)
+	}
+	t.Cleanup(func() { _ = a.Close() })
+
+	cases := []struct {
+		key, name string
+	}{
+		{rustExportsMetaKey, "ffi_entry"},
+		{rustExportsMetaKey, "KEEP"},
+		{rustTestSymbolsMetaKey, "async_case"},
+		{rustAllowDeadMetaKey, "intentionally_kept"},
+		{rustTraitImplMethodsMetaKey, "greet"},
+	}
+	for _, c := range cases {
+		set, err := readNameSet(ctx, a, c.key)
+		if err != nil {
+			t.Fatalf("read %s: %v", c.key, err)
+		}
+		if _, ok := set[c.name]; !ok {
+			t.Errorf("expected %q in %s, got %v", c.name, c.key, set)
+		}
+	}
+}
+
 // TestScanDeletesLegacyUnionKeys proves the in-place-upgrade cleanup: a scan
 // removes the stale bare `mentioned_names`/`dispatch_names` union keys a
 // pre-feature index left behind, while the per-language keys survive.

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -234,6 +234,10 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	}
 	warnMetaWrite(warn, "harvested-langs", writeHarvestedLangs(ctx, idx, h.harvestedLangs))
 	warnMetaWrite(warn, "cgo-exports", writeCgoExports(ctx, idx, h.cgoExports))
+	warnMetaWrite(warn, "rust-exports", writeRustExports(ctx, idx, h.rustExports))
+	warnMetaWrite(warn, "rust-test-symbols", writeRustTestSymbols(ctx, idx, h.rustTestSymbols))
+	warnMetaWrite(warn, "rust-trait-impl-methods", writeRustTraitImplMethods(ctx, idx, h.rustTraitMethods))
+	warnMetaWrite(warn, "rust-allow-dead", writeRustAllowDead(ctx, idx, h.rustAllowDead))
 	// A pre-feature index carried single bare union keys (no language suffix).
 	// The per-language reader globs `*:<lang>` and ignores them, but delete them
 	// on every full scan so an in-place upgrade leaves no stale meta to mislead a
@@ -530,6 +534,23 @@ type harness struct {
 	// persisted set so an unchanged file's exports are not lost.
 	cgoExports map[string]struct{}
 
+	// rustExports is the project-wide set of Rust function/static names whose
+	// reachability the edge graph cannot see (`#[no_mangle]` / `#[export_name]`
+	// functions, `#[no_mangle]` / `#[used]` statics). rustTestSymbols is the set
+	// of Rust test-only symbol names (`#[test]` / `#[bench]`, or nested under a
+	// `#[cfg(test)]` module). Both are written to flat sense_meta keys so the
+	// dead-code Rust voice keeps such a symbol open-world (rust_ffi / rust_used /
+	// rust_test). Flat (not per-language): these are Rust-only attributes, like
+	// cgo. Merged with the persisted set so an unchanged file's names survive.
+	// rustTraitMethods is the set of method names defined in `impl Trait for Type`
+	// blocks (the sound trait-impl signal, including external traits).
+	// rustAllowDead is the set of item names annotated `#[allow(dead_code)]` /
+	// `#[allow(unused)]` (intentionally retained; never in the cargo oracle).
+	rustExports      map[string]struct{}
+	rustTestSymbols  map[string]struct{}
+	rustTraitMethods map[string]struct{}
+	rustAllowDead    map[string]struct{}
+
 	// harvestedLangs is the set of languages whose mention harvest RAN this
 	// scan — every indexed file whose extractor is an extract.MentionHarvester
 	// marks its language here, regardless of how many names it produced. Written
@@ -764,6 +785,38 @@ func (h *harness) walkTree(root string) error {
 				h.cgoExports[n] = struct{}{}
 			}
 		}
+		if len(fr.RustExports) > 0 {
+			if h.rustExports == nil {
+				h.rustExports = map[string]struct{}{}
+			}
+			for _, n := range fr.RustExports {
+				h.rustExports[n] = struct{}{}
+			}
+		}
+		if len(fr.RustTestSymbols) > 0 {
+			if h.rustTestSymbols == nil {
+				h.rustTestSymbols = map[string]struct{}{}
+			}
+			for _, n := range fr.RustTestSymbols {
+				h.rustTestSymbols[n] = struct{}{}
+			}
+		}
+		if len(fr.RustTraitMethods) > 0 {
+			if h.rustTraitMethods == nil {
+				h.rustTraitMethods = map[string]struct{}{}
+			}
+			for _, n := range fr.RustTraitMethods {
+				h.rustTraitMethods[n] = struct{}{}
+			}
+		}
+		if len(fr.RustAllowDead) > 0 {
+			if h.rustAllowDead == nil {
+				h.rustAllowDead = map[string]struct{}{}
+			}
+			for _, n := range fr.RustAllowDead {
+				h.rustAllowDead[n] = struct{}{}
+			}
+		}
 
 		batch = append(batch, fr)
 		if len(batch) >= batchSize {
@@ -835,11 +888,15 @@ type fileResult struct {
 	Language       string
 	Source         []byte
 	Hash           string
-	Symbols        []extract.EmittedSymbol
-	Edges          []extract.EmittedEdge
-	DispatchNames  []string
-	MentionedNames []string
-	CgoExports     []string
+	Symbols         []extract.EmittedSymbol
+	Edges           []extract.EmittedEdge
+	DispatchNames   []string
+	MentionedNames  []string
+	CgoExports       []string
+	RustExports      []string
+	RustTestSymbols  []string
+	RustTraitMethods []string
+	RustAllowDead    []string
 }
 
 // 100 files per SQLite transaction amortizes BEGIN/COMMIT overhead (~10x
@@ -953,11 +1010,15 @@ func parseFileCore(po parseOpts, path, rel string, skip func(hash string) bool) 
 		Language:       ex.Language(),
 		Source:         source,
 		Hash:           newHash,
-		Symbols:        collected.symbols,
-		Edges:          collected.edges,
-		DispatchNames:  collected.dispatchNames,
-		MentionedNames: collected.mentionedNames,
-		CgoExports:     collected.cgoExports,
+		Symbols:         collected.symbols,
+		Edges:           collected.edges,
+		DispatchNames:   collected.dispatchNames,
+		MentionedNames:  collected.mentionedNames,
+		CgoExports:       collected.cgoExports,
+		RustExports:      collected.rustExports,
+		RustTestSymbols:  collected.rustTestSymbols,
+		RustTraitMethods: collected.rustTraitMethods,
+		RustAllowDead:    collected.rustAllowDead,
 	}
 }
 
@@ -1287,11 +1348,15 @@ func safeExtractRaw(ex extract.RawExtractor, source []byte, rel string, c *colle
 // ---- collector (per-file Emitter) ----
 
 type collector struct {
-	symbols        []extract.EmittedSymbol
-	edges          []extract.EmittedEdge
-	dispatchNames  []string
-	mentionedNames []string
-	cgoExports     []string
+	symbols         []extract.EmittedSymbol
+	edges           []extract.EmittedEdge
+	dispatchNames   []string
+	mentionedNames  []string
+	cgoExports       []string
+	rustExports      []string
+	rustTestSymbols  []string
+	rustTraitMethods []string
+	rustAllowDead    []string
 }
 
 func (c *collector) Symbol(s extract.EmittedSymbol) error {
@@ -1325,6 +1390,44 @@ func (c *collector) MentionName(name string) error {
 // instead of being falsely called dead.
 func (c *collector) CgoExportName(name string) error {
 	c.cgoExports = append(c.cgoExports, name)
+	return nil
+}
+
+// RustExportName implements extract.RustHarvestEmitter: an extractor streams every
+// Rust function/static whose reachability the edge graph cannot see (a
+// `#[no_mangle]` / `#[export_name]` function, a `#[no_mangle]` / `#[used]`
+// static). The project-wide set feeds the dead-code Rust voice so such a symbol
+// stays open-world (rust_ffi / rust_used) rather than being falsely called dead.
+func (c *collector) RustExportName(name string) error {
+	c.rustExports = append(c.rustExports, name)
+	return nil
+}
+
+// RustTestSymbol implements extract.RustHarvestEmitter: an extractor streams every
+// Rust test-only symbol (`#[test]` / `#[bench]`, or nested under `#[cfg(test)]`).
+// The project-wide set feeds the dead-code Rust voice so a test symbol stays
+// open-world (rust_test) instead of being falsely called dead.
+func (c *collector) RustTestSymbol(name string) error {
+	c.rustTestSymbols = append(c.rustTestSymbols, name)
+	return nil
+}
+
+// RustTraitImplMethod implements extract.RustHarvestEmitter: an extractor streams
+// every method defined in an `impl Trait for Type` block. The project-wide set
+// feeds the dead-code Rust voice so a trait-satisfying method stays open-world
+// (rust_trait_impl) instead of being falsely called dead.
+func (c *collector) RustTraitImplMethod(name string) error {
+	c.rustTraitMethods = append(c.rustTraitMethods, name)
+	return nil
+}
+
+// RustAllowDeadName implements extract.RustHarvestEmitter: an extractor streams
+// every item annotated `#[allow(dead_code)]` / `#[allow(unused)]`. The project-wide
+// set feeds the dead-code Rust voice so an intentionally-retained symbol stays
+// open-world (rust_allow_dead) instead of being called dead — rustc suppresses its
+// warning, so it is never in the cargo oracle.
+func (c *collector) RustAllowDeadName(name string) error {
+	c.rustAllowDead = append(c.rustAllowDead, name)
 	return nil
 }
 

--- a/testdata/smoke/dead-golden.json
+++ b/testdata/smoke/dead-golden.json
@@ -1,6 +1,13 @@
 {
   "findings": [
     {
+      "qualified": "Greeter::greet",
+      "kind": "method",
+      "file": "wallet.rs",
+      "verdict": "possibly_dead",
+      "reason": "rust_trait_impl"
+    },
+    {
       "qualified": "LineItem#orphaned_private",
       "kind": "method",
       "file": "line_item.rb",
@@ -12,6 +19,27 @@
       "file": "line_item.rb",
       "verdict": "possibly_dead",
       "reason": "core_exported_api"
+    },
+    {
+      "qualified": "Money::clone",
+      "kind": "method",
+      "file": "wallet.rs",
+      "verdict": "possibly_dead",
+      "reason": "rust_derive"
+    },
+    {
+      "qualified": "Registry",
+      "kind": "class",
+      "file": "wallet.rs",
+      "verdict": "possibly_dead",
+      "reason": "core_exported_api"
+    },
+    {
+      "qualified": "Robot::greet",
+      "kind": "method",
+      "file": "wallet.rs",
+      "verdict": "possibly_dead",
+      "reason": "rust_trait_impl"
     },
     {
       "qualified": "Trackable#track_change",
@@ -26,6 +54,12 @@
       "file": "user.rb",
       "verdict": "possibly_dead",
       "reason": "core_exported_api"
+    },
+    {
+      "qualified": "orphaned_rust",
+      "kind": "function",
+      "file": "wallet.rs",
+      "verdict": "dead"
     },
     {
       "qualified": "smoke.BaseService.Log",
@@ -76,7 +110,7 @@
       "verdict": "dead"
     }
   ],
-  "total_symbols": 34,
-  "dead_count": 2,
-  "possibly_dead_count": 9
+  "total_symbols": 42,
+  "dead_count": 3,
+  "possibly_dead_count": 13
 }

--- a/testdata/smoke/wallet.rs
+++ b/testdata/smoke/wallet.rs
@@ -1,0 +1,37 @@
+// orphaned_rust is non-pub, has no caller, and its name is mentioned nowhere
+// else — the genuinely-dead shape the Rust voice earns `dead` for.
+fn orphaned_rust() {}
+
+pub trait Greeter {
+    fn greet(&self);
+}
+
+struct Robot;
+
+impl Greeter for Robot {
+    // greet implements a trait method (Greeter::greet is in the index), so the
+    // Rust voice keeps it possibly_dead with reason rust_trait_impl even though
+    // no caller invokes it directly — it is reached through the trait.
+    fn greet(&self) {}
+}
+
+struct Money {
+    cents: i64,
+}
+
+impl Money {
+    // clone shares a name with the Clone derive's synthesized method. The Rust
+    // voice keeps it possibly_dead (rust_derive), proving derives do not flood
+    // the dead set — without the voice the soundness gate would call it dead.
+    fn clone(&self) -> Money {
+        Money { cents: self.cents }
+    }
+}
+
+// Registry holds Robot and Money as fields, giving each an incoming edge so they
+// are not dead candidates and their methods (greet / clone) surface with the
+// Rust voice's reason rather than being rolled up into a dead struct.
+pub struct Registry {
+    bot: Robot,
+    wallet: Money,
+}


### PR DESCRIPTION
## Problem

Rust symbols received the same all-`possibly_dead` `core_no_language_voice` treatment as any unsupported stack, even though Rust leaves the cleanest closed-world signal in the toolchain unused. Privacy is enforced at module granularity (`pub` vs private-by-default, already recorded in `Symbol.Visibility`), and rustc's own `dead_code` lint flags exactly the unused non-`pub` item. Without a Rust voice, Sense could never tell a Rust author which unreferenced symbol is safe to remove versus reached through a trait, derive, FFI boundary, or test harness.

## Summary

Add a Rust language voice so Rust becomes the third language (after Ruby and Go) whose symbols can earn the `dead` verdict. The verdict is validated against `cargo`'s `dead_code` lint as a compiler-grade oracle, with the binding invariant **Sense `dead` (Rust) ⊆ cargo `dead_code`** (zero false `dead`).

## Changes

- **Harvest (`internal/extract/rust`)** — a scan-time harvest feeding the per-language soundness gate: a shared-walker mention set, an `Any::downcast` dispatch set, and four structural signals the edge graph cannot see — `#[no_mangle]`/`#[export_name]`/`#[used]` exports, `#[test]`/`#[bench]`/`#[cfg(test)]` test symbols (including scoped `#[tokio::test]`), methods defined in `impl Trait for Type` blocks, and `#[allow(dead_code)]` markers. New optional `extract.RustHarvestEmitter` interface, type-asserted like the cgo emitter.
- **Scan (`internal/scan`)** — wires the harvest through the collector and per-file aggregation into four flat `sense_meta` keys, following the established cgo-export pattern (union-write, self-heals on rebuild, absent key reads empty).
- **Voice (`internal/dead`)** — `rustVoice` earns `dead` only for a non-`pub` fn / method / type / struct / enum / trait with zero incoming edges, absent from the Rust mention set, tied to no invisible-reach idiom. Everything else stays `possibly_dead` with an exact reason: `rust_trait_impl`, `rust_derive`, `rust_ffi`, `rust_used`, `rust_test`, `rust_allow_dead`, `rust_module`, `rust_pub`.
- **Oracle (`internal/dead/eval`)** — a `cargo check` `dead_code` parser plus subset checker, mirroring the staticcheck U1000 oracle used for Go.
- **Docs** — `CHANGELOG.md`.

## Architecture Highlights

- The primary trait-impl signal is **structural**: methods harvested from `impl Trait for Type` blocks, so the voice covers external traits (serde's `Deserializer`, `std::io::Write`) without enumerating their method names. `rust_derive` keeps a small static table only for derive-synthesized names that have no source impl block.
- Every Rust `sense_meta` read degrades to an empty set on absence or corruption (recall loss, never a crash, never a false `dead`); the soundness gate still fails closed.

## Test Plan

- [x] Per-reason and two-sided voice unit tests assert the exact reason code
- [x] Arbiter-level control: an orphan earns `dead` while trait/pub/ffi symbols stay `possibly_dead`
- [x] End-to-end smoke fixture + golden: a non-`pub` orphan earns `dead`; a trait-impl method and a derive-named method stay `possibly_dead`
- [x] Scan-level test asserts all four harvest sets land in `sense_meta`
- [x] cargo `dead_code` oracle: subset gate passes on a real crate; a planted live trait method fails it
- [x] Validated on the axum benchmark repo: zero false `dead` (792 zero-edge findings reclassified from `core_no_language_voice` into accurate reasons)
- [x] `go test ./...` passes; `make ci` green (0 lint issues); sense binary builds cleanly