### PR TITLE
fix(conventions): make example ordering deterministic

### DIFF
--- a/internal/conventions/conventions_test.go
+++ b/internal/conventions/conventions_test.go
@@ -407,7 +407,7 @@ func TestPickRepresentatives(t *testing.T) {
 			{Name: "C", Path: "c", EdgeCount: 5},
 			{Name: "D", Path: "d", EdgeCount: 1},
 		}, 3, []string{"B", "C", "A"}},
-		{"zero edge counts preserves input order", []Example{
+		{"zero edge counts sort by name ascending", []Example{
 			{Name: "A", Path: "a"}, {Name: "B", Path: "b"}, {Name: "C", Path: "c"},
 			{Name: "D", Path: "d"}, {Name: "E", Path: "e"}, {Name: "F", Path: "f"},
 		}, 3, []string{"A", "B", "C"}},

--- a/internal/conventions/detectors_framework.go
+++ b/internal/conventions/detectors_framework.go
@@ -124,7 +124,7 @@ func detectRailsCallbacks(symbols []symbolRow, _ []edgeRow, _ map[int64]symbolRo
 		return nil
 	}
 	sort.Slice(examples, func(i, j int) bool {
-		return examples[i].EdgeCount > examples[j].EdgeCount
+		return lessExample(examples[i], examples[j])
 	})
 	totalClasses := countByKind(symbols, "class")
 	return []Convention{{
@@ -144,7 +144,7 @@ func detectScopes(symbols []symbolRow, edges []edgeRow, symbolByID map[int64]sym
 		return nil
 	}
 	sort.Slice(examples, func(i, j int) bool {
-		return examples[i].EdgeCount > examples[j].EdgeCount
+		return lessExample(examples[i], examples[j])
 	})
 	totalClasses := countByKind(symbols, "class")
 	return []Convention{{

--- a/internal/conventions/detectors_generic.go
+++ b/internal/conventions/detectors_generic.go
@@ -472,7 +472,14 @@ func detectKeyTypes(symbols []symbolRow, edges []edgeRow, filePathByID map[int64
 	}
 
 	sort.Slice(candidates, func(i, j int) bool {
-		return candidates[i].count > candidates[j].count
+		a, b := candidates[i], candidates[j]
+		if a.count != b.count {
+			return a.count > b.count
+		}
+		if a.sym.name != b.sym.name {
+			return a.sym.name < b.sym.name
+		}
+		return a.path < b.path
 	})
 
 	const maxKeyTypes = 8

--- a/internal/conventions/detectors_go.go
+++ b/internal/conventions/detectors_go.go
@@ -94,7 +94,7 @@ func detectGoMiddleware(symbols []symbolRow, edges []edgeRow, symbolByID map[int
 		return nil
 	}
 	sort.Slice(factories, func(i, j int) bool {
-		return factories[i].EdgeCount > factories[j].EdgeCount
+		return lessExample(factories[i], factories[j])
 	})
 	totalFuncs := countByKind(symbols, "function")
 	return []Convention{{

--- a/internal/conventions/example_order_test.go
+++ b/internal/conventions/example_order_test.go
@@ -1,0 +1,196 @@
+package conventions
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestLessExampleStrictWeakOrdering exercises each branch of the shared
+// EdgeCount → Name → Path cascade and confirms it is a strict weak ordering:
+// irreflexive (a is not less than itself) and antisymmetric (a<b and b<a are
+// never both true). Each branch is checked in isolation so a regression in one
+// tier cannot hide behind another.
+func TestLessExampleStrictWeakOrdering(t *testing.T) {
+	hi := Example{Name: "M", Path: "m", EdgeCount: 10}
+	lo := Example{Name: "M", Path: "m", EdgeCount: 1}
+	// EdgeCount branch: higher count sorts first.
+	if !lessExample(hi, lo) || lessExample(lo, hi) {
+		t.Errorf("EdgeCount branch broken: less(hi,lo)=%v less(lo,hi)=%v", lessExample(hi, lo), lessExample(lo, hi))
+	}
+
+	nameA := Example{Name: "A", Path: "z", EdgeCount: 5}
+	nameB := Example{Name: "B", Path: "a", EdgeCount: 5}
+	// Name branch: equal EdgeCount falls through to Name ascending (Path ignored).
+	if !lessExample(nameA, nameB) || lessExample(nameB, nameA) {
+		t.Errorf("Name branch broken: less(A,B)=%v less(B,A)=%v", lessExample(nameA, nameB), lessExample(nameB, nameA))
+	}
+
+	pathA := Example{Name: "X", Path: "a", EdgeCount: 5}
+	pathB := Example{Name: "X", Path: "b", EdgeCount: 5}
+	// Path branch: equal EdgeCount and Name falls through to Path ascending.
+	if !lessExample(pathA, pathB) || lessExample(pathB, pathA) {
+		t.Errorf("Path branch broken: less(a,b)=%v less(b,a)=%v", lessExample(pathA, pathB), lessExample(pathB, pathA))
+	}
+
+	// Irreflexive: nothing is less than itself.
+	if lessExample(pathA, pathA) {
+		t.Error("lessExample(x, x) must be false")
+	}
+}
+
+// TestDetectRailsCallbacksExampleOrder pins detectRailsCallbacks' own output
+// order over a fixture where three classes tie on EdgeCount (two callbacks
+// each), so the cascade must fall through to Name ascending. The classes are
+// fed in non-alphabetical order so map iteration alone would not produce the
+// asserted result.
+func TestDetectRailsCallbacksExampleOrder(t *testing.T) {
+	p := func(id int64) *int64 { return &id }
+	symbols := []symbolRow{
+		{id: 1, fileID: 101, name: "Zebra", kind: "class"},
+		{id: 2, fileID: 102, name: "Apple", kind: "class"},
+		{id: 3, fileID: 103, name: "Mango", kind: "class"},
+		{id: 11, fileID: 101, name: "before_save", kind: "method", parentID: p(1)},
+		{id: 12, fileID: 101, name: "after_save", kind: "method", parentID: p(1)},
+		{id: 21, fileID: 102, name: "before_save", kind: "method", parentID: p(2)},
+		{id: 22, fileID: 102, name: "after_save", kind: "method", parentID: p(2)},
+		{id: 31, fileID: 103, name: "before_save", kind: "method", parentID: p(3)},
+		{id: 32, fileID: 103, name: "after_save", kind: "method", parentID: p(3)},
+	}
+	filePathByID := map[int64]string{101: "zebra.rb", 102: "apple.rb", 103: "mango.rb"}
+
+	out := detectRailsCallbacks(symbols, nil, indexSymbols(symbols), filePathByID)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 convention, got %d", len(out))
+	}
+	got := exampleNames(out[0].Examples)
+	want := []string{"Apple", "Mango", "Zebra"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("callback example order = %v, want %v (EdgeCount tie → Name asc)", got, want)
+	}
+}
+
+// TestDetectScopesExampleOrder pins detectScopes' order over three classes that
+// tie on scope count, asserting the Name-ascending fall-through.
+func TestDetectScopesExampleOrder(t *testing.T) {
+	p := func(id int64) *int64 { return &id }
+	symbols := []symbolRow{
+		{id: 1, fileID: 101, name: "Zebra", kind: "class"},
+		{id: 2, fileID: 102, name: "Apple", kind: "class"},
+		{id: 3, fileID: 103, name: "Mango", kind: "class"},
+		{id: 11, fileID: 101, name: "active", kind: "method", parentID: p(1)},
+		{id: 12, fileID: 101, name: "recent", kind: "method", parentID: p(1)},
+		{id: 21, fileID: 102, name: "active", kind: "method", parentID: p(2)},
+		{id: 22, fileID: 102, name: "recent", kind: "method", parentID: p(2)},
+		{id: 31, fileID: 103, name: "active", kind: "method", parentID: p(3)},
+		{id: 32, fileID: 103, name: "recent", kind: "method", parentID: p(3)},
+	}
+	filePathByID := map[int64]string{101: "zebra.rb", 102: "apple.rb", 103: "mango.rb"}
+	// Each class calls its own scope methods, marking them scope targets.
+	edges := []edgeRow{
+		{sourceID: 1, targetID: 11, kind: "calls"}, {sourceID: 1, targetID: 12, kind: "calls"},
+		{sourceID: 2, targetID: 21, kind: "calls"}, {sourceID: 2, targetID: 22, kind: "calls"},
+		{sourceID: 3, targetID: 31, kind: "calls"}, {sourceID: 3, targetID: 32, kind: "calls"},
+	}
+
+	out := detectScopes(symbols, edges, indexSymbols(symbols), filePathByID)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 convention, got %d", len(out))
+	}
+	got := exampleNames(out[0].Examples)
+	want := []string{"Apple", "Mango", "Zebra"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("scope example order = %v, want %v (EdgeCount tie → Name asc)", got, want)
+	}
+}
+
+// TestDetectGoMiddlewareExampleOrder pins detectGoMiddleware's order over three
+// factories that tie on call count, asserting the Name-ascending fall-through.
+func TestDetectGoMiddlewareExampleOrder(t *testing.T) {
+	symbols := []symbolRow{
+		{id: 1, fileID: 10, name: "Use", kind: "method"},
+		{id: 2, fileID: 11, name: "Zlog", kind: "function"},
+		{id: 3, fileID: 12, name: "Auth", kind: "function"},
+		{id: 4, fileID: 13, name: "Cors", kind: "function"},
+	}
+	filePathByID := map[int64]string{10: "router.go", 11: "zlog.go", 12: "auth.go", 13: "cors.go"}
+	// Each factory is called twice by the router, so all three tie on count.
+	edges := []edgeRow{
+		{sourceID: 1, targetID: 2, kind: "calls"}, {sourceID: 1, targetID: 2, kind: "calls"},
+		{sourceID: 1, targetID: 3, kind: "calls"}, {sourceID: 1, targetID: 3, kind: "calls"},
+		{sourceID: 1, targetID: 4, kind: "calls"}, {sourceID: 1, targetID: 4, kind: "calls"},
+	}
+
+	out := detectGoMiddleware(symbols, edges, indexSymbols(symbols), filePathByID)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 convention, got %d", len(out))
+	}
+	got := exampleNames(out[0].Examples)
+	want := []string{"Auth", "Cors", "Zlog"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("middleware example order = %v, want %v (EdgeCount tie → Name asc)", got, want)
+	}
+}
+
+// TestSortExamplesPathThenName pins the Path-first exception: examples group by
+// Path ascending, and same-Path examples fall through to Name ascending. The
+// input is ordered so a Path-only sort would leave the same-Path pair in the
+// wrong order, making this fail before the Name tiebreak was added.
+func TestSortExamplesPathThenName(t *testing.T) {
+	examples := []Example{
+		{Name: "Zeta", Path: "a.go"},
+		{Name: "Alpha", Path: "a.go"},
+		{Name: "Mid", Path: "b.go"},
+	}
+	sortExamples(examples)
+	got := exampleNames(examples)
+	want := []string{"Alpha", "Zeta", "Mid"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("sortExamples order = %v, want %v (Path asc, then Name asc)", got, want)
+	}
+}
+
+// TestDetectKeyTypesCandidateOrder pins the count → name → path cascade on
+// detectKeyTypes' candidate sort. Three types tie on reference count, so the
+// fall-through to Name ascending must hold; a same-named pair in two files
+// proves the Path tier decides which file's type surfaces (a.go over z.go). The
+// symbols are fed in a non-sorted order so a count-only sort would fail.
+func TestDetectKeyTypesCandidateOrder(t *testing.T) {
+	symbols := []symbolRow{
+		{id: 1, fileID: 10, name: "Zeta", kind: "struct"},
+		{id: 2, fileID: 11, name: "Alpha", kind: "struct"},
+		{id: 3, fileID: 12, name: "Order", kind: "struct"}, // z.go
+		{id: 4, fileID: 13, name: "Order", kind: "struct"}, // a.go
+	}
+	filePathByID := map[int64]string{10: "zeta.go", 11: "alpha.go", 12: "z.go", 13: "a.go"}
+	// Two inbound edges per type, so all four candidates tie on count.
+	edges := []edgeRow{
+		{sourceID: 99, targetID: 1, kind: "calls"}, {sourceID: 98, targetID: 1, kind: "calls"},
+		{sourceID: 99, targetID: 2, kind: "calls"}, {sourceID: 98, targetID: 2, kind: "calls"},
+		{sourceID: 99, targetID: 3, kind: "calls"}, {sourceID: 98, targetID: 3, kind: "calls"},
+		{sourceID: 99, targetID: 4, kind: "calls"}, {sourceID: 98, targetID: 4, kind: "calls"},
+	}
+
+	out := detectKeyTypes(symbols, edges, filePathByID, nil)
+	if len(out) != 1 {
+		t.Fatalf("expected 1 convention, got %d", len(out))
+	}
+	got := exampleNames(out[0].Examples)
+	want := []string{"Alpha", "Order", "Zeta"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("key-type example order = %v, want %v (count tie → name asc)", got, want)
+	}
+	// The Path tier broke the "Order" name tie: a.go wins over z.go.
+	for _, e := range out[0].Examples {
+		if e.Name == "Order" && e.Path != "a.go" {
+			t.Errorf("Order surfaced from %q, want a.go (Path tiebreak)", e.Path)
+		}
+	}
+}
+
+func exampleNames(examples []Example) []string {
+	names := make([]string, len(examples))
+	for i, e := range examples {
+		names[i] = e.Name
+	}
+	return names
+}

--- a/internal/conventions/helpers.go
+++ b/internal/conventions/helpers.go
@@ -67,20 +67,47 @@ func hasMatchingExample(examples []Example, domain string) bool {
 	return false
 }
 
+// sortExamples orders examples for alphabetical grouping by Path, with a Name
+// tiebreak so same-Path examples have a defined order. It is Path-first by
+// intent (the one exception to the EdgeCount-first lessExample family), so it
+// keeps its own inline cascade rather than sharing lessExample.
 func sortExamples(examples []Example) {
 	sort.Slice(examples, func(i, j int) bool {
-		return examples[i].Path < examples[j].Path
+		a, b := examples[i], examples[j]
+		if a.Path != b.Path {
+			return a.Path < b.Path
+		}
+		return a.Name < b.Name
 	})
+}
+
+// lessExample is the shared EdgeCount-first total order for ranking examples by
+// importance: EdgeCount descending, then Name ascending, then Path ascending.
+// Every cascade falls through on equality so sort.Slice is well-defined (strict
+// weak ordering). This is the single correct cascade for the EdgeCount-first
+// sites to copy; sortExamples (Path-first) keeps its own shape by intent.
+func lessExample(a, b Example) bool {
+	if a.EdgeCount != b.EdgeCount {
+		return a.EdgeCount > b.EdgeCount
+	}
+	if a.Name != b.Name {
+		return a.Name < b.Name
+	}
+	return a.Path < b.Path
 }
 
 func PickRepresentatives(examples []Example, limit int) []string {
 	if len(examples) == 0 {
 		return nil
 	}
-	sorted := make([]Example, len(examples))
-	copy(sorted, examples)
-	sort.SliceStable(sorted, func(i, j int) bool {
-		return sorted[i].EdgeCount > sorted[j].EdgeCount
+	// Dedupe by Name+Path so the sort below is a true total order: detectNaming
+	// emits many examples sharing a (Name, Path), and enrichEdgeCounts collapses
+	// them to the same EdgeCount, so EdgeCount/Name/Path can all tie and a bare
+	// tiebreak would still leave map order showing. Dedupe makes Name+Path unique
+	// by construction, then sort EdgeCount → Name → Path.
+	sorted := dedupeExamples(examples)
+	sort.Slice(sorted, func(i, j int) bool {
+		return lessExample(sorted[i], sorted[j])
 	})
 	n := limit
 	if n > len(sorted) {

--- a/internal/conventions/representatives_test.go
+++ b/internal/conventions/representatives_test.go
@@ -1,0 +1,48 @@
+package conventions
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestPickRepresentativesDropsRepeatedNames models the dominant maket defect:
+// detectNaming emits many examples sharing a (Name, Path) — e.g. *_bar.html.erb,
+// where one name repeats with the same enriched EdgeCount. Before dedupe the
+// top-3 showed the same name three times; after dedupe the repeats collapse and
+// the next distinct names surface into the window. The input is ordered so the
+// pre-fix SliceStable-by-EdgeCount returns the repeats deterministically, making
+// this a reliable (not flaky) regression.
+func TestPickRepresentativesDropsRepeatedNames(t *testing.T) {
+	examples := []Example{
+		{Name: "_horizontal_bar", Path: "a.erb", EdgeCount: 5},
+		{Name: "_horizontal_bar", Path: "a.erb", EdgeCount: 5},
+		{Name: "_horizontal_bar", Path: "a.erb", EdgeCount: 5},
+		{Name: "_vertical_bar", Path: "b.erb", EdgeCount: 5},
+		{Name: "_priority_actions", Path: "c.erb", EdgeCount: 3},
+	}
+	got := PickRepresentatives(examples, 3)
+	want := []string{"_horizontal_bar", "_vertical_bar", "_priority_actions"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("PickRepresentatives = %v, want %v (no repeated names, distinct names surfaced)", got, want)
+	}
+}
+
+// TestPickRepresentativesTiebreak asserts the EdgeCount → Name → Path cascade
+// for distinct examples that share an EdgeCount: equal weight falls through to
+// Name ascending, and equal (EdgeCount, Name) falls through to Path ascending.
+func TestPickRepresentativesTiebreak(t *testing.T) {
+	examples := []Example{
+		{Name: "User", Path: "z.go", EdgeCount: 10},
+		{Name: "Dup", Path: "b.go", EdgeCount: 10},
+		{Name: "Item", Path: "a.go", EdgeCount: 10},
+		{Name: "Dup", Path: "a.go", EdgeCount: 10},
+		{Name: "Order", Path: "m.go", EdgeCount: 7},
+	}
+	got := PickRepresentatives(examples, 5)
+	// EdgeCount desc: the four 10s before the 7. Among the 10s, Name asc puts the
+	// two "Dup" first, broken by Path asc (a.go before b.go), then Item, then User.
+	want := []string{"Dup", "Dup", "Item", "User", "Order"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("PickRepresentatives = %v, want %v", got, want)
+	}
+}

--- a/internal/mcpserver/oracle_test.go
+++ b/internal/mcpserver/oracle_test.go
@@ -158,7 +158,7 @@ func oracleDigest(t *testing.T, calls []labeledCall) (string, []string) {
 // not computed at runtime: a behavior-preserving split must leave it unchanged.
 // When a response changes on purpose, run the test with -v, copy the logged
 // digest here, and update it in the same commit.
-const oracleGolden = "da4fa4f45680b6b647dac0f42f499408986cba204ed4c1060c308e7bc5125b7d"
+const oracleGolden = "f432b5297d85bb445e5986024e6a7146b27b235ef354a2eb5c16968c04a21e49"
 
 func TestMCPServerResponseOracle(t *testing.T) {
 	got, content := oracleDigest(t, collectOracleCalls(t))


### PR DESCRIPTION
## Problem

`sense conventions` output was not byte-stable run-to-run: on an unchanged index, the representative example names shown in each convention's description and `instances` array flickered between queries. An AI consumer cannot cache or trust an answer whose wording changes on re-query, and every conventions refactor pays a tax because behavior cannot be checked with a byte oracle.

The root cause was single-key sorts fed by Go map iteration. The load-bearing sort (`PickRepresentatives`) ranked by `EdgeCount` alone with `sort.SliceStable`, but "stable" only preserves input order, which arrives from map iteration. Worse, the underlying examples were not a total order even with a tiebreak: `detectNaming` emits many examples sharing a `(Name, Path)` that `enrichEdgeCounts` collapses to the same `EdgeCount`, so all three keys could tie.

## Summary

Make the one observable sort a true total order via dedupe-then-sort, and regression-proof the remaining example sorts so no site is left as a single-key trap.

## Changes

- **`PickRepresentatives`** (the sole determinant of visible output): dedupe by `Name`+`Path` (reusing `dedupeExamples`), then sort `EdgeCount` desc → `Name` asc → `Path` asc; `sort.SliceStable` → `sort.Slice`. Dedupe is required, not just a tiebreak, because the duplicates tie on all three keys.
- **Shared `lessExample` comparator**: extracted once and applied to the four `EdgeCount`-first sites (`PickRepresentatives`, `detectRailsCallbacks`, `detectScopes`, `detectGoMiddleware`) so there is one correct cascade to copy.
- **The two exceptions** keep their own shapes by intent: `sortExamples` gains a `Name` tiebreak (`Path` → `Name`); `detectKeyTypes`' candidate sort gains `count` → `name` → `path`.
- **Oracle re-pin**: the `mcpserver` response oracle golden is updated in the same commit, since the fixture's conventions ordering legitimately changes with the fix.
- **Tests**: per-site order assertions over tied fixtures (`representatives_test.go`, `example_order_test.go`), including a duplicate-name fixture that fails before the dedupe and a strict-weak-ordering unit test for `lessExample`.

## Behavior change (intended, scoped)

Counts, strengths, categories, and which conventions are detected are unchanged (`Instances`/`Total` untouched). What changes is which representative names surface: repeated names in the top-3 collapse and previously-hidden distinct names appear. Verified against a live Rails index: 506 conventions before and after with identical category/strength/total_instances, and `conventions --json` now byte-identical across repeated runs (it flickered before).

## Test Plan

- [x] `go test ./internal/conventions/...` passes (per-site order tests + `lessExample` strict-weak-ordering)
- [x] `mcpserver` response oracle re-pinned and stable across 3 runs
- [x] `make ci` green (coverage gate PASS, lint 0 issues)
- [x] Verified on a live external index: byte-stable output, no change to counts/strengths/categories
- [x] sense binary builds cleanly