### PR TITLE
feat(dead): langspec dead-code voice — reasons for seven, dead for Java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ All notable changes to Sense.
 
 ### Added
 
+- The Standard-tier (`langspec`) languages — Java, Kotlin, C#, Scala, C++, PHP,
+  C — now carry `Symbol.Visibility` and get specific dead-code reasons instead of
+  the blanket `core_no_language_voice`. The table-driven walker gained three
+  per-grammar fields: `VisibilityFn` maps each grammar's access modifiers to a
+  visibility (Java package-private default → `package`, C# member default →
+  `private`, C `static` → file-local, C++ from the positional `public:`/`private:`
+  section), which makes the core library-API gate fire for these languages;
+  `AnnotationKinds` harvests every annotated/attributed symbol (`@Service`,
+  `[Fact]`, `#[Route]`) to the `langspec_annotated` set; `MentionKinds` opts a
+  grammar into the soundness mention harvest. The new `langspecVoice`
+  (`internal/dead/voice_langspec.go`, registered once per language) raises
+  `ls_annotated` (framework-dispatched), `ls_interface_method` (reached through an
+  implementor), `ls_public_no_framework` (a public symbol a Spring/JPA/JUnit/ASP.NET
+  path may reach — Sense models no framework here), `ls_reflective_type` (a
+  reflectively-loadable class/type/constant), `ls_dynamic` (a private PHP callable;
+  reflection is pervasive), and `ls_unvalidated` (a private callable in a static
+  language with no benchmark to validate a `dead` tier). **Java is the sixth
+  language to earn `dead`**, and only narrowly: an explicitly `private`
+  (class-local) callable that is unreferenced, non-annotated, not an interface
+  method, and absent from Java's mention set. Validated on the `javalin` benchmark
+  (313 symbols, 28 unreferenced, **zero false `dead`** — every unreferenced symbol
+  is public/annotated/interface and correctly held `possibly_dead`) plus a
+  two-sided synthetic control. The other six ship reasons-only: PHP is fixed
+  (reflection-pervasive), and Kotlin/C#/Scala/C++/C have no benchmark repo, so they
+  fail closed (`ls_unvalidated`) until one exists — only Java wires `MentionKinds`
+  and harvests mentions.
+
 - Python is the fifth language whose symbols can earn the `dead` verdict, and
   `Symbol.Visibility` is now populated for Python. An underscore pre-pass
   (`internal/extract/python/visibility.go`) marks each symbol `private` (a

--- a/internal/dead/arbiter.go
+++ b/internal/dead/arbiter.go
@@ -166,6 +166,15 @@ type Facts struct {
 	// misses because `__all__` lists names as string literals. Populated from the
 	// py_all_exports sense_meta key.
 	PythonAllExportNames map[string]struct{}
+	// LangspecAnnotatedNames is the set of langspec (Java/Kotlin/C#/Scala/C++/PHP/C)
+	// class/method/function names carrying any annotation or attribute (Java
+	// `@Service`/`@Test`, C# `[Fact]`/`[HttpGet]`, Kotlin/Scala annotations, PHP
+	// `#[Route]`). The langspec voice keeps such a name open-world (ls_annotated):
+	// with no per-framework voice for these languages, a DI container, test runner,
+	// or router may dispatch any annotated symbol with no source caller. Flat, not
+	// per-language — annotations span the shared table-driven extractor. Populated
+	// from the langspec_annotated sense_meta key.
+	LangspecAnnotatedNames map[string]struct{}
 	// HarvestedLangs is the set of languages whose mention harvest actually ran
 	// for this index. The soundness gate refuses `dead` for a symbol whose
 	// language is absent here (reason core_no_harvest): a missing harvest cannot

--- a/internal/dead/dead.go
+++ b/internal/dead/dead.go
@@ -132,15 +132,22 @@ func FindDead(ctx context.Context, db *sql.DB, opts Options) (Result, error) {
 }
 
 // defaultArbiter is the registered voice stack for this build: the generic core
-// voice plus the Ruby, Rails, Go, Rust, TypeScript/JavaScript, and Python
-// language voices. The TS voice is registered once per language string the shared
-// extractor emits ("typescript", "tsx", "javascript") so each is a language for
-// which closed-world can be proven. Adding a language voice is a one-line change
-// here once it exists.
+// voice plus the Ruby, Rails, Go, Rust, TypeScript/JavaScript, Python, and
+// langspec (Standard-tier) language voices. The TS and langspec voices are each
+// registered once per language string the shared extractor emits so each is a
+// language for which closed-world can be proven. Adding a language voice is a
+// one-line change here once it exists.
 func defaultArbiter() *Arbiter {
 	return NewArbiter(coreVoice{}, rubyVoice{}, railsVoice{}, goVoice{}, rustVoice{},
 		tsVoice{lang: "typescript"}, tsVoice{lang: "tsx"}, tsVoice{lang: "javascript"},
-		pythonVoice{})
+		pythonVoice{},
+		// One langspec voice per Standard-tier language the table-driven extractor
+		// emits. Each marks its language one Sense can prove closed-world for, but
+		// only langspecDeadEligible languages let a symbol actually fall through to
+		// `dead` (see voice_langspec.go); the rest ship reasons-only.
+		langspecVoice{lang: "java"}, langspecVoice{lang: "kotlin"}, langspecVoice{lang: "csharp"},
+		langspecVoice{lang: "scala"}, langspecVoice{lang: "cpp"}, langspecVoice{lang: "php"},
+		langspecVoice{lang: "c"})
 }
 
 // buildFacts gathers the project-wide index facts the voices consume. It is
@@ -196,6 +203,7 @@ func buildFacts(ctx context.Context, db *sql.DB) (Facts, error) {
 		PythonRouteNames:         readPythonRouteNames(ctx, db),
 		PythonDjangoNames:        readPythonDjangoNames(ctx, db),
 		PythonAllExportNames:     readPythonAllExportNames(ctx, db),
+		LangspecAnnotatedNames:   readLangspecAnnotatedNames(ctx, db),
 		ValueObjectClassIDs:      valueObjectClassIDs,
 		IncludedModuleIDs:        includedModuleIDs,
 		ControllerConcernIDs:     controllerConcernIDs,
@@ -911,6 +919,15 @@ func readPythonDjangoNames(ctx context.Context, db *sql.DB) map[string]struct{} 
 // or corrupt key yields an empty set.
 func readPythonAllExportNames(ctx context.Context, db *sql.DB) map[string]struct{} {
 	return readStringSetMeta(ctx, db, "py_all_exports")
+}
+
+// readLangspecAnnotatedNames returns the set of langspec (Java/Kotlin/C#/Scala/
+// C++/PHP/C) class/method/function names carrying an annotation or attribute,
+// persisted to the langspec_annotated sense_meta key. The langspec voice keeps
+// such a name open-world (ls_annotated). A missing or corrupt key yields an empty
+// set.
+func readLangspecAnnotatedNames(ctx context.Context, db *sql.DB) map[string]struct{} {
+	return readStringSetMeta(ctx, db, "langspec_annotated")
 }
 
 // readStringSetMeta reads a JSON string-array sense_meta value into a set,

--- a/internal/dead/reasons.go
+++ b/internal/dead/reasons.go
@@ -77,6 +77,16 @@ const (
 	ReasonPythonClass     = "py_class"
 	ReasonPythonConstant  = "py_constant"
 
+	// Langspec-voice reason codes (voice_langspec.go owns their catalog specs).
+	// Shared across the Standard-tier table-driven languages (Java, Kotlin, C#,
+	// Scala, C++, PHP, C), which have no per-framework voice.
+	ReasonLangspecInterfaceMethod   = "ls_interface_method"
+	ReasonLangspecAnnotated         = "ls_annotated"
+	ReasonLangspecPublicNoFramework = "ls_public_no_framework"
+	ReasonLangspecReflectiveType    = "ls_reflective_type"
+	ReasonLangspecDynamic           = "ls_dynamic"
+	ReasonLangspecUnvalidated       = "ls_unvalidated"
+
 	// Rust-voice reason codes (voice_rust.go owns their catalog specs).
 	ReasonRustTraitImpl = "rust_trait_impl"
 	ReasonRustDerive    = "rust_derive"

--- a/internal/dead/voice_langspec.go
+++ b/internal/dead/voice_langspec.go
@@ -1,0 +1,141 @@
+package dead
+
+// langspecVoice is the shared voice for the Standard-tier table-driven languages
+// (Java, Kotlin, C#, Scala, C++, PHP, C) that all run through the langspec
+// extractor. These languages have NO per-framework voice — Sense models no Spring
+// DI, no JPA, no ASP.NET, no Laravel — so the voice's whole job is to replace the
+// blanket core_no_language_voice fallback with specific, honest open-world reasons,
+// and to let only the narrowest, validated subset earn `dead`.
+//
+// One voice instance is registered per language string the extractor emits, so
+// Lang() scopes it and (per the arbiter) marks each language one Sense can prove
+// closed-world for. Like every voice it can only raise a hand (push →
+// possibly_dead); it never votes for `dead`.
+//
+// The crucial honesty move is ls_public_no_framework: with no framework
+// inference, ANY public symbol may be reached by a Spring bean, a JPA entity
+// method, a JUnit test, or an ASP.NET action that Sense cannot see, so every
+// public (or visibility-unknown) symbol stays open-world. Only an explicitly
+// file-local (private) callable is even a candidate, and then only for a language
+// in langspecDeadEligible — the statically-typed, visibility-enforcing subset
+// validated against a real-world repo (pitch 25-20). Everything else raises a
+// hand: ls_dynamic for the reflection-pervasive dynamic languages (PHP),
+// ls_unvalidated for a static language with no benchmark to validate its `dead`
+// tier yet.
+type langspecVoice struct{ lang string }
+
+// langspecDeadEligible names the langspec languages whose private (file-local)
+// callables may fall silent and so reach the arbiter's soundness gate — the only
+// path to `dead`. Treated as read-only after package init. It is deliberately
+// conservative: a language earns a place here
+// only after a real-world repo confirms zero false `dead` (the 25-13 trap is a
+// synthetic 1.00 that collapses to 0.22 on a real codebase). Java is validated
+// against the javalin benchmark; the other six langspec languages have no indexed
+// repo in the suite, so they ship reasons-only until one exists.
+var langspecDeadEligible = map[string]bool{
+	"java": true,
+}
+
+// langspecDynamic names the langspec languages whose privacy is not a sound
+// closed-world signal because reflection is pervasive: PHP reaches a private
+// method through call_user_func, the magic __call, or ReflectionMethod, none of
+// which leaves a static caller edge. Their private callables raise ls_dynamic
+// rather than falling silent, so PHP is fixed at reasons-only regardless of any
+// future benchmark.
+var langspecDynamic = map[string]bool{
+	"php": true,
+}
+
+func (v langspecVoice) Lang() string { return v.lang }
+
+// Inspect returns the most-specific (most-likely-live) reason a hidden caller
+// could exist for s, or nil when s is an explicitly file-local callable in a
+// dead-eligible language — the only shape that may fall through to the arbiter's
+// soundness gate and earn `dead`. Checks are ordered most-live-first so the
+// returned reason carries the most useful hint; the arbiter independently picks
+// the lowest-priority reason across voices.
+func (v langspecVoice) Inspect(s Symbol, f Facts) *Reason {
+	// Annotated / attributed: a DI container, test runner, or router dispatches it
+	// with no source caller (Java @Service/@Test, C# [Fact]/[HttpGet], Kotlin/Scala
+	// annotations, PHP #[Route]). True even for a file-local symbol, so it wins over
+	// the visibility gates below.
+	if _, ok := f.LangspecAnnotatedNames[s.Name]; ok {
+		return reasonPtr(ReasonLangspecAnnotated)
+	}
+	// Interface / abstract method: reached through any implementor, where the
+	// static graph shows no direct caller. Name-based, mirroring the Go voice.
+	if s.Kind == "method" {
+		if _, ok := f.InterfaceMethodNames[s.Name]; ok {
+			return reasonPtr(ReasonLangspecInterfaceMethod)
+		}
+	}
+	// Public (or visibility-unknown): with no framework voice, a framework may
+	// dispatch any public symbol invisibly. A library's public callable/type API is
+	// the core voice's concern (core_exported_api), matching the TS/Python voices.
+	if s.Visibility == "public" || s.Visibility == "" {
+		if f.IsLibrary && isPublicAPISymbol(s) {
+			return nil
+		}
+		return reasonPtr(ReasonLangspecPublicNoFramework)
+	}
+	// Non-public, explicit visibility. Only a callable may ever be `dead`; a
+	// non-callable (class / type / constant / module) is reachable by reflection
+	// (Class.forName, typeof, get_class, a metaclass/DI registry) with no direct
+	// reference, so it always raises a hand.
+	switch s.Kind {
+	case "function", "method":
+	default:
+		return reasonPtr(ReasonLangspecReflectiveType)
+	}
+	// protected / internal / package: reachable from a subclass, the same package,
+	// or the same assembly — not file-local, so never proven dead here.
+	if s.Visibility != "private" {
+		return reasonPtr(ReasonLangspecPublicNoFramework)
+	}
+	// Explicitly private (file-local) callable. The dead-tier decision is per
+	// language. A reflection-pervasive dynamic language never trusts privacy; a
+	// static language without a validated benchmark holds open-world until one
+	// exists; only a validated language falls silent so the soundness gate decides.
+	if langspecDynamic[v.lang] {
+		return reasonPtr(ReasonLangspecDynamic)
+	}
+	if !langspecDeadEligible[v.lang] {
+		return reasonPtr(ReasonLangspecUnvalidated)
+	}
+	return nil
+}
+
+func init() {
+	registerReasons(map[string]reasonSpec{
+		ReasonLangspecInterfaceMethod: {
+			priority: 30,
+			hint:     "interface/abstract method; an implementor is reached through the interface with no direct caller — confirm no implementor relies on it before removing",
+			verify:   "This method's name matches a method declared on an interface/abstract type, so it may satisfy that contract and be invoked through the interface with no direct caller. Check the implementors and the interface declaration before removing.",
+		},
+		ReasonLangspecAnnotated: {
+			priority: 30,
+			hint:     "annotated/attributed symbol (@Service/@Test/[Fact]/[HttpGet]/#[Route]); a DI container, test runner, or router may dispatch it with no source caller — do not remove without checking the framework wiring",
+			verify:   "This symbol carries an annotation/attribute. With no framework voice for this language, a DI container, test runner, ORM, or router may instantiate or invoke it by reflection with no source-level caller. Check what the annotation does and how the framework reaches it before removing.",
+		},
+		ReasonLangspecPublicNoFramework: {
+			priority: 55,
+			hint:     "public symbol with no caller in this repo; Sense models no framework for this language, so a Spring bean, JPA entity, JUnit test, or controller action may reach it — search callers and framework wiring before removing",
+			verify:   "Public symbols in this language can be reached by a framework Sense does not model (Spring DI, JPA, JUnit, ASP.NET, Laravel) or by an external consumer, with no source caller. For each, grep the repo for its name and check annotations/config wiring before removing.",
+		},
+		ReasonLangspecReflectiveType: {
+			priority: 45,
+			hint:     "class/type/constant with no static reference; it may be loaded reflectively (Class.forName / typeof / get_class) or by a DI/serialization registry — confirm before removing",
+			verify:   "Types and constants in these languages can be loaded by reflection (Class.forName, typeof, get_class) or registered by a DI/serialization framework with no direct reference. For each, grep the repo for its name as a string literal and bare reference before removing.",
+		},
+		ReasonLangspecDynamic: {
+			priority: 40,
+			hint:     "private symbol in a reflection-heavy language (PHP call_user_func / __call / ReflectionMethod); privacy is not a closed-world proof here — grep for the name before removing",
+			verify:   "PHP reaches even private methods through call_user_func, the magic __call, and ReflectionMethod, none of which leaves a static caller edge. Grep the repo for the name as a string literal and a `->name(` / `::name(` call before removing.",
+		},
+		ReasonLangspecUnvalidated: {
+			priority: 58,
+			hint:     "private symbol with no caller; Sense has no validated `dead` tier for this language yet (no benchmark repo), so it stays open-world — confirm it is unused before removing",
+			verify:   "This private symbol has no resolved caller and would be a strong removal candidate, but Sense has not validated a `dead` tier for this language against a real-world repo, so it holds it open-world. Grep the repo for the name and confirm no reflective/framework reach before removing.",
+		},
+	})
+}

--- a/internal/dead/voice_langspec_test.go
+++ b/internal/dead/voice_langspec_test.go
@@ -1,0 +1,189 @@
+package dead
+
+import "testing"
+
+func lsSym(name, kind, lang, visibility string) Symbol {
+	return Symbol{
+		Name:       name,
+		Qualified:  name,
+		Kind:       kind,
+		Language:   lang,
+		Visibility: visibility,
+		File:       "Thing." + lang,
+	}
+}
+
+func TestLangspecVoiceLang(t *testing.T) {
+	for _, lang := range []string{"java", "kotlin", "csharp", "scala", "cpp", "php", "c"} {
+		if got := (langspecVoice{lang: lang}).Lang(); got != lang {
+			t.Errorf("langspecVoice{%q}.Lang() = %q", lang, got)
+		}
+	}
+}
+
+func TestLangspecVoiceAnnotatedWins(t *testing.T) {
+	v := langspecVoice{lang: "java"}
+	f := Facts{LangspecAnnotatedNames: nameSet("handler")}
+	// Annotated beats every other gate, even for a private method that would
+	// otherwise fall silent in a dead-eligible language.
+	assertReason(t, v, lsSym("handler", "method", "java", "private"), f, ReasonLangspecAnnotated)
+	assertReason(t, v, lsSym("handler", "method", "java", "public"), f, ReasonLangspecAnnotated)
+}
+
+func TestLangspecVoiceInterfaceMethod(t *testing.T) {
+	v := langspecVoice{lang: "java"}
+	f := Facts{InterfaceMethodNames: nameSet("execute")}
+	// A method whose name matches an interface method is reachable through any
+	// implementor — even when explicitly private.
+	assertReason(t, v, lsSym("execute", "method", "java", "private"), f, ReasonLangspecInterfaceMethod)
+	// The interface gate is method-only: a same-named field/constant is not it.
+	assertReason(t, v, lsSym("execute", "constant", "java", "public"), f, ReasonLangspecPublicNoFramework)
+}
+
+func TestLangspecVoicePublicNoFramework(t *testing.T) {
+	v := langspecVoice{lang: "java"}
+	// A public application symbol stays open-world: a framework Sense does not
+	// model may dispatch it.
+	assertReason(t, v, lsSym("Service", "class", "java", "public"), Facts{}, ReasonLangspecPublicNoFramework)
+	assertReason(t, v, lsSym("run", "method", "java", "public"), Facts{}, ReasonLangspecPublicNoFramework)
+	// Visibility-unknown ("") is treated as public — the safe direction.
+	assertReason(t, v, lsSym("legacy", "method", "java", ""), Facts{}, ReasonLangspecPublicNoFramework)
+}
+
+func TestLangspecVoiceLibraryPublicDefersToCoreVoice(t *testing.T) {
+	v := langspecVoice{lang: "java"}
+	f := Facts{IsLibrary: true}
+	// A library's public callable/type API is the core voice's concern
+	// (core_exported_api), so the langspec voice stays silent and lets it win.
+	assertReason(t, v, lsSym("PublicApi", "class", "java", "public"), f, "")
+	assertReason(t, v, lsSym("doThing", "method", "java", "public"), f, "")
+}
+
+func TestLangspecVoiceReflectiveType(t *testing.T) {
+	v := langspecVoice{lang: "java"}
+	// A non-callable with explicit non-public visibility is still reflectively
+	// loadable (Class.forName / DI registry), so it never earns `dead`.
+	assertReason(t, v, lsSym("Inner", "class", "java", "private"), Facts{}, ReasonLangspecReflectiveType)
+	assertReason(t, v, lsSym("Helper", "type", "java", "private"), Facts{}, ReasonLangspecReflectiveType)
+	assertReason(t, v, lsSym("MAX", "constant", "java", "private"), Facts{}, ReasonLangspecReflectiveType)
+}
+
+func TestLangspecVoiceNonFileLocalCallable(t *testing.T) {
+	v := langspecVoice{lang: "java"}
+	// protected / internal / package callables are reachable from a subclass, the
+	// same package, or the same assembly — not file-local, so they raise a hand.
+	for _, vis := range []string{"protected", "internal", "package"} {
+		assertReason(t, v, lsSym("m", "method", "java", vis), Facts{}, ReasonLangspecPublicNoFramework)
+	}
+}
+
+func TestLangspecVoicePHPPrivateIsDynamic(t *testing.T) {
+	v := langspecVoice{lang: "php"}
+	// PHP reflection (call_user_func / __call / ReflectionMethod) reaches private
+	// methods, so privacy is not a closed-world proof — never silent.
+	assertReason(t, v, lsSym("helper", "method", "php", "private"), Facts{}, ReasonLangspecDynamic)
+	assertReason(t, v, lsSym("util", "function", "php", "private"), Facts{}, ReasonLangspecDynamic)
+}
+
+func TestLangspecVoiceUnvalidatedStaticPrivate(t *testing.T) {
+	// A statically-typed langspec language with no benchmark repo holds its
+	// private callables open-world (ls_unvalidated) until a `dead` tier is validated.
+	for _, lang := range []string{"kotlin", "csharp", "scala", "cpp", "c"} {
+		v := langspecVoice{lang: lang}
+		assertReason(t, v, lsSym("priv", "method", lang, "private"), Facts{}, ReasonLangspecUnvalidated)
+		assertReason(t, v, lsSym("priv", "function", lang, "private"), Facts{}, ReasonLangspecUnvalidated)
+	}
+}
+
+func TestLangspecVoiceJavaPrivateFallsSilent(t *testing.T) {
+	v := langspecVoice{lang: "java"}
+	// Java is the validated dead-eligible language: an explicitly private callable
+	// with no framework/interface/annotation hand falls silent, so the arbiter's
+	// soundness gate decides.
+	assertReason(t, v, lsSym("helper", "method", "java", "private"), Facts{}, "")
+	assertReason(t, v, lsSym("compute", "function", "java", "private"), Facts{}, "")
+}
+
+// TestLangspecArbiterTwoSided is the binding control (pitch 25-20): through the
+// real registered voice stack, a private, unmentioned, non-annotated Java method
+// earns `dead`, while annotated / public / interface-method / mentioned symbols
+// stay possibly_dead with their specific reasons — and a non-eligible langspec
+// language (C#) never earns `dead`. This pins the per-language decision validated
+// against the javalin benchmark (zero false `dead`) plus this synthetic positive.
+func TestLangspecArbiterTwoSided(t *testing.T) {
+	a := defaultArbiter()
+	f := Facts{
+		HarvestedLangs:         harvested("java"),
+		MentionedNames:         langNames("java", "usedName"),
+		LangspecAnnotatedNames: nameSet("handler"),
+		InterfaceMethodNames:   nameSet("execute"),
+	}
+	cands := []Symbol{
+		lsSym("deadHelper", "method", "java", "private"), // unmentioned, file-local → dead
+		lsSym("handler", "method", "java", "private"),    // annotated → ls_annotated
+		lsSym("publicApi", "method", "java", "public"),   // public → ls_public_no_framework
+		lsSym("execute", "method", "java", "private"),    // interface method → ls_interface_method
+		lsSym("usedName", "method", "java", "private"),   // mentioned → core_name_mentioned
+		lsSym("csPriv", "method", "csharp", "private"),   // not eligible → ls_unvalidated, never dead
+	}
+	got := a.Decide(cands, f)
+	want := []struct {
+		verdict Verdict
+		code    string // "" when dead (no reason)
+	}{
+		{VerdictDead, ""},
+		{VerdictPossiblyDead, ReasonLangspecAnnotated},
+		{VerdictPossiblyDead, ReasonLangspecPublicNoFramework},
+		{VerdictPossiblyDead, ReasonLangspecInterfaceMethod},
+		{VerdictPossiblyDead, ReasonNameMentioned},
+		{VerdictPossiblyDead, ReasonLangspecUnvalidated},
+	}
+	for i, w := range want {
+		if got[i].Verdict != w.verdict {
+			t.Errorf("%s: verdict = %q, want %q", cands[i].Name, got[i].Verdict, w.verdict)
+		}
+		if w.code == "" {
+			if got[i].Reason != nil {
+				t.Errorf("%s: dead must carry no reason, got %+v", cands[i].Name, got[i].Reason)
+			}
+			continue
+		}
+		if got[i].Reason == nil || got[i].Reason.Code != w.code {
+			t.Errorf("%s: reason = %+v, want %q", cands[i].Name, got[i].Reason, w.code)
+		}
+	}
+}
+
+// TestLangspecJavaNeedsHarvestToEarnDead proves the soundness precondition: the
+// same private, unmentioned Java method that earns `dead` when java harvested
+// falls closed to core_no_harvest when it did not — `dead` is never earned off an
+// absent mention set.
+func TestLangspecJavaNeedsHarvestToEarnDead(t *testing.T) {
+	a := defaultArbiter()
+	sym := lsSym("orphan", "method", "java", "private")
+	dead := a.Decide([]Symbol{sym}, Facts{HarvestedLangs: harvested("java"), MentionedNames: langNames("java", "other")})
+	if dead[0].Verdict != VerdictDead {
+		t.Fatalf("with harvest: got %q, want dead", dead[0].Verdict)
+	}
+	noHarvest := a.Decide([]Symbol{sym}, Facts{})
+	if noHarvest[0].Verdict != VerdictPossiblyDead || noHarvest[0].Reason.Code != ReasonNoHarvest {
+		t.Errorf("without harvest: got %q/%+v, want possibly_dead/core_no_harvest", noHarvest[0].Verdict, noHarvest[0].Reason)
+	}
+}
+
+func TestLangspecDeadEligibilityIsPerLanguage(t *testing.T) {
+	// The decision is recorded as data, pinned here: only Java is dead-eligible,
+	// PHP is fixed dynamic (reasons-only), and no other langspec language is
+	// eligible. This guards against silently widening the `dead` tier.
+	if !langspecDeadEligible["java"] {
+		t.Error("java must be dead-eligible (validated against javalin)")
+	}
+	for _, lang := range []string{"kotlin", "csharp", "scala", "cpp", "c", "php"} {
+		if langspecDeadEligible[lang] {
+			t.Errorf("%s must NOT be dead-eligible (no validated benchmark)", lang)
+		}
+	}
+	if !langspecDynamic["php"] {
+		t.Error("php must be fixed reasons-only (reflection-pervasive)")
+	}
+}

--- a/internal/extract/extractor.go
+++ b/internal/extract/extractor.go
@@ -377,6 +377,27 @@ type PythonHarvestEmitter interface {
 	PythonAllExportName(name string) error
 }
 
+// LangspecHarvestEmitter is an optional Emitter extension for streaming the
+// dead-code fact the table-driven langspec extractor produces for the
+// Standard-tier languages (Java, Kotlin, C#, Scala, C++, PHP, C):
+//
+//   - LangspecAnnotatedName: the name of a class/method/function carrying any
+//     annotation or attribute (Java `@Service`/`@Test`, C# `[Fact]`/`[HttpGet]`,
+//     Kotlin/Scala annotations, PHP `#[Route]`). These languages have no
+//     per-framework voice, so any annotated symbol may be dispatched by a DI
+//     container, a test runner, or a router with no source caller; the langspec
+//     voice keeps such a name open-world (ls_annotated).
+//
+// The name set feeds a flat (not per-language) sense_meta key — annotations span
+// the shared langspec extractor, like decorators span the .ts/.tsx/.js family.
+// Cross-language name overlap is the safe direction (it only ever raises a hand).
+// An extractor probes for this interface with a type assertion; an Emitter that
+// does not implement it simply receives no names. Returning an error aborts
+// extraction.
+type LangspecHarvestEmitter interface {
+	LangspecAnnotatedName(name string) error
+}
+
 // MentionHarvester marks an Extractor whose Extract streams the broad mention
 // set (via MentionEmitter) for every file it processes. The scan records such a
 // language as harvested even on a scan that yields zero mentions for it, so the

--- a/internal/extract/langspec/c.go
+++ b/internal/extract/langspec/c.go
@@ -19,5 +19,7 @@ func init() {
 		ImportTypes: []string{"preproc_include"},
 
 		NameField: "name",
+
+		VisibilityFn: cVisibility,
 	}))
 }

