### PR TITLE
feat(dead): Python earns the dead verdict via pythonVoice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ All notable changes to Sense.
 
 ### Added
 
+- Python is the fifth language whose symbols can earn the `dead` verdict, and
+  `Symbol.Visibility` is now populated for Python. An underscore pre-pass
+  (`internal/extract/python/visibility.go`) marks each symbol `private` (a
+  leading-underscore non-dunder name — `_helper`, `__mangled`) or `public`
+  (a dunder like `__init__`, or any non-underscore name). Python has no enforced
+  privacy, so the underscore is the only structural "not public API" signal, and
+  the `pythonVoice` (`internal/dead/voice_python.go`) earns `dead` only for an
+  **underscore-private function or method** with no caller, no mention, and no
+  invisible-reach idiom — the Ruby rule applied. Everything else stays
+  `possibly_dead` with an exact reason: `py_dunder` (a `__x__` protocol method,
+  matched by pattern so PEP 562 module `__getattr__` and dataclass
+  `__post_init__` are covered), `py_route` (a Flask `@app.route` / FastAPI
+  `@app.get`/`@router.post` handler the framework's router dispatches), `py_django`
+  (a `@receiver` signal handler or `@admin.register`), `py_decorator` (any other
+  decorated symbol — `@property`, `@pytest.fixture`, `@click.command`),
+  `py_all_export` (a name in `__all__`, re-exported by `import *`, overriding the
+  underscore convention), `py_public` (a public function/method reachable by
+  duck-typed dispatch), and `py_class` / `py_constant` (no Python class or
+  constant ever earns `dead`, reachable via importlib / getattr / `__subclasses__`
+  / metaclass registries). The extractor harvests its own mention set, the
+  getattr/setattr/hasattr dispatch set, the decorator/route/Django reach sets, and
+  the `__all__` export set. The binding gate is hand-labeled precision on a
+  synthetic corpus (100%) plus a before/after run on the `flask` benchmark repo
+  (one earned `dead`, verified genuinely unused, zero false `dead`). `py_django`'s
+  model-field/`Meta` cases rest on the synthetic corpus and `py_class` — the
+  benchmark suite has no Django repo, so `py_django` is exercised only
+  synthetically and through its decorator paths.
+
 - TypeScript is the fourth language whose symbols can earn the `dead` verdict,
   and `Symbol.Visibility` is now populated for the whole TS/JS family. The TS/JS
   extractor marks each symbol `public` (exported in any form — `export`, `export

--- a/internal/dead/arbiter.go
+++ b/internal/dead/arbiter.go
@@ -143,6 +143,29 @@ type Facts struct {
 	// Flat, like TSDecoratedNames. Populated from the ts_default_exports sense_meta
 	// key.
 	TSDefaultExportNames map[string]struct{}
+	// PythonDecoratedNames is the set of Python function/method/class names
+	// carrying any decorator. The Python voice keeps such a name open-world
+	// (py_decorator): a decorator changes the call story (an attribute access via
+	// @property, an injected @pytest.fixture, a CLI @click.command) so the static
+	// graph's zero-edge verdict cannot prove it unreachable. Flat, not
+	// per-language — Python-only. Populated from the py_decorated sense_meta key.
+	PythonDecoratedNames map[string]struct{}
+	// PythonRouteNames is the subset of decorated names whose decorator is a web
+	// route (Flask `@app.route`, FastAPI `@app.get`/`@router.post`). The Python
+	// voice raises the more specific py_route. Populated from the py_routes
+	// sense_meta key.
+	PythonRouteNames map[string]struct{}
+	// PythonDjangoNames is the subset of decorated names whose decorator is a
+	// Django-dispatch idiom (`@receiver` signal handler, `@admin.register`). The
+	// Python voice raises py_django. Populated from the py_django sense_meta key.
+	PythonDjangoNames map[string]struct{}
+	// PythonAllExportNames is the set of names Python modules declare public via
+	// `__all__`. The Python voice raises py_all_export — the one signal that
+	// overrides the underscore convention (a `_helper` listed in `__all__` is
+	// re-exported by `from mod import *`), and one the identifier mention set
+	// misses because `__all__` lists names as string literals. Populated from the
+	// py_all_exports sense_meta key.
+	PythonAllExportNames map[string]struct{}
 	// HarvestedLangs is the set of languages whose mention harvest actually ran
 	// for this index. The soundness gate refuses `dead` for a symbol whose
 	// language is absent here (reason core_no_harvest): a missing harvest cannot

--- a/internal/dead/dead.go
+++ b/internal/dead/dead.go
@@ -132,14 +132,15 @@ func FindDead(ctx context.Context, db *sql.DB, opts Options) (Result, error) {
 }
 
 // defaultArbiter is the registered voice stack for this build: the generic core
-// voice plus the Ruby, Rails, Go, Rust, and TypeScript/JavaScript language
-// voices. The TS voice is registered once per language string the shared
+// voice plus the Ruby, Rails, Go, Rust, TypeScript/JavaScript, and Python
+// language voices. The TS voice is registered once per language string the shared
 // extractor emits ("typescript", "tsx", "javascript") so each is a language for
 // which closed-world can be proven. Adding a language voice is a one-line change
 // here once it exists.
 func defaultArbiter() *Arbiter {
 	return NewArbiter(coreVoice{}, rubyVoice{}, railsVoice{}, goVoice{}, rustVoice{},
-		tsVoice{lang: "typescript"}, tsVoice{lang: "tsx"}, tsVoice{lang: "javascript"})
+		tsVoice{lang: "typescript"}, tsVoice{lang: "tsx"}, tsVoice{lang: "javascript"},
+		pythonVoice{})
 }
 
 // buildFacts gathers the project-wide index facts the voices consume. It is
@@ -183,18 +184,22 @@ func buildFacts(ctx context.Context, db *sql.DB) (Facts, error) {
 		// language that harvested an empty set (present here, absent from
 		// MentionedNames) is still allowed to earn `dead` against its empty set —
 		// distinct from a language that never harvested (absent here → fail closed).
-		HarvestedLangs:       readHarvestedLangs(ctx, db),
-		CgoExportNames:       readCgoExportNames(ctx, db),
+		HarvestedLangs:           readHarvestedLangs(ctx, db),
+		CgoExportNames:           readCgoExportNames(ctx, db),
 		RustExportNames:          readRustExportNames(ctx, db),
 		RustTestSymbolNames:      readRustTestSymbolNames(ctx, db),
 		RustTraitImplMethodNames: readRustTraitImplMethodNames(ctx, db),
 		RustAllowDeadNames:       readRustAllowDeadNames(ctx, db),
 		TSDecoratedNames:         readTSDecoratedNames(ctx, db),
 		TSDefaultExportNames:     readTSDefaultExportNames(ctx, db),
-		ValueObjectClassIDs:  valueObjectClassIDs,
-		IncludedModuleIDs:    includedModuleIDs,
-		ControllerConcernIDs: controllerConcernIDs,
-		InterfaceMethodNames: interfaceMethodNames,
+		PythonDecoratedNames:     readPythonDecoratedNames(ctx, db),
+		PythonRouteNames:         readPythonRouteNames(ctx, db),
+		PythonDjangoNames:        readPythonDjangoNames(ctx, db),
+		PythonAllExportNames:     readPythonAllExportNames(ctx, db),
+		ValueObjectClassIDs:      valueObjectClassIDs,
+		IncludedModuleIDs:        includedModuleIDs,
+		ControllerConcernIDs:     controllerConcernIDs,
+		InterfaceMethodNames:     interfaceMethodNames,
 	}, nil
 }
 
@@ -874,6 +879,38 @@ func readTSDecoratedNames(ctx context.Context, db *sql.DB) map[string]struct{} {
 // corrupt key yields an empty set.
 func readTSDefaultExportNames(ctx context.Context, db *sql.DB) map[string]struct{} {
 	return readStringSetMeta(ctx, db, "ts_default_exports")
+}
+
+// readPythonDecoratedNames returns the set of Python function/method/class names
+// carrying any decorator, persisted to the py_decorated sense_meta key by the
+// scan layer. The Python voice keeps such a name open-world (py_decorator). A
+// missing or corrupt key yields an empty set.
+func readPythonDecoratedNames(ctx context.Context, db *sql.DB) map[string]struct{} {
+	return readStringSetMeta(ctx, db, "py_decorated")
+}
+
+// readPythonRouteNames returns the set of Python handler names carrying a route
+// decorator (Flask/FastAPI), persisted to the py_routes sense_meta key. The
+// Python voice raises py_route for such a name. A missing or corrupt key yields
+// an empty set.
+func readPythonRouteNames(ctx context.Context, db *sql.DB) map[string]struct{} {
+	return readStringSetMeta(ctx, db, "py_routes")
+}
+
+// readPythonDjangoNames returns the set of Python names carrying a Django-dispatch
+// decorator (`@receiver` / `@admin.register`), persisted to the py_django
+// sense_meta key. The Python voice raises py_django for such a name. A missing or
+// corrupt key yields an empty set.
+func readPythonDjangoNames(ctx context.Context, db *sql.DB) map[string]struct{} {
+	return readStringSetMeta(ctx, db, "py_django")
+}
+
+// readPythonAllExportNames returns the set of names Python modules declare public
+// via `__all__`, persisted to the py_all_exports sense_meta key. The Python voice
+// raises py_all_export for such a name (even when underscore-private). A missing
+// or corrupt key yields an empty set.
+func readPythonAllExportNames(ctx context.Context, db *sql.DB) map[string]struct{} {
+	return readStringSetMeta(ctx, db, "py_all_exports")
 }
 
 // readStringSetMeta reads a JSON string-array sense_meta value into a set,

--- a/internal/dead/eval/corpus.go
+++ b/internal/dead/eval/corpus.go
@@ -17,7 +17,8 @@ package eval
 // detection and are added with the Rails voice; here the same class of lie
 // is captured through the framework-independent value-object path.
 func Corpus() []Fixture {
-	return append(rubyCorpus(), tsCorpus()...)
+	c := append(rubyCorpus(), tsCorpus()...)
+	return append(c, pythonCorpus()...)
 }
 
 // rubyCorpus is the Ruby slice of the trust corpus (see Corpus).

--- a/internal/dead/eval/corpus_python.go
+++ b/internal/dead/eval/corpus_python.go
@@ -1,0 +1,134 @@
+package eval
+
+// pythonCorpus is the hand-labeled Python slice of the trust corpus. Like the
+// Ruby and TS slices it pins the verdict a *trustworthy* engine must produce,
+// and it deliberately includes the hard invisible-reach cases that the naive
+// "unreferenced symbol" rule would lie about — a Django signal receiver, a model
+// class, a dunder protocol method, an `__all__`-exported private — alongside the
+// one shape that earns `dead` (an underscore-private, unmentioned function) and
+// the alive controls.
+//
+// Each fixture is its own isolated project, so it scans as a library (no entry
+// point, no framework): a public callable therefore reads as the core voice's
+// core_exported_api — observably possibly_dead, which is all the verdict-level
+// harness scores. The reason-level two-sided control lives in the dead package's
+// golden test.
+//
+// Ground-truth rule for Python (pitch 25-19): only a leading-underscore
+// (convention- or mangling-private) function/method that is not dunder, not
+// decorated/framework-reached, not in `__all__`, and mentioned nowhere may earn
+// `dead`. Every public symbol, every class, every constant, and every
+// framework-reached symbol stays possibly_dead — the precision discipline the
+// Ruby retro earned.
+func pythonCorpus() []Fixture {
+	return []Fixture{
+		{
+			// The one earned `dead`, plus the alive private (proving the underscore
+			// alone earns nothing) and the public entry (a hidden duck-typed caller
+			// could exist).
+			Name: "python_underscore_private_dead",
+			Files: map[string]string{
+				"report.py": `def render_report():
+    return _format_row()
+
+
+def _format_row():
+    return "row"
+
+
+def _orphaned_helper():
+    return "no caller, private, mentioned nowhere"
+`,
+			},
+			Want: []Sym{
+				{"_orphaned_helper", Dead,
+					"underscore-private, zero callers, name mentioned nowhere — the earned dead"},
+				{"_format_row", Alive,
+					"called by render_report — the underscore alone earns nothing"},
+				{"render_report", PossiblyDead,
+					"public, unreferenced — a hidden duck-typed caller could exist"},
+			},
+		},
+		{
+			// The planted false-dead control: a Django signal receiver is
+			// underscore-private AND unmentioned, so it would earn `dead` without the
+			// decorator harvest. Django's signal machinery invokes it invisibly, so a
+			// trustworthy engine must keep it possibly_dead. If this ever flips to
+			// `dead`, the precision gate fails — which is the point.
+			Name: "python_signal_receiver",
+			Files: map[string]string{
+				"signals.py": `from django.dispatch import receiver
+from django.db.models.signals import post_save
+
+
+@receiver(post_save, sender=User)
+def _on_user_saved(sender, **kwargs):
+    return None
+`,
+			},
+			Want: []Sym{
+				{"_on_user_saved", PossiblyDead,
+					"Django @receiver signal handler — invoked invisibly by the framework, never a false dead"},
+			},
+		},
+		{
+			// A dunder protocol method is invoked by the interpreter, never by a
+			// caller — it must never earn `dead` even though it is unreferenced.
+			// Cache is referenced by build_cache so it is alive (not a candidate) and
+			// __getitem__ is judged on its own rather than rolled up under a dead class.
+			Name: "python_dunder_protocol",
+			Files: map[string]string{
+				"cache.py": `class Cache:
+    def __getitem__(self, key):
+        return key
+
+
+def build_cache():
+    return Cache()
+`,
+			},
+			Want: []Sym{
+				{"Cache.__getitem__", PossiblyDead,
+					"dunder protocol method — invoked by the interpreter on subscription"},
+				{"Cache", Alive,
+					"referenced by build_cache — not a candidate"},
+				{"build_cache", PossiblyDead,
+					"public factory, unreferenced — a hidden caller could exist"},
+			},
+		},
+		{
+			// A Django model class is ORM-driven and reached by name; its fields are
+			// not even symbols. The class must stay possibly_dead.
+			Name: "python_model_class",
+			Files: map[string]string{
+				"models.py": `class Article(models.Model):
+    title = models.CharField(max_length=200)
+    author = models.ForeignKey(User, on_delete=models.CASCADE)
+`,
+			},
+			Want: []Sym{
+				{"Article", PossiblyDead,
+					"Django model class — ORM-driven, reached by name, never a false dead"},
+			},
+		},
+		{
+			// `__all__` overrides the underscore convention: a `_internal_api` listed
+			// there is re-exported by `from module import *`. The name appears only as
+			// a string literal, so the broad mention set misses it — the dedicated
+			// `__all__` harvest is what keeps it possibly_dead.
+			Name: "python_all_export_override",
+			Files: map[string]string{
+				"api.py": `__all__ = ["_internal_api"]
+
+
+def _internal_api():
+    return 1
+`,
+			},
+			Want: []Sym{
+				{"_internal_api", PossiblyDead,
+					"listed in __all__ — declared public API, re-exported by import *"},
+			},
+		},
+	}
+}

--- a/internal/dead/eval/corpus_python_test.go
+++ b/internal/dead/eval/corpus_python_test.go
@@ -1,0 +1,99 @@
+package eval
+
+import (
+	"context"
+	"testing"
+)
+
+// TestPythonCorpusPrecisionGate is the binding real-world-discipline gate for
+// the Python voice (pitch 25-19): the hand-labeled Python corpus must score
+// dead-precision == 1.0 with ZERO false deads when run through scan + the live
+// arbiter. Exactly one symbol earns `dead` (the underscore-private orphan); the
+// signal receiver, the dunder, the model class, and the `__all__` export all
+// stay possibly_dead. A regression that lets any of them earn `dead` fails here.
+func TestPythonCorpusPrecisionGate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("scans real fixtures; skipped in -short")
+	}
+	ctx := context.Background()
+	corpus := pythonCorpus()
+
+	report, results, err := RunCorpus(ctx, t.TempDir(), corpus)
+	if err != nil {
+		t.Fatalf("RunCorpus: %v", err)
+	}
+
+	if !approx(report.DeadPrecision, 1.0) {
+		t.Errorf("DeadPrecision = %.3f, want 1.0 — false deads: %v", report.DeadPrecision, report.FalseDeads())
+	}
+	if fd := report.FalseDeads(); len(fd) != 0 {
+		t.Errorf("FalseDeads = %v, want none (a Python `dead` at <100%% precision does not ship)", fd)
+	}
+	for _, o := range report.Mismatches() {
+		t.Errorf("mismatch %s: got=%s want=%s", o.Qualified, o.Got, o.Want)
+	}
+	if len(results) != len(corpus) {
+		t.Errorf("got %d fixture results, want %d", len(results), len(corpus))
+	}
+
+	// The earned `dead` must actually be found — proving the corpus exercises the
+	// tier, not that the engine simply never says `dead`.
+	got := mergeFixtureVerdicts(results)
+	if got["_orphaned_helper"] != Dead {
+		t.Errorf("_orphaned_helper = %q, want dead (the one earned dead)", got["_orphaned_helper"])
+	}
+	// The invisible-reach symbols must each stay open-world.
+	for q, want := range map[string]Verdict{
+		"_on_user_saved":    PossiblyDead, // Django @receiver
+		"Cache.__getitem__": PossiblyDead, // dunder
+		"Article":           PossiblyDead, // model class
+		"_internal_api":     PossiblyDead, // __all__ export
+	} {
+		if got[q] != want {
+			t.Errorf("%s = %q, want %q", q, got[q], want)
+		}
+	}
+}
+
+// TestPythonSignalReceiverFalseDeadCaught is the harness self-test: it confirms
+// the precision gate MEASURES rather than rubber-stamps. If the engine ever
+// wrongly called the Django signal receiver `dead`, the score must fall below
+// 1.0 and the receiver must surface in FalseDeads. (If this test passed with the
+// planted lie, a real false `dead` on a live receiver would slip through.)
+func TestPythonSignalReceiverFalseDeadCaught(t *testing.T) {
+	want := flatten(pythonCorpus())
+
+	got := map[string]Verdict{}
+	for _, w := range want {
+		got[w.Qualified] = w.Want // a perfect engine
+	}
+	// Plant the lie: the live signal receiver is wrongly reported removable.
+	victim := "_on_user_saved"
+	got[victim] = Dead
+
+	r := Score(got, want)
+	if r.DeadPrecision >= 1.0 {
+		t.Errorf("planted false dead on %s did not drop precision: got %.3f", victim, r.DeadPrecision)
+	}
+	found := false
+	for _, fd := range r.FalseDeads() {
+		if fd == victim {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("FalseDeads = %v, expected to contain planted victim %q", r.FalseDeads(), victim)
+	}
+}
+
+// mergeFixtureVerdicts unions the per-fixture verdict maps so a test can look up
+// a symbol by qualified name across the whole corpus run.
+func mergeFixtureVerdicts(results []FixtureResult) map[string]Verdict {
+	out := map[string]Verdict{}
+	for _, fr := range results {
+		for q, v := range fr.Got {
+			out[q] = v
+		}
+	}
+	return out
+}

--- a/internal/dead/golden_test.go
+++ b/internal/dead/golden_test.go
@@ -245,7 +245,7 @@ func TestDeadCLIIntegration(t *testing.T) {
 	// an exported symbol, a JSX component, a Next.js route default, and a
 	// decorator-annotated (module-private) class all stay open-world.
 	for q, wantReason := range map[string]string{
-		"exportedHelper": "core_exported_api", // exported callable in a library
+		"exportedHelper": "core_exported_api",  // exported callable in a library
 		"Badge":          "ts_jsx",             // PascalCase component in a .tsx file
 		"Page":           "ts_framework_route", // app/page.tsx default export
 		"TokenStore":     "ts_decorator",       // @Injectable on a module-private class
@@ -255,11 +255,42 @@ func TestDeadCLIIntegration(t *testing.T) {
 		}
 	}
 
+	// EARNED dead (Python): the underscore-private, zero-edge, unmentioned,
+	// non-dunder, non-decorated function — the one shape Python lets through.
+	if verdict["_orphaned_helper"] != "dead" {
+		t.Errorf("_orphaned_helper verdict = %q, want dead (underscore-private, no caller, no mention)", verdict["_orphaned_helper"])
+	}
+	// SOUNDNESS BACKSTOP (Python): an underscore-private name mentioned where the
+	// resolver could not bind it stays open-world via the mention gate — proving
+	// `dead` rests on the gate, not the underscore alone.
+	if v, r := verdict["_mentioned_private"], reason["_mentioned_private"]; v != "possibly_dead" || r != "core_name_mentioned" {
+		t.Errorf("_mentioned_private = (%q, %q), want (possibly_dead, core_name_mentioned)", v, r)
+	}
+	// POSSIBLY_DEAD (Python), exact reasons — the two-sided control for each
+	// hand-raise: a dunder, a decorated method, and a route handler all stay open.
+	for q, wantReason := range map[string]string{
+		"Account.__repr__": "py_dunder",    // interpreter-invoked protocol method
+		"Account.label":    "py_decorator", // @property — attribute access
+		"health_check":     "py_route",     // @app.route handler
+	} {
+		if v, r := verdict[q], reason[q]; v != "possibly_dead" || r != wantReason {
+			t.Errorf("%s = (%q, %q), want (possibly_dead, %q)", q, v, r, wantReason)
+		}
+	}
+	// SAFETY INVARIANT: no public (non-underscore) Python symbol earns dead —
+	// public Python is always reachable by duck-typed dispatch.
+	for _, e := range g.Findings {
+		if hasSuffix(e.File, ".py") && e.Verdict == "dead" && !startsWithUnderscore(lastSegment(e.Qualified)) {
+			t.Errorf("%s (public Python) was flagged dead; public symbols must stay possibly_dead", e.Qualified)
+		}
+	}
+
 	// Known-live symbols must not be reported at all.
 	for q := range verdict {
 		for _, live := range []string{
 			"smoke.OrderService.Process",
 			"smoke.PaymentGateway.Charge",
+			"_used_private", // underscore-private but CALLED — never a candidate
 		} {
 			if q == live {
 				t.Errorf("%s should be alive, but appears in findings", q)
@@ -291,6 +322,8 @@ func lastSegment(qualified string) string {
 // startsUpper reports whether s begins with an ASCII uppercase letter — Go's
 // exported-visibility rule.
 func startsUpper(s string) bool { return s != "" && s[0] >= 'A' && s[0] <= 'Z' }
+
+func startsWithUnderscore(s string) bool { return s != "" && s[0] == '_' }
 
 func hasSuffix(s, suffix string) bool {
 	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix

--- a/internal/dead/reasons.go
+++ b/internal/dead/reasons.go
@@ -67,6 +67,16 @@ const (
 	ReasonTSType           = "ts_type"
 	ReasonJSDynamic        = "js_dynamic"
 
+	// Python-voice reason codes (voice_python.go owns their catalog specs).
+	ReasonPythonDunder    = "py_dunder"
+	ReasonPythonDecorator = "py_decorator"
+	ReasonPythonRoute     = "py_route"
+	ReasonPythonDjango    = "py_django"
+	ReasonPythonAllExport = "py_all_export"
+	ReasonPythonPublic    = "py_public"
+	ReasonPythonClass     = "py_class"
+	ReasonPythonConstant  = "py_constant"
+
 	// Rust-voice reason codes (voice_rust.go owns their catalog specs).
 	ReasonRustTraitImpl = "rust_trait_impl"
 	ReasonRustDerive    = "rust_derive"

--- a/internal/dead/voice_python.go
+++ b/internal/dead/voice_python.go
@@ -1,0 +1,148 @@
+package dead
+
+import "strings"
+
+// pythonVoice is the Python language voice. Python is the language most like
+// Ruby — duck-typed, no enforced privacy, reached by getattr, decorators, dunder
+// protocols, signals, and string-named framework registration — so its `dead`
+// verdict is the hardest to make airtight and is shaped with the same discipline
+// the Ruby retro earned (pitch 25-19). Like every voice it can only raise a hand
+// (push → possibly_dead); it never votes for `dead`.
+//
+// The governing rule mirrors Ruby's: only a leading-underscore (convention- or
+// mangling-private) function or method that this voice cannot tie to any
+// dynamic-reach idiom may fall through to `dead`. A leading underscore is
+// Python's only structural "not part of the public API" signal, and even it is
+// trusted only in concert with the arbiter's broad mention gate (a `_helper`
+// imported elsewhere leaves a textual mention and stays open-world). Every
+// PUBLIC (non-underscore) function/method raises py_public — duck-typed dispatch
+// on a receiver whose type the static indexer never resolved — exactly as Ruby
+// keeps every public method open-world. Every class and constant raises a hand
+// too (reachable via importlib / getattr / `__subclasses__` / metaclass
+// registries), so no Python class or constant ever earns `dead`.
+type pythonVoice struct{}
+
+func (pythonVoice) Lang() string { return "python" }
+
+// Inspect returns the most-specific (most-likely-live) reason a hidden caller
+// could exist for s, or nil when s is an underscore-private function/method with
+// no invisible-reach idiom — the only shape that may fall through to `dead`.
+// Checks are ordered most-live-first so the returned reason carries the most
+// useful hint; the arbiter independently picks the lowest-priority reason across
+// voices (so a name in the reflection dispatch set still wins core_reflection).
+func (pythonVoice) Inspect(s Symbol, f Facts) *Reason {
+	// Dunder protocol methods (__init__, __call__, __enter__, __getitem__,
+	// __post_init__, a module-level __getattr__) are invoked by the interpreter,
+	// never by a visible caller. Matching the double-underscore PATTERN rather
+	// than a fixed table is deliberate: the protocol surface is vast and grows
+	// (PEP 562 module dunders, dataclass __post_init__), and a missed entry in a
+	// table would let a live protocol method earn a false `dead`. The pattern
+	// over-approximates toward caution, which is the safe direction.
+	if isDunderName(s.Name) {
+		return reasonPtr(ReasonPythonDunder)
+	}
+	// Framework reach, most-specific first. A route handler (Flask/FastAPI) and a
+	// Django signal/admin target are dispatched by the framework with no source
+	// caller; any other decorator (@property, @pytest.fixture, @click.command)
+	// still changes the call story. All three rest on the scan-time decorator
+	// harvest, so they hold even when the symbol is module-private.
+	if _, ok := f.PythonRouteNames[s.Name]; ok {
+		return reasonPtr(ReasonPythonRoute)
+	}
+	if _, ok := f.PythonDjangoNames[s.Name]; ok {
+		return reasonPtr(ReasonPythonDjango)
+	}
+	if _, ok := f.PythonDecoratedNames[s.Name]; ok {
+		return reasonPtr(ReasonPythonDecorator)
+	}
+	// Declared public API via `__all__` — re-exported by `from mod import *`,
+	// the one signal that overrides the underscore convention. The broad mention
+	// set misses it (names listed there are string literals, not identifiers), so
+	// this dedicated harvest is what keeps a `_helper` listed in `__all__` open.
+	if _, ok := f.PythonAllExportNames[s.Name]; ok {
+		return reasonPtr(ReasonPythonAllExport)
+	}
+
+	// Kind gate. Only an underscore-private function/method may fall through to
+	// `dead`; everything else raises a hand.
+	switch s.Kind {
+	case "function", "method":
+		// Public (or visibility-unknown) callables are reached by duck-typed
+		// dispatch on an unresolved receiver — the rule that keeps every public
+		// Python function/method possibly_dead, mirroring ruby_public_method. A
+		// library's public API is the core voice's concern (core_exported_api),
+		// which out-prioritizes py_public when IsLibrary.
+		if s.Visibility == "public" || s.Visibility == "" {
+			return reasonPtr(ReasonPythonPublic)
+		}
+		// Underscore-private with no special reach: stay silent so the arbiter's
+		// soundness gate (mention set + dispatch set) can earn `dead`.
+		return nil
+	case "class":
+		// No Python class earns `dead`: reachable via importlib, getattr,
+		// `__subclasses__`, or a metaclass registry with no direct caller.
+		return reasonPtr(ReasonPythonClass)
+	case "constant":
+		// No module constant earns `dead`: reachable dynamically (getattr /
+		// importlib) or re-exported indirectly.
+		return reasonPtr(ReasonPythonConstant)
+	default:
+		// Any other kind (a future module/type): hold open-world with the safe
+		// generic rather than mislabel it a constant.
+		return reasonPtr(ReasonPythonPublic)
+	}
+}
+
+// isDunderName reports whether name is a double-underscore "magic" name
+// (`__init__`, `__call__`, module `__getattr__`) — leading AND trailing `__`
+// around a non-empty core. Such names are invoked by the interpreter/runtime, so
+// the voice keeps them open-world regardless of kind. The length guard (> 4)
+// excludes the degenerate all-underscore forms (`____`).
+func isDunderName(name string) bool {
+	return len(name) > 4 && strings.HasPrefix(name, "__") && strings.HasSuffix(name, "__")
+}
+
+func init() {
+	registerReasons(map[string]reasonSpec{
+		ReasonPythonDunder: {
+			priority: 20,
+			hint:     "Python dunder/protocol method (__init__, __call__, __enter__, __getitem__, a module __getattr__); the interpreter invokes it, never a caller — do not remove as dead",
+			verify:   "Double-underscore names are invoked by the Python runtime through a protocol (construction, context-manager, iteration, operator overloading, dataclass __post_init__), with no source-level caller. Do not remove these as dead; if one is truly unused, the protocol it implements is simply unexercised.",
+		},
+		ReasonPythonRoute: {
+			priority: 25,
+			hint:     "route handler (Flask @app.route / FastAPI @app.get); the framework's router dispatches it with no source caller — do not remove unless deleting the route",
+			verify:   "This handler carries a web-route decorator, so the framework's router invokes it by URL with no source-level caller. Remove it only if you are deleting the route itself; check the route table first.",
+		},
+		ReasonPythonDjango: {
+			priority: 25,
+			hint:     "Django-dispatched symbol (@receiver signal handler / @admin.register); Django's signal or admin machinery invokes it with no source caller — confirm the wiring before removing",
+			verify:   "This symbol is wired into Django's signal or admin machinery by decorator, so it is invoked by the framework with no source-level caller. Check the signal connections / admin registry before removing.",
+		},
+		ReasonPythonDecorator: {
+			priority: 30,
+			hint:     "decorator-annotated (@property/@staticmethod/@pytest.fixture/@click.command/…); the decorator changes how it is reached (attribute access, injected fixture, CLI entry) — confirm before removing",
+			verify:   "A decorator changes the call story: @property makes a method an attribute access, @pytest.fixture injects it by name, @click.command makes it a CLI entry. Check what the decorator does and how the framework reaches it before removing.",
+		},
+		ReasonPythonAllExport: {
+			priority: 50,
+			hint:     "name listed in the module's __all__; it is re-exported by `from module import *`, so an external consumer may use it — search importers before removing",
+			verify:   "Names in `__all__` are the module's declared public API, re-exported by `from module import *`. Callers may live outside this scan. Search the repo and dependents for the name before removing.",
+		},
+		ReasonPythonPublic: {
+			priority: 60,
+			hint:     "public Python function/method with no static caller; may be reached by duck-typed dispatch on an unresolved receiver — grep for .name before removing",
+			verify:   "Public Python functions/methods can be called on a receiver whose type Sense can't resolve (duck typing), or bound dynamically. For each, grep for `.name` and the bare name (including in templates/serializers) before removing.",
+		},
+		ReasonPythonClass: {
+			priority: 55,
+			hint:     "Python class with no static reference; may be reached via importlib, getattr, __subclasses__, or a metaclass/registry — confirm before removing",
+			verify:   "Python classes can be loaded by importlib / getattr, discovered via `__subclasses__()`, or registered by a metaclass with no direct reference. For each, grep for the class name as a string and bare reference before removing.",
+		},
+		ReasonPythonConstant: {
+			priority: 55,
+			hint:     "Python module constant with no static reference; may be resolved dynamically (getattr / importlib) or re-exported — confirm before removing",
+			verify:   "Python module constants can be read via getattr / importlib or re-exported indirectly. For each, grep for the name as a string and bare reference before removing.",
+		},
+	})
+}

--- a/internal/dead/voice_python_test.go
+++ b/internal/dead/voice_python_test.go
@@ -1,0 +1,124 @@
+package dead
+
+import "testing"
+
+func pySym(name, qualified, kind, visibility string) Symbol {
+	return Symbol{
+		Name:       name,
+		Qualified:  qualified,
+		Kind:       kind,
+		Language:   "python",
+		Visibility: visibility,
+		File:       "mod.py",
+	}
+}
+
+func TestPythonVoiceLang(t *testing.T) {
+	if got := (pythonVoice{}).Lang(); got != "python" {
+		t.Errorf("pythonVoice.Lang() = %q, want python", got)
+	}
+}
+
+func TestPythonVoiceUnderscorePrivateEarnsSilent(t *testing.T) {
+	v := pythonVoice{}
+	// The only shapes that may fall through to `dead`: an underscore-private
+	// function or method with no invisible-reach idiom. The voice stays silent.
+	assertReason(t, v, pySym("_helper", "_helper", "function", "private"), Facts{}, "")
+	assertReason(t, v, pySym("_mangled", "C._mangled", "method", "private"), Facts{}, "")
+}
+
+func TestPythonVoicePublicNeverEarnsDead(t *testing.T) {
+	v := pythonVoice{}
+	// Every public function/method stays open-world (duck-typed dispatch),
+	// mirroring ruby_public_method — the rule that makes the eligible set narrow.
+	assertReason(t, v, pySym("process", "process", "function", "public"), Facts{}, ReasonPythonPublic)
+	assertReason(t, v, pySym("render", "C.render", "method", "public"), Facts{}, ReasonPythonPublic)
+	// Visibility-unknown (a pre-rescan index) is treated as public — the safe
+	// direction (raise a hand) rather than risk a false `dead`.
+	assertReason(t, v, pySym("legacy", "legacy", "function", ""), Facts{}, ReasonPythonPublic)
+}
+
+func TestPythonVoiceClassAndConstantNeverEarnDead(t *testing.T) {
+	v := pythonVoice{}
+	// No Python class or constant earns `dead` — reachable via importlib /
+	// getattr / __subclasses__ / metaclass registries, even when underscore-named.
+	assertReason(t, v, pySym("_Cache", "_Cache", "class", "private"), Facts{}, ReasonPythonClass)
+	assertReason(t, v, pySym("Widget", "Widget", "class", "public"), Facts{}, ReasonPythonClass)
+	assertReason(t, v, pySym("_SECRET", "_SECRET", "constant", "private"), Facts{}, ReasonPythonConstant)
+	assertReason(t, v, pySym("TIMEOUT", "TIMEOUT", "constant", "public"), Facts{}, ReasonPythonConstant)
+	// Any unexpected kind (a future module/type) holds open-world with the safe
+	// generic reason rather than being mislabeled or earning `dead`.
+	assertReason(t, v, pySym("Mod", "Mod", "module", "public"), Facts{}, ReasonPythonPublic)
+}
+
+func TestPythonVoiceDunder(t *testing.T) {
+	v := pythonVoice{}
+	// Dunder/protocol methods are interpreter-invoked regardless of visibility —
+	// the double-underscore pattern catches the whole protocol surface.
+	for _, name := range []string{"__init__", "__call__", "__enter__", "__getitem__", "__post_init__", "__getattr__"} {
+		assertReason(t, v, pySym(name, "C."+name, "method", "private"), Facts{}, ReasonPythonDunder)
+	}
+	// A module-level dunder function (PEP 562) is also a dunder.
+	assertReason(t, v, pySym("__getattr__", "__getattr__", "function", "public"), Facts{}, ReasonPythonDunder)
+}
+
+func TestPythonVoiceRoute(t *testing.T) {
+	v := pythonVoice{}
+	f := Facts{PythonRouteNames: nameSet("index"), PythonDecoratedNames: nameSet("index")}
+	// A route handler is dispatched by the framework's router — the more specific
+	// py_route wins over the generic py_decorator even though both sets match.
+	assertReason(t, v, pySym("index", "index", "function", "public"), f, ReasonPythonRoute)
+}
+
+func TestPythonVoiceDjango(t *testing.T) {
+	v := pythonVoice{}
+	f := Facts{PythonDjangoNames: nameSet("on_save"), PythonDecoratedNames: nameSet("on_save")}
+	// A Django signal receiver is invoked by Django with no source caller. The
+	// crucial precision case: even underscore-private it stays open-world (this is
+	// the planted false-`dead` the eval guards against).
+	assertReason(t, v, pySym("on_save", "on_save", "function", "private"), f, ReasonPythonDjango)
+}
+
+func TestPythonVoiceDecorator(t *testing.T) {
+	v := pythonVoice{}
+	f := Facts{PythonDecoratedNames: nameSet("name")}
+	// A generic decorator (@property/@pytest.fixture) changes the call story —
+	// py_decorator, even for an underscore-private method.
+	assertReason(t, v, pySym("name", "C.name", "method", "private"), f, ReasonPythonDecorator)
+}
+
+func TestPythonVoiceAllExport(t *testing.T) {
+	v := pythonVoice{}
+	f := Facts{PythonAllExportNames: nameSet("_reexported")}
+	// `__all__` overrides the underscore convention: a `_reexported` private name
+	// listed in __all__ is declared public API → py_all_export, not `dead`.
+	assertReason(t, v, pySym("_reexported", "_reexported", "function", "private"), f, ReasonPythonAllExport)
+}
+
+func TestPythonVoiceReasonPriorityOrder(t *testing.T) {
+	v := pythonVoice{}
+	// When a symbol matches several facts, the most-specific (most-live) reason is
+	// returned: dunder beats route beats django beats decorator beats all_export.
+	f := Facts{
+		PythonRouteNames:     nameSet("__call__"),
+		PythonDjangoNames:    nameSet("__call__"),
+		PythonDecoratedNames: nameSet("__call__"),
+		PythonAllExportNames: nameSet("__call__"),
+	}
+	assertReason(t, v, pySym("__call__", "C.__call__", "method", "private"), f, ReasonPythonDunder)
+
+	f = Facts{
+		PythonDjangoNames:    nameSet("handler"),
+		PythonDecoratedNames: nameSet("handler"),
+		PythonRouteNames:     nameSet("handler"),
+	}
+	assertReason(t, v, pySym("handler", "handler", "function", "public"), f, ReasonPythonRoute)
+}
+
+func nameSet(names ...string) map[string]struct{} {
+	m := map[string]struct{}{}
+	for _, n := range names {
+		m[n] = struct{}{}
+	}
+	return m
+}

--- a/internal/extract/extractor.go
+++ b/internal/extract/extractor.go
@@ -345,6 +345,38 @@ type TSHarvestEmitter interface {
 	TSDefaultExportName(name string) error
 }
 
+// PythonHarvestEmitter is an optional Emitter extension for streaming the Python
+// dead-code facts the Python voice reads — names whose reachability the edge
+// graph cannot see because a framework, a decorator, or a declared public API
+// reaches them:
+//
+//   - PythonDecoratedName: a function/method/class carrying any decorator
+//     (`@property`, `@staticmethod`, `@pytest.fixture`, `@click.command`, …).
+//     The decorator changes the call story (an attribute access, an injected
+//     fixture, a CLI entry), so the voice keeps it open-world (py_decorator).
+//   - PythonRouteName: a handler carrying a route decorator (Flask `@app.route`,
+//     FastAPI `@app.get`/`@router.post`/`@app.websocket`). The framework's router
+//     dispatches it with no source caller (py_route) — the more specific reason.
+//   - PythonDjangoName: a symbol carrying a Django-dispatch decorator (a
+//     `@receiver` signal handler, an `@admin.register`). Django's signal/admin
+//     machinery invokes it invisibly (py_django).
+//   - PythonAllExportName: a name listed in a module's `__all__`. It is declared
+//     public API — re-exported by `from mod import *` — so the voice keeps it
+//     open-world (py_all_export) even when it is underscore-private (the one case
+//     where the underscore convention is overridden, which the broad mention set
+//     does NOT catch because `__all__` lists names as string literals).
+//
+// The name sets feed flat (not per-language) sense_meta keys — these concepts are
+// Python-only. An extractor probes for this interface with a type assertion; an
+// Emitter that does not implement it simply receives no names. Returning an error
+// aborts extraction.
+type PythonHarvestEmitter interface {
+	PythonDecoratedName(name string) error
+	PythonRouteName(name string) error
+	PythonDjangoName(name string) error
+	PythonAllExportName(name string) error
+}
+
 // MentionHarvester marks an Extractor whose Extract streams the broad mention
 // set (via MentionEmitter) for every file it processes. The scan records such a
 // language as harvested even on a scan that yields zero mentions for it, so the

--- a/internal/extract/python/harvest.go
+++ b/internal/extract/python/harvest.go
@@ -1,0 +1,269 @@
+package python
+
+import (
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+)
+
+// HarvestsMentions reports that the Python extractor streams the broad mention
+// set (see emitHarvest), so the scan records "python" as harvested even on a
+// scan that yields zero mentions — the dead-code soundness gate then treats a
+// Python symbol as proven-against-an-empty-set, not never-harvested. Without
+// this opt-in every Python symbol would fail closed at the per-language gate
+// (core_no_harvest) and none could earn `dead`.
+func (Extractor) HarvestsMentions() bool { return true }
+
+// emitHarvest streams the file's dead-code fact sets to the emitter when it
+// accepts them, all from one set of tree walks (scan is not a hot path):
+//
+//   - mentions (MentionEmitter): every identifier token except a definition's
+//     own name — the broad superset feeding the arbiter's soundness gate. A
+//     method invoked as `obj.render()` leaves a `render` identifier mention, so a
+//     same-named method stays open-world instead of falsely `dead`.
+//   - dispatch (DispatchEmitter): the literal name argument of every
+//     getattr/setattr/hasattr call — Python's reflective dispatch. A name reached
+//     this way is invisible to the static graph, so the core voice keeps it
+//     open-world (core_reflection).
+//   - decorator / route / Django reach (PythonHarvestEmitter): the name of every
+//     decorated symbol, the subset carrying a route decorator, and the subset
+//     carrying a Django-dispatch decorator. A framework reaches each with no
+//     source caller, so the voice keeps it open-world (py_decorator / py_route /
+//     py_django).
+//   - `__all__` exports (PythonHarvestEmitter): each name a module declares
+//     public via `__all__`, so the voice raises py_all_export — the one signal
+//     that overrides the underscore convention, and one the mention set misses
+//     because `__all__` lists names as string literals.
+//
+// Each emit is best-effort — an Emitter that implements none of the extensions
+// simply receives no names.
+func emitHarvest(root *sitter.Node, source []byte, emit extract.Emitter) error {
+	if me, ok := emit.(extract.MentionEmitter); ok {
+		for _, name := range extract.HarvestMentions(root, source, mentionWalkSpec()) {
+			if err := me.MentionName(name); err != nil {
+				return err
+			}
+		}
+	}
+	if de, ok := emit.(extract.DispatchEmitter); ok {
+		for name := range collectReflectiveDispatch(root, source) {
+			if err := de.DispatchName(name); err != nil {
+				return err
+			}
+		}
+	}
+	if pe, ok := emit.(extract.PythonHarvestEmitter); ok {
+		decorated, routes, django := collectDecoratorReach(root, source)
+		for name := range decorated {
+			if err := pe.PythonDecoratedName(name); err != nil {
+				return err
+			}
+		}
+		for name := range routes {
+			if err := pe.PythonRouteName(name); err != nil {
+				return err
+			}
+		}
+		for name := range django {
+			if err := pe.PythonDjangoName(name); err != nil {
+				return err
+			}
+		}
+		for name := range collectAllExports(root, source) {
+			if err := pe.PythonAllExportName(name); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// mentionWalkSpec is the Python grammar parameterisation of the shared mention
+// harvest. A single `identifier` kind covers every mention position — a bare
+// call (`helper()`), an attribute object and attribute name (`obj.render` is two
+// identifiers), a keyword-argument name — because tree-sitter-python models all
+// of them as `identifier`. A definition's own name token is excluded so a symbol
+// is never cancelled by its own declaration.
+func mentionWalkSpec() extract.MentionWalkSpec {
+	return extract.MentionWalkSpec{
+		NameOf: map[string]func(*sitter.Node, []byte) string{
+			"identifier": extract.Text,
+		},
+		SkipDefinitionName: isPythonDefinitionName,
+	}
+}
+
+// isPythonDefinitionName reports whether n is the `name` field of a function or
+// class definition. Those tokens are excluded from the mention set so a symbol
+// does not count as a mention of itself — otherwise no symbol could ever earn
+// `dead`. Constant-assignment LHS names are intentionally NOT excluded: a
+// constant is never a `dead` candidate (the voice raises py_constant for it), so
+// leaving its name in the set only ever keeps a same-named symbol open-world (the
+// safe direction).
+func isPythonDefinitionName(n *sitter.Node) bool {
+	p := n.Parent()
+	if p == nil {
+		return false
+	}
+	switch p.Kind() {
+	case "function_definition", "class_definition":
+		name := p.ChildByFieldName("name")
+		return name != nil && name.Id() == n.Id()
+	}
+	return false
+}
+
+// reflectiveDispatchFns are the Python built-ins whose literal name argument is a
+// reflective dispatch target — the analog of Ruby `send` and JS `obj["name"]`. A
+// symbol reached via `getattr(obj, "render")` has no static caller edge, so the
+// core voice keeps a same-named symbol open-world.
+var reflectiveDispatchFns = map[string]bool{
+	"getattr": true, "setattr": true, "hasattr": true,
+}
+
+// collectReflectiveDispatch returns the set of literal name arguments to
+// getattr/setattr/hasattr calls (the second positional argument). A non-literal
+// argument (`getattr(obj, name)`) names nothing statically and is skipped — the
+// safe direction (the target stays whatever the static graph says).
+func collectReflectiveDispatch(root *sitter.Node, source []byte) map[string]struct{} {
+	seen := map[string]struct{}{}
+	_ = extract.WalkNamedDescendants(root, "call", func(call *sitter.Node) error {
+		fn := call.ChildByFieldName("function")
+		if fn == nil || fn.Kind() != "identifier" || !reflectiveDispatchFns[extract.Text(fn, source)] {
+			return nil
+		}
+		args := call.ChildByFieldName("arguments")
+		if args == nil {
+			return nil
+		}
+		pos := positionalArgs(args)
+		if len(pos) < 2 || pos[1].Kind() != "string" {
+			return nil
+		}
+		if name := stringContent(pos[1], source); name != "" {
+			seen[name] = struct{}{}
+		}
+		return nil
+	})
+	return seen
+}
+
+// routeDecorators are the trailing decorator names that mark a request handler
+// dispatched by a web framework's router with no source caller — Flask/Blueprint
+// `@app.route`, FastAPI `@app.get`/`@router.post`/`@app.websocket`. Matched on the
+// decorator's last segment so `@app.route` and `@bp.route` both qualify.
+var routeDecorators = map[string]bool{
+	"route": true, "websocket": true,
+	"get": true, "post": true, "put": true, "delete": true,
+	"patch": true, "head": true, "options": true,
+}
+
+// djangoDecorators are the trailing decorator names that mark a symbol Django's
+// signal/admin machinery invokes invisibly — `@receiver` (a signal handler) and
+// `@admin.register` / `@register` (admin registration). Name-based
+// over-approximation is safe: it only ever keeps a symbol open-world (py_django).
+var djangoDecorators = map[string]bool{
+	"receiver": true, "register": true,
+}
+
+// collectDecoratorReach walks every decorated_definition and returns three sets
+// of the decorated symbol's name: every decorated name, the subset whose
+// decorators include a route decorator, and the subset whose decorators include a
+// Django-dispatch decorator. The sets can overlap (a handler with several
+// decorators); the voice reads the most specific (route, then django, then the
+// generic decorated set).
+func collectDecoratorReach(root *sitter.Node, source []byte) (decorated, routes, django map[string]struct{}) {
+	decorated, routes, django = map[string]struct{}{}, map[string]struct{}{}, map[string]struct{}{}
+	_ = extract.WalkNamedDescendants(root, "decorated_definition", func(dd *sitter.Node) error {
+		def := dd.ChildByFieldName("definition")
+		if def == nil {
+			return nil
+		}
+		name := extract.Text(def.ChildByFieldName("name"), source)
+		if name == "" {
+			return nil
+		}
+		decorated[name] = struct{}{}
+		for _, dec := range collectDecorators(dd) {
+			last := decoratorLastName(dec, source)
+			if routeDecorators[last] {
+				routes[name] = struct{}{}
+			}
+			if djangoDecorators[last] {
+				django[name] = struct{}{}
+			}
+		}
+		return nil
+	})
+	return decorated, routes, django
+}
+
+// decoratorLastName returns the trailing identifier of a decorator's callee:
+// `@property` → "property", `@app.route(...)` → "route", `@admin.register` →
+// "register". A decorator is `@<expr>` or `@<expr>(...)`; the expression is the
+// decorator node's first named child, unwrapped one level when it is a call.
+func decoratorLastName(dec *sitter.Node, source []byte) string {
+	if dec.NamedChildCount() == 0 {
+		return ""
+	}
+	expr := dec.NamedChild(0)
+	if expr != nil && expr.Kind() == "call" {
+		expr = expr.ChildByFieldName("function")
+	}
+	if expr == nil {
+		return ""
+	}
+	switch expr.Kind() {
+	case "identifier":
+		return extract.Text(expr, source)
+	case "attribute":
+		return attrLastSegment(expr, source)
+	}
+	return ""
+}
+
+// collectAllExports returns the set of names a module lists in `__all__`
+// (`__all__ = ["foo", "_bar"]`, including `+=` augmentations). The names are
+// string literals, so the broad identifier mention set misses them — this is the
+// dedicated harvest that lets the voice raise py_all_export for an
+// underscore-private name a module deliberately re-exports.
+func collectAllExports(root *sitter.Node, source []byte) map[string]struct{} {
+	seen := map[string]struct{}{}
+	collect := func(kind string) {
+		_ = extract.WalkNamedDescendants(root, kind, func(n *sitter.Node) error {
+			lhs := n.ChildByFieldName("left")
+			if lhs == nil || lhs.Kind() != "identifier" || extract.Text(lhs, source) != "__all__" {
+				return nil
+			}
+			addStringElements(n.ChildByFieldName("right"), source, seen)
+			return nil
+		})
+	}
+	collect("assignment")
+	collect("augmented_assignment")
+	return seen
+}
+
+// addStringElements adds the payload of every string element of a list/tuple/set
+// literal to seen. A non-collection RHS (a name alias, a concatenation) adds
+// nothing — the safe direction, since a missed `__all__` entry only risks a
+// false `dead`, which the mention gate still backstops for non-string references.
+func addStringElements(rhs *sitter.Node, source []byte, seen map[string]struct{}) {
+	if rhs == nil {
+		return
+	}
+	switch rhs.Kind() {
+	case "list", "tuple", "set":
+	default:
+		return
+	}
+	count := rhs.NamedChildCount()
+	for i := uint(0); i < count; i++ {
+		el := rhs.NamedChild(i)
+		if el != nil && el.Kind() == "string" {
+			if name := stringContent(el, source); name != "" {
+				seen[name] = struct{}{}
+			}
+		}
+	}
+}

--- a/internal/extract/python/harvest_test.go
+++ b/internal/extract/python/harvest_test.go
@@ -1,0 +1,282 @@
+package python
+
+import (
+	"testing"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+)
+
+// harvestRecorder captures emitted symbols plus every optional harvest stream so
+// the harvest tests can assert on raw-byte extraction without the scan harness.
+type harvestRecorder struct {
+	symbols      []extract.EmittedSymbol
+	edges        []extract.EmittedEdge
+	mentions     []string
+	dispatch     []string
+	decorated    []string
+	routes       []string
+	django       []string
+	allExports   []string
+}
+
+func (r *harvestRecorder) Symbol(s extract.EmittedSymbol) error { r.symbols = append(r.symbols, s); return nil }
+func (r *harvestRecorder) Edge(e extract.EmittedEdge) error     { r.edges = append(r.edges, e); return nil }
+func (r *harvestRecorder) MentionName(n string) error           { r.mentions = append(r.mentions, n); return nil }
+func (r *harvestRecorder) DispatchName(n string) error          { r.dispatch = append(r.dispatch, n); return nil }
+func (r *harvestRecorder) PythonDecoratedName(n string) error   { r.decorated = append(r.decorated, n); return nil }
+func (r *harvestRecorder) PythonRouteName(n string) error       { r.routes = append(r.routes, n); return nil }
+func (r *harvestRecorder) PythonDjangoName(n string) error      { r.django = append(r.django, n); return nil }
+func (r *harvestRecorder) PythonAllExportName(n string) error   { r.allExports = append(r.allExports, n); return nil }
+
+// extractHarvest parses src and returns the recorded output including harvests.
+func extractHarvest(t *testing.T, src string) *harvestRecorder {
+	t.Helper()
+	ex := Extractor{}
+	p := sitter.NewParser()
+	defer p.Close()
+	if err := p.SetLanguage(ex.Grammar()); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	tree := p.Parse([]byte(src), nil)
+	if tree == nil {
+		t.Fatal("Parse returned nil tree")
+	}
+	defer tree.Close()
+	r := &harvestRecorder{}
+	if err := ex.Extract(tree, []byte(src), "test.py", r); err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return r
+}
+
+func toSet(names []string) map[string]bool {
+	m := map[string]bool{}
+	for _, n := range names {
+		m[n] = true
+	}
+	return m
+}
+
+func TestHarvestsMentionsOptIn(t *testing.T) {
+	if !(Extractor{}).HarvestsMentions() {
+		t.Error("Extractor.HarvestsMentions() = false, want true")
+	}
+}
+
+func TestHarvestMentions(t *testing.T) {
+	// Every identifier is mentioned EXCEPT a definition's own name. A method
+	// invoked as `obj.render()` leaves a `render` identifier mention, keeping a
+	// same-named method open-world.
+	src := `
+def caller():
+    svc = make_service()
+    svc.render()
+    return helper(svc)
+
+def helper(x):
+    return x
+`
+	mentions := toSet(extractHarvest(t, src).mentions)
+	for _, want := range []string{"make_service", "svc", "render", "helper", "x"} {
+		if !mentions[want] {
+			t.Errorf("mentions missing %q; got %v", want, mentions)
+		}
+	}
+	// `caller` and `helper` are definition names and must be excluded — otherwise
+	// each would cancel its own dead candidacy. (`helper` reappears via its call
+	// site, so it IS present; `caller` has no call site and must be absent.)
+	if mentions["caller"] {
+		t.Errorf("mentions should exclude the definition name 'caller'; got %v", mentions)
+	}
+}
+
+func TestHarvestReflectiveDispatch(t *testing.T) {
+	// getattr/setattr/hasattr with a literal name are reflective dispatch targets;
+	// a non-literal name argument names nothing statically.
+	src := `
+def f(obj, name):
+    getattr(obj, "render")
+    setattr(obj, "value", 1)
+    hasattr(obj, "ready")
+    getattr(obj, name)
+`
+	dispatch := toSet(extractHarvest(t, src).dispatch)
+	for _, want := range []string{"render", "value", "ready"} {
+		if !dispatch[want] {
+			t.Errorf("dispatch missing %q; got %v", want, dispatch)
+		}
+	}
+	if len(dispatch) != 3 {
+		t.Errorf("dispatch = %v, want exactly {render, value, ready} (literal args only)", dispatch)
+	}
+}
+
+func TestHarvestDecoratorReach(t *testing.T) {
+	src := `
+@property
+def name(self):
+    return self._name
+
+@staticmethod
+def build():
+    pass
+
+@app.route("/")
+def index():
+    pass
+
+@router.post("/orders")
+def create_order():
+    pass
+
+@app.websocket("/ws")
+def socket():
+    pass
+
+@receiver(post_save, sender=User)
+def on_save(sender, **kwargs):
+    pass
+
+@admin.register(Article)
+class ArticleAdmin:
+    pass
+
+@dataclass
+class Point:
+    pass
+`
+	r := extractHarvest(t, src)
+	decorated, routes, django := toSet(r.decorated), toSet(r.routes), toSet(r.django)
+
+	for _, want := range []string{"name", "build", "index", "create_order", "socket", "on_save", "ArticleAdmin", "Point"} {
+		if !decorated[want] {
+			t.Errorf("decorated missing %q; got %v", want, decorated)
+		}
+	}
+	for _, want := range []string{"index", "create_order", "socket"} {
+		if !routes[want] {
+			t.Errorf("routes missing %q; got %v", want, routes)
+		}
+	}
+	if routes["name"] || routes["on_save"] {
+		t.Errorf("routes over-captured non-route decorators; got %v", routes)
+	}
+	for _, want := range []string{"on_save", "ArticleAdmin"} {
+		if !django[want] {
+			t.Errorf("django missing %q; got %v", want, django)
+		}
+	}
+	if django["index"] {
+		t.Errorf("django over-captured a route handler; got %v", django)
+	}
+}
+
+func TestHarvestDecoratorUnusualForms(t *testing.T) {
+	// A subscript decorator (PEP 614 relaxed grammar) has no trailing name, so it
+	// classifies as neither route nor Django — but the symbol is still recorded as
+	// decorated, keeping it open-world. An empty-bodied decorated def with a name
+	// still harvests. This exercises decoratorLastName's non-identifier/attribute
+	// fall-through.
+	src := `
+@registry[0]
+def handler():
+    pass
+`
+	r := extractHarvest(t, src)
+	if !toSet(r.decorated)["handler"] {
+		t.Errorf("decorated missing 'handler'; got %v", r.decorated)
+	}
+	if toSet(r.routes)["handler"] || toSet(r.django)["handler"] {
+		t.Errorf("subscript decorator should classify as neither route nor django; routes=%v django=%v", r.routes, r.django)
+	}
+}
+
+func TestHarvestAllExports(t *testing.T) {
+	// A list, a tuple, and a `+=` augmentation all contribute; a private name in
+	// __all__ is captured (the override the underscore convention can't express).
+	src := `
+__all__ = ["public_api", "_reexported_private"]
+__all__ += ("more_api",)
+
+def public_api():
+    pass
+
+def _reexported_private():
+    pass
+`
+	all := toSet(extractHarvest(t, src).allExports)
+	for _, want := range []string{"public_api", "_reexported_private", "more_api"} {
+		if !all[want] {
+			t.Errorf("__all__ exports missing %q; got %v", want, all)
+		}
+	}
+}
+
+func TestHarvestAllExportsNonCollectionRHS(t *testing.T) {
+	// A non-list/tuple/set RHS (an alias) contributes nothing — the safe
+	// direction; the mention gate still backstops non-string references.
+	src := `__all__ = OTHER_LIST`
+	all := extractHarvest(t, src).allExports
+	if len(all) != 0 {
+		t.Errorf("__all__ = alias should harvest nothing; got %v", all)
+	}
+}
+
+// failEmitter returns an error from a chosen harvest stream so the per-stream
+// error-propagation branches in emitHarvest are exercised.
+type failEmitter struct {
+	extract.Emitter
+	failOn string
+}
+
+func (failEmitter) Symbol(extract.EmittedSymbol) error { return nil }
+func (failEmitter) Edge(extract.EmittedEdge) error     { return nil }
+func (e failEmitter) MentionName(string) error         { return failIf(e.failOn, "mention") }
+func (e failEmitter) DispatchName(string) error        { return failIf(e.failOn, "dispatch") }
+func (e failEmitter) PythonDecoratedName(string) error { return failIf(e.failOn, "decorated") }
+func (e failEmitter) PythonRouteName(string) error     { return failIf(e.failOn, "route") }
+func (e failEmitter) PythonDjangoName(string) error    { return failIf(e.failOn, "django") }
+func (e failEmitter) PythonAllExportName(string) error { return failIf(e.failOn, "all") }
+
+func failIf(failOn, stream string) error {
+	if failOn == stream {
+		return errStream
+	}
+	return nil
+}
+
+var errStream = &harvestError{}
+
+type harvestError struct{}
+
+func (*harvestError) Error() string { return "harvest stream failed" }
+
+func TestHarvestErrorPropagates(t *testing.T) {
+	// A source that produces at least one name in every stream, so each
+	// failOn target reaches its emit and returns the error.
+	src := `
+__all__ = ["thing"]
+
+@app.route("/")
+@receiver(sig)
+def thing(obj):
+    getattr(obj, "x")
+`
+	ex := Extractor{}
+	p := sitter.NewParser()
+	defer p.Close()
+	if err := p.SetLanguage(ex.Grammar()); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	tree := p.Parse([]byte(src), nil)
+	defer tree.Close()
+
+	for _, stream := range []string{"mention", "dispatch", "decorated", "route", "django", "all"} {
+		err := emitHarvest(tree.RootNode(), []byte(src), failEmitter{failOn: stream})
+		if err == nil {
+			t.Errorf("emitHarvest with failOn=%q returned nil, want error", stream)
+		}
+	}
+}

--- a/internal/extract/python/python.go
+++ b/internal/extract/python/python.go
@@ -36,9 +36,17 @@
 //   - Function:   f  (top-level only; nested defs are closures, skipped)
 //   - Constant:   NAME  or  Outer.NAME
 //
+// Visibility (see visibility.go): each symbol is marked `private` (leading
+// underscore, non-dunder) or `public`. The dead-code Python voice lets only
+// underscore-private functions/methods fall through to `dead`.
+//
+// Dead-code harvest (see harvest.go): the broad mention set, the
+// getattr/setattr/hasattr dispatch set, the decorator / route / Django reach
+// sets, and the `__all__` export set — the facts the Python voice and the
+// arbiter's soundness gate read.
+//
 // What is still skipped:
 //   - imports (edge resolution; handled in 01-03)
-//   - visibility (leading underscore convention)
 package python
 
 import (
@@ -63,7 +71,10 @@ func (Extractor) Tier() extract.Tier        { return extract.TierBasic }
 func (Extractor) Extract(tree *sitter.Tree, source []byte, _ string, emit extract.Emitter) error {
 	w := &walker{source: source, emit: emit, pkgBindings: map[string]string{}}
 	w.collectModuleConstants(tree.RootNode())
-	return w.walk(tree.RootNode(), nil)
+	if err := w.walk(tree.RootNode(), nil); err != nil {
+		return err
+	}
+	return emitHarvest(tree.RootNode(), source, emit)
 }
 
 func init() { extract.Register(Extractor{}) }
@@ -215,6 +226,7 @@ func (w *walker) handleClass(n *sitter.Node, scope []string) error {
 		Name:            name,
 		Qualified:       qualified,
 		Kind:            model.KindClass,
+		Visibility:      visibilityForName(name),
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
@@ -289,6 +301,7 @@ func (w *walker) emitFunctionAndWalkBody(n *sitter.Node, scope []string, decorat
 		Name:            name,
 		Qualified:       qualified,
 		Kind:            kind,
+		Visibility:      visibilityForName(name),
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
@@ -429,6 +442,7 @@ func (w *walker) handleAssignment(n *sitter.Node, scope []string) error {
 		Name:            name,
 		Qualified:       qualified,
 		Kind:            model.KindConstant,
+		Visibility:      visibilityForName(name),
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),

--- a/internal/extract/python/visibility.go
+++ b/internal/extract/python/visibility.go
@@ -1,0 +1,48 @@
+package python
+
+import "strings"
+
+// Underscore visibility is the Python analog of Ruby's method-visibility pass
+// and the structural capitalization rule Go/Rust get for free. Python has no
+// enforced privacy — a single leading underscore (`_helper`) is a convention and
+// a double leading underscore (`__mangled`) only triggers name-mangling — but
+// that convention is the only structural "not part of the public API" signal the
+// language offers, so it is what the dead-code Python voice keys its narrow
+// earned-`dead` candidacy on.
+//
+// A symbol is `private` iff its own name carries a leading underscore AND it is
+// not a dunder. Everything else is `public`. The split is deliberately
+// conservative in the safe direction: a falsely-public symbol never earns
+// `dead` (it only loses recall), mirroring the conservatism Ruby's visibility
+// pass and Go's magic-method table choose. The soundness of `dead` never rests
+// on the underscore alone — the arbiter's mention gate is the backstop for a
+// `_helper` imported and called from another module.
+
+// visibilityForName returns "private" for a leading-underscore non-dunder name
+// (the only shape the Python voice lets fall through to `dead`), else "public".
+// It is applied to every emitted symbol — function, method, class, constant —
+// by its own bare name; a private method on a public class is private, and a
+// public method on a private class is public, because each tracks its own
+// underscore.
+func visibilityForName(name string) string {
+	if isPrivateName(name) {
+		return "private"
+	}
+	return "public"
+}
+
+// isPrivateName reports whether name is underscore-private by Python convention:
+// a leading underscore that is not a dunder. `_helper` and `__mangled` are
+// private; `__init__` (a dunder, runtime-invoked protocol) and `render` are not.
+func isPrivateName(name string) bool {
+	return strings.HasPrefix(name, "_") && !isDunder(name)
+}
+
+// isDunder reports whether name is a double-underscore "magic" name
+// (`__init__`, `__call__`, `__name__`) — leading AND trailing `__` around a
+// non-empty core. Such names are part of Python's public protocol surface,
+// invoked by the interpreter, so they are not treated as private. The length
+// guard (> 4) excludes the degenerate all-underscore forms (`____`).
+func isDunder(name string) bool {
+	return len(name) > 4 && strings.HasPrefix(name, "__") && strings.HasSuffix(name, "__")
+}

--- a/internal/extract/python/visibility_test.go
+++ b/internal/extract/python/visibility_test.go
@@ -1,0 +1,78 @@
+package python
+
+import "testing"
+
+func TestVisibilityUnderscoreConvention(t *testing.T) {
+	src := `
+def public_fn():
+    pass
+
+def _private_fn():
+    pass
+
+def __mangled_fn():
+    pass
+
+PUBLIC_CONST = 1
+_PRIVATE_CONST = 2
+
+class PublicClass:
+    def method(self):
+        pass
+
+    def _helper(self):
+        pass
+
+    def __init__(self):
+        pass
+
+    def __mangled(self):
+        pass
+
+class _PrivateClass:
+    pass
+`
+	r := parse(t, src)
+
+	cases := map[string]string{
+		"public_fn":             "public",
+		"_private_fn":           "private",
+		"__mangled_fn":          "private",
+		"PUBLIC_CONST":          "public",
+		"_PRIVATE_CONST":        "private",
+		"PublicClass":           "public",
+		"_PrivateClass":         "private",
+		"PublicClass.method":    "public",
+		"PublicClass._helper":   "private",
+		"PublicClass.__init__":  "public", // dunder: public protocol, not private
+		"PublicClass.__mangled": "private",
+	}
+	for qualified, want := range cases {
+		sym := findSymbol(r, qualified)
+		if sym == nil {
+			t.Errorf("symbol %q not emitted", qualified)
+			continue
+		}
+		if sym.Visibility != want {
+			t.Errorf("%s visibility = %q, want %q", qualified, sym.Visibility, want)
+		}
+	}
+}
+
+func TestIsDunder(t *testing.T) {
+	cases := map[string]bool{
+		"__init__":  true,
+		"__name__":  true,
+		"__a__":     true,
+		"_private":  false,
+		"__mangled": false, // no trailing __
+		"plain":     false,
+		"____":      false, // degenerate: no core
+		"__":        false,
+	}
+	for name, want := range cases {
+		if got := isDunder(name); got != want {
+			t.Errorf("isDunder(%q) = %v, want %v", name, got, want)
+		}
+	}
+}

--- a/internal/extract/testdata/python/basic_class.golden.json
+++ b/internal/extract/testdata/python/basic_class.golden.json
@@ -4,6 +4,7 @@
       "name": "MAX_SIZE",
       "qualified": "MAX_SIZE",
       "kind": "constant",
+      "visibility": "public",
       "line_start": 1,
       "line_end": 1
     },
@@ -11,6 +12,7 @@
       "name": "User",
       "qualified": "User",
       "kind": "class",
+      "visibility": "public",
       "line_start": 4,
       "line_end": 17
     },
@@ -18,6 +20,7 @@
       "name": "__init__",
       "qualified": "User.__init__",
       "kind": "method",
+      "visibility": "public",
       "parent": "User",
       "line_start": 5,
       "line_end": 6
@@ -26,6 +29,7 @@
       "name": "build",
       "qualified": "User.build",
       "kind": "method",
+      "visibility": "public",
       "parent": "User",
       "line_start": 12,
       "line_end": 13
@@ -34,6 +38,7 @@
       "name": "verify",
       "qualified": "User.verify",
       "kind": "method",
+      "visibility": "public",
       "parent": "User",
       "line_start": 8,
       "line_end": 9
@@ -42,6 +47,7 @@
       "name": "version",
       "qualified": "User.version",
       "kind": "method",
+      "visibility": "public",
       "parent": "User",
       "line_start": 16,
       "line_end": 17

--- a/internal/extract/testdata/python/celery_tasks.golden.json
+++ b/internal/extract/testdata/python/celery_tasks.golden.json
@@ -4,6 +4,7 @@
       "name": "Mailer",
       "qualified": "Mailer",
       "kind": "class",
+      "visibility": "public",
       "line_start": 26,
       "line_end": 28
     },
@@ -11,6 +12,7 @@
       "name": "send",
       "qualified": "Mailer.send",
       "kind": "method",
+      "visibility": "public",
       "parent": "Mailer",
       "line_start": 27,
       "line_end": 28
@@ -19,6 +21,7 @@
       "name": "PaymentGateway",
       "qualified": "PaymentGateway",
       "kind": "class",
+      "visibility": "public",
       "line_start": 31,
       "line_end": 33
     },
@@ -26,6 +29,7 @@
       "name": "charge",
       "qualified": "PaymentGateway.charge",
       "kind": "method",
+      "visibility": "public",
       "parent": "PaymentGateway",
       "line_start": 32,
       "line_end": 33
@@ -34,6 +38,7 @@
       "name": "RETRY_LIMIT",
       "qualified": "RETRY_LIMIT",
       "kind": "constant",
+      "visibility": "public",
       "line_start": 5,
       "line_end": 5
     },
@@ -41,6 +46,7 @@
       "name": "cleanup_expired",
       "qualified": "cleanup_expired",
       "kind": "function",
+      "visibility": "public",
       "line_start": 22,
       "line_end": 23
     },
@@ -48,6 +54,7 @@
       "name": "process_payment",
       "qualified": "process_payment",
       "kind": "function",
+      "visibility": "public",
       "line_start": 15,
       "line_end": 18
     },
@@ -55,6 +62,7 @@
       "name": "send_email",
       "qualified": "send_email",
       "kind": "function",
+      "visibility": "public",
       "line_start": 9,
       "line_end": 11
     }

--- a/internal/extract/testdata/python/dataclass_pydantic.golden.json
+++ b/internal/extract/testdata/python/dataclass_pydantic.golden.json
@@ -4,6 +4,7 @@
       "name": "OrderCreate",
       "qualified": "OrderCreate",
       "kind": "class",
+      "visibility": "public",
       "line_start": 7,
       "line_end": 11
     },
@@ -11,6 +12,7 @@
       "name": "OrderResponse",
       "qualified": "OrderResponse",
       "kind": "class",
+      "visibility": "public",
       "line_start": 14,
       "line_end": 18
     },
@@ -18,6 +20,7 @@
       "name": "Receipt",
       "qualified": "Receipt",
       "kind": "class",
+      "visibility": "public",
       "line_start": 21,
       "line_end": 25
     }

--- a/internal/extract/testdata/python/django_models.golden.json
+++ b/internal/extract/testdata/python/django_models.golden.json
@@ -4,6 +4,7 @@
       "name": "Invoice",
       "qualified": "Invoice",
       "kind": "class",
+      "visibility": "public",
       "line_start": 15,
       "line_end": 17
     },
@@ -11,6 +12,7 @@
       "name": "Order",
       "qualified": "Order",
       "kind": "class",
+      "visibility": "public",
       "line_start": 9,
       "line_end": 12
     },
@@ -18,6 +20,7 @@
       "name": "Unrelated",
       "qualified": "Unrelated",
       "kind": "class",
+      "visibility": "public",
       "line_start": 20,
       "line_end": 22
     },
@@ -25,6 +28,7 @@
       "name": "User",
       "qualified": "User",
       "kind": "class",
+      "visibility": "public",
       "line_start": 4,
       "line_end": 6
     }

--- a/internal/extract/testdata/python/django_string_fk.golden.json
+++ b/internal/extract/testdata/python/django_string_fk.golden.json
@@ -4,6 +4,7 @@
       "name": "Author",
       "qualified": "Author",
       "kind": "class",
+      "visibility": "public",
       "line_start": 4,
       "line_end": 5
     },
@@ -11,6 +12,7 @@
       "name": "Book",
       "qualified": "Book",
       "kind": "class",
+      "visibility": "public",
       "line_start": 8,
       "line_end": 12
     },
@@ -18,6 +20,7 @@
       "name": "Chapter",
       "qualified": "Chapter",
       "kind": "class",
+      "visibility": "public",
       "line_start": 19,
       "line_end": 22
     },
@@ -25,6 +28,7 @@
       "name": "Tag",
       "qualified": "Tag",
       "kind": "class",
+      "visibility": "public",
       "line_start": 15,
       "line_end": 16
     }

--- a/internal/extract/testdata/python/dynamic_dispatch.golden.json
+++ b/internal/extract/testdata/python/dynamic_dispatch.golden.json
@@ -4,6 +4,7 @@
       "name": "Dispatcher",
       "qualified": "Dispatcher",
       "kind": "class",
+      "visibility": "public",
       "line_start": 1,
       "line_end": 8
     },
@@ -11,6 +12,7 @@
       "name": "dynamic",
       "qualified": "Dispatcher.dynamic",
       "kind": "method",
+      "visibility": "public",
       "parent": "Dispatcher",
       "line_start": 2,
       "line_end": 5
@@ -19,6 +21,7 @@
       "name": "helper",
       "qualified": "Dispatcher.helper",
       "kind": "method",
+      "visibility": "public",
       "parent": "Dispatcher",
       "line_start": 7,
       "line_end": 8

--- a/internal/extract/testdata/python/fastapi_routes.golden.json
+++ b/internal/extract/testdata/python/fastapi_routes.golden.json
@@ -4,6 +4,7 @@
       "name": "create_order",
       "qualified": "create_order",
       "kind": "function",
+      "visibility": "public",
       "line_start": 16,
       "line_end": 17
     },
@@ -11,6 +12,7 @@
       "name": "delete_item",
       "qualified": "delete_item",
       "kind": "function",
+      "visibility": "public",
       "line_start": 26,
       "line_end": 27
     },
@@ -18,6 +20,7 @@
       "name": "get_db",
       "qualified": "get_db",
       "kind": "function",
+      "visibility": "public",
       "line_start": 7,
       "line_end": 8
     },
@@ -25,6 +28,7 @@
       "name": "get_user",
       "qualified": "get_user",
       "kind": "function",
+      "visibility": "public",
       "line_start": 21,
       "line_end": 22
     },
@@ -32,6 +36,7 @@
       "name": "plain_function",
       "qualified": "plain_function",
       "kind": "function",
+      "visibility": "public",
       "line_start": 30,
       "line_end": 31
     },
@@ -39,6 +44,7 @@
       "name": "verify_token",
       "qualified": "verify_token",
       "kind": "function",
+      "visibility": "public",
       "line_start": 11,
       "line_end": 12
     }

--- a/internal/extract/testdata/python/flask_blueprint.golden.json
+++ b/internal/extract/testdata/python/flask_blueprint.golden.json
@@ -4,6 +4,7 @@
       "name": "MAX_PAGE_SIZE",
       "qualified": "MAX_PAGE_SIZE",
       "kind": "constant",
+      "visibility": "public",
       "line_start": 6,
       "line_end": 6
     },
@@ -11,6 +12,7 @@
       "name": "OrderService",
       "qualified": "OrderService",
       "kind": "class",
+      "visibility": "public",
       "line_start": 25,
       "line_end": 33
     },
@@ -18,6 +20,7 @@
       "name": "cancel",
       "qualified": "OrderService.cancel",
       "kind": "method",
+      "visibility": "public",
       "parent": "OrderService",
       "line_start": 31,
       "line_end": 33
@@ -26,6 +29,7 @@
       "name": "create",
       "qualified": "OrderService.create",
       "kind": "method",
+      "visibility": "public",
       "parent": "OrderService",
       "line_start": 26,
       "line_end": 29
@@ -34,6 +38,7 @@
       "name": "health_check",
       "qualified": "health_check",
       "kind": "function",
+      "visibility": "public",
       "line_start": 10,
       "line_end": 11
     },
@@ -41,6 +46,7 @@
       "name": "list_orders",
       "qualified": "list_orders",
       "kind": "function",
+      "visibility": "public",
       "line_start": 15,
       "line_end": 16
     },
@@ -48,6 +54,7 @@
       "name": "update_order",
       "qualified": "update_order",
       "kind": "function",
+      "visibility": "public",
       "line_start": 20,
       "line_end": 22
     }

--- a/internal/extract/testdata/python/framework_negatives.golden.json
+++ b/internal/extract/testdata/python/framework_negatives.golden.json
@@ -4,6 +4,7 @@
       "name": "Config",
       "qualified": "Config",
       "kind": "class",
+      "visibility": "public",
       "line_start": 11,
       "line_end": 12
     },
@@ -11,6 +12,7 @@
       "name": "Metrics",
       "qualified": "Metrics",
       "kind": "class",
+      "visibility": "public",
       "line_start": 27,
       "line_end": 31
     },
@@ -18,6 +20,7 @@
       "name": "get_items",
       "qualified": "get_items",
       "kind": "function",
+      "visibility": "public",
       "line_start": 16,
       "line_end": 17
     }

--- a/internal/extract/testdata/python/inheritance_and_dataclass.golden.json
+++ b/internal/extract/testdata/python/inheritance_and_dataclass.golden.json
@@ -4,6 +4,7 @@
       "name": "Base",
       "qualified": "Base",
       "kind": "class",
+      "visibility": "public",
       "line_start": 4,
       "line_end": 6
     },
@@ -11,6 +12,7 @@
       "name": "greet",
       "qualified": "Base.greet",
       "kind": "method",
+      "visibility": "public",
       "parent": "Base",
       "line_start": 5,
       "line_end": 6
@@ -19,6 +21,7 @@
       "name": "Box",
       "qualified": "Box",
       "kind": "class",
+      "visibility": "public",
       "line_start": 21,
       "line_end": 22
     },
@@ -26,6 +29,7 @@
       "name": "Child",
       "qualified": "Child",
       "kind": "class",
+      "visibility": "public",
       "line_start": 9,
       "line_end": 11
     },
@@ -33,6 +37,7 @@
       "name": "greet",
       "qualified": "Child.greet",
       "kind": "method",
+      "visibility": "public",
       "parent": "Child",
       "line_start": 10,
       "line_end": 11
@@ -41,6 +46,7 @@
       "name": "Item",
       "qualified": "Item",
       "kind": "class",
+      "visibility": "public",
       "line_start": 15,
       "line_end": 17
     }

--- a/internal/extract/testdata/python/nested_and_top_level.golden.json
+++ b/internal/extract/testdata/python/nested_and_top_level.golden.json
@@ -4,6 +4,7 @@
       "name": "DEBUG",
       "qualified": "DEBUG",
       "kind": "constant",
+      "visibility": "public",
       "line_start": 2,
       "line_end": 2
     },
@@ -11,6 +12,7 @@
       "name": "Outer",
       "qualified": "Outer",
       "kind": "class",
+      "visibility": "public",
       "line_start": 9,
       "line_end": 15
     },
@@ -18,6 +20,7 @@
       "name": "Inner",
       "qualified": "Outer.Inner",
       "kind": "class",
+      "visibility": "public",
       "parent": "Outer",
       "line_start": 10,
       "line_end": 12
@@ -26,6 +29,7 @@
       "name": "inner_method",
       "qualified": "Outer.Inner.inner_method",
       "kind": "method",
+      "visibility": "public",
       "parent": "Outer.Inner",
       "line_start": 11,
       "line_end": 12
@@ -34,6 +38,7 @@
       "name": "outer_method",
       "qualified": "Outer.outer_method",
       "kind": "method",
+      "visibility": "public",
       "parent": "Outer",
       "line_start": 14,
       "line_end": 15
@@ -42,6 +47,7 @@
       "name": "VERSION",
       "qualified": "VERSION",
       "kind": "constant",
+      "visibility": "public",
       "line_start": 1,
       "line_end": 1
     },
@@ -49,6 +55,7 @@
       "name": "top_level_function",
       "qualified": "top_level_function",
       "kind": "function",
+      "visibility": "public",
       "line_start": 5,
       "line_end": 6
     }

--- a/internal/extract/testdata/python/sqlalchemy_models.golden.json
+++ b/internal/extract/testdata/python/sqlalchemy_models.golden.json
@@ -4,6 +4,7 @@
       "name": "Order",
       "qualified": "Order",
       "kind": "class",
+      "visibility": "public",
       "line_start": 18,
       "line_end": 27
     },
@@ -11,6 +12,7 @@
       "name": "total",
       "qualified": "Order.total",
       "kind": "method",
+      "visibility": "public",
       "parent": "Order",
       "line_start": 26,
       "line_end": 27
@@ -19,6 +21,7 @@
       "name": "OrderItem",
       "qualified": "OrderItem",
       "kind": "class",
+      "visibility": "public",
       "line_start": 30,
       "line_end": 36
     },
@@ -26,6 +29,7 @@
       "name": "User",
       "qualified": "User",
       "kind": "class",
+      "visibility": "public",
       "line_start": 7,
       "line_end": 15
     },
@@ -33,6 +37,7 @@
       "name": "full_name",
       "qualified": "User.full_name",
       "kind": "method",
+      "visibility": "public",
       "parent": "User",
       "line_start": 14,
       "line_end": 15

--- a/internal/extract/testdata/python/type_annotations_advanced.golden.json
+++ b/internal/extract/testdata/python/type_annotations_advanced.golden.json
@@ -4,6 +4,7 @@
       "name": "Address",
       "qualified": "Address",
       "kind": "class",
+      "visibility": "public",
       "line_start": 5,
       "line_end": 7
     },
@@ -11,6 +12,7 @@
       "name": "Customer",
       "qualified": "Customer",
       "kind": "class",
+      "visibility": "public",
       "line_start": 10,
       "line_end": 16
     },
@@ -18,6 +20,7 @@
       "name": "InventoryItem",
       "qualified": "InventoryItem",
       "kind": "class",
+      "visibility": "public",
       "line_start": 27,
       "line_end": 32
     },
@@ -25,6 +28,7 @@
       "name": "ship",
       "qualified": "InventoryItem.ship",
       "kind": "method",
+      "visibility": "public",
       "parent": "InventoryItem",
       "line_start": 31,
       "line_end": 32
@@ -33,6 +37,7 @@
       "name": "Warehouse",
       "qualified": "Warehouse",
       "kind": "class",
+      "visibility": "public",
       "line_start": 19,
       "line_end": 24
     },
@@ -40,6 +45,7 @@
       "name": "dispatch",
       "qualified": "Warehouse.dispatch",
       "kind": "method",
+      "visibility": "public",
       "parent": "Warehouse",
       "line_start": 23,
       "line_end": 24

--- a/internal/scan/dispatch.go
+++ b/internal/scan/dispatch.go
@@ -195,6 +195,57 @@ func writeTSDefaultExports(ctx context.Context, idx *sqlite.Adapter, collected m
 	return writeNameSet(ctx, idx, tsDefaultExportsMetaKey, collected)
 }
 
+// pythonDecoratedMetaKey is the sense_meta key holding the project-wide set of
+// Python function/method/class names carrying any decorator. The dead-code
+// Python voice reads it: a decorator changes the call story (an attribute access,
+// an injected fixture, a CLI entry), so a decorated symbol stays open-world
+// (py_decorator) rather than earning `dead`. Flat, not per-language — Python-only.
+const pythonDecoratedMetaKey = "py_decorated"
+
+// writePythonDecorated persists the project-wide Python decorated-name set,
+// unioning with the existing set (same self-heals-on-rebuild rationale as above).
+func writePythonDecorated(ctx context.Context, idx *sqlite.Adapter, collected map[string]struct{}) error {
+	return writeNameSet(ctx, idx, pythonDecoratedMetaKey, collected)
+}
+
+// pythonRoutesMetaKey is the sense_meta key holding the project-wide set of
+// Python handler names carrying a route decorator (Flask `@app.route`, FastAPI
+// `@app.get`/`@router.post`). The Python voice reads it (py_route) so a
+// framework-dispatched handler stays open-world rather than earning `dead`.
+const pythonRoutesMetaKey = "py_routes"
+
+// writePythonRoutes persists the project-wide Python route-handler set, unioning
+// with the existing set (same self-heals-on-rebuild rationale as above).
+func writePythonRoutes(ctx context.Context, idx *sqlite.Adapter, collected map[string]struct{}) error {
+	return writeNameSet(ctx, idx, pythonRoutesMetaKey, collected)
+}
+
+// pythonDjangoMetaKey is the sense_meta key holding the project-wide set of
+// Python names carrying a Django-dispatch decorator (`@receiver` signal handler,
+// `@admin.register`). The Python voice reads it (py_django) so a symbol Django's
+// signal/admin machinery invokes invisibly stays open-world.
+const pythonDjangoMetaKey = "py_django"
+
+// writePythonDjango persists the project-wide Python Django-dispatch set, unioning
+// with the existing set (same self-heals-on-rebuild rationale as above).
+func writePythonDjango(ctx context.Context, idx *sqlite.Adapter, collected map[string]struct{}) error {
+	return writeNameSet(ctx, idx, pythonDjangoMetaKey, collected)
+}
+
+// pythonAllExportsMetaKey is the sense_meta key holding the project-wide set of
+// names Python modules declare public via `__all__`. The Python voice reads it
+// (py_all_export): such a name is re-exported by `from mod import *`, so it stays
+// open-world even when underscore-private — the one case overriding the
+// underscore convention, which the identifier mention set misses (`__all__` lists
+// names as string literals).
+const pythonAllExportsMetaKey = "py_all_exports"
+
+// writePythonAllExports persists the project-wide Python `__all__` set, unioning
+// with the existing set (same self-heals-on-rebuild rationale as above).
+func writePythonAllExports(ctx context.Context, idx *sqlite.Adapter, collected map[string]struct{}) error {
+	return writeNameSet(ctx, idx, pythonAllExportsMetaKey, collected)
+}
+
 // addNamesByLang unions names into byLang[lang], creating the language's set on
 // first use. Both per-language name accumulators (dispatch, mention) share it so
 // the handler keeps each language's names apart for per-language meta writes.

--- a/internal/scan/dispatch_test.go
+++ b/internal/scan/dispatch_test.go
@@ -217,11 +217,12 @@ func TestDispatchNamesAdapterErrors(t *testing.T) {
 }
 
 // TestScanWritesHarvestedLangs proves the harvested-langs capability gate
-// end to end: Ruby and Go files mark their languages harvested (both extractors
-// are MentionHarvesters), while a Python file in the same scan does NOT mark
-// `python` — Python harvests no mentions, so its symbols must fail closed rather
-// than earn `dead` off an absent set. This is what lets HarvestedLangs diverge
-// from the mention keyset for a real, non-harvesting language.
+// end to end: Ruby, Go, and Python files mark their languages harvested (all
+// three extractors are MentionHarvesters), while a Java file in the same scan
+// does NOT mark `java` — the generic-spec Java extractor harvests no mentions, so
+// its symbols must fail closed rather than earn `dead` off an absent set. This is
+// what lets HarvestedLangs diverge from the mention keyset for a real,
+// non-harvesting language.
 func TestScanWritesHarvestedLangs(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()
@@ -239,6 +240,10 @@ func TestScanWritesHarvestedLangs(t *testing.T) {
 		[]byte("def helper():\n    pass\n"), 0o644); err != nil {
 		t.Fatalf("write python: %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(root, "Thing.java"),
+		[]byte("class Thing {\n  void go() {}\n}\n"), 0o644); err != nil {
+		t.Fatalf("write java: %v", err)
+	}
 
 	if _, err := Run(ctx, Options{Root: root, Sense: senseDir, Output: &bytes.Buffer{}, Warnings: io.Discard}); err != nil {
 		t.Fatalf("scan.Run: %v", err)
@@ -254,13 +259,13 @@ func TestScanWritesHarvestedLangs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read harvested_langs: %v", err)
 	}
-	for _, lang := range []string{"ruby", "go"} {
+	for _, lang := range []string{"ruby", "go", "python"} {
 		if _, ok := got[lang]; !ok {
 			t.Errorf("expected %s in harvested_langs, got %v", lang, got)
 		}
 	}
-	if _, ok := got["python"]; ok {
-		t.Errorf("python harvests no mentions; must be absent from harvested_langs, got %v", got)
+	if _, ok := got["java"]; ok {
+		t.Errorf("java (generic-spec extractor) harvests no mentions; must be absent from harvested_langs, got %v", got)
 	}
 }
 
@@ -549,5 +554,80 @@ func TestScanWritesDispatchNames(t *testing.T) {
 	}
 	if _, ok := got["hidden_handler"]; !ok {
 		t.Errorf("expected 'hidden_handler' in dispatch_names:ruby meta, got %v", got)
+	}
+}
+
+// TestScanWritesPythonHarvest proves the Python dead-code harvest flows end to
+// end: a Python file with a route decorator, a generic decorator, a `@receiver`
+// signal handler, and an `__all__` export lands each name in its flat sense_meta
+// key, where the dead-code Python voice reads them to keep the symbols
+// open-world. It also confirms python is recorded as a mention-harvesting
+// language.
+func TestScanWritesPythonHarvest(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	senseDir := filepath.Join(root, ".sense")
+
+	src := `__all__ = ["_exported"]
+
+
+@app.route("/health")
+def health():
+    return "ok"
+
+
+@property
+def label(self):
+    return self._owner
+
+
+@receiver(post_save)
+def on_save(sender, **kwargs):
+    return None
+
+
+def _exported():
+    return 1
+`
+	if err := os.WriteFile(filepath.Join(root, "app.py"), []byte(src), 0o644); err != nil {
+		t.Fatalf("write python: %v", err)
+	}
+
+	if _, err := Run(ctx, Options{Root: root, Sense: senseDir, Output: &bytes.Buffer{}, Warnings: io.Discard}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+
+	a, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatalf("open index: %v", err)
+	}
+	t.Cleanup(func() { _ = a.Close() })
+
+	cases := []struct {
+		key  string
+		want string
+	}{
+		{pythonRoutesMetaKey, "health"},
+		{pythonDecoratedMetaKey, "label"},
+		{pythonDjangoMetaKey, "on_save"},
+		{pythonAllExportsMetaKey, "_exported"},
+	}
+	for _, c := range cases {
+		got, err := readNameSet(ctx, a, c.key)
+		if err != nil {
+			t.Fatalf("read %s: %v", c.key, err)
+		}
+		if _, ok := got[c.want]; !ok {
+			t.Errorf("expected %q in %s, got %v", c.want, c.key, got)
+		}
+	}
+
+	// Route and Django handlers are also in the generic decorated set (a name can
+	// be in several sets; the voice reads the most specific).
+	decorated, _ := readNameSet(ctx, a, pythonDecoratedMetaKey)
+	for _, name := range []string{"health", "on_save"} {
+		if _, ok := decorated[name]; !ok {
+			t.Errorf("expected %q in %s (superset), got %v", name, pythonDecoratedMetaKey, decorated)
+		}
 	}
 }

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -240,6 +240,10 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	warnMetaWrite(warn, "rust-allow-dead", writeRustAllowDead(ctx, idx, h.rustAllowDead))
 	warnMetaWrite(warn, "ts-decorated", writeTSDecorated(ctx, idx, h.tsDecorated))
 	warnMetaWrite(warn, "ts-default-exports", writeTSDefaultExports(ctx, idx, h.tsDefaultExports))
+	warnMetaWrite(warn, "py-decorated", writePythonDecorated(ctx, idx, h.pyDecorated))
+	warnMetaWrite(warn, "py-routes", writePythonRoutes(ctx, idx, h.pyRoutes))
+	warnMetaWrite(warn, "py-django", writePythonDjango(ctx, idx, h.pyDjango))
+	warnMetaWrite(warn, "py-all-exports", writePythonAllExports(ctx, idx, h.pyAllExports))
 	// A pre-feature index carried single bare union keys (no language suffix).
 	// The per-language reader globs `*:<lang>` and ignores them, but delete them
 	// on every full scan so an in-place upgrade leaves no stale meta to mislead a
@@ -562,6 +566,17 @@ type harness struct {
 	tsDecorated      map[string]struct{}
 	tsDefaultExports map[string]struct{}
 
+	// pyDecorated / pyRoutes / pyDjango are the Python decorator-reach sets
+	// (any decorator; the route-decorator subset; the Django-dispatch subset),
+	// and pyAllExports is the set of names modules declare public via `__all__`.
+	// All four are written to flat sense_meta keys so the dead-code Python voice
+	// keeps a decorated / routed / Django-dispatched / declared-public symbol
+	// open-world (py_decorator / py_route / py_django / py_all_export).
+	pyDecorated  map[string]struct{}
+	pyRoutes     map[string]struct{}
+	pyDjango     map[string]struct{}
+	pyAllExports map[string]struct{}
+
 	// harvestedLangs is the set of languages whose mention harvest RAN this
 	// scan — every indexed file whose extractor is an extract.MentionHarvester
 	// marks its language here, regardless of how many names it produced. Written
@@ -844,6 +859,38 @@ func (h *harness) walkTree(root string) error {
 				h.tsDefaultExports[n] = struct{}{}
 			}
 		}
+		if len(fr.PyDecorated) > 0 {
+			if h.pyDecorated == nil {
+				h.pyDecorated = map[string]struct{}{}
+			}
+			for _, n := range fr.PyDecorated {
+				h.pyDecorated[n] = struct{}{}
+			}
+		}
+		if len(fr.PyRoutes) > 0 {
+			if h.pyRoutes == nil {
+				h.pyRoutes = map[string]struct{}{}
+			}
+			for _, n := range fr.PyRoutes {
+				h.pyRoutes[n] = struct{}{}
+			}
+		}
+		if len(fr.PyDjango) > 0 {
+			if h.pyDjango == nil {
+				h.pyDjango = map[string]struct{}{}
+			}
+			for _, n := range fr.PyDjango {
+				h.pyDjango[n] = struct{}{}
+			}
+		}
+		if len(fr.PyAllExports) > 0 {
+			if h.pyAllExports == nil {
+				h.pyAllExports = map[string]struct{}{}
+			}
+			for _, n := range fr.PyAllExports {
+				h.pyAllExports[n] = struct{}{}
+			}
+		}
 
 		batch = append(batch, fr)
 		if len(batch) >= batchSize {
@@ -911,14 +958,14 @@ func (h *harness) flushBatch(batch []*fileResult) error {
 // fileResult holds the output of parseFile — everything needed to
 // persist a file's symbols and edges without re-reading or re-parsing.
 type fileResult struct {
-	Rel            string
-	Language       string
-	Source         []byte
-	Hash           string
-	Symbols         []extract.EmittedSymbol
-	Edges           []extract.EmittedEdge
-	DispatchNames   []string
-	MentionedNames  []string
+	Rel              string
+	Language         string
+	Source           []byte
+	Hash             string
+	Symbols          []extract.EmittedSymbol
+	Edges            []extract.EmittedEdge
+	DispatchNames    []string
+	MentionedNames   []string
 	CgoExports       []string
 	RustExports      []string
 	RustTestSymbols  []string
@@ -926,6 +973,10 @@ type fileResult struct {
 	RustAllowDead    []string
 	TSDecorated      []string
 	TSDefaultExports []string
+	PyDecorated      []string
+	PyRoutes         []string
+	PyDjango         []string
+	PyAllExports     []string
 }
 
 // 100 files per SQLite transaction amortizes BEGIN/COMMIT overhead (~10x
@@ -1035,14 +1086,14 @@ func parseFileCore(po parseOpts, path, rel string, skip func(hash string) bool) 
 	})
 
 	return &fileResult{
-		Rel:            rel,
-		Language:       ex.Language(),
-		Source:         source,
-		Hash:           newHash,
-		Symbols:         collected.symbols,
-		Edges:           collected.edges,
-		DispatchNames:   collected.dispatchNames,
-		MentionedNames:  collected.mentionedNames,
+		Rel:              rel,
+		Language:         ex.Language(),
+		Source:           source,
+		Hash:             newHash,
+		Symbols:          collected.symbols,
+		Edges:            collected.edges,
+		DispatchNames:    collected.dispatchNames,
+		MentionedNames:   collected.mentionedNames,
 		CgoExports:       collected.cgoExports,
 		RustExports:      collected.rustExports,
 		RustTestSymbols:  collected.rustTestSymbols,
@@ -1050,6 +1101,10 @@ func parseFileCore(po parseOpts, path, rel string, skip func(hash string) bool) 
 		RustAllowDead:    collected.rustAllowDead,
 		TSDecorated:      collected.tsDecorated,
 		TSDefaultExports: collected.tsDefaultExports,
+		PyDecorated:      collected.pyDecorated,
+		PyRoutes:         collected.pyRoutes,
+		PyDjango:         collected.pyDjango,
+		PyAllExports:     collected.pyAllExports,
 	}
 }
 
@@ -1379,10 +1434,10 @@ func safeExtractRaw(ex extract.RawExtractor, source []byte, rel string, c *colle
 // ---- collector (per-file Emitter) ----
 
 type collector struct {
-	symbols         []extract.EmittedSymbol
-	edges           []extract.EmittedEdge
-	dispatchNames   []string
-	mentionedNames  []string
+	symbols          []extract.EmittedSymbol
+	edges            []extract.EmittedEdge
+	dispatchNames    []string
+	mentionedNames   []string
 	cgoExports       []string
 	rustExports      []string
 	rustTestSymbols  []string
@@ -1390,6 +1445,10 @@ type collector struct {
 	rustAllowDead    []string
 	tsDecorated      []string
 	tsDefaultExports []string
+	pyDecorated      []string
+	pyRoutes         []string
+	pyDjango         []string
+	pyAllExports     []string
 }
 
 func (c *collector) Symbol(s extract.EmittedSymbol) error {
@@ -1480,6 +1539,42 @@ func (c *collector) TSDecoratedName(name string) error {
 // ts_default_export reason rather than the generic ts_exported.
 func (c *collector) TSDefaultExportName(name string) error {
 	c.tsDefaultExports = append(c.tsDefaultExports, name)
+	return nil
+}
+
+// PythonDecoratedName implements extract.PythonHarvestEmitter: an extractor
+// streams every decorated Python function/method/class. The project-wide set
+// feeds the dead-code Python voice so a decorator-dispatched symbol stays
+// open-world (py_decorator) instead of being falsely called dead.
+func (c *collector) PythonDecoratedName(name string) error {
+	c.pyDecorated = append(c.pyDecorated, name)
+	return nil
+}
+
+// PythonRouteName implements extract.PythonHarvestEmitter: an extractor streams
+// every handler carrying a route decorator (Flask/FastAPI). The project-wide set
+// feeds the Python voice so a framework-routed handler stays open-world
+// (py_route) instead of being falsely called dead.
+func (c *collector) PythonRouteName(name string) error {
+	c.pyRoutes = append(c.pyRoutes, name)
+	return nil
+}
+
+// PythonDjangoName implements extract.PythonHarvestEmitter: an extractor streams
+// every symbol carrying a Django-dispatch decorator (`@receiver`,
+// `@admin.register`). The project-wide set feeds the Python voice so a
+// signal/admin-dispatched symbol stays open-world (py_django).
+func (c *collector) PythonDjangoName(name string) error {
+	c.pyDjango = append(c.pyDjango, name)
+	return nil
+}
+
+// PythonAllExportName implements extract.PythonHarvestEmitter: an extractor
+// streams every name a module declares public via `__all__`. The project-wide set
+// feeds the Python voice so a declared-public name stays open-world
+// (py_all_export) even when underscore-private.
+func (c *collector) PythonAllExportName(name string) error {
+	c.pyAllExports = append(c.pyAllExports, name)
 	return nil
 }
 

--- a/testdata/smoke/dead-golden.json
+++ b/testdata/smoke/dead-golden.json
@@ -1,6 +1,20 @@
 {
   "findings": [
     {
+      "qualified": "Account.__repr__",
+      "kind": "method",
+      "file": "payments.py",
+      "verdict": "possibly_dead",
+      "reason": "py_dunder"
+    },
+    {
+      "qualified": "Account.label",
+      "kind": "method",
+      "file": "payments.py",
+      "verdict": "possibly_dead",
+      "reason": "py_decorator"
+    },
+    {
       "qualified": "Badge",
       "kind": "function",
       "file": "badge.tsx",
@@ -77,6 +91,19 @@
       "reason": "core_exported_api"
     },
     {
+      "qualified": "_mentioned_private",
+      "kind": "function",
+      "file": "payments.py",
+      "verdict": "possibly_dead",
+      "reason": "core_name_mentioned"
+    },
+    {
+      "qualified": "_orphaned_helper",
+      "kind": "function",
+      "file": "payments.py",
+      "verdict": "dead"
+    },
+    {
       "qualified": "configureTokens",
       "kind": "function",
       "file": "token_store.ts",
@@ -91,9 +118,23 @@
       "reason": "core_exported_api"
     },
     {
+      "qualified": "health_check",
+      "kind": "function",
+      "file": "payments.py",
+      "verdict": "possibly_dead",
+      "reason": "py_route"
+    },
+    {
       "qualified": "legacyEntry",
       "kind": "function",
       "file": "legacy.js",
+      "verdict": "possibly_dead",
+      "reason": "core_exported_api"
+    },
+    {
+      "qualified": "make_account",
+      "kind": "function",
+      "file": "payments.py",
       "verdict": "possibly_dead",
       "reason": "core_exported_api"
     },
@@ -115,6 +156,20 @@
       "kind": "function",
       "file": "wallet.rs",
       "verdict": "dead"
+    },
+    {
+      "qualified": "public_handler",
+      "kind": "function",
+      "file": "payments.py",
+      "verdict": "possibly_dead",
+      "reason": "core_exported_api"
+    },
+    {
+      "qualified": "registry",
+      "kind": "function",
+      "file": "payments.py",
+      "verdict": "possibly_dead",
+      "reason": "core_exported_api"
     },
     {
       "qualified": "smoke.BaseService.Log",
@@ -165,7 +220,7 @@
       "verdict": "dead"
     }
   ],
-  "total_symbols": 50,
-  "dead_count": 4,
-  "possibly_dead_count": 20
+  "total_symbols": 61,
+  "dead_count": 5,
+  "possibly_dead_count": 27
 }

--- a/testdata/smoke/payments.py
+++ b/testdata/smoke/payments.py
@@ -1,0 +1,60 @@
+"""Python smoke fixture for the dead-code arbiter's two-sided gate.
+
+It pins the one shape that EARNS `dead` (an underscore-private, unmentioned,
+non-dunder, non-decorated function) against the shapes that must stay
+`possibly_dead`: a dunder, a decorated method, a route handler, a public symbol,
+and an underscore-private name kept open by the mention gate.
+"""
+
+
+def _orphaned_helper():
+    # Underscore-private, zero callers, mentioned nowhere, no dunder/decorator
+    # idiom — the single earned `dead`.
+    return 1
+
+
+def _used_private(payload):
+    # Underscore-private but CALLED by public_handler, so it carries an incoming
+    # edge and is never a candidate (proves the underscore alone earns nothing).
+    return payload * 2
+
+
+def public_handler(payload):
+    return _used_private(payload)
+
+
+def registry():
+    # _mentioned_private appears here as a value (not a call), leaving a textual
+    # mention but no resolved edge — so the mention gate keeps it open-world
+    # (core_name_mentioned), proving soundness rests on the gate, not the underscore.
+    return {"handler": _mentioned_private}
+
+
+def _mentioned_private():
+    return 2
+
+
+@app.route("/health")
+def health_check():
+    # Route handler dispatched by the framework's router with no source caller.
+    return "ok"
+
+
+class Account:
+    def __init__(self, owner):
+        # Dunder: invoked by the interpreter on construction, never by a caller.
+        self.owner = owner
+
+    def __repr__(self):
+        # Dunder: invoked by the interpreter (repr/print), never by a caller.
+        return self.owner
+
+    @property
+    def label(self):
+        # Decorated: @property turns this into an attribute access.
+        return self.owner
+
+
+def make_account(owner):
+    # Keeps Account referenced (alive) so its methods are judged individually.
+    return Account(owner)


### PR DESCRIPTION
## Problem

Every Python symbol with no resolved caller was reported as `core_no_language_voice` — a single, uninformative "Sense can't reason about this stack" bucket. Python is a top-tier language for Sense, and an agent deserves precise, actionable reasons (and a sound `dead` verdict where one is provable) the way Ruby, Go, Rust, and TS/JS already get.

## Summary

Python is now the fifth language whose symbols can earn the `dead` verdict. An underscore-visibility pass plus a per-language harvest feed a new `pythonVoice` that earns `dead` only for an underscore-private function/method with no caller, no mention, and no invisible-reach idiom — and raises precise hand-raise reasons for everything else.

## Changes

- **extract**: `Symbol.Visibility` populated for Python (leading-underscore non-dunder → `private`); a harvest streams the mention set, the getattr/setattr/hasattr dispatch set, the decorator/route/Django reach sets, and the `__all__` export set via a new `PythonHarvestEmitter`.
- **scan**: the four Python reach sets are aggregated and persisted to flat `sense_meta` keys (`py_decorated`, `py_routes`, `py_django`, `py_all_exports`).
- **dead**: `pythonVoice` registered in the arbiter with reasons `py_dunder`, `py_route`, `py_django`, `py_decorator`, `py_all_export`, `py_public`, `py_class`, `py_constant`. Only underscore-private functions/methods fall through to `dead`.
- **tests**: a smoke fixture proving the two-sided gate end to end, a hand-labeled eval corpus with a 100%-precision binding gate, and a planted-false-dead self-test on a live signal receiver.

## Architecture Highlights

- Mirrors the Ruby decision: every public (non-underscore) symbol stays `possibly_dead` (duck-typed dispatch), so the eligible-for-`dead` set is small and intentionally private. The arbiter's broad mention gate is the soundness backstop — the `dead` tier never rests on the underscore alone.
- Dunders are matched by the `__x__` pattern rather than a fixed table, so the whole protocol surface (incl. PEP 562 module `__getattr__`, dataclass `__post_init__`) is covered without a table to maintain.
- Framework reach sets are project-wide and name-based — sound over-approximation, identical to the existing dispatch / TS-decorator sets.

## Test Plan

- [x] `go test ./...` passes
- [x] sense binary builds cleanly
- [x] Synthetic corpus: dead-precision == 100%, zero false `dead`; planted-false-dead self-test fails the gate as expected
- [x] Smoke golden pins the two-sided gate (one earned `dead`; `py_dunder` / `py_decorator` / `py_route` / `core_name_mentioned` hand-raises)
- [x] flask benchmark before/after: `0 → 1` `dead` (verified genuinely unused), zero false `dead`