### PR TITLE
feat(dead): TypeScript/JavaScript dead-code voice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ All notable changes to Sense.
 
 ### Added
 
+- TypeScript is the fourth language whose symbols can earn the `dead` verdict,
+  and `Symbol.Visibility` is now populated for the whole TS/JS family. The TS/JS
+  extractor marks each symbol `public` (exported in any form — `export`, `export
+  default`, an `export { g }` clause, or a re-export) or `private` (module-local).
+  With no compiler dead-code lint to bind against, the closed-world signal is the
+  module system: the `tsVoice` earns `dead` only for a **module-private `.ts`/`.tsx`
+  function / const / class** with no caller, no mention, and no framework idiom.
+  Everything export- or framework-reachable stays `possibly_dead` with an exact
+  reason: `ts_decorator` (an `@Component`/`@Injectable`/`@Controller` or
+  route-decorated class/method a DI container dispatches), `ts_framework_route` (a
+  Next.js `app/` page/layout/route or any `pages/` export rendered by file-system
+  routing), `ts_jsx` (an exported PascalCase `.tsx`/`.jsx` component used as
+  `<Component/>`), `ts_default_export` (imported by path, not by name), `ts_exported`
+  (a re-export / dynamic `import()` / external consumer may reach it), `ts_method` (a
+  method may satisfy an interface or a framework protocol like React's
+  `componentDidMount`), and `ts_type` (an interface/type reached structurally or by
+  declaration-merging). **Plain JavaScript stays conservative:** a module-private
+  `.js` symbol that would earn `dead` in TypeScript is held `possibly_dead`
+  (`js_dynamic`) instead — CommonJS mutation and the absence of types make the
+  closed-world bet unsound for JS. A symbol earns `dead` only in an ES *module* (a
+  file with a top-level import/export); a global *script* (no module syntax — a
+  bundler runtime, an ambient file) has concatenation-reachable symbols that never
+  earn `dead`. `.d.ts` and test-fixture directories (`testdata/`, `test/`,
+  `__testfixtures__/`) are excluded from candidacy. The extractor harvests its own
+  mention set, computed-property dispatch keys (`obj["render"]`), decorator names,
+  and default-export names. There is no compiler oracle as clean as `staticcheck` /
+  `cargo` here, so the binding gate is hand-labeled precision on a synthetic corpus
+  (100%) plus a before/after run on the `nextjs` benchmark repo (zero false `dead`).
+
 - Rust is the third language whose symbols can earn the `dead` verdict. The Rust
   voice earns `dead` only for a non-`pub` fn / method / type / struct / enum /
   trait with no caller, no mention, and no invisible-reach idiom; everything else

--- a/internal/dead/arbiter.go
+++ b/internal/dead/arbiter.go
@@ -130,6 +130,19 @@ type Facts struct {
 	// rustc never warns it and it is absent from the cargo oracle. Populated from
 	// the rust_allow_dead sense_meta key.
 	RustAllowDeadNames map[string]struct{}
+	// TSDecoratedNames is the set of TS/JS class and method names carrying a
+	// decorator (`@Component` / `@Injectable` / `@Controller` / route-method
+	// decorators). The TS voice keeps such a name open-world (ts_decorator): a
+	// framework's DI/router instantiates or routes to it with no source caller,
+	// even when the symbol is module-private. Flat, not per-language — decorators
+	// span the .ts/.tsx/.js family. Populated from the ts_decorated sense_meta key.
+	TSDecoratedNames map[string]struct{}
+	// TSDefaultExportNames is the set of TS/JS names bound by an `export default`
+	// form. The TS voice raises the more specific ts_default_export (over the
+	// generic ts_exported) for such a name: it is imported by path, not by name.
+	// Flat, like TSDecoratedNames. Populated from the ts_default_exports sense_meta
+	// key.
+	TSDefaultExportNames map[string]struct{}
 	// HarvestedLangs is the set of languages whose mention harvest actually ran
 	// for this index. The soundness gate refuses `dead` for a symbol whose
 	// language is absent here (reason core_no_harvest): a missing harvest cannot

--- a/internal/dead/dead.go
+++ b/internal/dead/dead.go
@@ -131,11 +131,15 @@ func FindDead(ctx context.Context, db *sql.DB, opts Options) (Result, error) {
 	}, nil
 }
 
-// defaultArbiter is the registered voice stack for this build: the generic
-// core voice plus the Ruby and Rails language voices. Adding a language voice
-// (Go, TS, Python) is a one-line change here once it exists.
+// defaultArbiter is the registered voice stack for this build: the generic core
+// voice plus the Ruby, Rails, Go, Rust, and TypeScript/JavaScript language
+// voices. The TS voice is registered once per language string the shared
+// extractor emits ("typescript", "tsx", "javascript") so each is a language for
+// which closed-world can be proven. Adding a language voice is a one-line change
+// here once it exists.
 func defaultArbiter() *Arbiter {
-	return NewArbiter(coreVoice{}, rubyVoice{}, railsVoice{}, goVoice{}, rustVoice{})
+	return NewArbiter(coreVoice{}, rubyVoice{}, railsVoice{}, goVoice{}, rustVoice{},
+		tsVoice{lang: "typescript"}, tsVoice{lang: "tsx"}, tsVoice{lang: "javascript"})
 }
 
 // buildFacts gathers the project-wide index facts the voices consume. It is
