### PR TITLE
refactor(scan): seam the embedder and add a scan test foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,10 @@ jobs:
         # Single definition of "tests pass": the same `make cover` a contributor
         # runs locally (go test -race -coverpkg=./... + a total-% floor). Remote
         # CI can no longer disagree with `make ci` about what green means.
+        # `make cover` sets the onnx_integration tag, so this step also runs the
+        # ONNX integration test against the deps fetched above — exercising the
+        # CGO embedding shell for real, and failing loud (never skipping) if the
+        # bundled model or runtime is missing.
         run: make cover
 
       - name: Hermetic unit tests (offline)

--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,17 @@ test-hermetic:
 # per-file 95% floor (scoped to covered packages) lands in 27-13. The hard
 # fail is this local `go tool cover` check, NOT a Codecov status, so a flaky
 # upload never reds the build.
+#
+# The onnx_integration tag is set here (and ONLY here) so the gate exercises the
+# CGO embedding shell (internal/embed/onnx.go) for real — the one place the
+# bundled model and ORT runtime run inference. It depends on fetch-deps so the
+# integration test always has its deps and fails loud (never skips) if they are
+# somehow absent. The plain `go test ./...` / `make test` / `make test-hermetic`
+# paths carry NO tag, so unit tests stay ONNX-free; the tag lives only in the
+# coverage gate, which already requires the deps `make build` fetches.
 COVER_FLOOR ?= 91
-cover:
-	go test -race -count=1 -coverprofile=coverage.txt -coverpkg=./... ./...
+cover: fetch-deps
+	go test -race -count=1 -tags onnx_integration -coverprofile=coverage.txt -coverpkg=./... ./...
 	@# Parse depends on `go tool cover`'s total line being last and %-suffixed.
 	@# If that format ever changes, t becomes 0 and the gate fails closed (safe).
 	@total=$$(go tool cover -func=coverage.txt | awk 'END {gsub(/%/,"",$$NF); print $$NF}'); \

--- a/internal/embed/bundle.go
+++ b/internal/embed/bundle.go
@@ -35,18 +35,30 @@ func NewBundledEmbedder(intraOpThreads int) (*ONNXEmbedder, error) {
 	return NewONNXEmbedder(modelBytes, vocabBytes, intraOpThreads)
 }
 
-// ensureORTLib extracts the bundled ONNX Runtime shared library to a
-// cache directory if it doesn't already exist (or if the binary version
-// changed). Returns the path to the extracted library. Uses atomic
-// writes (temp file + rename) to prevent partial extraction.
+// ensureORTLib extracts the bundled ONNX Runtime shared library to the
+// per-user cache directory, keyed by the binary version. It is thin wiring
+// over extractLib: resolve the cache dir, then extract. The bug-prone logic
+// (atomic write, version invalidation) lives in extractLib, which takes its
+// bytes and directory as parameters so it can be tested without the bundled
+// library or the real cache location.
 func ensureORTLib() (string, error) {
-	libData := loadBundledORTLib()
-
 	cacheDir, err := ortCacheDir()
 	if err != nil {
 		return "", err
 	}
+	return extractLib(loadBundledORTLib(), cacheDir, version.Version)
+}
 
