### PR TITLE
test(mcp): cover the process and server edges without live subsystems

### DIFF
--- a/internal/freshen/git_test.go
+++ b/internal/freshen/git_test.go
@@ -45,6 +45,32 @@ func TestNewGitHeadWatcherNonRepo(t *testing.T) {
 	}
 }
 
+// TestNewGitHeadWatcherAddFails drives the fsnotify-Add failure branch: .git
+// exists as a directory (so the stat passes) but cannot be watched because it
+// is unreadable. Root-guarded — root ignores the permission bits.
+func TestNewGitHeadWatcherAddFails(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("permission bits are ignored when running as root")
+	}
+	root := t.TempDir()
+	gitDir := filepath.Join(root, ".git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(gitDir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(gitDir, 0o755) })
+
+	w, err := newGitHeadWatcher(root)
+	if w != nil {
+		_ = w.Close()
+	}
+	if err == nil {
+		t.Skip("this platform allowed a watch on an unreadable .git; nothing to assert")
+	}
+}
+
 func TestGitDiffNamesSameCommit(t *testing.T) {
 	c, r := gitDiffNames(t.TempDir(), "abc", "abc")
 	if c != nil || r != nil {

--- a/internal/freshen/lock_test.go
+++ b/internal/freshen/lock_test.go
@@ -199,6 +199,15 @@ func TestWriterLockReclaimRemoveFails(t *testing.T) {
 	}
 }
 
+// TestLockIsStaleMissingFile covers the stat-error branch: a lock path that
+// does not exist is treated as reclaimable (it vanished between a create
+// attempt and the stat).
+func TestLockIsStaleMissingFile(t *testing.T) {
+	if !lockIsStale(filepath.Join(t.TempDir(), "does-not-exist.lock")) {
+		t.Error("a missing lock file should be reclaimable (stale)")
+	}
+}
+
 func TestPidAlive(t *testing.T) {
 	if !pidAlive(os.Getpid()) {
 		t.Error("current process should be alive")

--- a/internal/freshen/service_test.go
+++ b/internal/freshen/service_test.go
@@ -311,6 +311,111 @@ func TestServiceNewBadConfig(t *testing.T) {
 	}
 }
 
+// TestServiceRunExitsOnClosedBatches covers run's closed-channel branch: when
+// the debounce loop closes the batch channel, the consumer goroutine returns.
+func TestServiceRunExitsOnClosedBatches(t *testing.T) {
+	s := &Service{}
+	s.wg.Add(1)
+
+	batches := make(chan Batch)
+	close(batches)
+
+	done := make(chan struct{})
+	go func() {
+		s.run(context.Background(), batches)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not exit when the batch channel closed")
+	}
+}
+
+// TestRepairFilesNilAdapterAfterClose covers RepairFiles' raced-shutdown
+// guard: a repair that runs (on the query goroutine) after Stop closed the
+// adapter sees a nil adapter under the write mutex and bails instead of
+// writing through a closed handle.
+func TestRepairFilesNilAdapterAfterClose(t *testing.T) {
+	s := &Service{}
+	s.mu.Lock()
+	s.started = true
+	s.writing = true // pass the Writing() gate so we reach the adapter check
+	s.mu.Unlock()
+	s.adapter = nil
+
+	if err := s.RepairFiles(context.Background(), []string{"main.go"}); err != nil {
+		t.Errorf("RepairFiles with a nil adapter should be a safe no-op, got %v", err)
+	}
+}
+
+// lockDir creates an unreadable (chmod 000) subdirectory and restores its
+// permissions on cleanup so the temp tree can be removed. It is the harness
+// for the permission-error branches; callers must root-guard.
+func lockDir(t *testing.T, parent string) {
+	t.Helper()
+	locked := filepath.Join(parent, "locked")
+	if err := os.MkdirAll(locked, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+}
+
+// TestServiceNewIgnoreBuildError covers NewService's ignore-matcher failure
+// branch: an unreadable directory present before construction makes the
+// gitignore walk fail to open a nested .gitignore, so NewService returns the
+// error. Root-guarded.
+func TestServiceNewIgnoreBuildError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("permission bits are ignored when running as root")
+	}
+	root := t.TempDir()
+	lockDir(t, root)
+
+	if _, err := NewService(Config{Root: root}); err == nil {
+		t.Skip("this platform let the ignore walk read an unreadable dir; nothing to assert")
+	}
+}
+
+// TestServiceStartWatcherCreateError covers Start's watcher-creation failure
+// branch: the writer lock is acquired, but building the watcher fails because
+// an unreadable directory appeared after construction (so the ignore matcher
+// built on the clean tree), so Start releases the lock, closes the adapter,
+// and returns the error. Root-guarded.
+func TestServiceStartWatcherCreateError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("permission bits are ignored when running as root")
+	}
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "main.go"),
+		[]byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	scanRepo(t, root, false)
+
+	// NewService walks the clean tree, so the ignore matcher builds fine.
+	svc, err := NewService(Config{Root: root})
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	defer svc.Stop()
+
+	// Now lock a subdirectory: Start acquires the writer lock, then the
+	// watcher's registerAll surfaces the unreadable dir as a New error.
+	lockDir(t, root)
+
+	if err := svc.Start(context.Background()); err == nil {
+		t.Skip("this platform let the watcher register an unreadable dir; nothing to assert")
+	}
+	if svc.Writing() {
+		t.Error("Start should not report writing after a watcher-creation failure")
+	}
+}
+
 func TestServiceStartDegradesWhenLockCheckFails(t *testing.T) {
 	root := t.TempDir()
 	if err := os.WriteFile(filepath.Join(root, "main.go"),

--- a/internal/freshen/watcher_edge_test.go
+++ b/internal/freshen/watcher_edge_test.go
@@ -1,0 +1,89 @@
+package freshen
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/luuuc/sense/internal/ignore"
+)
+
+// A path that cannot be made relative to an absolute root (a relative input)
+// drives the filepath.Rel error returns. These returns are the watcher's
+// defensive contract: an un-relativizable event path is treated as
+// non-actionable (ignore/skip) rather than crashing the watch loop.
+
+func TestWatcherAddDirRelError(t *testing.T) {
+	w, err := New(t.TempDir(), ignore.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = w.Close() }()
+
+	// A relative path cannot be made relative to the absolute root, so AddDir
+	// returns nil without registering anything.
+	if err := w.AddDir("relative/not/absolute"); err != nil {
+		t.Errorf("AddDir with un-relativizable path should be a no-op, got %v", err)
+	}
+	if w.dirs["relative/not/absolute"] {
+		t.Error("AddDir must not register an un-relativizable path")
+	}
+}
+
+func TestWatcherRemoveDirRelError(t *testing.T) {
+	w, err := New(t.TempDir(), ignore.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = w.Close() }()
+
+	// Must not panic and must leave tracked dirs untouched.
+	w.RemoveDir("relative/not/absolute")
+}
+
+func TestWatcherShouldIgnoreRelError(t *testing.T) {
+	w, err := New(t.TempDir(), ignore.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = w.Close() }()
+
+	// An un-relativizable path is conservatively ignored (true).
+	if !w.ShouldIgnore("relative/not/absolute") {
+		t.Error("ShouldIgnore should return true for an un-relativizable path")
+	}
+}
+
+// TestWatcherRegisterAllUnreadableDir drives registerAll's walk over a
+// directory the process cannot read (chmod 000). It is root-guarded: root
+// ignores permission bits, so the branch is unreachable there. The assertion
+// records the actual behavior so the watcher's resilience contract is pinned.
+// The unprivileged Linux/macOS CI runners are the reference platform where
+// this branch is reachable; the in-test skip is a belt for odd local setups,
+// not the expected path.
+func TestWatcherRegisterAllUnreadableDir(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("permission bits are ignored when running as root")
+	}
+	root := t.TempDir()
+	locked := filepath.Join(root, "locked")
+	if err := os.MkdirAll(locked, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	// Restore perms so t.TempDir cleanup can remove the tree.
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+
+	w, err := New(root, ignore.New())
+	if w != nil {
+		_ = w.Close()
+	}
+	// Record the real behavior: an unreadable subdirectory surfaces from the
+	// walk as a New error (the watcher cannot enumerate the tree it must
+	// watch). This is asserted, not assumed.
+	if err == nil {
+		t.Skip("this platform let the walk pass an unreadable dir; nothing to assert")
+	}
+}

--- a/internal/mcpserver/bootstrap_test.go
+++ b/internal/mcpserver/bootstrap_test.go
@@ -1,0 +1,257 @@
+package mcpserver
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/internal/embed"
+	"github.com/luuuc/sense/internal/scan"
+	"github.com/luuuc/sense/internal/scan/scantest"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// hermeticEnv disables embeddings and the background watcher so a build
+// exercises the bootstrap branches without ONNX, a writer lock, or
+// background goroutines. The rebuild path runs a real scan, which stays
+// ONNX-free only while SENSE_EMBEDDINGS is off.
+func hermeticEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("SENSE_EMBEDDINGS", "false")
+	t.Setenv("SENSE_WATCH", "false")
+}
+
+// symbolCount reports how many symbols with the given name are in the index
+// the handlers serve, proving a (re)scan populated it.
+func symbolCount(t *testing.T, h *handlers, name string) int {
+	t.Helper()
+	var n int
+	if err := h.db.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM sense_symbols WHERE name = ?`, name).Scan(&n); err != nil {
+		t.Fatalf("count symbols: %v", err)
+	}
+	return n
+}
+
+// staleUserVersion stamps a non-zero schema version different from the
+// current one onto the index, so the next open takes sqlite's rebuild path
+// (adapter.Rebuilt == true).
+func staleUserVersion(t *testing.T, dir string) {
+	t.Helper()
+	ctx := context.Background()
+	db, err := sqlite.Open(ctx, filepath.Join(dir, ".sense", "index.db"))
+	if err != nil {
+		t.Fatalf("open for stamp: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	// Any non-zero version that differs from SchemaVersion triggers a rebuild.
+	if _, err := db.DB().ExecContext(ctx, "PRAGMA user_version = 1"); err != nil {
+		t.Fatalf("stamp stale user_version: %v", err)
+	}
+}
+
+// TestBuildMCPServerRebuildsOnSchemaMismatch drives buildMCPServer's
+// upgrade-time rebuild branch: an index whose stored schema version is stale
+// is detected by cli.OpenIndex (adapter.Rebuilt), so the server runs a fresh
+// scan and reopens before building the engine. Embeddings are explicitly off
+// so the real rebuild scan stays ONNX-free.
+func TestBuildMCPServerRebuildsOnSchemaMismatch(t *testing.T) {
+	hermeticEnv(t)
+
+	repo := scantest.NewRepo(t, map[string]string{
+		"main.go": "package main\n\nfunc Hello() {}\n",
+	})
+	repo.Scan(scan.Options{})
+	staleUserVersion(t, repo.Root)
+
+	s, h, cleanup, err := buildMCPServer(RunOptions{Dir: repo.Root})
+	if err != nil {
+		t.Fatalf("buildMCPServer: %v", err)
+	}
+	defer cleanup()
+
+	if s == nil || h == nil {
+		t.Fatal("rebuild branch should still build a server and handlers")
+	}
+	// The rebuild scan repopulated the index from source.
+	if got := symbolCount(t, h, "Hello"); got == 0 {
+		t.Error("rebuild scan should have repopulated the index, but Hello is absent")
+	}
+}
+
+// TestBuildMCPServerWarnsOnModelMismatch drives the embedding-model warning
+// branch: the stored model differs from the binary's, so buildMCPServer warns
+// (to stderr) yet still builds the engine. The assertion is the branch
+// outcome — engine built despite the mismatch — not the warning text, which
+// goes to os.Stderr (a 27-05 cleanup makes it injectable/assertable).
+func TestBuildMCPServerWarnsOnModelMismatch(t *testing.T) {
+	hermeticEnv(t)
+
+	repo := scantest.NewRepo(t, map[string]string{
+		"main.go": "package main\n\nfunc Hello() {}\n",
+	})
+	_, adapter := repo.Scan(scan.Options{})
+	if err := adapter.WriteMeta(context.Background(), "embedding_model", "stale-model-v0"); err != nil {
+		t.Fatalf("write stale model meta: %v", err)
+	}
+
+	s, h, cleanup, err := buildMCPServer(RunOptions{Dir: repo.Root})
+	if err != nil {
+		t.Fatalf("buildMCPServer: %v", err)
+	}
+	defer cleanup()
+
+	if s == nil || h == nil {
+		t.Fatal("model-mismatch warning must not stop the server from building")
+	}
+	if got := symbolCount(t, h, "Hello"); got == 0 {
+		t.Error("engine should serve the existing index despite the model warning")
+	}
+}
+
+// TestBuildMCPServerHostsBackgroundWatcher covers the self-hosted freshening
+// branch: with no external watcher (WatchState nil) and watching enabled, the
+// server starts its own freshen.Service so the index stays current for the
+// session. Embeddings are off, so the Service runs ONNX-free; cleanup stops
+// it deterministically.
+func TestBuildMCPServerHostsBackgroundWatcher(t *testing.T) {
+	t.Setenv("SENSE_EMBEDDINGS", "false")
+	t.Setenv("SENSE_WATCH", "true")
+
+	repo := scantest.NewRepo(t, map[string]string{
+		"main.go": "package main\n\nfunc Hello() {}\n",
+	})
+	repo.Scan(scan.Options{})
+
+	s, h, cleanup, err := buildMCPServer(RunOptions{Dir: repo.Root})
+	if err != nil {
+		t.Fatalf("buildMCPServer: %v", err)
+	}
+	defer cleanup()
+
+	if s == nil {
+		t.Fatal("expected a server")
+	}
+	if h.freshen == nil {
+		t.Error("expected the server to host its own freshen.Service when watching is enabled")
+	}
+}
+
+// TestBuildMCPServerDegradesWhenWatcherUnavailable covers the graceful
+// degrade branch: watching is enabled, but the freshen.Service cannot be
+// constructed (here, a malformed config.yml fails its config load). The
+// server warns and still builds, serving queries read-only without auto
+// refresh.
+func TestBuildMCPServerDegradesWhenWatcherUnavailable(t *testing.T) {
+	t.Setenv("SENSE_EMBEDDINGS", "false")
+	t.Setenv("SENSE_WATCH", "true")
+
+	repo := scantest.NewRepo(t, map[string]string{
+		"main.go": "package main\n\nfunc Hello() {}\n",
+	})
+	repo.Scan(scan.Options{})
+	// Malformed config.yml: cli.OpenIndex still works (it only opens sqlite),
+	// but freshen.NewService's config load fails, so the watcher is skipped.
+	repo.Write(filepath.Join(".sense", "config.yml"), "ignore: [unterminated\n")
+
+	s, h, cleanup, err := buildMCPServer(RunOptions{Dir: repo.Root})
+	if err != nil {
+		t.Fatalf("buildMCPServer should degrade, not error: %v", err)
+	}
+	defer cleanup()
+
+	if s == nil {
+		t.Fatal("expected a server even when the watcher is unavailable")
+	}
+	if h.freshen != nil {
+		t.Error("freshen.Service should be nil when it could not be constructed")
+	}
+}
+
+// TestBuildMCPServerOneShotEmbedFallback covers the one-shot background embed
+// branch: embeddings are enabled, but no freshen.Service runs (watching off)
+// and no external watcher owns the index, so the server itself closes the
+// embedding debt once and upgrades search to hybrid in place. This path needs
+// the bundled embedder (real ONNX inference), so it skips when the model is
+// unavailable, mirroring the other embedding-path tests. It runs under the
+// coverage gate's onnx_integration build, which fetches the model.
+func TestBuildMCPServerOneShotEmbedFallback(t *testing.T) {
+	probe, err := embed.NewBundledEmbedder(0)
+	if err != nil {
+		t.Skipf("bundled embedder unavailable: %v", err)
+	}
+	_ = probe.Close()
+
+	t.Setenv("SENSE_EMBEDDINGS", "true")
+	t.Setenv("SENSE_WATCH", "false") // no Service → the one-shot embed is the fallback
+
+	// A real repo on disk with outstanding embedding debt (scanned with
+	// embeddings off), so the fallback's EmbedPending has source to embed.
+	repo := scantest.NewRepo(t, map[string]string{
+		"main.go": "package main\n\nfunc Hello() {}\n",
+	})
+	repo.Scan(scan.Options{})
+
+	s, _, cleanup, err := buildMCPServer(RunOptions{Dir: repo.Root})
+	if err != nil {
+		t.Fatalf("buildMCPServer: %v", err)
+	}
+	defer cleanup()
+	if s == nil {
+		t.Fatal("expected a server")
+	}
+
+	// Let the fallback embed drain the debt before cleanup cancels its
+	// context, so the success path (load + upgrade search in place) runs
+	// rather than the cancel branch. We assert the observable outcome — debt
+	// reaches zero — not the timing of the in-place SetVectors upgrade.
+	waitForEmbedDebtZero(t, repo.Root)
+}
+
+// waitForEmbedDebtZero polls the index until the embedding debt drains to
+// zero, proving the background embed committed. It opens its own read
+// connection so it observes the embed goroutine's WAL writes.
+func waitForEmbedDebtZero(t *testing.T, dir string) {
+	t.Helper()
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(dir, ".sense", "index.db"))
+	if err != nil {
+		t.Fatalf("open for debt poll: %v", err)
+	}
+	defer func() { _ = a.Close() }()
+
+	deadline := time.After(15 * time.Second)
+	for {
+		n, err := a.EmbeddingDebtCount(ctx)
+		if err == nil && n == 0 {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("embedding debt did not drain (last count err=%v)", err)
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+}
+
+// TestBuildMCPServerDefaultsDirToCWD covers the empty-Dir branch: when Dir is
+// blank, buildMCPServer falls back to the working directory.
+func TestBuildMCPServerDefaultsDirToCWD(t *testing.T) {
+	hermeticEnv(t)
+
+	repo := scantest.NewRepo(t, map[string]string{
+		"main.go": "package main\n\nfunc Hello() {}\n",
+	})
+	repo.Scan(scan.Options{})
+	t.Chdir(repo.Root)
+
+	s, _, cleanup, err := buildMCPServer(RunOptions{Dir: ""})
+	if err != nil {
+		t.Fatalf("buildMCPServer with empty Dir: %v", err)
+	}
+	defer cleanup()
+	if s == nil {
+		t.Fatal("empty Dir should default to the working directory and build a server")
+	}
+}

--- a/internal/watch/run.go
+++ b/internal/watch/run.go
@@ -27,11 +27,54 @@ type RunOptions struct {
 	MCP               bool // co-host an MCP server alongside the watcher
 }
 
+// serviceRunner is the part of *freshen.Service that Run drives: start the
+// background freshening, stop it on shutdown. It exists only so a test can
+// substitute a fake and exercise process lifecycle (the co-host goroutine,
+// the start-error return, clean shutdown) without a live index or watcher.
+// Unexported: Run's public signature is unchanged and no test-only seam
+// leaks into the package API.
+type serviceRunner interface {
+	Start(context.Context) error
+	Stop()
+}
+
+// deps are Run's three live collaborators, injected so the lifecycle logic
+// is reachable without spinning up the real subsystems. Production wires the
+// real functions via defaultDeps; a test substitutes fakes. The struct is
+// unexported and defaulted inside Run, so the public Run(ctx, RunOptions)
+// signature carries no seam.
+type deps struct {
+	scan       func(context.Context, scan.Options) (*scan.Result, error)
+	newService func(freshen.Config) (serviceRunner, error)
+	runServer  func(mcpserver.RunOptions) error
+}
+
+// defaultDeps wires Run's collaborators to the real implementations.
+func defaultDeps() deps {
+	return deps{
+		scan: scan.Run,
+		newService: func(cfg freshen.Config) (serviceRunner, error) {
+			// NewService returns a nil *Service only alongside a non-nil
+			// error, and run checks the error first, so this never hands back
+			// a non-nil interface wrapping a typed-nil pointer.
+			return freshen.NewService(cfg)
+		},
+		runServer: mcpserver.RunWithOptions,
+	}
+}
+
 // Run performs an initial full scan, then starts a freshen.Service to keep
 // the index current. When MCP is set it also co-hosts an MCP server,
 // sharing the watch state so the server reports watching status and skips
 // starting its own watcher. Blocks until SIGINT/SIGTERM or ctx cancel.
 func Run(ctx context.Context, opts RunOptions) error {
+	return run(ctx, opts, defaultDeps())
+}
+
+// run is Run's testable core: identical lifecycle, but every live
+// collaborator arrives through d so a test can drive the co-host goroutine,
+// the initial-scan-error return, and signal-driven shutdown with fakes.
+func run(ctx context.Context, opts RunOptions, d deps) error {
 	root := opts.Root
 	if root == "" {
 		root = "."
@@ -45,7 +88,7 @@ func Run(ctx context.Context, opts RunOptions) error {
 	log("sense: watch mode starting (root=%s)", root)
 
 	log("sense: initial scan...")
-	initialRes, err := scan.Run(ctx, scan.Options{
+	initialRes, err := d.scan(ctx, scan.Options{
 		Root:              root,
 		Output:            os.Stderr,
 		Warnings:          os.Stderr,
@@ -63,7 +106,7 @@ func Run(ctx context.Context, opts RunOptions) error {
 	// signal the server uses to defer watching to this process.
 	ws := &mcpio.WatchState{}
 
-	svc, err := freshen.NewService(freshen.Config{
+	svc, err := d.newService(freshen.Config{
 		Root:              root,
 		EmbeddingsEnabled: opts.EmbeddingsEnabled,
 		WatchState:        ws,
@@ -81,7 +124,7 @@ func Run(ctx context.Context, opts RunOptions) error {
 	// state, so its WatchState != nil guard makes it skip its own watcher.
 	if opts.MCP {
 		go func() {
-			if err := mcpserver.RunWithOptions(mcpserver.RunOptions{
+			if err := d.runServer(mcpserver.RunOptions{
 				Dir:        root,
 				WatchState: ws,
 			}); err != nil {

--- a/internal/watch/run_test.go
+++ b/internal/watch/run_test.go
@@ -2,10 +2,16 @@ package watch
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
+
+	"github.com/luuuc/sense/internal/freshen"
+	"github.com/luuuc/sense/internal/mcpserver"
+	"github.com/luuuc/sense/internal/scan"
 )
 
 func TestRunOptionsDefaults(t *testing.T) {
@@ -21,9 +27,11 @@ func TestRunOptionsDefaults(t *testing.T) {
 	}
 }
 
-// TestRunInitializesAndExits verifies that Run performs its initialization
-// (initial scan, service start) and then exits cleanly when the context is
-// cancelled.
+// TestRunInitializesAndExits verifies that the real Run wiring performs its
+// initialization (initial scan, service start) end to end and then exits
+// cleanly when the context is cancelled. This drives defaultDeps so the
+// production scan + freshen.Service path stays exercised alongside the
+// fake-driven lifecycle tests below.
 func TestRunInitializesAndExits(t *testing.T) {
 	dir := t.TempDir()
 
@@ -42,5 +50,200 @@ func TestRunInitializesAndExits(t *testing.T) {
 	err := Run(ctx, RunOptions{Root: dir})
 	if err != nil {
 		t.Fatalf("Run error: %v", err)
+	}
+}
+
+// fakeService stands in for *freshen.Service so the lifecycle tests drive
+// Run's orchestration without a real index, watcher, or write adapter.
+type fakeService struct {
+	startErr error
+	started  bool
+	stopped  bool
+}
+
+func (f *fakeService) Start(context.Context) error { f.started = true; return f.startErr }
+func (f *fakeService) Stop()                       { f.stopped = true }
+
+// okScan is a no-op initial scan that reports success.
+func okScan(context.Context, scan.Options) (*scan.Result, error) {
+	return &scan.Result{}, nil
+}
+
+// TestRunInitialScanError returns the wrapped scan error and never reaches
+// service creation.
+func TestRunInitialScanError(t *testing.T) {
+	wantErr := errors.New("boom")
+	newServiceCalled := false
+	d := deps{
+		scan: func(context.Context, scan.Options) (*scan.Result, error) {
+			return nil, wantErr
+		},
+		newService: func(freshen.Config) (serviceRunner, error) {
+			newServiceCalled = true
+			return &fakeService{}, nil
+		},
+		runServer: func(mcpserver.RunOptions) error { return nil },
+	}
+
+	// Empty Root also exercises the default-to-"." branch; the scan fails
+	// before any filesystem work, so no real index is needed.
+	err := run(context.Background(), RunOptions{Root: ""}, d)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("run error = %v, want wrapped %v", err, wantErr)
+	}
+	if newServiceCalled {
+		t.Error("newService must not be called after an initial-scan failure")
+	}
+}
+
+// TestRunNewServiceError surfaces a service-construction failure.
+func TestRunNewServiceError(t *testing.T) {
+	wantErr := errors.New("no index")
+	d := deps{
+		scan: okScan,
+		newService: func(freshen.Config) (serviceRunner, error) {
+			return nil, wantErr
+		},
+		runServer: func(mcpserver.RunOptions) error { return nil },
+	}
+
+	err := run(context.Background(), RunOptions{Root: t.TempDir()}, d)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("run error = %v, want %v", err, wantErr)
+	}
+}
+
+// TestRunServiceStartError surfaces a Start failure and does not leave the
+// service stopped (Start failed before the defer was armed).
+func TestRunServiceStartError(t *testing.T) {
+	wantErr := errors.New("start failed")
+	fake := &fakeService{startErr: wantErr}
+	d := deps{
+		scan:       okScan,
+		newService: func(freshen.Config) (serviceRunner, error) { return fake, nil },
+		runServer:  func(mcpserver.RunOptions) error { return nil },
+	}
+
+	err := run(context.Background(), RunOptions{Root: t.TempDir()}, d)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("run error = %v, want %v", err, wantErr)
+	}
+	if fake.stopped {
+		t.Error("Stop must not run when Start failed")
+	}
+}
+
+// TestRunCoHostsAndShutsDownCleanly drives the co-host goroutine and a
+// context-cancel shutdown with fakes, and asserts a zero goroutine-leak: the
+// MCP co-host goroutine the orchestrator spawned has fully unwound after Run
+// returns. The fake runServer blocks on the test context exactly as
+// ServeStdio blocks on stdin, so cancellation unwinds deterministically.
+func TestRunCoHostsAndShutsDownCleanly(t *testing.T) {
+	base := runtime.NumGoroutine()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	started := make(chan struct{})
+	serverReturned := make(chan struct{})
+	fake := &fakeService{}
+	d := deps{
+		scan:       okScan,
+		newService: func(freshen.Config) (serviceRunner, error) { return fake, nil },
+		runServer: func(mcpserver.RunOptions) error {
+			close(started)
+			<-ctx.Done() // mirror ServeStdio blocking until shutdown
+			close(serverReturned)
+			return nil
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- run(ctx, RunOptions{Root: t.TempDir(), MCP: true}, d) }()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("co-host server was never started")
+	}
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("run returned error on clean shutdown: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not shut down after cancel")
+	}
+
+	select {
+	case <-serverReturned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("co-host goroutine did not exit")
+	}
+
+	if !fake.started {
+		t.Error("service Start was not called")
+	}
+	if !fake.stopped {
+		t.Error("service Stop was not called on shutdown")
+	}
+	assertNoLeak(t, base)
+}
+
+// TestRunCoHostServerErrorTriggersShutdown covers the co-host goroutine's
+// error branch: when the MCP server returns an error, the goroutine cancels
+// the run context, so Run unwinds and stops the service.
+func TestRunCoHostServerErrorTriggersShutdown(t *testing.T) {
+	base := runtime.NumGoroutine()
+
+	fake := &fakeService{}
+	d := deps{
+		scan:       okScan,
+		newService: func(freshen.Config) (serviceRunner, error) { return fake, nil },
+		runServer: func(mcpserver.RunOptions) error {
+			return errors.New("mcp server crashed")
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- run(context.Background(), RunOptions{Root: t.TempDir(), MCP: true}, d)
+	}()
+
+	select {
+	case err := <-done:
+		// The goroutine's cancel() drives a clean shutdown, so Run returns nil.
+		if err != nil {
+			t.Fatalf("run returned error, want nil after co-host self-cancel: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("co-host server error did not trigger shutdown")
+	}
+
+	if !fake.stopped {
+		t.Error("service Stop was not called after co-host error")
+	}
+	assertNoLeak(t, base)
+}
+
+// assertNoLeak polls until the live goroutine count returns to base, failing
+// if the orchestrator leaked the goroutines it was meant to manage. Polling
+// (rather than a single read) absorbs scheduler settle without asserting on
+// timing.
+func assertNoLeak(t *testing.T, base int) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for {
+		if runtime.NumGoroutine() <= base {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Errorf("goroutine leak: have %d, want <= %d", runtime.NumGoroutine(), base)
+			return
+		case <-time.After(10 * time.Millisecond):
+		}
 	}
 }


### PR DESCRIPTION
## Problem
The long-running edges where Sense meets the real world — the `sense scan --watch` process, the MCP server bootstrap, and the file watcher — were the least covered code in the tree because they hard-wired their collaborators inline. The watch orchestration (the co-host goroutine, clean shutdown), the server's upgrade-time schema rebuild, and the watcher's OS-error branches could not run without three live subsystems, so none of them were tested.

## Summary
Invert those edges so their logic is reachable offline, and cover the bug-prone branches with real temp resources rather than mocks of the OS.

## Changes
- **watch**: introduce an unexported `deps` seam (a narrow `serviceRunner` interface plus injected scan/newService/runServer funcs), defaulted inside `Run`. The public `Run(ctx, RunOptions)` signature is unchanged. Fakes drive the co-host goroutine, both error returns, and a context-cancel shutdown that asserts a zero goroutine-leak. `run.go` 72.4% → 100%.
- **freshen**: a real temp-dir `fsnotify` harness covers the watcher, git-head, lock, and service OS-error edges — including permission paths via `chmod 000` (root-guarded). 94.4% → 97.4%.
- **mcpserver**: drive `buildMCPServer` with `scantest` temp indexes in known states (schema-rebuild ONNX-free, model-mismatch warning, watcher-host, degrade, one-shot embed fallback). 59.3% → 85.2%; no production code moved.

## Architecture Highlights
- The `watch.Run` seam is package-private — no exported symbol gains a test-only parameter. The fake `runServer` blocks on the test context exactly as `ServeStdio` blocks on stdin, so shutdown unwinds with production topology.
- Irreducible OS-error branches (fsnotify-constructor failures, post-`O_EXCL` write/close, a Unix `FindProcess` that never errors) are left uncovered and documented, not faked.

## Test Plan
- [x] `go test ./...` passes (hermetic, offline)
- [x] `make ci` green — total coverage 92.4% (floor 91%), lint 0 issues
- [x] `-race` clean on the watch and freshen packages
- [x] `sense mcp` over stdio verified end-to-end against a real repo
- [x] sense binary builds cleanly