### PR TITLE
chore(ci): gate format, complexity, coverage, and side effects

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,12 +1,19 @@
+# Codecov is INFORMATIONAL only. The build-failing coverage gate is the
+# deterministic total-% floor in `make cover` (no upload dependency, so a flaky
+# Codecov upload never reds the build). These statuses surface per-file coverage
+# for visibility but must not fail CI.
+#
+# The real per-file 95% floor — scoped to the packages cycle 27 covers — is a
+# 27-13 deliverable. Until then Codecov stays advisory and the total-% floor in
+# `make cover` is the only hard coverage gate.
 coverage:
   status:
     project:
       default:
-        target: auto
-        threshold: 2%
+        informational: true
     patch:
       default:
-        target: 80%
+        informational: true
 
 ignore:
   # benchmark harness and vendored fixture repos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,20 @@ jobs:
       - name: Test
         run: go test -race -count=1 -v -coverprofile=coverage.txt -coverpkg=./... ./...
 
+      - name: Hermetic unit tests (offline)
+        # Goal 5 proof: the hermetic package set must pass with no network,
+        # no ONNX, and no external binary. The set ratchets per-package as
+        # 27-02→04 inject seams (fully on by 27-04). Linux enforces the
+        # network bite by running in a private network namespace; the package
+        # set guarantees no ONNX/external-binary by construction. macOS has no
+        # unshare, so it runs the same set without the netns wrapper.
+        run: |
+          if [ "${{ matrix.os }}" = "linux" ]; then
+            sudo -E env "PATH=$PATH" unshare -n make test-hermetic
+          else
+            make test-hermetic
+          fi
+
       - name: Upload coverage
         if: matrix.os == 'linux'
         uses: codecov/codecov-action@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Complexity ledger is non-increasing
+        # The inline //nolint:gocyclo/gocognit ledger is tracked debt the
+        # 27-05→12 pitches retire. This fails if it grows past LEDGER_MAX —
+        # new complexity must be decomposed, not suppressed. Exit condition
+        # for cycle 27: LEDGER_MAX = 0 by 27-12.
+        run: make ledger
+
       - name: No bare fmt.Print in internal/ (except MCP transport)
         run: |
           # Grep for fmt.Print / fmt.Println / fmt.Printf (not fmt.Fprint*)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,11 @@ jobs:
       - name: Build
         run: make build
 
-      - name: Test
-        run: go test -race -count=1 -v -coverprofile=coverage.txt -coverpkg=./... ./...
+      - name: Test & coverage gate
+        # Single definition of "tests pass": the same `make cover` a contributor
+        # runs locally (go test -race -coverpkg=./... + a total-% floor). Remote
+        # CI can no longer disagree with `make ci` about what green means.
+        run: make cover
 
       - name: Hermetic unit tests (offline)
         # Goal 5 proof: the hermetic package set must pass with no network,
@@ -76,11 +79,10 @@ jobs:
         run: make smoke
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          # Pinned (not "latest") so the v2 formatters: block and the gocyclo/
-          # gocognit thresholds are reproducible. Keep in sync with the Makefile.
-          version: v2.12.2
+        # Same `make lint` a contributor runs locally — golangci-lint is pinned
+        # in the Makefile (GOLANGCI_VERSION), so the v2 formatters: block and the
+        # gocyclo/gocognit thresholds are reproducible and cannot drift from CI.
+        run: make lint
 
   stdout-hygiene:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,9 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          # Pinned (not "latest") so the v2 formatters: block and the gocyclo/
+          # gocognit thresholds are reproducible. Keep in sync with the Makefile.
+          version: v2.12.2
 
   stdout-hygiene:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,14 +57,20 @@ jobs:
       - name: Hermetic unit tests (offline)
         # Goal 5 proof: the hermetic package set must pass with no network,
         # no ONNX, and no external binary. The set ratchets per-package as
-        # 27-02→04 inject seams (fully on by 27-04). Linux enforces the
-        # network bite by running in a private network namespace; the package
-        # set guarantees no ONNX/external-binary by construction. macOS has no
-        # unshare, so it runs the same set without the netns wrapper.
+        # 27-02→04 inject seams (fully on by 27-04). No-ONNX/no-external-binary
+        # is structural (the set imports neither embed nor os/exec). The network
+        # bite is added via an UNPRIVILEGED network namespace (unshare -rn,
+        # which preserves the build/module cache and env, no sudo). We probe
+        # the capability first and fall back to a plain run if the runner
+        # restricts unprivileged userns, so the sandbox never reds CI for
+        # infrastructure reasons — depguard already forbids net/os-exec/syscall
+        # in every package currently in the set, so the compile-time guarantee
+        # holds even where the runtime netns is unavailable.
         run: |
-          if [ "${{ matrix.os }}" = "linux" ]; then
-            sudo -E env "PATH=$PATH" unshare -n make test-hermetic
+          if unshare -rn true 2>/dev/null; then
+            unshare -rn make test-hermetic
           else
+            echo "note: unprivileged netns unavailable; depguard enforces no-network for the current set"
             make test-hermetic
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ Thumbs.db
 *.test
 *.out
 coverage.html
+coverage.txt
 
 # Go workspace files
 go.work

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,12 +15,37 @@ linters:
     - dupword
     - revive
     - nolintlint
+    - depguard
   settings:
     exhaustive:
       default-signifies-exhaustive: true
     nolintlint:
       require-explanation: true
       require-specific: true
+    depguard:
+      # Goal 5 (no side effects), enforced at compile time: the verified
+      # pure-core packages may not reach for effects. They take bytes and
+      # return data; effects live at the edges (scan, watch, search's
+      # ripgrep, dead/eval's analyzers, the ONNX shell). This set is locked
+      # at today's import-clean state and GROWS as later pitches clean more
+      # packages — never add a package that legitimately shells out.
+      rules:
+        pure-core:
+          files:
+            - "**/internal/extract/**"
+            - "**/internal/blast/**"
+            - "**/internal/conventions/**"
+            - "**/internal/mcpio/**"
+            - "**/internal/model/**"
+          deny:
+            - pkg: os/exec
+              desc: "pure-core must not shell out; inject the effect at the edge"
+            - pkg: net
+              desc: "pure-core must not touch the network; inject the effect at the edge"
+            - pkg: syscall
+              desc: "pure-core must not call syscalls directly; inject the effect at the edge"
+            - pkg: github.com/fsnotify/fsnotify
+              desc: "pure-core must not watch the filesystem; that is the watch package's job"
   exclusions:
     paths:
       - bench/lib/test_fixtures

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,21 @@ linters:
     - revive
     - nolintlint
     - depguard
+    - gocyclo
+    - gocognit
   settings:
+    # Two branching linters, no line-counting one. gocyclo/gocognit measure
+    # the branching that makes code hard to read and test; funlen is
+    # deliberately NOT enabled (raw line count punishes flat switches and
+    # table literals). Thresholds are the cycle's TARGET, not today's worst —
+    # today's violators carry an inline //nolint:goc... ledger pointing at the
+    # pitch that retires them. grep -rn 'nolint:goc' is the burndown.
+    gocyclo:
+      # golangci-lint reports complexity STRICTLY greater than min-complexity,
+      # so 15 == "over 15" (flags 16+).
+      min-complexity: 15
+    gocognit:
+      min-complexity: 30
     exhaustive:
       default-signifies-exhaustive: true
     nolintlint:
@@ -50,6 +64,18 @@ linters:
     paths:
       - bench/lib/test_fixtures
     rules:
+      # gocyclo/gocognit: gate production branching only. Table-driven tests
+      # are legitimately long and branchy; their complexity is not what the
+      # 27-05→12 split/extractor pitches retire, so it stays out of the ledger.
+      - linters: [gocyclo, gocognit]
+        path: _test\.go
+      # gocyclo/gocognit: scoped to the packages cycle 27 actually refactors,
+      # symmetric with the per-file coverage gate (see 27-00 honest boundary).
+      # The long tail below has no in-cycle split owner; its //nolint ledger
+      # would never burn down, so it is left ungated until a follow-up cycle
+      # claims it. Shrink this list as each package is brought into scope.
+      - linters: [gocyclo, gocognit]
+        path: (cmd/sense|internal/(benchmark|cli|freshen|hook|ignore|mcpio|summary))/
       # dupword: SQL NULL repetitions and embedded Ruby/test fixtures are fine
       - linters: [dupword]
         path: _test\.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,3 +66,17 @@ linters:
       # revive: indent-error-flow is noisy in CLI command handlers
       - linters: [revive]
         text: "indent-error-flow: "
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      # Settle imports into stdlib / external / internal (github.com/luuuc/sense)
+      # groups so future diffs stay stable.
+      local-prefixes:
+        - github.com/luuuc/sense
+  exclusions:
+    paths:
+      - bench/lib/test_fixtures

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,11 +19,29 @@ Note: `.claude/` and `CLAUDE.md` are local-only files excluded from version cont
 ## Before pushing
 
 ```bash
-make ci       # build + test + lint
+make ci       # build + cover (with coverage floor) + lint
 make smoke    # contributor regression smoke test
 ```
 
-Both must pass. CI runs the same checks. `make smoke` runs `sense scan` and `sense graph` against a fixture project — if it fails, the output will show which command broke.
+Both must pass. CI invokes the same `make` targets, so a green local `make ci` is a green remote build — they cannot drift. `make smoke` runs `sense scan` and `sense graph` against a fixture project — if it fails, the output will show which command broke.
+
+## Quality gates and the inline ledger
+
+CI enforces five mechanical gates, all reproducible locally:
+
+- **Format** — `gofmt` + `goimports` (`-local github.com/luuuc/sense`) via golangci-lint's `formatters:`. Run `make fmt` to auto-fix; `make lint` rejects unformatted code.
+- **Complexity** — `gocyclo` (over 15) and `gocognit` (over 30) on production code in the packages the current cleanup cycle covers. No `funlen` (raw line count is noise). A function over threshold must be **decomposed**, not suppressed — but while the cleanup is in flight, today's known violators carry an inline directive that names the pitch retiring them:
+
+  ```go
+  //nolint:gocyclo // 27-07: retired by the storage/query split
+  func Compute(...) { ... }
+  ```
+
+  This ledger is the burndown: `grep -rnE 'nolint:goc(yclo|ognit)' internal cmd` lists every outstanding entry, and `make ledger` fails CI if the count grows past its cap (`LEDGER_MAX` in the Makefile). The exit condition is the cap reaching zero. A stray directive left on a now-simple function is itself flagged by `nolintlint`, so the ledger cannot quietly lie.
+- **Side effects** — `depguard` forbids the verified pure-core packages (`extract`, `blast`, `conventions`, `mcpio`, `model`) from importing `os/exec`/`net`/`syscall`/`fsnotify`; effects belong at the edges. Pair it with `make test-hermetic`, which runs the hermetic package set offline (no network/ONNX/external binary).
+- **Coverage** — `make cover` runs the race suite and fails below the total-% floor (`COVER_FLOOR`). Codecov is informational only.
+
+Do not lower a gate to make a change pass. Decompose the function, inject the effect behind a seam, or add the test.
 
 ## Branches
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-hermetic cover clean install lint fmt ci run fetch-deps bench smoke
+.PHONY: build test test-hermetic cover ledger clean install lint fmt ci run fetch-deps bench smoke
 
 VERSION ?= dev
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
@@ -50,6 +50,20 @@ cover:
 		printf "total coverage: %s%% (floor: %s%%)\n", t, f; \
 		if (t+0 < f+0) { printf "FAIL: coverage %s%% is below the %s%% floor\n", t, f; exit 1 } \
 	}'
+
+# Complexity-ledger burndown. Every inline //nolint:gocyclo/gocognit is tracked
+# debt a 27-05→12 split/extractor pitch retires. This asserts the ledger never
+# GROWS: new complexity must be decomposed, not suppressed. Lower LEDGER_MAX as
+# pitches retire entries; the cycle's exit condition is LEDGER_MAX = 0 by 27-12.
+# (Matches gocyclo/gocognit only — an unrelated gocritic suppression is not debt.)
+LEDGER_MAX ?= 48
+ledger:
+	@n=$$(grep -rnE 'nolint:goc(yclo|ognit)' --include='*.go' internal cmd | wc -l | tr -d ' '); \
+	echo "complexity ledger: $$n entries (cap: $(LEDGER_MAX))"; \
+	if [ "$$n" -gt "$(LEDGER_MAX)" ]; then \
+		echo "FAIL: ledger grew past $(LEDGER_MAX). Decompose the function or retire an entry — do not add a new //nolint."; \
+		exit 1; \
+	fi
 
 clean:
 	rm -rf bin/ dist/

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,14 @@
-.PHONY: build test clean install lint ci run fetch-deps bench smoke
+.PHONY: build test clean install lint fmt ci run fetch-deps bench smoke
 
 VERSION ?= dev
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
 LDFLAGS := -ldflags="-s -w -X 'github.com/luuuc/sense/internal/version.Version=$(VERSION)'"
+
+# Pinned so the gate definition (v2 formatters: block, complexity thresholds)
+# does not float with upstream releases. Keep in sync with .github/workflows/ci.yml.
+GOLANGCI_VERSION ?= v2.12.2
+ensure-golangci = command -v golangci-lint >/dev/null 2>&1 || \
+	(echo "Installing golangci-lint $(GOLANGCI_VERSION)..." && go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_VERSION))
 
 fetch-deps: ## Downloads model + ORT lib on first run; no-ops if already present
 	./scripts/fetch-deps.sh --local
@@ -20,9 +26,12 @@ install: build
 	cp bin/sense /usr/local/bin/sense
 
 lint:
-	@command -v golangci-lint >/dev/null 2>&1 || \
-		(echo "Installing golangci-lint..." && go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest)
+	@$(ensure-golangci)
 	@PATH="$$PATH:$$(go env GOPATH)/bin" golangci-lint run