@@ -185,6 +189,8 @@ func buildFacts(ctx context.Context, db *sql.DB) (Facts, error) {
 		RustTestSymbolNames:      readRustTestSymbolNames(ctx, db),
 		RustTraitImplMethodNames: readRustTraitImplMethodNames(ctx, db),
 		RustAllowDeadNames:       readRustAllowDeadNames(ctx, db),
+		TSDecoratedNames:         readTSDecoratedNames(ctx, db),
+		TSDefaultExportNames:     readTSDefaultExportNames(ctx, db),
 		ValueObjectClassIDs:  valueObjectClassIDs,
 		IncludedModuleIDs:    includedModuleIDs,
 		ControllerConcernIDs: controllerConcernIDs,
@@ -253,7 +259,8 @@ func queryCandidates(ctx context.Context, db *sql.DB, opts Options) ([]Symbol, e
 		WHERE NOT EXISTS (` + edgeFilter + `)
 		AND s.kind IN ('function', 'method', 'class', 'module', 'type', 'interface', 'constant')
 		AND s.qualified NOT LIKE '` + syntheticPrefixPattern + `'
-		AND s.qualified NOT LIKE '` + routePrefixPattern + `'`
+		AND s.qualified NOT LIKE '` + routePrefixPattern + `'
+		AND f.path NOT LIKE '%.d.ts'`
 	var args []any
 
 	if opts.Language != "" {
@@ -658,7 +665,9 @@ func isTestSymbol(s Symbol) bool {
 func isInTestFile(s Symbol) bool {
 	return strings.Contains(s.File, "_test.") ||
 		strings.Contains(s.File, "/test/") ||
+		strings.HasPrefix(s.File, "test/") ||
 		strings.Contains(s.File, "/tests/") ||
+		strings.HasPrefix(s.File, "tests/") ||
 		strings.Contains(s.File, "/spec/") ||
 		strings.Contains(s.File, "/__tests__/") ||
 		// `testdata/` is a fixture directory the Go toolchain (go build/vet,
@@ -668,6 +677,12 @@ func isInTestFile(s Symbol) bool {
 		// `dead` set aligned with the toolchain's universe and free of fixture noise.
 		strings.Contains(s.File, "/testdata/") ||
 		strings.HasPrefix(s.File, "testdata/") ||
+		// `__testfixtures__/` is the jscodeshift convention for transform
+		// input/output samples (next-codemod uses it heavily): standalone code the
+		// test runner reads as text, never imported. Its symbols are fixtures, not
+		// removable code — the TS/JS analog of `testdata/`.
+		strings.Contains(s.File, "/__testfixtures__/") ||
+		strings.HasPrefix(s.File, "__testfixtures__/") ||
 		strings.HasSuffix(s.File, ".spec.ts") ||
 		strings.HasSuffix(s.File, ".spec.js") ||
 		strings.HasSuffix(s.File, ".test.ts") ||
@@ -843,6 +858,22 @@ func readRustTraitImplMethodNames(ctx context.Context, db *sql.DB) map[string]st
 // (rust_allow_dead). A missing or corrupt key yields an empty set.
 func readRustAllowDeadNames(ctx context.Context, db *sql.DB) map[string]struct{} {
 	return readStringSetMeta(ctx, db, "rust_allow_dead")
+}
+
+// readTSDecoratedNames returns the set of TS/JS class/method names carrying a
+// decorator, persisted to the ts_decorated sense_meta key by the scan layer. The
+// TS voice keeps such a name open-world (ts_decorator). A missing or corrupt key
+// yields an empty set.
+func readTSDecoratedNames(ctx context.Context, db *sql.DB) map[string]struct{} {
+	return readStringSetMeta(ctx, db, "ts_decorated")
+}
+
+// readTSDefaultExportNames returns the set of TS/JS names bound by an `export
+// default` form, persisted to the ts_default_exports sense_meta key by the scan
+// layer. The TS voice raises ts_default_export for such a name. A missing or
+// corrupt key yields an empty set.
+func readTSDefaultExportNames(ctx context.Context, db *sql.DB) map[string]struct{} {
+	return readStringSetMeta(ctx, db, "ts_default_exports")
 }
 
 // readStringSetMeta reads a JSON string-array sense_meta value into a set,

--- a/internal/dead/eval/corpus.go
+++ b/internal/dead/eval/corpus.go
@@ -17,6 +17,11 @@ package eval
 // detection and are added with the Rails voice; here the same class of lie
 // is captured through the framework-independent value-object path.
 func Corpus() []Fixture {
+	return append(rubyCorpus(), tsCorpus()...)
+}
+
+// rubyCorpus is the Ruby slice of the trust corpus (see Corpus).
+func rubyCorpus() []Fixture {
 	return []Fixture{
 		{
 			Name: "genuine_dead_private",

--- a/internal/dead/eval/corpus_ts.go
+++ b/internal/dead/eval/corpus_ts.go
@@ -1,0 +1,102 @@
+package eval
+
+// tsCorpus is the hand-labeled TypeScript / JavaScript slice of the trust
+// corpus. Like the Ruby corpus it pins the verdict a *trustworthy* engine must
+// produce, and it deliberately includes the hard export-reachable cases the
+// naive "unreferenced export" rule would lie about (a JSX component used
+// cross-file, a Next.js route entry, a decorator-dispatched class) alongside
+// the one shape that earns `dead` (a module-private symbol) and its
+// JavaScript counterpart that must NOT (the precision split).
+//
+// Each fixture is its own isolated project, so it scans as a library
+// (no entry point, no framework): an exported callable therefore reads as
+// the core voice's core_exported_api — observably possibly_dead, which is all
+// the verdict-level harness scores. The reason-level two-sided control lives in
+// the dead package's golden test.
+//
+// Ground-truth rule for TS/JS: only a module-private (non-exported) `.ts`/`.tsx`
+// symbol that is unmentioned and reached by no framework idiom earns `dead`.
+// Every exported symbol, every framework-reached symbol, and every plain
+// JavaScript symbol stays possibly_dead.
+func tsCorpus() []Fixture {
+	return []Fixture{
+		{
+			Name: "ts_module_private_dead",
+			Files: map[string]string{
+				"widget.ts": `export function renderWidget(): string {
+  return formatLabel();
+}
+
+function formatLabel(): string {
+  return "label";
+}
+
+function orphanedWidget(): number {
+  return 42;
+}
+`,
+			},
+			Want: []Sym{
+				{"orphanedWidget", Dead,
+					"module-private, zero callers, name mentioned nowhere — the earned dead"},
+				{"formatLabel", Alive,
+					"called by renderWidget in the same module"},
+				{"renderWidget", PossiblyDead,
+					"exported — a re-export / dynamic import / external consumer may reach it"},
+			},
+		},
+		{
+			Name: "ts_jsx_component",
+			Files: map[string]string{
+				"Card.tsx": `export function Card(): null {
+  return null;
+}
+`,
+			},
+			Want: []Sym{
+				{"Card", PossiblyDead,
+					"exported PascalCase component in a .tsx file — may be rendered as <Card/> elsewhere (ts_jsx)"},
+			},
+		},
+		{
+			Name: "ts_next_route",
+			Files: map[string]string{
+				"app/dashboard/page.tsx": `export default function Page(): null {
+  return null;
+}
+`,
+			},
+			Want: []Sym{
+				{"Page", PossiblyDead,
+					"Next.js app/ route default export — file-system routing renders it with no edge (ts_framework_route)"},
+			},
+		},
+		{
+			Name: "ts_decorator_module_private",
+			Files: map[string]string{
+				"mailer.ts": `export function configureMailer(): void {}
+
+@Injectable()
+class MailerService {}
+`,
+			},
+			Want: []Sym{
+				{"MailerService", PossiblyDead,
+					"module-private but @Injectable — a DI container instantiates it with no source caller (ts_decorator)"},
+			},
+		},
+		{
+			Name: "js_module_private_conservative",
+			Files: map[string]string{
+				"legacy.js": `function orphanedLegacy() {
+  return 42;
+}
+`,
+			},
+			Want: []Sym{
+				{"orphanedLegacy", PossiblyDead,
+					"byte-identical to the .ts dead shape, but plain JS is held open-world (js_dynamic) — the precision split"},
+			},
+		},
+	}
+}

--- a/internal/dead/golden_test.go
+++ b/internal/dead/golden_test.go
@@ -232,6 +232,29 @@ func TestDeadCLIIntegration(t *testing.T) {
 		}
 	}
 
+	// EARNED dead (TS): the module-private, zero-edge, unmentioned .ts function.
+	if verdict["orphanedTs"] != "dead" {
+		t.Errorf("orphanedTs verdict = %q, want dead (module-private .ts, no caller, no mention)", verdict["orphanedTs"])
+	}
+	// TS/JS PRECISION SPLIT: the byte-identical shape in a .js file stays
+	// possibly_dead (js_dynamic) — plain JS is too loose for the closed-world bet.
+	if v, r := verdict["orphanedJs"], reason["orphanedJs"]; v != "possibly_dead" || r != "js_dynamic" {
+		t.Errorf("orphanedJs = (%q, %q), want (possibly_dead, js_dynamic) — the TS/JS split", v, r)
+	}
+	// POSSIBLY_DEAD (TS), exact reasons — the two-sided control for each hand-raise:
+	// an exported symbol, a JSX component, a Next.js route default, and a
+	// decorator-annotated (module-private) class all stay open-world.
+	for q, wantReason := range map[string]string{
+		"exportedHelper": "core_exported_api", // exported callable in a library
+		"Badge":          "ts_jsx",             // PascalCase component in a .tsx file
+		"Page":           "ts_framework_route", // app/page.tsx default export
+		"TokenStore":     "ts_decorator",       // @Injectable on a module-private class
+	} {
+		if v, r := verdict[q], reason[q]; v != "possibly_dead" || r != wantReason {
+			t.Errorf("%s = (%q, %q), want (possibly_dead, %q)", q, v, r, wantReason)
+		}
+	}
+
 	// Known-live symbols must not be reported at all.
 	for q := range verdict {
 		for _, live := range []string{

--- a/internal/dead/predicates_internal_test.go
+++ b/internal/dead/predicates_internal_test.go
@@ -195,3 +195,42 @@ func TestFrameworkNamesSorted(t *testing.T) {
 		t.Error("frameworkNames(nil) should be empty")
 	}
 }
+
+// TestIsInTestFile pins the test-fixture exclusion, including the patterns the
+// nextjs eval surfaced: a top-level `test/` directory (no leading slash) and the
+// jscodeshift `__testfixtures__` convention. Symbols in these are fixtures or
+// test code, never removable production code, so they are excluded from
+// dead-code candidacy.
+func TestIsInTestFile(t *testing.T) {
+	in := []string{
+		"order_test.go",
+		"pkg/sub/thing_test.go",
+		"app/test/helper.ts",
+		"test/e2e/app-dir/fixtures/simple/typecheck-validation.ts",
+		"test/production/tsconfig-verifier/pages/index.tsx",
+		"tests/unit/helper.rb",
+		"app/spec/models/user.rb",
+		"src/__tests__/widget.tsx",
+		"internal/extract/testdata/typescript/basic.ts",
+		"packages/next-codemod/transforms/__testfixtures__/x/y.input.ts",
+		"__testfixtures__/standalone.ts",
+		"components/Button.spec.ts",
+		"components/Button.test.js",
+	}
+	for _, f := range in {
+		if !isInTestFile(Symbol{File: f}) {
+			t.Errorf("isInTestFile(%q) = false, want true", f)
+		}
+	}
+	out := []string{
+		"packages/next/src/server/render.tsx",
+		"app/users/page.tsx",
+		"lib/contest/scoring.ts", // "test" appears mid-word, not as a segment
+		"src/latest/index.ts",
+	}
+	for _, f := range out {
+		if isInTestFile(Symbol{File: f}) {
+			t.Errorf("isInTestFile(%q) = true, want false", f)
+		}
+	}
+}

--- a/internal/dead/reasons.go
+++ b/internal/dead/reasons.go
@@ -57,6 +57,16 @@ const (
 	ReasonGoConst     = "go_const"
 	ReasonGoExported  = "go_exported"
 
+	// TS-voice reason codes (voice_ts.go owns their catalog specs).
+	ReasonTSExported       = "ts_exported"
+	ReasonTSJSX            = "ts_jsx"
+	ReasonTSDecorator      = "ts_decorator"
+	ReasonTSFrameworkRoute = "ts_framework_route"
+	ReasonTSDefaultExport  = "ts_default_export"
+	ReasonTSMethod         = "ts_method"
+	ReasonTSType           = "ts_type"
+	ReasonJSDynamic        = "js_dynamic"
+
 	// Rust-voice reason codes (voice_rust.go owns their catalog specs).
 	ReasonRustTraitImpl = "rust_trait_impl"
 	ReasonRustDerive    = "rust_derive"

--- a/internal/dead/voice_ts.go
+++ b/internal/dead/voice_ts.go
@@ -1,0 +1,214 @@
+package dead
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// tsVoice is the TypeScript / JavaScript language voice. It reasons about the
+// .ts / .tsx / .js family — one voice registered once per language string the
+// shared extractor emits ("typescript", "tsx", "javascript"), carried in the
+// `lang` field. Unlike Go (capitalization) and Rust (`pub`), TS/JS has no
+// compiler dead-code lint to bind against; its closed-world signal is the module
+// system: a symbol NOT exported from its module is reachable only within its own
+// file. A module-private symbol with zero incoming edges, unmentioned and not
+// reached by any framework idiom, is the narrow shape that may earn `dead`.
+//
+// The voice re-expresses TS/JS's invisible-reach idioms as open-world reasons;
+// like every voice it can only raise a hand (push → possibly_dead), never vote
+// for `dead`. Every EXPORTED symbol stays open-world: a barrel re-export
+// (`export * from`), a dynamic `import()`, or an external consumer may reach it
+// where the static graph shows zero callers — the analog of "staticcheck flags
+// only unexported symbols".
+//
+// TS earns `dead`; JS stays conservative. TypeScript's module discipline and
+// type annotations make the module-private closed-world bet sound. Plain
+// JavaScript is looser (no types, CommonJS `module.exports` mutation, more
+// dynamic patterns), so a would-be-`dead` JS symbol raises js_dynamic and stays
+// possibly_dead — the honest ship pending the eval.
+type tsVoice struct{ lang string }
+
+func (v tsVoice) Lang() string { return v.lang }
+
+// Inspect returns the most-specific (most-likely-live) reason a hidden caller
+// could exist for s, or nil when s is a module-private .ts/.tsx symbol with no
+// invisible-reach idiom — the only shape that may fall through to `dead`.
+func (v tsVoice) Inspect(s Symbol, f Facts) *Reason {
+	// Specific framework-reach idioms first (matching the Go/Rust voices, which
+	// check init/interface/cgo and ffi/test/trait before the generic public
+	// gate). Each is a way a hidden caller exists that is more precise than "it
+	// is exported", so it wins over the export/library deferral below.
+
+	// Decorator-annotated: Angular's @Component/@Injectable, Nest's @Controller,
+	// a class-method route decorator — the framework's DI container or router
+	// instantiates or routes to it with no source caller. True even when the
+	// symbol is module-private.
+	if _, ok := f.TSDecoratedNames[s.Name]; ok {
+		return reasonPtr(ReasonTSDecorator)
+	}
+	// Next.js file-system routing renders a page/layout/route export with no
+	// import edge anywhere — recognized by path/name convention. A route entry is
+	// always an export, so this is gated on public.
+	if s.Visibility == "public" && isNextRouteSymbol(s) {
+		return reasonPtr(ReasonTSFrameworkRoute)
+	}
+	// A JSX component is used as `<Component/>`; the usage edge may live in a file
+	// the resolver could not bind to this definition (a re-export, a dynamic
+	// import, a prop-passed component).
+	if s.Visibility == "public" && isJSXComponent(s) {
+		return reasonPtr(ReasonTSJSX)
+	}
+
+	// Generic export gate: an exported symbol never earns `dead` — a re-export, a
+	// dynamic import, or an external consumer may reach it.
+	if s.Visibility == "public" {
+		// A library's public callable/type API is the core voice's concern
+		// (core_exported_api), matching the Go/Rust voices.
+		if f.IsLibrary && isPublicAPISymbol(s) {
+			return nil
+		}
+		// A default export is imported by path, not by name.
+		if _, ok := f.TSDefaultExportNames[s.Name]; ok {
+			return reasonPtr(ReasonTSDefaultExport)
+		}
+		return reasonPtr(ReasonTSExported)
+	}
+
+	// Module-private from here. Plain JavaScript is held open-world pending the
+	// eval: its looser module/typing discipline makes the closed-world bet
+	// unsound, so a would-be-`dead` JS symbol raises js_dynamic instead.
+	if s.Language == "javascript" {
+		return reasonPtr(ReasonJSDynamic)
+	}
+
+	// Module-private .ts/.tsx. The earned-`dead` candidate is narrow — the pitch
+	// scopes it to a non-exported function / const / class. Only those three
+	// kinds fall through to `dead`; everything else raises a hand, because a
+	// module boundary does NOT prove a method or a type unreachable:
+	//
+	//   - A method may satisfy an interface, a structural type, or a framework
+	//     protocol (React's componentDidMount/getDerivedStateFromError, Node's
+	//     AsyncLocalStorage.enterWith) — invoked by name with no source caller,
+	//     exactly the class of false `dead` the nextjs eval surfaced.
+	//   - An interface / type alias is reached structurally and by
+	//     declaration-merging (a `declare global { interface Window }` augmentation,
+	//     a type used only in an annotation position) with no value-level reference
+	//     edge the resolver can see.
+	switch s.Kind {
+	case "function", "class", "constant":
+		return nil
+	case "method":
+		return reasonPtr(ReasonTSMethod)
+	default: // interface, type, module
+		return reasonPtr(ReasonTSType)
+	}
+}
+
+// isJSXComponent reports whether s is a PascalCase function or class in a JSX
+// file (.tsx/.jsx). Such a symbol is the shape used as a `<Component/>` element,
+// whose usage edge may live in a file the resolver could not bind here. Checked
+// only in the exported branch — a module-private component used as JSX in its own
+// file already carries an incoming edge and is not a candidate.
+func isJSXComponent(s Symbol) bool {
+	switch s.Kind {
+	case "function", "class":
+	default:
+		return false
+	}
+	if !isJSXFile(s.File) {
+		return false
+	}
+	return s.Name != "" && s.Name[0] >= 'A' && s.Name[0] <= 'Z'
+}
+
+// isJSXFile reports whether path is a JSX-bearing file.
+func isJSXFile(path string) bool {
+	return strings.HasSuffix(path, ".tsx") || strings.HasSuffix(path, ".jsx")
+}
+
+// isNextRouteSymbol reports whether s lives in a Next.js route file — a
+// framework-dispatched entry rendered by file-system routing with no import edge.
+func isNextRouteSymbol(s Symbol) bool { return isNextRouteFile(s.File) }
+
+// nextAppRouteFiles are the reserved file names the Next.js `app/` router renders
+// by convention. Their default (and, for route.ts, named GET/POST/…) exports are
+// framework-dispatched. Pinning the exact set keeps the convention from being too
+// broad (which would mute real dead code in `app/`).
+var nextAppRouteFiles = map[string]bool{
+	"page": true, "layout": true, "route": true, "loading": true,
+	"error": true, "not-found": true, "template": true, "default": true,
+	"global-error": true,
+}
+
+// isNextRouteFile reports whether path is a Next.js route file: any file under a
+// `pages/` directory (the pages router treats every file as a route), or a
+// reserved-name file under an `app/` directory (the app router). The extension
+// must be a TS/JS one. Convention-based by design — there is no import edge to
+// follow, so path/name is the only signal.
+func isNextRouteFile(path string) bool {
+	p := filepath.ToSlash(path)
+	ext := filepath.Ext(p)
+	switch ext {
+	case ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs":
+	default:
+		return false
+	}
+	if pathHasDir(p, "pages") {
+		return true
+	}
+	if pathHasDir(p, "app") {
+		base := strings.TrimSuffix(filepath.Base(p), ext)
+		return nextAppRouteFiles[base]
+	}
+	return false
+}
+
+// pathHasDir reports whether a forward-slash path contains dir as a path segment.
+func pathHasDir(path, dir string) bool {
+	return strings.HasPrefix(path, dir+"/") || strings.Contains(path, "/"+dir+"/")
+}
+
+func init() {
+	registerReasons(map[string]reasonSpec{
+		ReasonJSDynamic: {
+			priority: 60,
+			hint:     "module-private JavaScript symbol with no caller; Sense holds JS open-world (CommonJS `module.exports`, no types, dynamic dispatch) — confirm it is unused, then it is likely removable",
+			verify:   "This module-private JavaScript symbol has no resolved caller and would earn `dead` in TypeScript, but Sense holds plain JS open-world: CommonJS `module.exports` mutation and untyped dynamic access can reach it invisibly. Grep the repo for its bare name and as a string key before removing.",
+		},
+		ReasonTSExported: {
+			priority: 50,
+			hint:     "exported TS/JS symbol with no caller in this repo; a barrel re-export, a dynamic import(), or an external consumer may use it — search dependents before removing",
+			verify:   "Exported TS/JS symbols can be reached by a barrel re-export (`export * from`), a dynamic `import()`, or a consumer outside this repo. For each, search dependents and grep the repo for its name before removing.",
+		},
+		ReasonTSDefaultExport: {
+			priority: 48,
+			hint:     "default export; imported by path rather than by name, so callers are invisible to a name-based graph — search for imports of this module before removing",
+			verify:   "This is a default export, imported as `import X from './module'` under any local name. The import names the module path, not this symbol, so callers do not reference its name. Search for imports of this module's path before removing.",
+		},
+		ReasonTSJSX: {
+			priority: 40,
+			hint:     "JSX component (PascalCase, in a .tsx/.jsx file); it may be rendered as `<Component/>` in a file the resolver could not bind — grep for `<Name` before removing",
+			verify:   "This is a JSX component. It may be rendered as `<Component/>` somewhere the resolver could not tie back to this definition (a re-export, a dynamic import, a prop-passed component). Grep the repo for `<Name` and for the name in import statements before removing.",
+		},
+		ReasonTSDecorator: {
+			priority: 30,
+			hint:     "decorator-annotated class/method (@Component/@Injectable/@Controller/route decorator); a framework's DI container or router invokes it with no source caller — do not remove without checking the framework wiring",
+			verify:   "This symbol carries a decorator, so a framework (Angular/Nest DI, a route decorator) instantiates or routes to it with no source-level caller. Check the module/provider registration and route table before removing.",
+		},
+		ReasonTSFrameworkRoute: {
+			priority: 25,
+			hint:     "Next.js route file export (page/layout/route in app/, or any file in pages/); file-system routing renders it with no import edge — do not remove unless deleting the route",
+			verify:   "This export lives in a Next.js route file and is rendered/invoked by the framework's file-system router with no import edge anywhere. It is a route entry point; remove it only if you are deleting the route itself.",
+		},
+		ReasonTSMethod: {
+			priority: 30,
+			hint:     "method with no resolved caller; it may satisfy an interface, a structural type, or a framework protocol (React lifecycle like componentDidMount/getDerivedStateFromError, AsyncLocalStorage) — confirm before removing",
+			verify:   "TS methods are reached by name through interfaces, structural types, and framework protocols (React class-component lifecycle, web/Node API implementations) with no source-level caller. Check whether the enclosing class extends a framework base or implements an interface, and grep for the method name as a `.member` access before removing.",
+		},
+		ReasonTSType: {
+			priority: 35,
+			hint:     "interface/type with no resolved reference; it may be used structurally, in a type annotation, or via declaration-merging (e.g. `declare global { interface Window }`) — confirm before removing",
+			verify:   "TS interfaces and type aliases are reached structurally and by declaration-merging, with no value-level reference edge. Grep for the name in type-annotation and `extends`/`implements` positions, and check for a `declare global` augmentation, before removing.",
+		},
+	})
+}

--- a/internal/dead/voice_ts_test.go
+++ b/internal/dead/voice_ts_test.go
@@ -1,0 +1,124 @@
+package dead
+
+import "testing"
+
+func tsSym(name, qualified, kind, visibility, lang, file string) Symbol {
+	return Symbol{
+		Name:       name,
+		Qualified:  qualified,
+		Kind:       kind,
+		Language:   lang,
+		Visibility: visibility,
+		File:       file,
+	}
+}
+
+func TestTSVoiceLang(t *testing.T) {
+	for _, lang := range []string{"typescript", "tsx", "javascript"} {
+		if got := (tsVoice{lang: lang}).Lang(); got != lang {
+			t.Errorf("tsVoice{%q}.Lang() = %q, want %q", lang, got, lang)
+		}
+	}
+}
+
+func TestTSVoiceModulePrivateEarnsSilent(t *testing.T) {
+	v := tsVoice{lang: "typescript"}
+	// The narrow shapes that may fall through to `dead` (the pitch's
+	// function / const / class): the voice stays silent (nil) for them.
+	assertReason(t, v, tsSym("helper", "helper", "function", "private", "typescript", "mod.ts"), Facts{}, "")
+	assertReason(t, v, tsSym("CONST", "CONST", "constant", "private", "typescript", "mod.ts"), Facts{}, "")
+	assertReason(t, v, tsSym("Widget", "Widget", "class", "private", "typescript", "mod.ts"), Facts{}, "")
+}
+
+func TestTSVoiceMethodAndTypeNeverEarnDead(t *testing.T) {
+	v := tsVoice{lang: "typescript"}
+	// A module-private method may satisfy an interface or a framework protocol
+	// (React lifecycle, AsyncLocalStorage) — it must never earn `dead`. This is
+	// the false-`dead` class the nextjs eval surfaced (componentDidMount, etc.).
+	assertReason(t, v, tsSym("getDerivedStateFromError", "C.getDerivedStateFromError", "method", "private", "typescript", "c.tsx"), Facts{}, ReasonTSMethod)
+	// A module-private interface / type is reached structurally or by
+	// declaration-merging (e.g. `declare global { interface Window }`).
+	assertReason(t, v, tsSym("Window", "Window", "interface", "private", "typescript", "index.tsx"), Facts{}, ReasonTSType)
+	assertReason(t, v, tsSym("Loader", "Loader", "type", "private", "typescript", "types.ts"), Facts{}, ReasonTSType)
+}
+
+func TestTSVoiceExported(t *testing.T) {
+	v := tsVoice{lang: "typescript"}
+	// An exported symbol never earns `dead` — a re-export / dynamic import /
+	// external consumer may reach it. In a non-library (app) context.
+	assertReason(t, v, tsSym("publicFn", "publicFn", "function", "public", "typescript", "mod.ts"),
+		Facts{IsLibrary: false}, ReasonTSExported)
+}
+
+func TestTSVoiceExportedLibraryDefersToCore(t *testing.T) {
+	v := tsVoice{lang: "typescript"}
+	// In a library, a public callable/type defers to the core voice
+	// (core_exported_api), matching the Go/Rust convention.
+	assertReason(t, v, tsSym("publicFn", "publicFn", "function", "public", "typescript", "mod.ts"),
+		Facts{IsLibrary: true}, "")
+}
+
+func TestTSVoiceDefaultExport(t *testing.T) {
+	v := tsVoice{lang: "typescript"}
+	f := Facts{TSDefaultExportNames: map[string]struct{}{"Page": {}}}
+	// A default export is imported by path → the more specific ts_default_export.
+	assertReason(t, v, tsSym("Page", "Page", "function", "public", "typescript", "lib.ts"), f, ReasonTSDefaultExport)
+}
+
+func TestTSVoiceJSXComponent(t *testing.T) {
+	v := tsVoice{lang: "tsx"}
+	// A PascalCase exported function/class in a .tsx file is a JSX component.
+	assertReason(t, v, tsSym("Button", "Button", "function", "public", "tsx", "Button.tsx"), Facts{}, ReasonTSJSX)
+	assertReason(t, v, tsSym("Card", "Card", "class", "public", "tsx", "Card.tsx"), Facts{}, ReasonTSJSX)
+	// A lowercase exported function in a .tsx file is NOT a component → ts_exported.
+	assertReason(t, v, tsSym("useThing", "useThing", "function", "public", "tsx", "hooks.tsx"), Facts{}, ReasonTSExported)
+	// A PascalCase symbol in a non-JSX .ts file is not a JSX component.
+	assertReason(t, v, tsSym("Button", "Button", "function", "public", "typescript", "Button.ts"), Facts{}, ReasonTSExported)
+	// A PascalCase CONSTANT in a .tsx file is not a component (only func/class) → ts_exported.
+	assertReason(t, v, tsSym("Theme", "Theme", "constant", "public", "tsx", "theme.tsx"), Facts{}, ReasonTSExported)
+}
+
+func TestTSVoiceDecorator(t *testing.T) {
+	v := tsVoice{lang: "typescript"}
+	f := Facts{TSDecoratedNames: map[string]struct{}{"AppComponent": {}, "list": {}}}
+	// A decorated class is framework-dispatched → ts_decorator, even module-private.
+	assertReason(t, v, tsSym("AppComponent", "AppComponent", "class", "private", "typescript", "app.ts"), f, ReasonTSDecorator)
+	// A decorated method (in a private class) is also kept open-world.
+	assertReason(t, v, tsSym("list", "Ctrl.list", "method", "private", "typescript", "ctrl.ts"), f, ReasonTSDecorator)
+	// Decorator wins over the exported branch (more specific framework hint).
+	assertReason(t, v, tsSym("AppComponent", "AppComponent", "class", "public", "typescript", "app.ts"), f, ReasonTSDecorator)
+	// An undecorated module-private symbol is unaffected.
+	assertReason(t, v, tsSym("plain", "plain", "function", "private", "typescript", "app.ts"), f, "")
+}
+
+func TestTSVoiceFrameworkRoute(t *testing.T) {
+	v := tsVoice{lang: "tsx"}
+	// A page/layout/route export in app/ is framework-dispatched.
+	assertReason(t, v, tsSym("Page", "Page", "function", "public", "tsx", "app/users/page.tsx"), Facts{}, ReasonTSFrameworkRoute)
+	assertReason(t, v, tsSym("Layout", "Layout", "function", "public", "tsx", "app/layout.tsx"), Facts{}, ReasonTSFrameworkRoute)
+	// Any file in pages/ is a route.
+	assertReason(t, v, tsSym("About", "About", "function", "public", "tsx", "pages/about.tsx"), Facts{}, ReasonTSFrameworkRoute)
+	// A non-reserved name in app/ is NOT a route file → ts_exported (a non-JSX .ts
+	// helper, isolated from the JSX-component refinement).
+	assertReason(t, v, tsSym("getThing", "getThing", "function", "public", "tsx", "app/lib/helper.ts"), Facts{}, ReasonTSExported)
+	// Route wins over the JSX refinement (route is the more specific reason).
+	assertReason(t, v, tsSym("Page", "Page", "function", "public", "tsx", "app/page.tsx"), Facts{}, ReasonTSFrameworkRoute)
+	// A MODULE-PRIVATE helper in a route file is NOT muted — it may earn `dead`.
+	assertReason(t, v, tsSym("formatDate", "formatDate", "function", "private", "tsx", "app/page.tsx"), Facts{}, "")
+}
+
+func TestTSVoiceJavaScriptHeldConservative(t *testing.T) {
+	v := tsVoice{lang: "javascript"}
+	// A module-private JS symbol that would earn `dead` in TS is held open-world
+	// (js_dynamic) — JS is looser (CommonJS, no types).
+	assertReason(t, v, tsSym("helper", "helper", "function", "private", "javascript", "mod.js"), Facts{}, ReasonJSDynamic)
+	// An exported JS symbol still reads as ts_exported (export reach is the same).
+	assertReason(t, v, tsSym("publicFn", "publicFn", "function", "public", "javascript", "mod.js"), Facts{}, ReasonTSExported)
+}
+
+func TestTSVoiceReasonPriorityOrder(t *testing.T) {
+	v := tsVoice{lang: "tsx"}
+	// A decorated, exported, PascalCase .tsx symbol → decorator wins (checked first).
+	f := Facts{TSDecoratedNames: map[string]struct{}{"Widget": {}}}
+	assertReason(t, v, tsSym("Widget", "Widget", "class", "public", "tsx", "app/page.tsx"), f, ReasonTSDecorator)
+}

--- a/internal/extract/extractor.go
+++ b/internal/extract/extractor.go
@@ -324,6 +324,27 @@ type MentionEmitter interface {
 	MentionName(name string) error
 }
 
+// TSHarvestEmitter is an optional Emitter extension for streaming the TS/JS
+// dead-code facts the TypeScript voice reads — names whose reachability the edge
+// graph cannot see because a framework or the module system reaches them:
+//
+//   - TSDecoratedName: a class or method carrying a decorator (`@Component`,
+//     `@Injectable`, `@Controller`, a route-method decorator). Angular/Nest's
+//     DI/router instantiates or routes to it with no source caller, so the voice
+//     keeps it open-world (ts_decorator) even when module-private.
+//   - TSDefaultExportName: the name bound by an `export default` form. A default
+//     export is imported by path rather than by name, so the voice raises the more
+//     specific ts_default_export instead of the generic ts_exported.
+//
+// The name sets feed flat (not per-language) sense_meta keys — these concepts span
+// the .ts/.tsx/.js family, which shares one extractor. An extractor probes for this
+// interface with a type assertion; an Emitter that does not implement it simply
+// receives no names. Returning an error aborts extraction.
+type TSHarvestEmitter interface {
+	TSDecoratedName(name string) error
+	TSDefaultExportName(name string) error
+}
+
 // MentionHarvester marks an Extractor whose Extract streams the broad mention
 // set (via MentionEmitter) for every file it processes. The scan records such a
 // language as harvested even on a scan that yields zero mentions for it, so the

--- a/internal/extract/testdata/javascript/basic.golden.json
+++ b/internal/extract/testdata/javascript/basic.golden.json
@@ -4,6 +4,7 @@
       "name": "Counter",
       "qualified": "Counter",
       "kind": "class",
+      "visibility": "public",
       "line_start": 1,
       "line_end": 9
     },
@@ -11,6 +12,7 @@
       "name": "constructor",
       "qualified": "Counter.constructor",
       "kind": "method",
+      "visibility": "public",
       "parent": "Counter",
       "line_start": 2,
       "line_end": 4
@@ -19,6 +21,7 @@
       "name": "inc",
       "qualified": "Counter.inc",
       "kind": "method",
+      "visibility": "public",
       "parent": "Counter",
       "line_start": 6,
       "line_end": 8
@@ -27,6 +30,7 @@
       "name": "PI",
       "qualified": "PI",
       "kind": "constant",
+      "visibility": "public",
       "line_start": 11,
       "line_end": 11
     },
@@ -34,6 +38,7 @@
       "name": "Widget",
       "qualified": "Widget",
       "kind": "class",
+      "visibility": "private",
       "line_start": 21,
       "line_end": 25
     },
@@ -41,6 +46,7 @@
       "name": "reset",
       "qualified": "Widget.reset",
       "kind": "method",
+      "visibility": "private",
       "parent": "Widget",
       "line_start": 22,
       "line_end": 24
@@ -49,6 +55,7 @@
       "name": "handler",
       "qualified": "handler",
       "kind": "function",
+      "visibility": "public",
       "line_start": 13,
       "line_end": 15
     },
@@ -56,6 +63,7 @@
       "name": "helper",
       "qualified": "helper",
       "kind": "function",
+      "visibility": "public",
       "line_start": 17,
       "line_end": 19
     }

--- a/internal/extract/testdata/javascript/calls.golden.json
+++ b/internal/extract/testdata/javascript/calls.golden.json
@@ -4,6 +4,7 @@
       "name": "Dispatcher",
       "qualified": "Dispatcher",
       "kind": "class",
+      "visibility": "public",
       "line_start": 1,
       "line_end": 15
     },
@@ -11,6 +12,7 @@
       "name": "greet",
       "qualified": "Dispatcher.greet",
       "kind": "method",
+      "visibility": "public",
       "parent": "Dispatcher",
       "line_start": 2,
       "line_end": 4
@@ -19,6 +21,7 @@
       "name": "hello",
       "qualified": "Dispatcher.hello",
       "kind": "method",
+      "visibility": "public",
       "parent": "Dispatcher",
       "line_start": 6,
       "line_end": 8
@@ -27,6 +30,7 @@
       "name": "mixed",
       "qualified": "Dispatcher.mixed",
       "kind": "method",
+      "visibility": "public",
       "parent": "Dispatcher",
       "line_start": 10,
       "line_end": 14
@@ -35,6 +39,7 @@
       "name": "entry",
       "qualified": "entry",
       "kind": "function",
+      "visibility": "public",
       "line_start": 17,
       "line_end": 20
     },
@@ -42,6 +47,7 @@
       "name": "runner",
       "qualified": "runner",
       "kind": "function",
+      "visibility": "public",
       "line_start": 22,
       "line_end": 24
     }

--- a/internal/extract/testdata/javascript/classes.golden.json
+++ b/internal/extract/testdata/javascript/classes.golden.json
@@ -4,6 +4,7 @@
       "name": "DEFAULT_LEVEL",
       "qualified": "DEFAULT_LEVEL",
       "kind": "constant",
+      "visibility": "public",
       "line_start": 21,
       "line_end": 21
     },
@@ -11,6 +12,7 @@
       "name": "EventEmitter",
       "qualified": "EventEmitter",
       "kind": "class",
+      "visibility": "public",
       "line_start": 1,
       "line_end": 12
     },