--- a/internal/extract/langspec/cpp.go
+++ b/internal/extract/langspec/cpp.go
@@ -21,5 +21,7 @@ func init() {
 		InheritKinds: []string{"base_class_clause"},
 
 		NameField: "name",
+
+		VisibilityFn: cppVisibility,
 	}))
 }

--- a/internal/extract/langspec/csharp.go
+++ b/internal/extract/langspec/csharp.go
@@ -21,5 +21,8 @@ func init() {
 		InheritKinds: []string{"base_list"},
 
 		NameField: "name",
+
+		VisibilityFn:    csharpVisibility,
+		AnnotationKinds: []string{"attribute_list"},
 	}))
 }

--- a/internal/extract/langspec/harvest_test.go
+++ b/internal/extract/langspec/harvest_test.go
@@ -1,0 +1,249 @@
+package langspec
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/luuuc/sense/internal/extract"
+)
+
+// harvestEmitter captures symbols plus the dead-code harvest streams (annotated
+// names, mentions) so a test can assert what the langspec extractor produces.
+type harvestEmitter struct {
+	symbols   []extract.EmittedSymbol
+	annotated []string
+	mentions  []string
+}
+
+func (e *harvestEmitter) Symbol(s extract.EmittedSymbol) error {
+	e.symbols = append(e.symbols, s)
+	return nil
+}
+func (e *harvestEmitter) Edge(extract.EmittedEdge) error { return nil }
+func (e *harvestEmitter) LangspecAnnotatedName(n string) error {
+	e.annotated = append(e.annotated, n)
+	return nil
+}
+func (e *harvestEmitter) MentionName(n string) error { e.mentions = append(e.mentions, n); return nil }
+
+// runJava parses src and runs the real registered Java extractor against em.
+func runReal(t *testing.T, lang, ext, src string, em extract.Emitter) {
+	t.Helper()
+	ex := extract.ForExtension(ext)
+	if ex == nil {
+		t.Fatalf("no registered extractor for %q", ext)
+	}
+	if ex.Language() != lang {
+		t.Fatalf("extractor for %q is %q, want %q", ext, ex.Language(), lang)
+	}
+	tree := parse(t, ex.Grammar(), src)
+	if err := ex.Extract(tree, []byte(src), "f"+ext, em); err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+}
+
+func TestJavaAnnotationHarvest(t *testing.T) {
+	src := `@Service
+public class Svc {
+    @Autowired private Repo repo;
+    @Test public void shouldWork() {}
+    public void plain() {}
+}`
+	em := &harvestEmitter{}
+	runReal(t, "java", ".java", src, em)
+	// The annotated class and the annotated method are harvested; the plain
+	// method is not. (Field annotations are not symbols, so @Autowired on a field
+	// produces no harvested name.)
+	if !slices.Contains(em.annotated, "Svc") {
+		t.Errorf("expected annotated class Svc, got %v", em.annotated)
+	}
+	if !slices.Contains(em.annotated, "shouldWork") {
+		t.Errorf("expected annotated method shouldWork, got %v", em.annotated)
+	}
+	if slices.Contains(em.annotated, "plain") {
+		t.Errorf("plain (un-annotated) method must not be harvested, got %v", em.annotated)
+	}
+}
+
+func TestCSharpAttributeHarvest(t *testing.T) {
+	src := `[ApiController]
+public class C {
+    [HttpGet] public void Get() {}
+    public void Plain() {}
+}`
+	em := &harvestEmitter{}
+	runReal(t, "csharp", ".cs", src, em)
+	if !slices.Contains(em.annotated, "C") || !slices.Contains(em.annotated, "Get") {
+		t.Errorf("expected attributed C and Get, got %v", em.annotated)
+	}
+	if slices.Contains(em.annotated, "Plain") {
+		t.Errorf("plain method must not be harvested, got %v", em.annotated)
+	}
+}
+
+func TestKotlinAnnotationHarvest(t *testing.T) {
+	src := `@Component class Bean {
+    @Test fun checks() {}
+    fun plain() {}
+}`
+	em := &harvestEmitter{}
+	runReal(t, "kotlin", ".kt", src, em)
+	if !slices.Contains(em.annotated, "Bean") || !slices.Contains(em.annotated, "checks") {
+		t.Errorf("expected annotated Bean and checks, got %v", em.annotated)
+	}
+	if slices.Contains(em.annotated, "plain") {
+		t.Errorf("plain method must not be harvested, got %v", em.annotated)
+	}
+}
+
+func TestPHPAttributeHarvest(t *testing.T) {
+	src := `<?php class Ctrl {
+    #[Route("/x")] public function handle() {}
+    public function plain() {}
+}`
+	em := &harvestEmitter{}
+	runReal(t, "php", ".php", src, em)
+	if !slices.Contains(em.annotated, "handle") {
+		t.Errorf("expected attributed handle, got %v", em.annotated)
+	}
+	if slices.Contains(em.annotated, "plain") {
+		t.Errorf("plain method must not be harvested, got %v", em.annotated)
+	}
+}
+
+func TestJavaMentionHarvest(t *testing.T) {
+	src := `public class App {
+    private void caller() {
+        helper();
+        service.process();
+    }
+    private void helper() {}
+}`
+	em := &harvestEmitter{}
+	runReal(t, "java", ".java", src, em)
+	// A call target leaves a mention so a same-named symbol stays open-world.
+	if !slices.Contains(em.mentions, "helper") {
+		t.Errorf("expected 'helper' mentioned (it is called), got %v", em.mentions)
+	}
+	if !slices.Contains(em.mentions, "process") {
+		t.Errorf("expected 'process' mentioned, got %v", em.mentions)
+	}
+	// 'caller' is only ever a definition name here, never a mention — so it can
+	// fall through to the soundness gate. (App is the class name, also excluded.)
+	if slices.Contains(em.mentions, "caller") {
+		t.Errorf("definition name 'caller' must be excluded from mentions, got %v", em.mentions)
+	}
+}
+
+func TestHarvestsMentionsPerGrammar(t *testing.T) {
+	cases := map[string]bool{
+		".java":  true,  // the validated benchmark language harvests
+		".cs":    false, // no benchmark repo → no harvest → fails closed (core_no_harvest)
+		".kt":    false,
+		".scala": false,
+		".php":   false,
+		".c":     false,
+		".cpp":   false,
+	}
+	for ext, want := range cases {
+		ex := extract.ForExtension(ext)
+		if ex == nil {
+			t.Fatalf("no extractor for %q", ext)
+		}
+		mh, ok := ex.(extract.MentionHarvester)
+		got := ok && mh.HarvestsMentions()
+		if got != want {
+			t.Errorf("HarvestsMentions(%s) = %v, want %v", ext, got, want)
+		}
+	}
+}
+
+func TestNonHarvestingGrammarEmitsNoMentions(t *testing.T) {
+	// C# does not opt into mention harvest, so even with a MentionEmitter present
+	// it streams nothing — its symbols fail closed at the soundness gate.
+	em := &harvestEmitter{}
+	runReal(t, "csharp", ".cs", `class C { void m() { other(); } }`, em)
+	if len(em.mentions) != 0 {
+		t.Errorf("non-harvesting C# emitted mentions: %v", em.mentions)
+	}
+}
+
+// TestExtractWithoutHarvestEmitter proves the harvest streams are best-effort: an
+// Emitter that implements neither MentionEmitter nor LangspecHarvestEmitter still
+// extracts symbols without error (the type assertions fall through to no-ops).
+func TestExtractWithoutHarvestEmitter(t *testing.T) {
+	em := &testEmitter{} // implements only Symbol + Edge
+	runReal(t, "java", ".java", `@Service public class S {
+    private void m() { helper(); }
+}`, em)
+	if len(em.symbols) == 0 {
+		t.Fatal("expected symbols even with a no-harvest emitter")
+	}
+}
+
+// errEmitter errors on a chosen harvest stream to exercise the error-propagation
+// paths in emitMentions / emitAnnotation.
+type errEmitter struct {
+	failMention   bool
+	failAnnotated bool
+}
+
+func (errEmitter) Symbol(extract.EmittedSymbol) error { return nil }
+func (errEmitter) Edge(extract.EmittedEdge) error     { return nil }
+func (e errEmitter) MentionName(string) error {
+	if e.failMention {
+		return errMentionForced
+	}
+	return nil
+}
+func (e errEmitter) LangspecAnnotatedName(string) error {
+	if e.failAnnotated {
+		return errMentionForced
+	}
+	return nil
+}
+
+var errMentionForced = &harvestErr{}
+
+type harvestErr struct{}
+
+func (*harvestErr) Error() string { return "forced harvest error" }
+
+func TestMentionEmitErrorPropagates(t *testing.T) {
+	ex := extract.ForExtension(".java")
+	tree := parse(t, ex.Grammar(), `class A { void m() { go(); } }`)
+	if err := ex.Extract(tree, []byte(`class A { void m() { go(); } }`), "A.java", errEmitter{failMention: true}); err == nil {
+		t.Error("expected error from MentionName to propagate")
+	}
+}
+
+func TestAnnotationEmitErrorPropagates(t *testing.T) {
+	ex := extract.ForExtension(".java")
+	src := `@Service class A {}`
+	tree := parse(t, ex.Grammar(), src)
+	if err := ex.Extract(tree, []byte(src), "A.java", errEmitter{failAnnotated: true}); err == nil {
+		t.Error("expected error from LangspecAnnotatedName to propagate")
+	}
+}
+
+func TestVisibilityFlowsThroughExtract(t *testing.T) {
+	// End-to-end: the emitted symbol carries the visibility the fn computes.
+	em := &harvestEmitter{}
+	runReal(t, "java", ".java", `public class K {
+    private void hidden() {}
+    public void shown() {}
+}`, em)
+	vis := map[string]string{}
+	for _, s := range em.symbols {
+		vis[s.Name] = s.Visibility
+	}
+	if vis["hidden"] != "private" {
+		t.Errorf("hidden visibility = %q, want private", vis["hidden"])
+	}
+	if vis["shown"] != "public" {
+		t.Errorf("shown visibility = %q, want public", vis["shown"])
+	}
+	if vis["K"] != "public" {
+		t.Errorf("class K visibility = %q, want public", vis["K"])
+	}
+}

