### PR TITLE
feat(index): metrics-preserving rebuild and sense scan --rebuild

### DIFF
--- a/cmd/sense/main.go
+++ b/cmd/sense/main.go
@@ -65,6 +65,7 @@ func main() {
 		fs := flag.NewFlagSet("sense scan", flag.ContinueOnError)
 		fs.SetOutput(os.Stderr)
 		watchFlag := fs.Bool("watch", false, "keep running and re-index on file changes")
+		rebuildFlag := fs.Bool("rebuild", false, "drop and rebuild the index from source (preserves lifetime metrics)")
 		embedFlag := fs.Bool("embed", false, "block until embeddings complete (default: defer to MCP server)")
 		quietFlag := fs.Bool("quiet", false, "suppress warnings")
 		dir := fs.String("dir", ".", "project root")
@@ -108,6 +109,7 @@ func main() {
 				Quiet:             *quietFlag,
 				EmbeddingsEnabled: cli.EmbeddingsEnabled(*dir),
 				Embed:             *embedFlag,
+				Rebuild:           *rebuildFlag,
 			}); err != nil {
 				fmt.Fprintln(os.Stderr, "sense scan:", err)
 				os.Exit(1)

--- a/internal/cli/blast.go
+++ b/internal/cli/blast.go
@@ -45,8 +45,8 @@ Exit codes:
   1  general error
   2  symbol not found or ambiguous
   3  index missing (run 'sense scan' first)
-  4  index corrupt (rebuild via 'rm .sense/index.db && sense scan';
-     'sense scan --force' lands in pitch 01-06)
+  4  index corrupt (rebuild via 'rm -rf .sense/ && sense scan';
+     for a version/model-stale index use 'sense scan --rebuild')
 `
 
 // blastOptions is the parsed flag shape for the blast subcommand.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -107,7 +107,7 @@ func runDoctorChecks(ctx context.Context, cio IO) doctorResponse {
 			Name:       "schema_version",
 			Status:     "fail",
 			Message:    fmt.Sprintf("Cannot open index: %v", err),
-			Suggestion: "Run `sense scan --force` to rebuild",
+			Suggestion: "Run `rm -rf .sense/ && sense scan` to rebuild (the index can't be opened to reset in place)",
 		})
 		return builddoctorResponse(checks)
 	}
@@ -127,7 +127,7 @@ func runDoctorChecks(ctx context.Context, cio IO) doctorResponse {
 			Name:       "schema_version",
 			Status:     "fail",
 			Message:    fmt.Sprintf("Schema version mismatch (index: v%d, binary: v%d)", schemaVer, sqlite.SchemaVersion),
-			Suggestion: "Run `sense scan --force` to rebuild",
+			Suggestion: "Run `sense scan --rebuild` to rebuild",
 		})
 	}
 
@@ -144,7 +144,7 @@ func runDoctorChecks(ctx context.Context, cio IO) doctorResponse {
 			Name:       "embedding_model",
 			Status:     "fail",
 			Message:    fmt.Sprintf("Embedding model mismatch (index: %s, binary: %s)", storedModel, embed.ModelID),
-			Suggestion: "Run `sense scan --force` to re-embed with the new model",
+			Suggestion: "Run `sense scan --rebuild` to re-embed with the new model",
 		})
 	}
 
@@ -186,7 +186,7 @@ func runDoctorChecks(ctx context.Context, cio IO) doctorResponse {
 			Name:       "orphaned_edges",
 			Status:     "fail",
 			Message:    fmt.Sprintf("%d orphaned edges pointing to missing symbols", orphanCount),
-			Suggestion: "Index may be corrupt, run `sense scan --force`",
+			Suggestion: "Index may be corrupt, run `sense scan --rebuild`",
 		})
 	}
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -375,6 +375,28 @@ func TestDoctorSENSE_DIR(t *testing.T) {
 	}
 }
 
+func TestDoctorOrphanedEdgesFail(t *testing.T) {
+	dir := t.TempDir()
+	db := createTestDB(t, dir, sqlite.SchemaVersion)
+	ctx := context.Background()
+
+	// One valid symbol, plus an edge whose target_id points to a missing symbol.
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_files VALUES (1, 'a.go', 'go', 'abc', 1, '2026-01-01T00:00:00Z')`)
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_symbols VALUES (1, 1, 'Foo', 'Foo', 'function', 'public', NULL, 1, 5, NULL, NULL, NULL)`)
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_edges VALUES (1, 1, 99, 'calls', 1, 3, 1.0)`)
+	_ = db.Close()
+
+	t.Setenv("SENSE_EMBEDDINGS", "false")
+	var stdout, stderr bytes.Buffer
+	code := RunDoctor(nil, IO{Stdout: &stdout, Stderr: &stderr, Dir: dir})
+	if code != ExitGeneralError {
+		t.Errorf("doctor with orphaned edges: exit=%d, want %d", code, ExitGeneralError)
+	}
+	if !strings.Contains(stdout.String(), "orphaned edges") {
+		t.Errorf("expected orphaned edges fail message, got: %s", stdout.String())
+	}
+}
+
 func TestDoctorPassesOnHealthyIndex(t *testing.T) {
 	dir := t.TempDir()
 	senseDir := filepath.Join(dir, ".sense")

--- a/internal/cli/graph.go
+++ b/internal/cli/graph.go
@@ -40,8 +40,8 @@ Exit codes:
   1  general error
   2  symbol not found or ambiguous
   3  index missing (run 'sense scan' first)
-  4  index corrupt (rebuild via 'rm .sense/index.db && sense scan';
-     'sense scan --force' lands in pitch 01-06)
+  4  index corrupt (rebuild via 'rm -rf .sense/ && sense scan';
+     for a version/model-stale index use 'sense scan --rebuild')
 `
 
 // GraphDirection aliases model.Direction so existing callers and tests
@@ -152,8 +152,8 @@ func RunGraph(args []string, cio IO) int {
 }
 
 // handleIndexOpenError maps OpenIndex's sentinels to the right exit
-// code and hint. Missing → 3 ("run sense scan"); corrupt → 4 ("run
-// sense scan --force"); anything else → 1.
+// code and hint. Missing → 3 ("run sense scan"); corrupt → 4 ("rm -rf
+// .sense/ && sense scan"); anything else → 1.
 func handleIndexOpenError(stderr io.Writer, err error) int {
 	switch {
 	case errors.Is(err, ErrIndexMissing):

--- a/internal/cli/index.go
+++ b/internal/cli/index.go
@@ -33,7 +33,7 @@ var (
 // locked by another process), that error falls through unwrapped
 // so handleIndexOpenError's default branch maps it to exit 1 — a
 // permission problem is not "corrupt", and the exit-4 hint
-// ("rebuild with sense scan --force") would mislead the user.
+// ("rebuild with rm -rf .sense/ && sense scan") would mislead the user.
 //
 // The caller owns the returned Adapter and must Close it.
 func OpenIndex(ctx context.Context, dir string) (*sqlite.Adapter, error) {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -143,19 +143,19 @@ func computeHealth(ctx context.Context, db *sql.DB, dir string, resp mcpio.Statu
 
 	if resp.Version != nil && !resp.Version.SchemaCurrent {
 		h.verdict = "unhealthy"
-		h.detail = "schema mismatch — run 'sense scan --force'"
+		h.detail = "schema mismatch — run 'sense scan --rebuild'"
 		return h
 	}
 
 	if countOrphanedEdges(ctx, db) > 0 {
 		h.verdict = "unhealthy"
-		h.detail = "orphaned edges — run 'sense scan --force'"
+		h.detail = "orphaned edges — run 'sense scan --rebuild'"
 		return h
 	}
 
 	if resp.Version != nil && !resp.Version.EmbeddingModelCurrent {
 		h.verdict = "unhealthy"
-		h.detail = "embedding model mismatch — run 'sense scan --force'"
+		h.detail = "embedding model mismatch — run 'sense scan --rebuild'"
 		return h
 	}
 
@@ -385,7 +385,7 @@ func renderStatusHuman(cio IO, resp mcpio.StatusResponse, health healthInfo) {
 		if resp.Version.SchemaCurrent {
 			_, _ = fmt.Fprintf(w, " (current)\n")
 		} else {
-			_, _ = fmt.Fprintf(w, " (mismatch — run 'sense scan --force')\n")
+			_, _ = fmt.Fprintf(w, " (mismatch — run 'sense scan --rebuild')\n")
 		}
 		_, _ = fmt.Fprintf(w, "Embedding model: %s", resp.Version.EmbeddingModel)
 		if resp.Version.EmbeddingModelCurrent {

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -3,12 +3,14 @@ package cli
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/luuuc/sense/internal/mcpio"
 	"github.com/luuuc/sense/internal/model"
 	"github.com/luuuc/sense/internal/sqlite"
 )
@@ -69,6 +71,69 @@ func TestFormatTokens(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("formatTokens(%d) = %q, want %q", tt.n, got, tt.want)
 		}
+	}
+}
+
+// healthTestDB builds an in-memory-equivalent index with the schema
+// computeHealth queries, so the verdict branches can be driven directly.
+func healthTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "health.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := context.Background()
+	_, err = db.ExecContext(ctx, `
+		CREATE TABLE sense_files (id INTEGER PRIMARY KEY, path TEXT UNIQUE, language TEXT, hash TEXT, symbols INTEGER, indexed_at TEXT);
+		CREATE TABLE sense_symbols (id INTEGER PRIMARY KEY, file_id INTEGER, name TEXT, qualified TEXT, kind TEXT, visibility TEXT, parent_id INTEGER, line_start INTEGER, line_end INTEGER, docstring TEXT, complexity INTEGER, snippet TEXT, UNIQUE(file_id, qualified));
+		CREATE TABLE sense_edges (id INTEGER PRIMARY KEY, source_id INTEGER, target_id INTEGER, kind TEXT, file_id INTEGER, line INTEGER, confidence REAL);
+	`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func TestComputeHealthOrphanedEdges(t *testing.T) {
+	ctx := context.Background()
+	db := healthTestDB(t)
+
+	// A symbol exists, plus an edge whose target_id points to a missing symbol.
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_files VALUES (1, 'a.go', 'go', 'abc', 1, '2026-01-01T00:00:00Z')`)
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_symbols VALUES (1, 1, 'Foo', 'Foo', 'function', 'public', NULL, 1, 5, NULL, NULL, NULL)`)
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_edges VALUES (1, 1, 99, 'calls', 1, 3, 1.0)`)
+
+	resp := mcpio.StatusResponse{
+		Version: &mcpio.StatusVersion{SchemaCurrent: true, EmbeddingModelCurrent: true},
+	}
+	h := computeHealth(ctx, db, t.TempDir(), resp)
+
+	if h.verdict != "unhealthy" {
+		t.Errorf("verdict = %q, want %q", h.verdict, "unhealthy")
+	}
+	if h.detail != "orphaned edges — run 'sense scan --rebuild'" {
+		t.Errorf("detail = %q, want orphaned edges message", h.detail)
+	}
+}
+
+func TestComputeHealthEmbeddingModelMismatch(t *testing.T) {
+	ctx := context.Background()
+	db := healthTestDB(t)
+
+	// No orphaned edges, schema current, but the embedding model is stale.
+	resp := mcpio.StatusResponse{
+		Version: &mcpio.StatusVersion{SchemaCurrent: true, EmbeddingModelCurrent: false},
+	}
+	h := computeHealth(ctx, db, t.TempDir(), resp)
+
+	if h.verdict != "unhealthy" {
+		t.Errorf("verdict = %q, want %q", h.verdict, "unhealthy")
+	}
+	if h.detail != "embedding model mismatch — run 'sense scan --rebuild'" {
+		t.Errorf("detail = %q, want embedding model mismatch message", h.detail)
 	}
 }
 

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -52,5 +52,4 @@ type Index interface {
 	WriteEdge(ctx context.Context, e *model.Edge) (int64, error)
 	ReadSymbol(ctx context.Context, id int64) (*model.SymbolContext, error)
 	Query(ctx context.Context, f Filter) ([]model.Symbol, error)
-	Clear(ctx context.Context) error
 }

