### PR TITLE
fix(conventions): disambiguate repeated representative labels

### DIFF
--- a/internal/cli/conventions.go
+++ b/internal/cli/conventions.go
@@ -83,7 +83,7 @@ func RunConventions(args []string, cio IO) int {
 				Category:       string(c.Category),
 				Description:    c.Description,
 				Strength:       mcpio.Confidence(c.Strength),
-				Instances:      conventions.PickRepresentatives(c.Examples, 3),
+				Instances:      conventions.RepresentativeLabels(c.Examples, 3),
 				TotalInstances: c.Instances,
 			}
 		}

--- a/internal/conventions/helpers.go
+++ b/internal/conventions/helpers.go
@@ -96,7 +96,12 @@ func lessExample(a, b Example) bool {
 	return a.Path < b.Path
 }
 
-func PickRepresentatives(examples []Example, limit int) []string {
+// pickRepresentatives is the shared pick: dedupe by Name+Path, sort by the
+// EdgeCount-first total order, and take the top `limit` examples. The two public
+// renderers build on it — PickRepresentatives projects the raw Names (a lookup
+// key into sense_symbols), RepresentativeLabels disambiguates collisions for
+// display. They must select the identical set, so the pick lives here once.
+func pickRepresentatives(examples []Example, limit int) []Example {
 	if len(examples) == 0 {
 		return nil
 	}
@@ -113,15 +118,146 @@ func PickRepresentatives(examples []Example, limit int) []string {
 	if n > len(sorted) {
 		n = len(sorted)
 	}
-	names := make([]string, n)
-	for i := 0; i < n; i++ {
-		names[i] = sorted[i].Name
+	return sorted[:n]
+}
+
+// PickRepresentatives returns the raw Names of the top representatives. These
+// are symbol/file names used as a lookup key (lookupInstanceSnippets keys on
+// sense_symbols.name), so they stay bare even when two share a name — use
+// RepresentativeLabels for anything shown to a reader.
+func PickRepresentatives(examples []Example, limit int) []string {
+	picked := pickRepresentatives(examples, limit)
+	if len(picked) == 0 {
+		return nil
+	}
+	names := make([]string, len(picked))
+	for i, e := range picked {
+		names[i] = e.Name
 	}
 	return names
 }
 
+// RepresentativeLabels returns display labels for the top representatives: bare
+// Name when unique within the picked set, else the Name with the shortest
+// trailing path segments that distinguish it from its same-named siblings, e.g.
+// "_add_modal.html.erb (categories/categorizations)". The same convention can
+// surface the same displayed name from several distinct files; a bare repeat
+// reads as one example shown N times rather than N real files.
+func RepresentativeLabels(examples []Example, limit int) []string {
+	picked := pickRepresentatives(examples, limit)
+	return disambiguateLabels(picked)
+}
+
 func topNames(examples []Example) string {
-	return strings.Join(PickRepresentatives(examples, maxDescriptionNames), ", ")
+	return strings.Join(RepresentativeLabels(examples, maxDescriptionNames), ", ")
+}
+
+// disambiguateLabels labels each picked example: bare Name when its Name is
+// unique in the set, else Name + " (suffix)" where suffix is the shortest
+// trailing directory segments of its Path that distinguish it from its
+// same-named siblings. dedupeExamples guarantees every picked example has a
+// distinct (Name, Path), so a group's full Paths are always distinct — when the
+// per-member dir suffixes still collide (a dir suffix and a full-Path fallback
+// live in different string spaces, so a shallow member's fallback can equal a
+// deeper sibling's suffix), escalateColliding relabels the whole group with full
+// Paths, guaranteeing every label in a group is unique.
+func disambiguateLabels(picked []Example) []string {
+	groups := make(map[string][]int, len(picked))
+	for i, e := range picked {
+		groups[e.Name] = append(groups[e.Name], i)
+	}
+	labels := make([]string, len(picked))
+	for i, e := range picked {
+		group := groups[e.Name]
+		if len(group) == 1 {
+			labels[i] = e.Name
+			continue
+		}
+		labels[i] = e.Name + " (" + uniqueDirSuffix(e.Path, siblingPaths(picked, group, i)) + ")"
+	}
+	escalateColliding(picked, groups, labels)
+	return labels
+}
+
+// siblingPaths returns the Paths of the group members other than i.
+func siblingPaths(picked []Example, group []int, i int) []string {
+	paths := make([]string, 0, len(group)-1)
+	for _, j := range group {
+		if j != i {
+			paths = append(paths, picked[j].Path)
+		}
+	}
+	return paths
+}
+
+// uniqueDirSuffix returns the shortest join of trailing directory segments of
+// target that no sibling shares at the same depth. The depth grows one segment
+// at a time (one segment is not always enough: two files can share a trailing
+// dir, e.g. .../categories/categorizations and .../navigations/categorizations).
+// If the directory segments are exhausted without distinguishing target — its
+// only dir suffix is shared by a deeper sibling, or a sibling differs only in
+// basename — the full target Path is returned as the fallback.
+func uniqueDirSuffix(target string, siblings []string) string {
+	segs := dirSegments(target)
+	for k := 1; k <= len(segs); k++ {
+		cand := suffixOf(segs, k)
+		collision := false
+		for _, s := range siblings {
+			other := dirSegments(s)
+			if len(other) >= k && suffixOf(other, k) == cand {
+				collision = true
+				break
+			}
+		}
+		if !collision {
+			return cand
+		}
+	}
+	return target
+}
+
+// escalateColliding is the airtight backstop. A dir-suffix label and a full-Path
+// fallback occupy different string spaces, so a shallow member's fallback can
+// still equal a deeper sibling's dir suffix (e.g. fallback "foo/bar" vs suffix
+// "foo/bar"). If any same-named group still holds a duplicate label, relabel that
+// whole group with full Paths, distinct by dedupeExamples. It only fires on the
+// rare residual collision, leaving the minimal dir-suffix labels untouched.
+func escalateColliding(picked []Example, groups map[string][]int, labels []string) {
+	for _, group := range groups {
+		if len(group) < 2 || labelsDistinct(group, labels) {
+			continue
+		}
+		for _, i := range group {
+			labels[i] = picked[i].Name + " (" + picked[i].Path + ")"
+		}
+	}
+}
+
+// labelsDistinct reports whether the labels at the given indices are all unique.
+func labelsDistinct(group []int, labels []string) bool {
+	seen := make(map[string]bool, len(group))
+	for _, i := range group {
+		if seen[labels[i]] {
+			return false
+		}
+		seen[labels[i]] = true
+	}
+	return true
+}
+
+// dirSegments splits the directory portion of a path into segments, dropping the
+// basename. A path with no directory (root-level file) yields no segments.
+func dirSegments(p string) []string {
+	dir := path.Dir(p)
+	if dir == "." || dir == "/" || dir == "" {
+		return nil
+	}
+	return strings.Split(strings.TrimPrefix(dir, "/"), "/")
+}
+
+// suffixOf joins the last k segments with "/".
+func suffixOf(segs []string, k int) string {
+	return strings.Join(segs[len(segs)-k:], "/")
 }
 
 func extractFileSuffix(basename string) string {

--- a/internal/conventions/representatives_test.go
+++ b/internal/conventions/representatives_test.go
@@ -2,6 +2,7 @@ package conventions
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -44,5 +45,192 @@ func TestPickRepresentativesTiebreak(t *testing.T) {
 	want := []string{"Dup", "Dup", "Item", "User", "Order"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("PickRepresentatives = %v, want %v", got, want)
+	}
+}
+
+// TestRepresentativeLabelsUniqueStayBare asserts the no-collision path: distinct
+// names render bare, with no parenthetical suffix.
+func TestRepresentativeLabelsUniqueStayBare(t *testing.T) {
+	examples := []Example{
+		{Name: "User", Path: "app/models/user.rb", EdgeCount: 10},
+		{Name: "Order", Path: "app/models/order.rb", EdgeCount: 9},
+		{Name: "Item", Path: "app/models/item.rb", EdgeCount: 8},
+	}
+	got := RepresentativeLabels(examples, 5)
+	want := []string{"User", "Order", "Item"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("RepresentativeLabels = %v, want %v", got, want)
+	}
+}
+
+// TestRepresentativeLabelsTwoSegmentCollision is the headline maket case: four
+// files share the basename Name _add_modal.html.erb. One trailing segment is
+// enough for the two that sit under unique dirs, but the two under a
+// categorizations/ dir must extend to a second segment to separate. The picked
+// set is ordered by the EdgeCount→Name→Path cascade, so equal-weight equal-name
+// examples emerge in Path-ascending order — the want order reflects that.
+func TestRepresentativeLabelsTwoSegmentCollision(t *testing.T) {
+	examples := []Example{
+		{Name: "_add_modal.html.erb", Path: "app/views/admin/catalog/categories/specifications/_add_modal.html.erb", EdgeCount: 4},
+		{Name: "_add_modal.html.erb", Path: "app/views/admin/catalog/categories/categorizations/_add_modal.html.erb", EdgeCount: 4},
+		{Name: "_add_modal.html.erb", Path: "app/views/admin/catalog/navigations/categorizations/_add_modal.html.erb", EdgeCount: 4},
+		{Name: "_add_modal.html.erb", Path: "app/views/admin/catalog/specification_definitions/specification_values/_add_modal.html.erb", EdgeCount: 4},
+	}
+	got := RepresentativeLabels(examples, 5)
+	want := []string{
+		"_add_modal.html.erb (categories/categorizations)",
+		"_add_modal.html.erb (specifications)",
+		"_add_modal.html.erb (navigations/categorizations)",
+		"_add_modal.html.erb (specification_values)",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("RepresentativeLabels =\n %v\nwant\n %v", got, want)
+	}
+}
+
+// TestRepresentativeLabelsSymbolCollision covers a symbol-name collision (same
+// class in two trees): one trailing segment collides (both "controllers"), so
+// the suffix extends to "app/controllers" vs "test/controllers".
+func TestRepresentativeLabelsSymbolCollision(t *testing.T) {
+	examples := []Example{
+		{Name: "AcceptancesController", Path: "app/controllers/acceptances_controller.rb", EdgeCount: 5},
+		{Name: "AcceptancesController", Path: "test/controllers/acceptances_controller.rb", EdgeCount: 5},
+	}
+	got := RepresentativeLabels(examples, 5)
+	want := []string{
+		"AcceptancesController (app/controllers)",
+		"AcceptancesController (test/controllers)",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("RepresentativeLabels = %v, want %v", got, want)
+	}
+}
+
+// TestRepresentativeLabelsPreserveSet is the no-counts-change property: labeling
+// is pure decoration over the picked set. For any input, RepresentativeLabels
+// selects exactly the same examples in the same order as PickRepresentatives —
+// each label is the raw name, optionally with a " (suffix)" appended, never a
+// drop, reorder, or substitution. This keeps Instances/Total honest: the four
+// colliding files stay four instances; only their displayed names change.
+func TestRepresentativeLabelsPreserveSet(t *testing.T) {
+	fixtures := [][]Example{
+		{
+			{Name: "User", Path: "app/models/user.rb", EdgeCount: 10},
+			{Name: "Order", Path: "app/models/order.rb", EdgeCount: 9},
+		},
+		{
+			{Name: "X", Path: "a/controllers/x.rb", EdgeCount: 5},
+			{Name: "X", Path: "b/controllers/x.rb", EdgeCount: 5},
+			{Name: "Y", Path: "c/y.rb", EdgeCount: 4},
+		},
+		{
+			{Name: "_modal.erb", Path: "views/a/categories/_modal.erb", EdgeCount: 3},
+			{Name: "_modal.erb", Path: "views/b/categories/_modal.erb", EdgeCount: 3},
+			{Name: "_modal.erb", Path: "views/c/_modal.erb", EdgeCount: 3},
+		},
+	}
+	for fi, examples := range fixtures {
+		names := PickRepresentatives(examples, 5)
+		labels := RepresentativeLabels(examples, 5)
+		if len(labels) != len(names) {
+			t.Fatalf("fixture %d: %d labels, %d names — set size changed", fi, len(labels), len(names))
+		}
+		for i, label := range labels {
+			base := label
+			if idx := strings.Index(label, " ("); idx >= 0 {
+				base = label[:idx]
+			}
+			if base != names[i] {
+				t.Errorf("fixture %d index %d: label %q has base %q, want raw name %q", fi, i, label, base, names[i])
+			}
+		}
+	}
+}
+
+// TestRepresentativeLabelsBasenameFallback covers siblings that share a Name and
+// an entire directory, differing only in basename. Directory segments cannot
+// distinguish them, so the rule falls back to the full Path — unique by
+// construction (dedupeExamples guarantees distinct (Name, Path)).
+func TestRepresentativeLabelsBasenameFallback(t *testing.T) {
+	examples := []Example{
+		{Name: "Widget", Path: "app/models/widget_a.rb", EdgeCount: 6},
+		{Name: "Widget", Path: "app/models/widget_b.rb", EdgeCount: 6},
+	}
+	got := RepresentativeLabels(examples, 5)
+	want := []string{
+		"Widget (app/models/widget_a.rb)",
+		"Widget (app/models/widget_b.rb)",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("RepresentativeLabels = %v, want %v", got, want)
+	}
+}
+
+// TestRepresentativeLabelsStrictSuffixDir covers a shallow member whose only dir
+// suffix is shared by a deeper sibling: "categorizations" (depth 1) sits inside
+// "categories/categorizations" (depth 2). The shallow member cannot extend, so it
+// falls back to its full Path; the deep member separates at depth 2. The labels
+// are unambiguous (no escalation), just asymmetric — this pins that degradation.
+func TestRepresentativeLabelsStrictSuffixDir(t *testing.T) {
+	examples := []Example{
+		{Name: "_modal.erb", Path: "categorizations/_modal.erb", EdgeCount: 3},
+		{Name: "_modal.erb", Path: "categories/categorizations/_modal.erb", EdgeCount: 3},
+	}
+	got := RepresentativeLabels(examples, 5)
+	// Path-ascending: "categories/..." sorts before "categorizations/..." ('e'<'z').
+	want := []string{
+		"_modal.erb (categories/categorizations)",
+		"_modal.erb (categorizations/_modal.erb)",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("RepresentativeLabels =\n %v\nwant\n %v", got, want)
+	}
+}
+
+// TestRepresentativeLabelsEscalatesCrossNamespaceCollision covers the residual
+// collision the escalation backstop exists for: a shallow member's full-Path
+// fallback ("foo/bar") equals a deeper member's dir suffix ("foo/bar"). Without
+// the backstop both would render "Thing (foo/bar)"; with it, the whole group
+// relabels to full Paths, which are distinct by construction.
+func TestRepresentativeLabelsEscalatesCrossNamespaceCollision(t *testing.T) {
+	examples := []Example{
+		{Name: "Thing", Path: "foo/bar", EdgeCount: 1},
+		{Name: "Thing", Path: "p/foo/bar/qux.go", EdgeCount: 1},
+		{Name: "Thing", Path: "x/foo/baz.go", EdgeCount: 1},
+		{Name: "Thing", Path: "z/bar/m.go", EdgeCount: 1},
+	}
+	got := RepresentativeLabels(examples, 5)
+	// Path-ascending order; every member shown as its full Path, all distinct.
+	want := []string{
+		"Thing (foo/bar)",
+		"Thing (p/foo/bar/qux.go)",
+		"Thing (x/foo/baz.go)",
+		"Thing (z/bar/m.go)",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("RepresentativeLabels =\n %v\nwant\n %v", got, want)
+	}
+	// The invariant the backstop guarantees: no two labels in the group collide.
+	seen := map[string]bool{}
+	for _, l := range got {
+		if seen[l] {
+			t.Fatalf("duplicate label %q survived escalation", l)
+		}
+		seen[l] = true
+	}
+}
+
+// TestRepresentativeLabelsRootLevelFallback covers same-named root-level files
+// (no directory to distinguish them): dirSegments yields nothing, so the suffix
+// is the full Path.
+func TestRepresentativeLabelsRootLevelFallback(t *testing.T) {
+	examples := []Example{
+		{Name: "Config", Path: "config_a.go", EdgeCount: 2},
+		{Name: "Config", Path: "config_b.go", EdgeCount: 2},
+	}
+	got := RepresentativeLabels(examples, 5)
+	want := []string{"Config (config_a.go)", "Config (config_b.go)"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("RepresentativeLabels = %v, want %v", got, want)
 	}
 }

--- a/internal/mcpserver/conventions.go
+++ b/internal/mcpserver/conventions.go
@@ -44,13 +44,17 @@ func (h *handlers) handleConventions(ctx context.Context, req mcp.CallToolReques
 		},
 	}
 	for _, c := range results {
-		instances := conventions.PickRepresentatives(c.Examples, instanceCap)
-		snippets := lookupInstanceSnippets(ctx, h.db, instances, 3)
+		// Display labels disambiguate same-named representatives; snippet lookup
+		// keys on the raw symbol names (sense_symbols.name), so it must use the
+		// bare PickRepresentatives output, not the labels.
+		labels := conventions.RepresentativeLabels(c.Examples, instanceCap)
+		rawNames := conventions.PickRepresentatives(c.Examples, instanceCap)
+		snippets := lookupInstanceSnippets(ctx, h.db, rawNames, 3)
 		resp.Conventions = append(resp.Conventions, mcpio.ConventionEntry{
 			Category:       string(c.Category),
 			Description:    c.Description,
 			Strength:       mcpio.Confidence(c.Strength),
-			Instances:      instances,
+			Instances:      labels,
 			TotalInstances: c.Instances,
 			KeySymbol:      c.KeySymbol,
 			Snippets:       snippets,


### PR DESCRIPTION
## Problem

`sense conventions` could show the same representative name several times within a single convention's top-N list when those names came from distinct files (e.g. four different `_add_modal.html.erb` files rendered as four identical strings). To the AI consumer this reads as one example repeated rather than several real files, so it cannot tell whether a convention is broad (many files) or narrow (one file shown repeatedly). The representative set is the point of the convention summary, and an ambiguous label degrades it.

## Summary

Disambiguate representative names at the single render chokepoint so every detector and consumer is fixed once, while keeping the raw symbol names intact for snippet lookup.

## Changes

- Split `PickRepresentatives` into an unexported `pickRepresentatives` (dedupe → sort → top-N picker) returning the chosen examples.
- `PickRepresentatives` now projects raw names from that picker — still the `sense_symbols.name` key used for snippet retrieval.
- Add `RepresentativeLabels`: bare name when unique in the picked set, else the name with the shortest trailing path segments that distinguish same-named siblings, e.g. `_add_modal.html.erb (categories/categorizations)`.
- Wire `topNames` (baked descriptions), MCP `Instances`, and CLI `Instances` to the labels for display; MCP snippet lookup keeps the raw names.

## Architecture Highlights

- Display labels and DB lookup keys are deliberately separate: both derive from the same `pickRepresentatives` pick, so they always select the identical set, but only the display path is disambiguated.
- A final `escalateColliding` pass relabels a whole same-named group with full `Path`s if per-member suffixes still collide (a dir suffix and a full-`Path` fallback occupy different string spaces). Full paths are distinct by construction, so every label in a group is guaranteed unique. It fires only on rare pathological trees.
- No change to counts, strengths, categories, or which conventions are detected — only how representatives are named in the top-N. No new field on the example struct; labels are computed at render.

## Test Plan

- [x] Unit tests assert exact labels: unique-stay-bare, two-segment collision, symbol-name collision, strict-suffix degradation, cross-namespace escalation, basename and root-level fallbacks
- [x] No-counts-change property test: labels are pure decoration over the picked set (same length, same order, base name unchanged)
- [x] Verified against a real Ruby index: repeated labels eliminated, conventions disambiguated, instance counts identical; snippets still resolve via the raw-name path
- [x] `go test ./...` and `make ci` pass (per-file 92% coverage gate green, lint clean)
- [x] sense binary builds cleanly