@@ -18,6 +20,7 @@
       "name": "dispatch",
       "qualified": "EventEmitter.dispatch",
       "kind": "method",
+      "visibility": "public",
       "parent": "EventEmitter",
       "line_start": 11,
       "line_end": 11
@@ -26,6 +29,7 @@
       "name": "emit",
       "qualified": "EventEmitter.emit",
       "kind": "method",
+      "visibility": "public",
       "parent": "EventEmitter",
       "line_start": 6,
       "line_end": 8
@@ -34,6 +38,7 @@
       "name": "on",
       "qualified": "EventEmitter.on",
       "kind": "method",
+      "visibility": "public",
       "parent": "EventEmitter",
       "line_start": 2,
       "line_end": 4
@@ -42,6 +47,7 @@
       "name": "register",
       "qualified": "EventEmitter.register",
       "kind": "method",
+      "visibility": "public",
       "parent": "EventEmitter",
       "line_start": 10,
       "line_end": 10
@@ -50,6 +56,7 @@
       "name": "Logger",
       "qualified": "Logger",
       "kind": "class",
+      "visibility": "public",
       "line_start": 14,
       "line_end": 19
     },
@@ -57,6 +64,7 @@
       "name": "log",
       "qualified": "Logger.log",
       "kind": "method",
+      "visibility": "public",
       "parent": "Logger",
       "line_start": 15,
       "line_end": 18
@@ -65,6 +73,7 @@
       "name": "createLogger",
       "qualified": "createLogger",
       "kind": "function",
+      "visibility": "public",
       "line_start": 23,
       "line_end": 27
     },
@@ -72,6 +81,7 @@
       "name": "handleData",
       "qualified": "handleData",
       "kind": "function",
+      "visibility": "public",
       "line_start": 33,
       "line_end": 35
     },
@@ -79,6 +89,7 @@
       "name": "processEvents",
       "qualified": "processEvents",
       "kind": "function",
+      "visibility": "public",
       "line_start": 29,
       "line_end": 31
     },
@@ -86,6 +97,7 @@
       "name": "transform",
       "qualified": "transform",
       "kind": "function",
+      "visibility": "public",
       "line_start": 37,
       "line_end": 39
     }

--- a/internal/extract/testdata/tsx/component.golden.json
+++ b/internal/extract/testdata/tsx/component.golden.json
@@ -4,6 +4,7 @@
       "name": "Button",
       "qualified": "Button",
       "kind": "function",
+      "visibility": "public",
       "line_start": 7,
       "line_end": 9
     },
@@ -11,6 +12,7 @@
       "name": "ButtonProps",
       "qualified": "ButtonProps",
       "kind": "interface",
+      "visibility": "public",
       "line_start": 3,
       "line_end": 5
     },
@@ -18,6 +20,7 @@
       "name": "Greeting",
       "qualified": "Greeting",
       "kind": "function",
+      "visibility": "public",
       "line_start": 11,
       "line_end": 13
     }