--- a/internal/index/indextest/conformance.go
+++ b/internal/index/indextest/conformance.go
@@ -42,7 +42,6 @@ func RunConformance(t *testing.T, newIdx Factory) {
 		{"QueryByFileID", testQueryByFileID},
 		{"QueryByName", testQueryByName},
 		{"QueryLimit", testQueryLimit},
-		{"Clear", testClear},
 		{"Close", testClose},
 	}
 	for _, tc := range cases {
@@ -463,30 +462,6 @@ func testQueryLimit(t *testing.T, newIdx Factory) {
 	}
 	if len(got) != 3 {
 		t.Errorf("Query(Limit=3) = %d rows, want 3", len(got))
-	}
-}
-
-func testClear(t *testing.T, newIdx Factory) {
-	ctx := context.Background()
-	idx := open(t, newIdx)
-
-	fileID := mustWriteFile(ctx, t, idx, sampleFile("app/models/temp.rb"))
-	symID := mustWriteSymbol(ctx, t, idx, sampleSymbol(fileID, "Temp", "Temp", model.KindClass))
-
-	if err := idx.Clear(ctx); err != nil {
-		t.Fatalf("Clear: %v", err)
-	}
-
-	got, err := idx.Query(ctx, index.Filter{})
-	if err != nil {
-		t.Fatalf("Query after Clear: %v", err)
-	}
-	if len(got) != 0 {
-		t.Errorf("Query after Clear = %d rows, want 0", len(got))
-	}
-
-	if _, err := idx.ReadSymbol(ctx, symID); !errors.Is(err, index.ErrNotFound) {
-		t.Errorf("ReadSymbol after Clear: err = %v, want ErrNotFound", err)
 	}
 }
 

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -115,7 +115,7 @@ func buildMCPServer(opts RunOptions) (*server.MCPServer, *handlers, func(), erro
 	}
 
 	if storedModel, _ := adapter.ReadMeta(ctx, "embedding_model"); storedModel != "" && storedModel != embed.ModelID {
-		fmt.Fprintf(os.Stderr, "sense mcp: embedding model changed (index: %s, binary: %s). Search results may be degraded. Run `sense scan --force` to re-embed.\n", storedModel, embed.ModelID)
+		fmt.Fprintf(os.Stderr, "sense mcp: embedding model changed (index: %s, binary: %s). Search results may be degraded. Run `sense scan --rebuild` to re-embed.\n", storedModel, embed.ModelID)
 	}
 
 	engine, embedder, err := search.BuildEngine(ctx, adapter, dir)

