### PR TITLE
test(scan): cover orchestration rollback and temporal failure paths

### DIFF
--- a/internal/scan/rollback_internal_test.go
+++ b/internal/scan/rollback_internal_test.go
@@ -1,0 +1,333 @@
+package scan
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/index"
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// errInjectedWrite is the failure the fault store returns; a sentinel so a
+// test can tell the injected failure apart from a real index error.
+var errInjectedWrite = errors.New("injected WriteFile failure")
+
+// faultWriteStore is the seam substitution that drives flushBatch's rollback
+// branch. It embeds the real adapter — so it satisfies indexStore unchanged —
+// and overrides exactly one named method, WriteFile, to fail once for a named
+// path before delegating. One path, one shot: no counter map, no failure
+// schedule, nothing that would turn it into the mock framework the cycle's
+// no-gos forbid. A single forced mid-transaction failure is all flushBatch's
+// snapshot/undo path needs.
+type faultWriteStore struct {
+	*sqlite.Adapter
+	failPath string
+	fired    bool
+}
+
+func (f *faultWriteStore) WriteFile(ctx context.Context, file *model.File) (int64, error) {
+	if !f.fired && file.Path == f.failPath {
+		f.fired = true
+		return 0, errInjectedWrite
+	}
+	return f.Adapter.WriteFile(ctx, file)
+}
+
+// openIndex opens a real index under dir/.sense. The caller owns closing it,
+// so a test can release the handle before a rescan opens its own.
+func openIndex(t *testing.T, dir string) *sqlite.Adapter {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, ".sense"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	a, err := sqlite.Open(context.Background(), filepath.Join(dir, ".sense", "index.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	return a
+}
+
+// writeSource writes content to dir/rel, creating parents.
+func writeSource(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	full := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// classFile builds a one-symbol fileResult for a Ruby class, the minimum
+// flushBatch needs to write a file row plus a symbol row.
+func classFile(rel, class string) *fileResult {
+	return &fileResult{
+		Rel:      rel,
+		Language: "ruby",
+		Source:   []byte("class " + class + "\nend\n"),
+		Hash:     "hash-" + rel,
+		Symbols: []extract.EmittedSymbol{
+			{Name: class, Qualified: class, Kind: "class", LineStart: 1, LineEnd: 2},
+		},
+	}
+}
+
+// TestFlushBatchPartialFailureRollsBackAndRetries forces a partial-batch
+// failure inside flushBatch's transaction and asserts the result through the
+// observable index, never through flushBatch's internal snapshot slices — so
+// the test survives the 27-05 split that reshapes flushBatch.
+//
+// The batch holds two files; the fault store fails the second file's WriteFile
+// once. The whole transaction must roll back (undoing the first file's writes
+// and the in-memory appends), the failing file must be dropped with a warning,
+// and the retry must re-commit the surviving file. After that a clean rescan —
+// the real production path, no fault — must converge on the full, correct set.
+func TestFlushBatchPartialFailureRollsBackAndRetries(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	writeSource(t, dir, "a.rb", "class A\nend\n")
+	writeSource(t, dir, "b.rb", "class B\nend\n")
+
+	adapter := openIndex(t, dir)
+	store := &faultWriteStore{Adapter: adapter, failPath: "b.rb"}
+	h := &harness{
+		ctx:       ctx,
+		idx:       store,
+		out:       io.Discard,
+		warn:      io.Discard,
+		collector: newWarningCollector(),
+		progress:  &progress{},
+		seenPaths: map[string]bool{},
+	}
+
+	// a.rb writes cleanly; b.rb's WriteFile fails mid-transaction.
+	if err := h.flushBatch([]*fileResult{classFile("a.rb", "A"), classFile("b.rb", "B")}); err != nil {
+		t.Fatalf("flushBatch should recover by retrying without the failing file, got %v", err)
+	}
+	if !store.fired {
+		t.Fatal("fault was never triggered — fixture no longer exercises the rollback path")
+	}
+
+	// Tallies reflect one survivor, not a double-count from a botched undo.
+	if h.indexed != 1 || h.changed != 1 || h.symbols != 1 {
+		t.Errorf("after rollback: indexed=%d changed=%d symbols=%d, want 1/1/1", h.indexed, h.changed, h.symbols)
+	}
+	// The dropped file is surfaced as a warning, not swallowed.
+	if got := h.collector.count(); got != 1 {
+		t.Errorf("warnings = %d, want 1 (the dropped b.rb)", got)
+	}
+
+	// Observable index: A survived the rollback+retry, B did not.
+	assertQualified(t, adapter, map[string]bool{"A": true, "B": false})
+
+	// Release the faulted handle, then rescan through the real pipeline (its
+	// own adapter, no fault). The dropped file must now converge into the index.
+	if err := adapter.Close(); err != nil {
+		t.Fatalf("close faulted adapter: %v", err)
+	}
+	if _, err := Run(ctx, Options{Root: dir, Output: io.Discard, Warnings: io.Discard}); err != nil {
+		t.Fatalf("clean rescan: %v", err)
+	}
+	fresh := openIndex(t, dir)
+	t.Cleanup(func() { _ = fresh.Close() })
+	assertQualified(t, fresh, map[string]bool{"A": true, "B": true})
+}
+
+// TestFlushBatchWholeBatchFailsDropsAllCleanly covers flushBatch's
+// retry-exhausted branch: when the only file in a batch fails, the retry list
+// is empty, so flushBatch returns cleanly with nothing indexed and a warning
+// for the dropped file.
+func TestFlushBatchWholeBatchFailsDropsAllCleanly(t *testing.T) {
+	dir := t.TempDir()
+	adapter := openIndex(t, dir)
+	t.Cleanup(func() { _ = adapter.Close() })
+	store := &faultWriteStore{Adapter: adapter, failPath: "only.rb"}
+	h := &harness{
+		ctx:       context.Background(),
+		idx:       store,
+		out:       io.Discard,
+		warn:      io.Discard,
+		collector: newWarningCollector(),
+		progress:  &progress{},
+		seenPaths: map[string]bool{},
+	}
+
+	if err := h.flushBatch([]*fileResult{classFile("only.rb", "Only")}); err != nil {
+		t.Fatalf("flushBatch should return cleanly after the whole batch is dropped, got %v", err)
+	}
+	if h.indexed != 0 || h.symbols != 0 {
+		t.Errorf("nothing should be indexed, got indexed=%d symbols=%d", h.indexed, h.symbols)
+	}
+	if got := h.collector.count(); got != 1 {
+		t.Errorf("warnings = %d, want 1", got)
+	}
+	assertQualified(t, adapter, map[string]bool{"Only": false})
+}
+
+// TestFlushBatchBeginErrorPropagates covers flushBatch's non-rollback error
+// path: a closed index fails the transaction's BEGIN before any file is
+// written, so failedIdx is never set and the error propagates instead of
+// triggering the (inapplicable) undo.
+func TestFlushBatchBeginErrorPropagates(t *testing.T) {
+	h := &harness{
+		ctx:       context.Background(),
+		idx:       newClosedAdapter(t),
+		out:       io.Discard,
+		warn:      io.Discard,
+		collector: newWarningCollector(),
+		progress:  &progress{},
+		seenPaths: map[string]bool{},
+	}
+	if err := h.flushBatch([]*fileResult{classFile("a.rb", "A")}); err == nil {
+		t.Fatal("expected error when the batch transaction cannot begin")
+	}
+}
+
+// TestWriteFileResultInnerWriteFailsRollsBack covers writeFileResult's inner
+// error path: the transaction begins, then the file write fails inside it, so
+// writeFileInner's error surfaces and nothing is committed.
+func TestWriteFileResultInnerWriteFailsRollsBack(t *testing.T) {
+	dir := t.TempDir()
+	adapter := openIndex(t, dir)
+	t.Cleanup(func() { _ = adapter.Close() })
+	store := &faultWriteStore{Adapter: adapter, failPath: "a.rb"}
+	h := &harness{ctx: context.Background(), idx: store, out: io.Discard, warn: io.Discard}
+
+	if err := h.writeFileResult(classFile("a.rb", "A")); err == nil {
+		t.Fatal("expected error when the file write fails inside the transaction")
+	}
+	assertQualified(t, adapter, map[string]bool{"A": false})
+}
+
+// assertQualified checks which qualified names the index holds, reading the
+// committed database rather than any in-memory state.
+func assertQualified(t *testing.T, adapter *sqlite.Adapter, want map[string]bool) {
+	t.Helper()
+	syms, err := adapter.Query(context.Background(), index.Filter{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	got := map[string]bool{}
+	for _, s := range syms {
+		got[s.Qualified] = true
+	}
+	for name, present := range want {
+		if got[name] != present {
+			t.Errorf("symbol %q present=%v, want %v (index has %v)", name, got[name], present, got)
+		}
+	}
+}
+
+// TestWriteFileResultErrorReturnsToCaller covers writeFileResult's error
+// return: when the per-file transaction cannot even begin (closed index), the
+// error propagates so processFile can warn rather than silently dropping work.
+func TestWriteFileResultErrorReturnsToCaller(t *testing.T) {
+	h := &harness{ctx: context.Background(), idx: newClosedAdapter(t), warn: io.Discard}
+	if err := h.writeFileResult(classFile("a.rb", "A")); err == nil {
+		t.Fatal("expected error from writeFileResult on a closed index")
+	}
+}
+
+// faultPrepareEdgeStore fails PrepareEdgeStmt once the resolve transaction has
+// begun, so the failure lands inside InTx rather than before it. One named
+// method, one shot — the same fault-once discipline as faultWriteStore.
+type faultPrepareEdgeStore struct {
+	*sqlite.Adapter
+}
+
+func (f *faultPrepareEdgeStore) PrepareEdgeStmt(context.Context) (*sql.Stmt, error) {
+	return nil, errors.New("injected PrepareEdgeStmt failure")
+}
+
+// TestResolveAndWriteEdgesPrepareStmtFails covers resolveAndWriteEdges'
+// in-transaction error path: SymbolRefs loads fine and the transaction begins,
+// then PrepareEdgeStmt fails, so the closure's error rolls the transaction back
+// and surfaces to the caller. Exercising it needs at least one pending edge so
+// the function does not short-circuit on an empty buffer.
+func TestResolveAndWriteEdgesPrepareStmtFails(t *testing.T) {
+	dir := t.TempDir()
+	adapter := openIndex(t, dir)
+	t.Cleanup(func() { _ = adapter.Close() })
+	h := &harness{
+		ctx:          context.Background(),
+		idx:          &faultPrepareEdgeStore{Adapter: adapter},
+		warn:         io.Discard,
+		pendingEdges: []pendingEdge{{SourceID: 1, TargetName: "X", Kind: model.EdgeCalls}},
+	}
+	if err := h.resolveAndWriteEdges(); err == nil {
+		t.Fatal("expected error when PrepareEdgeStmt fails inside the transaction")
+	}
+}
+
+// faultWriteEdgeStore fails WriteEdge once, the path resolveAndWriteEdges takes
+// for a file-level edge (one with no source symbol). Single named method,
+// fail-once.
+type faultWriteEdgeStore struct {
+	*sqlite.Adapter
+	fired bool
+}
+
+func (f *faultWriteEdgeStore) WriteEdge(ctx context.Context, e *model.Edge) (int64, error) {
+	if !f.fired {
+		f.fired = true
+		return 0, errors.New("injected WriteEdge failure")
+	}
+	return f.Adapter.WriteEdge(ctx, e)
+}
+
+// TestResolveAndWriteEdgesFileLevelEdgeWriteFails covers the file-level edge
+// write error: a pending edge with no source symbol resolves to a seeded
+// target, takes the WriteEdge branch (not the prepared-statement branch), and
+// the write fails — the error must surface from the transaction.
+func TestResolveAndWriteEdgesFileLevelEdgeWriteFails(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	adapter := openIndex(t, dir)
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	// Seed a target the file-level edge can resolve to.
+	fileID, err := adapter.WriteFile(ctx, &model.File{Path: "x.rb", Language: "ruby", Hash: "h", IndexedAt: time.Now().UTC()})
+	if err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	if _, err := adapter.WriteSymbol(ctx, &model.Symbol{FileID: fileID, Name: "X", Qualified: "X", Kind: "class", LineStart: 1, LineEnd: 1}); err != nil {
+		t.Fatalf("seed symbol: %v", err)
+	}
+
+	h := &harness{
+		ctx:  ctx,
+		idx:  &faultWriteEdgeStore{Adapter: adapter},
+		warn: io.Discard,
+		// SourceID 0 ⇒ a file-level edge ⇒ the WriteEdge branch. A high base
+		// confidence keeps "X" out of the bare-guess path so the exact
+		// qualified lookup resolves it.
+		pendingEdges: []pendingEdge{{SourceID: 0, TargetName: "X", Kind: model.EdgeInherits, FileID: fileID, Confidence: 1.0}},
+	}
+	if err := h.resolveAndWriteEdges(); err == nil {
+		t.Fatal("expected error when the file-level edge write fails")
+	}
+}
+
+// TestResolveAndWriteEdgesErrorReturnsToCaller covers resolveAndWriteEdges'
+// load-symbols error return: with a pending edge queued but the index closed,
+// SymbolRefs fails and the error surfaces instead of writing a partial graph.
+func TestResolveAndWriteEdgesErrorReturnsToCaller(t *testing.T) {
+	h := &harness{
+		ctx:          context.Background(),
+		idx:          newClosedAdapter(t),
+		warn:         io.Discard,
+		pendingEdges: []pendingEdge{{SourceID: 1, TargetName: "X", Kind: model.EdgeCalls}},
+	}
+	if err := h.resolveAndWriteEdges(); err == nil {
+		t.Fatal("expected error from resolveAndWriteEdges on a closed index")
+	}
+}

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -499,7 +499,7 @@ func addSenseToGitignore(root string) bool {
 // files. The consequence is called out on resolveAndWriteEdges.
 type harness struct {
 	ctx       context.Context
-	idx       *sqlite.Adapter
+	idx       indexStore
 	out       io.Writer // summary-line sink
 	warn      io.Writer // infrastructure warning sink (not per-file)
 	root      string    // repository root directory

--- a/internal/scan/scantest/scantest.go
+++ b/internal/scan/scantest/scantest.go
@@ -11,8 +11,10 @@ import (
 	"context"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/luuuc/sense/internal/scan"
 	"github.com/luuuc/sense/internal/sqlite"
@@ -80,4 +82,80 @@ func (r *Repo) Scan(opts scan.Options) (*scan.Result, *sqlite.Adapter) {
 	}
 	r.t.Cleanup(func() { _ = adapter.Close() })
 	return res, adapter
+}
+
+// Commit is one scripted commit in a WithGitHistory replay: the files to
+// write (relative path → content) before committing, and the message.
+// Files in the same commit co-change; temporal coupling only pairs files
+// in different directories, so a fixture that wants an edge must spread
+// the pair across directories.
+type Commit struct {
+	Files   map[string]string
+	Message string
+}
+
+// WithGitHistory runs a real `git init` at the repo root and replays the
+// given commits in order, so temporal-coupling code runs against genuine
+// `git log` output rather than a stub. Every source of nondeterminism is
+// pinned per-command (never via the developer's global config): author and
+// committer identity, author and committer date (set together — they
+// differ as env vars and a missing committer date is a classic flake), a
+// fixed TZ, and isolation from ~/.gitconfig and the system config. The
+// co-change structure is therefore identical across machines and CI
+// runners. Commit timestamps are anchored to the wall clock (one hour
+// apart, ending at roughly now) so the history stays inside temporal.go's
+// `--since=6 months ago` window on any run date; commit SHAs consequently
+// vary run-to-run and are never asserted. Skips the test if git is absent.
+func (r *Repo) WithGitHistory(commits []Commit) {
+	r.t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		r.t.Skip("git not available")
+	}
+
+	r.git(gitEnv(time.Time{}), "init")
+
+	base := time.Now().UTC().Add(-time.Duration(len(commits)) * time.Hour)
+	for i, c := range commits {
+		for rel, content := range c.Files {
+			r.Write(rel, content)
+		}
+		env := gitEnv(base.Add(time.Duration(i) * time.Hour))
+		r.git(env, "add", "-A")
+		r.git(env, "commit", "-m", c.Message)
+	}
+}
+
+// git runs `git <args>` in the repo root with the given environment,
+// failing the test on a non-zero exit. CombinedOutput surfaces git's own
+// diagnostics in the failure message.
+func (r *Repo) git(env []string, args ...string) {
+	r.t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = r.Root
+	cmd.Env = env
+	if out, err := cmd.CombinedOutput(); err != nil {
+		r.t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+// gitEnv builds a fully-pinned git environment: fixed identity, both date
+// vars stamped to date (zero date means "leave the commit date to git",
+// used for `init` which writes no commit), a fixed TZ, and global/system
+// config redirected to the null device so no developer or CI machine
+// setting can perturb the result.
+func gitEnv(date time.Time) []string {
+	env := append(os.Environ(),
+		"GIT_CONFIG_GLOBAL="+os.DevNull,
+		"GIT_CONFIG_SYSTEM="+os.DevNull,
+		"GIT_AUTHOR_NAME=sense-test",
+		"GIT_AUTHOR_EMAIL=test@sense.test",
+		"GIT_COMMITTER_NAME=sense-test",
+		"GIT_COMMITTER_EMAIL=test@sense.test",
+		"TZ=UTC",
+	)
+	if !date.IsZero() {
+		stamp := date.Format(time.RFC3339)
+		env = append(env, "GIT_AUTHOR_DATE="+stamp, "GIT_COMMITTER_DATE="+stamp)
+	}
+	return env
 }

--- a/internal/scan/seam.go
+++ b/internal/scan/seam.go
@@ -1,0 +1,61 @@
+package scan
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/luuuc/sense/internal/index"
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// indexStore is the seam the scan harness writes and reads the index
+// through. It is the exact method set the harness already calls on
+// *sqlite.Adapter — nothing wider — promoted from a concrete dependency to
+// an interface so the real-world effect (the database) sits behind a seam a
+// caller controls, per cycle 27's no-side-effects goal. Production wires the
+// concrete *sqlite.Adapter, which satisfies this unchanged; a white-box test
+// can substitute an adapter that fails one named method to drive the
+// harness's rollback and error-return branches without a SQL-driver shim.
+//
+// It is deliberately unexported and scan-local: this is a test seam, not a
+// new public storage contract (that boundary is internal/index). Methods are
+// grouped by role to keep the surface legible, not to suggest sub-seams.
+type indexStore interface {
+	// Transactions and prepared statements — the batched write path.
+	InTx(ctx context.Context, fn func() error) error
+	PrepareSymbolStmt(ctx context.Context) (*sql.Stmt, error)
+	PrepareEdgeStmt(ctx context.Context) (*sql.Stmt, error)
+	PrepareEmbeddingStmt(ctx context.Context) (*sql.Stmt, error)
+
+	// Row writes.
+	WriteFile(ctx context.Context, f *model.File) (int64, error)
+	WriteSymbol(ctx context.Context, s *model.Symbol) (int64, error)
+	WriteEdge(ctx context.Context, e *model.Edge) (int64, error)
+	DeleteFile(ctx context.Context, path string) error
+
+	// Reads used across the resolve, temporal, satisfy and embed passes.
+	Query(ctx context.Context, f index.Filter) ([]model.Symbol, error)
+	SymbolRefs(ctx context.Context) ([]model.SymbolRef, error)
+	FileMeta(ctx context.Context, path string) (int64, string, error)
+	FileHashMap(ctx context.Context) (map[string]sqlite.CachedFile, error)
+	FilePaths(ctx context.Context) ([]string, error)
+	FilePathsByIDs(ctx context.Context, fileIDs []int64) (map[int64]string, error)
+	FileIDsByLanguage(ctx context.Context, lang string) (map[int64]bool, error)
+	EdgesOfKind(ctx context.Context, kind model.EdgeKind) ([]model.Edge, error)
+	ContextForFile(ctx context.Context, fileID int64) (map[int64]string, error)
+	SymbolsForFiles(ctx context.Context, fileIDs []int64) ([]sqlite.EmbedSymbol, error)
+
+	// Metadata and embeddings.
+	ReadMeta(ctx context.Context, key string) (string, error)
+	WriteMeta(ctx context.Context, key, value string) error
+	DeleteMeta(ctx context.Context, key string) error
+	ClearEmbeddings(ctx context.Context) error
+
+	// DB exposes the handle the temporal and satisfy passes run raw SQL on.
+	DB() *sql.DB
+}
+
+// Compile-time proof the production adapter satisfies the seam, so a drift
+// in either surface fails the build rather than a test.
+var _ indexStore = (*sqlite.Adapter)(nil)

--- a/internal/scan/temporal_external_test.go
+++ b/internal/scan/temporal_external_test.go
@@ -3,153 +3,243 @@ package scan_test
 import (
 	"context"
 	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"testing"
 
+	"github.com/luuuc/sense/internal/model"
 	"github.com/luuuc/sense/internal/scan"
+	"github.com/luuuc/sense/internal/scan/scantest"
 	"github.com/luuuc/sense/internal/sqlite"
 )
 
-// gitInit creates a real git repo at root with deterministic identity.
-// Centralises the env-var boilerplate that several tests would otherwise
-// duplicate. Returns a runner for `git <args...>` against that repo.
-func gitInit(t *testing.T, root string) func(args ...string) {
-	t.Helper()
-	if _, err := exec.LookPath("git"); err != nil {
-		t.Skip("git not available")
+// coChange builds a Commit that rewrites the same two cross-directory
+// files at revision i. The pair lives in pkg/ and lib/ so temporal
+// coupling (which ignores same-directory pairs) can form an edge between
+// them. They are Ruby classes with a real inherits edge (B < A) so each
+// file's representative symbol carries non-temporal connectivity —
+// exercising representativeSymbols' inbound and outbound connectivity
+// queries, not just its empty-graph path.
+func coChange(i int) scantest.Commit {
+	return scantest.Commit{
+		Files: map[string]string{
+			"pkg/a.rb": fmt.Sprintf("# rev %d\nclass A\n  def hi; end\nend\n", i),
+			"lib/b.rb": fmt.Sprintf("# rev %d\nclass B < A\n  def yo; end\nend\n", i),
+		},
+		Message: fmt.Sprintf("co-change %d", i),
 	}
-	run := func(args ...string) {
-		t.Helper()
-		cmd := exec.Command("git", args...)
-		cmd.Dir = root
-		cmd.Env = append(os.Environ(),
-			"GIT_AUTHOR_NAME=test",
-			"GIT_AUTHOR_EMAIL=test@test.com",
-			"GIT_COMMITTER_NAME=test",
-			"GIT_COMMITTER_EMAIL=test@test.com",
-		)
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\n%s", args, err, out)
+}
+
+func temporalEdgeCount(t *testing.T, adapter *sqlite.Adapter) int {
+	t.Helper()
+	edges, err := adapter.EdgesOfKind(context.Background(), model.EdgeTemporal)
+	if err != nil {
+		t.Fatalf("EdgesOfKind: %v", err)
+	}
+	return len(edges)
+}
+
+// TestExtractTemporalCoupling_whenPairCoChangesAboveThreshold_writesBidirectionalEdges
+// is the positive path the negative cases never reach: a cross-directory
+// pair that co-changes four times (≥ minCoChanges) with both files indexed
+// drives the full pipeline — significant-pair selection, representativeSymbols,
+// clearTemporalEdges, and the bidirectional edge write. It asserts the
+// observable graph: one temporal edge each way, carrying the co-change count
+// on Line and strength 1.0 on Confidence (4 co-changes / 4 max changes).
+func TestExtractTemporalCoupling_whenPairCoChangesAboveThreshold_writesBidirectionalEdges(t *testing.T) {
+	repo := scantest.NewRepo(t, nil)
+	commits := make([]scantest.Commit, 4)
+	for i := range commits {
+		commits[i] = coChange(i)
+	}
+	repo.WithGitHistory(commits)
+
+	ctx := context.Background()
+	_, adapter := repo.Scan(scan.Options{})
+
+	edges, err := adapter.EdgesOfKind(ctx, model.EdgeTemporal)
+	if err != nil {
+		t.Fatalf("EdgesOfKind: %v", err)
+	}
+	if len(edges) != 2 {
+		t.Fatalf("temporal edges = %d, want 2 (one each way for the pkg/a.rb ↔ lib/b.rb pair)", len(edges))
+	}
+
+	// Both directions present: the two edges are mirror images.
+	a, b := edges[0], edges[1]
+	if a.SourceID == nil || b.SourceID == nil {
+		t.Fatalf("temporal edges must have source symbols, got %+v and %+v", a, b)
+	}
+	if *a.SourceID != b.TargetID || *b.SourceID != a.TargetID {
+		t.Errorf("expected mirrored edges, got A(src=%d,tgt=%d) B(src=%d,tgt=%d)",
+			*a.SourceID, a.TargetID, *b.SourceID, b.TargetID)
+	}
+	for _, e := range edges {
+		if e.Kind != model.EdgeTemporal {
+			t.Errorf("edge kind = %q, want %q", e.Kind, model.EdgeTemporal)
+		}
+		if e.Confidence != 1.0 {
+			t.Errorf("edge confidence = %v, want 1.0 (4 co-changes / 4 max changes)", e.Confidence)
+		}
+		if e.Line == nil || *e.Line != 4 {
+			t.Errorf("edge Line = %v, want 4 (co-change count)", e.Line)
 		}
 	}
-	run("init")
-	run("config", "user.email", "test@test.com")
-	run("config", "user.name", "test")
-	return run
+}
+
+// TestExtractTemporalCoupling_multiplePairsExerciseRankingAndStrength drives
+// the branches a single symmetric pair never reaches:
+//   - two significant pairs, so the deterministic sort comparator runs;
+//   - an asymmetric change count, so the "other file changed more" branch
+//     in the strength denominator fires;
+//   - a co-changing file with no symbols (comment-only), so both the
+//     skip-file-without-symbols path in representativeSymbols and the
+//     skip-pair-without-a-representative path in the edge loop run.
+//
+// The graph assertion stays observable: only the A↔B pair (both files have
+// a class) yields edges; the pair involving the symbol-less file is dropped.
+func TestExtractTemporalCoupling_multiplePairsExerciseRankingAndStrength(t *testing.T) {
+	repo := scantest.NewRepo(t, nil)
+
+	classA := func(i int) string { return fmt.Sprintf("# rev %d\nclass A\n  def hi; end\nend\n", i) }
+	classB := func(i int) string { return fmt.Sprintf("# rev %d\nclass B < A\n  def yo; end\nend\n", i) }
+	notesOnly := func(i int) string { return fmt.Sprintf("# rev %d — comments only, no symbols\n", i) }
+
+	var commits []scantest.Commit
+	// 4 commits couple x/a.rb ↔ z/b.rb (A↔B co-change = 4).
+	for i := 0; i < 4; i++ {
+		commits = append(commits, scantest.Commit{
+			Files:   map[string]string{"x/a.rb": classA(i), "z/b.rb": classB(i)},
+			Message: fmt.Sprintf("ab %d", i),
+		})
+	}
+	// 4 commits couple z/b.rb ↔ w/notes.rb (B↔notes co-change = 4), which
+	// pushes z/b.rb's total change count to 8 — higher than its partner in
+	// either pair, exercising the asymmetric-strength branch.
+	for i := 0; i < 4; i++ {
+		commits = append(commits, scantest.Commit{
+			Files:   map[string]string{"z/b.rb": classB(i + 4), "w/notes.rb": notesOnly(i)},
+			Message: fmt.Sprintf("bn %d", i),
+		})
+	}
+	repo.WithGitHistory(commits)
+
+	_, adapter := repo.Scan(scan.Options{})
+
+	// Only A↔B produces edges; B↔notes is dropped because notes.rb has no
+	// representative symbol. Bidirectional ⇒ exactly 2 temporal edges.
+	if got := temporalEdgeCount(t, adapter); got != 2 {
+		t.Errorf("temporal edges = %d, want 2 (only the A↔B pair anchors symbols)", got)
+	}
+}
+
+// TestExtractTemporalCoupling_sharedFirstFileSortsBySecond covers the
+// deterministic ordering's secondary tiebreak: two significant pairs that
+// share their first (lexically smaller) file must be ordered by their
+// second file. One hub file (a/hub.rb) co-changes with two leaves in
+// other directories, producing pairs (a/hub.rb, m/x.rb) and
+// (a/hub.rb, n/y.rb) — equal on the first element, so the comparator falls
+// through to comparing the second.
+func TestExtractTemporalCoupling_sharedFirstFileSortsBySecond(t *testing.T) {
+	repo := scantest.NewRepo(t, nil)
+	hub := func(i int) string { return fmt.Sprintf("# rev %d\nclass Hub\n  def go; end\nend\n", i) }
+	leaf := func(name string, i int) string {
+		return fmt.Sprintf("# rev %d\nclass %s < Hub\nend\n", i, name)
+	}
+	var commits []scantest.Commit
+	for i := 0; i < 4; i++ {
+		commits = append(commits, scantest.Commit{
+			Files:   map[string]string{"a/hub.rb": hub(i), "m/x.rb": leaf("X", i)},
+			Message: fmt.Sprintf("hx %d", i),
+		})
+	}
+	for i := 0; i < 4; i++ {
+		commits = append(commits, scantest.Commit{
+			Files:   map[string]string{"a/hub.rb": hub(i + 4), "n/y.rb": leaf("Y", i)},
+			Message: fmt.Sprintf("hy %d", i),
+		})
+	}
+	repo.WithGitHistory(commits)
+
+	_, adapter := repo.Scan(scan.Options{})
+
+	// Two pairs, both bidirectional ⇒ 4 temporal edges.
+	if got := temporalEdgeCount(t, adapter); got != 4 {
+		t.Errorf("temporal edges = %d, want 4 (hub↔x and hub↔y, both directions)", got)
+	}
+}
+
+// TestExtractTemporalCoupling_isIdempotentAcrossRescans pins clearTemporalEdges'
+// purpose: a second scan must not double the temporal edges. Without the
+// clear-before-recompute step the count would grow each run.
+func TestExtractTemporalCoupling_isIdempotentAcrossRescans(t *testing.T) {
+	repo := scantest.NewRepo(t, nil)
+	commits := make([]scantest.Commit, 4)
+	for i := range commits {
+		commits[i] = coChange(i)
+	}
+	repo.WithGitHistory(commits)
+
+	_, firstAdapter := repo.Scan(scan.Options{})
+	if got := temporalEdgeCount(t, firstAdapter); got != 2 {
+		t.Fatalf("temporal edges after first scan = %d, want 2 (baseline for the idempotency check)", got)
+	}
+
+	_, adapter := repo.Scan(scan.Options{})
+	if got := temporalEdgeCount(t, adapter); got != 2 {
+		t.Errorf("temporal edges after rescan = %d, want 2 (clearTemporalEdges must prevent doubling)", got)
+	}
 }
 
 // TestExtractTemporalCoupling_whenCoChangesBelowThreshold_writesNoEdges
-// exercises the "drop pairs below minCoChanges" branch in
-// extractTemporalCoupling: two files in different directories that
-// co-change only twice (below the threshold of 3) must produce zero
-// temporal edges, even though structurally they would qualify.
+// exercises the "drop pairs below minCoChanges" branch: a cross-directory
+// pair that co-changes only twice (below the threshold of three) must
+// produce zero temporal edges even though it is structurally eligible.
 func TestExtractTemporalCoupling_whenCoChangesBelowThreshold_writesNoEdges(t *testing.T) {
-	root := t.TempDir()
-	gitCmd := gitInit(t, root)
+	repo := scantest.NewRepo(t, nil)
+	repo.WithGitHistory([]scantest.Commit{coChange(0), coChange(1)})
 
-	pathA := filepath.Join(root, "pkg", "a.go")
-	pathB := filepath.Join(root, "lib", "b.go")
+	_, adapter := repo.Scan(scan.Options{})
 
-	// Only 2 co-changes — below minCoChanges (3).
-	for i := 0; i < 2; i++ {
-		writeFile(t, pathA, fmt.Sprintf("package pkg\n\n// v%d\nfunc A() {}\n", i))
-		writeFile(t, pathB, fmt.Sprintf("package lib\n\n// v%d\nfunc B() {}\n", i))
-		gitCmd("add", "-A")
-		gitCmd("commit", "-m", fmt.Sprintf("co-change %d", i))
-	}
-
-	ctx := context.Background()
-	if _, err := scan.Run(ctx, quietOpts(root)); err != nil {
-		t.Fatalf("Run: %v", err)
-	}
-
-	dbPath := filepath.Join(root, ".sense", "index.db")
-	a, err := sqlite.Open(ctx, dbPath)
-	if err != nil {
-		t.Fatalf("sqlite.Open: %v", err)
-	}
-	t.Cleanup(func() { _ = a.Close() })
-
-	var edgeCount int
-	err = a.DB().QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM sense_edges WHERE kind = 'temporal'`).Scan(&edgeCount)
-	if err != nil {
-		t.Fatalf("query temporal edges: %v", err)
-	}
-	if edgeCount != 0 {
-		t.Errorf("expected 0 temporal edges below threshold, got %d", edgeCount)
+	if got := temporalEdgeCount(t, adapter); got != 0 {
+		t.Errorf("expected 0 temporal edges below threshold, got %d", got)
 	}
 }
 
-// TestExtractTemporalCoupling_whenNoIndexedFiles_returnsEarly
-// covers the len(indexedFiles)==0 branch: a git repo with commits whose
-// only files are unindexed (e.g. plain text) means temporal coupling
-// has nothing to anchor against and must short-circuit cleanly.
+// TestExtractTemporalCoupling_whenNoIndexedFiles_returnsEarly covers the
+// len(indexedFiles)==0 branch: commits touching only unindexed files (plain
+// text) leave temporal coupling nothing to anchor against, so it must
+// short-circuit cleanly.
 func TestExtractTemporalCoupling_whenNoIndexedFiles_returnsEarly(t *testing.T) {
-	root := t.TempDir()
-	gitCmd := gitInit(t, root)
-
-	// Co-changes between two .txt files — git sees them but the scanner
-	// won't extract symbols, so the indexed-file map will be empty.
+	repo := scantest.NewRepo(t, nil)
+	var commits []scantest.Commit
 	for i := 0; i < 4; i++ {
-		writeFile(t, filepath.Join(root, "docs", "a.txt"), fmt.Sprintf("v%d\n", i))
-		writeFile(t, filepath.Join(root, "notes", "b.txt"), fmt.Sprintf("v%d\n", i))
-		gitCmd("add", "-A")
-		gitCmd("commit", "-m", fmt.Sprintf("co-change %d", i))
+		commits = append(commits, scantest.Commit{
+			Files: map[string]string{
+				"docs/a.txt":  fmt.Sprintf("v%d\n", i),
+				"notes/b.txt": fmt.Sprintf("v%d\n", i),
+			},
+			Message: fmt.Sprintf("co-change %d", i),
+		})
 	}
+	repo.WithGitHistory(commits)
 
-	ctx := context.Background()
-	if _, err := scan.Run(ctx, quietOpts(root)); err != nil {
-		t.Fatalf("Run: %v", err)
-	}
+	_, adapter := repo.Scan(scan.Options{})
 
-	dbPath := filepath.Join(root, ".sense", "index.db")
-	a, err := sqlite.Open(ctx, dbPath)
-	if err != nil {
-		t.Fatalf("sqlite.Open: %v", err)
-	}
-	t.Cleanup(func() { _ = a.Close() })
-
-	var edgeCount int
-	if err := a.DB().QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM sense_edges WHERE kind = 'temporal'`).Scan(&edgeCount); err != nil {
-		t.Fatalf("query temporal edges: %v", err)
-	}
-	if edgeCount != 0 {
-		t.Errorf("expected 0 temporal edges when no files are indexed, got %d", edgeCount)
+	if got := temporalEdgeCount(t, adapter); got != 0 {
+		t.Errorf("expected 0 temporal edges when no files are indexed, got %d", got)
 	}
 }
 
-// TestExtractTemporalCoupling_whenRepoHasNoHistory_writesNoEdges
-// exercises the early return when parseGitLog returns empty commits
-// (a fresh git repo with no commits yet).
+// TestExtractTemporalCoupling_whenRepoHasNoHistory_writesNoEdges exercises
+// the early return when parseGitLog yields no commits (a git repo with an
+// indexed file but no commits yet).
 func TestExtractTemporalCoupling_whenRepoHasNoHistory_writesNoEdges(t *testing.T) {
-	root := t.TempDir()
-	gitCmd := gitInit(t, root)
-	_ = gitCmd // init only; no commits
+	repo := scantest.NewRepo(t, nil)
+	repo.WithGitHistory(nil) // init only, no commits
+	repo.Write("pkg/a.go", "package pkg\nfunc A() {}\n")
 
-	writeFile(t, filepath.Join(root, "pkg", "a.go"), "package pkg\nfunc A() {}\n")
+	_, adapter := repo.Scan(scan.Options{})
 
-	ctx := context.Background()
-	if _, err := scan.Run(ctx, quietOpts(root)); err != nil {
-		t.Fatalf("Run: %v", err)
-	}
-
-	dbPath := filepath.Join(root, ".sense", "index.db")
-	a, err := sqlite.Open(ctx, dbPath)
-	if err != nil {
-		t.Fatalf("sqlite.Open: %v", err)
-	}
-	t.Cleanup(func() { _ = a.Close() })
-
-	var edgeCount int
-	if err := a.DB().QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM sense_edges WHERE kind = 'temporal'`).Scan(&edgeCount); err != nil {
-		t.Fatalf("query temporal edges: %v", err)
-	}
-	if edgeCount != 0 {
-		t.Errorf("expected 0 temporal edges with no commits, got %d", edgeCount)
+	if got := temporalEdgeCount(t, adapter); got != 0 {
+		t.Errorf("expected 0 temporal edges with no commits, got %d", got)
 	}
 }

--- a/internal/scan/temporal_internal_test.go
+++ b/internal/scan/temporal_internal_test.go
@@ -1,0 +1,54 @@
+package scan
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// newClosedAdapter opens an index and immediately closes it, so every
+// subsequent query or exec fails. It is the in-package lever for the
+// temporal coupling error returns, which only fire when the index round
+// trip fails — a state the happy-path tests never reach.
+func newClosedAdapter(t *testing.T) *sqlite.Adapter {
+	t.Helper()
+	a, err := sqlite.Open(context.Background(), filepath.Join(t.TempDir(), "index.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := a.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	return a
+}
+
+// TestIndexedFilePathsQueryError covers indexedFilePaths' error return
+// (temporal.go:245-247): FilePaths fails against a closed index.
+func TestIndexedFilePathsQueryError(t *testing.T) {
+	h := &harness{ctx: context.Background(), idx: newClosedAdapter(t), warn: io.Discard}
+	if _, err := h.indexedFilePaths(); err == nil {
+		t.Fatal("expected error from indexedFilePaths on closed adapter")
+	}
+}
+
+// TestRepresentativeSymbolsQueryError covers representativeSymbols' first
+// error return (temporal.go:266-267): the outbound-connectivity query
+// fails against a closed index before any row is read.
+func TestRepresentativeSymbolsQueryError(t *testing.T) {
+	h := &harness{ctx: context.Background(), idx: newClosedAdapter(t), warn: io.Discard}
+	if _, err := h.representativeSymbols(map[string]bool{"pkg/a.rb": true}); err == nil {
+		t.Fatal("expected error from representativeSymbols on closed adapter")
+	}
+}
+
+// TestClearTemporalEdgesExecError covers clearTemporalEdges' error return
+// (temporal.go:370-372): the DELETE fails against a closed index.
+func TestClearTemporalEdgesExecError(t *testing.T) {
+	h := &harness{ctx: context.Background(), idx: newClosedAdapter(t), warn: io.Discard}
+	if err := h.clearTemporalEdges(); err == nil {
+		t.Fatal("expected error from clearTemporalEdges on closed adapter")
+	}
+}

--- a/internal/scan/walkpaths_internal_test.go
+++ b/internal/scan/walkpaths_internal_test.go
@@ -1,0 +1,142 @@
+package scan
+
+import (
+	"context"
+	"errors"
+	"io"
+	"path/filepath"
+	"testing"
+	"time"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// newWalkHarness builds a harness with the per-file walk machinery wired up
+// (parser cache, warning sinks, seen-path set) around the given store.
+func newWalkHarness(idx indexStore) *harness {
+	return &harness{
+		ctx:       context.Background(),
+		idx:       idx,
+		out:       io.Discard,
+		warn:      io.Discard,
+		collector: newWarningCollector(),
+		progress:  &progress{},
+		parsers:   map[string]*sitter.Parser{},
+		seenPaths: map[string]bool{},
+	}
+}
+
+// TestParserForCachesByLanguage covers parserFor's cache-hit return: a second
+// request for the same language must hand back the same parser, not build a
+// fresh one. The incremental path relies on this to avoid re-binding a grammar
+// per file.
+func TestParserForCachesByLanguage(t *testing.T) {
+	h := &harness{parsers: map[string]*sitter.Parser{}}
+	t.Cleanup(h.closeParsers)
+
+	ex := extract.ForExtension(".rb")
+	if ex == nil {
+		t.Fatal("no extractor for .rb")
+	}
+	first, err := h.parserFor(ex)
+	if err != nil {
+		t.Fatalf("first parserFor: %v", err)
+	}
+	second, err := h.parserFor(ex)
+	if err != nil {
+		t.Fatalf("second parserFor: %v", err)
+	}
+	if first != second {
+		t.Error("parserFor should reuse the cached parser for the same language")
+	}
+}
+
+// TestProcessFileWriteErrorWarns covers processFile's write-failure branch: the
+// file parses, but the per-file write fails, so processFile records a warning
+// and indexes nothing rather than crashing the incremental scan.
+func TestProcessFileWriteErrorWarns(t *testing.T) {
+	dir := t.TempDir()
+	writeSource(t, dir, "a.rb", "class A\nend\n")
+	adapter := openIndex(t, dir)
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	h := newWalkHarness(&faultWriteStore{Adapter: adapter, failPath: "a.rb"})
+	h.processFile(filepath.Join(dir, "a.rb"), "a.rb")
+	t.Cleanup(h.closeParsers)
+
+	if h.indexed != 0 {
+		t.Errorf("indexed = %d, want 0 (the write failed)", h.indexed)
+	}
+	if got := h.collector.count(); got != 1 {
+		t.Errorf("warnings = %d, want 1 (the failed write)", got)
+	}
+}
+
+// TestParseFileMetaErrorWarnsButStillParses covers parseFile's FileMeta error
+// path: the incremental hash lookup fails, so the file cannot be skipped — the
+// scan logs a warning and parses it anyway rather than dropping it silently.
+func TestParseFileMetaErrorWarnsButStillParses(t *testing.T) {
+	dir := t.TempDir()
+	writeSource(t, dir, "a.rb", "class A\nend\n")
+
+	h := newWalkHarness(newClosedAdapter(t)) // closed ⇒ FileMeta fails
+	t.Cleanup(h.closeParsers)
+
+	fr := h.parseFile(filepath.Join(dir, "a.rb"), "a.rb")
+	if fr == nil {
+		t.Fatal("parseFile should still return a result when the hash lookup fails")
+	}
+	if got := h.collector.count(); got != 1 {
+		t.Errorf("warnings = %d, want 1 (the FileMeta error)", got)
+	}
+}
+
+// TestRemoveStaleFilesListErrorPropagates covers removeStaleFiles' first error
+// return: listing tracked files fails against a closed index.
+func TestRemoveStaleFilesListErrorPropagates(t *testing.T) {
+	h := &harness{ctx: context.Background(), idx: newClosedAdapter(t), warn: io.Discard}
+	if err := h.removeStaleFiles(); err == nil {
+		t.Fatal("expected error when listing tracked files fails")
+	}
+}
+
+// faultDeleteFileStore fails DeleteFile, the write removeStaleFiles issues
+// inside its transaction. Single named method, fail-always — the stale set in
+// the test has one entry, so one failure is enough.
+type faultDeleteFileStore struct {
+	*sqlite.Adapter
+}
+
+func (f *faultDeleteFileStore) DeleteFile(context.Context, string) error {
+	return errors.New("injected DeleteFile failure")
+}
+
+// TestRemoveStaleFilesDeleteErrorPropagates covers removeStaleFiles' in-tx
+// delete-error path: a tracked file is absent from this walk's seen set (so it
+// is stale), but deleting it fails, and the error surfaces from the transaction
+// rather than leaving a half-applied cleanup.
+func TestRemoveStaleFilesDeleteErrorPropagates(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	adapter := openIndex(t, dir)
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	// Seed a tracked file the walk never sees, so it is classified stale.
+	if _, err := adapter.WriteFile(ctx, &model.File{Path: "gone.rb", Language: "ruby", Hash: "h", IndexedAt: time.Now().UTC()}); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	h := &harness{
+		ctx:       ctx,
+		idx:       &faultDeleteFileStore{Adapter: adapter},
+		warn:      io.Discard,
+		seenPaths: map[string]bool{}, // nothing seen ⇒ gone.rb is stale
+	}
+	if err := h.removeStaleFiles(); err == nil {
+		t.Fatal("expected error when deleting a stale file fails")
+	}
+}


### PR DESCRIPTION
## Problem

The scan pipeline's orchestration branches were its least-tested code. `flushBatch` keeps a hand-rolled in-memory snapshot/undo that fires when a batch transaction rolls back (54.8% covered) — a silent bug there would corrupt the in-memory edge/file state after a partial-batch failure, with nothing to catch it. The git temporal-coupling pipeline (`representativeSymbols` 60.4%, `extractTemporalCoupling` 80.3%) shipped its co-change edge logic unverified, and the per-file error, incremental, and stale-removal paths were only exercised on the happy path.

## Summary

Put the index behind an unexported interface seam so a test can substitute a failing one, then drive the rollback, error-return, incremental, stale-removal, and real-git temporal branches as behavior — asserted through the observable index, never internal state.

## Changes

- **Seam.** Retype `harness.idx` from the concrete `*sqlite.Adapter` to a new unexported, scan-local `indexStore` interface holding the exact method set the harness already calls. Pure type swap: the adapter satisfies it unchanged, every call site is identical, and a compile-time assertion guards against drift. This puts the database — the pipeline's largest trapped side effect — behind a boundary a test controls.
- **Rollback proof.** A fault store overriding one named method (fail-once, embedding the real adapter) forces `flushBatch`'s partial-batch failure; the test asserts the committed index after a clean rescan, not the internal snapshot slices, so it survives a future split of the scan pipeline.
- **Temporal coupling.** New `scantest.WithGitHistory` replays a real, fully-pinned `git init`/`commit` history (identity, both dates, `TZ`, and global/system config redirected to the null device), so the co-change code runs against genuine `git log`. Tests cover bidirectional edges, strength, ranking tiebreaks, idempotency, and the leaf error returns.
- **Walk paths.** `parserFor` cache reuse, `processFile` warn-and-continue, `parseFile` hash-lookup error, `removeStaleFiles` list/delete errors, and `writeFileResult`/`resolveAndWriteEdges` write failures.

## Architecture highlights

- The seam is unexported and scan-local — not a change to the public storage contract. Fault doubles are single-method, fail-once stubs, not a mock framework.
- Behavior-preserving. Coverage of the targeted functions: `flushBatch` 54.8→100%, `writeFileResult` 81.8→100%, `processFile`/`removeStaleFiles`/`indexedFilePaths`/`clearTemporalEdges` →100%, `resolveAndWriteEdges` →97.1%.
- A few defensive guards remain uncovered by design — an unreachable grammar-version error, raw multi-query DB error paths, and the orchestrator's error-propagation glue — each reachable only via tooling out of scope for this change.

## Test plan

- [x] `go test ./...` passes
- [x] `make ci` green at 92.2% (floor 91%), lint 0 issues
- [x] sense binary builds cleanly
- [x] Full rescan of a real Ruby project: clean exit, 1853 files indexed, 27053 edges, 1358 temporal edges