--- a/internal/extract/langspec/java.go
+++ b/internal/extract/langspec/java.go
@@ -21,5 +21,12 @@ func init() {
 		InheritFields: []string{"superclass", "interfaces"},
 
 		NameField: "name",
+
+		VisibilityFn:    javaVisibility,
+		AnnotationKinds: []string{"marker_annotation", "annotation"},
+		// Java is the one langspec language with a real-world benchmark repo
+		// (javalin), so it harvests mentions and its file-local symbols may earn
+		// `dead` (gated by the per-language decision in the langspec voice).
+		MentionKinds: []string{"identifier", "type_identifier"},
 	}))
 }

--- a/internal/extract/langspec/kotlin.go
+++ b/internal/extract/langspec/kotlin.go
@@ -26,7 +26,9 @@ func init() {
 
 		NameField: "name",
 
-		CallNameFn: kotlinCallName,
+		CallNameFn:      kotlinCallName,
+		VisibilityFn:    kotlinVisibility,
+		AnnotationKinds: []string{"annotation"},
 	}))
 }
 

--- a/internal/extract/langspec/langspec.go
+++ b/internal/extract/langspec/langspec.go
@@ -20,9 +20,9 @@ type langSpec struct {
 	Tier      extract.Tier
 	Separator string
 
-	FuncTypes  []string
-	ClassTypes []string
-	CallTypes  []string
+	FuncTypes   []string
+	ClassTypes  []string
+	CallTypes   []string
 	ImportTypes []string
 
 	// InheritFields are field names on class nodes that hold superclass/interface
@@ -36,6 +36,32 @@ type langSpec struct {
 	NameField string
 
 	CallNameFn func(node *sitter.Node, source []byte) string
+
+	// VisibilityFn computes a func/class node's visibility ("public", "private",
+	// "protected", "internal", or a grammar-specific token like "package") from
+	// its access modifiers, or "" when the grammar offers no signal. Set per
+	// grammar; nil leaves Visibility unset. The dead-code langspec voice treats
+	// any non-"private" value (including unset "") as not-file-local and raises a
+	// hand, so the only direction that risks a false `dead` is mislabeling a
+	// reachable symbol "private" — which the per-grammar fns never do.
+	VisibilityFn func(n *sitter.Node, source []byte) string
+
+	// AnnotationKinds are the node kinds that represent an annotation/attribute on
+	// a declaration (Java "marker_annotation"/"annotation", C#/PHP "attribute_list",
+	// Kotlin/Scala "annotation"). Their presence as a direct child — or one level
+	// inside a "modifiers" wrapper — marks the symbol annotated, which the langspec
+	// voice reads (ls_annotated) because a framework's DI/reflection/test runner may
+	// dispatch any annotated symbol with no source caller.
+	AnnotationKinds []string
+
+	// MentionKinds are the node kinds whose text is a bare-name mention for the
+	// dead-code soundness harvest (e.g. "identifier", "type_identifier"). A
+	// non-empty list opts this grammar into mention harvesting, which is the
+	// prerequisite for any of its symbols to earn `dead`: the soundness gate proves
+	// a name unreachable only against the harvested mention set. An empty list
+	// means the language never harvests, so its symbols fail closed (core_no_harvest)
+	// — the honest default for a language with no validated `dead` tier.
+	MentionKinds []string
 }
 
 type genericExtractor struct {
@@ -75,7 +101,74 @@ func (g *genericExtractor) Extract(tree *sitter.Tree, source []byte, _ string, e
 		source: source,
 		emit:   emit,
 	}
-	return w.walk(tree.RootNode(), nil)
+	if err := w.walk(tree.RootNode(), nil); err != nil {
+		return err
+	}
+	return w.emitMentions(tree.RootNode())
+}
+
+// HarvestsMentions reports whether this grammar streams the broad mention set
+// (see walker.emitMentions). It is true exactly when MentionKinds is configured,
+// so the scan records the language as harvested and the dead-code soundness gate
+// can reason about it. A grammar with no MentionKinds never harvests, so its
+// symbols fail closed (core_no_harvest) rather than earn `dead` off an absent set.
+func (g *genericExtractor) HarvestsMentions() bool { return len(g.spec.MentionKinds) > 0 }
+
+// emitMentions streams every bare-name mention in the tree to the emitter when it
+// is a MentionEmitter and this grammar opted in via MentionKinds. The project-wide
+// union feeds the dead-code arbiter's soundness gate: a candidate earns `dead`
+// only when its name is absent from this set, so a live-but-unbindable reference
+// (an inherited bare call, a chain receiver, a reflectively-named string) still
+// leaves a textual mention and keeps the symbol open-world. A grammar with no
+// MentionKinds emits nothing.
+func (w *walker) emitMentions(root *sitter.Node) error {
+	if len(w.spec.MentionKinds) == 0 {
+		return nil
+	}
+	me, ok := w.emit.(extract.MentionEmitter)
+	if !ok {
+		return nil
+	}
+	for _, name := range extract.HarvestMentions(root, w.source, w.mentionWalkSpec()) {
+		if err := me.MentionName(name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// mentionWalkSpec parameterises the shared mention harvest for this grammar: the
+// configured MentionKinds carry a bare-name mention (read via extract.Text), and a
+// definition's own name token is excluded so a symbol is never cancelled by its
+// own declaration (otherwise no symbol could ever earn `dead`).
+func (w *walker) mentionWalkSpec() extract.MentionWalkSpec {
+	nameOf := make(map[string]func(*sitter.Node, []byte) string, len(w.spec.MentionKinds))
+	for _, kind := range w.spec.MentionKinds {
+		nameOf[kind] = extract.Text
+	}
+	return extract.MentionWalkSpec{
+		NameOf:             nameOf,
+		SkipDefinitionName: w.isDefinitionName,
+	}
+}
+
+// isDefinitionName reports whether n is the NameField child of a func/class
+// declaration — the symbol's own name token, excluded from the mention set. It is
+// the generic analog of the Ruby/Python definition-name skip; it covers the
+// grammars whose name is a direct NameField child (Java/C#/Kotlin/Scala/PHP). A
+// grammar whose name hides inside a declarator (C/C++) is not matched here, which
+// is harmless: those languages have no validated `dead` tier, so their mention
+// gate is never the deciding factor.
+func (w *walker) isDefinitionName(n *sitter.Node) bool {
+	p := n.Parent()
+	if p == nil {
+		return false
+	}
+	if !w.isFunc(p.Kind()) && !w.isClass(p.Kind()) {
+		return false
+	}
+	name := p.ChildByFieldName(w.spec.NameField)
+	return name != nil && name.Equals(*n)
 }
 
 type walker struct {
@@ -142,10 +235,15 @@ func (w *walker) handleClass(n *sitter.Node, scope []string) error {
 		Name:            name,
 		Qualified:       qualified,
 		Kind:            symKind,
+		Visibility:      w.visibility(n),
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
 	}); err != nil {
+		return err
+	}
+
+	if err := w.emitAnnotation(n, name); err != nil {
 		return err
 	}
 
@@ -176,10 +274,15 @@ func (w *walker) handleFunc(n *sitter.Node, scope []string) error {
 		Name:            name,
 		Qualified:       qualified,
 		Kind:            kind,
+		Visibility:      w.visibility(n),
 		ParentQualified: parent,
 		LineStart:       extract.Line(n.StartPosition()),
 		LineEnd:         extract.Line(n.EndPosition()),
 	}); err != nil {
+		return err
+	}
+
+	if err := w.emitAnnotation(n, name); err != nil {
 		return err
 	}
 
@@ -518,6 +621,58 @@ func (w *walker) extractDeclaratorName(n *sitter.Node) string {
 		}
 	}
 	return ""
+}
+
+// visibility returns the access visibility of a func/class node via the
+// grammar's VisibilityFn, or "" when the grammar configures none.
+func (w *walker) visibility(n *sitter.Node) string {
+	if w.spec.VisibilityFn == nil {
+		return ""
+	}
+	return w.spec.VisibilityFn(n, w.source)
+}
+
+// emitAnnotation streams name to the LangspecHarvestEmitter when n carries an
+// annotation/attribute (per AnnotationKinds) and the emitter accepts it. A
+// framework's DI/reflection/test runner may dispatch any annotated symbol with no
+// source caller, so the langspec voice keeps such a name open-world (ls_annotated).
+// An Emitter that does not implement the extension, or a grammar with no
+// AnnotationKinds, is a no-op.
+func (w *walker) emitAnnotation(n *sitter.Node, name string) error {
+	if name == "" || len(w.spec.AnnotationKinds) == 0 || !w.hasAnnotation(n) {
+		return nil
+	}
+	he, ok := w.emit.(extract.LangspecHarvestEmitter)
+	if !ok {
+		return nil
+	}
+	return he.LangspecAnnotatedName(name)
+}
+
+// hasAnnotation reports whether n carries an annotation/attribute, checking its
+// direct children and one level inside a "modifiers" wrapper (Java/Kotlin/Scala
+// hold annotations there; C#/PHP carry an attribute_list as a direct child).
+func (w *walker) hasAnnotation(n *sitter.Node) bool {
+	count := n.NamedChildCount()
+	for i := uint(0); i < count; i++ {
+		child := n.NamedChild(i)
+		if child == nil {
+			continue
+		}
+		if slices.Contains(w.spec.AnnotationKinds, child.Kind()) {
+			return true
+		}
+		if child.Kind() == "modifiers" {
+			mc := child.NamedChildCount()
+			for j := uint(0); j < mc; j++ {
+				gc := child.NamedChild(j)
+				if gc != nil && slices.Contains(w.spec.AnnotationKinds, gc.Kind()) {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 func (w *walker) qualify(scope []string) string {

--- a/internal/extract/langspec/php.go
+++ b/internal/extract/langspec/php.go
@@ -21,5 +21,8 @@ func init() {
 		InheritKinds: []string{"base_clause", "class_interface_clause"},
 
 		NameField: "name",
+
+		VisibilityFn:    phpVisibility,
+		AnnotationKinds: []string{"attribute_list"},
 	}))
 }

--- a/internal/extract/langspec/scala.go
+++ b/internal/extract/langspec/scala.go
@@ -21,5 +21,8 @@ func init() {
 		InheritFields: []string{"extend"},
 
 		NameField: "name",
+
+		VisibilityFn:    scalaVisibility,
+		AnnotationKinds: []string{"annotation"},
 	}))
 }

--- a/internal/extract/langspec/visibility.go
+++ b/internal/extract/langspec/visibility.go
@@ -1,0 +1,172 @@
+package langspec
+
+import (
+	"strings"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+)
+
+// accessKeywords maps an access-modifier keyword to the visibility string the
+// dead-code langspec voice reasons about. Only an explicit keyword maps; the
+// per-grammar default (Java "package", C# "private", others "public") is applied
+// by each grammar's fn when no keyword is present.
+var accessKeywords = map[string]string{
+	"public":    "public",
+	"private":   "private",
+	"protected": "protected",
+	"internal":  "internal",
+}
+
+// modifierNodeKinds are the named node kinds that wrap a single access-modifier
+// keyword as their TEXT (C# "modifier", Kotlin/PHP "visibility_modifier", Scala
+// "access_modifier"). Java differs — its keyword is an unnamed token whose KIND is
+// the keyword itself ("public"/"private"/"protected") — so accessModifierVisibility
+// checks both a child's kind and, for these wrappers, its text.
+var modifierNodeKinds = map[string]bool{
+	"modifier":            true,
+	"visibility_modifier": true,
+	"access_modifier":     true,
+}
+
+// accessModifierVisibility scans a declaration node for an access-modifier
+// keyword and returns the mapped visibility, or def when none is present. It
+// looks at every direct child AND one level inside a "modifiers" wrapper, which
+// together cover Java (unnamed keyword token inside `modifiers`), C# (named
+// `modifier` direct children), Kotlin/Scala (a `visibility_modifier` /
+// `access_modifier` inside `modifiers`), and PHP (a `visibility_modifier` direct
+// child). The first keyword found wins; a declaration with several modifiers
+// (`internal protected`) keeps the first, which is the safe direction (any
+// non-"private" value only ever raises a hand).
+func accessModifierVisibility(n *sitter.Node, source []byte, def string) string {
+	if v := scanAccessTokens(n, source); v != "" {
+		return v
+	}
+	count := n.NamedChildCount()
+	for i := uint(0); i < count; i++ {
+		child := n.NamedChild(i)
+		if child != nil && child.Kind() == "modifiers" {
+			if v := scanAccessTokens(child, source); v != "" {
+				return v
+			}
+		}
+	}
+	return def
+}
+
+// scanAccessTokens returns the visibility of the first access-modifier token
+// among n's direct children (named and unnamed), or "" when none is present. A
+// child matches by kind (Java's `public` token node) or, for a modifier-wrapper
+// kind, by its text (C#/Kotlin/Scala/PHP).
+func scanAccessTokens(n *sitter.Node, source []byte) string {
+	count := n.ChildCount()
+	for i := uint(0); i < count; i++ {
+		child := n.Child(i)
+		if child == nil {
+			continue
+		}
+		if v := accessKeywords[child.Kind()]; v != "" {
+			return v
+		}
+		if modifierNodeKinds[child.Kind()] {
+			if v := accessKeywords[strings.TrimSpace(extract.Text(child, source))]; v != "" {
+				return v
+			}
+		}
+	}
+	return ""
+}
+
+// javaVisibility reads a Java declaration's access modifier. The default — no
+// access keyword — is package-private, which Java exposes to the rest of its
+// package; it is NOT file-local, so it maps to "package" (not "private") and the
+// voice keeps it open-world. Only an explicit `private` member is file-local and
+// thus `dead`-eligible.
+func javaVisibility(n *sitter.Node, source []byte) string {
+	return accessModifierVisibility(n, source, "package")
+}
+
+// csharpVisibility reads a C# declaration's access modifier. With no explicit
+// modifier the default is kind-dependent: a class member (method/constructor)
+// defaults to private, but a namespace is global and a top-level type is
+// internal — neither is file-local nor cleanly public, so those map to "" rather
+// than a guessed token (the voice treats "" as not-file-local and raises a hand).
+func csharpVisibility(n *sitter.Node, source []byte) string {
+	if v := accessModifierVisibility(n, source, ""); v != "" {
+		return v
+	}
+	switch n.Kind() {
+	case "method_declaration", "constructor_declaration":
+		return "private"
+	}
+	return ""
+}
+
+// kotlinVisibility reads a Kotlin declaration's access modifier; Kotlin defaults
+// to public when none is present.
+func kotlinVisibility(n *sitter.Node, source []byte) string {
+	return accessModifierVisibility(n, source, "public")
+}
+
+// scalaVisibility reads a Scala declaration's access modifier; Scala defaults to
+// public when none is present.
+func scalaVisibility(n *sitter.Node, source []byte) string {
+	return accessModifierVisibility(n, source, "public")
+}
+
+// phpVisibility reads a PHP method's visibility modifier; a method (and any
+// top-level function) defaults to public when none is present.
+func phpVisibility(n *sitter.Node, source []byte) string {
+	return accessModifierVisibility(n, source, "public")
+}
+
+// cVisibility maps C's storage class to visibility: a `static` function is
+// file-local ("private"); everything else has external linkage ("public"). C has
+// no other access concept.
+func cVisibility(n *sitter.Node, source []byte) string {
+	count := n.NamedChildCount()
+	for i := uint(0); i < count; i++ {
+		child := n.NamedChild(i)
+		if child != nil && child.Kind() == "storage_class_specifier" &&
+			strings.TrimSpace(extract.Text(child, source)) == "static" {
+			return "private"
+		}
+	}
+	return "public"
+}
+
+// cppVisibility maps a C++ member function's positional access section to
+// visibility. Members live in a field_declaration_list with `access_specifier`
+// markers (`public:` / `private:` / `protected:`); the nearest specifier before
+// the node sets visibility. With no specifier, the enclosing aggregate's default
+// applies — private for a class, public for a struct. A function defined outside a
+// class body (a free function, or an out-of-line `Foo::bar` definition) has no
+// enclosing field_declaration_list and is treated as public.
+func cppVisibility(n *sitter.Node, source []byte) string {
+	parent := n.Parent()
+	if parent == nil || parent.Kind() != "field_declaration_list" {
+		return "public"
+	}
+	for sib := n.PrevSibling(); sib != nil; sib = sib.PrevSibling() {
+		if sib.Kind() == "access_specifier" {
+			if v := accessKeywords[accessSpecifierKeyword(sib, source)]; v != "" {
+				return v
+			}
+		}
+	}
+	if grand := parent.Parent(); grand != nil && grand.Kind() == "struct_specifier" {
+		return "public"
+	}
+	return "private"
+}
+
+// accessSpecifierKeyword returns the leading keyword of a C++ access_specifier
+// node, stripping the trailing colon and any whitespace (`public:` → "public").
+func accessSpecifierKeyword(n *sitter.Node, source []byte) string {
+	text := strings.TrimSpace(extract.Text(n, source))
+	if i := strings.IndexByte(text, ':'); i >= 0 {
+		text = text[:i]
+	}
+	return strings.TrimSpace(text)
+}

--- a/internal/extract/langspec/visibility_test.go
+++ b/internal/extract/langspec/visibility_test.go
@@ -1,0 +1,226 @@
+package langspec
+
+import (
+	"testing"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/grammars"
+)
+
+// findFirst returns the first node of the given kind in a pre-order walk, or nil.
+func findFirst(n *sitter.Node, kind string) *sitter.Node {
+	if n.Kind() == kind {
+		return n
+	}
+	count := n.ChildCount()
+	for i := uint(0); i < count; i++ {
+		if hit := findFirst(n.Child(i), kind); hit != nil {
+			return hit
+		}
+	}
+	return nil
+}
+
+// findNamed returns the first declaration node of the given kind whose NameField
+// (or, for grammars without one, whose scanned identifier) text equals name.
+func findNamed(t *testing.T, n *sitter.Node, kind, nameField, name string, source []byte) *sitter.Node {
+	t.Helper()
+	var hit *sitter.Node
+	var walk func(*sitter.Node)
+	walk = func(node *sitter.Node) {
+		if hit != nil {
+			return
+		}
+		if node.Kind() == kind {
+			if nm := node.ChildByFieldName(nameField); nm != nil && nm.Utf8Text(source) == name {
+				hit = node
+				return
+			}
+		}
+		count := node.ChildCount()
+		for i := uint(0); i < count; i++ {
+			walk(node.Child(i))
+		}
+	}
+	walk(n)
+	if hit == nil {
+		t.Fatalf("no %s named %q found", kind, name)
+	}
+	return hit
+}
+
+func TestJavaVisibility(t *testing.T) {
+	src := []byte(`public class Foo {
+    public void pub() {}
+    private void priv() {}
+    protected void prot() {}
+    void pkg() {}
+}`)
+	tree := parse(t, grammars.Java(), string(src))
+	root := tree.RootNode()
+	cases := map[string]string{"pub": "public", "priv": "private", "prot": "protected", "pkg": "package"}
+	for method, want := range cases {
+		n := findNamed(t, root, "method_declaration", "name", method, src)
+		if got := javaVisibility(n, src); got != want {
+			t.Errorf("javaVisibility(%s) = %q, want %q", method, got, want)
+		}
+	}
+	// A public top-level class is public.
+	cls := findNamed(t, root, "class_declaration", "name", "Foo", src)
+	if got := javaVisibility(cls, src); got != "public" {
+		t.Errorf("javaVisibility(class Foo) = %q, want public", got)
+	}
+}
+
+func TestCSharpVisibility(t *testing.T) {
+	src := []byte(`class Foo {
+    public void Pub() {}
+    private void Priv() {}
+    protected void Prot() {}
+    internal void Int() {}
+    void Def() {}
+}`)
+	root := parse(t, grammars.CSharp(), string(src)).RootNode()
+	cases := map[string]string{"Pub": "public", "Priv": "private", "Prot": "protected", "Int": "internal", "Def": "private"}
+	for method, want := range cases {
+		n := findNamed(t, root, "method_declaration", "name", method, src)
+		if got := csharpVisibility(n, src); got != want {
+			t.Errorf("csharpVisibility(%s) = %q, want %q", method, got, want)
+		}
+	}
+}
+
+func TestKotlinVisibility(t *testing.T) {
+	src := []byte(`class Foo {
+    fun pub() {}
+    private fun priv() {}
+    protected fun prot() {}
+    internal fun int() {}
+}`)
+	root := parse(t, grammars.Kotlin(), string(src)).RootNode()
+	cases := map[string]string{"pub": "public", "priv": "private", "prot": "protected", "int": "internal"}
+	// fwcd/tree-sitter-kotlin has no "name" field; the function name is a
+	// simple_identifier child. Collect each function_declaration by that name.
+	got := map[string]string{}
+	var walk func(*sitter.Node)
+	walk = func(n *sitter.Node) {
+		if n.Kind() == "function_declaration" {
+			if id := findFirst(n, "simple_identifier"); id != nil {
+				got[id.Utf8Text(src)] = kotlinVisibility(n, src)
+			}
+		}
+		count := n.ChildCount()
+		for i := uint(0); i < count; i++ {
+			walk(n.Child(i))
+		}
+	}
+	walk(root)
+	for fn, want := range cases {
+		if got[fn] != want {
+			t.Errorf("kotlinVisibility(%s) = %q, want %q", fn, got[fn], want)
+		}
+	}
+}
+
+func TestScalaVisibility(t *testing.T) {
+	src := []byte(`class Foo {
+    def pub(): Unit = {}
+    private def priv(): Unit = {}
+    protected def prot(): Unit = {}
+}`)
+	root := parse(t, grammars.Scala(), string(src)).RootNode()
+	cases := map[string]string{"pub": "public", "priv": "private", "prot": "protected"}
+	for fn, want := range cases {
+		n := findNamed(t, root, "function_definition", "name", fn, src)
+		if got := scalaVisibility(n, src); got != want {
+			t.Errorf("scalaVisibility(%s) = %q, want %q", fn, got, want)
+		}
+	}
+}
+
+func TestPHPVisibility(t *testing.T) {
+	src := []byte(`<?php class Foo {
+    public function pub() {}
+    private function priv() {}
+    protected function prot() {}
+    function def() {}
+}`)
+	root := parse(t, grammars.PHP(), string(src)).RootNode()
+	cases := map[string]string{"pub": "public", "priv": "private", "prot": "protected", "def": "public"}
+	for method, want := range cases {
+		n := findNamed(t, root, "method_declaration", "name", method, src)
+		if got := phpVisibility(n, src); got != want {
+			t.Errorf("phpVisibility(%s) = %q, want %q", method, got, want)
+		}
+	}
+}
+
+func TestCVisibility(t *testing.T) {
+	src := []byte(`static int priv(void) { return 0; }
+int pub(void) { return 1; }`)
+	root := parse(t, grammars.C(), string(src)).RootNode()
+	count := root.ChildCount()
+	got := map[string]string{}
+	for i := uint(0); i < count; i++ {
+		fn := root.Child(i)
+		if fn.Kind() != "function_definition" {
+			continue
+		}
+		decl := findFirst(fn, "identifier")
+		got[decl.Utf8Text(src)] = cVisibility(fn, src)
+	}
+	if got["priv"] != "private" {
+		t.Errorf("cVisibility(static priv) = %q, want private", got["priv"])
+	}
+	if got["pub"] != "public" {
+		t.Errorf("cVisibility(extern pub) = %q, want public", got["pub"])
+	}
+}
+
+func TestCppVisibility(t *testing.T) {
+	src := []byte(`class Cls {
+    void implicitPriv() {}
+public:
+    void pub() {}
+private:
+    void priv() {}
+protected:
+    void prot() {}
+};
+struct Str {
+    void implicitPub() {}
+};
+void freeFn() {}`)
+	root := parse(t, grammars.Cpp(), string(src)).RootNode()
+	cases := map[string]string{
+		"implicitPriv": "private", // class default
+		"pub":          "public",
+		"priv":         "private",
+		"prot":         "protected",
+		"implicitPub":  "public", // struct default
+		"freeFn":       "public", // free function
+	}
+	// function_definition nodes carry the bodies; find each by its declarator name.
+	var got = map[string]string{}
+	var walk func(*sitter.Node)
+	walk = func(n *sitter.Node) {
+		if n.Kind() == "function_definition" {
+			if id := findFirst(n, "field_identifier"); id != nil {
+				got[id.Utf8Text(src)] = cppVisibility(n, src)
+			} else if id := findFirst(n, "identifier"); id != nil {
+				got[id.Utf8Text(src)] = cppVisibility(n, src)
+			}
+		}
+		count := n.ChildCount()
+		for i := uint(0); i < count; i++ {
+			walk(n.Child(i))
+		}
+	}
+	walk(root)
+	for name, want := range cases {
+		if got[name] != want {
+			t.Errorf("cppVisibility(%s) = %q, want %q", name, got[name], want)
+		}
+	}
+}

--- a/internal/extract/testdata/c/basic.golden.json
+++ b/internal/extract/testdata/c/basic.golden.json
@@ -4,6 +4,7 @@
       "name": "Color",
       "qualified": "Color",
       "kind": "type",
+      "visibility": "public",
       "line_start": 9,
       "line_end": 13
     },