--- a/internal/scan/fts_migration_test.go
+++ b/internal/scan/fts_migration_test.go
@@ -1,0 +1,71 @@
+package scan_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/internal/scan"
+	_ "modernc.org/sqlite"
+)
+
+// downgradeFTS rewrites the index's FTS table to an older shape that lacks the
+// snippet and name_parts columns, so the next sqlite.Open detects a stale FTS
+// table and migrates it. It drops the four sync triggers first because they
+// reference the dropped columns.
+func downgradeFTS(t *testing.T, dbPath string) {
+	t.Helper()
+	ctx := context.Background()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open to downgrade fts: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	for _, trig := range []string{
+		"sense_symbols_fts_insert", "sense_symbols_fts_delete",
+		"sense_symbols_fts_update", "sense_symbols_fts_update_after",
+	} {
+		if _, err := db.ExecContext(ctx, "DROP TRIGGER IF EXISTS "+trig); err != nil {
+			t.Fatalf("drop trigger %s: %v", trig, err)
+		}
+	}
+	if _, err := db.ExecContext(ctx, "DROP TABLE IF EXISTS sense_symbols_fts"); err != nil {
+		t.Fatalf("drop fts table: %v", err)
+	}
+	// Recreate without snippet/name_parts so ftsNeedsMigration returns true.
+	if _, err := db.ExecContext(ctx,
+		"CREATE VIRTUAL TABLE sense_symbols_fts USING fts5(name, qualified, docstring)"); err != nil {
+		t.Fatalf("recreate stale fts table: %v", err)
+	}
+}
+
+// TestScanMigratesStaleFTSIndex covers the scan-time notice that fires when the
+// index carries a pre-snippet FTS table: sqlite.Open migrates it on reopen and
+// scan reports that keyword search will repopulate during the run.
+func TestScanMigratesStaleFTSIndex(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "main.go"), "package main\n\nfunc Run() int { return 1 }\n")
+	ctx := context.Background()
+
+	if _, err := scan.Run(ctx, quietOpts(root)); err != nil {
+		t.Fatalf("first scan: %v", err)
+	}
+
+	dbPath := filepath.Join(root, ".sense", "index.db")
+	downgradeFTS(t, dbPath)
+
+	var out bytes.Buffer
+	opts := scan.Options{Root: root, Output: &out, Warnings: io.Discard}
+	if _, err := scan.Run(ctx, opts); err != nil {
+		t.Fatalf("rescan after fts downgrade: %v", err)
+	}
+
+	if !strings.Contains(out.String(), "migrated fts index") {
+		t.Errorf("expected migrated fts index notice, got:\n%s", out.String())
+	}
+}

--- a/internal/scan/rebuild_test.go
+++ b/internal/scan/rebuild_test.go
@@ -1,0 +1,109 @@
+package scan_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/luuuc/sense/internal/scan"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// seedMetric writes a lifetime counter into the index the way metrics/tracker
+// would, so a rebuild has something to preserve.
+func seedMetric(t *testing.T, dbPath, key string, value int) {
+	t.Helper()
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open to seed metric: %v", err)
+	}
+	defer func() { _ = a.Close() }()
+	if _, err := a.DB().ExecContext(ctx,
+		"INSERT INTO sense_metrics(key, value) VALUES (?, ?) "+
+			"ON CONFLICT(key) DO UPDATE SET value = excluded.value", key, value); err != nil {
+		t.Fatalf("seed metric %s: %v", key, err)
+	}
+}
+
+func readMetric(t *testing.T, dbPath, key string) int {
+	t.Helper()
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open to read metric: %v", err)
+	}
+	defer func() { _ = a.Close() }()
+	var v int
+	if err := a.DB().QueryRowContext(ctx,
+		"SELECT value FROM sense_metrics WHERE key = ?", key).Scan(&v); err != nil {
+		t.Fatalf("read metric %s: %v", key, err)
+	}
+	return v
+}
+
+// TestScanRebuildRegeneratesAndPreservesMetrics is the --rebuild contract: it
+// bypasses the content-hash skip so every file is re-parsed and re-resolved
+// from source, while the lifetime metrics survive. A plain rescan (which skips
+// unchanged files) is run first as the baseline the rebuild departs from.
+func TestScanRebuildRegeneratesAndPreservesMetrics(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "lib.go"), "package main\n\nfunc Helper() int { return 1 }\n")
+	writeFile(t, filepath.Join(root, "main.go"), "package main\n\nfunc Run() int { return Helper() }\n")
+	ctx := context.Background()
+
+	first, err := scan.Run(ctx, quietOpts(root))
+	if err != nil {
+		t.Fatalf("first scan: %v", err)
+	}
+	if first.Symbols == 0 {
+		t.Fatal("first scan produced no symbols — test cannot prove regeneration")
+	}
+	if first.Edges == 0 {
+		t.Fatal("first scan produced no edges — test cannot prove edge regeneration")
+	}
+
+	dbPath := filepath.Join(root, ".sense", "index.db")
+	seedMetric(t, dbPath, "lifetime_queries", 77)
+
+	// Baseline: a plain rescan skips every unchanged file via the hash map.
+	plain, err := scan.Run(ctx, quietOpts(root))
+	if err != nil {
+		t.Fatalf("plain rescan: %v", err)
+	}
+	if plain.Changed != 0 {
+		t.Errorf("plain rescan Changed = %d, want 0 (hashes unchanged)", plain.Changed)
+	}
+	if plain.Skipped == 0 {
+		t.Error("plain rescan Skipped = 0, want >0 (unchanged files should skip)")
+	}
+
+	// --rebuild empties sense_files, so the hash-skip misses and every file
+	// is re-parsed and re-resolved.
+	opts := quietOpts(root)
+	opts.Rebuild = true
+	rebuilt, err := scan.Run(ctx, opts)
+	if err != nil {
+		t.Fatalf("rebuild scan: %v", err)
+	}
+	if rebuilt.Skipped != 0 {
+		t.Errorf("rebuild Skipped = %d, want 0 (nothing should skip)", rebuilt.Skipped)
+	}
+	if rebuilt.Changed != rebuilt.Indexed {
+		t.Errorf("rebuild Changed = %d, want = Indexed %d (every file re-parsed)",
+			rebuilt.Changed, rebuilt.Indexed)
+	}
+	if rebuilt.Symbols != first.Symbols {
+		t.Errorf("rebuild Symbols = %d, want %d (regenerated from source)",
+			rebuilt.Symbols, first.Symbols)
+	}
+	if rebuilt.Edges != first.Edges {
+		t.Errorf("rebuild Edges = %d, want %d (regenerated from source)",
+			rebuilt.Edges, first.Edges)
+	}
+
+	// The lifetime metric survived the drop-and-recreate.
+	if got := readMetric(t, dbPath, "lifetime_queries"); got != 77 {
+		t.Errorf("lifetime_queries after rebuild = %d, want 77 (metrics must persist)", got)
+	}
+}

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -61,6 +61,7 @@ type Options struct {
 	Quiet             bool      // suppress progress display and warning hints; forces non-TTY behavior
 	EmbeddingsEnabled bool      // when true, embeddings are part of the index pipeline
 	Embed             bool      // block until embeddings complete; requires EmbeddingsEnabled. When false, embeddings are deferred and a watermark is written for the MCP server to pick up.
+	Rebuild           bool      // drop and recreate the index from source (preserving lifetime metrics) before walking, so every file is re-parsed and re-resolved even when its hash is unchanged
 }
 
 // PhaseTiming records how long each scan phase took.