+// extractLib writes libData to cacheDir as the platform's ONNX Runtime shared
+// library, returning its path. It skips the write when an extraction tagged
+// wantVersion is already present (the cache hit), and otherwise writes
+// atomically — temp file, chmod, rename — so a crash mid-write never leaves a
+// partial library a later run would load. The version is recorded in a sidecar
+// file so a binary upgrade re-extracts. Pure in the sense that matters for
+// testing: every input (bytes, directory, version) is a parameter, so the
+// atomic-write and stale-version paths are reachable with a temp dir and a few
+// bytes, no bundled library required.
+func extractLib(libData []byte, cacheDir, wantVersion string) (string, error) {
 	libName := "libonnxruntime.so"
 	if runtime.GOOS == "darwin" {
 		libName = "libonnxruntime.dylib"
@@ -55,7 +67,6 @@ func ensureORTLib() (string, error) {
 	libPath := filepath.Join(cacheDir, libName)
 	versionPath := libPath + ".version"
 
-	wantVersion := version.Version
 	if existing, err := os.ReadFile(versionPath); err == nil {
 		if string(existing) == wantVersion {
 			if _, err := os.Stat(libPath); err == nil {

--- a/internal/embed/bundle_test.go
+++ b/internal/embed/bundle_test.go
@@ -1,84 +1,252 @@
 package embed
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
-
-	"github.com/luuuc/sense/internal/version"
+	"time"
 )
 
-func TestNewBundledEmbedder(t *testing.T) {
-	if len(modelBytes) == 0 {
-		t.Skip("model not bundled; run scripts/fetch-deps.sh --local")
+// fakeLib is stand-in shared-library bytes. extractLib never interprets the
+// content, so a few bytes exercise the atomic-write and version-invalidation
+// logic without the bundled ONNX Runtime — the seam card 27-02 opened.
+var fakeLib = []byte{0x7f, 'E', 'L', 'F', 0x01, 0x02, 0x03}
+
+// libFileName mirrors extractLib's platform branch so tests can locate the
+// extracted library.
+func libFileName() string {
+	if runtime.GOOS == "darwin" {
+		return "libonnxruntime.dylib"
 	}
-	if len(vocabBytes) == 0 {
-		t.Skip("vocab not bundled; run scripts/fetch-deps.sh --local")
+	return "libonnxruntime.so"
+}
+
+func TestExtractLibWritesAndReturnsPath(t *testing.T) {
+	cacheDir := filepath.Join(t.TempDir(), "lib")
+
+	libPath, err := extractLib(fakeLib, cacheDir, "v1")
+	if err != nil {
+		t.Fatalf("extractLib: %v", err)
 	}
-	if len(ortLibData) == 0 {
-		t.Skip("ORT library not bundled; run scripts/fetch-deps.sh --local")
+	if want := filepath.Join(cacheDir, libFileName()); libPath != want {
+		t.Errorf("libPath = %q, want %q", libPath, want)
 	}
 
-	emb, err := NewBundledEmbedder(0)
+	got, err := os.ReadFile(libPath)
 	if err != nil {
-		t.Fatalf("NewBundledEmbedder: %v", err)
+		t.Fatalf("read extracted lib: %v", err)
 	}
-	defer func() { _ = emb.Close() }()
+	if string(got) != string(fakeLib) {
+		t.Errorf("extracted bytes = %v, want %v", got, fakeLib)
+	}
 
-	vecs, err := emb.Embed(context.Background(), []EmbedInput{
-		{QualifiedName: "Foo#bar", Kind: "method", Snippet: "def bar"},
-	})
+	version, err := os.ReadFile(libPath + ".version")
 	if err != nil {
-		t.Fatalf("embed: %v", err)
+		t.Fatalf("read version sidecar: %v", err)
 	}
-	if len(vecs) != 1 || len(vecs[0]) != Dimensions {
-		t.Fatalf("unexpected result: %d vectors, dims=%d", len(vecs), len(vecs[0]))
+	if string(version) != "v1" {
+		t.Errorf("version sidecar = %q, want %q", string(version), "v1")
 	}
 }
 
-func TestEnsureORTLibCacheInvalidation(t *testing.T) {
-	if len(ortLibData) == 0 {
-		t.Skip("ORT library not bundled; run scripts/fetch-deps.sh --local")
+func TestExtractLibCacheHit(t *testing.T) {
+	cacheDir := filepath.Join(t.TempDir(), "lib")
+
+	first, err := extractLib(fakeLib, cacheDir, "v1")
+	if err != nil {
+		t.Fatalf("first extractLib: %v", err)
+	}
+	// Mark the file so we can prove a cache hit did not rewrite it.
+	if err := os.Chtimes(first, time.Time{}, time.Unix(1, 0)); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	before, err := os.Stat(first)
+	if err != nil {
+		t.Fatal(err)
 	}
 
+	second, err := extractLib(fakeLib, cacheDir, "v1")
+	if err != nil {
+		t.Fatalf("second extractLib: %v", err)
+	}
+	if second != first {
+		t.Errorf("path changed: %q vs %q", first, second)
+	}
+	after, err := os.Stat(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !after.ModTime().Equal(before.ModTime()) {
+		t.Error("cache hit rewrote the library (mod time changed)")
+	}
+}
+
+func TestExtractLibStaleVersionReextracts(t *testing.T) {
+	cacheDir := filepath.Join(t.TempDir(), "lib")
+
+	libPath, err := extractLib(fakeLib, cacheDir, "v1")
+	if err != nil {
+		t.Fatalf("first extractLib: %v", err)
+	}
+
+	// A binary upgrade: same dir, newer version → re-extract with new bytes.
+	newBytes := []byte("newer library payload")
+	libPath2, err := extractLib(newBytes, cacheDir, "v2")
+	if err != nil {
+		t.Fatalf("second extractLib: %v", err)
+	}
+	if libPath2 != libPath {
+		t.Errorf("path changed: %q vs %q", libPath, libPath2)
+	}
+
+	got, err := os.ReadFile(libPath2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(newBytes) {
+		t.Errorf("stale version not re-extracted: bytes = %q", string(got))
+	}
+	version, _ := os.ReadFile(libPath2 + ".version")
+	if string(version) != "v2" {
+		t.Errorf("version sidecar = %q, want v2", string(version))
+	}
+}
+
+func TestExtractLibMissingLibReextracts(t *testing.T) {
+	cacheDir := filepath.Join(t.TempDir(), "lib")
+
+	libPath, err := extractLib(fakeLib, cacheDir, "v1")
+	if err != nil {
+		t.Fatalf("first extractLib: %v", err)
+	}
+	// Remove the library but keep the matching version sidecar: the version
+	// check passes, the os.Stat fails, so it must re-extract.
+	if err := os.Remove(libPath); err != nil {
+		t.Fatalf("remove lib: %v", err)
+	}
+
+	libPath2, err := extractLib(fakeLib, cacheDir, "v1")
+	if err != nil {
+		t.Fatalf("re-extract: %v", err)
+	}
+	if libPath2 != libPath {
+		t.Errorf("path changed: %q vs %q", libPath, libPath2)
+	}
+	if _, err := os.Stat(libPath2); err != nil {
+		t.Fatalf("lib not recreated: %v", err)
+	}
+}
+
+func TestExtractLibMkdirFails(t *testing.T) {
+	// Point the cache dir's parent at a regular file so MkdirAll fails.
+	tmp := t.TempDir()
+	notADir := filepath.Join(tmp, "notadir")
+	if err := os.WriteFile(notADir, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := extractLib(fakeLib, filepath.Join(notADir, "lib"), "v1"); err == nil {
+		t.Fatal("expected error when cache dir parent is a file")
+	}
+}
+
+func TestExtractLibCreateTempFails(t *testing.T) {
+	// A read-only cache dir: the version check and MkdirAll pass (dir exists),
+	// but CreateTemp cannot write into it.
+	cacheDir := filepath.Join(t.TempDir(), "lib")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(cacheDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chmod(cacheDir, 0o755) }()
+
+	if _, err := extractLib(fakeLib, cacheDir, "v1"); err == nil {
+		t.Fatal("expected error when cache dir is read-only")
+	}
+}
+
+func TestExtractLibRenameFails(t *testing.T) {
+	// Force the rename to fail with a real OS condition: a directory already
+	// sits at the target library path, so rename(tmp → libPath) cannot replace
+	// it. No fault-injecting filesystem — just a directory where a file goes.
+	cacheDir := filepath.Join(t.TempDir(), "lib")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	libPath := filepath.Join(cacheDir, libFileName())
+	if err := os.Mkdir(libPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := extractLib(fakeLib, cacheDir, "v1"); err == nil {
+		t.Fatal("expected error when target path is a directory")
+	}
+}
+
+func TestExtractLibWriteVersionFails(t *testing.T) {
+	cacheDir := filepath.Join(t.TempDir(), "lib")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Pre-create the version sidecar as a directory so WriteFile fails after a
+	// successful library rename, exercising the final error branch.
+	if err := os.Mkdir(filepath.Join(cacheDir, libFileName()+".version"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := extractLib(fakeLib, cacheDir, "v1"); err == nil {
+		t.Fatal("expected error when version sidecar cannot be written")
+	}
+}
+
+func TestEnsureORTLibWiring(t *testing.T) {
+	// ensureORTLib is thin wiring over extractLib; here we exercise the wiring
+	// (cache-dir resolution + extraction) using whatever bytes are bundled. The
+	// bytes' validity does not matter — only that the path resolves and the file
+	// lands under the resolved cache dir.
 	tmp := t.TempDir()
 	t.Setenv("SENSE_CACHE_DIR", tmp)
 
-	libName := "libonnxruntime.so"
-	if runtime.GOOS == "darwin" {
-		libName = "libonnxruntime.dylib"
-	}
-
-	// First extraction
 	libPath, err := ensureORTLib()
 	if err != nil {
-		t.Fatalf("first ensureORTLib: %v", err)
+		t.Fatalf("ensureORTLib: %v", err)
 	}
+	if want := filepath.Join(tmp, "lib", libFileName()); libPath != want {
+		t.Errorf("libPath = %q, want %q", libPath, want)
+	}
+	if _, err := os.Stat(libPath); err != nil {
+		t.Errorf("extracted lib missing: %v", err)
+	}
+}
 
-	// Write a stale version marker to simulate a version bump
-	versionPath := filepath.Join(tmp, "lib", libName+".version")
-	if err := os.WriteFile(versionPath, []byte("old-version"), 0o644); err != nil {
-		t.Fatalf("write stale version: %v", err)
-	}
+func TestEnsureORTLibCacheDirError(t *testing.T) {
+	// SENSE_CACHE_DIR empty and HOME unavailable → ortCacheDir fails, and
+	// ensureORTLib must surface that before touching the filesystem.
+	t.Setenv("SENSE_CACHE_DIR", "")
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
 
-	// Second extraction should overwrite due to version mismatch
-	libPath2, err := ensureORTLib()
-	if err != nil {
-		t.Fatalf("second ensureORTLib: %v", err)
+	if _, err := ensureORTLib(); err == nil {
+		t.Fatal("expected error when the cache dir cannot be resolved")
 	}
-	if libPath2 != libPath {
-		t.Fatalf("path changed: %s vs %s", libPath, libPath2)
-	}
+}
 
-	// Version file should now contain the current version
-	got, err := os.ReadFile(versionPath)
-	if err != nil {
-		t.Fatalf("read version file: %v", err)
+func TestNewBundledEmbedderExtractError(t *testing.T) {
+	// Point the cache dir at a regular file so extraction fails inside
+	// ensureORTLib; NewBundledEmbedder must wrap and surface it rather than
+	// proceeding to ONNX init. Hermetic: no real library is touched.
+	tmp := t.TempDir()
+	filePath := filepath.Join(tmp, "notadir")
+	if err := os.WriteFile(filePath, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
 	}
-	if string(got) != version.Version {
-		t.Errorf("version file = %q, want %q", string(got), version.Version)
+	t.Setenv("SENSE_CACHE_DIR", filePath)
+
+	if _, err := NewBundledEmbedder(0); err == nil {
+		t.Fatal("expected error when ORT library extraction fails")
 	}
 }
 
@@ -104,7 +272,6 @@ func TestORTCacheDirDefault(t *testing.T) {
 		t.Fatalf("ortCacheDir: %v", err)
 	}
 
-	// Should be under home dir
 	home, err := os.UserHomeDir()
 	if err != nil {
 		t.Skip("cannot get home dir")
@@ -116,210 +283,11 @@ func TestORTCacheDirDefault(t *testing.T) {
 }
 
 func TestORTCacheDirHomeDirFails(t *testing.T) {
-	// Force os.UserHomeDir to fail by unsetting both HOME and USERPROFILE.
-	// SENSE_CACHE_DIR must also be empty so we hit the fallback path.
 	t.Setenv("SENSE_CACHE_DIR", "")
 	t.Setenv("HOME", "")
 	t.Setenv("USERPROFILE", "")
 
 	if _, err := ortCacheDir(); err == nil {
 		t.Fatal("ortCacheDir: expected error when HOME unavailable")
-	}
-}
-
-func TestEnsureORTLibMkdirFails(t *testing.T) {
-	if len(ortLibData) == 0 {
-		t.Skip("ORT library not bundled; run scripts/fetch-deps.sh --local")
-	}
-
-	// Create a file and point SENSE_CACHE_DIR at it so MkdirAll fails
-	tmp := t.TempDir()
-	filePath := filepath.Join(tmp, "notadir")
-	if err := os.WriteFile(filePath, []byte("x"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("SENSE_CACHE_DIR", filePath)
-
-	_, err := ensureORTLib()
-	if err == nil {
-		t.Fatal("expected error when cache dir parent is a file")
-	}
-}
-
-func TestEnsureORTLibCreateTempFails(t *testing.T) {
-	if len(ortLibData) == 0 {
-		t.Skip("ORT library not bundled; run scripts/fetch-deps.sh --local")
-	}
-
-	// Create a read-only directory so CreateTemp fails
-	tmp := t.TempDir()
-	cacheDir := filepath.Join(tmp, "lib")
-	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Chmod(cacheDir, 0o000); err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = os.Chmod(cacheDir, 0o755) }()
-
-	t.Setenv("SENSE_CACHE_DIR", tmp)
-
-	_, err := ensureORTLib()
-	if err == nil {
-		t.Fatal("expected error when cache dir is read-only")
-	}
-}
-
-func TestEnsureORTLibRenameFails(t *testing.T) {
-	if len(ortLibData) == 0 {
-		t.Skip("ORT library not bundled; run scripts/fetch-deps.sh --local")
-	}
-
-	tmp := t.TempDir()
-	t.Setenv("SENSE_CACHE_DIR", tmp)
-
-	libName := "libonnxruntime.so"
-	if runtime.GOOS == "darwin" {
-		libName = "libonnxruntime.dylib"
-	}
-
-	// First, extract successfully
-	_, err := ensureORTLib()
-	if err != nil {
-		t.Fatalf("first ensureORTLib: %v", err)
-	}
-
-	// Now make the version stale to force re-extraction
-	versionPath := filepath.Join(tmp, "lib", libName+".version")
-	if err := os.WriteFile(versionPath, []byte("old-version"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	// Create a directory at the target lib path so rename fails
-	libPath := filepath.Join(tmp, "lib", libName)
-	if err := os.Remove(libPath); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Mkdir(libPath, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	_, err = ensureORTLib()
-	if err == nil {
-		t.Fatal("expected error when target path is a directory")
-	}
-
-	// Clean up so subsequent tests aren't affected
-	_ = os.RemoveAll(libPath)
-}
-
-func TestNewBundledEmbedderEnsureORTLibError(t *testing.T) {
-	// Point cache dir at a file so ensureORTLib fails
-	tmp := t.TempDir()
-	filePath := filepath.Join(tmp, "notadir")
-	if err := os.WriteFile(filePath, []byte("x"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("SENSE_CACHE_DIR", filePath)
-
-	_, err := NewBundledEmbedder(0)
-	if err == nil {
-		t.Fatal("expected error when ensureORTLib fails")
-	}
-}
-
-func TestEnsureORTLibCacheHit(t *testing.T) {
-	if len(ortLibData) == 0 {
-		t.Skip("ORT library not bundled; run scripts/fetch-deps.sh --local")
-	}
-
-	tmp := t.TempDir()
-	t.Setenv("SENSE_CACHE_DIR", tmp)
-
-	// First extraction
-	libPath1, err := ensureORTLib()
-	if err != nil {
-		t.Fatalf("first ensureORTLib: %v", err)
-	}
-
-	// Second call with matching version should return cached path immediately
-	libPath2, err := ensureORTLib()
-	if err != nil {
-		t.Fatalf("second ensureORTLib: %v", err)
-	}
-	if libPath2 != libPath1 {
-		t.Fatalf("path changed: %s vs %s", libPath1, libPath2)
-	}
-}
-
-func TestEnsureORTLibMissingLib(t *testing.T) {
-	if len(ortLibData) == 0 {
-		t.Skip("ORT library not bundled; run scripts/fetch-deps.sh --local")
-	}
-
-	tmp := t.TempDir()
-	t.Setenv("SENSE_CACHE_DIR", tmp)
-
-	// First extraction
-	libPath, err := ensureORTLib()
-	if err != nil {
-		t.Fatalf("first ensureORTLib: %v", err)
-	}
-
-	// Remove the library but keep the correct version file
-	if err := os.Remove(libPath); err != nil {
-		t.Fatalf("remove lib: %v", err)
-	}
-
-	// Should re-extract because lib is missing
-	libPath2, err := ensureORTLib()
-	if err != nil {
-		t.Fatalf("second ensureORTLib: %v", err)
-	}
-	if libPath2 != libPath {
-		t.Fatalf("path changed: %s vs %s", libPath, libPath2)
-	}
-
-	// Verify the lib was recreated
-	if _, err := os.Stat(libPath); err != nil {
-		t.Fatalf("lib not recreated: %v", err)
-	}
-}
-
-func TestEnsureORTLibWriteVersionFails(t *testing.T) {
-	if len(ortLibData) == 0 {
-		t.Skip("ORT library not bundled; run scripts/fetch-deps.sh --local")
-	}
-
-	tmp := t.TempDir()
-	t.Setenv("SENSE_CACHE_DIR", tmp)
-
-	libName := "libonnxruntime.so"
-	if runtime.GOOS == "darwin" {
-		libName = "libonnxruntime.dylib"
-	}
-
-	// First extraction to create the cache dir
-	_, err := ensureORTLib()
-	if err != nil {
-		t.Fatalf("first ensureORTLib: %v", err)
-	}
-
-	// Make the version stale to force re-extraction
-	versionPath := filepath.Join(tmp, "lib", libName+".version")
-	if err := os.WriteFile(versionPath, []byte("old-version"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	// Make cache dir read-only so WriteFile(versionPath) fails
-	cacheDir := filepath.Join(tmp, "lib")
-	if err := os.Chmod(cacheDir, 0o555); err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = os.Chmod(cacheDir, 0o755) }()
-
-	_, err = ensureORTLib()
-	if err == nil {
-		t.Fatal("expected error when version file write fails")
 	}
 }

--- a/internal/embed/embed_test.go
+++ b/internal/embed/embed_test.go
@@ -400,6 +400,16 @@ func TestFormatContext(t *testing.T) {
 			in:   EmbedInput{QualifiedName: "Foo#bar", Kind: "method", Snippet: "def bar(x)"},
 			want: "method Foo#bar\ndef bar(x)",
 		},
+		{
+			name: "fallback kind+name+filepath (directory signal)",
+			in:   EmbedInput{QualifiedName: "Config", Kind: "class", FilePath: "app/config.rb"},
+			want: "File: app/config.rb\nclass Config",
+		},
+		{
+			name: "fallback kind+name+filepath+snippet",
+			in:   EmbedInput{QualifiedName: "Foo#bar", Kind: "method", FilePath: "lib/foo.rb", Snippet: "def bar"},
+			want: "File: lib/foo.rb\nmethod Foo#bar\ndef bar",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/embed/embedtest/embedtest.go
+++ b/internal/embed/embedtest/embedtest.go
@@ -1,0 +1,75 @@
+// Package embedtest provides a deterministic fake embedder for tests that
+// need to exercise the embedding pipeline without spinning up ONNX. It lives
+// next to the embed.Embedder interface (not folded into a scan helper) so any
+// embedder consumer — scan, search, the MCP server — can reuse the same fake
+// and keep ONNX out of its test imports.
+package embedtest
+
+import (
+	"context"
+	"math"
+
+	"github.com/luuuc/sense/internal/embed"
+)
+
+// FakeEmbedder is a deterministic embed.Embedder. It produces one fixed-length
+// vector per input, derived from the formatted input text, so equal inputs map
+// to equal vectors and distinct inputs almost always differ. The vectors are
+// L2-normalized like the real model's so cosine-similarity consumers behave,
+// but the numbers carry no semantic meaning — they exist only to drive the
+// fan-out, persistence, and presence paths. Not safe for concurrent use by a
+// single instance; the embed pool gives each worker its own.
+type FakeEmbedder struct {
+	dims int
+}
+
+// NewFakeEmbedder returns a FakeEmbedder producing vectors of dims components.
+// Use embed.Dimensions to match the bundled model's width.
+func NewFakeEmbedder(dims int) *FakeEmbedder {
+	return &FakeEmbedder{dims: dims}
+}
+
+// Embed returns one deterministic vector per input. Never errors.
+func (f *FakeEmbedder) Embed(_ context.Context, inputs []embed.EmbedInput) ([][]float32, error) {
+	out := make([][]float32, len(inputs))
+	for i, in := range inputs {
+		out[i] = f.vector(embed.FormatContext(in))
+	}
+	return out, nil
+}
+
+// Close is a no-op; the fake holds no resources.
+func (f *FakeEmbedder) Close() error { return nil }
+
+// vector hashes text into a normalized vector. A small FNV-1a walk seeds each
+// component, so the mapping is stable across runs and platforms (no maps, no
+// randomness) — the property the behavior oracle relies on.
+func (f *FakeEmbedder) vector(text string) []float32 {
+	const (
+		offset = 2166136261
+		prime  = 16777619
+	)
+	vec := make([]float32, f.dims)
+	h := uint32(offset)
+	for _, b := range []byte(text) {
+		h ^= uint32(b)
+		h *= prime
+	}
+	var sumSq float64
+	for k := range vec {
+		h ^= uint32(k)
+		h *= prime
+		// Map the unsigned hash into [-1, 1) deterministically: h/2^31 lands
+		// in [0, 2), shifted down by 1. No signed conversion, so no overflow.
+		v := float32(h)/float32(1<<31) - 1.0
+		vec[k] = v
+		sumSq += float64(v) * float64(v)
+	}
+	if sumSq > 0 {
+		norm := float32(math.Sqrt(sumSq))
+		for k := range vec {
+			vec[k] /= norm
+		}
+	}
+	return vec
+}

--- a/internal/embed/embedtest/embedtest_test.go
+++ b/internal/embed/embedtest/embedtest_test.go
@@ -1,0 +1,90 @@
+package embedtest_test
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/luuuc/sense/internal/embed"
+	"github.com/luuuc/sense/internal/embed/embedtest"
+)
+
+func TestFakeEmbedderShapeAndDeterminism(t *testing.T) {
+	f := embedtest.NewFakeEmbedder(embed.Dimensions)
+	inputs := []embed.EmbedInput{
+		{QualifiedName: "Auth#login", Kind: "method", Snippet: "def login"},
+		{QualifiedName: "Auth#logout", Kind: "method", Snippet: "def logout"},
+	}
+
+	got, err := f.Embed(context.Background(), inputs)
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(got) != len(inputs) {
+		t.Fatalf("len(got) = %d, want %d", len(got), len(inputs))
+	}
+	for i, vec := range got {
+		if len(vec) != embed.Dimensions {
+			t.Errorf("vec[%d] dims = %d, want %d", i, len(vec), embed.Dimensions)
+		}
+	}
+
+	// Same inputs → byte-identical vectors (the oracle depends on this).
+	again, _ := f.Embed(context.Background(), inputs)
+	for i := range got {
+		for j := range got[i] {
+			if got[i][j] != again[i][j] {
+				t.Fatalf("non-deterministic at [%d][%d]: %v vs %v", i, j, got[i][j], again[i][j])
+			}
+		}
+	}
+}
+
+func TestFakeEmbedderDistinctInputsDiffer(t *testing.T) {
+	f := embedtest.NewFakeEmbedder(embed.Dimensions)
+	got, _ := f.Embed(context.Background(), []embed.EmbedInput{
+		{Snippet: "alpha"},
+		{Snippet: "beta"},
+	})
+	if vecEqual(got[0], got[1]) {
+		t.Error("distinct inputs produced identical vectors")
+	}
+}
+
+func TestFakeEmbedderNormalized(t *testing.T) {
+	f := embedtest.NewFakeEmbedder(embed.Dimensions)
+	got, _ := f.Embed(context.Background(), []embed.EmbedInput{{Snippet: "normalize me"}})
+	var sumSq float64
+	for _, v := range got[0] {
+		sumSq += float64(v) * float64(v)
+	}
+	if math.Abs(math.Sqrt(sumSq)-1.0) > 1e-5 {
+		t.Errorf("vector not unit length: |v| = %v", math.Sqrt(sumSq))
+	}
+}
+
+func TestFakeEmbedderEmptyAndZeroDims(t *testing.T) {
+	f := embedtest.NewFakeEmbedder(0)
+	got, err := f.Embed(context.Background(), []embed.EmbedInput{{Snippet: "x"}})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(got) != 1 || len(got[0]) != 0 {
+		t.Errorf("zero-dim embedder: got %d vectors of len %d, want 1 of len 0", len(got), len(got[0]))
+	}
+	if err := f.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+}
+
+func vecEqual(a, b []float32) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/embed/onnx_integration_test.go
+++ b/internal/embed/onnx_integration_test.go
@@ -1,0 +1,127 @@
+//go:build onnx_integration
+
+// This file is the ONNX integration test. It is excluded from the default
+// `go test` path by the onnx_integration build tag, so unit tests stay
+// ONNX-free; CI runs it explicitly (make cover passes the tag, with deps
+// fetched first). Unlike a skipped test, it FAILS LOUD when the bundled model
+// or runtime is missing — a skipped integration test reads green while
+// asserting nothing, which is the failure mode this test exists to prevent.
+package embed
+
+import (
+	"context"
+	"math"
+	"testing"
+)
+
+// requireDeps fails loudly (never t.Skip) when the bundled model, vocabulary,
+// or ONNX Runtime library is absent. Under the onnx_integration tag the deps
+// are a precondition, not an option: a missing dep is a broken CI setup, not a
+// reason to silently pass.
+func requireDeps(t *testing.T) {
+	t.Helper()
+	if len(modelBytes) == 0 {
+		t.Fatal("model not bundled; run scripts/fetch-deps.sh --local before the onnx_integration run")
+	}
+	if len(vocabBytes) == 0 {
+		t.Fatal("vocab not bundled; run scripts/fetch-deps.sh --local before the onnx_integration run")
+	}
+	if len(loadBundledORTLib()) == 0 {
+		t.Fatal("ONNX Runtime library not bundled; run scripts/fetch-deps.sh --local before the onnx_integration run")
+	}
+}
+
+// TestIntegrationBundledEmbedRoundTrip drives one real embedding end to end:
+// extract the bundled runtime, init the ONNX environment, build a session, and
+// embed real inputs. It exercises the CGO shell (NewBundledEmbedder →
+// InitORTLibrary → NewONNXEmbedder → Embed → embedBatch → session.Run → Close)
+// that no fake can reach, and asserts the model's contract: 384-dimensional,
+// L2-normalized vectors.
+func TestIntegrationBundledEmbedRoundTrip(t *testing.T) {
+	requireDeps(t)
+
+	emb, err := NewBundledEmbedder(0)
+	if err != nil {
+		t.Fatalf("NewBundledEmbedder: %v", err)
+	}
+	defer func() { _ = emb.Close() }()
+
+	inputs := []EmbedInput{
+		{QualifiedName: "Auth#login", Kind: "method", Snippet: "def login(email, password)"},
+		{QualifiedName: "Auth#logout", Kind: "method", Snippet: "def logout(token)"},
+	}
+	vecs, err := emb.Embed(context.Background(), inputs)
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(vecs) != len(inputs) {
+		t.Fatalf("got %d vectors, want %d", len(vecs), len(inputs))
+	}
+	for i, v := range vecs {
+		if len(v) != Dimensions {
+			t.Errorf("vec[%d] dims = %d, want %d", i, len(v), Dimensions)
+		}
+		var sumSq float64
+		for _, x := range v {
+			sumSq += float64(x) * float64(x)
+		}
+		if math.Abs(math.Sqrt(sumSq)-1.0) > 1e-3 {
+			t.Errorf("vec[%d] not L2-normalized: |v| = %v", i, math.Sqrt(sumSq))
+		}
+	}
+}
+
+// TestIntegrationThreadCountDeterminism covers the intraOpThreads > 0 session
+// option (an all-cores default leaves it unset) and proves the thread count is
+// a performance knob, not a correctness one: the same inputs embed to the same
+// vectors whether the session runs single- or multi-threaded.
+func TestIntegrationThreadCountDeterminism(t *testing.T) {
+	requireDeps(t)
+
+	inputs := []EmbedInput{{QualifiedName: "Svc#run", Kind: "method", Snippet: "def run"}}
+
+	allCores, err := NewBundledEmbedder(0)
+	if err != nil {
+		t.Fatalf("NewBundledEmbedder(0): %v", err)
+	}
+	defer func() { _ = allCores.Close() }()
+	a, err := allCores.Embed(context.Background(), inputs)
+	if err != nil {
+		t.Fatalf("embed (all cores): %v", err)
+	}
+
+	twoThreads, err := NewBundledEmbedder(2)
+	if err != nil {
+		t.Fatalf("NewBundledEmbedder(2): %v", err)
+	}
+	defer func() { _ = twoThreads.Close() }()
+	b, err := twoThreads.Embed(context.Background(), inputs)
+	if err != nil {
+		t.Fatalf("embed (2 threads): %v", err)
+	}
+
+	for i := range a[0] {
+		if a[0][i] != b[0][i] {
+			t.Fatalf("thread count changed the vector at [%d]: %v vs %v", i, a[0][i], b[0][i])
+		}
+	}
+}
+
+// TestIntegrationEmbedRespectsCancel covers the context-cancellation branch in
+// Embed against the real session — a unit fake cannot, because the branch sits
+// before any embedder-specific work.
+func TestIntegrationEmbedRespectsCancel(t *testing.T) {
+	requireDeps(t)
+
+	emb, err := NewBundledEmbedder(0)
+	if err != nil {
+		t.Fatalf("NewBundledEmbedder: %v", err)
+	}
+	defer func() { _ = emb.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := emb.Embed(ctx, []EmbedInput{{Snippet: "x"}}); err == nil {
+		t.Fatal("expected Embed to honor a cancelled context")
+	}
+}

--- a/internal/embed/onnx_internal_test.go
+++ b/internal/embed/onnx_internal_test.go
@@ -1,0 +1,13 @@
+package embed
+
+import "testing"
+
+// TestONNXEmbedderCloseNilSession covers Close's guard for an embedder whose
+// session was never created (the zero value). It needs no ONNX runtime — the
+// session.Destroy path is exercised by the onnx_integration round-trip.
+func TestONNXEmbedderCloseNilSession(t *testing.T) {
+	var e ONNXEmbedder // session is nil
+	if err := e.Close(); err != nil {
+		t.Errorf("Close on nil session = %v, want nil", err)
+	}
+}

--- a/internal/embed/tokenizer_internal_test.go
+++ b/internal/embed/tokenizer_internal_test.go
@@ -1,0 +1,28 @@
+package embed
+
+import "testing"
+
+// TestLookupID covers both branches of lookupID — a known token returns its id,
+// an unknown token falls back to 0 — using an inline vocabulary so the test
+// needs no downloaded model files.
+func TestLookupID(t *testing.T) {
+	vocab := []byte("[PAD]\n[UNK]\n[CLS]\n[SEP]\nhello\nworld\n")
+	tok := newTokenizer(vocab, 16)
+
+	// newTokenizer resolves the special tokens through lookupID; confirm the
+	// hit path landed them on the right ids.
+	if tok.clsID != 2 {
+		t.Errorf("clsID = %d, want 2", tok.clsID)
+	}
+	if tok.sepID != 3 {
+		t.Errorf("sepID = %d, want 3", tok.sepID)
+	}
+
+	if got := tok.lookupID("hello"); got != 4 {
+		t.Errorf("lookupID(hello) = %d, want 4", got)
+	}
+	// Miss branch: a token absent from the vocab falls back to 0.
+	if got := tok.lookupID("absent-token"); got != 0 {
+		t.Errorf("lookupID(absent) = %d, want 0", got)
+	}
+}

--- a/internal/scan/embed.go
+++ b/internal/scan/embed.go
@@ -30,24 +30,47 @@ type embedPool struct {
 	workers   int
 }
 
-func newEmbedPool() (*embedPool, error) {
-	ncpu := runtime.NumCPU()
-	workers := ncpu / 2
+// embedderFactory constructs one embedder configured for threads intra-op
+// threads. It is the seam that keeps ONNX out of the scan pipeline's tests:
+// production wires defaultEmbedderFactory (the bundled ONNX model); a test
+// substitutes a fake via SetEmbedderFactory (see export_test.go).
+type embedderFactory func(threads int) (embed.Embedder, error)
+
+// defaultEmbedderFactory is the production embedder: the ONNX model bundled in
+// the binary. It is a package var, not a hard call, so the export_test.go seam
+// can swap it for a fake without widening any exported surface. Mutated only by
+// SetEmbedderFactory (with t.Cleanup restore); not safe to override under
+// t.Parallel — the scan embedding tests run serially, which is why it can be a
+// plain global rather than threaded through Options.
+var defaultEmbedderFactory embedderFactory = func(threads int) (embed.Embedder, error) {
+	return embed.NewBundledEmbedder(threads)
+}
+
+// embedPoolSizing decides the worker count and per-worker intra-op thread
+// count from the available CPUs: half the cores, clamped to [2, maxEmbedWorkers],
+// then threads split evenly across workers (at least one). Pure so the clamps
+// can be exercised across CPU counts without depending on the test host.
+func embedPoolSizing(ncpu int) (workers, threadsPerWorker int) {
+	workers = ncpu / 2
 	if workers < 2 {
 		workers = 2
 	}
 	if workers > maxEmbedWorkers {
 		workers = maxEmbedWorkers
 	}
-
-	threadsPerWorker := ncpu / workers
+	threadsPerWorker = ncpu / workers
 	if threadsPerWorker < 1 {
 		threadsPerWorker = 1
 	}
+	return workers, threadsPerWorker
+}
+
+func newEmbedPool(newEmbedder embedderFactory) (*embedPool, error) {
+	workers, threadsPerWorker := embedPoolSizing(runtime.NumCPU())
 
 	embedders := make([]embed.Embedder, workers)
 	for i := range embedders {
-		emb, err := embed.NewBundledEmbedder(threadsPerWorker)
+		emb, err := newEmbedder(threadsPerWorker)
 		if err != nil {
 			for j := 0; j < i; j++ {
 				_ = embedders[j].Close()
@@ -165,7 +188,7 @@ func EmbedPending(ctx context.Context, idx *sqlite.Adapter, root string) (int, e
 		return 0, nil
 	}
 
-	h := &harness{ctx: ctx, idx: idx, root: root, out: io.Discard, warn: io.Discard}
+	h := &harness{ctx: ctx, idx: idx, root: root, out: io.Discard, warn: io.Discard, newEmbedder: defaultEmbedderFactory}
 	h.extendMethodSnippets(syms)
 	contextMap := h.buildContextMap(syms)
 
@@ -186,7 +209,7 @@ func EmbedPending(ctx context.Context, idx *sqlite.Adapter, root string) (int, e
 		}
 	}
 
-	pool, err := newEmbedPool()
+	pool, err := newEmbedPool(h.newEmbedder)
 	if err != nil {
 		return 0, fmt.Errorf("create embed pool: %w", err)
 	}
@@ -275,7 +298,7 @@ func (h *harness) embedSymbols() error {
 		}
 	}
 
-	pool, err := newEmbedPool()
+	pool, err := newEmbedPool(h.newEmbedder)
 	if err != nil {
 		return fmt.Errorf("create embed pool: %w", err)
 	}

--- a/internal/scan/embed_pool_internal_test.go
+++ b/internal/scan/embed_pool_internal_test.go
@@ -127,3 +127,92 @@ func (c *closingEmbedder) Embed(context.Context, []embed.EmbedInput) ([][]float3
 	return nil, nil
 }
 func (c *closingEmbedder) Close() error { return c.closeErr }
+
+// trackingEmbedder records whether Close was called, so the factory
+// error-cleanup path can be asserted.
+type trackingEmbedder struct {
+	closed bool
+}
+
+func (e *trackingEmbedder) Embed(context.Context, []embed.EmbedInput) ([][]float32, error) {
+	return nil, nil
+}
+func (e *trackingEmbedder) Close() error { e.closed = true; return nil }
+
+func TestEmbedPoolSizing(t *testing.T) {
+	cases := []struct {
+		ncpu        int
+		wantWorkers int
+		wantThreads int
+	}{
+		{ncpu: 1, wantWorkers: 2, wantThreads: 1},  // clamp up to 2; threads floor at 1
+		{ncpu: 2, wantWorkers: 2, wantThreads: 1},  // half = 1 → clamp to 2
+		{ncpu: 4, wantWorkers: 2, wantThreads: 2},  // half = 2, no clamp
+		{ncpu: 6, wantWorkers: 3, wantThreads: 2},  // half = 3
+		{ncpu: 8, wantWorkers: 4, wantThreads: 2},  // half = 4 = cap
+		{ncpu: 16, wantWorkers: 4, wantThreads: 4}, // half = 8 → clamp down to 4
+	}
+	for _, c := range cases {
+		workers, threads := embedPoolSizing(c.ncpu)
+		if workers != c.wantWorkers || threads != c.wantThreads {
+			t.Errorf("embedPoolSizing(%d) = (%d, %d), want (%d, %d)",
+				c.ncpu, workers, threads, c.wantWorkers, c.wantThreads)
+		}
+	}
+}
+
+func TestNewEmbedPoolBuildsWorkers(t *testing.T) {
+	var threads []int
+	pool, err := newEmbedPool(func(t int) (embed.Embedder, error) {
+		threads = append(threads, t)
+		return &trackingEmbedder{}, nil
+	})
+	if err != nil {
+		t.Fatalf("newEmbedPool: %v", err)
+	}
+	defer func() { _ = pool.Close() }()
+
+	if pool.workers < 2 || pool.workers > maxEmbedWorkers {
+		t.Errorf("workers = %d, want within [2,%d]", pool.workers, maxEmbedWorkers)
+	}
+	if len(pool.embedders) != pool.workers {
+		t.Errorf("embedders = %d, want %d", len(pool.embedders), pool.workers)
+	}
+	if len(threads) != pool.workers {
+		t.Errorf("factory called %d times, want %d", len(threads), pool.workers)
+	}
+	for _, n := range threads {
+		if n < 1 {
+			t.Errorf("threadsPerWorker = %d, want >= 1", n)
+		}
+	}
+}
+
+func TestNewEmbedPoolFactoryErrorClosesCreated(t *testing.T) {
+	want := errors.New("factory boom")
+	var created []*trackingEmbedder
+	calls := 0
+	pool, err := newEmbedPool(func(int) (embed.Embedder, error) {
+		calls++
+		if calls == 2 {
+			return nil, want
+		}
+		e := &trackingEmbedder{}
+		created = append(created, e)
+		return e, nil
+	})
+	if pool != nil {
+		t.Errorf("pool = %v, want nil on factory error", pool)
+	}
+	if !errors.Is(err, want) {
+		t.Errorf("err = %v, want %v", err, want)
+	}
+	// Workers is always >= 2, so the first embedder was built before the
+	// second call failed — it must have been closed during cleanup.
+	if len(created) != 1 {
+		t.Fatalf("created %d embedders before failure, want 1", len(created))
+	}
+	if !created[0].closed {
+		t.Error("embedder created before the failure was not closed")
+	}
+}

--- a/internal/scan/embed_test.go
+++ b/internal/scan/embed_test.go
@@ -4,40 +4,33 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
+	"github.com/luuuc/sense/internal/embed"
+	"github.com/luuuc/sense/internal/embed/embedtest"
 	"github.com/luuuc/sense/internal/index"
 	"github.com/luuuc/sense/internal/scan"
 	"github.com/luuuc/sense/internal/sqlite"
 )
 
-func skipWithoutORT(t *testing.T) {
+// useFakeEmbedder swaps the scan pipeline's embedder for a deterministic fake,
+// so the embedding paths run without ONNX. This is the seam card 27-02 added:
+// the production embedder stays the default, the test substitutes a fake via
+// the export_test.go setter, and scan.Run / scan.Options are untouched.
+func useFakeEmbedder(t *testing.T) {
 	t.Helper()
-	// Check model is bundled (via fetch-deps.sh)
-	_, thisFile, _, _ := runtime.Caller(0)
-	bundleDir := filepath.Join(filepath.Dir(thisFile), "..", "embed", "bundle")
-	if _, err := os.Stat(filepath.Join(bundleDir, "model.onnx")); err != nil {
-		t.Skip("model not bundled; run scripts/fetch-deps.sh --local")
-	}
-	libName := "libonnxruntime.dylib"
-	if runtime.GOOS == "linux" {
-		libName = "libonnxruntime.so"
-	}
-	arch := runtime.GOARCH
-	platformDir := filepath.Join(bundleDir, runtime.GOOS+"_"+arch)
-	if _, err := os.Stat(filepath.Join(platformDir, libName)); err != nil {
-		t.Skip("ORT library not bundled; run scripts/fetch-deps.sh --local")
-	}
+	scan.SetEmbedderFactory(t, func(int) (embed.Embedder, error) {
+		return embedtest.NewFakeEmbedder(embed.Dimensions), nil
+	})
 }
 
 func TestScanEmbeddings(t *testing.T) {
-	skipWithoutORT(t)
+	useFakeEmbedder(t)
 
 	root := t.TempDir()
 	writeFile(t, filepath.Join(root, "auth.go"), `package auth
@@ -86,7 +79,7 @@ func Logout(token string) {
 }
 
 func TestScanEmbeddingsIncremental(t *testing.T) {
-	skipWithoutORT(t)
+	useFakeEmbedder(t)
 
 	root := t.TempDir()
 	writeFile(t, filepath.Join(root, "auth.go"), `package auth
@@ -169,7 +162,7 @@ func Verify(token string) bool {
 }
 
 func TestEmbedPending(t *testing.T) {
-	skipWithoutORT(t)
+	useFakeEmbedder(t)
 
 	root := t.TempDir()
 	writeFile(t, filepath.Join(root, "auth.go"), `package auth
@@ -276,7 +269,7 @@ func Logout(token string) {
 }
 
 func TestEmbedPendingCancelSafe(t *testing.T) {
-	skipWithoutORT(t)
+	useFakeEmbedder(t)
 
 	root := t.TempDir()
 	// Create enough symbols to make embedding take non-trivial time.
@@ -329,7 +322,7 @@ func TestEmbedPendingCancelSafe(t *testing.T) {
 }
 
 func TestDeferredEmbedTransition(t *testing.T) {
-	skipWithoutORT(t)
+	useFakeEmbedder(t)
 
 	root := t.TempDir()
 	writeFile(t, filepath.Join(root, "svc.go"), `package svc
@@ -398,7 +391,7 @@ func Validate() bool { return true }
 }
 
 func TestScanEmbedBackfillsOnNoChange(t *testing.T) {
-	skipWithoutORT(t)
+	useFakeEmbedder(t)
 
 	root := t.TempDir()
 	writeFile(t, filepath.Join(root, "svc.go"), `package svc
@@ -476,6 +469,89 @@ func firstEmbeddingBlobSize(t *testing.T, dbPath string) int {
 		t.Fatalf("read embedding: %v", err)
 	}
 	return len(blob)
+}
+
+// deferredScan runs a structural scan (no embeddings) so a temp index has
+// symbols and embedding debt, then returns its db path. Shared by the
+// embed-error tests below.
+func deferredScan(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for rel, content := range files {
+		writeFile(t, filepath.Join(root, rel), content)
+	}
+	_, err := scan.Run(context.Background(), scan.Options{
+		Root:              root,
+		Output:            io.Discard,
+		Warnings:          io.Discard,
+		EmbeddingsEnabled: true,
+		Embed:             false,
+	})
+	if err != nil {
+		t.Fatalf("deferred scan: %v", err)
+	}
+	return filepath.Join(root, ".sense", "index.db")
+}
+
+// TestEmbedPendingPoolError covers the newEmbedPool failure branch in
+// EmbedPending: a factory that errors leaves the pending debt unembedded and
+// the error surfaces to the caller.
+func TestEmbedPendingPoolError(t *testing.T) {
+	dbPath := deferredScan(t, map[string]string{"a.go": "package a\n\nfunc F() {}\n"})
+	scan.SetEmbedderFactory(t, func(int) (embed.Embedder, error) {
+		return nil, errors.New("no embedder")
+	})
+
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open adapter: %v", err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	if _, err := scan.EmbedPending(ctx, adapter, filepath.Dir(filepath.Dir(dbPath))); err == nil {
+		t.Fatal("expected error when the embedder factory fails")
+	}
+}
+
+// TestEmbedPendingQueryError covers the SymbolsWithoutEmbeddings failure branch
+// in EmbedPending via a closed adapter — a real condition, not a fault-injecting
+// interface.
+func TestEmbedPendingQueryError(t *testing.T) {
+	dbPath := deferredScan(t, map[string]string{"a.go": "package a\n\nfunc F() {}\n"})
+
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("open adapter: %v", err)
+	}
+	_ = adapter.Close() // close first so the pending-symbols query fails
+
+	if _, err := scan.EmbedPending(ctx, adapter, filepath.Dir(filepath.Dir(dbPath))); err == nil {
+		t.Fatal("expected error querying pending symbols on a closed adapter")
+	}
+}
+
+// TestScanEmbedSymbolsPoolError covers the newEmbedPool failure branch in
+// embedSymbols: a failing factory aborts the pass-3 embed and Run returns the
+// error.
+func TestScanEmbedSymbolsPoolError(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "a.go"), "package a\n\nfunc F() {}\n")
+	scan.SetEmbedderFactory(t, func(int) (embed.Embedder, error) {
+		return nil, errors.New("no embedder")
+	})
+
+	_, err := scan.Run(context.Background(), scan.Options{
+		Root:              root,
+		Output:            io.Discard,
+		Warnings:          io.Discard,
+		EmbeddingsEnabled: true,
+		Embed:             true,
+	})
+	if err == nil {
+		t.Fatal("expected Run to fail when the embedder factory fails")
+	}
 }
 
 func readMeta(t *testing.T, dbPath, key string) string {

--- a/internal/scan/export_test.go
+++ b/internal/scan/export_test.go
@@ -1,0 +1,23 @@
+package scan
+
+import (
+	"testing"
+
+	"github.com/luuuc/sense/internal/embed"
+)
+
+// SetEmbedderFactory swaps the package-default embedder constructor for the
+// duration of a test, restoring it on cleanup. It is the test-only seam that
+// lets scan_test drive the embedding pipeline with a fake (e.g.
+// embedtest.FakeEmbedder) instead of the bundled ONNX model — without adding
+// any test knob to the exported scan.Run / scan.Options surface.
+//
+// Both Run (via the harness field) and the package-level EmbedPending read the
+// default at the moment they build their pool, so a call here before either
+// takes effect for that scan.
+func SetEmbedderFactory(t *testing.T, f func(threads int) (embed.Embedder, error)) {
+	t.Helper()
+	old := defaultEmbedderFactory
+	defaultEmbedderFactory = f
+	t.Cleanup(func() { defaultEmbedderFactory = old })
+}

--- a/internal/scan/oracle_test.go
+++ b/internal/scan/oracle_test.go
@@ -1,0 +1,165 @@
+package scan_test
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/internal/scan"
+	"github.com/luuuc/sense/internal/scan/scantest"
+)
+
+// oracleRepo is the fixed working tree the behavior oracle scans. It is chosen
+// to exercise every category the digest covers: cross-file call edges, a
+// reflective dispatch that lands in the per-language sense_meta name-sets, and
+// enough symbols that embedding presence is non-trivial. Keep it small and
+// stable — changing it changes the golden digest.
+var oracleRepo = map[string]string{
+	"app/models/user.rb": `class User
+  def greet
+    "hi, #{name}"
+  end
+
+  def name
+    "anon"
+  end
+end
+`,
+	"app/services/notifier.rb": `class Notifier
+  def notify(user)
+    user.greet
+    send(:log)
+  end
+
+  def log
+    "logged"
+  end
+end
+`,
+}
+
+// oracleDigest hashes everything the scan derives — the sorted symbol set, the
+// edge set, the per-language sense_meta name-sets, and embedding presence — into
+// a single content fingerprint. It hashes WHAT came out, not HOW MUCH: a seam
+// that swapped two edges, mislabeled a kind, or routed a harvested name into the
+// wrong language's set would change the digest even though every count held.
+// Volatile meta (timestamps) is excluded so the digest depends only on derived
+// structure. It also returns the sorted content lines so a mismatch can report
+// WHAT changed, not just that two hashes differ. Other tests in 27-03/04 reuse
+// this as the net under their seams.
+func oracleDigest(t *testing.T, dbPath string) (digest string, content []string) {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	var lines []string
+	collect := func(query string, scan func(*sql.Rows) (string, error)) {
+		rows, err := db.Query(query)
+		if err != nil {
+			t.Fatalf("oracle query %q: %v", query, err)
+		}
+		defer func() { _ = rows.Close() }()
+		for rows.Next() {
+			line, err := scan(rows)
+			if err != nil {
+				t.Fatalf("oracle scan %q: %v", query, err)
+			}
+			lines = append(lines, line)
+		}
+		if err := rows.Err(); err != nil {
+			t.Fatalf("oracle rows %q: %v", query, err)
+		}
+	}
+
+	collect(`SELECT qualified, kind FROM sense_symbols`, func(r *sql.Rows) (string, error) {
+		var q, k string
+		err := r.Scan(&q, &k)
+		return fmt.Sprintf("S\t%s\t%s", q, k), err
+	})
+	collect(`SELECT IFNULL(src.qualified, ''), tgt.qualified, e.kind
+	         FROM sense_edges e
+	         LEFT JOIN sense_symbols src ON e.source_id = src.id
+	         JOIN sense_symbols tgt ON e.target_id = tgt.id`, func(r *sql.Rows) (string, error) {
+		var src, tgt, kind string
+		err := r.Scan(&src, &tgt, &kind)
+		return fmt.Sprintf("E\t%s\t%s\t%s", src, tgt, kind), err
+	})
+	collect(`SELECT key, value FROM sense_meta
+	         WHERE key NOT IN ('last_scan_at', 'embedding_watermark')`, func(r *sql.Rows) (string, error) {
+		var k, v string
+		err := r.Scan(&k, &v)
+		return fmt.Sprintf("M\t%s\t%s", k, v), err
+	})
+	collect(`SELECT s.qualified FROM sense_embeddings em
+	         JOIN sense_symbols s ON em.symbol_id = s.id`, func(r *sql.Rows) (string, error) {
+		var q string
+		err := r.Scan(&q)
+		return fmt.Sprintf("EMB\t%s", q), err
+	})
+
+	// Sort after collection so the digest never depends on row order, which
+	// SQLite does not guarantee absent ORDER BY.
+	sort.Strings(lines)
+	sum := sha256.Sum256([]byte(strings.Join(lines, "\n")))
+	return hex.EncodeToString(sum[:]), lines
+}
+
+// oracleGolden is the content fingerprint of oracleRepo. It is pinned, not
+// computed at runtime: a behavior-preserving refactor (a seam, a split) must
+// leave it unchanged, and a refactor that alters derived output fails here
+// loudly. When output changes on purpose, regenerate it (see the capture line
+// in TestScanContentOracleDigest) and update this constant in the same commit.
+const oracleGolden = "e2ae251f1928556d5f19a8a195ace3c7b109d6ebd8b3337c661d1d4332ab8fcb"
+
+func TestScanContentOracleDigest(t *testing.T) {
+	useFakeEmbedder(t)
+	repo := scantest.NewRepo(t, oracleRepo)
+	res, _ := repo.Scan(scan.Options{EmbeddingsEnabled: true, Embed: true})
+	if res.Embedded == 0 {
+		t.Fatal("expected the fake embedder to produce embeddings")
+	}
+
+	got, content := oracleDigest(t, filepath.Join(repo.Root, ".sense", "index.db"))
+	// Capture line: run `go test -run TestScanContentOracleDigest -v` and copy
+	// the logged digest into oracleGolden when the change is intentional.
+	t.Logf("oracle digest: %s", got)
+	if got != oracleGolden {
+		// Print the content so the failure says WHAT changed, not just that two
+		// hashes differ — the diff against the prior run is where the regression is.
+		t.Errorf("oracle digest changed:\n got  %s\n want %s\nIf this change is intentional, update oracleGolden. Derived content:\n%s",
+			got, oracleGolden, strings.Join(content, "\n"))
+	}
+}
+
+// TestScanContentOracleStable proves the digest is the net it claims to be: a
+// rescan with no source change reproduces it byte-for-byte, while editing a
+// file moves it. The first guards against nondeterminism; the second against a
+// digest so coarse it would miss a real change.
+func TestScanContentOracleStable(t *testing.T) {
+	useFakeEmbedder(t)
+	repo := scantest.NewRepo(t, oracleRepo)
+	opts := scan.Options{EmbeddingsEnabled: true, Embed: true}
+
+	repo.Scan(opts)
+	dbPath := filepath.Join(repo.Root, ".sense", "index.db")
+	first, _ := oracleDigest(t, dbPath)
+
+	repo.Scan(opts) // rescan, no change
+	if again, _ := oracleDigest(t, dbPath); again != first {
+		t.Errorf("digest not stable across rescans:\n first %s\n again %s", first, again)
+	}
+
+	repo.Write("app/models/user.rb", "class User\n  def farewell\n    \"bye\"\n  end\nend\n")
+	repo.Scan(opts)
+	if changed, _ := oracleDigest(t, dbPath); changed == first {
+		t.Error("digest unchanged after editing a source file; oracle is too coarse")
+	}
+}

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -215,6 +215,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 		defaultMatcher: ignore.New(ignore.DefaultPatterns()...),
 		maxFileSizeKB:  cfg.Scan.MaxFileSizeKB,
 		seenPaths:      map[string]bool{},
+		newEmbedder:    defaultEmbedderFactory,
 	}
 	defer h.closeParsers()
 
@@ -509,6 +510,13 @@ type harness struct {
 	matcher        *ignore.Matcher
 	defaultMatcher *ignore.Matcher
 	maxFileSizeKB  int
+
+	// newEmbedder constructs the embedders for pass 3. Defaulted from
+	// defaultEmbedderFactory (the bundled ONNX model) so production is
+	// unchanged; a test swaps the package default via SetEmbedderFactory to
+	// drive embedding without ONNX. The field threads that choice from Run
+	// into embedSymbols without touching the exported Options.
+	newEmbedder embedderFactory
 
 	// symbolStmt is a prepared statement for WriteSymbol, created at
 	// the start of walkTree and closed when walkTree returns.

--- a/internal/scan/scantest/scantest.go
+++ b/internal/scan/scantest/scantest.go
@@ -1,0 +1,83 @@
+// Package scantest drives the real scan pipeline against a throwaway temp
+// repository and index, so a test can assert on what a scan derives without a
+// checked-in fixture repo or ONNX. It is deliberately small — a temp-repo
+// builder and a scan driver, nothing more. If it grows modes, options structs,
+// or a fluent builder it has become the framework this cycle exists to avoid;
+// keep it near 100 lines.
+package scantest
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/luuuc/sense/internal/scan"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// Repo is a temp working tree under t.TempDir(). Build one with NewRepo, scan
+// it with Scan; the temp dir and any opened index close via t.Cleanup.
+type Repo struct {
+	Root string
+	t    *testing.T
+}
+
+// NewRepo writes files (relative path → content) into a fresh t.TempDir and
+// returns the repo. Parent directories are created as needed.
+func NewRepo(t *testing.T, files map[string]string) *Repo {
+	t.Helper()
+	r := &Repo{Root: t.TempDir(), t: t}
+	for rel, content := range files {
+		r.Write(rel, content)
+	}
+	return r
+}
+
+// Write adds or replaces a file in the repo. Use between scans to drive the
+// incremental path.
+func (r *Repo) Write(rel, content string) {
+	r.t.Helper()
+	full := filepath.Join(r.Root, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		r.t.Fatalf("mkdir %s: %v", filepath.Dir(full), err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		r.t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+// Scan runs the real pipeline against the repo and returns the result plus an
+// adapter opened on the resulting index. Root, Output, and Warnings default to
+// the repo root and discarded sinks; any other field the caller sets on opts
+// (EmbeddingsEnabled, Embed, Rebuild) is honored. The adapter is registered for
+// cleanup, so the caller may query it directly and need not close it.
+//
+// To exercise the embedding path without ONNX, override the embedder seam with
+// scan.SetEmbedderFactory before calling Scan (only the scan_test package can,
+// which is the point — the production embedder stays the default).
+func (r *Repo) Scan(opts scan.Options) (*scan.Result, *sqlite.Adapter) {
+	r.t.Helper()
+	opts.Root = r.Root
+	if opts.Output == nil {
+		opts.Output = &bytes.Buffer{}
+	}
+	if opts.Warnings == nil {
+		opts.Warnings = io.Discard
+	}
+
+	ctx := context.Background()
+	res, err := scan.Run(ctx, opts)
+	if err != nil {
+		r.t.Fatalf("scan.Run: %v", err)
+	}
+
+	adapter, err := sqlite.Open(ctx, filepath.Join(r.Root, ".sense", "index.db"))
+	if err != nil {
+		r.t.Fatalf("open index: %v", err)
+	}
+	r.t.Cleanup(func() { _ = adapter.Close() })
+	return res, adapter
+}


### PR DESCRIPTION
## Problem

The embedding pipeline's testability was trapped at one line: `newEmbedPool`
hard-called `embed.NewBundledEmbedder`, so every caller (`EmbedPending`,
`embedSymbols`, `migrateEmbeddingModel`) could only be exercised by spinning up
ONNX, and the bug-prone ONNX-runtime extraction logic (atomic temp-write,
version-keyed cache invalidation) was unreachable without the bundled library.
There was also no behavior oracle proving a scan derives the same symbols,
edges, and metadata before and after a refactor — so "behavior-preserving" was a
claim with no evidence.

## Summary

Invert the embedding I/O edge behind an unexported seam and build the reusable
test foundation (a content-digest oracle and capped helpers) that future
testability work swings under. Behavior-preserving — no functionality added or
removed.

## Changes

- **Embedder seam (scan):** `newEmbedPool` takes an `embedderFactory` defaulting
  to the bundled model, threaded through `EmbedPending`/`embedSymbols` and an
  unexported harness field. A test-only `export_test.go` setter lets tests
  substitute a fake. `scan.Run` and `scan.Options` are unchanged — no test knob
  on the public API. The worker-count math is extracted into a pure
  `embedPoolSizing` helper.
- **Test helpers:** `embed/embedtest.FakeEmbedder` (deterministic, no ONNX) next
  to the `embed.Embedder` interface, and a ~80-line `scan/scantest` repo-builder
  + scan-driver so any package can drive a real scan offline.
- **Behavior oracle:** `scan/oracle_test.go` hashes the full derived state
  (symbols, edges, per-language metadata name-sets, embedding presence) into one
  fingerprint that is stable across rescans and moves on a source edit; a
  mismatch prints what changed.
- **Pure extraction (embed):** `extractLib` lifted out of `ensureORTLib`, testable
  with a temp dir and fake bytes; the rename-failure branch is forced with a real
  OS condition, not a fault-injecting filesystem. `ensureORTLib` becomes thin
  wiring.
- **ONNX integration test:** a build-tagged (`onnx_integration`) real-embedding
  test that fails loud if deps are absent (never skips). `make cover` sets the
  tag with deps fetched, so the coverage gate exercises the CGO shell for real;
  plain `go test` / `make test` / `make test-hermetic` stay ONNX-free.

## Architecture Highlights

- The seam is the `export_test.go` idiom over a package-level default — the
  production API stays sealed; tests reach the seam, callers cannot.
- The oracle pins *what* a scan derives, not *how much*, so a swapped edge,
  mislabeled kind, or mis-routed metadata set fails even when every count holds.
- A small set of ONNX C-API error branches remain unreachable without a corrupt
  model; they are left as documented exclusions rather than reached via mocks.

## Test Plan

- [x] `make cover` green (92.0%, floor 91)
- [x] `make lint` clean; complexity ledger non-increasing
- [x] Plain `go test ./...` passes without ONNX; integration test runs under the
      `onnx_integration` tag with deps present
- [x] Validated on a real Rails repo over a full `--embed` rescan: structural
      index, embeddings, graph, and embedding-backed search all working
- [x] sense binary builds cleanly