@@ -11,6 +12,7 @@
       "name": "Point",
       "qualified": "Point",
       "kind": "class",
+      "visibility": "public",
       "line_start": 4,
       "line_end": 7
     },
@@ -18,6 +20,7 @@
       "name": "add",
       "qualified": "add",
       "kind": "function",
+      "visibility": "public",
       "line_start": 19,
       "line_end": 21
     },
@@ -25,6 +28,7 @@
       "name": "greet",
       "qualified": "greet",
       "kind": "function",
+      "visibility": "public",
       "line_start": 15,
       "line_end": 17
     },
@@ -32,6 +36,7 @@
       "name": "main",
       "qualified": "main",
       "kind": "function",
+      "visibility": "public",
       "line_start": 23,
       "line_end": 28
     }

--- a/internal/extract/testdata/cpp/basic.golden.json
+++ b/internal/extract/testdata/cpp/basic.golden.json
@@ -4,6 +4,7 @@
       "name": "geometry",
       "qualified": "geometry",
       "kind": "module",
+      "visibility": "public",
       "line_start": 3,
       "line_end": 28
     },
@@ -11,6 +12,7 @@
       "name": "Circle",
       "qualified": "geometry::Circle",
       "kind": "class",
+      "visibility": "public",
       "parent": "geometry",
       "line_start": 12,
       "line_end": 21