@@ -183,6 +184,17 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	}
 	if idx.FTSMigrated {
 		_, _ = fmt.Fprintf(out, "migrated fts index — keyword search will repopulate during this scan\n")
+	}
+
+	// --rebuild drops the derived tables (preserving lifetime metrics) before
+	// the walk, so the emptied sense_files forces every file to re-parse and
+	// re-resolve even when its hash is unchanged. Skipped when Open already
+	// rebuilt for a schema mismatch — that path left the same empty state.
+	if opts.Rebuild && !idx.Rebuilt {
+		if err := idx.Rebuild(ctx); err != nil {
+			return nil, fmt.Errorf("rebuild index: %w", err)
+		}
+		_, _ = fmt.Fprintf(out, "rebuilding index from source (lifetime metrics preserved)\n")
 	}
 
 	prog := newProgress(out, opts.Quiet)

--- a/internal/sqlite/adapter.go
+++ b/internal/sqlite/adapter.go
@@ -32,6 +32,14 @@ var schemaFTSSQL string
 // before a scan completes successfully; see StampSchemaVersion.
 const SchemaVersion = 5
 
+// metricsPreserve is the preserve-set every reset path honors: the lifetime
+// counters in sense_metrics (total queries, estimated tokens saved) survive
+// both an automatic schema-bump rebuild and an explicit `sense scan
+// --rebuild`. They are the only data in the index not re-derivable from source
+// (03-data-model.md), so a reset must not zero them. The shape-stability
+// invariant for excluding a table from the drop lives on resetSenseTables.
+var metricsPreserve = map[string]bool{"sense_metrics": true}
+
 // maxOpenConns is the connection-pool size Open applies. InTx relies on
 // this being 1 — its raw BEGIN/COMMIT approach shares a transaction
 // across Adapter calls by sharing the single pooled connection. If this