--- a/internal/extract/testdata/tsx/default_exports.golden.json
+++ b/internal/extract/testdata/tsx/default_exports.golden.json
@@ -4,6 +4,7 @@
       "name": "DefaultExports",
       "qualified": "DefaultExports",
       "kind": "function",
+      "visibility": "public",
       "line_start": 1,
       "line_end": 7
     }

--- a/internal/extract/testdata/tsx/react_components.golden.json
+++ b/internal/extract/testdata/tsx/react_components.golden.json
@@ -4,6 +4,7 @@
       "name": "TestListZeta",
       "qualified": "TestListZeta",
       "kind": "function",
+      "visibility": "public",
       "line_start": 21,
       "line_end": 29
     },
@@ -11,6 +12,7 @@
       "name": "TestWidgetAlpha",
       "qualified": "TestWidgetAlpha",
       "kind": "function",
+      "visibility": "public",
       "line_start": 7,
       "line_end": 19
     },
@@ -18,6 +20,7 @@
       "name": "TestWidgetAlphaProps",
       "qualified": "TestWidgetAlphaProps",
       "kind": "interface",
+      "visibility": "private",
       "line_start": 3,
       "line_end": 5
     }

--- a/internal/extract/testdata/typescript/barrel.golden.json
+++ b/internal/extract/testdata/typescript/barrel.golden.json
@@ -4,6 +4,7 @@
       "name": "TestButtonAlpha",
       "qualified": "TestButtonAlpha",
       "kind": "constant",
+      "visibility": "public",
       "line_start": 1,
       "line_end": 1
     },
@@ -11,6 +12,7 @@
       "name": "TestButtonPropsZeta",
       "qualified": "TestButtonPropsZeta",
       "kind": "constant",
+      "visibility": "public",
       "line_start": 5,
       "line_end": 5
     },
@@ -18,6 +20,7 @@
       "name": "TestCardBeta",
       "qualified": "TestCardBeta",
       "kind": "constant",
+      "visibility": "public",
       "line_start": 2,
       "line_end": 2
     },
@@ -25,6 +28,7 @@
       "name": "TestCardHeaderGamma",
       "qualified": "TestCardHeaderGamma",
       "kind": "constant",
+      "visibility": "public",
       "line_start": 2,
       "line_end": 2
     },
@@ -32,6 +36,7 @@
       "name": "TestModalDelta",
       "qualified": "TestModalDelta",
       "kind": "constant",
+      "visibility": "public",
       "line_start": 3,
       "line_end": 3
     }

--- a/internal/extract/testdata/typescript/basic.golden.json
+++ b/internal/extract/testdata/typescript/basic.golden.json
@@ -4,6 +4,7 @@
       "name": "Color",
       "qualified": "Color",
       "kind": "class",
+      "visibility": "public",
       "line_start": 23,
       "line_end": 26
     },
@@ -11,6 +12,7 @@
       "name": "Greeter",
       "qualified": "Greeter",
       "kind": "interface",
+      "visibility": "public",
       "line_start": 17,
       "line_end": 19
     },
@@ -18,6 +20,7 @@
       "name": "Name",
       "qualified": "Name",
       "kind": "type",
+      "visibility": "public",
       "line_start": 21,
       "line_end": 21
     },
@@ -25,6 +28,7 @@
       "name": "User",
       "qualified": "User",
       "kind": "class",
+      "visibility": "public",
       "line_start": 1,
       "line_end": 15
     },
@@ -32,6 +36,7 @@
       "name": "build",
       "qualified": "User.build",
       "kind": "method",
+      "visibility": "public",
       "parent": "User",
       "line_start": 12,
       "line_end": 14
@@ -40,6 +45,7 @@
       "name": "constructor",
       "qualified": "User.constructor",
       "kind": "method",
+      "visibility": "public",
       "parent": "User",
       "line_start": 4,
       "line_end": 6
@@ -48,6 +54,7 @@
       "name": "greet",
       "qualified": "User.greet",
       "kind": "method",
+      "visibility": "public",
       "parent": "User",
       "line_start": 8,
       "line_end": 10
@@ -56,6 +63,7 @@
       "name": "VERSION",
       "qualified": "VERSION",
       "kind": "constant",
+      "visibility": "public",
       "line_start": 28,
       "line_end": 28
     },
@@ -63,6 +71,7 @@
       "name": "handler",
       "qualified": "handler",
       "kind": "function",
+      "visibility": "public",
       "line_start": 30,
       "line_end": 32
     },
@@ -70,6 +79,7 @@
       "name": "helper",
       "qualified": "helper",
       "kind": "function",
+      "visibility": "public",
       "line_start": 34,
       "line_end": 36
     }

--- a/internal/extract/testdata/typescript/calls.golden.json
+++ b/internal/extract/testdata/typescript/calls.golden.json
@@ -4,6 +4,7 @@
       "name": "Greeter",
       "qualified": "Greeter",
       "kind": "class",
+      "visibility": "public",
       "line_start": 1,
       "line_end": 9
     },
@@ -11,6 +12,7 @@
       "name": "greet",
       "qualified": "Greeter.greet",
       "kind": "method",
+      "visibility": "public",
       "parent": "Greeter",
       "line_start": 2,
       "line_end": 4
@@ -19,6 +21,7 @@
       "name": "hello",
       "qualified": "Greeter.hello",
       "kind": "method",
+      "visibility": "public",
       "parent": "Greeter",
       "line_start": 6,
       "line_end": 8
@@ -27,6 +30,7 @@
       "name": "make",
       "qualified": "make",
       "kind": "function",
+      "visibility": "public",
       "line_start": 11,
       "line_end": 15
     },
@@ -34,6 +38,7 @@
       "name": "runner",
       "qualified": "runner",
       "kind": "function",
+      "visibility": "public",
       "line_start": 17,
       "line_end": 19
     }

--- a/internal/extract/testdata/typescript/conditional_types.golden.json
+++ b/internal/extract/testdata/typescript/conditional_types.golden.json
@@ -4,6 +4,7 @@
       "name": "AdminModel",
       "qualified": "AdminModel",
       "kind": "type",
+      "visibility": "public",
       "line_start": 19,
       "line_end": 19
     },
@@ -11,6 +12,7 @@
       "name": "DEFAULT_TIMEOUT",
       "qualified": "DEFAULT_TIMEOUT",
       "kind": "constant",
+      "visibility": "public",
       "line_start": 23,
       "line_end": 23
     },
@@ -18,6 +20,7 @@
       "name": "Identifiable",
       "qualified": "Identifiable",
       "kind": "interface",
+      "visibility": "public",
       "line_start": 13,
       "line_end": 15
     },
@@ -25,6 +28,7 @@
       "name": "IsString",
       "qualified": "IsString",
       "kind": "type",
+      "visibility": "public",
       "line_start": 1,
       "line_end": 1
     },
@@ -32,6 +36,7 @@
       "name": "MAX_RETRIES",
       "qualified": "MAX_RETRIES",
       "kind": "constant",
+      "visibility": "public",
       "line_start": 21,
       "line_end": 21
     },
@@ -39,6 +44,7 @@
       "name": "Model",
       "qualified": "Model",
       "kind": "type",
+      "visibility": "public",
       "line_start": 17,
       "line_end": 17
     },
@@ -46,6 +52,7 @@
       "name": "ReadonlyDeep",
       "qualified": "ReadonlyDeep",
       "kind": "type",
+      "visibility": "public",
       "line_start": 5,
       "line_end": 7
     },
@@ -53,6 +60,7 @@
       "name": "Serializable",
       "qualified": "Serializable",
       "kind": "interface",
+      "visibility": "public",
       "line_start": 9,
       "line_end": 11
     },
@@ -60,6 +68,7 @@
       "name": "Unwrap",
       "qualified": "Unwrap",
       "kind": "type",
+      "visibility": "public",
       "line_start": 3,
       "line_end": 3
     },
@@ -67,6 +76,7 @@
       "name": "handleRequest",
       "qualified": "handleRequest",
       "kind": "function",
+      "visibility": "public",
       "line_start": 31,
       "line_end": 33
     },
@@ -74,6 +84,7 @@
       "name": "processModel",
       "qualified": "processModel",
       "kind": "function",
+      "visibility": "public",
       "line_start": 27,
       "line_end": 29
     }

--- a/internal/extract/testdata/typescript/dynamic_imports.golden.json
+++ b/internal/extract/testdata/typescript/dynamic_imports.golden.json
@@ -4,6 +4,7 @@
       "name": "TestPanelPhi",
       "qualified": "TestPanelPhi",
       "kind": "constant",
+      "visibility": "public",
       "line_start": 1,
       "line_end": 1
     },
@@ -11,6 +12,7 @@
       "name": "loadTestModuleChi",
       "qualified": "loadTestModuleChi",
       "kind": "function",
+      "visibility": "public",
       "line_start": 3,
       "line_end": 6
     }

--- a/internal/extract/testdata/typescript/generic_interfaces.golden.json
+++ b/internal/extract/testdata/typescript/generic_interfaces.golden.json
@@ -4,6 +4,7 @@
       "name": "CachedRepository",
       "qualified": "CachedRepository",
       "kind": "interface",
+      "visibility": "public",
       "line_start": 6,
       "line_end": 8
     },
@@ -11,6 +12,7 @@
       "name": "CachedUserRepository",
       "qualified": "CachedUserRepository",
       "kind": "class",
+      "visibility": "public",
       "line_start": 15,
       "line_end": 20
     },
@@ -18,6 +20,7 @@
       "name": "invalidate",
       "qualified": "CachedUserRepository.invalidate",
       "kind": "method",
+      "visibility": "public",
       "parent": "CachedUserRepository",
       "line_start": 16,
       "line_end": 16
@@ -26,6 +29,7 @@
       "name": "lookup",
       "qualified": "CachedUserRepository.lookup",
       "kind": "method",
+      "visibility": "public",
       "parent": "CachedUserRepository",
       "line_start": 17,
       "line_end": 19
@@ -34,6 +38,7 @@
       "name": "Comparable",
       "qualified": "Comparable",
       "kind": "interface",
+      "visibility": "public",
       "line_start": 26,
       "line_end": 28
     },
@@ -41,6 +46,7 @@
       "name": "EntityMap",
       "qualified": "EntityMap",
       "kind": "type",
+      "visibility": "public",
       "line_start": 30,
       "line_end": 30
     },
@@ -48,6 +54,7 @@
       "name": "Repository",
       "qualified": "Repository",
       "kind": "interface",
+      "visibility": "public",
       "line_start": 1,
       "line_end": 4
     },
@@ -55,6 +62,7 @@
       "name": "User",
       "qualified": "User",
       "kind": "class",
+      "visibility": "public",
       "line_start": 22,
       "line_end": 24
     },
@@ -62,6 +70,7 @@
       "name": "UserRepository",
       "qualified": "UserRepository",
       "kind": "class",
+      "visibility": "public",
       "line_start": 10,
       "line_end": 13
     },
@@ -69,6 +78,7 @@
       "name": "find",
       "qualified": "UserRepository.find",
       "kind": "method",
+      "visibility": "public",
       "parent": "UserRepository",
       "line_start": 11,
       "line_end": 11
@@ -77,6 +87,7 @@
       "name": "save",
       "qualified": "UserRepository.save",
       "kind": "method",
+      "visibility": "public",
       "parent": "UserRepository",
       "line_start": 12,
       "line_end": 12

--- a/internal/extract/testdata/typescript/inheritance.golden.json
+++ b/internal/extract/testdata/typescript/inheritance.golden.json
@@ -4,6 +4,7 @@
       "name": "Admin",
       "qualified": "Admin",
       "kind": "class",
+      "visibility": "public",
       "line_start": 13,
       "line_end": 18
     },
@@ -11,6 +12,7 @@
       "name": "greet",
       "qualified": "Admin.greet",
       "kind": "method",
+      "visibility": "public",
       "parent": "Admin",
       "line_start": 14,
       "line_end": 16
@@ -19,6 +21,7 @@
       "name": "Base",
       "qualified": "Base",
       "kind": "class",
+      "visibility": "public",
       "line_start": 9,
       "line_end": 11
     },
@@ -26,6 +29,7 @@
       "name": "hello",
       "qualified": "Base.hello",
       "kind": "method",
+      "visibility": "public",
       "parent": "Base",
       "line_start": 10,
       "line_end": 10
@@ -34,6 +38,7 @@
       "name": "Greeter",
       "qualified": "Greeter",
       "kind": "interface",
+      "visibility": "public",
       "line_start": 1,
       "line_end": 3
     },
@@ -41,6 +46,7 @@
       "name": "Named",
       "qualified": "Named",
       "kind": "interface",
+      "visibility": "public",
       "line_start": 5,
       "line_end": 7
     }

--- a/internal/extract/testdata/typescript/namespaces.golden.json
+++ b/internal/extract/testdata/typescript/namespaces.golden.json
@@ -4,6 +4,7 @@
       "name": "Direction",
       "qualified": "Direction",
       "kind": "class",
+      "visibility": "public",
       "line_start": 19,
       "line_end": 24
     },
@@ -11,6 +12,7 @@
       "name": "HttpStatus",
       "qualified": "HttpStatus",
       "kind": "class",
+      "visibility": "public",
       "line_start": 26,
       "line_end": 30
     },
@@ -18,6 +20,7 @@
       "name": "LettersOnlyValidator",
       "qualified": "LettersOnlyValidator",
       "kind": "class",
+      "visibility": "public",
       "line_start": 6,
       "line_end": 10
     },
@@ -25,6 +28,7 @@
       "name": "isValid",
       "qualified": "LettersOnlyValidator.isValid",
       "kind": "method",
+      "visibility": "public",
       "parent": "LettersOnlyValidator",
       "line_start": 7,
       "line_end": 9
@@ -33,6 +37,7 @@
       "name": "StringValidator",
       "qualified": "StringValidator",
       "kind": "interface",
+      "visibility": "public",
       "line_start": 2,
       "line_end": 4
     },
@@ -40,6 +45,7 @@
       "name": "ZipCodeValidator",
       "qualified": "ZipCodeValidator",
       "kind": "class",
+      "visibility": "public",
       "line_start": 12,
       "line_end": 16
     },
@@ -47,6 +53,7 @@
       "name": "isValid",
       "qualified": "ZipCodeValidator.isValid",
       "kind": "method",
+      "visibility": "public",
       "parent": "ZipCodeValidator",
       "line_start": 13,
       "line_end": 15
@@ -55,6 +62,7 @@
       "name": "createValidator",
       "qualified": "createValidator",
       "kind": "function",
+      "visibility": "public",
       "line_start": 32,
       "line_end": 34
     }

--- a/internal/extract/testdata/typescript/reexport_named.golden.json
+++ b/internal/extract/testdata/typescript/reexport_named.golden.json
@@ -4,6 +4,7 @@
       "name": "Config",
       "qualified": "Config",
       "kind": "constant",
+      "visibility": "public",
       "line_start": 3,
       "line_end": 3
     },
@@ -11,6 +12,7 @@
       "name": "OrderDTO",
       "qualified": "OrderDTO",
       "kind": "constant",
+      "visibility": "public",
       "line_start": 2,
       "line_end": 2
     },
@@ -18,6 +20,7 @@
       "name": "OrderService",
       "qualified": "OrderService",
       "kind": "constant",
+      "visibility": "public",
       "line_start": 2,
       "line_end": 2
     },