@@ -19,6 +21,7 @@
       "name": "area",
       "qualified": "geometry::Circle::area",
       "kind": "method",
+      "visibility": "public",
       "parent": "geometry::Circle",
       "line_start": 18,
       "line_end": 20
@@ -27,6 +30,7 @@
       "name": "draw",
       "qualified": "geometry::Circle::draw",
       "kind": "method",
+      "visibility": "public",
       "parent": "geometry::Circle",
       "line_start": 14,
       "line_end": 16
@@ -35,6 +39,7 @@
       "name": "Point",
       "qualified": "geometry::Point",
       "kind": "class",
+      "visibility": "public",
       "parent": "geometry",
       "line_start": 23,
       "line_end": 26
@@ -43,6 +48,7 @@
       "name": "Shape",
       "qualified": "geometry::Shape",
       "kind": "class",
+      "visibility": "public",
       "parent": "geometry",
       "line_start": 5,
       "line_end": 10
@@ -51,6 +57,7 @@
       "name": "draw",
       "qualified": "geometry::Shape::draw",
       "kind": "method",
+      "visibility": "public",
       "parent": "geometry::Shape",
       "line_start": 7,
       "line_end": 9
@@ -59,6 +66,7 @@
       "name": "greet",
       "qualified": "greet",
       "kind": "function",