+
+fmt:
+	@$(ensure-golangci)
+	@PATH="$$PATH:$$(go env GOPATH)/bin" golangci-lint fmt
 
 ci: build test lint
 	@echo "All CI checks passed!"

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,10 @@ VERSION ?= dev
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
 LDFLAGS := -ldflags="-s -w -X 'github.com/luuuc/sense/internal/version.Version=$(VERSION)'"
 
-# Pinned so the gate definition (v2 formatters: block, complexity thresholds)
-# does not float with upstream releases. Keep in sync with .github/workflows/ci.yml.
+# Single source of the golangci-lint version: CI runs `make lint`, so it
+# inherits this pin. Pinned (not "latest") so the gate definition — the v2
+# formatters: block and the gocyclo/gocognit thresholds — does not float with
+# upstream releases.
 GOLANGCI_VERSION ?= v2.12.2
 ensure-golangci = command -v golangci-lint >/dev/null 2>&1 || \
 	(echo "Installing golangci-lint $(GOLANGCI_VERSION)..." && go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_VERSION))
@@ -23,8 +25,13 @@ test:
 # with no network, no ONNX, and no external binary. The set RATCHETS — it
 # grows per-package as the testability arc (27-02→04) injects seams, fully
 # on by 27-04. A package only joins once it can be unit-tested offline.
-# CI runs this under a private network namespace on Linux (the network bite);
+# CI runs this under an unprivileged network namespace (the network bite);
 # the set guarantees no ONNX/external-binary by construction (no embed/exec deps).
+#
+# This set currently equals the depguard `pure-core` list in .golangci.yml on
+# purpose — those packages are both effect-free (depguard) and offline-testable
+# (here). Grow the two together; they will diverge once a package that is
+# offline-testable but not import-clean joins the hermetic set.
 HERMETIC_PKGS := \
 	./internal/extract/... \
 	./internal/blast/... \
@@ -45,6 +52,8 @@ test-hermetic:
 COVER_FLOOR ?= 91
 cover:
 	go test -race -count=1 -coverprofile=coverage.txt -coverpkg=./... ./...
+	@# Parse depends on `go tool cover`'s total line being last and %-suffixed.
+	@# If that format ever changes, t becomes 0 and the gate fails closed (safe).
 	@total=$$(go tool cover -func=coverage.txt | awk 'END {gsub(/%/,"",$$NF); print $$NF}'); \
 	awk -v t="$$total" -v f="$(COVER_FLOOR)" 'BEGIN { \
 		printf "total coverage: %s%% (floor: %s%%)\n", t, f; \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-hermetic clean install lint fmt ci run fetch-deps bench smoke
+.PHONY: build test test-hermetic cover clean install lint fmt ci run fetch-deps bench smoke
 
 VERSION ?= dev
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
@@ -35,8 +35,25 @@ HERMETIC_PKGS := \
 test-hermetic:
 	go test $(HERMETIC_PKGS)
 
+# Coverage floor (scaffold). Measured under this exact invocation
+# (-race -coverpkg=./...): 91.9% on 2026-06-03, so the floor sits just under
+# it with headroom for run-to-run and cross-platform variance. This is the
+# gross-regression scaffold that ratchets toward the cycle's 95% target; the
+# per-file 95% floor (scoped to covered packages) lands in 27-13. The hard
+# fail is this local `go tool cover` check, NOT a Codecov status, so a flaky
+# upload never reds the build.
+COVER_FLOOR ?= 91
+cover:
+	go test -race -count=1 -coverprofile=coverage.txt -coverpkg=./... ./...
+	@total=$$(go tool cover -func=coverage.txt | awk 'END {gsub(/%/,"",$$NF); print $$NF}'); \
+	awk -v t="$$total" -v f="$(COVER_FLOOR)" 'BEGIN { \
+		printf "total coverage: %s%% (floor: %s%%)\n", t, f; \
+		if (t+0 < f+0) { printf "FAIL: coverage %s%% is below the %s%% floor\n", t, f; exit 1 } \
+	}'
+
 clean:
 	rm -rf bin/ dist/
+	rm -f coverage.txt
 
 install: build
 	cp bin/sense /usr/local/bin/sense
@@ -49,7 +66,7 @@ fmt:
 	@$(ensure-golangci)
 	@PATH="$$PATH:$$(go env GOPATH)/bin" golangci-lint fmt
 
-ci: build test lint
+ci: build cover lint
 	@echo "All CI checks passed!"
 
 smoke:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test clean install lint fmt ci run fetch-deps bench smoke
+.PHONY: build test test-hermetic clean install lint fmt ci run fetch-deps bench smoke
 
 VERSION ?= dev
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
@@ -18,6 +18,22 @@ build: fetch-deps
 
 test:
 	go test -v ./...
+
+# Goal 5 (no side effects), enforced by outcome: these packages must pass
+# with no network, no ONNX, and no external binary. The set RATCHETS — it
+# grows per-package as the testability arc (27-02→04) injects seams, fully
+# on by 27-04. A package only joins once it can be unit-tested offline.
+# CI runs this under a private network namespace on Linux (the network bite);
+# the set guarantees no ONNX/external-binary by construction (no embed/exec deps).
+HERMETIC_PKGS := \
+	./internal/extract/... \
+	./internal/blast/... \
+	./internal/conventions/... \
+	./internal/mcpio/... \
+	./internal/model/...
+
+test-hermetic:
+	go test $(HERMETIC_PKGS)
 
 clean:
 	rm -rf bin/ dist/