@@ -25,6 +28,7 @@
       "name": "UserService",
       "qualified": "UserService",
       "kind": "constant",
+      "visibility": "public",
       "line_start": 1,
       "line_end": 1
     }

--- a/internal/extract/testdata/typescript/types.golden.json
+++ b/internal/extract/testdata/typescript/types.golden.json
@@ -4,6 +4,7 @@
       "name": "TestAdminSigma",
       "qualified": "TestAdminSigma",
       "kind": "type",
+      "visibility": "public",
       "line_start": 13,
       "line_end": 13
     },
@@ -11,6 +12,7 @@
       "name": "TestManagerUpsilon",
       "qualified": "TestManagerUpsilon",
       "kind": "class",
+      "visibility": "public",
       "line_start": 15,
       "line_end": 18
     },
@@ -18,6 +20,7 @@
       "name": "serialize",
       "qualified": "TestManagerUpsilon.serialize",
       "kind": "method",
+      "visibility": "public",
       "parent": "TestManagerUpsilon",
       "line_start": 16,
       "line_end": 16
@@ -26,6 +29,7 @@
       "name": "validate",
       "qualified": "TestManagerUpsilon.validate",
       "kind": "method",
+      "visibility": "public",
       "parent": "TestManagerUpsilon",
       "line_start": 17,
       "line_end": 17
@@ -34,6 +38,7 @@
       "name": "TestOrderOmicron",
       "qualified": "TestOrderOmicron",
       "kind": "type",
+      "visibility": "public",
       "line_start": 9,
       "line_end": 9
     },
@@ -41,6 +46,7 @@
       "name": "TestOrderWithUserPi",
       "qualified": "TestOrderWithUserPi",
       "kind": "type",
+      "visibility": "public",
       "line_start": 11,
       "line_end": 11
     },
@@ -48,6 +54,7 @@
       "name": "TestSerializableMu",
       "qualified": "TestSerializableMu",
       "kind": "interface",
+      "visibility": "public",
       "line_start": 1,
       "line_end": 3
     },
@@ -55,6 +62,7 @@
       "name": "TestValidatableNu",
       "qualified": "TestValidatableNu",
       "kind": "interface",
+      "visibility": "public",
       "line_start": 5,
       "line_end": 7
     }