+      "visibility": "public",
       "line_start": 30,
       "line_end": 32
     },
@@ -66,6 +74,7 @@
       "name": "main",
       "qualified": "main",
       "kind": "function",
+      "visibility": "public",
       "line_start": 34,
       "line_end": 39
     }

--- a/internal/extract/testdata/csharp/basic.golden.json
+++ b/internal/extract/testdata/csharp/basic.golden.json
@@ -11,6 +11,7 @@
       "name": "Animal",
       "qualified": "MyApp.Animal",
       "kind": "class",
+      "visibility": "public",
       "parent": "MyApp",
       "line_start": 5,
       "line_end": 12
@@ -19,6 +20,7 @@
       "name": "Animal",
       "qualified": "MyApp.Animal.Animal",
       "kind": "method",
+      "visibility": "public",
       "parent": "MyApp.Animal",
       "line_start": 6,
       "line_end": 7
@@ -27,6 +29,7 @@
       "name": "Speak",
       "qualified": "MyApp.Animal.Speak",
       "kind": "method",
+      "visibility": "public",
       "parent": "MyApp.Animal",
       "line_start": 9,
       "line_end": 11
@@ -35,6 +38,7 @@
       "name": "Color",
       "qualified": "MyApp.Color",
       "kind": "type",
+      "visibility": "public",
       "parent": "MyApp",
       "line_start": 32,
       "line_end": 34
@@ -43,6 +47,7 @@
       "name": "Dog",
       "qualified": "MyApp.Dog",
       "kind": "class",
+      "visibility": "public",
       "parent": "MyApp",
       "line_start": 14,
       "line_end": 21
@@ -51,6 +56,7 @@
       "name": "Dog",
       "qualified": "MyApp.Dog.Dog",
       "kind": "method",
+      "visibility": "public",
       "parent": "MyApp.Dog",
       "line_start": 15,
       "line_end": 16
@@ -59,6 +65,7 @@
       "name": "Speak",
       "qualified": "MyApp.Dog.Speak",
       "kind": "method",
+      "visibility": "public",
       "parent": "MyApp.Dog",
       "line_start": 18,
       "line_end": 20
@@ -67,6 +74,7 @@
       "name": "IGroomable",
       "qualified": "MyApp.IGroomable",
       "kind": "interface",
+      "visibility": "public",
       "parent": "MyApp",
       "line_start": 23,
       "line_end": 25
@@ -75,6 +83,7 @@
       "name": "Groom",
       "qualified": "MyApp.IGroomable.Groom",
       "kind": "method",
+      "visibility": "private",
       "parent": "MyApp.IGroomable",
       "line_start": 24,
       "line_end": 24
@@ -83,6 +92,7 @@
       "name": "Point",
       "qualified": "MyApp.Point",
       "kind": "class",
+      "visibility": "public",
       "parent": "MyApp",
       "line_start": 27,
       "line_end": 30

--- a/internal/extract/testdata/java/basic.golden.json
+++ b/internal/extract/testdata/java/basic.golden.json
@@ -4,6 +4,7 @@
       "name": "Animal",
       "qualified": "Animal",
       "kind": "class",