@@ -128,33 +136,55 @@ func Open(ctx context.Context, path string) (*Adapter, error) {
 	var storedVersion int
 	_ = db.QueryRowContext(ctx, "PRAGMA user_version").Scan(&storedVersion)
 	rebuilt := false
+	ftsMigrated := false
 	if storedVersion != 0 && storedVersion != SchemaVersion {
+		// Binary upgraded against an older schema: drop and recreate from
+		// source via the one reset primitive. resetSenseTables resets
+		// user_version to 0 and re-applies the full schema, so the apply
+		// branch below is skipped — the state is indistinguishable from a
+		// fresh DB until StampSchemaVersion is called after scan. The
+		// preserve-set keeps lifetime metrics across the rebuild; everything
+		// else is re-derived by the scan.
 		rebuilt = true
-		if err := dropAllSenseTables(ctx, db); err != nil {
+		if err := resetSenseTables(ctx, db, metricsPreserve); err != nil {
 			_ = db.Close()
 			return nil, err
 		}
-		// Reset user_version so the state is indistinguishable from a
-		// fresh DB until StampSchemaVersion is called after scan.
-		if _, err := db.ExecContext(ctx, "PRAGMA user_version = 0"); err != nil {
+	} else {
+		// Fresh or current DB: apply the schema in place. CREATE ... IF NOT
+		// EXISTS makes this a no-op on an already-current index, and a stale
+		// FTS table is migrated in passing.
+		var err error
+		ftsMigrated, err = applySchema(ctx, db)
+		if err != nil {
 			_ = db.Close()
-			return nil, fmt.Errorf("sqlite reset user_version: %w", err)
+			return nil, err
 		}
 	}
 
+	return &Adapter{db: db, Rebuilt: rebuilt, FTSMigrated: ftsMigrated}, nil
+}
+
+// applySchema applies the base schema, then the FTS5 virtual table, then its
+// triggers — each as a separate ExecContext because modernc.org/sqlite
+// silently drops virtual-table and trigger DDL embedded after other
+// statements in one multi-statement string. It returns whether a stale FTS
+// table was migrated (dropped and recreated), so the caller can warn that
+// keyword search will repopulate on the next scan.
+//
+// CREATE ... IF NOT EXISTS makes this safe on a fresh, current, or
+// just-reset database alike. The migration path only fires on an in-place
+// upgrade where the FTS table survived but lost columns; after a full reset
+// the table is gone, so ftsMigrated is false.
+func applySchema(ctx context.Context, db *sql.DB) (ftsMigrated bool, err error) {
 	if _, err := db.ExecContext(ctx, schemaSQL); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("sqlite schema: %w", err)
+		return false, fmt.Errorf("sqlite schema: %w", err)
 	}
 
-	// FTS5 virtual table and triggers are applied separately because
-	// modernc.org/sqlite's ExecContext silently drops virtual-table
-	// statements embedded in a long multi-statement string.
-	//
-	// Migration: if the FTS table exists but is missing the snippet
-	// column (added in search-quality pitch), drop it and its triggers
-	// so the CREATE IF NOT EXISTS below picks up the new schema.
-	ftsMigrated := ftsNeedsMigration(ctx, db)
+	// Migration: if the FTS table exists but is missing the snippet column
+	// (added in the search-quality pitch), drop it and its triggers so the
+	// CREATE IF NOT EXISTS below picks up the new schema.
+	ftsMigrated = ftsNeedsMigration(ctx, db)
 	if ftsMigrated {
 		for _, name := range []string{
 			"sense_symbols_fts_insert", "sense_symbols_fts_delete",
@@ -166,17 +196,27 @@ func Open(ctx context.Context, path string) (*Adapter, error) {
 	}
 
 	if _, err := db.ExecContext(ctx, schemaFTSSQL); err != nil {
-		_ = db.Close()
-		return nil, fmt.Errorf("sqlite fts schema: %w", err)
+		return ftsMigrated, fmt.Errorf("sqlite fts schema: %w", err)
 	}
 	for _, stmt := range ftsTriggerStatements {
 		if _, err := db.ExecContext(ctx, stmt); err != nil {
-			_ = db.Close()
-			return nil, fmt.Errorf("sqlite fts trigger: %w", err)
+			return ftsMigrated, fmt.Errorf("sqlite fts trigger: %w", err)
 		}
 	}
+	return ftsMigrated, nil
+}
 
-	return &Adapter{db: db, Rebuilt: rebuilt, FTSMigrated: ftsMigrated}, nil
+// Rebuild drops and recreates every source-derived sense_% table, preserving
+// the lifetime metrics, then leaves an empty current-schema index. It is the
+// explicit counterpart to Open's automatic schema-mismatch rebuild: `sense
+// scan --rebuild` calls it after Open and before the walk, so the emptied
+// sense_files makes the scan's hash-skip miss on every file and re-parse and
+// re-resolve the whole tree (and re-embed, inline with --embed or deferred to
+// the MCP server otherwise). user_version is left at 0 until the scan
+// completes and StampSchemaVersion runs, so a crash mid-rebuild reopens as a
+// fresh index and rescans.
+func (a *Adapter) Rebuild(ctx context.Context) error {
+	return resetSenseTables(ctx, a.db, metricsPreserve)
 }
 
 // ftsNeedsMigration returns true if the FTS5 table exists but is
@@ -1217,27 +1257,31 @@ func (a *Adapter) DeleteMeta(ctx context.Context, key string) error {
 	return nil
 }
 
-func (a *Adapter) Clear(ctx context.Context) error {
-	// Order respects foreign keys even if ON DELETE CASCADE would handle
-	// it — explicit is clearer than clever.
-	for _, tbl := range []string{
-		"sense_edges",
-		"sense_embeddings",
-		"sense_symbols",
-		"sense_files",
-	} {
-		if _, err := a.db.ExecContext(ctx, "DELETE FROM "+tbl); err != nil {
-			return fmt.Errorf("sqlite Clear %s: %w", tbl, err)
-		}
-	}
-	return nil
-}
-
-// dropAllSenseTables discovers and drops every sense_* table/view in the
-// database. Using sqlite_master makes this future-proof — new tables added
-// in later schema versions get dropped automatically without maintaining a
+// resetSenseTables is the single index-reset primitive. It drops every
+// sense_% table/view NOT named in preserve, resets PRAGMA user_version to 0,
+// and re-applies the full schema (base tables, FTS virtual table, triggers)
+// via applySchema. Both reset callers share it: Open's schema-mismatch branch
+// (automatic, on a binary upgrade) and Adapter.Rebuild (explicit, behind
+// `sense scan --rebuild`). They differ only in the preserve-set.
+//
+// DROP (not DELETE) is deliberate. A schema bump changes table *shape*, so the
+// structure must be recreated — DELETE would leave the stale shape. An
+// explicit same-binary rebuild uses the same drop path because it is strictly
+// more thorough (it also heals any structural drift) and repopulates
+// immediately, so index.db self-levels via SQLite page reuse.
+//
+// Preserve-via-exclude invariant: a preserved table keeps both its rows and
+// its existing shape, because it is never dropped and CREATE TABLE IF NOT
+// EXISTS is a no-op on it. This is correct only while the preserved table's
+// shape is stable across schema versions. If a future SchemaVersion ever
+// changes a preserved table (e.g. sense_metrics) itself, that release must
+// ship a hand-written migration for that one table, since it is no longer
+// auto-dropped here.
+//
+// Discovering tables via sqlite_master keeps this future-proof: tables added
+// in later schema versions are dropped automatically without maintaining a
 // parallel list.
-func dropAllSenseTables(ctx context.Context, db *sql.DB) error {
+func resetSenseTables(ctx context.Context, db *sql.DB, preserve map[string]bool) error {
 	rows, err := db.QueryContext(ctx,
 		"SELECT type, name FROM sqlite_master WHERE type IN ('table','view') AND name LIKE 'sense_%'")
 	if err != nil {
@@ -1252,17 +1296,52 @@ func dropAllSenseTables(ctx context.Context, db *sql.DB) error {
 		if err := rows.Scan(&e.typ, &e.name); err != nil {
 			return fmt.Errorf("sqlite list tables scan: %w", err)
 		}
+		if preserve[e.name] {
+			continue
+		}
 		entries = append(entries, e)
 	}
 	if err := rows.Err(); err != nil {
 		return fmt.Errorf("sqlite list tables iterate: %w", err)
 	}
 
+	// Drop with foreign keys disabled so order is irrelevant: sqlite_master
+	// lists tables in creation order (parents first), but ON DELETE CASCADE
+	// makes a FK-enforced DROP of a parent fail once its children's rows are
+	// gone. Every dropped table is recreated by applySchema below, and the
+	// only preserved table (sense_metrics) participates in no FK, so disabling
+	// enforcement for the structural reset is safe. Restored to ON before
+	// returning — the single pooled connection (maxOpenConns) keeps the DSN's
+	// foreign_keys(1) default otherwise. modernc applies PRAGMA foreign_keys
+	// only outside a transaction, which holds here (each Exec autocommits).
+	if _, err := db.ExecContext(ctx, "PRAGMA foreign_keys = OFF"); err != nil {
+		return fmt.Errorf("sqlite disable foreign_keys: %w", err)
+	}
+	// Restore on a non-cancellable context: re-enabling enforcement is a
+	// safety invariant, and with one pooled connection a missed restore would
+	// leave FK checks off for the rest of the process. A cancelled ctx must
+	// not skip it.
+	defer func() {
+		_, _ = db.ExecContext(context.WithoutCancel(ctx), "PRAGMA foreign_keys = ON")
+	}()
+
 	for _, e := range entries {
 		stmt := fmt.Sprintf("DROP %s IF EXISTS %s", strings.ToUpper(e.typ), e.name)
 		if _, err := db.ExecContext(ctx, stmt); err != nil {
 			return fmt.Errorf("sqlite drop %s %s: %w", e.typ, e.name, err)
 		}
+	}
+
+	// Reset user_version so the state is indistinguishable from a fresh DB
+	// until StampSchemaVersion is called after the scan completes.
+	if _, err := db.ExecContext(ctx, "PRAGMA user_version = 0"); err != nil {
+		return fmt.Errorf("sqlite reset user_version: %w", err)
+	}
+
+	// ftsMigrated is intentionally discarded: after a full drop the FTS table
+	// is gone, so applySchema recreates it fresh and never reports a migration.
+	if _, err := applySchema(ctx, db); err != nil {
+		return err
 	}
 	return nil
 }

--- a/internal/sqlite/adapter_test.go
+++ b/internal/sqlite/adapter_test.go
@@ -161,6 +161,77 @@ func TestSchemaVersionMismatchRebuilds(t *testing.T) {
 	}
 }
 
+// TestSchemaMismatchPreservesMetrics is the metrics-preservation contract:
+// a binary upgrade that bumps SchemaVersion triggers a rebuild on the next
+// Open, and the lifetime counters in sense_metrics survive it while all
+// source-derived data is dropped.
+func TestSchemaMismatchPreservesMetrics(t *testing.T) {
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "index.db")
+
+	// Build a current-schema index with a lifetime metric and some data.
+	a, err := sqlite.Open(ctx, path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if _, err := a.DB().ExecContext(ctx,
+		"INSERT INTO sense_metrics(key, value) VALUES ('lifetime_queries', 99)"); err != nil {
+		t.Fatalf("seed metrics: %v", err)
+	}
+	if _, err := a.DB().ExecContext(ctx,
+		"INSERT INTO sense_files(path, language, hash, symbols, indexed_at) VALUES ('old.go','go','h',0,'t')"); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	if err := a.StampSchemaVersion(ctx); err != nil {
+		t.Fatalf("StampSchemaVersion: %v", err)
+	}
+	if err := a.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Simulate a binary built against an older schema by rewinding the
+	// stored version, the way an upgrade would surface.
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("raw open: %v", err)
+	}
+	if _, err := db.ExecContext(ctx,
+		fmt.Sprintf("PRAGMA user_version = %d", sqlite.SchemaVersion-1)); err != nil {
+		t.Fatalf("rewind user_version: %v", err)
+	}
+	_ = db.Close()
+
+	// Reopen: mismatch detected, rebuild, metrics preserved.
+	a2, err := sqlite.Open(ctx, path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = a2.Close() }()
+
+	if !a2.Rebuilt {
+		t.Fatal("expected Rebuilt=true after schema version mismatch")
+	}
+
+	var queries int
+	if err := a2.DB().QueryRowContext(ctx,
+		"SELECT value FROM sense_metrics WHERE key='lifetime_queries'").Scan(&queries); err != nil {
+		t.Fatalf("read lifetime_queries after rebuild: %v", err)
+	}
+	if queries != 99 {
+		t.Errorf("lifetime_queries after rebuild = %d, want 99 (metrics must survive)", queries)
+	}
+
+	// Source-derived data is gone — proving the rebuild really happened and
+	// only sense_metrics was spared.
+	paths, err := a2.FilePaths(ctx)
+	if err != nil {
+		t.Fatalf("FilePaths: %v", err)
+	}
+	if len(paths) != 0 {
+		t.Errorf("files after rebuild = %d, want 0", len(paths))
+	}
+}
+
 func TestFreshDBNotRebuilt(t *testing.T) {
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "index.db")

--- a/internal/sqlite/closed_adapter_test.go
+++ b/internal/sqlite/closed_adapter_test.go
@@ -136,11 +136,6 @@ func TestClosedAdapterReturnsErrors(t *testing.T) {
 			t.Error("expected error")
 		}
 	})
-	t.Run("Clear", func(t *testing.T) {
-		if err := a.Clear(ctx); err == nil {
-			t.Error("expected error")
-		}
-	})
 	t.Run("ReadSymbol", func(t *testing.T) {
 		if _, err := a.ReadSymbol(ctx, 1); err == nil {
 			t.Error("expected error")
@@ -148,6 +143,11 @@ func TestClosedAdapterReturnsErrors(t *testing.T) {
 	})
 	t.Run("StampSchemaVersion", func(t *testing.T) {
 		if err := a.StampSchemaVersion(ctx); err == nil {
+			t.Error("expected error")
+		}
+	})
+	t.Run("Rebuild", func(t *testing.T) {
+		if err := a.Rebuild(ctx); err == nil {
 			t.Error("expected error")
 		}
 	})
@@ -180,4 +180,3 @@ func TestInTxPanicsWhenPoolSizeChanges(t *testing.T) {
 	}()
 	_ = a.InTx(ctx, func() error { return nil })
 }
-

--- a/internal/sqlite/coverage_test.go
+++ b/internal/sqlite/coverage_test.go
@@ -1068,44 +1068,6 @@ func TestDeleteFile(t *testing.T) {
 	}
 }
 
-func TestClear(t *testing.T) {
-	a := openTestDB(t)
-	ctx := context.Background()
-
-	fid := seedFile(t, a, "app.go", "go", "h1")
-	sid := seedSymbol(t, a, fid, "A", "pkg.A", "class")
-	line := 5
-	if _, err := a.WriteEdge(ctx, &model.Edge{
-		SourceID: &sid, TargetID: sid, Kind: model.EdgeCalls,
-		FileID: fid, Line: &line, Confidence: 1.0,
-	}); err != nil {
-		t.Fatalf("WriteEdge: %v", err)
-	}
-	if err := a.WriteEmbedding(ctx, sid, floatVec(1.0)); err != nil {
-		t.Fatalf("WriteEmbedding: %v", err)
-	}
-
-	if err := a.Clear(ctx); err != nil {
-		t.Fatalf("Clear: %v", err)
-	}
-
-	paths, err := a.FilePaths(ctx)
-	if err != nil {
-		t.Fatalf("FilePaths after clear: %v", err)
-	}
-	if len(paths) != 0 {
-		t.Errorf("FilePaths after clear = %v, want empty", paths)
-	}
-
-	count, err := a.SymbolCount(ctx)
-	if err != nil {
-		t.Fatalf("SymbolCount after clear: %v", err)
-	}
-	if count != 0 {
-		t.Errorf("SymbolCount after clear = %d, want 0", count)
-	}
-}
-
 func TestSymbolCountEmptyAndPopulated(t *testing.T) {
 	a := openTestDB(t)
 	ctx := context.Background()

--- a/internal/sqlite/fault_driver_test.go
+++ b/internal/sqlite/fault_driver_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
+	"io"
 	"strings"
 	"sync"
 	"testing"
@@ -16,10 +17,25 @@ import (
 // which a healthy database never reaches and the closed-adapter test (an
 // entry-point failure) cannot reach either.
 
+// rowsFaultMode selects how an armed QueryContext result misbehaves, so the
+// two post-query failure points in resetSenseTables can be driven separately:
+// a Scan failure (wrong column count) versus a Next/Err failure (iteration
+// error). rowsFaultNone leaves QueryContext untouched.
+type rowsFaultMode int
+
+const (
+	rowsFaultNone rowsFaultMode = iota
+	rowsFaultScan               // report one column so a 2-target Scan fails
+	rowsFaultNext               // return a non-EOF error from Next, surfaced by rows.Err
+)
+
 var (
 	faultOnce sync.Once
 	faultMu   sync.Mutex
 	faultSub  string // when non-empty, fail the first matching Exec
+
+	rowsFaultSub  string // when non-empty, the first matching Query returns faulty rows
+	rowsFaultKind rowsFaultMode
 )
 
 func armFault(sub string) {
@@ -30,6 +46,15 @@ func armFault(sub string) {
 
 func disarmFault() { armFault("") }
 
+func armRowsFault(sub string, kind rowsFaultMode) {
+	faultMu.Lock()
+	rowsFaultSub = sub
+	rowsFaultKind = kind
+	faultMu.Unlock()
+}
+
+func disarmRowsFault() { armRowsFault("", rowsFaultNone) }
+
 func matchFault(query string) bool {
 	faultMu.Lock()
 	defer faultMu.Unlock()
@@ -38,6 +63,18 @@ func matchFault(query string) bool {
 		return true
 	}
 	return false
+}
+
+func matchRowsFault(query string) (rowsFaultMode, bool) {
+	faultMu.Lock()
+	defer faultMu.Unlock()
+	if rowsFaultSub != "" && strings.Contains(query, rowsFaultSub) {
+		kind := rowsFaultKind
+		rowsFaultSub = "" // one-shot
+		rowsFaultKind = rowsFaultNone
+		return kind, true
+	}
+	return rowsFaultNone, false
 }
 
 type faultDriver struct{ base driver.Driver }
@@ -72,7 +109,47 @@ func (c *faultConn) QueryContext(ctx context.Context, query string, args []drive
 	if !ok {
 		return nil, driver.ErrSkip
 	}
+	if kind, armed := matchRowsFault(query); armed {
+		return &faultRows{mode: kind}, nil
+	}
 	return qc.QueryContext(ctx, query, args)
+}
+
+// faultRows is a driver.Rows that misbehaves once on the armed query so the
+// rows.Scan and rows.Err error paths in resetSenseTables get exercised without
+// touching production code.
+type faultRows struct {
+	mode rowsFaultMode
+	done bool
+}
+
+func (r *faultRows) Columns() []string {
+	if r.mode == rowsFaultScan {
+		// One column against a two-target Scan: database/sql rejects the
+		// destination count, hitting the rows.Scan error return.
+		return []string{"name"}
+	}
+	return []string{"type", "name"}
+}
+
+func (r *faultRows) Close() error { return nil }
+
+func (r *faultRows) Next(dest []driver.Value) error {
+	if r.done {
+		return io.EOF
+	}
+	r.done = true
+	switch r.mode {
+	case rowsFaultScan:
+		dest[0] = "sense_files"
+		return nil
+	case rowsFaultNext:
+		// A non-EOF error from Next is stored by database/sql and surfaced
+		// through rows.Err after the loop, hitting the rows.Err error return.
+		return fmt.Errorf("injected fault: rows iteration")
+	default:
+		return io.EOF
+	}
 }
 
 // openFaultDB returns a *sql.DB on the fault driver with the schema applied,
@@ -123,6 +200,38 @@ func TestResetSenseTablesInjectedErrors(t *testing.T) {
 
 			armFault(tc.trigger)
 			defer disarmFault()
+
+			err := resetSenseTables(ctx, db, metricsPreserve)
+			if err == nil {
+				t.Fatalf("resetSenseTables: expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestResetSenseTablesRowsErrors covers the two post-query iteration failures
+// in resetSenseTables: a Scan error (driver reports a mismatched column count)
+// and a rows.Err error (driver Next returns a non-EOF error). Both are armed by
+// the sqlite_master listing query that opens the reset.
+func TestResetSenseTablesRowsErrors(t *testing.T) {
+	cases := []struct {
+		name    string
+		mode    rowsFaultMode
+		wantErr string
+	}{
+		{"scan", rowsFaultScan, "sqlite list tables scan"},
+		{"iterate", rowsFaultNext, "sqlite list tables iterate"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := openFaultDB(t)
+			ctx := context.Background()
+
+			armRowsFault("FROM sqlite_master", tc.mode)
+			defer disarmRowsFault()
 
 			err := resetSenseTables(ctx, db, metricsPreserve)
 			if err == nil {

--- a/internal/sqlite/fault_driver_test.go
+++ b/internal/sqlite/fault_driver_test.go
@@ -1,0 +1,146 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// The fault driver wraps the registered modernc "sqlite" driver and fails the
+// first ExecContext whose SQL contains an armed substring. It exists to drive
+// resetSenseTables / applySchema down their mid-sequence DB-error returns,
+// which a healthy database never reaches and the closed-adapter test (an
+// entry-point failure) cannot reach either.
+
+var (
+	faultOnce sync.Once
+	faultMu   sync.Mutex
+	faultSub  string // when non-empty, fail the first matching Exec
+)
+
+func armFault(sub string) {
+	faultMu.Lock()
+	faultSub = sub
+	faultMu.Unlock()
+}
+
+func disarmFault() { armFault("") }
+
+func matchFault(query string) bool {
+	faultMu.Lock()
+	defer faultMu.Unlock()
+	if faultSub != "" && strings.Contains(query, faultSub) {
+		faultSub = "" // one-shot: fire once, then let the sequence unwind
+		return true
+	}
+	return false
+}
+
+type faultDriver struct{ base driver.Driver }
+
+func (d *faultDriver) Open(name string) (driver.Conn, error) {
+	c, err := d.base.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return &faultConn{base: c}, nil
+}
+
+type faultConn struct{ base driver.Conn }
+
+func (c *faultConn) Prepare(q string) (driver.Stmt, error) { return c.base.Prepare(q) }
+func (c *faultConn) Close() error                          { return c.base.Close() }
+func (c *faultConn) Begin() (driver.Tx, error)             { return c.base.Begin() } //nolint:staticcheck // delegating to base
+
+func (c *faultConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	if matchFault(query) {
+		return nil, fmt.Errorf("injected fault: exec %q", query)
+	}
+	ec, ok := c.base.(driver.ExecerContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	return ec.ExecContext(ctx, query, args)
+}
+
+func (c *faultConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	qc, ok := c.base.(driver.QueryerContext)
+	if !ok {
+		return nil, driver.ErrSkip
+	}
+	return qc.QueryContext(ctx, query, args)
+}
+
+// openFaultDB returns a *sql.DB on the fault driver with the schema applied,
+// pinned to a single connection so the fault fires deterministically within
+// one statement sequence.
+func openFaultDB(t *testing.T) *sql.DB {
+	t.Helper()
+	faultOnce.Do(func() {
+		probe, err := sql.Open("sqlite", ":memory:")
+		if err != nil {
+			panic(err)
+		}
+		base := probe.Driver()
+		_ = probe.Close()
+		sql.Register("sqlite-fault", &faultDriver{base: base})
+	})
+	db, err := sql.Open("sqlite-fault", "file::memory:?cache=shared")
+	if err != nil {
+		t.Fatalf("open fault db: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := applySchema(context.Background(), db); err != nil {
+		t.Fatalf("apply schema on fault db: %v", err)
+	}
+	return db
+}
+
+// TestResetSenseTablesInjectedErrors drives every write step of the reset
+// sequence to its error return by failing exactly that statement.
+func TestResetSenseTablesInjectedErrors(t *testing.T) {
+	cases := []struct {
+		name    string
+		trigger string
+		wantErr string
+	}{
+		{"foreign_keys_off", "foreign_keys = OFF", "disable foreign_keys"},
+		{"drop_table", "DROP TABLE", "sqlite drop"},
+		{"user_version", "user_version = 0", "reset user_version"},
+		{"base_schema", "CREATE TABLE IF NOT EXISTS sense_files", "sqlite schema"},
+		{"fts_schema", "CREATE VIRTUAL TABLE", "fts schema"},
+		{"fts_trigger", "sense_symbols_fts_insert", "fts trigger"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := openFaultDB(t)
+			ctx := context.Background()
+
+			armFault(tc.trigger)
+			defer disarmFault()
+
+			err := resetSenseTables(ctx, db, metricsPreserve)
+			if err == nil {
+				t.Fatalf("resetSenseTables: expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestResetSenseTablesListTablesError covers the entry-point query failure:
+// a closed connection makes the sqlite_master read fail before any drop.
+func TestResetSenseTablesListTablesError(t *testing.T) {
+	db := openFaultDB(t)
+	_ = db.Close() // subsequent queries fail
+	if err := resetSenseTables(context.Background(), db, metricsPreserve); err == nil {
+		t.Fatal("resetSenseTables on closed db: expected error, got nil")
+	}
+}

--- a/internal/sqlite/reset_internal_test.go
+++ b/internal/sqlite/reset_internal_test.go
@@ -1,0 +1,163 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+)
+
+// openForReset returns a fresh adapter whose schema is fully applied, so a
+// reset can be exercised against a populated, current-shape database.
+func openForReset(t *testing.T) *Adapter {
+	t.Helper()
+	ctx := context.Background()
+	a, err := Open(ctx, filepath.Join(t.TempDir(), "reset.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = a.Close() })
+	return a
+}
+
+func tableCount(t *testing.T, db *sql.DB, table string) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRow("SELECT COUNT(*) FROM " + table).Scan(&n); err != nil {
+		t.Fatalf("count %s: %v", table, err)
+	}
+	return n
+}
+
+func objectExists(t *testing.T, db *sql.DB, typ, name string) bool {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(
+		"SELECT COUNT(*) FROM sqlite_master WHERE type=? AND name=?", typ, name,
+	).Scan(&n); err != nil {
+		t.Fatalf("sqlite_master lookup %s %s: %v", typ, name, err)
+	}
+	return n > 0
+}
+
+// seedReset populates every derived table plus a sense_metrics counter so a
+// reset has something to drop and something to preserve.
+func seedReset(t *testing.T, a *Adapter) {
+	t.Helper()
+	ctx := context.Background()
+	fid := seedFileInternal(t, a)
+	sid := seedSymbolInternal(t, a, fid)
+	if _, err := a.db.ExecContext(ctx,
+		"INSERT INTO sense_edges(source_id, target_id, kind, file_id, line, confidence) VALUES (?,?,?,?,?,?)",
+		sid, sid, "calls", fid, 1, 1.0); err != nil {
+		t.Fatalf("seed edge: %v", err)
+	}
+	if _, err := a.db.ExecContext(ctx,
+		"INSERT INTO sense_meta(key, value) VALUES ('embedding_model','test-model')"); err != nil {
+		t.Fatalf("seed meta: %v", err)
+	}
+	if _, err := a.db.ExecContext(ctx,
+		"INSERT INTO sense_metrics(key, value) VALUES ('lifetime_queries', 42), ('lifetime_tokens_saved', 1000)"); err != nil {
+		t.Fatalf("seed metrics: %v", err)
+	}
+}
+
+func seedFileInternal(t *testing.T, a *Adapter) int64 {
+	t.Helper()
+	res, err := a.db.Exec(
+		"INSERT INTO sense_files(path, language, hash, symbols, indexed_at) VALUES ('a.go','go','h1',1,0)")
+	if err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	id, _ := res.LastInsertId()
+	return id
+}
+
+func seedSymbolInternal(t *testing.T, a *Adapter, fid int64) int64 {
+	t.Helper()
+	res, err := a.db.Exec(
+		"INSERT INTO sense_symbols(file_id, name, qualified, kind, line_start, line_end) VALUES (?,?,?,?,?,?)",
+		fid, "A", "pkg.A", "class", 1, 10)
+	if err != nil {
+		t.Fatalf("seed symbol: %v", err)
+	}
+	id, _ := res.LastInsertId()
+	return id
+}
+
+// TestResetPreservesMetrics is the core primitive contract: with
+// preserve={sense_metrics}, the lifetime counters survive while every other
+// sense_% table is dropped and recreated empty at the current schema.
+func TestResetPreservesMetrics(t *testing.T) {
+	ctx := context.Background()
+	a := openForReset(t)
+	seedReset(t, a)
+
+	if err := resetSenseTables(ctx, a.db, map[string]bool{"sense_metrics": true}); err != nil {
+		t.Fatalf("resetSenseTables: %v", err)
+	}
+
+	// sense_metrics rows survive untouched.
+	if got := tableCount(t, a.db, "sense_metrics"); got != 2 {
+		t.Errorf("sense_metrics rows after reset = %d, want 2", got)
+	}
+	var queries int
+	if err := a.db.QueryRow(
+		"SELECT value FROM sense_metrics WHERE key='lifetime_queries'").Scan(&queries); err != nil {
+		t.Fatalf("read lifetime_queries: %v", err)
+	}
+	if queries != 42 {
+		t.Errorf("lifetime_queries after reset = %d, want 42", queries)
+	}
+
+	// Every derived table exists and is empty.
+	for _, tbl := range []string{"sense_files", "sense_symbols", "sense_edges", "sense_embeddings", "sense_meta"} {
+		if !objectExists(t, a.db, "table", tbl) {
+			t.Errorf("table %s missing after reset", tbl)
+			continue
+		}
+		if got := tableCount(t, a.db, tbl); got != 0 {
+			t.Errorf("%s rows after reset = %d, want 0", tbl, got)
+		}
+	}
+
+	// FTS virtual table and its triggers are re-applied.
+	if !objectExists(t, a.db, "table", "sense_symbols_fts") {
+		t.Error("sense_symbols_fts missing after reset")
+	}
+	for _, trig := range []string{
+		"sense_symbols_fts_insert", "sense_symbols_fts_delete",
+		"sense_symbols_fts_update", "sense_symbols_fts_update_after",
+	} {
+		if !objectExists(t, a.db, "trigger", trig) {
+			t.Errorf("FTS trigger %s missing after reset", trig)
+		}
+	}
+
+	// user_version is reset to 0; StampSchemaVersion sets it after scan.
+	var uv int
+	if err := a.db.QueryRow("PRAGMA user_version").Scan(&uv); err != nil {
+		t.Fatalf("read user_version: %v", err)
+	}
+	if uv != 0 {
+		t.Errorf("user_version after reset = %d, want 0", uv)
+	}
+}
+
+// TestResetNilPreserveDropsMetrics confirms the preserve-set is the only thing
+// that spares a table: with no preserve-set, sense_metrics is dropped like
+// everything else. This is the behavior Open's schema-mismatch branch had
+// before the metrics-preserving change.
+func TestResetNilPreserveDropsMetrics(t *testing.T) {
+	ctx := context.Background()
+	a := openForReset(t)
+	seedReset(t, a)
+
+	if err := resetSenseTables(ctx, a.db, nil); err != nil {
+		t.Fatalf("resetSenseTables: %v", err)
+	}
+
+	if got := tableCount(t, a.db, "sense_metrics"); got != 0 {
+		t.Errorf("sense_metrics rows after nil-preserve reset = %d, want 0", got)
+	}
+}


### PR DESCRIPTION
## Problem
The only honest way to fully refresh the index is `rm -rf .sense/ && sense scan`, which destroys the one thing in the index not derived from source: the lifetime `sense_metrics` counters (total queries, estimated tokens saved). Worse, the same wipe fires automatically on a schema-version bump during `Open`, so upgrading the binary silently zeros a user's accumulated metrics. Meanwhile `sense doctor`, `sense status`, and the MCP server all advise `sense scan --force` — a flag that never existed, so the repair advice was dead on arrival.

## Summary
Collapse the two reset paths into one drop-and-recreate primitive parametrized by a preserve-set, expose it as `sense scan --rebuild`, and point every repair message at the now-real flag.

## Changes
- **sqlite**: new `resetSenseTables(db, preserve)` primitive + extracted `applySchema`; `Open`'s schema-mismatch branch now preserves `sense_metrics`; retire the redundant `DELETE`-based `Clear` from the `Index` interface.
- **scan**: `Adapter.Rebuild` + `--rebuild` flag — empties `sense_files` before the walk so every file re-parses and re-resolves from source, with lifetime metrics intact and no `rm -rf .sense/`.
- **cli / mcp**: repoint dead `sense scan --force` advice at `sense scan --rebuild` (doctor, status, MCP model-change warning); keep plain `sense scan` on stale-file checks and `rm -rf .sense/` on cannot-open/corrupt paths where the index can't be reset in place.

## Architecture Highlights
- One preserve-set defines "what a rebuild preserves", honored identically by the automatic schema-bump path and the manual `--rebuild` — exactly one reset path.
- Drops run with foreign keys disabled so order is irrelevant, fixing a latent bug where the FK-enforced drop would fail on a real FK-bearing index (the prior test used an FK-less schema and never caught it).

## Test Plan
- [x] reset primitive preserves `sense_metrics`, empties all other tables at current schema (incl. fault-injected mid-sequence error paths)
- [x] schema-mismatch `Open` rebuilds and preserves metrics
- [x] `sense scan --rebuild` regenerates symbols/edges from source, metrics unchanged; plain rescan still skips unchanged files
- [x] validated on a real repo: 1853 files re-resolved, three lifetime counters byte-identical
- [x] `go test ./...` / `make ci` green; binary builds and `--rebuild` verified end-to-end