--- a/internal/extract/tsjs/harvest.go
+++ b/internal/extract/tsjs/harvest.go
@@ -1,0 +1,189 @@
+package tsjs
+
+import (
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+)
+
+// HarvestsMentions reports that the TS/JS extractor streams the broad mention
+// set (see emitHarvest), so the scan records the language as harvested even on a
+// scan that yields zero mentions — the dead-code soundness gate then treats a
+// TS/JS symbol as proven-against-an-empty-set, not never-harvested. Without this
+// opt-in every TS/JS symbol would fail closed at the per-language soundness gate
+// (core_no_harvest) and none could earn `dead`. Declared on each of the three
+// extractor types (TypeScript, TSX, JavaScript) so all three languages register
+// as harvested — they share this one walker.
+func (TypeScript) HarvestsMentions() bool { return true }
+func (TSX) HarvestsMentions() bool        { return true }
+func (JavaScript) HarvestsMentions() bool { return true }
+
+// emitHarvest streams the file's four dead-code fact sets to the emitter when it
+// accepts them, all from one set of tree walks (scan is not a hot path):
+//
+//   - mentions (MentionEmitter): every identifier / property / type token except a
+//     definition's own name — the broad superset feeding the arbiter's soundness
+//     gate. A method invoked as `obj.render()` leaves a `render` property mention,
+//     so a same-named method stays open-world instead of falsely `dead`.
+//   - dispatch (DispatchEmitter): the literal key of every computed-property access
+//     (`obj["render"]`) — the JS/TS analog of Ruby `send`. A name reached this way
+//     is invisible to the static graph, so the core voice keeps it open-world.
+//   - decorated names (TSHarvestEmitter): the name of every class / method carrying
+//     a decorator (`@Component`, `@Injectable`, `@Get`). A framework's DI/router
+//     instantiates or routes to it with no source caller, so the TS voice keeps it
+//     open-world (ts_decorator) even when module-private.
+//   - default-export names (TSHarvestEmitter): the name bound by each `export
+//     default` form, so the TS voice can raise the more specific ts_default_export.
+//
+// Each emit is best-effort — an Emitter that implements none of the extensions
+// simply receives no names.
+func emitHarvest(root *sitter.Node, source []byte, filePath string, emit extract.Emitter) error {
+	if me, ok := emit.(extract.MentionEmitter); ok {
+		for _, name := range extract.HarvestMentions(root, source, mentionWalkSpec()) {
+			if err := me.MentionName(name); err != nil {
+				return err
+			}
+		}
+	}
+	if de, ok := emit.(extract.DispatchEmitter); ok {
+		for name := range collectComputedDispatch(root, source) {
+			if err := de.DispatchName(name); err != nil {
+				return err
+			}
+		}
+	}
+	if te, ok := emit.(extract.TSHarvestEmitter); ok {
+		for name := range collectDecoratedNames(root, source) {
+			if err := te.TSDecoratedName(name); err != nil {
+				return err
+			}
+		}
+		_, defaults := collectExportedNames(root, source, filePath)
+		for name := range defaults {
+			if err := te.TSDefaultExportName(name); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// mentionWalkSpec is the TS/JS grammar parameterisation of the shared mention
+// harvest. Plain identifiers, member-access property names, type references, and
+// `{ foo }` shorthand keys each carry a mention; a definition's own name token is
+// excluded so a symbol is never cancelled by its own declaration. property_identifier
+// is included so a `obj.render()` call keeps a same-named method open-world even
+// when the resolver could not bind the member access to the class.
+func mentionWalkSpec() extract.MentionWalkSpec {
+	return extract.MentionWalkSpec{
+		NameOf: map[string]func(*sitter.Node, []byte) string{
+			"identifier":                    extract.Text,
+			"property_identifier":           extract.Text,
+			"type_identifier":               extract.Text,
+			"shorthand_property_identifier": extract.Text,
+		},
+		SkipDefinitionName: isTSDefinitionName,
+	}
+}
+
+// isTSDefinitionName reports whether n is the `name` field of a symbol-producing
+// declaration (function / class / interface / type-alias / enum / method /
+// const declarator). Those tokens are excluded from the mention set so a symbol
+// does not count as a mention of itself — otherwise no symbol could ever earn
+// `dead`. Class-field and parameter names are intentionally NOT excluded: leaving
+// them in the set only ever keeps a same-named symbol open-world (the safe
+// direction).
+func isTSDefinitionName(n *sitter.Node) bool {
+	p := n.Parent()
+	if p == nil {
+		return false
+	}
+	switch p.Kind() {
+	case "function_declaration", "generator_function_declaration",
+		"class_declaration", "abstract_class_declaration",
+		"interface_declaration", "type_alias_declaration", "enum_declaration",
+		"method_definition", "variable_declarator":
+		name := p.ChildByFieldName("name")
+		return name != nil && name.Id() == n.Id()
+	}
+	return false
+}
+
+// collectComputedDispatch returns the set of string-literal keys used in
+// computed-property access (`obj["render"]`, `obj["render"]()`). A non-literal
+// index (`obj[name]`) names no statically-knowable member, so it is skipped — the
+// safe direction (the target stays whatever the static graph says). These are the
+// reflective dispatch targets the core voice keeps open-world.
+func collectComputedDispatch(root *sitter.Node, source []byte) map[string]struct{} {
+	seen := map[string]struct{}{}
+	_ = extract.WalkNamedDescendants(root, "subscript_expression", func(n *sitter.Node) error {
+		idx := n.ChildByFieldName("index")
+		if idx == nil || idx.Kind() != "string" {
+			return nil
+		}
+		if name := stringFragmentText(idx, source); name != "" {
+			seen[name] = struct{}{}
+		}
+		return nil
+	})
+	return seen
+}
+
+// collectDecoratedNames returns the set of class and method names carrying a
+// decorator. A decorator attaches as a `decorator` node in three structural
+// positions — preceding a bare class_declaration, inside the export_statement
+// that wraps an exported class, or inside a class_body preceding a
+// method_definition — so the decorated symbol's name is read from the decorator's
+// structural context. Name-based over-approximation is safe: a decorated name only
+// ever keeps a symbol open-world (ts_decorator), never forces `dead`.
+func collectDecoratedNames(root *sitter.Node, source []byte) map[string]struct{} {
+	seen := map[string]struct{}{}
+	_ = extract.WalkNamedDescendants(root, "decorator", func(d *sitter.Node) error {
+		if name := decoratedName(d, source); name != "" {
+			seen[name] = struct{}{}
+		}
+		return nil
+	})
+	return seen
+}
+
+// decoratedName returns the name of the symbol a decorator node annotates, read
+// from its parent context: a class_declaration's name (bare decorated class), the
+// declaration named in a wrapping export_statement (exported decorated class), or
+// the next method_definition sibling in a class_body (decorated method).
+func decoratedName(d *sitter.Node, source []byte) string {
+	p := d.Parent()
+	if p == nil {
+		return ""
+	}
+	switch p.Kind() {
+	case "class_declaration", "abstract_class_declaration":
+		return extract.Text(p.ChildByFieldName("name"), source)
+	case "export_statement":
+		if decl := p.ChildByFieldName("declaration"); decl != nil {
+			return extract.Text(decl.ChildByFieldName("name"), source)
+		}
+	case "class_body":
+		for sib := d.NextNamedSibling(); sib != nil; sib = sib.NextNamedSibling() {
+			if sib.Kind() == "method_definition" {
+				return extract.Text(sib.ChildByFieldName("name"), source)
+			}
+			if sib.Kind() != "decorator" {
+				return ""
+			}
+		}
+	}
+	return ""
+}
+
+// stringFragmentText returns the text of a string node's string_fragment child
+// (`"render"` → `render`), or "" for an empty string or one with no fragment.
+func stringFragmentText(str *sitter.Node, source []byte) string {
+	for i := uint(0); i < str.NamedChildCount(); i++ {
+		c := str.NamedChild(i)
+		if c != nil && c.Kind() == "string_fragment" {
+			return extract.Text(c, source)
+		}
+	}
+	return ""
+}

--- a/internal/extract/tsjs/harvest_test.go
+++ b/internal/extract/tsjs/harvest_test.go
@@ -1,0 +1,211 @@
+package tsjs
+
+import (
+	"testing"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+)
+
+func TestHarvestsMentionsOptIn(t *testing.T) {
+	// All three extractor types must report they harvest mentions, so the scan
+	// records each language as harvested and its symbols can earn `dead`.
+	for _, ex := range []extract.MentionHarvester{TypeScript{}, TSX{}, JavaScript{}} {
+		if !ex.HarvestsMentions() {
+			t.Errorf("%T.HarvestsMentions() = false, want true", ex)
+		}
+	}
+}
+
+func TestHarvestMentions(t *testing.T) {
+	// Every identifier / property / type token is mentioned EXCEPT a definition's
+	// own name. A method invoked as `obj.render()` leaves a `render` property
+	// mention, keeping a same-named method open-world.
+	src := `function caller() {
+  const svc = makeService();
+  svc.render();
+  return helper(svc);
+}
+function helper(x) { return x; }
+`
+	r := extractTS(t, TypeScript{}, "mod.ts", src)
+	mentions := toSet(r.mentions)
+	for _, want := range []string{"makeService", "svc", "render", "helper", "x"} {
+		if _, ok := mentions[want]; !ok {
+			t.Errorf("mentions missing %q; got %v", want, r.mentions)
+		}
+	}
+	// `caller` is a definition's own name and must be excluded — otherwise it
+	// would cancel its own dead candidacy.
+	if _, ok := mentions["caller"]; ok {
+		t.Errorf("mentions should exclude the definition name 'caller'; got %v", r.mentions)
+	}
+}
+
+func TestHarvestDispatchComputedAccess(t *testing.T) {
+	// A literal computed-property key is a reflective dispatch target (the JS/TS
+	// analog of Ruby `send`); a non-literal index names nothing statically.
+	src := `function f(obj, name) {
+  obj["render"]();
+  obj["value"];
+  obj[name]();
+}
+`
+	r := extractTS(t, TypeScript{}, "mod.ts", src)
+	dispatch := toSet(r.dispatch)
+	for _, want := range []string{"render", "value"} {
+		if _, ok := dispatch[want]; !ok {
+			t.Errorf("dispatch missing %q; got %v", want, r.dispatch)
+		}
+	}
+	if len(dispatch) != 2 {
+		t.Errorf("dispatch = %v, want exactly {render, value} (the literal keys, not obj[name])", r.dispatch)
+	}
+}
+
+func TestHarvestDecoratedClass(t *testing.T) {
+	// A decorator on an exported class (decorator attaches to the export_statement)
+	// and on a bare class (decorator attaches to the class_declaration) both yield
+	// the class name in the decorated set.
+	src := `@Component({ selector: 'app' })
+export class AppComponent {}
+
+@Injectable
+class TokenService {}
+`
+	r := extractTS(t, TypeScript{}, "app.ts", src)
+	decorated := toSet(r.decorated)
+	for _, want := range []string{"AppComponent", "TokenService"} {
+		if _, ok := decorated[want]; !ok {
+			t.Errorf("decorated missing %q; got %v", want, r.decorated)
+		}
+	}
+}
+
+func TestHarvestDecoratedMethod(t *testing.T) {
+	// A method decorator (`@Get()`) yields the method name in the decorated set.
+	src := `class UsersController {
+  @Get()
+  list() {}
+
+  plain() {}
+}
+`
+	r := extractTS(t, TypeScript{}, "users.controller.ts", src)
+	decorated := toSet(r.decorated)
+	if _, ok := decorated["list"]; !ok {
+		t.Errorf("decorated missing 'list'; got %v", r.decorated)
+	}
+	if _, ok := decorated["plain"]; ok {
+		t.Errorf("decorated should not contain undecorated 'plain'; got %v", r.decorated)
+	}
+}
+
+func TestHarvestDefaultExportName(t *testing.T) {
+	r := extractTS(t, TypeScript{}, "page.tsx", "export default function Page() {}\n")
+	if !contains(r.defaultExports, "Page") {
+		t.Errorf("default exports = %v, want to contain Page", r.defaultExports)
+	}
+}
+
+func TestHarvestComputedEmptyStringKey(t *testing.T) {
+	// `obj[""]()` has no string fragment, so it contributes no dispatch name.
+	r := extractTS(t, TypeScript{}, "mod.ts", "function f(obj) { obj[\"\"](); }\n")
+	if len(r.dispatch) != 0 {
+		t.Errorf("dispatch = %v, want empty for an empty-string computed key", r.dispatch)
+	}
+}
+
+func TestHarvestDecoratorNoTargetMethod(t *testing.T) {
+	// A decorator in a class body with no following method_definition (here it
+	// precedes a field) contributes no decorated name — decoratedName returns "".
+	src := `class C {
+  @Watch()
+  count = 0;
+}
+`
+	r := extractTS(t, TypeScript{}, "c.ts", src)
+	// `count` is a field, not a method_definition, so nothing is recorded for it.
+	if contains(r.decorated, "count") {
+		t.Errorf("decorated should not contain field 'count'; got %v", r.decorated)
+	}
+}
+
+// failEmitter returns an error from exactly one harvest stream, leaving the rest
+// succeeding, so each error-propagation path in emitHarvest is exercised.
+type failEmitter struct {
+	failMention, failDispatch, failDecorated, failDefault bool
+}
+
+func (failEmitter) Symbol(extract.EmittedSymbol) error { return nil }
+func (failEmitter) Edge(extract.EmittedEdge) error     { return nil }
+func (e failEmitter) MentionName(string) error {
+	if e.failMention {
+		return errBoom
+	}
+	return nil
+}
+func (e failEmitter) DispatchName(string) error {
+	if e.failDispatch {
+		return errBoom
+	}
+	return nil
+}
+func (e failEmitter) TSDecoratedName(string) error {
+	if e.failDecorated {
+		return errBoom
+	}
+	return nil
+}
+func (e failEmitter) TSDefaultExportName(string) error {
+	if e.failDefault {
+		return errBoom
+	}
+	return nil
+}
+
+var errBoom = errBoomType{}
+
+type errBoomType struct{}
+
+func (errBoomType) Error() string { return "boom" }
+
+func TestEmitHarvestPropagatesEmitterErrors(t *testing.T) {
+	src := `@Component({})
+export default function Page(obj) { obj["render"](); }
+`
+	root, source, cleanup := parseRoot(t, TypeScript{}, src)
+	defer cleanup()
+	for name, em := range map[string]failEmitter{
+		"mention":   {failMention: true},
+		"dispatch":  {failDispatch: true},
+		"decorated": {failDecorated: true},
+		"default":   {failDefault: true},
+	} {
+		if err := emitHarvest(root, source, "page.ts", em); err == nil {
+			t.Errorf("%s: emitHarvest returned nil, want the emitter error propagated", name)
+		}
+	}
+}
+
+func parseRoot(t *testing.T, ex extract.Extractor, src string) (*sitter.Node, []byte, func()) {
+	t.Helper()
+	p := sitter.NewParser()
+	if err := p.SetLanguage(ex.Grammar()); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	tree := p.Parse([]byte(src), nil)
+	if tree == nil {
+		t.Fatal("nil tree")
+	}
+	return tree.RootNode(), []byte(src), func() { tree.Close(); p.Close() }
+}
+
+func toSet(xs []string) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, x := range xs {
+		out[x] = struct{}{}
+	}
+	return out
+}

--- a/internal/extract/tsjs/tsjs.go
+++ b/internal/extract/tsjs/tsjs.go
@@ -106,11 +106,15 @@ func extractAll(tree *sitter.Tree, source []byte, filePath string, emit extract.
 		stimulusName: inferStimulusController(filePath),
 		pkgBindings:  map[string]string{},
 	}
+	w.collectExports(tree.RootNode())
 	w.collectModuleConstants(tree.RootNode())
 	if err := w.walk(tree.RootNode(), nil); err != nil {
 		return err
 	}
-	return w.walkDynamicImports(tree.RootNode())
+	if err := w.walkDynamicImports(tree.RootNode()); err != nil {
+		return err
+	}
+	return emitHarvest(tree.RootNode(), source, filePath, emit)
 }
 
 // ---- walker ----
@@ -121,6 +125,15 @@ type walker struct {
 	filePath     string
 	stimulusName string            // non-empty if this file is a Stimulus controller
 	pkgBindings  map[string]string // unqualified name → qualified name for module-level constants
+	// exported is the set of local names the module exports in any form; it
+	// drives each emitted symbol's Visibility ("public" if present, else
+	// "private"). defaultExports is the subset that are default exports.
+	// isModule is false for a global script (no top-level import/export), where
+	// every symbol is treated as public (globally reachable by concatenation).
+	// All three are populated by collectExports before the main walk.
+	exported       map[string]bool
+	defaultExports map[string]bool
+	isModule       bool
 }
 
 // collectModuleConstants pre-scans top-level const declarations for
@@ -293,6 +306,7 @@ func (w *walker) emitClassWithBody(n *sitter.Node, name string, scope []string) 
 		Name:            name,
 		Qualified:       qualified,
 		Kind:            model.KindClass,
+		Visibility:      w.visibilityOf(name),
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
@@ -427,6 +441,7 @@ func (w *walker) handleMethod(n *sitter.Node, scope []string) error {
 		Name:            name,
 		Qualified:       qualified,
 		Kind:            model.KindMethod,
+		Visibility:      w.methodVisibility(scope),
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
@@ -460,6 +475,7 @@ func (w *walker) handleInterface(n *sitter.Node, scope []string) error {
 		Name:            name,
 		Qualified:       qualified,
 		Kind:            model.KindInterface,
+		Visibility:      w.visibilityOf(name),
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
@@ -501,6 +517,7 @@ func (w *walker) handleTypeAlias(n *sitter.Node, scope []string) error {
 		Name:            name,
 		Qualified:       qualified,
 		Kind:            model.KindType,
+		Visibility:      w.visibilityOf(name),
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
@@ -626,6 +643,7 @@ func (w *walker) handleEnum(n *sitter.Node, scope []string) error {
 		Name:            name,
 		Qualified:       qualified,
 		Kind:            model.KindClass,
+		Visibility:      w.visibilityOf(name),
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
@@ -661,6 +679,7 @@ func (w *walker) emitFunctionWithBody(n *sitter.Node, name string, scope []strin
 		Name:            name,
 		Qualified:       qualified,
 		Kind:            model.KindFunction,
+		Visibility:      w.visibilityOf(name),
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
@@ -728,6 +747,7 @@ func (w *walker) handleVariableDeclarator(decl *sitter.Node, scope []string) err
 		Name:            name,
 		Qualified:       qualified,
 		Kind:            kind,
+		Visibility:      w.visibilityOf(name),
 		ParentQualified: parent,
 		LineStart:       extract.Line(decl.StartPosition()),
 		LineEnd:         extract.Line(decl.EndPosition()),
@@ -897,12 +917,15 @@ func (w *walker) handleReexport(n *sitter.Node, modulePath string) error {
 			if name == "" || name == "default" {
 				continue
 			}
+			// A re-exported name is definitionally an export of this module, so
+			// it is always public — it never falls to the closed-world dead test.
 			if err := w.emit.Symbol(extract.EmittedSymbol{
-				Name:      name,
-				Qualified: name,
-				Kind:      model.KindConstant,
-				LineStart: extract.Line(spec.StartPosition()),
-				LineEnd:   extract.Line(spec.EndPosition()),
+				Name:       name,
+				Qualified:  name,
+				Kind:       model.KindConstant,
+				Visibility: "public",
+				LineStart:  extract.Line(spec.StartPosition()),
+				LineEnd:    extract.Line(spec.EndPosition()),
 			}); err != nil {
 				return err
 			}
@@ -941,13 +964,18 @@ func hasDefaultKeyword(n *sitter.Node, source []byte) bool {
 	return false
 }
 
-// fileBasedName derives a PascalCase symbol name from the file path.
-// Returns "" if the path is empty or the file is an index file.
-func (w *walker) fileBasedName() string {
-	if w.filePath == "" {
+// fileBasedName derives a PascalCase symbol name from the walker's file path.
+func (w *walker) fileBasedName() string { return fileBasedNameOf(w.filePath) }
+
+// fileBasedNameOf derives a PascalCase symbol name from a file path. Returns ""
+// if the path is empty or the file is an index file. Shared by the walker
+// (synthesizing anonymous default-export symbol names) and the visibility pass
+// (recognizing the same names as exported).
+func fileBasedNameOf(path string) string {
+	if path == "" {
 		return ""
 	}
-	base := filepath.Base(w.filePath)
+	base := filepath.Base(path)
 	name := strings.TrimSuffix(base, filepath.Ext(base))
 	if name == "" || name == "index" {
 		return ""

--- a/internal/extract/tsjs/visibility.go
+++ b/internal/extract/tsjs/visibility.go
@@ -1,0 +1,198 @@
+package tsjs
+
+import (
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+)
+
+// Export visibility is the TS/JS analog of Ruby's method-visibility pass and the
+// structural capitalization rule Go/Rust get for free: it marks each emitted
+// symbol `public` (exported in any form) or `private` (module-local). It is the
+// unlock for two dead-code gates — the core voice's library-API gate and the
+// TS voice's closed-world test — because a NON-exported symbol is reachable only
+// within its own module, the one shape the module system proves closed-world.
+//
+// A symbol is `public` when its name is exported by any form the module system
+// offers:
+//
+//   - `export function f` / `export class C` / `export const x` / `export
+//     interface I` / `export type T` / `export enum E` — a declaration directly
+//     under an `export_statement`.
+//   - `export default …` — a default export (named or file-named anonymous).
+//   - `export { g }` / `export { g as h }` — a clause naming a locally-declared
+//     symbol elsewhere in the module (the LOCAL `name`, not the external alias).
+//   - a re-exported name (`export { X } from './x'`) — handled inline by
+//     handleReexport, which marks its synthesized symbols public directly.
+//
+// Everything else is `private` (module-local). The name-set approach can mark a
+// nested member public when it collides with a top-level export name — that is
+// the SAFE direction (a falsely-public symbol never earns `dead`, only loses
+// recall), exactly the conservatism Ruby's visibility pass and Go's magic-method
+// table choose.
+
+// collectExports pre-scans the module for every export form and records the set
+// of exported LOCAL names and, separately, the names that are default exports.
+// Both feed the walker: `exported` drives each symbol's Visibility, and
+// `defaultExports` is streamed by the harvest so the TS voice can raise the more
+// specific ts_default_export reason. It also records whether the file is an ES
+// module at all (see fileIsModule).
+func (w *walker) collectExports(root *sitter.Node) {
+	w.exported, w.defaultExports = collectExportedNames(root, w.source, w.filePath)
+	w.isModule = fileIsModule(root)
+}
+
+// fileIsModule reports whether root is an ES module — a file with at least one
+// top-level `import` or `export` statement. A file with neither is a global
+// *script*: its top-level declarations share the global scope and are reachable
+// by any other concatenated script (bundler runtimes, `/// <reference>` ambient
+// files, classic `<script>`-style code), so "not exported" does NOT prove a
+// symbol file-local. The dead-code closed-world bet is valid only for modules;
+// in a script every symbol is treated as globally reachable (see visibilityOf).
+// A dynamic `import()` is an expression, not a top-level import, so a file whose
+// only import is dynamic is correctly a script.
+func fileIsModule(root *sitter.Node) bool {
+	for i := uint(0); i < root.NamedChildCount(); i++ {
+		switch root.NamedChild(i).Kind() {
+		case "import_statement", "export_statement":
+			return true
+		}
+	}
+	return false
+}
+
+// visibilityOf returns the visibility of a top-level symbol. In a script file
+// (not an ES module) every symbol is globally reachable by concatenation, so it
+// is "public" — never a closed-world dead candidate. In a module, a symbol is
+// "public" iff it is in the exported set, else "private" (file-local).
+func (w *walker) visibilityOf(name string) string {
+	if !w.isModule {
+		return "public"
+	}
+	if w.exported[name] {
+		return "public"
+	}
+	return "private"
+}
+
+// methodVisibility returns the visibility of a method. In a script file it is
+// "public" (global scope). In a module it is "public" when the method's enclosing
+// top-level class is exported (so the method is reachable on the exported class
+// from another module), else "private": a method is never itself named in an
+// export clause, so its export-reachability tracks its class.
+func (w *walker) methodVisibility(scope []string) string {
+	if !w.isModule {
+		return "public"
+	}
+	if len(scope) > 0 && w.exported[scope[0]] {
+		return "public"
+	}
+	return "private"
+}
+
+// collectExportedNames walks every export_statement under root and returns the
+// set of exported local names plus the subset that are default exports. It is a
+// free function (not a walker method) so the harvest pass can reuse it without
+// the walker's mutable state. filePath supplies the file-based name an anonymous
+// default export is synthesized under (matching handleDefaultExport).
+func collectExportedNames(root *sitter.Node, source []byte, filePath string) (exported, defaultExports map[string]bool) {
+	exported = map[string]bool{}
+	defaultExports = map[string]bool{}
+	_ = extract.WalkNamedDescendants(root, "export_statement", func(es *sitter.Node) error {
+		// A re-export (`export { X } from './x'`, `export * from './x'`) names
+		// symbols defined in another module, not local declarations —
+		// handleReexport emits and marks those public itself. Skip it here so a
+		// re-export clause's name is not mistaken for a local export.
+		if reexportSource(es, source) != "" {
+			return nil
+		}
+		isDefault := hasDefaultKeyword(es, source)
+
+		// `export { g }` / `export { g as h }`: the LOCAL name is the specifier's
+		// `name` field (g), exported under the alias if present.
+		for i := uint(0); i < es.NamedChildCount(); i++ {
+			clause := es.NamedChild(i)
+			if clause == nil || clause.Kind() != "export_clause" {
+				continue
+			}
+			for j := uint(0); j < clause.NamedChildCount(); j++ {
+				spec := clause.NamedChild(j)
+				if spec == nil || spec.Kind() != "export_specifier" {
+					continue
+				}
+				if name := extract.Text(spec.ChildByFieldName("name"), source); name != "" && name != "default" {
+					exported[name] = true
+				}
+			}
+		}
+
+		// `export [default] <declaration>`: a function/class/interface/enum/type
+		// declaration or a `const` lexical declaration carried in the
+		// `declaration` field.
+		if decl := es.ChildByFieldName("declaration"); decl != nil {
+			for _, name := range declaredNames(decl, source) {
+				exported[name] = true
+				if isDefault {
+					defaultExports[name] = true
+				}
+			}
+			return nil
+		}
+
+		// `export default <expr>`: a named identifier (`export default foo`) or an
+		// anonymous function/class expression synthesized under the file-based name.
+		if isDefault {
+			if name := defaultExportName(es, source, filePath); name != "" {
+				exported[name] = true
+				defaultExports[name] = true
+			}
+		}
+		return nil
+	})
+	return exported, defaultExports
+}
+
+// declaredNames returns the names a declaration node introduces: the `name`
+// field for a function/class/interface/enum/type-alias declaration, or every
+// variable_declarator name for a `const` lexical declaration.
+func declaredNames(decl *sitter.Node, source []byte) []string {
+	switch decl.Kind() {
+	case "lexical_declaration":
+		var names []string
+		for i := uint(0); i < decl.NamedChildCount(); i++ {
+			d := decl.NamedChild(i)
+			if d == nil || d.Kind() != "variable_declarator" {
+				continue
+			}
+			if name := extract.Text(d.ChildByFieldName("name"), source); name != "" {
+				names = append(names, name)
+			}
+		}
+		return names
+	default:
+		if name := extract.Text(decl.ChildByFieldName("name"), source); name != "" {
+			return []string{name}
+		}
+	}
+	return nil
+}
+
+// defaultExportName returns the name a `export default <expr>` form binds, but
+// ONLY for shapes the walker actually emits a symbol for: an identifier
+// (`export default foo`) or an anonymous function/class expression synthesized
+// under the file-based name. A literal or other expression (`export default 42`)
+// emits no symbol, so it binds no name and returns "" — recording a file-based
+// name there would be a phantom that no symbol matches.
+func defaultExportName(es *sitter.Node, source []byte, filePath string) string {
+	v := es.ChildByFieldName("value")
+	if v == nil {
+		return ""
+	}
+	switch v.Kind() {
+	case "identifier", "type_identifier":
+		return extract.Text(v, source)
+	case "function_expression", "arrow_function", "class", "class_expression":
+		return fileBasedNameOf(filePath)
+	}
+	return ""
+}

--- a/internal/extract/tsjs/visibility_test.go
+++ b/internal/extract/tsjs/visibility_test.go
@@ -1,0 +1,282 @@
+package tsjs
+
+import (
+	"testing"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+)
+
+// harvestRecorder captures emitted symbols plus every optional harvest stream so
+// the visibility and harvest tests can assert on raw-byte extraction without the
+// scan harness.
+type harvestRecorder struct {
+	symbols        []extract.EmittedSymbol
+	edges          []extract.EmittedEdge
+	mentions       []string
+	dispatch       []string
+	decorated      []string
+	defaultExports []string
+}
+
+func (r *harvestRecorder) Symbol(s extract.EmittedSymbol) error {
+	r.symbols = append(r.symbols, s)
+	return nil
+}
+func (r *harvestRecorder) Edge(e extract.EmittedEdge) error { r.edges = append(r.edges, e); return nil }
+func (r *harvestRecorder) MentionName(n string) error       { r.mentions = append(r.mentions, n); return nil }
+func (r *harvestRecorder) DispatchName(n string) error {
+	r.dispatch = append(r.dispatch, n)
+	return nil
+}
+func (r *harvestRecorder) TSDecoratedName(n string) error {
+	r.decorated = append(r.decorated, n)
+	return nil
+}
+func (r *harvestRecorder) TSDefaultExportName(n string) error {
+	r.defaultExports = append(r.defaultExports, n)
+	return nil
+}
+
+// extractTS parses src with the given extractor and returns the recorded output.
+func extractTS(t *testing.T, ex extract.Extractor, path, src string) *harvestRecorder {
+	t.Helper()
+	p := sitter.NewParser()
+	defer p.Close()
+	if err := p.SetLanguage(ex.Grammar()); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	tree := p.Parse([]byte(src), nil)
+	if tree == nil {
+		t.Fatal("Parse returned nil tree")
+	}
+	defer tree.Close()
+	r := &harvestRecorder{}
+	if err := ex.Extract(tree, []byte(src), path, r); err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return r
+}
+
+// visibilityOfSym returns the recorded Visibility for the symbol with the given
+// name, or "<missing>" when no such symbol was emitted.
+func visibilityOfSym(r *harvestRecorder, name string) string {
+	for _, s := range r.symbols {
+		if s.Name == name {
+			return s.Visibility
+		}
+	}
+	return "<missing>"
+}
+
+func TestVisibilityExportForms(t *testing.T) {
+	src := `export function exportedFn() {}
+function privateFn() {}
+export class ExportedClass {}
+class PrivateClass {}
+export const exportedConst = 5;
+const privateConst = 5;
+export interface ExportedIface {}
+interface PrivateIface {}
+export type ExportedType = string;
+type PrivateType = string;
+export enum ExportedEnum { A }
+enum PrivateEnum { A }
+`
+	r := extractTS(t, TypeScript{}, "mod.ts", src)
+	cases := map[string]string{
+		"exportedFn":    "public",
+		"privateFn":     "private",
+		"ExportedClass": "public",
+		"PrivateClass":  "private",
+		"exportedConst": "public",
+		"privateConst":  "private",
+		"ExportedIface": "public",
+		"PrivateIface":  "private",
+		"ExportedType":  "public",
+		"PrivateType":   "private",
+		"ExportedEnum":  "public",
+		"PrivateEnum":   "private",
+	}
+	for name, want := range cases {
+		if got := visibilityOfSym(r, name); got != want {
+			t.Errorf("%s visibility = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestVisibilityExportClause(t *testing.T) {
+	// `export { g }` / `export { h as alias }` mark the LOCAL name public even
+	// though the declaration is separate from the export statement.
+	src := `function g() {}
+function h() {}
+function unexported() {}
+export { g };
+export { h as alias };
+`
+	r := extractTS(t, TypeScript{}, "mod.ts", src)
+	if got := visibilityOfSym(r, "g"); got != "public" {
+		t.Errorf("g visibility = %q, want public (export { g })", got)
+	}
+	if got := visibilityOfSym(r, "h"); got != "public" {
+		t.Errorf("h visibility = %q, want public (export { h as alias })", got)
+	}
+	if got := visibilityOfSym(r, "unexported"); got != "private" {
+		t.Errorf("unexported visibility = %q, want private", got)
+	}
+}
+
+func TestVisibilityDefaultExportNamed(t *testing.T) {
+	src := "export default function Page() {}\n"
+	r := extractTS(t, TypeScript{}, "page.ts", src)
+	if got := visibilityOfSym(r, "Page"); got != "public" {
+		t.Errorf("Page visibility = %q, want public (export default)", got)
+	}
+	if !contains(r.defaultExports, "Page") {
+		t.Errorf("default exports = %v, want to contain Page", r.defaultExports)
+	}
+}
+
+func TestVisibilityDefaultExportAnonymous(t *testing.T) {
+	// An anonymous default export is synthesized under the file-based name and
+	// recognized as both public and a default export.
+	src := "export default function() {}\n"
+	r := extractTS(t, TypeScript{}, "widget.ts", src)
+	if got := visibilityOfSym(r, "Widget"); got != "public" {
+		t.Errorf("Widget visibility = %q, want public (anonymous default)", got)
+	}
+	if !contains(r.defaultExports, "Widget") {
+		t.Errorf("default exports = %v, want to contain Widget", r.defaultExports)
+	}
+}
+
+func TestVisibilityDefaultExportIdentifier(t *testing.T) {
+	// `export default foo` where foo is declared above marks foo public + default.
+	src := `function foo() {}
+export default foo;
+`
+	r := extractTS(t, TypeScript{}, "mod.ts", src)
+	if got := visibilityOfSym(r, "foo"); got != "public" {
+		t.Errorf("foo visibility = %q, want public (export default foo)", got)
+	}
+	if !contains(r.defaultExports, "foo") {
+		t.Errorf("default exports = %v, want to contain foo", r.defaultExports)
+	}
+}
+
+func TestVisibilityDefaultExportAnonymousClass(t *testing.T) {
+	// An anonymous default-export class is synthesized under the file-based name.
+	src := "export default class { method() {} }\n"
+	r := extractTS(t, TypeScript{}, "service.ts", src)
+	if got := visibilityOfSym(r, "Service"); got != "public" {
+		t.Errorf("Service visibility = %q, want public (anonymous default class)", got)
+	}
+}
+
+func TestVisibilityDefaultExportExpression(t *testing.T) {
+	// `export default <expr>` with a literal value emits no symbol, so it binds
+	// no name — no phantom file-based name is recorded as a default export.
+	src := "export default 42;\n"
+	r := extractTS(t, TypeScript{}, "answer.ts", src)
+	if len(r.defaultExports) != 0 {
+		t.Errorf("default exports = %v, want empty (a literal default binds no symbol)", r.defaultExports)
+	}
+	if len(r.symbols) != 0 {
+		t.Errorf("symbols = %v, want none for a literal default export", r.symbols)
+	}
+}
+
+func TestVisibilityDestructuringConstSkipped(t *testing.T) {
+	// Destructuring patterns are skipped in Tier-Basic; the export pass must not
+	// crash on `export const { a, b } = obj`.
+	src := "export const { a, b } = obj;\n"
+	r := extractTS(t, TypeScript{}, "mod.ts", src)
+	// No named const symbol is emitted for a destructuring declarator.
+	if got := visibilityOfSym(r, "a"); got != "<missing>" {
+		t.Errorf("destructured 'a' should not be emitted as a symbol; got visibility %q", got)
+	}
+}
+
+func TestVisibilityReexportIsPublic(t *testing.T) {
+	// `export { Button } from './Button'` emits a public symbol — a re-export is
+	// definitionally an export, never a module-private dead candidate.
+	src := `export { Button } from './Button';
+`
+	r := extractTS(t, TypeScript{}, "index.ts", src)
+	if got := visibilityOfSym(r, "Button"); got != "public" {
+		t.Errorf("re-exported Button visibility = %q, want public", got)
+	}
+}
+
+func TestVisibilityMethodTracksClass(t *testing.T) {
+	// A method of an exported class is reachable on that class (public); a method
+	// of a module-private class is itself module-private.
+	src := `export class Service {
+  doWork() {}
+}
+class Helper {
+  assist() {}
+}
+`
+	r := extractTS(t, TypeScript{}, "mod.ts", src)
+	if got := visibilityOfSym(r, "doWork"); got != "public" {
+		t.Errorf("doWork visibility = %q, want public (exported class)", got)
+	}
+	if got := visibilityOfSym(r, "assist"); got != "private" {
+		t.Errorf("assist visibility = %q, want private (module-private class)", got)
+	}
+}
+
+func TestVisibilityJavaScript(t *testing.T) {
+	// The same pass runs for JavaScript (one walker, three grammars).
+	src := `export function used() {}
+function local() {}
+`
+	r := extractTS(t, JavaScript{}, "mod.js", src)
+	if got := visibilityOfSym(r, "used"); got != "public" {
+		t.Errorf("used visibility = %q, want public", got)
+	}
+	if got := visibilityOfSym(r, "local"); got != "private" {
+		t.Errorf("local visibility = %q, want private", got)
+	}
+}
+
+func TestVisibilityScriptFileSymbolsArePublic(t *testing.T) {
+	// A file with no top-level import/export is a global *script* (a bundler
+	// runtime, a `/// <reference>` ambient file, classic <script> code), not an ES
+	// module. Its symbols share the global scope and are reachable by concatenation,
+	// so they are "public" — never a closed-world dead candidate.
+	src := `function registerChunkList() {}
+const ASSET = "x";
+`
+	r := extractTS(t, TypeScript{}, "runtime-backend.ts", src)
+	if got := visibilityOfSym(r, "registerChunkList"); got != "public" {
+		t.Errorf("registerChunkList visibility = %q, want public (script file, no import/export)", got)
+	}
+	if got := visibilityOfSym(r, "ASSET"); got != "public" {
+		t.Errorf("ASSET visibility = %q, want public (script file)", got)
+	}
+}
+
+func TestVisibilityDynamicImportOnlyIsScript(t *testing.T) {
+	// A file whose only "import" is a dynamic import() expression has no top-level
+	// import/export statement, so it is still a script — its private-looking
+	// symbols are global and stay public.
+	src := `const mod = import("./x");
+function helper() {}
+`
+	r := extractTS(t, TypeScript{}, "loader.ts", src)
+	if got := visibilityOfSym(r, "helper"); got != "public" {
+		t.Errorf("helper visibility = %q, want public (dynamic import only = script)", got)
+	}
+}
+
+func contains(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/scan/dispatch.go
+++ b/internal/scan/dispatch.go
@@ -169,6 +169,32 @@ func writeRustAllowDead(ctx context.Context, idx *sqlite.Adapter, collected map[
 	return writeNameSet(ctx, idx, rustAllowDeadMetaKey, collected)
 }
 
+// tsDecoratedMetaKey is the sense_meta key holding the project-wide set of TS/JS
+// class and method names carrying a decorator (`@Component` / `@Injectable` /
+// `@Controller` / route-method decorators). The dead-code TS voice reads it: a
+// framework's DI/router reaches such a symbol with no source caller, so it stays
+// open-world (ts_decorator) rather than earning `dead`. Flat, not per-language —
+// decorators span the .ts/.tsx/.js family, which shares one extractor.
+const tsDecoratedMetaKey = "ts_decorated"
+
+// writeTSDecorated persists the project-wide TS decorated-name set, unioning with
+// the existing set (same self-heals-on-rebuild rationale as the other name sets).
+func writeTSDecorated(ctx context.Context, idx *sqlite.Adapter, collected map[string]struct{}) error {
+	return writeNameSet(ctx, idx, tsDecoratedMetaKey, collected)
+}
+
+// tsDefaultExportsMetaKey is the sense_meta key holding the project-wide set of
+// TS/JS names bound by an `export default` form. The dead-code TS voice reads it:
+// a default export is imported by path, not by name, so the voice raises the more
+// specific ts_default_export reason. Flat, like the decorated set.
+const tsDefaultExportsMetaKey = "ts_default_exports"
+
+// writeTSDefaultExports persists the project-wide TS default-export set, unioning
+// with the existing set (same self-heals-on-rebuild rationale as the other sets).
+func writeTSDefaultExports(ctx context.Context, idx *sqlite.Adapter, collected map[string]struct{}) error {
+	return writeNameSet(ctx, idx, tsDefaultExportsMetaKey, collected)
+}
+
 // addNamesByLang unions names into byLang[lang], creating the language's set on
 // first use. Both per-language name accumulators (dispatch, mention) share it so
 // the handler keeps each language's names apart for per-language meta writes.

--- a/internal/scan/dispatch_test.go
+++ b/internal/scan/dispatch_test.go
@@ -366,6 +366,101 @@ impl Greeter for Robot {
 	}
 }
 
+// TestScanWritesTSHarvest proves the TS/JS harvest flows end to end through the
+// scan collector and aggregation: a TypeScript file carrying a decorator, a
+// default export, a computed-property dispatch, and a method call lands each name
+// in its sense_meta key, and `typescript` is recorded as harvested. It exercises
+// the TSHarvestEmitter collector paths plus the shared mention/dispatch harvest in
+// one scan.
+func TestScanWritesTSHarvest(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	senseDir := filepath.Join(root, ".sense")
+
+	src := `@Component({})
+export class AppComponent {
+  render(obj: any) {
+    obj["serialize"]();
+    this.helper();
+  }
+  helper() {}
+}
+
+export default function Page() {}
+`
+	if err := os.WriteFile(filepath.Join(root, "app.ts"), []byte(src), 0o644); err != nil {
+		t.Fatalf("write ts: %v", err)
+	}
+
+	if _, err := Run(ctx, Options{Root: root, Sense: senseDir, Output: &bytes.Buffer{}, Warnings: io.Discard}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+
+	a, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatalf("open index: %v", err)
+	}
+	t.Cleanup(func() { _ = a.Close() })
+
+	cases := []struct {
+		key, name string
+	}{
+		{tsDecoratedMetaKey, "AppComponent"},
+		{tsDefaultExportsMetaKey, "Page"},
+		{dispatchNamesKey("typescript"), "serialize"},
+		{mentionedNamesKey("typescript"), "helper"},
+	}
+	for _, c := range cases {
+		set, err := readNameSet(ctx, a, c.key)
+		if err != nil {
+			t.Fatalf("read %s: %v", c.key, err)
+		}
+		if _, ok := set[c.name]; !ok {
+			t.Errorf("expected %q in %s, got %v", c.name, c.key, set)
+		}
+	}
+	// typescript registers as harvested so its symbols can earn `dead`.
+	harvested, err := readNameSet(ctx, a, harvestedLangsMetaKey)
+	if err != nil {
+		t.Fatalf("read harvested_langs: %v", err)
+	}
+	if _, ok := harvested["typescript"]; !ok {
+		t.Errorf("expected typescript in harvested_langs, got %v", harvested)
+	}
+}
+
+// TestWriteReadTSHarvestRoundTrip pins the flat TS meta keys' write/read contract,
+// mirroring the dispatch/mention round-trips: a written set reads back, and an
+// empty set leaves the key absent (self-heals on the next scan).
+func TestWriteReadTSHarvestRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	a := openTempAdapter(t)
+
+	if err := writeTSDecorated(ctx, a, map[string]struct{}{"AppComponent": {}}); err != nil {
+		t.Fatalf("writeTSDecorated: %v", err)
+	}
+	if err := writeTSDefaultExports(ctx, a, map[string]struct{}{"Page": {}}); err != nil {
+		t.Fatalf("writeTSDefaultExports: %v", err)
+	}
+	dec, _ := readNameSet(ctx, a, tsDecoratedMetaKey)
+	if _, ok := dec["AppComponent"]; !ok {
+		t.Errorf("ts_decorated missing AppComponent: %v", dec)
+	}
+	def, _ := readNameSet(ctx, a, tsDefaultExportsMetaKey)
+	if _, ok := def["Page"]; !ok {
+		t.Errorf("ts_default_exports missing Page: %v", def)
+	}
+
+	// Empty collected + nothing persisted → key stays absent.
+	a2 := openTempAdapter(t)
+	if err := writeTSDecorated(ctx, a2, nil); err != nil {
+		t.Fatalf("writeTSDecorated empty: %v", err)
+	}
+	if raw, _ := a2.ReadMeta(ctx, tsDecoratedMetaKey); raw != "" {
+		t.Errorf("expected no ts_decorated key for empty set, got %q", raw)
+	}
+}
+
 // TestScanDeletesLegacyUnionKeys proves the in-place-upgrade cleanup: a scan
 // removes the stale bare `mentioned_names`/`dispatch_names` union keys a
 // pre-feature index left behind, while the per-language keys survive.

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -238,6 +238,8 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	warnMetaWrite(warn, "rust-test-symbols", writeRustTestSymbols(ctx, idx, h.rustTestSymbols))
 	warnMetaWrite(warn, "rust-trait-impl-methods", writeRustTraitImplMethods(ctx, idx, h.rustTraitMethods))
 	warnMetaWrite(warn, "rust-allow-dead", writeRustAllowDead(ctx, idx, h.rustAllowDead))
+	warnMetaWrite(warn, "ts-decorated", writeTSDecorated(ctx, idx, h.tsDecorated))
+	warnMetaWrite(warn, "ts-default-exports", writeTSDefaultExports(ctx, idx, h.tsDefaultExports))
 	// A pre-feature index carried single bare union keys (no language suffix).
 	// The per-language reader globs `*:<lang>` and ignores them, but delete them
 	// on every full scan so an in-place upgrade leaves no stale meta to mislead a
@@ -551,6 +553,15 @@ type harness struct {
 	rustTraitMethods map[string]struct{}
 	rustAllowDead    map[string]struct{}
 
+	// tsDecorated is the set of TS/JS class/method names carrying a decorator
+	// (`@Component` / `@Injectable` / route-method decorators); tsDefaultExports
+	// is the set of names bound by an `export default` form. Both are written to
+	// flat sense_meta keys so the dead-code TS voice keeps a decorated symbol
+	// open-world (ts_decorator) and labels a default export ts_default_export.
+	// Flat (not per-language): these concepts span the .ts/.tsx/.js family.
+	tsDecorated      map[string]struct{}
+	tsDefaultExports map[string]struct{}
+
 	// harvestedLangs is the set of languages whose mention harvest RAN this
 	// scan — every indexed file whose extractor is an extract.MentionHarvester
 	// marks its language here, regardless of how many names it produced. Written
@@ -817,6 +828,22 @@ func (h *harness) walkTree(root string) error {
 				h.rustAllowDead[n] = struct{}{}
 			}
 		}
+		if len(fr.TSDecorated) > 0 {
+			if h.tsDecorated == nil {
+				h.tsDecorated = map[string]struct{}{}
+			}
+			for _, n := range fr.TSDecorated {
+				h.tsDecorated[n] = struct{}{}
+			}
+		}
+		if len(fr.TSDefaultExports) > 0 {
+			if h.tsDefaultExports == nil {
+				h.tsDefaultExports = map[string]struct{}{}
+			}
+			for _, n := range fr.TSDefaultExports {
+				h.tsDefaultExports[n] = struct{}{}
+			}
+		}
 
 		batch = append(batch, fr)
 		if len(batch) >= batchSize {
@@ -897,6 +924,8 @@ type fileResult struct {
 	RustTestSymbols  []string
 	RustTraitMethods []string
 	RustAllowDead    []string
+	TSDecorated      []string
+	TSDefaultExports []string
 }
 
 // 100 files per SQLite transaction amortizes BEGIN/COMMIT overhead (~10x
@@ -1019,6 +1048,8 @@ func parseFileCore(po parseOpts, path, rel string, skip func(hash string) bool) 
 		RustTestSymbols:  collected.rustTestSymbols,
 		RustTraitMethods: collected.rustTraitMethods,
 		RustAllowDead:    collected.rustAllowDead,
+		TSDecorated:      collected.tsDecorated,
+		TSDefaultExports: collected.tsDefaultExports,
 	}
 }
 
@@ -1357,6 +1388,8 @@ type collector struct {
 	rustTestSymbols  []string
 	rustTraitMethods []string
 	rustAllowDead    []string
+	tsDecorated      []string
+	tsDefaultExports []string
 }
 
 func (c *collector) Symbol(s extract.EmittedSymbol) error {
@@ -1428,6 +1461,25 @@ func (c *collector) RustTraitImplMethod(name string) error {
 // warning, so it is never in the cargo oracle.
 func (c *collector) RustAllowDeadName(name string) error {
 	c.rustAllowDead = append(c.rustAllowDead, name)
+	return nil
+}
+
+// TSDecoratedName implements extract.TSHarvestEmitter: an extractor streams every
+// TS/JS class/method carrying a decorator (`@Component` / `@Injectable` / route
+// decorator). The project-wide set feeds the dead-code TS voice so a
+// framework-dispatched symbol stays open-world (ts_decorator) instead of being
+// falsely called dead.
+func (c *collector) TSDecoratedName(name string) error {
+	c.tsDecorated = append(c.tsDecorated, name)
+	return nil
+}
+
+// TSDefaultExportName implements extract.TSHarvestEmitter: an extractor streams
+// every name bound by an `export default` form. The project-wide set feeds the
+// dead-code TS voice so a default export carries the more specific
+// ts_default_export reason rather than the generic ts_exported.
+func (c *collector) TSDefaultExportName(name string) error {
+	c.tsDefaultExports = append(c.tsDefaultExports, name)
 	return nil
 }
 

--- a/testdata/smoke/app/page.tsx
+++ b/testdata/smoke/app/page.tsx
@@ -1,0 +1,7 @@
+// Page is the default export of a Next.js `app/` route file. File-system routing
+// renders it with no import edge anywhere, so the TS voice keeps it
+// possibly_dead (ts_framework_route) — recognized by the app/ + page convention,
+// not by a caller.
+export default function Page(): null {
+  return null;
+}

--- a/testdata/smoke/badge.tsx
+++ b/testdata/smoke/badge.tsx
@@ -1,0 +1,7 @@
+// Badge is an exported PascalCase component in a .tsx file — a JSX component.
+// It may be rendered as <Badge/> in a file the resolver could not bind here, so
+// the TS voice keeps it possibly_dead (ts_jsx) rather than letting the absent
+// edge earn `dead`.
+export function Badge(): null {
+  return null;
+}

--- a/testdata/smoke/dead-golden.json
+++ b/testdata/smoke/dead-golden.json
@@ -1,6 +1,13 @@
 {
   "findings": [
     {
+      "qualified": "Badge",
+      "kind": "function",
+      "file": "badge.tsx",
+      "verdict": "possibly_dead",
+      "reason": "ts_jsx"
+    },
+    {
       "qualified": "Greeter::greet",
       "kind": "method",
       "file": "wallet.rs",
@@ -28,6 +35,13 @@
       "reason": "rust_derive"
     },
     {
+      "qualified": "Page",
+      "kind": "function",
+      "file": "app/page.tsx",
+      "verdict": "possibly_dead",
+      "reason": "ts_framework_route"
+    },
+    {
       "qualified": "Registry",
       "kind": "class",
       "file": "wallet.rs",
@@ -42,6 +56,13 @@
       "reason": "rust_trait_impl"
     },
     {
+      "qualified": "TokenStore",
+      "kind": "class",
+      "file": "token_store.ts",
+      "verdict": "possibly_dead",
+      "reason": "ts_decorator"
+    },
+    {
       "qualified": "Trackable#track_change",
       "kind": "method",
       "file": "trackable.rb",
@@ -54,6 +75,40 @@
       "file": "user.rb",
       "verdict": "possibly_dead",
       "reason": "core_exported_api"
+    },
+    {
+      "qualified": "configureTokens",
+      "kind": "function",
+      "file": "token_store.ts",
+      "verdict": "possibly_dead",
+      "reason": "core_exported_api"
+    },
+    {
+      "qualified": "exportedHelper",
+      "kind": "function",
+      "file": "widget.ts",
+      "verdict": "possibly_dead",
+      "reason": "core_exported_api"
+    },
+    {
+      "qualified": "legacyEntry",
+      "kind": "function",
+      "file": "legacy.js",
+      "verdict": "possibly_dead",
+      "reason": "core_exported_api"
+    },
+    {
+      "qualified": "orphanedJs",
+      "kind": "function",
+      "file": "legacy.js",
+      "verdict": "possibly_dead",
+      "reason": "js_dynamic"
+    },
+    {
+      "qualified": "orphanedTs",
+      "kind": "function",
+      "file": "widget.ts",
+      "verdict": "dead"
     },
     {
       "qualified": "orphaned_rust",
@@ -110,7 +165,7 @@
       "verdict": "dead"
     }
   ],
-  "total_symbols": 42,
-  "dead_count": 3,
-  "possibly_dead_count": 13
+  "total_symbols": 50,
+  "dead_count": 4,
+  "possibly_dead_count": 20
 }

--- a/testdata/smoke/ground-truth.json
+++ b/testdata/smoke/ground-truth.json
@@ -1,9 +1,13 @@
 {
   "symbols": {
-    "min_total": 30,
+    "min_total": 48,
     "by_language": {
-      "go": 17,
-      "ruby": 13
+      "go": 19,
+      "javascript": 1,
+      "ruby": 15,
+      "rust": 8,
+      "tsx": 2,
+      "typescript": 3
     }
   },
   "edges": {
@@ -54,7 +58,7 @@
         "kind": "tests"
       }
     ],
-    "min_total": 28
+    "min_total": 32
   },
   "search": [
     {
@@ -73,7 +77,7 @@
     }
   ],
   "conventions": {
-    "min_detected": 6
+    "min_detected": 9
   },
   "performance": {
     "scan_max_seconds": 10,

--- a/testdata/smoke/legacy.js
+++ b/testdata/smoke/legacy.js
@@ -1,0 +1,12 @@
+// legacy.js is an ES module (it exports), so orphanedJs is genuinely
+// module-private. orphanedJs is the .js counterpart of orphanedTs: no caller,
+// name unmentioned. In TypeScript this shape earns `dead`, but plain JavaScript
+// is looser (CommonJS interop, no types), so the TS voice holds it open-world
+// (js_dynamic) — the honest TS/JS precision split.
+export function legacyEntry() {
+  return "entry";
+}
+
+function orphanedJs() {
+  return 42;
+}

--- a/testdata/smoke/token_store.ts
+++ b/testdata/smoke/token_store.ts
@@ -1,0 +1,9 @@
+// This file is an ES module (it exports configureTokens), so TokenStore below
+// is genuinely module-private. TokenStore carries an @Injectable decorator, so a
+// framework's DI container instantiates it with no source caller. The TS voice
+// keeps it possibly_dead (ts_decorator) — proving the decorator harvest rescues a
+// module-private class the soundness gate would otherwise call dead.
+export function configureTokens(): void {}
+
+@Injectable()
+class TokenStore {}

--- a/testdata/smoke/widget.ts
+++ b/testdata/smoke/widget.ts
@@ -1,0 +1,14 @@
+// orphanedTs is module-private (not exported), has no caller, and its name is
+// mentioned nowhere else — the genuinely-dead shape the TS voice earns `dead`
+// for. A .ts module proves the closed-world bet: a non-exported symbol is
+// reachable only within this file.
+function orphanedTs(): number {
+  return 42;
+}
+
+// exportedHelper is exported, so a barrel re-export / dynamic import / external
+// consumer may reach it. The TS voice never earns `dead` for it; in this
+// library-shaped fixture the core voice labels it core_exported_api.
+export function exportedHelper(): string {
+  return "help";
+}


### PR DESCRIPTION
## Problem

TypeScript and JavaScript symbols were all reported `possibly_dead` with the
single reason `core_no_language_voice` — Sense had no voice for the stack, so
it could only say "I can't help, check callers manually." TS/JS is the largest
front-end surface Sense indexes, and `Symbol.Visibility` was never populated for
it, so even the generic library-API gate could not fire.

## Summary

Adds a TypeScript/JavaScript dead-code voice. TypeScript becomes the fourth
language whose symbols can earn the `dead` verdict; JavaScript ships
`possibly_dead`-only. The whole family now gets export visibility, and every
unreferenced symbol gets a precise, actionable reason instead of one undifferentiated bucket.

## Changes

**Extraction**
- Populate `Symbol.Visibility` (`public`/`private`) for `.ts`/`.tsx`/`.js` across every export form (named, default, `export { g }` clauses, re-exports). A file with no top-level import/export is a global script whose symbols are treated public.
- Harvest the broad mention set (shared walker), computed-property dispatch keys (`obj["render"]`), decorator names, and default-export names via a new `TSHarvestEmitter`.

**Scan**
- Persist the decorator and default-export sets to `ts_decorated` / `ts_default_exports` `sense_meta` keys; mention/dispatch ride the existing per-language keys.

**Dead-code voice**
- With no compiler dead-code lint to bind against, the closed-world signal is the module system: the voice earns `dead` only for a **module-private `.ts`/`.tsx` function / const / class** with no caller, no mention, and no framework idiom.
- Hand-raise reasons: `ts_decorator` (DI/router dispatch), `ts_framework_route` (Next.js `app/`+`pages/` routing), `ts_jsx`, `ts_default_export`, `ts_exported`, `ts_method` (interface/React-lifecycle protocol), `ts_type` (structural / declaration-merging).
- JavaScript stays conservative: a module-private `.js` symbol that would earn `dead` in TS is held `possibly_dead` (`js_dynamic`).
- `.d.ts` and test-fixture directories (`test/`, `__testfixtures__/`, …) are excluded from candidacy.

## Architecture Highlights

- **`dead` is scoped to function/const/class.** Methods (which may satisfy an interface or a React lifecycle protocol) and types/interfaces (reached structurally or by declaration-merging) never earn `dead` — they raise `ts_method`/`ts_type`.
- **Module-vs-script gate.** A symbol earns `dead` only inside a real ES module; global scripts (bundler runtimes, ambient files) have concatenation-reachable symbols that never earn `dead`.

## Test Plan

- [x] Hand-labeled synthetic corpus scores precision-of-`dead` == 1.00
- [x] Two-sided golden gate: a module-private `.ts` function earns `dead`; the byte-identical `.js` shape stays `js_dynamic`; JSX/route/decorator/exported each get the exact reason
- [x] Before/after full rescan on a 75,611-symbol Next.js codebase: **zero false `dead`**
- [x] Per-file coverage floor met on every new file (≥93%)
- [x] `make ci` green (build, `go test ./...`, lint)