+      "visibility": "public",
       "line_start": 3,
       "line_end": 13
     },
@@ -11,6 +12,7 @@
       "name": "Animal",
       "qualified": "Animal.Animal",
       "kind": "method",
+      "visibility": "public",
       "parent": "Animal",
       "line_start": 6,
       "line_end": 8
@@ -19,6 +21,7 @@
       "name": "speak",
       "qualified": "Animal.speak",
       "kind": "method",
+      "visibility": "public",
       "parent": "Animal",
       "line_start": 10,
       "line_end": 12
@@ -27,6 +30,7 @@
       "name": "Color",
       "qualified": "Color",
       "kind": "type",
+      "visibility": "package",
       "line_start": 30,
       "line_end": 32
     },
@@ -34,6 +38,7 @@
       "name": "Dog",
       "qualified": "Dog",
       "kind": "class",
+      "visibility": "package",
       "line_start": 15,
       "line_end": 24
     },
@@ -41,6 +46,7 @@
       "name": "Dog",
       "qualified": "Dog.Dog",
       "kind": "method",
+      "visibility": "public",
       "parent": "Dog",
       "line_start": 16,
       "line_end": 18
@@ -49,6 +55,7 @@
       "name": "speak",
       "qualified": "Dog.speak",
       "kind": "method",
+      "visibility": "public",
       "parent": "Dog",
       "line_start": 20,
       "line_end": 23
@@ -57,6 +64,7 @@
       "name": "Groomable",
       "qualified": "Groomable",
       "kind": "interface",
+      "visibility": "package",
       "line_start": 26,
       "line_end": 28
     },
@@ -64,6 +72,7 @@
       "name": "groom",
       "qualified": "Groomable.groom",
       "kind": "method",
+      "visibility": "package",
       "parent": "Groomable",
       "line_start": 27,
       "line_end": 27

--- a/internal/extract/testdata/kotlin/basic.golden.json
+++ b/internal/extract/testdata/kotlin/basic.golden.json
@@ -4,6 +4,7 @@
       "name": "Animal",
       "qualified": "Animal",
       "kind": "class",
+      "visibility": "public",
       "line_start": 3,
       "line_end": 7
     },
@@ -11,6 +12,7 @@
       "name": "speak",
       "qualified": "Animal.speak",
       "kind": "method",
+      "visibility": "public",
       "parent": "Animal",
       "line_start": 4,
       "line_end": 6
@@ -19,6 +21,7 @@
       "name": "Dog",
       "qualified": "Dog",
       "kind": "class",
+      "visibility": "public",
       "line_start": 9,
       "line_end": 13
     },
@@ -26,6 +29,7 @@
       "name": "speak",
       "qualified": "Dog.speak",
       "kind": "method",
+      "visibility": "public",
       "parent": "Dog",
       "line_start": 10,
       "line_end": 12
@@ -34,6 +38,7 @@
       "name": "Groomable",
       "qualified": "Groomable",
       "kind": "class",
+      "visibility": "public",
       "line_start": 15,
       "line_end": 17
     },
@@ -41,6 +46,7 @@
       "name": "groom",
       "qualified": "Groomable.groom",
       "kind": "method",
+      "visibility": "public",
       "parent": "Groomable",
       "line_start": 16,
       "line_end": 16
@@ -49,6 +55,7 @@
       "name": "Singleton",
       "qualified": "Singleton",
       "kind": "class",
+      "visibility": "public",
       "line_start": 19,
       "line_end": 23
     },
@@ -56,6 +63,7 @@
       "name": "doWork",
       "qualified": "Singleton.doWork",
       "kind": "method",
+      "visibility": "public",
       "parent": "Singleton",
       "line_start": 20,
       "line_end": 22
@@ -64,6 +72,7 @@
       "name": "main",
       "qualified": "main",
       "kind": "function",
+      "visibility": "public",
       "line_start": 25,
       "line_end": 28
     }

--- a/internal/extract/testdata/php/basic.golden.json
+++ b/internal/extract/testdata/php/basic.golden.json
@@ -4,6 +4,7 @@
       "name": "Animal",
       "qualified": "Animal",
       "kind": "class",
+      "visibility": "public",
       "line_start": 6,
       "line_end": 13
     },
@@ -11,6 +12,7 @@
       "name": "__construct",
       "qualified": "Animal\\__construct",
       "kind": "method",
+      "visibility": "public",
       "parent": "Animal",
       "line_start": 7,
       "line_end": 8
@@ -19,6 +21,7 @@
       "name": "speak",
       "qualified": "Animal\\speak",
       "kind": "method",
+      "visibility": "public",
       "parent": "Animal",
       "line_start": 10,
       "line_end": 12
@@ -27,6 +30,7 @@
       "name": "App\\Models",
       "qualified": "App\\Models",
       "kind": "module",
+      "visibility": "public",
       "line_start": 2,
       "line_end": 2
     },
@@ -34,6 +38,7 @@
       "name": "Dog",
       "qualified": "Dog",
       "kind": "class",
+      "visibility": "public",
       "line_start": 15,
       "line_end": 19
     },
@@ -41,6 +46,7 @@
       "name": "speak",
       "qualified": "Dog\\speak",
       "kind": "method",
+      "visibility": "public",
       "parent": "Dog",
       "line_start": 16,
       "line_end": 18
@@ -49,6 +55,7 @@
       "name": "Serializable",
       "qualified": "Serializable",
       "kind": "interface",
+      "visibility": "public",
       "line_start": 21,
       "line_end": 23
     },
@@ -56,6 +63,7 @@
       "name": "serialize",
       "qualified": "Serializable\\serialize",
       "kind": "method",
+      "visibility": "public",
       "parent": "Serializable",
       "line_start": 22,
       "line_end": 22
@@ -64,6 +72,7 @@
       "name": "greet",
       "qualified": "greet",
       "kind": "function",
+      "visibility": "public",
       "line_start": 25,
       "line_end": 27
     }

--- a/internal/extract/testdata/scala/basic.golden.json
+++ b/internal/extract/testdata/scala/basic.golden.json
@@ -4,6 +4,7 @@
       "name": "Animal",
       "qualified": "Animal",
       "kind": "class",
+      "visibility": "public",
       "line_start": 3,
       "line_end": 7
     },
@@ -11,6 +12,7 @@
       "name": "speak",
       "qualified": "Animal.speak",
       "kind": "method",
+      "visibility": "public",
       "parent": "Animal",
       "line_start": 4,
       "line_end": 6
@@ -19,6 +21,7 @@
       "name": "Dog",
       "qualified": "Dog",
       "kind": "class",
+      "visibility": "public",
       "line_start": 9,
       "line_end": 13
     },
@@ -26,6 +29,7 @@
       "name": "speak",
       "qualified": "Dog.speak",
       "kind": "method",
+      "visibility": "public",
       "parent": "Dog",
       "line_start": 10,
       "line_end": 12
@@ -34,6 +38,7 @@
       "name": "Groomable",
       "qualified": "Groomable",
       "kind": "class",
+      "visibility": "public",
       "line_start": 15,
       "line_end": 17
     },
@@ -41,6 +46,7 @@
       "name": "groom",
       "qualified": "Groomable.groom",
       "kind": "method",
+      "visibility": "public",
       "parent": "Groomable",
       "line_start": 16,
       "line_end": 16
@@ -49,6 +55,7 @@
       "name": "Singleton",
       "qualified": "Singleton",
       "kind": "class",
+      "visibility": "public",
       "line_start": 19,
       "line_end": 23
     },
@@ -56,6 +63,7 @@
       "name": "doWork",
       "qualified": "Singleton.doWork",
       "kind": "method",
+      "visibility": "public",
       "parent": "Singleton",
       "line_start": 20,
       "line_end": 22

--- a/internal/scan/dispatch.go
+++ b/internal/scan/dispatch.go
@@ -246,6 +246,21 @@ func writePythonAllExports(ctx context.Context, idx *sqlite.Adapter, collected m
 	return writeNameSet(ctx, idx, pythonAllExportsMetaKey, collected)
 }
 
+// langspecAnnotatedMetaKey is the sense_meta key holding the project-wide set of
+// langspec (Java/Kotlin/C#/Scala/C++/PHP/C) class/method/function names carrying
+// any annotation or attribute. The dead-code langspec voice reads it: with no
+// per-framework voice for these languages, a framework's DI/router/test runner may
+// dispatch an annotated symbol with no source caller, so it stays open-world
+// (ls_annotated) rather than earning `dead`. Flat, not per-language — annotations
+// span the shared table-driven langspec extractor.
+const langspecAnnotatedMetaKey = "langspec_annotated"
+
+// writeLangspecAnnotated persists the project-wide langspec annotated-name set,
+// unioning with the existing set (same self-heals-on-rebuild rationale as above).
+func writeLangspecAnnotated(ctx context.Context, idx *sqlite.Adapter, collected map[string]struct{}) error {
+	return writeNameSet(ctx, idx, langspecAnnotatedMetaKey, collected)
+}
+
 // addNamesByLang unions names into byLang[lang], creating the language's set on
 // first use. Both per-language name accumulators (dispatch, mention) share it so
 // the handler keeps each language's names apart for per-language meta writes.

--- a/internal/scan/dispatch_test.go
+++ b/internal/scan/dispatch_test.go
@@ -217,12 +217,13 @@ func TestDispatchNamesAdapterErrors(t *testing.T) {
 }
 
 // TestScanWritesHarvestedLangs proves the harvested-langs capability gate