--- a/internal/benchmark/benchmark.go
+++ b/internal/benchmark/benchmark.go
@@ -7,10 +7,10 @@ import (
 	"math"
 	"os"
 	"os/exec"
-	"strings"
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/luuuc/sense/internal/blast"
@@ -40,11 +40,11 @@ type Latency struct {
 }
 
 type ScanMetrics struct {
-	FullScan          time.Duration
-	FilesPerSec       float64
-	SymbolsPerSec     float64
-	IncrementalClean  time.Duration
-	IncrementalDirty  time.Duration
+	FullScan         time.Duration
+	FilesPerSec      float64
+	SymbolsPerSec    float64
+	IncrementalClean time.Duration
+	IncrementalDirty time.Duration
 }
 
 type IndexMetrics struct {

--- a/internal/benchmark/format_test.go
+++ b/internal/benchmark/format_test.go
@@ -18,7 +18,7 @@ func TestFmtMs(t *testing.T) {
 		{"sub-ms", 500 * time.Microsecond, "0.50ms"},
 		{"1ms", 1 * time.Millisecond, "1.0ms"},
 		{"ms-range", 50 * time.Millisecond, "50.0ms"},
-		{"near-100ms", 99 * time.Millisecond + 900 * time.Microsecond, "99.9ms"},
+		{"near-100ms", 99*time.Millisecond + 900*time.Microsecond, "99.9ms"},
 		{"100ms", 100 * time.Millisecond, "100ms"},
 		{">=100ms", 150 * time.Millisecond, "150ms"},
 		{"negative", -1 * time.Millisecond, "-1.00ms"},
@@ -100,12 +100,12 @@ func TestMarshalJSONOptionalFields(t *testing.T) {
 			Scan: ScanMetrics{
 				FullScan: 1 * time.Second,
 			},
-			GraphLatency:    Latency{P50: 1 * time.Millisecond},
-			SearchKeyword:   Latency{P50: 1 * time.Millisecond},
-			BlastShallow:    Latency{P50: 1 * time.Millisecond},
-			BlastDeep:       Latency{P50: 1 * time.Millisecond},
+			GraphLatency:       Latency{P50: 1 * time.Millisecond},
+			SearchKeyword:      Latency{P50: 1 * time.Millisecond},
+			BlastShallow:       Latency{P50: 1 * time.Millisecond},
+			BlastDeep:          Latency{P50: 1 * time.Millisecond},
 			ConventionsLatency: Latency{P50: 1 * time.Millisecond},
-			StatusLatency:   Latency{P50: 1 * time.Millisecond},
+			StatusLatency:      Latency{P50: 1 * time.Millisecond},
 		}
 	}
 

--- a/internal/blast/blast_bench_test.go
+++ b/internal/blast/blast_bench_test.go
@@ -22,11 +22,11 @@ import (
 // the cost curve is visible when `go test -bench` runs with -count
 // or -benchtime:
 //
-//   small_graph (~1K symbols, branching 8)  — sanity check that the
-//                                              hot path isn't doing
-//                                              something O(N²).
-//   large_graph (~30K symbols, branching 30) — the pitch's explicit
-//                                              acceptance target.
+//	small_graph (~1K symbols, branching 8)  — sanity check that the
+//	                                           hot path isn't doing
+//	                                           something O(N²).
+//	large_graph (~30K symbols, branching 30) — the pitch's explicit
+//	                                           acceptance target.
 //
 // The graph shape is a uniform fan-in tree: symbol 1 is the root,
 // symbols at depth k have branching-factor callers in depth k+1,

--- a/internal/blast/engine.go
+++ b/internal/blast/engine.go
@@ -199,6 +199,8 @@ type Result struct {
 // point to any reopening, so all must be seeds.
 //
 // For single-symbol queries, pass a one-element slice.
+//
+//nolint:gocyclo,gocognit // 27-07: retired by the storage/query split
 func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (Result, error) {
 	if len(symbolIDs) == 0 {
 		return Result{}, fmt.Errorf("blast: no symbol IDs provided")

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -321,4 +321,3 @@ func renderDoctorHuman(cio IO, resp doctorResponse) {
 		}
 	}
 }
-

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -12,8 +12,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/luuuc/sense/internal/sqlite"
 	_ "modernc.org/sqlite"
+
+	"github.com/luuuc/sense/internal/sqlite"
 )
 
 func TestFormatAge(t *testing.T) {

--- a/internal/cli/index_test.go
+++ b/internal/cli/index_test.go
@@ -9,8 +9,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/luuuc/sense/internal/sqlite"
 	_ "modernc.org/sqlite"
+
+	"github.com/luuuc/sense/internal/sqlite"
 )
 
 func TestOpenIndexRebuiltOnSchemaMismatch(t *testing.T) {

--- a/internal/conventions/conventions.go
+++ b/internal/conventions/conventions.go
@@ -54,6 +54,7 @@ type Options struct {
 	MinStrength float64
 }
 
+//nolint:gocyclo // 27-08: retired by the conventions split
 func Detect(ctx context.Context, db *sql.DB, opts Options) ([]Convention, int, error) {
 	fileFilter, err := resolveFileFilter(ctx, db, opts.Domain)
 	if err != nil {
@@ -625,6 +626,7 @@ func detectComposition(symbols []symbolRow, edges []edgeRow, symbolByID map[int6
 	return out
 }
 
+//nolint:gocyclo,gocognit // 27-08: retired by the conventions split
 func detectTesting(_ []symbolRow, edges []edgeRow, filePathByID map[int64]string, symbolByID map[int64]symbolRow) []Convention {
 	// Detect test file naming conventions from files with "tests" edges
 	testFileIDs := map[int64]struct{}{}
@@ -1021,6 +1023,7 @@ func detectRailsCallbacks(symbols []symbolRow, _ []edgeRow, _ map[int64]symbolRo
 	}}
 }
 
+//nolint:gocyclo // 27-08: retired by the conventions split
 func detectScopes(symbols []symbolRow, edges []edgeRow, symbolByID map[int64]symbolRow, filePathByID map[int64]string) []Convention {
 	classByID := map[int64]symbolRow{}
 	for _, s := range symbols {
@@ -1202,6 +1205,7 @@ func detectGoTypeAliases(symbols []symbolRow, _ []edgeRow, _ map[int64]symbolRow
 	}}
 }
 
+//nolint:gocyclo // 27-08: retired by the conventions split
 func detectGoMiddleware(symbols []symbolRow, edges []edgeRow, symbolByID map[int64]symbolRow, filePathByID map[int64]string) []Convention {
 	routerMethods := map[string]bool{
 		"Use": true, "GET": true, "POST": true, "PUT": true, "DELETE": true,
@@ -1263,6 +1267,7 @@ func detectGoMiddleware(symbols []symbolRow, edges []edgeRow, symbolByID map[int
 	}}
 }
 
+//nolint:gocyclo // 27-08: retired by the conventions split
 func detectArchitectureLayers(symbols []symbolRow, edges []edgeRow, symbolByID map[int64]symbolRow, filePathByID map[int64]string) []Convention {
 	symbolDir := map[int64]string{}
 	for _, s := range symbols {

--- a/internal/conventions/conventions.go
+++ b/internal/conventions/conventions.go
@@ -21,15 +21,15 @@ const minPrevalenceInstances = 5
 type Category string
 
 const (
-	CategoryInheritance  Category = "inheritance"
-	CategoryNaming       Category = "naming"
-	CategoryStructure    Category = "structure"
-	CategoryComposition  Category = "composition"
-	CategoryTesting      Category = "testing"
+	CategoryInheritance   Category = "inheritance"
+	CategoryNaming        Category = "naming"
+	CategoryStructure     Category = "structure"
+	CategoryComposition   Category = "composition"
+	CategoryTesting       Category = "testing"
 	CategoryDesignPattern Category = "design_pattern"
-	CategoryFramework    Category = "framework"
-	CategoryArchitecture Category = "architecture"
-	CategoryKeyTypes     Category = "key_types"
+	CategoryFramework     Category = "framework"
+	CategoryArchitecture  Category = "architecture"
+	CategoryKeyTypes      Category = "key_types"
 )
 
 type Example struct {
@@ -144,12 +144,12 @@ func Detect(ctx context.Context, db *sql.DB, opts Options) ([]Convention, int, e
 }
 
 type symbolRow struct {
-	id       int64
-	fileID   int64
-	name     string
+	id        int64
+	fileID    int64
+	name      string
 	qualified string
-	kind     string
-	parentID *int64
+	kind      string
+	parentID  *int64
 }
 
 type edgeRow struct {

--- a/internal/conventions/conventions_test.go
+++ b/internal/conventions/conventions_test.go
@@ -1218,12 +1218,12 @@ func setupCallbackFixture(t *testing.T) *sqlite.Adapter {
 		symIDs[sd.qualified] = id
 	}
 	parents := map[string]string{
-		"Order.before_save":        "Order",
-		"Order.after_create":       "Order",
-		"User.before_validation":   "User",
-		"User.after_save":          "User",
-		"Product.before_destroy":   "Product",
-		"Product.after_commit":     "Product",
+		"Order.before_save":      "Order",
+		"Order.after_create":     "Order",
+		"User.before_validation": "User",
+		"User.after_save":        "User",
+		"Product.before_destroy": "Product",
+		"Product.after_commit":   "Product",
 	}
 	for childQ, parentQ := range parents {
 		_, err := adapter.DB().ExecContext(ctx, `UPDATE sense_symbols SET parent_id = ? WHERE id = ?`, symIDs[parentQ], symIDs[childQ])
@@ -1787,4 +1787,3 @@ func TestDetectExternalDependenciesNoDomain(t *testing.T) {
 		t.Errorf("expected no conventions without domain, got %d", len(convs))
 	}
 }
-

--- a/internal/conventions/helpers_test.go
+++ b/internal/conventions/helpers_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 )
 
-
 func TestChunkIDsSingleChunk(t *testing.T) {
 	ids := make([]int64, 100)
 	for i := range ids {
@@ -82,13 +81,13 @@ func TestPluralizeBranches(t *testing.T) {
 		input string
 		want  string
 	}{
-		{"class", "classes"},     // ends in "ss"
-		{"match", "matches"},    // ends in "ch"
-		{"flash", "flashes"},    // ends in "sh"
-		{"box", "boxes"},        // ends in "x"
-		{"bus", "buses"},        // ends in "s" (but not "ss")
-		{"function", "functions"}, // default
-		{"method", "methods"},    // default
+		{"class", "classes"},        // ends in "ss"
+		{"match", "matches"},        // ends in "ch"
+		{"flash", "flashes"},        // ends in "sh"
+		{"box", "boxes"},            // ends in "x"
+		{"bus", "buses"},            // ends in "s" (but not "ss")
+		{"function", "functions"},   // default
+		{"method", "methods"},       // default
 		{"interface", "interfaces"}, // default (ends in "e")
 	}
 	for _, tt := range tests {
@@ -143,7 +142,7 @@ func TestDedupeExamplesCoverage(t *testing.T) {
 	examples := []Example{
 		{Name: "Order", Path: "order.go"},
 		{Name: "User", Path: "user.go"},
-		{Name: "Order", Path: "order.go"}, // duplicate
+		{Name: "Order", Path: "order.go"},        // duplicate
 		{Name: "Order", Path: "models/order.go"}, // different path -> not duplicate
 	}
 	got := dedupeExamples(examples)

--- a/internal/dead/dead.go
+++ b/internal/dead/dead.go
@@ -553,6 +553,8 @@ func excludeEntryPoints(candidates []Symbol, filters entryPointFilters) []Symbol
 // at least one child with incoming edges (i.e., child is NOT in the
 // dead candidate set). A container with live children is alive by
 // purpose — it's the namespace for referenced code.
+//
+//nolint:gocyclo // 27-09: retired by the dead-code split
 func findLiveContainers(ctx context.Context, db *sql.DB, candidates []Symbol) (map[int64]struct{}, error) {
 	deadIDs := make(map[int64]struct{}, len(candidates))
 	for _, s := range candidates {

--- a/internal/dead/voice_rust.go
+++ b/internal/dead/voice_rust.go
@@ -104,13 +104,13 @@ func (rustVoice) Inspect(s Symbol, f Facts) *Reason {
 // unaffected.
 var rustDerivableTraitMethods = map[string]bool{
 	"clone": true, "clone_from": true, // Clone
-	"fmt":                              true, // Debug
-	"eq":  true, "ne": true,                 // PartialEq
+	"fmt": true,             // Debug
+	"eq":  true, "ne": true, // PartialEq
 	"partial_cmp": true, "lt": true, "le": true, "gt": true, "ge": true, // PartialOrd
-	"cmp":  true,                            // Ord
-	"hash": true,                            // Hash
-	"default":     true,                     // Default
-	"serialize":   true, "deserialize": true, // serde
+	"cmp":       true,                      // Ord
+	"hash":      true,                      // Hash
+	"default":   true,                      // Default
+	"serialize": true, "deserialize": true, // serde
 }
 
 func init() {

--- a/internal/embed/tokenizer.go
+++ b/internal/embed/tokenizer.go
@@ -9,12 +9,12 @@ import (
 // all-MiniLM-L6-v2. It handles lowercasing, punctuation splitting,
 // and subword decomposition using the model's vocabulary.
 type tokenizer struct {
-	vocab   map[string]int32
-	maxLen  int
-	clsID   int32
-	sepID   int32
-	unkID   int32
-	padID   int32
+	vocab  map[string]int32
+	maxLen int
+	clsID  int32
+	sepID  int32
+	unkID  int32
+	padID  int32
 }
 
 func newTokenizer(vocabData []byte, maxLen int) *tokenizer {

--- a/internal/extract/erb/embedded_test.go
+++ b/internal/extract/erb/embedded_test.go
@@ -119,14 +119,14 @@ func TestEmbeddedRuby_KeywordNotEmitted(t *testing.T) {
 
 func TestEmbeddedRubyCode(t *testing.T) {
 	cases := map[string]string{
-		"= current_user":  "current_user", // <%= output marker
-		" foo.bar ":       "foo.bar",       // <% plain
-		"- trimmed":       "trimmed",       // <%- whitespace-trim marker
-		"= -1":            "-1",            // unary minus after the output marker survives
-		" -1":             "-1",            // <% -1 %>: leading space means '-' is unary minus, not a marker
-		"":                "",
-		"   ":             "",
-		"current_user":    "current_user",
+		"= current_user": "current_user", // <%= output marker
+		" foo.bar ":      "foo.bar",      // <% plain
+		"- trimmed":      "trimmed",      // <%- whitespace-trim marker
+		"= -1":           "-1",           // unary minus after the output marker survives
+		" -1":            "-1",           // <% -1 %>: leading space means '-' is unary minus, not a marker
+		"":               "",
+		"   ":            "",
+		"current_user":   "current_user",
 	}
 	for in, want := range cases {
 		if got := embeddedRubyCode(in); got != want {

--- a/internal/extract/erb/erb_test.go
+++ b/internal/extract/erb/erb_test.go
@@ -19,8 +19,11 @@ type recorder struct {
 	edges   []extract.EmittedEdge
 }
 
-func (r *recorder) Symbol(s extract.EmittedSymbol) error { r.symbols = append(r.symbols, s); return nil }
-func (r *recorder) Edge(e extract.EmittedEdge) error     { r.edges = append(r.edges, e); return nil }
+func (r *recorder) Symbol(s extract.EmittedSymbol) error {
+	r.symbols = append(r.symbols, s)
+	return nil
+}
+func (r *recorder) Edge(e extract.EmittedEdge) error { r.edges = append(r.edges, e); return nil }
 
 func TestSmokeExtract(t *testing.T) {
 	ex := Extractor{}
@@ -569,7 +572,7 @@ func TestExtractI18nKeys(t *testing.T) {
 <span><%= I18n.t("users.greeting") %></span>`, "app/views/users/show.html.erb")
 
 	for _, want := range []string{
-		"i18n:users.show.title",     // lazy key expanded against the view scope
+		"i18n:users.show.title", // lazy key expanded against the view scope
 		"i18n:shared.footer.copyright",
 		"i18n:users.greeting",
 	} {

--- a/internal/extract/golang/docstring.go
+++ b/internal/extract/golang/docstring.go
@@ -130,4 +130,3 @@ func isLicenseHeader(line string) bool {
 	return strings.HasPrefix(line, "Copyright") ||
 		strings.HasPrefix(line, "SPDX-")
 }
-

--- a/internal/extract/golang/docstring_test.go
+++ b/internal/extract/golang/docstring_test.go
@@ -289,4 +289,3 @@ func Hush() {}
 		t.Errorf("Docstring on body-less comments = %q, want \"\"", sym.Docstring)
 	}
 }
-

--- a/internal/extract/golang/golang.go
+++ b/internal/extract/golang/golang.go
@@ -612,6 +612,8 @@ type localType struct {
 // variables. The locals set tracks every declared variable name
 // (even those with unknown types) so callers can distinguish
 // unresolved locals from package references.
+//
+//nolint:gocyclo // 27-12: retired by the python/golang/langspec split
 func (w *walker) buildTypeMap(funcNode *sitter.Node) (map[string]localType, map[string]bool) {
 	types := map[string]localType{}
 	locals := map[string]bool{}
@@ -728,6 +730,8 @@ func (w *walker) collectShortVarDecl(n *sitter.Node, types map[string]localType,
 
 // collectRangeVars handles `for _, v := range src` — assigns the
 // element type of the range source to the value variable.
+//
+//nolint:gocyclo // 27-12: retired by the python/golang/langspec split
 func (w *walker) collectRangeVars(rc *sitter.Node, types map[string]localType, locals map[string]bool) {
 	left := rc.ChildByFieldName("left")
 	right := rc.ChildByFieldName("right")
@@ -799,6 +803,8 @@ func sliceElemType(typeNode *sitter.Node, source []byte) string {
 }
 
 // inferType attempts to determine the type of a value expression.
+//
+//nolint:gocyclo // 27-12: retired by the python/golang/langspec split
 func (w *walker) inferType(val *sitter.Node) (localType, bool) {
 	if val == nil {
 		return localType{}, false

--- a/internal/extract/golang/golang_test.go
+++ b/internal/extract/golang/golang_test.go
@@ -14,8 +14,11 @@ type recorder struct {
 	edges   []extract.EmittedEdge
 }
 
-func (r *recorder) Symbol(s extract.EmittedSymbol) error { r.symbols = append(r.symbols, s); return nil }
-func (r *recorder) Edge(e extract.EmittedEdge) error     { r.edges = append(r.edges, e); return nil }
+func (r *recorder) Symbol(s extract.EmittedSymbol) error {
+	r.symbols = append(r.symbols, s)
+	return nil
+}
+func (r *recorder) Edge(e extract.EmittedEdge) error { r.edges = append(r.edges, e); return nil }
 
 // counter counts emitted symbols and edges.
 type counter struct {
@@ -513,7 +516,7 @@ func TestConstructorType(t *testing.T) {
 		{"NewOrder", "Order"},
 		{"newOrder", "Order"},
 		{"NewA", "A"},
-		{"New", ""},  // too short
+		{"New", ""},   // too short
 		{"Newer", ""}, // no uppercase after "New"
 		{"new", ""},   // too short
 		{"abc", ""},
@@ -1017,7 +1020,6 @@ const MaxSize = 1024
 		t.Error("expected error on constant symbol emit")
 	}
 }
-
 
 func TestReceiverTypeQualifiedType(t *testing.T) {
 	r := parse(t, `package svc

--- a/internal/extract/langspec/c.go
+++ b/internal/extract/langspec/c.go
@@ -13,9 +13,9 @@ func init() {
 		Tier:      extract.TierStandard,
 		Separator: ".",
 
-		FuncTypes:  []string{"function_definition"},
-		ClassTypes: []string{"struct_specifier", "enum_specifier"},
-		CallTypes:  []string{"call_expression"},
+		FuncTypes:   []string{"function_definition"},
+		ClassTypes:  []string{"struct_specifier", "enum_specifier"},
+		CallTypes:   []string{"call_expression"},
 		ImportTypes: []string{"preproc_include"},
 
 		NameField: "name",

--- a/internal/extract/langspec/coverage_test.go
+++ b/internal/extract/langspec/coverage_test.go
@@ -96,9 +96,9 @@ func TestJava_MethodInvocation_WithReceiver(t *testing.T) {
 		Tier:      extract.TierStandard,
 		Separator: ".",
 
-		FuncTypes:  []string{"method_declaration", "constructor_declaration"},
-		ClassTypes: []string{"class_declaration", "interface_declaration"},
-		CallTypes:  []string{"method_invocation", "object_creation_expression"},
+		FuncTypes:   []string{"method_declaration", "constructor_declaration"},
+		ClassTypes:  []string{"class_declaration", "interface_declaration"},
+		CallTypes:   []string{"method_invocation", "object_creation_expression"},
 		ImportTypes: []string{"import_declaration"},
 
 		InheritFields: []string{"superclass", "interfaces"},
@@ -149,9 +149,9 @@ func TestKotlin_CallNameFn(t *testing.T) {
 		Tier:      extract.TierStandard,
 		Separator: ".",
 
-		FuncTypes:  []string{"function_declaration"},
-		ClassTypes: []string{"class_declaration", "object_declaration"},
-		CallTypes:  []string{"call_expression"},
+		FuncTypes:   []string{"function_declaration"},
+		ClassTypes:  []string{"class_declaration", "object_declaration"},
+		CallTypes:   []string{"call_expression"},
 		ImportTypes: []string{"import_header"},
 
 		InheritKinds: []string{"delegation_specifier"},
@@ -267,9 +267,9 @@ func TestCSharp_Imports(t *testing.T) {
 		Tier:      extract.TierStandard,
 		Separator: ".",
 
-		FuncTypes:  []string{"method_declaration", "constructor_declaration"},
-		ClassTypes: []string{"class_declaration", "interface_declaration", "struct_declaration"},
-		CallTypes:  []string{"invocation_expression"},
+		FuncTypes:   []string{"method_declaration", "constructor_declaration"},
+		ClassTypes:  []string{"class_declaration", "interface_declaration", "struct_declaration"},
+		CallTypes:   []string{"invocation_expression"},
 		ImportTypes: []string{"using_directive"},
 
 		InheritKinds: []string{"base_list"},
@@ -312,9 +312,9 @@ func TestScala_Imports(t *testing.T) {
 		Tier:      extract.TierStandard,
 		Separator: ".",
 
-		FuncTypes:  []string{"function_definition"},
-		ClassTypes: []string{"class_definition", "object_definition", "trait_definition"},
-		CallTypes:  []string{"call_expression"},
+		FuncTypes:   []string{"function_definition"},
+		ClassTypes:  []string{"class_definition", "object_definition", "trait_definition"},
+		CallTypes:   []string{"call_expression"},
 		ImportTypes: []string{"import_declaration"},
 
 		InheritFields: []string{"extend_clause"},
@@ -356,9 +356,9 @@ func TestPHP_Calls(t *testing.T) {
 		Tier:      extract.TierStandard,
 		Separator: "\\",
 
-		FuncTypes:  []string{"function_definition", "method_declaration"},
-		ClassTypes: []string{"class_declaration", "interface_declaration", "trait_declaration"},
-		CallTypes:  []string{"function_call_expression", "member_call_expression", "scoped_call_expression"},
+		FuncTypes:   []string{"function_definition", "method_declaration"},
+		ClassTypes:  []string{"class_declaration", "interface_declaration", "trait_declaration"},
+		CallTypes:   []string{"function_call_expression", "member_call_expression", "scoped_call_expression"},
 		ImportTypes: []string{"namespace_use_declaration"},
 
 		InheritFields: []string{"base_clause", "interfaces"},
@@ -686,4 +686,3 @@ func TestWalkForCalls_SkipsNestedClasses(t *testing.T) {
 		t.Error("missing symbol Outer.Inner.innerMethod")
 	}
 }
-

--- a/internal/extract/langspec/cpp.go
+++ b/internal/extract/langspec/cpp.go
@@ -13,9 +13,9 @@ func init() {
 		Tier:      extract.TierStandard,
 		Separator: "::",
 
-		FuncTypes:  []string{"function_definition"},
-		ClassTypes: []string{"class_specifier", "struct_specifier", "namespace_definition", "enum_specifier"},
-		CallTypes:  []string{"call_expression"},
+		FuncTypes:   []string{"function_definition"},
+		ClassTypes:  []string{"class_specifier", "struct_specifier", "namespace_definition", "enum_specifier"},
+		CallTypes:   []string{"call_expression"},
 		ImportTypes: []string{"preproc_include"},
 
 		InheritKinds: []string{"base_class_clause"},

--- a/internal/extract/langspec/csharp.go
+++ b/internal/extract/langspec/csharp.go
@@ -13,9 +13,9 @@ func init() {
 		Tier:      extract.TierStandard,
 		Separator: ".",
 
-		FuncTypes:  []string{"method_declaration", "constructor_declaration"},
-		ClassTypes: []string{"class_declaration", "interface_declaration", "struct_declaration", "enum_declaration", "record_declaration", "namespace_declaration"},
-		CallTypes:  []string{"invocation_expression", "object_creation_expression"},
+		FuncTypes:   []string{"method_declaration", "constructor_declaration"},
+		ClassTypes:  []string{"class_declaration", "interface_declaration", "struct_declaration", "enum_declaration", "record_declaration", "namespace_declaration"},
+		CallTypes:   []string{"invocation_expression", "object_creation_expression"},
 		ImportTypes: []string{"using_directive"},
 
 		InheritKinds: []string{"base_list"},

--- a/internal/extract/langspec/java.go
+++ b/internal/extract/langspec/java.go
@@ -13,9 +13,9 @@ func init() {
 		Tier:      extract.TierStandard,
 		Separator: ".",
 
-		FuncTypes:  []string{"method_declaration", "constructor_declaration"},
-		ClassTypes: []string{"class_declaration", "interface_declaration", "enum_declaration", "record_declaration"},
-		CallTypes:  []string{"method_invocation", "object_creation_expression"},
+		FuncTypes:   []string{"method_declaration", "constructor_declaration"},
+		ClassTypes:  []string{"class_declaration", "interface_declaration", "enum_declaration", "record_declaration"},
+		CallTypes:   []string{"method_invocation", "object_creation_expression"},
 		ImportTypes: []string{"import_declaration"},
 
 		InheritFields: []string{"superclass", "interfaces"},

--- a/internal/extract/langspec/kotlin.go
+++ b/internal/extract/langspec/kotlin.go
@@ -17,9 +17,9 @@ func init() {
 		Tier:      extract.TierStandard,
 		Separator: ".",
 
-		FuncTypes:  []string{"function_declaration"},
-		ClassTypes: []string{"class_declaration", "object_declaration"},
-		CallTypes:  []string{"call_expression"},
+		FuncTypes:   []string{"function_declaration"},
+		ClassTypes:  []string{"class_declaration", "object_declaration"},
+		CallTypes:   []string{"call_expression"},
 		ImportTypes: []string{"import_header"},
 
 		InheritKinds: []string{"delegation_specifier"},

--- a/internal/extract/langspec/langspec.go
+++ b/internal/extract/langspec/langspec.go
@@ -506,6 +506,7 @@ func (w *walker) callReceiver(n *sitter.Node) string {
 	return ""
 }
 
+//nolint:gocyclo,gocognit // 27-12: retired by the python/golang/langspec split
 func (w *walker) importTarget(n *sitter.Node) string {
 	// Try specific import path fields. Skip bare identifiers — they may be
 	// only the first component of a split path (e.g., Scala imports).

--- a/internal/extract/langspec/langspec_test.go
+++ b/internal/extract/langspec/langspec_test.go
@@ -51,13 +51,12 @@ func TestSyntheticSpec_ClassesAndMethods(t *testing.T) {
 		Tier:      extract.TierStandard,
 		Separator: ".",
 
-		FuncTypes:    []string{"function_definition"},
-		ClassTypes:   []string{"class_definition"},
-		CallTypes:    []string{"call"},
-		ImportTypes:  []string{"import_from_statement"},
+		FuncTypes:     []string{"function_definition"},
+		ClassTypes:    []string{"class_definition"},
+		CallTypes:     []string{"call"},
+		ImportTypes:   []string{"import_from_statement"},
 		InheritFields: []string{"superclasses"},
-		NameField:    "name",
-
+		NameField:     "name",
 	}
 
 	src := `

--- a/internal/extract/langspec/php.go
+++ b/internal/extract/langspec/php.go
@@ -13,9 +13,9 @@ func init() {
 		Tier:      extract.TierStandard,
 		Separator: "\\",
 
-		FuncTypes:  []string{"function_definition", "method_declaration"},
-		ClassTypes: []string{"class_declaration", "interface_declaration", "trait_declaration", "enum_declaration", "namespace_definition"},
-		CallTypes:  []string{"function_call_expression", "member_call_expression", "scoped_call_expression"},
+		FuncTypes:   []string{"function_definition", "method_declaration"},
+		ClassTypes:  []string{"class_declaration", "interface_declaration", "trait_declaration", "enum_declaration", "namespace_definition"},
+		CallTypes:   []string{"function_call_expression", "member_call_expression", "scoped_call_expression"},
 		ImportTypes: []string{"namespace_use_declaration"},
 
 		InheritKinds: []string{"base_clause", "class_interface_clause"},

--- a/internal/extract/langspec/scala.go
+++ b/internal/extract/langspec/scala.go
@@ -13,9 +13,9 @@ func init() {
 		Tier:      extract.TierStandard,
 		Separator: ".",
 
-		FuncTypes:  []string{"function_definition", "function_declaration"},
-		ClassTypes: []string{"class_definition", "object_definition", "trait_definition", "enum_definition"},
-		CallTypes:  []string{"call_expression"},
+		FuncTypes:   []string{"function_definition", "function_declaration"},
+		ClassTypes:  []string{"class_definition", "object_definition", "trait_definition", "enum_definition"},
+		CallTypes:   []string{"call_expression"},
 		ImportTypes: []string{"import_declaration"},
 
 		InheritFields: []string{"extend"},

--- a/internal/extract/python/framework.go
+++ b/internal/extract/python/framework.go
@@ -27,6 +27,8 @@ var djangoRelationFields = map[string]bool{
 // (`models.ForeignKey(User)`). The first positional argument is the
 // target: either an identifier (confidence 0.9) or a string literal
 // like `"app.User"` (confidence 0.8, last dot-segment used as target).
+//
+//nolint:gocyclo // 27-12: retired by the python/golang/langspec split
 func (w *walker) emitDjangoModelField(assign *sitter.Node, scope []string) error {
 	if len(scope) == 0 {
 		return nil
@@ -248,6 +250,8 @@ func (w *walker) emitURLPatternEdges(assign *sitter.Node) error {
 }
 
 // emitSingleURLPattern handles one path()/re_path()/include() call inside urlpatterns.
+//
+//nolint:gocyclo,gocognit // 27-12: retired by the python/golang/langspec split
 func (w *walker) emitSingleURLPattern(call *sitter.Node) error {
 	fn := call.ChildByFieldName("function")
 	if fn == nil {
@@ -376,6 +380,8 @@ var pythonGenericWrappers = map[string]bool{
 // annotation node. Handles plain identifiers, generic types
 // (Optional[X], list[X], Union[X, Y], dict[str, X]), and skips
 // primitives.
+//
+//nolint:gocyclo // 27-12: retired by the python/golang/langspec split
 func (w *walker) emitTypeAnnotationEdge(typeNode *sitter.Node, ownerQualified string, line int) error {
 	if typeNode == nil {
 		return nil

--- a/internal/extract/python/harvest.go
+++ b/internal/extract/python/harvest.go
@@ -37,6 +37,8 @@ func (Extractor) HarvestsMentions() bool { return true }
 //
 // Each emit is best-effort — an Emitter that implements none of the extensions
 // simply receives no names.
+//
+//nolint:gocyclo,gocognit // 27-12: retired by the python/golang/langspec split
 func emitHarvest(root *sitter.Node, source []byte, emit extract.Emitter) error {
 	if me, ok := emit.(extract.MentionEmitter); ok {
 		for _, name := range extract.HarvestMentions(root, source, mentionWalkSpec()) {

--- a/internal/extract/python/harvest_test.go
+++ b/internal/extract/python/harvest_test.go
@@ -11,24 +11,39 @@ import (
 // harvestRecorder captures emitted symbols plus every optional harvest stream so
 // the harvest tests can assert on raw-byte extraction without the scan harness.
 type harvestRecorder struct {
-	symbols      []extract.EmittedSymbol
-	edges        []extract.EmittedEdge
-	mentions     []string
-	dispatch     []string
-	decorated    []string
-	routes       []string
-	django       []string
-	allExports   []string
+	symbols    []extract.EmittedSymbol
+	edges      []extract.EmittedEdge
+	mentions   []string
+	dispatch   []string
+	decorated  []string
+	routes     []string
+	django     []string
+	allExports []string
 }
 
-func (r *harvestRecorder) Symbol(s extract.EmittedSymbol) error { r.symbols = append(r.symbols, s); return nil }
-func (r *harvestRecorder) Edge(e extract.EmittedEdge) error     { r.edges = append(r.edges, e); return nil }
-func (r *harvestRecorder) MentionName(n string) error           { r.mentions = append(r.mentions, n); return nil }
-func (r *harvestRecorder) DispatchName(n string) error          { r.dispatch = append(r.dispatch, n); return nil }
-func (r *harvestRecorder) PythonDecoratedName(n string) error   { r.decorated = append(r.decorated, n); return nil }
-func (r *harvestRecorder) PythonRouteName(n string) error       { r.routes = append(r.routes, n); return nil }
-func (r *harvestRecorder) PythonDjangoName(n string) error      { r.django = append(r.django, n); return nil }
-func (r *harvestRecorder) PythonAllExportName(n string) error   { r.allExports = append(r.allExports, n); return nil }
+func (r *harvestRecorder) Symbol(s extract.EmittedSymbol) error {
+	r.symbols = append(r.symbols, s)
+	return nil
+}
+func (r *harvestRecorder) Edge(e extract.EmittedEdge) error { r.edges = append(r.edges, e); return nil }
+func (r *harvestRecorder) MentionName(n string) error       { r.mentions = append(r.mentions, n); return nil }
+func (r *harvestRecorder) DispatchName(n string) error {
+	r.dispatch = append(r.dispatch, n)
+	return nil
+}
+func (r *harvestRecorder) PythonDecoratedName(n string) error {
+	r.decorated = append(r.decorated, n)
+	return nil
+}
+func (r *harvestRecorder) PythonRouteName(n string) error { r.routes = append(r.routes, n); return nil }
+func (r *harvestRecorder) PythonDjangoName(n string) error {
+	r.django = append(r.django, n)
+	return nil
+}
+func (r *harvestRecorder) PythonAllExportName(n string) error {
+	r.allExports = append(r.allExports, n)
+	return nil
+}
 
 // extractHarvest parses src and returns the recorded output including harvests.
 func extractHarvest(t *testing.T, src string) *harvestRecorder {

--- a/internal/extract/python/python.go
+++ b/internal/extract/python/python.go
@@ -9,8 +9,8 @@
 //
 // Intra-file edges:
 //   - class B(A)             → inherits edge (B → A) when A is defined
-//                              in the same file; cross-file inheritance
-//                              is dropped for 01-03 to backfill.
+//     in the same file; cross-file inheritance
+//     is dropped for 01-03 to backfill.
 //
 // Calls edges:
 //   - Function / method bodies are walked for `call` nodes. The target
@@ -30,9 +30,9 @@
 // Qualified-name rules (per 05-languages.md):
 //   - Class:      A  or  Outer.Inner
 //   - Method:     A.method  (Python has no syntactic instance/class
-//                            split at def-site; decorators identify
-//                            classmethods but we don't emit a separate
-//                            qualified form).
+//     split at def-site; decorators identify
+//     classmethods but we don't emit a separate
+//     qualified form).
 //   - Function:   f  (top-level only; nested defs are closures, skipped)
 //   - Constant:   NAME  or  Outer.NAME
 //
@@ -82,8 +82,8 @@ func init() { extract.Register(Extractor{}) }
 // ---- walker ----
 
 type walker struct {
-	source []byte
-	emit   extract.Emitter
+	source      []byte
+	emit        extract.Emitter
 	pkgBindings map[string]string // unqualified name → qualified name for module-level constants
 }
 
@@ -492,7 +492,7 @@ func isAllCaps(s string) bool {
 		return false
 	}
 	for _, r := range s {
-		if (r >= 'A' && r <= 'Z') {
+		if r >= 'A' && r <= 'Z' {
 			return true
 		}
 	}

--- a/internal/extract/python/python_test.go
+++ b/internal/extract/python/python_test.go
@@ -15,8 +15,11 @@ type recorder struct {
 	edges   []extract.EmittedEdge
 }
 
-func (r *recorder) Symbol(s extract.EmittedSymbol) error { r.symbols = append(r.symbols, s); return nil }
-func (r *recorder) Edge(e extract.EmittedEdge) error     { r.edges = append(r.edges, e); return nil }
+func (r *recorder) Symbol(s extract.EmittedSymbol) error {
+	r.symbols = append(r.symbols, s)
+	return nil
+}
+func (r *recorder) Edge(e extract.EmittedEdge) error { r.edges = append(r.edges, e); return nil }
 
 // counter counts emitted symbols and edges.
 type counter struct {
@@ -933,7 +936,6 @@ DEFAULT_TIMEOUT = 30
 	}
 }
 
-
 func TestDecoratedClassFullPath(t *testing.T) {
 	r := parse(t, `
 @dataclass
@@ -1678,4 +1680,3 @@ def run(*ARGS, **KWARGS):
 		t.Error("should not emit references for **kwargs param name")
 	}
 }
-

--- a/internal/extract/ruby/inflect_test.go
+++ b/internal/extract/ruby/inflect_test.go
@@ -17,18 +17,18 @@ func TestSingularize(t *testing.T) {
 		{"invoice", "invoice"},
 		{"", ""},
 		// Additional test cases for full coverage
-		{"processes", "process"},    // sses → ss
-		{"kisses", "kiss"},         // sses → ss
-		{"boxes", "box"},           // xes → x
-		{"faxes", "fax"},           // xes → x
-		{"buzzes", "buzz"},         // zes → z
-		{"quizzes", "quiz"},        // zes → z
-		{"ass", "ass"},             // should not remove s from "ass"
-		{"mass", "mass"},           // should not remove s from "mass"
-		{"glass", "glass"},         // should not remove s from "glass"
-		{"companies", "company"},   // ies → y
-		{"cities", "city"},         // ies → y
-		{"stories", "story"},       // ies → y
+		{"processes", "process"}, // sses → ss
+		{"kisses", "kiss"},       // sses → ss
+		{"boxes", "box"},         // xes → x
+		{"faxes", "fax"},         // xes → x
+		{"buzzes", "buzz"},       // zes → z
+		{"quizzes", "quiz"},      // zes → z
+		{"ass", "ass"},           // should not remove s from "ass"
+		{"mass", "mass"},         // should not remove s from "mass"
+		{"glass", "glass"},       // should not remove s from "glass"
+		{"companies", "company"}, // ies → y
+		{"cities", "city"},       // ies → y
+		{"stories", "story"},     // ies → y
 	}
 	for _, tc := range cases {
 		if got := singularize(tc.in); got != tc.want {

--- a/internal/extract/ruby/ruby.go
+++ b/internal/extract/ruby/ruby.go
@@ -180,6 +180,8 @@ func (w *walker) walk(n *sitter.Node, scope []string) error {
 // dispatchCall extracts the method name from a call node once and routes
 // to the appropriate handler. Returns true if the node was fully consumed
 // (caller should not descend into children).
+//
+//nolint:gocyclo // 27-10: retired by the ruby extractor split
 func (w *walker) dispatchCall(n *sitter.Node, scope []string) (bool, error) {
 	methodNode := n.ChildByFieldName("method")
 	if methodNode == nil {
@@ -322,6 +324,8 @@ func (w *walker) handleTestBlock(n *sitter.Node, scope []string, methodName stri
 
 // buildTestScopeSegment extracts a scope segment from a test DSL call.
 // Returns "" when the block should fall back to file-level scope.
+//
+//nolint:gocyclo // 27-10: retired by the ruby extractor split
 func (w *walker) buildTestScopeSegment(n *sitter.Node, methodName string) string {
 	args := n.ChildByFieldName("arguments")
 	if args == nil || args.NamedChildCount() == 0 {
@@ -596,6 +600,8 @@ func sanitizeDesc(s string) string {
 
 // handleClassOrModule emits the symbol, records inheritance (class only),
 // and descends into the body with the class/module pushed onto the scope.
+//
+//nolint:gocognit // 27-10: retired by the ruby extractor split
 func (w *walker) handleClassOrModule(n *sitter.Node, scope []string, kind model.SymbolKind) error {
 	nameNode := n.ChildByFieldName("name")
 	if nameNode == nil {
@@ -987,6 +993,8 @@ func (w *walker) resolveCallTarget(recv *sitter.Node, methodName string, scope [
 // resolveChainReceiver recursively resolves a call-chain receiver to a type
 // by looking up local-variable types and method return types. It caps at 3
 // hops to avoid exponential lookups and absurd qualified names.
+//
+//nolint:gocyclo // 27-10: retired by the ruby extractor split
 func (w *walker) resolveChainReceiver(recv *sitter.Node, scope []string, localTypes map[string]string, depth int) string {
 	if depth > 3 || recv == nil || recv.Kind() != "call" {
 		return ""
@@ -1697,6 +1705,8 @@ func inferSendTargetFromVariable(call *sitter.Node, source []byte) (string, floa
 // collectConstants recursively pre-scans for constant assignments so
 // method bodies can emit references edges. Descends into class/module
 // bodies to find nested constants (e.g. MyClass::TIMEOUT).
+//
+//nolint:gocognit // 27-10: retired by the ruby extractor split
 func (w *walker) collectConstants(n *sitter.Node, scope []string) {
 	if n == nil {
 		return
@@ -1761,6 +1771,8 @@ func (w *walker) collectConstants(n *sitter.Node, scope []string) {
 // an assignment. When skipNestedDefs is set (class-body walks) anything
 // inside a nested def/class/module is skipped too, so a method's
 // references stay attributed to the method, not its enclosing class.
+//
+//nolint:gocyclo,gocognit // 27-10: retired by the ruby extractor split
 func (w *walker) collectConstRefs(root *sitter.Node, sourceQualified string, skipNestedDefs bool) error {
 	if root == nil {
 		return nil

--- a/internal/extract/rust/docstring_test.go
+++ b/internal/extract/rust/docstring_test.go
@@ -242,10 +242,10 @@ func TestDocstring_MalformedUTF8(t *testing.T) {
 //     ever does.
 func TestHasBlankLineGap_Contract(t *testing.T) {
 	for _, tc := range []struct {
-		name    string
-		src     string
-		s, e    uint
-		want    bool
+		name string
+		src  string
+		s, e uint
+		want bool
 	}{
 		{"whitespace-only blank gap", "a\n \nb", 1, 4, true},
 		{"non-newline byte transparent", "a\nx\nb", 1, 4, true},

--- a/internal/extract/rust/harvest.go
+++ b/internal/extract/rust/harvest.go
@@ -25,6 +25,8 @@ func (Extractor) HarvestsMentions() bool { return true }
 // sets feed the Rust voice's rust_ffi / rust_used / rust_test reasons. All four
 // are gathered in one tree walk; each emit is best-effort — an Emitter that
 // implements neither extension simply receives no names.
+//
+//nolint:gocyclo,gocognit // 27-11: retired by the tsjs/rust extractor split
 func emitHarvest(root *sitter.Node, source []byte, emit extract.Emitter) error {
 	h := collectRustHarvest(root, source)
 	if de, ok := emit.(extract.DispatchEmitter); ok {

--- a/internal/extract/rust/rust.go
+++ b/internal/extract/rust/rust.go
@@ -193,6 +193,8 @@ func (w *walker) collectDeriveTraits(n *sitter.Node, scope []string) {
 // forEachDerivedTrait walks #[derive(...)] attributes preceding a node
 // and calls fn for each derived trait name. The node argument to fn is
 // the identifier node (for line information).
+//
+//nolint:gocyclo,gocognit // 27-11: retired by the tsjs/rust extractor split
 func (w *walker) forEachDerivedTrait(n *sitter.Node, fn func(traitName string, ident *sitter.Node) error) error {
 	for sib := n.PrevNamedSibling(); sib != nil; sib = sib.PrevNamedSibling() {
 		if sib.Kind() != "attribute_item" {
@@ -765,6 +767,8 @@ func (w *walker) emitStructFieldCompositions(list *sitter.Node, qualified string
 
 // resolveComposeTargets extracts user-defined type names from a type
 // node, unwrapping generic wrappers like Vec<T>, Option<T>, Box<T>.
+//
+//nolint:gocyclo // 27-11: retired by the tsjs/rust extractor split
 func (w *walker) resolveComposeTargets(typeNode *sitter.Node) []string {
 	if typeNode == nil {
 		return nil

--- a/internal/extract/rust/rust.go
+++ b/internal/extract/rust/rust.go
@@ -11,7 +11,7 @@
 //   - function_item in impl     → KindMethod with parent = impl type
 //   - mod_item                  → KindModule
 //   - function_signature_item   → KindMethod (trait method signatures,
-//                                 parented to the trait)
+//     parented to the trait)
 //
 // Visibility:
 //   - `pub` → "public"; `pub(crate)`, `pub(super)`, `pub(in path)` and
@@ -33,8 +33,8 @@
 //   - Rust uses `::` for path separators. Module-scoped items carry
 //     the module chain: `inner::helper`.
 //   - Impl methods qualify through the impl's type:
-//       impl Money               → methods qualified `Money::display`
-//       impl Formatter for Money → methods qualified `Money::format`
+//     impl Money               → methods qualified `Money::display`
+//     impl Formatter for Money → methods qualified `Money::format`
 package rust
 
 import (

--- a/internal/extract/rust/rust_test.go
+++ b/internal/extract/rust/rust_test.go
@@ -14,8 +14,11 @@ type recorder struct {
 	edges   []extract.EmittedEdge
 }
 
-func (r *recorder) Symbol(s extract.EmittedSymbol) error { r.symbols = append(r.symbols, s); return nil }
-func (r *recorder) Edge(e extract.EmittedEdge) error     { r.edges = append(r.edges, e); return nil }
+func (r *recorder) Symbol(s extract.EmittedSymbol) error {
+	r.symbols = append(r.symbols, s)
+	return nil
+}
+func (r *recorder) Edge(e extract.EmittedEdge) error { r.edges = append(r.edges, e); return nil }
 
 // counter counts emitted symbols and edges.
 type counter struct {
@@ -1258,7 +1261,6 @@ impl Parser {
 		t.Errorf("expected at least 2 calls from Parser::parse, got %d", calls)
 	}
 }
-
 
 func TestUnwrapReferenceType(t *testing.T) {
 	r := parse(t, `

--- a/internal/extract/testdata/go/depth.go
+++ b/internal/extract/testdata/go/depth.go
@@ -22,8 +22,8 @@ func (w BaseWorker) ClockIn() {}
 func (w *BaseWorker) ClockOut() {}
 
 type PickerBot struct {
-	BaseWorker         // embedded → includes edge
-	*Logger            // embedded pointer → includes edge
+	BaseWorker          // embedded → includes edge
+	*Logger             // embedded pointer → includes edge
 	assignedZone string // regular field, not embedded
 }
 

--- a/internal/extract/tsjs/tsjs.go
+++ b/internal/extract/tsjs/tsjs.go
@@ -26,7 +26,7 @@
 //     text — `foo`, `obj.bar`, `a.b.c` — as written, with one rewrite:
 //     a leading `this.` is stripped so `this.helper()` resolves against
 //     the enclosing class's members. Tagged template invocations
-//     (`` tag`literal` ``) parse as `call_expression` in tree-sitter and
+//     (“ tag`literal` “) parse as `call_expression` in tree-sitter and
 //     are emitted as regular calls. `new X()` is a `new_expression`,
 //     not a call_expression; constructors aren't emitted in Tier-Basic.
 //     Subscript / dynamic callees (`obj[k]()`, `f()()`) are skipped.
@@ -36,9 +36,10 @@
 //     tags emit the full surface text (`<Form.Input>` → calls Form.Input).
 //
 // Qualified-name rules (per 05-languages.md, "pkg.module.Class.method"):
-//   Class/Interface/Enum/Type: Name or Outer.Inner
-//   Method:                    Class.method
-//   Function / Const:          Name (no further qualification in Tier-Basic)
+//
+//	Class/Interface/Enum/Type: Name or Outer.Inner
+//	Method:                    Class.method
+//	Function / Const:          Name (no further qualification in Tier-Basic)
 //
 // What Tier-Basic skips:
 //   - class fields (public_field_definition)
@@ -85,9 +86,9 @@ func (TSX) Extract(tree *sitter.Tree, source []byte, filePath string, emit extra
 type JavaScript struct{}
 
 func (JavaScript) Grammar() *sitter.Language { return grammars.JavaScript() }
-func (JavaScript) Language() string           { return "javascript" }
-func (JavaScript) Extensions() []string       { return []string{".js", ".jsx", ".mjs", ".cjs"} }
-func (JavaScript) Tier() extract.Tier         { return extract.TierBasic }
+func (JavaScript) Language() string          { return "javascript" }
+func (JavaScript) Extensions() []string      { return []string{".js", ".jsx", ".mjs", ".cjs"} }
+func (JavaScript) Tier() extract.Tier        { return extract.TierBasic }
 func (JavaScript) Extract(tree *sitter.Tree, source []byte, filePath string, emit extract.Emitter) error {
 	return extractAll(tree, source, filePath, emit)
 }
@@ -328,9 +329,9 @@ func (w *walker) emitClassWithBody(n *sitter.Node, name string, scope []string) 
 //
 // The two grammars shape this differently:
 //
-//   TypeScript: class_heritage → extends_clause (value: identifier)
-//               class_heritage → implements_clause (type_identifier*)
-//   JavaScript: class_heritage → identifier (direct child, no clause)
+//	TypeScript: class_heritage → extends_clause (value: identifier)
+//	            class_heritage → implements_clause (type_identifier*)
+//	JavaScript: class_heritage → identifier (direct child, no clause)
 //
 // We handle both: clause children are walked with emitHeritageTargets,
 // bare identifiers are converted into a one-target edge in place.
@@ -1045,11 +1046,11 @@ func (w *walker) handleStimulusClass(n *sitter.Node, _ []string) error {
 	qualified := w.stimulusName
 
 	if err := w.emit.Symbol(extract.EmittedSymbol{
-		Name:       qualified,
-		Qualified:  qualified,
-		Kind:       model.KindClass,
-		LineStart:  extract.Line(n.StartPosition()),
-		LineEnd:    extract.Line(n.EndPosition()),
+		Name:      qualified,
+		Qualified: qualified,
+		Kind:      model.KindClass,
+		LineStart: extract.Line(n.StartPosition()),
+		LineEnd:   extract.Line(n.EndPosition()),
 	}); err != nil {
 		return err
 	}
@@ -1146,7 +1147,6 @@ func extractStringArray(fieldDef *sitter.Node, source []byte) []string {
 	}
 	return result
 }
-
 
 // inferStimulusController derives a Stimulus controller qualified name from a
 // file path. Returns "" if the file doesn't match the Stimulus convention.

--- a/internal/extract/tsjs/tsjs.go
+++ b/internal/extract/tsjs/tsjs.go
@@ -140,6 +140,8 @@ type walker struct {
 // collectModuleConstants pre-scans top-level const declarations for
 // value-type constants (not arrow functions or class expressions) so
 // function bodies can emit references edges.
+//
+//nolint:gocyclo,gocognit // 27-11: retired by the tsjs/rust extractor split
 func (w *walker) collectModuleConstants(root *sitter.Node) {
 	if root == nil {
 		return
@@ -220,6 +222,7 @@ func (w *walker) emitConstRefs(body *sitter.Node, sourceQualified string) error 
 	})
 }
 
+//nolint:gocyclo // 27-11: retired by the tsjs/rust extractor split
 func (w *walker) walk(n *sitter.Node, scope []string) error {
 	if n == nil {
 		return nil

--- a/internal/extract/tsjs/tsjs_test.go
+++ b/internal/extract/tsjs/tsjs_test.go
@@ -56,8 +56,11 @@ type recorder struct {
 	edges   []extract.EmittedEdge
 }
 
-func (r *recorder) Symbol(s extract.EmittedSymbol) error { r.symbols = append(r.symbols, s); return nil }
-func (r *recorder) Edge(e extract.EmittedEdge) error     { r.edges = append(r.edges, e); return nil }
+func (r *recorder) Symbol(s extract.EmittedSymbol) error {
+	r.symbols = append(r.symbols, s)
+	return nil
+}
+func (r *recorder) Edge(e extract.EmittedEdge) error { r.edges = append(r.edges, e); return nil }
 
 func TestInferStimulusController(t *testing.T) {
 	tests := []struct {
@@ -210,8 +213,8 @@ export default class extends Controller {
 
 	// Check outlet edges
 	wantOutlets := map[string]bool{
-		"SearchController":          false,
-		"Admin::ResultsController":  false,
+		"SearchController":         false,
+		"Admin::ResultsController": false,
 	}
 	for _, e := range r.edges {
 		if _, ok := wantOutlets[e.TargetQualified]; ok {
@@ -1160,7 +1163,6 @@ func TestStarReexportEdge(t *testing.T) {
 	}
 }
 
-
 func TestAbstractClassDeclaration(t *testing.T) {
 	r := parseTS(t, `abstract class Animal {
   abstract speak(): string;
@@ -1881,7 +1883,6 @@ func TestInterfaceHeritageError(t *testing.T) {
 	}
 }
 
-
 func TestTypeAliasSymbolErrorTS(t *testing.T) {
 	err := parseWithEmitter(t, `type ID = string;`, &failAfter{symbolsLeft: 0, edgesLeft: 100})
 	if err == nil {
@@ -1895,7 +1896,6 @@ func TestTypeAliasIntersectionEdgeError(t *testing.T) {
 		t.Error("expected error on type alias intersection edge emit")
 	}
 }
-
 
 func TestFunctionWithCallError(t *testing.T) {
 	err := parseWithEmitter(t, `function f() { g(); h(); }`, &failAfter{symbolsLeft: 100, edgesLeft: 0})

--- a/internal/extract/tsjs/visibility.go
+++ b/internal/extract/tsjs/visibility.go
@@ -95,6 +95,8 @@ func (w *walker) methodVisibility(scope []string) string {
 // free function (not a walker method) so the harvest pass can reuse it without
 // the walker's mutable state. filePath supplies the file-based name an anonymous
 // default export is synthesized under (matching handleDefaultExport).
+//
+//nolint:gocognit // 27-11: retired by the tsjs/rust extractor split
 func collectExportedNames(root *sitter.Node, source []byte, filePath string) (exported, defaultExports map[string]bool) {
 	exported = map[string]bool{}
 	defaultExports = map[string]bool{}

--- a/internal/grammars/kotlin.go
+++ b/internal/grammars/kotlin.go
@@ -1,8 +1,8 @@
 package grammars
 
 import (
-	sitter "github.com/tree-sitter/go-tree-sitter"
 	ts_kotlin "github.com/fwcd/tree-sitter-kotlin/bindings/go"
+	sitter "github.com/tree-sitter/go-tree-sitter"
 )
 
 func Kotlin() *sitter.Language { return sitter.NewLanguage(ts_kotlin.Language()) }

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -13,9 +13,10 @@ import (
 	"testing/iotest"
 	"time"
 
+	_ "modernc.org/sqlite"
+
 	"github.com/luuuc/sense/internal/scan"
 	"github.com/luuuc/sense/internal/sqlite"
-	_ "modernc.org/sqlite"
 )
 
 func indexedDir(t *testing.T) string {

--- a/internal/hook/pre_tool_use.go
+++ b/internal/hook/pre_tool_use.go
@@ -198,7 +198,6 @@ func buildContext(count int, pattern, source string) string {
 	return sb.String()
 }
 
-
 func extractPattern(req preToolUseInput) string {
 	if req.Input.Pattern != "" {
 		return req.Input.Pattern

--- a/internal/ignore/build_test.go
+++ b/internal/ignore/build_test.go
@@ -31,15 +31,15 @@ func TestBuildNestedGitignore(t *testing.T) {
 		path string
 		want bool
 	}{
-		{"app.log", true},               // root .gitignore
-		{"sub/app.log", true},            // root .gitignore applies everywhere
-		{"sub/local-only", true},         // sub/.gitignore anchored with prefix
-		{"local-only", false},            // not at root
-		{"sub/foo.tmp", true},            // sub/.gitignore unanchored
-		{"foo.tmp", false},               // sub/.gitignore doesn't apply at root
-		{"sub/deep/secret.txt", true},    // deep/.gitignore
-		{"secret.txt", false},            // deep/.gitignore doesn't apply at root
-		{"sub/deep/other.txt", false},    // not ignored
+		{"app.log", true},             // root .gitignore
+		{"sub/app.log", true},         // root .gitignore applies everywhere
+		{"sub/local-only", true},      // sub/.gitignore anchored with prefix
+		{"local-only", false},         // not at root
+		{"sub/foo.tmp", true},         // sub/.gitignore unanchored
+		{"foo.tmp", false},            // sub/.gitignore doesn't apply at root
+		{"sub/deep/secret.txt", true}, // deep/.gitignore
+		{"secret.txt", false},         // deep/.gitignore doesn't apply at root
+		{"sub/deep/other.txt", false}, // not ignored
 	}
 	for _, tt := range tests {
 		if got := m.Match(tt.path, false); got != tt.want {

--- a/internal/mcpio/marshal.go
+++ b/internal/mcpio/marshal.go
@@ -308,7 +308,6 @@ func normalizeStatusResponse(r *StatusResponse) {
 	}
 }
 
-
 // MarshalUnreferenced renders an UnreferencedResponse with the shared
 // CLI pretty-print contract.
 func MarshalUnreferenced(r UnreferencedResponse) ([]byte, error) {

--- a/internal/mcpserver/aliases_test.go
+++ b/internal/mcpserver/aliases_test.go
@@ -84,8 +84,8 @@ func TestWithAliasingRewritesBeforeHandler(t *testing.T) {
 	req := mcp.CallToolRequest{}
 	req.Params.Name = "sense_graph"
 	req.Params.Arguments = map[string]any{
-		"name": "User", // global alias → symbol
-		"dir":  "callers", // tool alias → direction
+		"name": "User",       // global alias → symbol
+		"dir":  "callers",    // tool alias → direction
 		"text": "user model", // global alias → query
 	}
 	if _, err := wrapped(context.Background(), req); err != nil {

--- a/internal/mcpserver/blastdiff_test.go
+++ b/internal/mcpserver/blastdiff_test.go
@@ -230,11 +230,11 @@ func TestBlastDiffMultipleFiles(t *testing.T) {
 	}
 
 	edge := model.Edge{
-		SourceID: &symID,
-		TargetID: symID,
-		Kind:     model.EdgeCalls,
-		FileID:   fileID,
-		Line:     intPtr(1),
+		SourceID:   &symID,
+		TargetID:   symID,
+		Kind:       model.EdgeCalls,
+		FileID:     fileID,
+		Line:       intPtr(1),
 		Confidence: 1.0,
 	}
 	if _, err := h.adapter.WriteEdge(ctx, &edge); err != nil {

--- a/internal/mcpserver/compaction_test.go
+++ b/internal/mcpserver/compaction_test.go
@@ -71,13 +71,13 @@ func setupCompactionFixture(t *testing.T) *handlers {
 	t.Cleanup(func() { tracker.Close() })
 
 	return &handlers{
-		adapter:      adapter,
-		db:           adapter.DB(),
-		dir:          dir,
-		search:       search.NewEngine(adapter, nil, nil),
-		tracker:      tracker,
-		defaults:     profile.DefaultParams(),
-		seenSymbols:  make(map[int64]bool),
+		adapter:     adapter,
+		db:          adapter.DB(),
+		dir:         dir,
+		search:      search.NewEngine(adapter, nil, nil),
+		tracker:     tracker,
+		defaults:    profile.DefaultParams(),
+		seenSymbols: make(map[int64]bool),
 	}
 }
 

--- a/internal/mcpserver/server.go
+++ b/internal/mcpserver/server.go
@@ -81,6 +81,8 @@ func RunWithOptions(opts RunOptions) error {
 
 // buildMCPServer creates the MCP server and handlers without starting stdio
 // transport. Returns the server, handlers, a cleanup function, and any error.
+//
+//nolint:gocyclo,gocognit // 27-05: retired by the mcpserver split
 func buildMCPServer(opts RunOptions) (*server.MCPServer, *handlers, func(), error) {
 	dir := opts.Dir
 	if dir == "" {
@@ -419,6 +421,7 @@ func statusTool() mcp.Tool {
 // sense_graph handler
 // ---------------------------------------------------------------
 
+//nolint:gocyclo // 27-05: retired by the mcpserver split
 func (h *handlers) handleGraph(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	if req.GetBool("dead_code", false) {
 		return h.handleDeadCode(ctx, req)
@@ -607,6 +610,7 @@ func enrichAlsoCalledBy(ctx context.Context, adapter *sqlite.Adapter, symbolCoun
 	}
 }
 
+//nolint:gocyclo // 27-05: retired by the mcpserver split
 func (h *handlers) resolveDispatchCallers(ctx context.Context, root *model.SymbolContext, resp *mcpio.GraphResponse, lookup mcpio.FileLookup) []mcpio.DispatchInferredRef {
 	sym := root.Symbol
 	if sym.Kind != model.KindMethod || sym.ParentID == nil {
@@ -795,6 +799,7 @@ func isTestFile(path string) bool {
 // sense_search handler
 // ---------------------------------------------------------------
 
+//nolint:gocyclo // 27-05: retired by the mcpserver split
 func (h *handlers) handleSearch(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	query, err := req.RequireString("query")
 	if err != nil {
@@ -1518,6 +1523,7 @@ func statusHints(resp mcpio.StatusResponse, sessionQueries int) []mcpio.NextStep
 	return hints
 }
 
+//nolint:gocyclo // 27-05: retired by the mcpserver split
 func buildStatusResponse(ctx context.Context, db *sql.DB, dir string, ws *mcpio.WatchState) (mcpio.StatusResponse, error) {
 	var resp mcpio.StatusResponse
 

--- a/internal/metrics/tracker.go
+++ b/internal/metrics/tracker.go
@@ -19,10 +19,10 @@ type Tracker struct {
 	flushInterval time.Duration
 
 	session struct {
-		queries            atomic.Int64
-		fileReadsAvoided   atomic.Int64
-		tokensSaved        atomic.Int64
-		textFallbackFired  atomic.Int64
+		queries           atomic.Int64
+		fileReadsAvoided  atomic.Int64
+		tokensSaved       atomic.Int64
+		textFallbackFired atomic.Int64
 	}
 
 	topQuery struct {

--- a/internal/model/edge.go
+++ b/internal/model/edge.go
@@ -22,11 +22,11 @@ func Int64Ptr(v int64) *int64 { return &v }
 type EdgeKind string
 
 const (
-	EdgeCalls    EdgeKind = "calls"
-	EdgeImports  EdgeKind = "imports"
-	EdgeInherits EdgeKind = "inherits"
-	EdgeIncludes EdgeKind = "includes"
-	EdgeTests    EdgeKind = "tests"
+	EdgeCalls      EdgeKind = "calls"
+	EdgeImports    EdgeKind = "imports"
+	EdgeInherits   EdgeKind = "inherits"
+	EdgeIncludes   EdgeKind = "includes"
+	EdgeTests      EdgeKind = "tests"
 	EdgeComposes   EdgeKind = "composes"
 	EdgeTemporal   EdgeKind = "temporal"
 	EdgeReferences EdgeKind = "references"

--- a/internal/model/rails.go
+++ b/internal/model/rails.go
@@ -26,8 +26,8 @@ var RailsCallbackNames = map[string]bool{
 	// the lifecycle hooks above. Without it the predicate reads as zero-edge.
 	// (`validates :attr, ...` takes attribute names, not method symbols, so it
 	// is deliberately omitted — it would emit edges to non-method targets.)
-	"validate": true,
-	"before_commit":     true,
-	"after_commit":      true,
-	"after_rollback":    true,
+	"validate":       true,
+	"before_commit":  true,
+	"after_commit":   true,
+	"after_rollback": true,
 }

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -14,9 +14,9 @@ const (
 )
 
 const (
-	smallThreshold         = 3000
-	largeDynamicThreshold  = 15000
-	largeStaticThreshold   = 20000
+	smallThreshold        = 3000
+	largeDynamicThreshold = 15000
+	largeStaticThreshold  = 20000
 )
 
 var dynamicLanguages = map[string]bool{

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -128,6 +128,8 @@ const nameCollisionConfidence = extract.ConfidenceNameCollision
 //     blast's floor as an unverified cross-scope guess unless the
 //     qualifier can be verified — see isUnverifiedCrossScope.
 //  4. No match ⇒ ok=false.
+//
+//nolint:gocyclo,gocognit // 27-07: retired by the storage/query split
 func (ix *Index) Resolve(req Request) (Result, bool) {
 	target := rewriteReceiver(req.Target, req.SourceQualified, req.SourceParentQualified)
 	gatedKind := req.Kind == model.EdgeCalls || req.Kind == model.EdgeTests || req.Kind == model.EdgeReferences
@@ -518,6 +520,8 @@ func filterByTestDirection(matches []model.SymbolRef, sourceIsTest bool, fileIsT
 // `test/`/`spec/` directories, `_test`/`_spec`/`.test.` infixes, a `test_`
 // prefix, and a `Test`/`Tests` filename suffix — are stable across the
 // supported languages.
+//
+//nolint:gocyclo // 27-07: retired by the storage/query split
 func isTestPath(path string) bool {
 	if strings.Contains(path, "_test.") ||
 		strings.Contains(path, ".test.") ||

--- a/internal/scan/embed.go
+++ b/internal/scan/embed.go
@@ -154,6 +154,8 @@ func (h *harness) migrateEmbeddingModel() (bool, error) {
 // minimal harness internally and clears the embedding watermark on success.
 // Returns the number of symbols embedded. The caller rebuilds the in-memory
 // vector index from the embeddings table afterward.
+//
+//nolint:gocyclo // 27-06: retired by the scan-pipeline split
 func EmbedPending(ctx context.Context, idx *sqlite.Adapter, root string) (int, error) {
 	syms, err := idx.SymbolsWithoutEmbeddings(ctx)
 	if err != nil {
@@ -238,6 +240,8 @@ func EmbedPending(ctx context.Context, idx *sqlite.Adapter, root string) (int, e
 // embedSymbols is pass 3: generate embeddings for symbols in changed files.
 // Only symbols whose file was re-indexed this scan get new embeddings.
 // Orphaned embeddings are cleaned by FK CASCADE when symbols are deleted.
+//
+//nolint:gocyclo // 27-06: retired by the scan-pipeline split
 func (h *harness) embedSymbols() error {
 	if len(h.changedFileIDs) == 0 {
 		return nil

--- a/internal/scan/fts_migration_test.go
+++ b/internal/scan/fts_migration_test.go
@@ -9,8 +9,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/luuuc/sense/internal/scan"
 	_ "modernc.org/sqlite"
+
+	"github.com/luuuc/sense/internal/scan"
 )
 
 // downgradeFTS rewrites the index's FTS table to an older shape that lacks the

--- a/internal/scan/incremental.go
+++ b/internal/scan/incremental.go
@@ -30,6 +30,8 @@ type IncrementalOptions struct {
 // RunIncremental re-indexes a specific set of changed files and removes
 // deleted ones. It uses the same per-file processing, edge resolution,
 // and embedding logic as the full scan but scoped to the provided paths.
+//
+//nolint:gocyclo // 27-06: retired by the scan-pipeline split
 func RunIncremental(ctx context.Context, opts IncrementalOptions) (*Result, error) {
 	out := opts.Output
 	if out == nil {

--- a/internal/scan/incremental.go
+++ b/internal/scan/incremental.go
@@ -22,8 +22,8 @@ type IncrementalOptions struct {
 	EmbeddingsEnabled bool
 	Output            io.Writer
 	Warnings          io.Writer
-	Changed           []string // relative paths of modified/created files
-	Removed           []string // relative paths of deleted files
+	Changed           []string     // relative paths of modified/created files
+	Removed           []string     // relative paths of deleted files
 	Parsers           *ParserCache // reusable parser cache; nil creates a temporary one
 }
 

--- a/internal/scan/naming.go
+++ b/internal/scan/naming.go
@@ -38,6 +38,8 @@ type namingCandidate struct {
 //
 // Only runs for projects with Ruby or Python files — Go and TypeScript
 // have explicit references that tree-sitter already captures.
+//
+//nolint:gocyclo // 27-06: retired by the scan-pipeline split
 func (h *harness) namingConventionEdges() error {
 	rubyFiles, err := h.idx.FileIDsByLanguage(h.ctx, "ruby")
 	if err != nil {

--- a/internal/scan/naming_test.go
+++ b/internal/scan/naming_test.go
@@ -28,9 +28,9 @@ func TestSingularize(t *testing.T) {
 
 func TestSplitQualified(t *testing.T) {
 	cases := []struct {
-		in        string
-		wantBare  string
-		wantNS    string
+		in       string
+		wantBare string
+		wantNS   string
 	}{
 		{"WorkPackages::CreateService", "CreateService", "WorkPackages"},
 		{"Admin::WorkPackages::CreateService", "CreateService", "WorkPackages"},

--- a/internal/scan/satisfy.go
+++ b/internal/scan/satisfy.go
@@ -52,6 +52,8 @@ type structInfo struct {
 // resolved and available for promoted-method computation. Scoped to
 // Go files only — implicit interface satisfaction is a Go-specific
 // semantic.
+//
+//nolint:gocyclo,gocognit // 27-06: retired by the scan-pipeline split
 func (h *harness) satisfyInterfaces() error {
 	goFiles, err := h.idx.FileIDsByLanguage(h.ctx, "go")
 	if err != nil {

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -116,6 +116,8 @@ const docstringTruncMarker = "…"
 // summary and any fatal error. Per-file parse/extract errors are
 // non-fatal: a warning is logged, the scan continues, and the result's
 // Warnings counter is incremented.
+//
+//nolint:gocyclo,gocognit // 27-06: retired by the scan-pipeline split
 func Run(ctx context.Context, opts Options) (*Result, error) {
 	root := opts.Root
 	if root == "" {
@@ -697,6 +699,8 @@ type walkEntry struct {
 // walkTree walks root depth-first. Dot-prefixed directories (.git,
 // .vscode) and the .sense directory are always skipped. Paths matched
 // by the ignore matcher are skipped. Symlinks are not followed.
+//
+//nolint:gocyclo,gocognit // 27-06: retired by the scan-pipeline split
 func (h *harness) walkTree(root string) error {
 	stmt, err := h.idx.PrepareSymbolStmt(h.ctx)
 	if err != nil {

--- a/internal/scan/scan_test.go
+++ b/internal/scan/scan_test.go
@@ -134,7 +134,6 @@ func TestScanSecondRunSkipsSetup(t *testing.T) {
 	}
 }
 
-
 func TestScanSchemaApplied(t *testing.T) {
 	root := t.TempDir()
 	buildTree(t, root, []string{"a.go"})
@@ -598,7 +597,6 @@ end
 		t.Error("expected Greeter#dispatch outbound edge to Greeter#say, none found")
 	}
 }
-
 
 // TestScanEmitsTestsEdgesByFilenameConvention pins Card 12's test-
 // association contract: a `widget.go` / `widget_test.go` pair in

--- a/internal/scan/temporal.go
+++ b/internal/scan/temporal.go
@@ -25,6 +25,8 @@ const (
 
 // extractTemporalCoupling derives temporal edges from git co-change history.
 // No-op if git is absent or the git log exceeds gitTimeout.
+//
+//nolint:gocyclo,gocognit // 27-06: retired by the scan-pipeline split
 func (h *harness) extractTemporalCoupling() error {
 	ctx, cancel := context.WithTimeout(h.ctx, gitTimeout)
 	defer cancel()

--- a/internal/scan/temporal_test.go
+++ b/internal/scan/temporal_test.go
@@ -94,7 +94,7 @@ func TestCountCoChanges(t *testing.T) {
 		{"pkg/a/file.go", "pkg/b/file.go", "pkg/c/file.go"},
 		{"pkg/a/file.go", "pkg/b/file.go"},
 		{"pkg/a/file.go", "pkg/a/other.go"}, // same directory — should not count
-		{"pkg/c/file.go", "untracked.go"},    // untracked not in indexed
+		{"pkg/c/file.go", "untracked.go"},   // untracked not in indexed
 	}
 
 	pairs, fileCounts := countCoChanges(commits, indexed)

--- a/internal/scan/tests.go
+++ b/internal/scan/tests.go
@@ -27,6 +27,8 @@ import (
 // mirror trees (Rails: spec/models/user_spec.rb → app/models/user.rb)
 // are handled by mirrorImpl. Other frameworks (Django, etc.) remain
 // same-directory only until a real case demands it.
+//
+//nolint:gocyclo,gocognit // 27-06: retired by the scan-pipeline split
 func (h *harness) associateTests() error {
 	if len(h.indexedFiles) == 0 {
 		return nil
@@ -113,6 +115,8 @@ func (h *harness) associateTests() error {
 // convention. Matching is suffix / prefix -based and same-directory
 // only; cross-directory mirror trees (Rails, Django) are not
 // handled.
+//
+//nolint:gocyclo // 27-06: retired by the scan-pipeline split
 func implSibling(path, language string) (string, bool) {
 	dir := filepath.Dir(path)
 	base := filepath.Base(path)

--- a/internal/scan/warnings.go
+++ b/internal/scan/warnings.go
@@ -12,7 +12,7 @@ import (
 type warningKind int
 
 const (
-	warnParseFailed  warningKind = iota
+	warnParseFailed warningKind = iota
 	warnFileTooLarge
 	warnWriteFailed
 	warnMetaError

--- a/internal/search/flat_test.go
+++ b/internal/search/flat_test.go
@@ -90,8 +90,8 @@ func TestFlatBuildSkipsMismatchedAndEmptyVectors(t *testing.T) {
 	// vector are skipped; the index keeps only the dimension-3 rows.
 	embeddings := map[int64][]float32{
 		1: normalize([]float32{1, 0, 0}),
-		2: {1, 0},     // wrong dim — skipped
-		3: {},         // empty — skipped
+		2: {1, 0}, // wrong dim — skipped
+		3: {},     // empty — skipped
 		4: normalize([]float32{0, 1, 0}),
 	}
 	idx := search.BuildFlatIndex(embeddings)

--- a/internal/search/fusion_internal_test.go
+++ b/internal/search/fusion_internal_test.go
@@ -290,9 +290,9 @@ func TestApplyTestDemotion(t *testing.T) {
 	paths := map[int64]string{1: "internal/dead/dead.go", 2: "internal/dead/dead_test.go", 3: "internal/x/y.go"}
 	mk := func() []Result {
 		return []Result{
-			{SymbolID: 1, Name: "FindDead", FileID: 1, Score: 0.6},  // impl
+			{SymbolID: 1, Name: "FindDead", FileID: 1, Score: 0.6},     // impl
 			{SymbolID: 2, Name: "TestFindDead", FileID: 2, Score: 1.0}, // test by path+name
-			{SymbolID: 3, Name: "MockThing", FileID: 3, Score: 0.9},  // test by name only
+			{SymbolID: 3, Name: "MockThing", FileID: 3, Score: 0.9},    // test by name only
 		}
 	}
 

--- a/internal/search/internals_test.go
+++ b/internal/search/internals_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/luuuc/sense/internal/sqlite"
 )
 
-
 func TestExpandQueryIdenticalSplit(t *testing.T) {
 	// "hello world" splits into "hello world" (identical) -> no second sub-query
 	got := expandQuery("hello world")

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -136,6 +136,8 @@ type SearchMeta struct {
 }
 
 // Search runs hybrid search and returns fused, re-ranked results.
+//
+//nolint:gocyclo,gocognit // 27-07: retired by the storage/query split
 func (e *Engine) Search(ctx context.Context, opts Options) ([]Result, SearchMeta, error) {
 	if opts.Limit <= 0 {
 		opts.Limit = 10
@@ -873,6 +875,8 @@ const parentPromotionThreshold = 2
 // promoteParents replaces multiple child methods from the same parent
 // class/struct with the parent symbol when 2+ children appear in the
 // top-K results. The parent inherits the highest child score.
+//
+//nolint:gocyclo // 27-07: retired by the storage/query split
 func (e *Engine) promoteParents(ctx context.Context, results []Result, limit int) ([]Result, error) {
 	if len(results) == 0 {
 		return results, nil

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -9,10 +9,11 @@ import (
 	"sync"
 	"unicode"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/luuuc/sense/internal/embed"
 	"github.com/luuuc/sense/internal/extract"
 	"github.com/luuuc/sense/internal/sqlite"
-	"golang.org/x/sync/errgroup"
 )
 
 // Result is a single fused search hit with metadata from both backends.

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -266,7 +266,7 @@ func TestFusionCentralityBreaksTie(t *testing.T) {
 		callerID, err := a.WriteSymbol(ctx, &model.Symbol{
 			FileID: fid2, Name: fmt.Sprintf("Caller%d", i),
 			Qualified: fmt.Sprintf("pkg.Caller%d", i),
-			Kind: "function", LineStart: i * 10, LineEnd: i*10 + 5,
+			Kind:      "function", LineStart: i * 10, LineEnd: i*10 + 5,
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -352,7 +352,7 @@ func TestSearchRanksHubSymbolHigher(t *testing.T) {
 		callerID, err := a.WriteSymbol(ctx, &model.Symbol{
 			FileID: callerFile, Name: fmt.Sprintf("Caller%d", i),
 			Qualified: fmt.Sprintf("pkg.Caller%d", i),
-			Kind: "function", LineStart: i * 10, LineEnd: i*10 + 5,
+			Kind:      "function", LineStart: i * 10, LineEnd: i*10 + 5,
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -369,7 +369,7 @@ func TestSearchRanksHubSymbolHigher(t *testing.T) {
 		callerID, err := a.WriteSymbol(ctx, &model.Symbol{
 			FileID: callerFile, Name: fmt.Sprintf("HelperCaller%d", i),
 			Qualified: fmt.Sprintf("pkg.HelperCaller%d", i),
-			Kind: "function", LineStart: 300 + i*10, LineEnd: 305 + i*10,
+			Kind:      "function", LineStart: 300 + i*10, LineEnd: 305 + i*10,
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -594,7 +594,7 @@ func TestSearchDemotesTestSymbols(t *testing.T) {
 		callerID, err := a.WriteSymbol(ctx, &model.Symbol{
 			FileID: callerFile, Name: fmt.Sprintf("Caller%d", i),
 			Qualified: fmt.Sprintf("pkg.Caller%d", i),
-			Kind: "function", LineStart: i * 10, LineEnd: i*10 + 5,
+			Kind:      "function", LineStart: i * 10, LineEnd: i*10 + 5,
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/internal/sqlite/adapter.go
+++ b/internal/sqlite/adapter.go
@@ -625,6 +625,8 @@ func (a *Adapter) ReadSymbol(ctx context.Context, id int64) (*model.SymbolContex
 // expands the frontier in the requested direction, deduplicating
 // against already-visited nodes. MaxPerHop caps new symbols per hop;
 // zero means unlimited.
+//
+//nolint:gocyclo,gocognit // 27-07: retired by the storage/query split
 func (a *Adapter) ReadSymbolGraph(ctx context.Context, id int64, depth int, direction model.Direction, maxPerHop int) (*model.GraphResult, error) {
 	root, err := a.ReadSymbol(ctx, id)
 	if err != nil {

--- a/internal/sqlite/adapter_test.go
+++ b/internal/sqlite/adapter_test.go
@@ -9,11 +9,12 @@ import (
 	"testing"
 	"time"
 
+	_ "modernc.org/sqlite"
+
 	"github.com/luuuc/sense/internal/index"
 	"github.com/luuuc/sense/internal/index/indextest"
 	"github.com/luuuc/sense/internal/model"
 	"github.com/luuuc/sense/internal/sqlite"
-	_ "modernc.org/sqlite"
 )
 
 func TestAdapterConformance(t *testing.T) {

--- a/internal/sqlite/context.go
+++ b/internal/sqlite/context.go
@@ -204,6 +204,8 @@ type labeledItems struct {
 // Lines are added in priority order (highest first). When a line
 // would exceed contextBudget, its items are truncated to fit. If
 // even one item won't fit, remaining lines are dropped.
+//
+//nolint:gocyclo // 27-07: retired by the storage/query split
 func formatSymbolContext(filePath string, sym symbolCtx, edges symbolEdges) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "File: %s\n", filePath)

--- a/internal/sqlite/context_test.go
+++ b/internal/sqlite/context_test.go
@@ -389,7 +389,7 @@ func seedChain(ctx context.Context, t *testing.T, a *sqlite.Adapter, n int) []in
 		sid, err := a.WriteSymbol(ctx, &model.Symbol{
 			FileID: fid, Name: fmt.Sprintf("S%d", i),
 			Qualified: fmt.Sprintf("S%d", i),
-			Kind: model.KindMethod, LineStart: 1, LineEnd: 5,
+			Kind:      model.KindMethod, LineStart: 1, LineEnd: 5,
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -540,7 +540,7 @@ func TestReadSymbolGraphTruncation(t *testing.T) {
 		callerID, _ := a.WriteSymbol(ctx, &model.Symbol{
 			FileID: fid, Name: fmt.Sprintf("Caller%d", i),
 			Qualified: fmt.Sprintf("Caller%d", i),
-			Kind: model.KindMethod, LineStart: 1, LineEnd: 5,
+			Kind:      model.KindMethod, LineStart: 1, LineEnd: 5,
 		})
 		if _, err := a.WriteEdge(ctx, &model.Edge{
 			SourceID: model.Int64Ptr(callerID), TargetID: hubID,
@@ -556,7 +556,7 @@ func TestReadSymbolGraphTruncation(t *testing.T) {
 		grandID, _ := a.WriteSymbol(ctx, &model.Symbol{
 			FileID: gfid, Name: fmt.Sprintf("Grand%d", i),
 			Qualified: fmt.Sprintf("Grand%d", i),
-			Kind: model.KindMethod, LineStart: 1, LineEnd: 5,
+			Kind:      model.KindMethod, LineStart: 1, LineEnd: 5,
 		})
 		if _, err := a.WriteEdge(ctx, &model.Edge{
 			SourceID: model.Int64Ptr(grandID), TargetID: callerID,

--- a/internal/sqlite/coverage_test.go
+++ b/internal/sqlite/coverage_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 	"time"
 
+	_ "modernc.org/sqlite"
+
 	"github.com/luuuc/sense/internal/model"
 	"github.com/luuuc/sense/internal/sqlite"
-	_ "modernc.org/sqlite"
 )
 
 // openTestDB creates a fresh in-tempdir database for a test.

--- a/internal/sqlite/fts5_docstring_test.go
+++ b/internal/sqlite/fts5_docstring_test.go
@@ -12,7 +12,7 @@ import (
 
 // TestFTS5DocstringStaleRowUpsert pins the FTS5 contract that pitch
 // 25-07's Card 7 calls out: every prior-version scan wrote
-// `docstring=''` rows into sense_symbols_fts (the column existed long
+// `docstring=”` rows into sense_symbols_fts (the column existed long
 // before any extractor populated it). When a re-scan UPSERTs the same
 // (file_id, qualified) symbol with a new non-empty docstring, the
 // FTS5 update trigger must overwrite the stale empty row so a MATCH

--- a/internal/sqlite/search.go
+++ b/internal/sqlite/search.go
@@ -487,4 +487,3 @@ func sanitizeFTS5Query(q string) string {
 	}
 	return strings.Join(quoted, " OR ")
 }
-

--- a/internal/summary/helpers_test.go
+++ b/internal/summary/helpers_test.go
@@ -71,9 +71,9 @@ func TestCapitalize(t *testing.T) {
 
 func TestReadStructuredDescription(t *testing.T) {
 	tests := []struct {
-		name    string
-		files   map[string]string
-		want    string
+		name  string
+		files map[string]string
+		want  string
 	}{
 		{
 			name: "package.json",

--- a/internal/summary/render_test.go
+++ b/internal/summary/render_test.go
@@ -9,9 +9,10 @@ import (
 	"testing"
 	"time"
 
+	_ "modernc.org/sqlite"
+
 	"github.com/luuuc/sense/internal/model"
 	"github.com/luuuc/sense/internal/sqlite"
-	_ "modernc.org/sqlite"
 )
 
 func seedTestDB(t *testing.T) (*sql.DB, func()) {

--- a/internal/summary/summary.go
+++ b/internal/summary/summary.go
@@ -241,7 +241,7 @@ func scanTOMLValue(path, section, key string) string {
 			if strings.HasPrefix(trimmed, prefix) {
 				val := strings.TrimSpace(strings.TrimPrefix(trimmed, prefix))
 				val = strings.Trim(val, `"`)
-				val = strings.Trim(val, `'`)  
+				val = strings.Trim(val, `'`)
 				if len(val) > maxDescBytes {
 					val = truncateUTF8(val, maxDescBytes-3) + "..."
 				}

--- a/internal/versioncheck/coverage_test.go
+++ b/internal/versioncheck/coverage_test.go
@@ -162,4 +162,3 @@ func TestUpdateDevBuild(t *testing.T) {
 		t.Errorf("stderr = %q, expected development build message", stderr.String())
 	}
 }
-

--- a/internal/versioncheck/semver_test.go
+++ b/internal/versioncheck/semver_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 )
 
-
 func TestUpdateAlreadyLatest_NonDev(t *testing.T) {
 	// The Update function checks version.Version == "0.0.0-dev" first,
 	// which always returns 1 in test builds. TestUpdateDevBuild in

--- a/internal/versioncheck/update_test.go
+++ b/internal/versioncheck/update_test.go
@@ -277,7 +277,7 @@ func TestUpdateNewerAvailable(t *testing.T) {
 	var installCalled bool
 	var installVersion string
 	origRunInstall := runInstallScriptFn
-		runInstallScriptFn = func(ver string, _, _ io.Writer) error {
+	runInstallScriptFn = func(ver string, _, _ io.Writer) error {
 		installCalled = true
 		installVersion = ver
 		return nil


### PR DESCRIPTION
## Problem

`gofmt` fails on 61 source files with no CI gate to catch it, complexity is
ungated (functions reach cyclomatic 78), and coverage is measured but never
enforced. Worse, `make ci` and the remote workflow disagreed on what "tests
pass" means (`go test -v ./...` locally vs `-race -coverpkg=./...` remotely),
so a green local run did not guarantee a green build. Nothing stopped the next
change from regressing any of these.

## Summary

Installs five mechanical quality gates (format, complexity with an inline debt
ledger, side-effect isolation via depguard + hermetic tests, and a coverage
floor) and unifies `make ci` with the remote workflow so a green local run
guarantees a green build. Configuration, formatting, and CI only: no behavior
change, all tests and golden fixtures pass byte-identical before and after.

## Changes

- **Format gate** — add a golangci-lint v2 `formatters:` block (`gofmt` +
  `goimports -local github.com/luuuc/sense`), pin the linter binary to
  `v2.12.2`, add a `make fmt` target. A one-time reformat of 62 files lands in
  its own isolated commit so `git blame` stays honest.
- **Complexity gate** — enable `gocyclo` (over 15) and `gocognit` (over 30) on
  the actively-cleaned packages (no `funlen`; line count is noise). Existing
  violators carry an inline `//nolint` directive naming the follow-up work that
  retires them, and `make ledger` fails CI if that suppression count grows.
- **Side-effect gates** — `depguard` forbids the verified pure-core packages
  (`extract`, `blast`, `conventions`, `mcpio`, `model`) from importing
  `os/exec`/`net`/`syscall`/`fsnotify`; `make test-hermetic` runs that set
  offline (no network, ONNX, or external binary).
- **Coverage + CI unification** — `make cover` runs the race suite and fails
  below a total-% floor; `make ci` is now `build cover lint`, and the workflow
  invokes the `make` targets instead of duplicating the test/lint commands.
  `.codecov.yml` drops to informational only, so a flaky upload never reds the
  build.
- **Docs** — `CONTRIBUTING.md` documents all five gates and the inline ledger.

## Architecture Highlights

- The complexity gate is scoped to the packages under active cleanup,
  symmetric with the coverage scope, so the inline ledger only ever holds
  entries that will be retired (its exit condition is the count reaching zero).
- The hard coverage failure is a deterministic local `go tool cover` check, not
  a flaky Codecov status.
- The golangci-lint version is single-sourced in the Makefile; CI runs
  `make lint`, so local and remote cannot drift.

## Notes for contributors

CI now fails on unformatted code, a new over-complexity function, a coverage
regression below the floor, or a pure-core package reaching for a side effect.
Run `make ci` and `make fmt` locally before pushing.

## Test Plan

- [x] Each gate verified to bite on a throwaway violation, then reverted
      (unformatted file, complexity-16 function, stray `//nolint`, `os/exec`
      in a pure-core package, a synthetic coverage drop, a grown ledger).
- [x] `make ci` green (build + coverage floor + lint, 0 issues).
- [x] Full `go test ./...` passes; golden extractor fixtures byte-identical.
- [x] `sense` binary builds cleanly.
- [x] First remote run confirms the Linux coverage number clears the floor and
      the hermetic network-namespace step engages (macOS has no `unshare`).