-// end to end: Ruby, Go, and Python files mark their languages harvested (all
-// three extractors are MentionHarvesters), while a Java file in the same scan
-// does NOT mark `java` — the generic-spec Java extractor harvests no mentions, so
-// its symbols must fail closed rather than earn `dead` off an absent set. This is
-// what lets HarvestedLangs diverge from the mention keyset for a real,
-// non-harvesting language.
+// end to end: Ruby, Go, Python, and Java files mark their languages harvested
+// (Java is the one langspec language wired with MentionKinds, validated against
+// the javalin benchmark), while a C# file in the same scan does NOT mark `csharp`
+// — the generic-spec C# extractor harvests no mentions (no benchmark repo), so its
+// symbols must fail closed rather than earn `dead` off an absent set. This is what
+// lets HarvestedLangs diverge from the mention keyset for a real, non-harvesting
+// language.
 func TestScanWritesHarvestedLangs(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()
@@ -244,6 +245,10 @@ func TestScanWritesHarvestedLangs(t *testing.T) {
 		[]byte("class Thing {\n  void go() {}\n}\n"), 0o644); err != nil {
 		t.Fatalf("write java: %v", err)
 	}
+	if err := os.WriteFile(filepath.Join(root, "Thing.cs"),
+		[]byte("class Thing {\n  void Go() {}\n}\n"), 0o644); err != nil {
+		t.Fatalf("write csharp: %v", err)
+	}
 
 	if _, err := Run(ctx, Options{Root: root, Sense: senseDir, Output: &bytes.Buffer{}, Warnings: io.Discard}); err != nil {
 		t.Fatalf("scan.Run: %v", err)
@@ -259,13 +264,13 @@ func TestScanWritesHarvestedLangs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read harvested_langs: %v", err)
 	}
-	for _, lang := range []string{"ruby", "go", "python"} {
+	for _, lang := range []string{"ruby", "go", "python", "java"} {
 		if _, ok := got[lang]; !ok {
 			t.Errorf("expected %s in harvested_langs, got %v", lang, got)
 		}
 	}
-	if _, ok := got["java"]; ok {
-		t.Errorf("java (generic-spec extractor) harvests no mentions; must be absent from harvested_langs, got %v", got)
+	if _, ok := got["csharp"]; ok {
+		t.Errorf("csharp (no benchmark, no MentionKinds) harvests no mentions; must be absent from harvested_langs, got %v", got)
 	}
 }
 
@@ -431,6 +436,50 @@ export default function Page() {}
 	}
 	if _, ok := harvested["typescript"]; !ok {
 		t.Errorf("expected typescript in harvested_langs, got %v", harvested)
+	}
+}
+
+// TestScanWritesLangspecAnnotated proves the langspec annotation harvest flows
+// end to end through the scan collector: an annotated Java class and method land
+// their names in the flat langspec_annotated sense_meta key, while a plain method
+// does not. It exercises the LangspecHarvestEmitter collector path plus the
+// harness aggregation in one scan.
+func TestScanWritesLangspecAnnotated(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	senseDir := filepath.Join(root, ".sense")
+
+	src := `@Service
+public class Svc {
+    @Test public void shouldWork() {}
+    public void plain() {}
+}
+`
+	if err := os.WriteFile(filepath.Join(root, "Svc.java"), []byte(src), 0o644); err != nil {
+		t.Fatalf("write java: %v", err)
+	}
+
+	if _, err := Run(ctx, Options{Root: root, Sense: senseDir, Output: &bytes.Buffer{}, Warnings: io.Discard}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+
+	a, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatalf("open index: %v", err)
+	}
+	t.Cleanup(func() { _ = a.Close() })
+
+	set, err := readNameSet(ctx, a, langspecAnnotatedMetaKey)
+	if err != nil {
+		t.Fatalf("read langspec_annotated: %v", err)
+	}
+	for _, name := range []string{"Svc", "shouldWork"} {
+		if _, ok := set[name]; !ok {
+			t.Errorf("expected %q in langspec_annotated, got %v", name, set)
+		}
+	}
+	if _, ok := set["plain"]; ok {
+		t.Errorf("plain (un-annotated) method must not be in langspec_annotated, got %v", set)
 	}
 }
 

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -244,6 +244,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	warnMetaWrite(warn, "py-routes", writePythonRoutes(ctx, idx, h.pyRoutes))
 	warnMetaWrite(warn, "py-django", writePythonDjango(ctx, idx, h.pyDjango))
 	warnMetaWrite(warn, "py-all-exports", writePythonAllExports(ctx, idx, h.pyAllExports))
+	warnMetaWrite(warn, "langspec-annotated", writeLangspecAnnotated(ctx, idx, h.lsAnnotated))
 	// A pre-feature index carried single bare union keys (no language suffix).
 	// The per-language reader globs `*:<lang>` and ignores them, but delete them
 	// on every full scan so an in-place upgrade leaves no stale meta to mislead a
@@ -577,6 +578,13 @@ type harness struct {
 	pyDjango     map[string]struct{}
 	pyAllExports map[string]struct{}
 
+	// lsAnnotated is the set of langspec (Java/Kotlin/C#/Scala/C++/PHP/C)
+	// class/method/function names carrying any annotation or attribute. Written to
+	// a flat sense_meta key so the dead-code langspec voice keeps an annotated
+	// symbol open-world (ls_annotated): with no per-framework voice, a DI
+	// container, test runner, or router may dispatch it with no source caller.
+	lsAnnotated map[string]struct{}
+
 	// harvestedLangs is the set of languages whose mention harvest RAN this
 	// scan — every indexed file whose extractor is an extract.MentionHarvester
 	// marks its language here, regardless of how many names it produced. Written
@@ -891,6 +899,14 @@ func (h *harness) walkTree(root string) error {
 				h.pyAllExports[n] = struct{}{}
 			}
 		}
+		if len(fr.LangspecAnnotated) > 0 {
+			if h.lsAnnotated == nil {
+				h.lsAnnotated = map[string]struct{}{}
+			}
+			for _, n := range fr.LangspecAnnotated {
+				h.lsAnnotated[n] = struct{}{}
+			}
+		}
 
 		batch = append(batch, fr)
 		if len(batch) >= batchSize {
@@ -958,25 +974,26 @@ func (h *harness) flushBatch(batch []*fileResult) error {
 // fileResult holds the output of parseFile — everything needed to
 // persist a file's symbols and edges without re-reading or re-parsing.
 type fileResult struct {
-	Rel              string
-	Language         string
-	Source           []byte
-	Hash             string
-	Symbols          []extract.EmittedSymbol
-	Edges            []extract.EmittedEdge
-	DispatchNames    []string
-	MentionedNames   []string
-	CgoExports       []string
-	RustExports      []string
-	RustTestSymbols  []string
-	RustTraitMethods []string
-	RustAllowDead    []string
-	TSDecorated      []string
-	TSDefaultExports []string
-	PyDecorated      []string
-	PyRoutes         []string
-	PyDjango         []string
-	PyAllExports     []string
+	Rel               string
+	Language          string
+	Source            []byte
+	Hash              string
+	Symbols           []extract.EmittedSymbol
+	Edges             []extract.EmittedEdge
+	DispatchNames     []string
+	MentionedNames    []string
+	CgoExports        []string
+	RustExports       []string
+	RustTestSymbols   []string
+	RustTraitMethods  []string
+	RustAllowDead     []string
+	TSDecorated       []string
+	TSDefaultExports  []string
+	PyDecorated       []string
+	PyRoutes          []string
+	PyDjango          []string
+	PyAllExports      []string
+	LangspecAnnotated []string
 }
 
 // 100 files per SQLite transaction amortizes BEGIN/COMMIT overhead (~10x
@@ -1086,25 +1103,26 @@ func parseFileCore(po parseOpts, path, rel string, skip func(hash string) bool) 
 	})
 
 	return &fileResult{
-		Rel:              rel,
-		Language:         ex.Language(),
-		Source:           source,
-		Hash:             newHash,
-		Symbols:          collected.symbols,
-		Edges:            collected.edges,
-		DispatchNames:    collected.dispatchNames,
-		MentionedNames:   collected.mentionedNames,
-		CgoExports:       collected.cgoExports,
-		RustExports:      collected.rustExports,
-		RustTestSymbols:  collected.rustTestSymbols,
-		RustTraitMethods: collected.rustTraitMethods,
-		RustAllowDead:    collected.rustAllowDead,
-		TSDecorated:      collected.tsDecorated,
-		TSDefaultExports: collected.tsDefaultExports,
-		PyDecorated:      collected.pyDecorated,
-		PyRoutes:         collected.pyRoutes,
-		PyDjango:         collected.pyDjango,
-		PyAllExports:     collected.pyAllExports,
+		Rel:               rel,
+		Language:          ex.Language(),
+		Source:            source,
+		Hash:              newHash,
+		Symbols:           collected.symbols,
+		Edges:             collected.edges,
+		DispatchNames:     collected.dispatchNames,
+		MentionedNames:    collected.mentionedNames,
+		CgoExports:        collected.cgoExports,
+		RustExports:       collected.rustExports,
+		RustTestSymbols:   collected.rustTestSymbols,
+		RustTraitMethods:  collected.rustTraitMethods,
+		RustAllowDead:     collected.rustAllowDead,
+		TSDecorated:       collected.tsDecorated,
+		TSDefaultExports:  collected.tsDefaultExports,
+		PyDecorated:       collected.pyDecorated,
+		PyRoutes:          collected.pyRoutes,
+		PyDjango:          collected.pyDjango,
+		PyAllExports:      collected.pyAllExports,
+		LangspecAnnotated: collected.lsAnnotated,
 	}
 }
 
@@ -1449,6 +1467,7 @@ type collector struct {
 	pyRoutes         []string
 	pyDjango         []string
 	pyAllExports     []string
+	lsAnnotated      []string
 }
 
 func (c *collector) Symbol(s extract.EmittedSymbol) error {
@@ -1575,6 +1594,16 @@ func (c *collector) PythonDjangoName(name string) error {
 // (py_all_export) even when underscore-private.
 func (c *collector) PythonAllExportName(name string) error {
 	c.pyAllExports = append(c.pyAllExports, name)
+	return nil
+}
+
+// LangspecAnnotatedName implements extract.LangspecHarvestEmitter: the langspec
+// extractor streams every annotated/attributed class/method/function (Java
+// `@Service`, C# `[Fact]`, Kotlin/Scala annotations, PHP `#[Route]`). The
+// project-wide set feeds the dead-code langspec voice so a framework-dispatched
+// symbol stays open-world (ls_annotated) instead of being falsely called dead.
+func (c *collector) LangspecAnnotatedName(name string) error {
+	c.lsAnnotated = append(c.lsAnnotated, name)
 	return nil
 }
 


### PR DESCRIPTION
## Problem

The Standard-tier languages that share the table-driven `langspec` extractor —
Java, Kotlin, C#, Scala, C++, PHP, C — had no dead-code voice. Every
unreferenced symbol in these languages got the blanket `core_no_language_voice`
reason, which tells an agent only "Sense can't reason about this stack." The
extractor also never populated `Symbol.Visibility` for them, so the core
library-API gate couldn't fire. These languages were *safe* (nothing earned a
false `dead`) but unhelpful.

## Summary

Add generic visibility + annotation + mention extraction to the langspec walker,
and a conservative `langspecVoice` that replaces the blanket reason with specific,
actionable ones. Java earns a narrow `dead` tier; the other six ship reasons-only.

## Changes

- **Extractor** — three per-grammar `langSpec` fields (no per-language walker
  code): `VisibilityFn` (access-modifier → `Symbol.Visibility`, including C++
  positional `public:`/`private:` sections and C `static`), `AnnotationKinds`
  (harvests annotated/attributed symbols via a new `LangspecHarvestEmitter`), and
  `MentionKinds` (opts a grammar into the soundness mention harvest). Golden
  fixtures regenerated to carry visibility.
- **Scan** — persists the annotated-name set to the flat `langspec_annotated`
  `sense_meta` key, following the existing harvest pattern.
- **Dead** — `langspecVoice` raises `ls_annotated`, `ls_interface_method`,
  `ls_public_no_framework`, `ls_reflective_type`, `ls_dynamic`, and
  `ls_unvalidated`. The blanket `core_no_language_voice` no longer dominates
  Standard-tier output.

## Architecture Highlights

- **Java is the sixth language to earn `dead`, narrowly.** Only an explicitly
  private (class-local) callable that is unreferenced, non-annotated, not an
  interface method, and absent from Java's mention set. Java `private` is a
  stronger closed-world signal than the Ruby/Python `private` that already ship
  `dead`, and the verdict rides the per-language mention gate (which catches
  `getDeclaredMethod("name")` reflection and annotation-value names).
- **The other six ship reasons-only — by design.** PHP is fixed
  (reflection-pervasive); Kotlin/C#/Scala/C++/C have no benchmark repo, so they
  fail closed (`ls_unvalidated`) until one exists. Only Java wires `MentionKinds`,
  so only Java harvests mentions; the rest never reach the soundness gate. A
  future language opts into the dead tier consciously, not by accident.

## Test Plan

- [x] Visibility asserted per grammar on raw bytes (Java/Kotlin/C#/Scala/PHP/C/C++)
- [x] Annotation + mention harvest asserted through the registered extractors
- [x] Two-sided dead control through the real arbiter: a private unmentioned Java
      method earns `dead`; annotated/public/interface/mentioned symbols stay
      `possibly_dead`; a non-eligible language never earns `dead`
- [x] Benchmark validation (javalin, 313 symbols): blanket reason eliminated
      (28 → 14 annotated / 10 public-no-framework / 4 interface-method), zero false `dead`
- [x] `make ci` passes (build, test, lint 0 issues)
- [x] Coverage floor met on new files (visibility.go 95.9% line / 100% func; voice_langspec.go 100% / 100%)