### PR TITLE
chore(contributing): contributor guides, setup registry, MIT license

### DIFF
--- a/CONTRIBUTING-A-FRAMEWORK.md
+++ b/CONTRIBUTING-A-FRAMEWORK.md
@@ -1,0 +1,337 @@
+# Adding framework support to Sense
+
+This guide walks you through adding support for a framework on top of a language
+Sense already parses (Rails on Ruby, Django on Python, React on TypeScript), and
+through the dead-code fine-graining that goes with it. It is written to be
+followed literally, by an AI agent or a human, with no prior knowledge of the
+codebase.
+
+Framework support is **two halves of one job**:
+
+1. **Emit the framework's edges.** A framework creates relationships no plain
+   syntactic rule sees: a Rails `has_many :orders` is a `composes` edge, a
+   FastAPI `@app.get("/x")` wires a route to a handler, a React component renders
+   another. You teach the extractor to recognize the idiom and emit the edge.
+2. **Keep the framework's invisibly-reached symbols out of the dead report.** The
+   same idioms reach symbols with no source caller: a router dispatches a handler,
+   a signal framework invokes a `@receiver`, an ORM callback fires
+   `before_save`. The dead-code analyzer would call those symbols dead unless a
+   voice knows the framework reaches them. You teach the analyzer that too.
+
+Most contributors think of the first half and forget the second. They are the
+same contribution: a framework that emits edges but leaves its handlers looking
+dead is half-done. This guide covers both, in that order.
+
+> **Prerequisite.** Framework inference needs a **full-tier** extractor (a
+> bespoke package), because the idioms require more than the table-driven
+> standard tier can express. If your target language is standard-tier today, read
+> the full-tier section of [`CONTRIBUTING-A-LANGUAGE.md`](CONTRIBUTING-A-LANGUAGE.md)
+> first. If it is already full-tier (Go, Ruby, Python, TypeScript/JS, Rust), you
+> are in the right place.
+
+> **Maintainer note.** The normative dead-code spec and the per-language
+> soundness gate live in the internal `.doc/definition/` tree, which is **not**
+> part of a public clone. References to `.doc/...` below are for maintainers; an
+> external contributor can ignore them and a reviewer will wire them up.
+
+### Before you start
+
+```bash
+git clone https://github.com/luuuc/sense.git
+cd sense
+./scripts/fetch-deps.sh --local   # ONNX runtime + model, required once
+make build
+```
+
+---
+
+## Architecture in one screen
+
+A framework contribution touches at most these places. Keep the list in view; the
+steps fill it in. The first group is the edges (Part 1), the second is the
+dead-code half (Part 2).
+
+| File | Role |
+|---|---|
+| `internal/extract/<lang>/framework.go` (or inline) | recognize the idiom, emit edges |
+| `internal/extract/extractor.go` | the harvest-emitter interface, if a new open-world signal is needed |
+| `internal/extract/testdata/<lang>/` | fixtures + goldens, including negative cases |
+| `internal/scan/collector.go` | accumulate the harvested names |
+| `internal/scan/scan.go` | a harness field for the accumulator |
+| `internal/scan/dispatch.go` | a `sense_meta` key + a writer for the set |
+| `internal/dead/arbiter.go` | a `Facts` field carrying the set into the voice |
+| `internal/dead/meta_readers.go` | read the set from `sense_meta` into `Facts` |
+| `internal/dead/voice_<lang>.go` | the voice that raises the open-world reason |
+| `internal/dead/reasons.go` | the reason code (often registered from the voice) |
+
+That looks like a lot. Most framework additions touch only the first three rows:
+they emit an edge and (if the idiom is "another decorator / another annotation")
+ride an open-world signal that **already exists**. The full round-trip in the
+second group is only for a genuinely new kind of invisible reach. Part 2 has a
+decision step so you do the minimum.
+
+---
+
+# Part 1. Emitting the framework's edges
+
+Framework inference adds domain-specific edges on top of a language's base
+extraction. Two code patterns exist; pick by size.
+
+- **Pattern A, a separate file** (recommended for non-trivial frameworks). Python
+  uses this: [`internal/extract/python/framework.go`](internal/extract/python/framework.go)
+  holds all Django/FastAPI logic as methods on the same `walker`. The base
+  extractor calls into framework methods at integration points; a non-match
+  returns nil and base extraction continues unchanged.
+- **Pattern B, inline** (for a handful of `case` branches). Ruby's `dispatchCall`
+  routes on method name (`case "has_many", "belongs_to": ...`). Move to a separate
+  file when it grows.
+
+**What framework extractors emit:**
+
+- `composes` for ORM associations and typed fields (Rails `has_many :orders`,
+  Django `ForeignKey(User)`).
+- `calls` for lifecycle callbacks and route-to-handler wiring (Rails
+  `before_action`, FastAPI `@app.get`).
+- `imports` for module inclusion.
+
+Framework edges use `ConfidenceConvention` (0.9): they rely on naming patterns,
+not syntactic proof. Use the shared confidence constants from
+[`internal/extract/extractor.go`](internal/extract/extractor.go); never invent
+literals.
+
+**Cross-language edges.** Some frameworks bridge languages. The ERB extractor
+connects templates to JS: `data-controller="checkout"` resolves to
+`CheckoutController`, `<turbo-stream-from>` to a `turbo-channel:` prefix.
+Cross-language resolution works through synthetic qualified-name prefixes defined
+in `extractor.go` (`PrefixTurboChannel`, `PrefixImportmap`, ...); **both** emitter
+and receiver must produce the same qualified name. The shared helper
+`extract.StimulusControllerQualified()` keeps ERB and TS/JS in agreement.
+
+**RawExtractor (non-tree-sitter languages).** Template languages like ERB have no
+grammar. Implement `RawExtractor` (`ExtractRaw(source, filePath, emit) error`)
+instead; when an extractor implements both, the harness calls `ExtractRaw` and
+skips parsing, and `Grammar()` returns nil. See
+[`internal/extract/erb/`](internal/extract/erb/).
+
+**The `filePath` parameter** carries file-path-dependent semantics: Ruby checks
+for `config/routes.rb`, Python detects `urls.py` for Django URL patterns. Store
+`filePath` on the walker if your framework's meaning depends on location.
+
+**Fixtures.** Add framework fixtures alongside the language's existing ones
+(`testdata/ruby/rails_associations.rb` + `.golden.json`), and **include negative
+cases**: patterns that look like framework code but should emit nothing. Generate
+the golden, then read the diff before committing it:
+
+```bash
+go test ./internal/extract -run 'TestFixtures/<lang>' -update   # regenerate
+go test ./internal/extract -run 'TestFixtures/<lang>'           # verify
+```
+
+`-update` will happily bless wrong output. Check that the right edges appear, with
+the right kinds and confidences, and that negative cases stay empty.
+
+---
+
+# Part 2. Dead-code fine-graining
+
+A framework reaches symbols the static call graph cannot see. Without this half,
+those symbols show up as false positives in `sense dead`. This is where you teach
+the analyzer the framework's invisible-reach idioms.
+
+## The one invariant that makes this safe
+
+The dead-code analyzer runs a panel of **voices**
+([`internal/dead/arbiter.go`](internal/dead/arbiter.go)). A voice answers one
+question about a candidate symbol: *"could a hidden caller exist?"* It may only
+ever **raise its hand**: return a `Reason` to push a symbol to `possibly_dead`.
+No voice can vote *for* `dead`. A symbol earns `dead` only when **every** voice
+stays silent **and** a language voice for its language is registered (so
+closed-world is provable) **and** the soundness gate passes.
+
+```go
+type Voice interface {
+    Lang() string                          // "" = applies to all languages
+    Inspect(s Symbol, f Facts) *Reason     // a reason, or nil for "no risk I see"
+}
+```
+
+This is why adding framework knowledge is safe: the worst a wrong voice can do is
+keep a symbol open-world (recall loss), never falsely call something dead
+(soundness loss). Always err toward raising a hand.
+
+## Step 1. Decide how much wiring you actually need
+
+Three cases, cheapest first. Do not build more than your framework needs.
+
+**Case A: an existing open-world signal already covers it.** The harvested signals
+are deliberately broad. Python harvests *every decorated symbol* as
+`PythonDecoratedName` (reason `py_decorator`); langspec harvests *every annotated
+symbol* as `LangspecAnnotatedName` (reason `ls_annotated`). If your framework's
+idiom is "this symbol carries a decorator/annotation", the **extractor already
+emits the harvest name** and the voice already raises a hand. You may have
+nothing to do in Part 2. Verify against a real repo (Step 4) before assuming so.
+
+**Case B: a new, more specific reason on an existing harvest.** Your idiom is
+already harvested broadly, but you want a precise hint. Example: Flask routes are
+decorated (so `py_decorator` already keeps them open-world), but `py_route` tells
+the user *why* with a routing-specific message. This adds a harvest fact and a
+reason, but no new voice. This is the full round-trip in Step 2.
+
+**Case C: a brand-new invisible-reach idiom** the language voice cannot express
+with existing facts. Same round-trip as Case B, and possibly a new check inside
+the voice. This is rare; the existing voices cover most idioms.
+
+If you are in Case A, skip to Step 4. Cases B and C use Step 2 and Step 3.
+
+## Step 2. The harvest round-trip
+
+A harvested fact is a project-wide set of names the scan collects once and the
+voice reads. The set flows extract -> scan -> `sense_meta` -> dead. Adding one
+means touching each layer. Use the Python decorated-name path as the worked
+example to copy; every file below already contains it.
+
+1. **Declare the emitter method** on the language's harvest interface in
+   [`internal/extract/extractor.go`](internal/extract/extractor.go). Example: the
+   `PythonHarvestEmitter` interface declares `PythonRouteName(name string) error`.
+   The interface doc comment is the normative description of what each name means;
+   write yours there.
+
+2. **Emit the name** from the extractor, in `framework.go`, when you recognize the
+   idiom. Probe the emitter with a type assertion so an emitter that does not
+   implement the interface simply receives nothing:
+
+   ```go
+   if h, ok := w.emit.(extract.PythonHarvestEmitter); ok {
+       _ = h.PythonRouteName(handlerName)
+   }
+   ```
+
+3. **Accumulate it** in [`internal/scan/collector.go`](internal/scan/collector.go).
+   The `collector` implements the harvest-emitter interfaces; add the method that
+   appends to a slice:
+
+   ```go
+   func (c *collector) PythonRouteName(name string) error {
+       c.pyRoutes = append(c.pyRoutes, name)
+       return nil
+   }
+   ```
+
+4. **Hold the project-wide set** with a harness field in
+   [`internal/scan/scan.go`](internal/scan/scan.go) (e.g. `pyRoutes map[string]struct{}`),
+   folded in by `partitionHarvestedNames`.
+
+5. **Persist it** in [`internal/scan/dispatch.go`](internal/scan/dispatch.go): a
+   `sense_meta` key const and a writer, called from `writeHarvestedMeta`:
+
+   ```go
+   const pythonRoutesMetaKey = "py_routes"
+   func writePythonRoutes(ctx context.Context, idx *sqlite.Adapter, c map[string]struct{}) error {
+       return writeNameSet(ctx, idx, pythonRoutesMetaKey, c)
+   }
+   ```
+
+6. **Carry it into the voice** with a `Facts` field in
+   [`internal/dead/arbiter.go`](internal/dead/arbiter.go) (e.g.
+   `PythonRouteNames map[string]struct{}`). Document it where the other fields are
+   documented; the field comment is part of the contract.
+
+7. **Read it** in [`internal/dead/meta_readers.go`](internal/dead/meta_readers.go),
+   inside `buildFacts`, via `readStringSetMeta(ctx, db, "py_routes")` (flat key) or
+   `readNameSetMetaByLang` (per-language key).
+
+8. **Consume it and raise a reason** in the voice
+   ([`internal/dead/voice_python.go`](internal/dead/voice_python.go)): if the
+   symbol's name is in the set, return the reason. Order checks most-live-first so
+   the most specific hint wins.
+
+9. **Register the reason** in [`internal/dead/reasons.go`](internal/dead/reasons.go),
+   usually from the voice file's `init()` via `registerReasons`. A reason carries a
+   `priority` (the arbiter picks the lowest across voices), a one-line `hint`, and
+   a fuller `verify` recipe telling the user how to confirm before deleting.
+
+> **Why so spread out?** Each step is small and the pattern is identical to the
+> rows already there, but the round-trip crosses three packages
+> (`extract` emits, `scan` persists, `dead` reads) and that is intentional:
+> extractors are stateless and database-free, so a fact they discover has to be
+> carried to the analyzer through `sense_meta` rather than recomputed. Copy an
+> existing fact end-to-end rather than inventing a new shape. *(Maintainers: this
+> per-fact boilerplate is a known rough edge; a `harvestFact{key, reader}` table
+> could collapse steps 5 and 7. Not done yet; do not block a contribution on it.)*
+
+## Step 3. Register a new language voice (only if there is none)
+
+If you are adding the **first** framework for a language that has no voice yet,
+register one. A voice is a small struct with `Lang()` and `Inspect()`, plus its
+reasons. Add it to the panel in
+[`internal/dead/dead.go`](internal/dead/dead.go) (`defaultArbiter`): a one-line
+addition to the `NewArbiter(...)` call. Read
+[`internal/dead/voice_go.go`](internal/dead/voice_go.go) as the cleanest complete
+example, and the langspec voice for the table-driven case.
+
+A non-empty `Lang()` does two things at once: it scopes the voice to that
+language's symbols, **and** it declares that Sense can prove closed-world for the
+language (so its symbols become eligible for `dead` at all). Do not register a
+voice for a language whose dead verdict you have not validated against a real
+repo.
+
+## Step 4. Validate against a real repo, not a fixture
+
+Goldens prove the extractor emits what you wrote; they cannot prove the dead
+verdict is *right*, because rightness is a property of real code. Point Sense at a
+real project on the framework and read the dead report by hand.
+
+```bash
+cd /path/to/a/real/<framework>/app
+sense scan                      # scan-layer facts need a fresh scan to take effect
+sense dead --language <lang>
+```
+
+Confirm two things: framework-reached symbols (routes, callbacks, signal
+handlers) are **not** in the `dead` list (they should be `possibly_dead` with your
+reason), and genuinely-unused code still **is**. A maintainer keeps reference
+repos for this (for example, a Rails app validates the Ruby/Rails voices); ask in
+the PR which repo to validate against if you do not have one.
+
+> **Scan-layer vs query-layer.** Anything you change in `extract` or `scan`
+> (emitting a harvest name, persisting a `sense_meta` key) only takes effect after
+> `rm -rf .sense && sense scan`. Changes confined to `dead` (a voice raising a new
+> reason from facts already in `sense_meta`) take effect against the existing
+> index immediately. Knowing which layer you touched saves a rescan.
+
+## Step 5. Cover your logic and run the gates
+
+A bespoke voice is real logic held to the per-file coverage floor (see
+[`CONTRIBUTING.md`](CONTRIBUTING.md)). Unit-test the voice's `Inspect` directly
+against constructed `Symbol`/`Facts` values (the existing `voice_*_test.go` files
+show the pattern), not only through end-to-end scans. Then:
+
+```bash
+go test ./internal/extract/... ./internal/scan/... ./internal/dead/...
+make ci
+make smoke
+```
+
+---
+
+## Reference: existing framework support
+
+- **Ruby/Rails** ([`internal/extract/ruby/`](internal/extract/ruby/),
+  [`internal/dead/voice_rails.go`](internal/dead/voice_rails.go)), covering associations,
+  callbacks, routes, Stimulus/Turbo. The fullest example.
+- **Python/Django+FastAPI** ([`internal/extract/python/framework.go`](internal/extract/python/framework.go),
+  [`internal/dead/voice_python.go`](internal/dead/voice_python.go)), covering decorators,
+  routes, signal handlers, `__all__`. The cleanest harvest round-trip to copy.
+- **TypeScript/React** ([`internal/extract/tsjs/`](internal/extract/tsjs/),
+  [`internal/dead/voice_ts.go`](internal/dead/voice_ts.go)), covering JSX components,
+  decorators, default exports.
+- **ERB cross-language** ([`internal/extract/erb/`](internal/extract/erb/)), covering
+  template-to-JS via synthetic prefixes, the `RawExtractor` path.
+
+---
+
+## When you get stuck
+
+If a step here does not match what you see in the repo, the **doc** is wrong, not
+you. Open an issue or PR against this file. This guide is meant to be followable
+end-to-end with zero gaps; a gap a newcomer hits is a bug in the guide.

--- a/CONTRIBUTING-A-LANGUAGE.md
+++ b/CONTRIBUTING-A-LANGUAGE.md
@@ -540,41 +540,12 @@ allows it.
 
 ## Adding framework support to an existing language
 
-Framework inference adds domain-specific edges on top of a language's base
-extraction. Two patterns exist:
-
-- **Pattern A — separate file** (recommended for non-trivial frameworks). Python
-  uses this: `internal/extract/python/framework.go` holds all Django/FastAPI
-  logic as methods on the same `walker`. The base extractor calls into framework
-  methods at integration points; a non-match returns nil and base extraction
-  continues unchanged.
-- **Pattern B — inline** (for a handful of `case` branches). Ruby's `dispatchCall`
-  routes on method name (`case "has_many", "belongs_to": …`). Move to a separate
-  file when it grows.
-
-**What framework extractors emit:** `composes` for ORM associations/typed fields
-(Rails `has_many :orders`, Django `ForeignKey(User)`); `calls` for lifecycle
-callbacks and route-to-handler wiring (Rails `before_action`, FastAPI
-`@app.get`); `imports` for module inclusion. Framework edges use
-`ConfidenceConvention` (0.9) — they rely on naming patterns, not syntactic proof.
-
-**Cross-language edges.** Some frameworks bridge languages. The ERB extractor
-connects templates to JS: `data-controller="checkout"` → `CheckoutController`,
-`<turbo-stream-from>` → `turbo-channel:` prefix. Cross-language resolution works
-through synthetic qualified-name prefixes defined in `extract/extractor.go`
-(`PrefixTurboChannel`, `PrefixImportmap`, …); **both** emitter and receiver must
-produce the same qualified name. The shared helper
-`extract.StimulusControllerQualified()` keeps ERB and TS/JS in agreement.
-
-**RawExtractor (non-tree-sitter languages).** Template languages like ERB have no
-grammar. Implement `RawExtractor` (`ExtractRaw(source, filePath, emit) error`)
-instead; when an extractor implements both, the harness calls `ExtractRaw` and
-skips parsing, and `Grammar()` returns nil. See
-[`internal/extract/erb/`](internal/extract/erb/).
-
-**Fixtures.** Add framework fixtures alongside the language's existing ones
-(`testdata/ruby/rails_associations.rb` + `.golden.json`), including negative
-cases — patterns that look like framework code but should emit nothing.
+Adding a framework (Rails on Ruby, Django on Python, React on TypeScript) has its
+own dedicated guide: [`CONTRIBUTING-A-FRAMEWORK.md`](CONTRIBUTING-A-FRAMEWORK.md).
+It covers both halves of the job, emitting the framework's edges (associations,
+routes, callbacks, cross-language wiring, the `RawExtractor` path) and the
+dead-code fine-graining that keeps a framework's invisibly-reached symbols out of
+the dead report. Start there rather than here once your language is full-tier.
 
 ---
 

--- a/CONTRIBUTING-AN-AI-TOOL.md
+++ b/CONTRIBUTING-AN-AI-TOOL.md
@@ -1,0 +1,303 @@
+# Adding (or tuning) an AI tool integration
+
+This guide walks you through teaching `sense setup` about a new AI coding tool,
+or changing what an existing one is told. It is written to be followed literally,
+by an AI agent or a human, with no prior knowledge of the codebase.
+
+`sense setup` writes integration files into a project so an AI tool discovers the
+Sense MCP server and prefers it over grep and file-walking. Each supported tool
+gets an **MCP server entry** (so the tool can call Sense), an **instructions
+file** (so the model knows to), and optionally **hooks, skills, and agents**.
+
+There are two tasks this guide covers, in rising order of effort:
+
+- **Tuning what tools are told.** A one-place edit to the shared guidance, or to
+  one tool's files. No new tool. Start here if the integration exists and you
+  only want to improve the prompt.
+- **Adding a new tool.** A new per-tool file plus one registry line. The registry
+  is the single source of truth, so there are no `switch` statements to hunt
+  down.
+
+Everything lives in [`internal/setup/`](internal/setup/).
+
+---
+
+## Architecture in one screen
+
+The set of tools Sense configures is a **registry**
+([`internal/setup/registry.go`](internal/setup/registry.go)): a slice of `tool`
+values, each pairing a detector with a configurer.
+
+```go
+type tool struct {
+    id          Tool
+    displayName string
+    detect      func() DetectResult        // is this tool installed?
+    configure   func(root string) (*ToolResult, error) // write its files
+}
+```
+
+Every public entry point loops over that slice, so the registry is the only place
+the tool list is enumerated:
+
+- `AllTools()` and `DetectAll()` iterate the registry.
+- `Detect(t)` and `configureTool(root, t)` call `lookup(t)`, then the matching
+  field.
+- `ParseTools("a,b")` validates each name against the registry.
+- `Tool.DisplayName()` returns `lookup(t).displayName`.
+
+Each tool's detector, configurer, and file writers live in **one file named for
+the tool** ([`claude.go`](internal/setup/claude.go),
+[`cursor.go`](internal/setup/cursor.go), [`codex.go`](internal/setup/codex.go),
+[`opencode.go`](internal/setup/opencode.go)). Read `claude.go` first: it is the
+fullest example (MCP entry, settings and hooks, guidance, skills, agents).
+`cursor.go` is the smallest (MCP entry plus one guidance file).
+
+The shared pieces a tool composes from:
+
+| Piece | Where | What it does |
+|---|---|---|
+| `Tool` constant | [`detect.go`](internal/setup/detect.go) | the tool's id, also its `--tools` name |
+| `guidanceMarkdown` | [`marker.go`](internal/setup/marker.go) | **the single guidance source** every instructions file gets |
+| `writeMarkerFile` | [`marker.go`](internal/setup/marker.go) | idempotent merge of a marker-delimited section into a Markdown file |
+| `readJSONFile` / `writeJSONFile` | [`merge.go`](internal/setup/merge.go) | read, deep-merge, and write a JSON config without clobbering other tools' entries |
+| `mergeHooks` / `mergePermissions` | [`merge.go`](internal/setup/merge.go) | Claude-style settings merges |
+| `skills` / `agents` | [`skills.go`](internal/setup/skills.go), [`agents.go`](internal/setup/agents.go) | the shared skill and agent file contents |
+| `mcpio.ServerInstructions` | [`internal/mcpio/types.go`](internal/mcpio/types.go) | the MCP protocol-level instruction string |
+
+**The two guidance surfaces, and why there are exactly two.** There is one
+in-repo prompt (`guidanceMarkdown`, the Markdown a model reads from
+CLAUDE.md, .cursorrules, or AGENTS.md) and one protocol-level prompt
+(`mcpio.ServerInstructions`, the `serverInstructions` string an MCP client
+receives at connect time). They live in different packages on purpose:
+`ServerInstructions` is sent by the running `sense mcp` server too, so it cannot
+live in `setup`. Keep them aligned in spirit, each edited in its own one place.
+There is no third copy. If you find yourself pasting guidance into a per-tool
+file, stop and reference `guidanceMarkdown` instead.
+
+**The idempotency contract.** Running `sense setup` twice must produce the same
+files. JSON configs are deep-merged (an existing `sense` entry is replaced, other
+servers untouched), Markdown sections are replaced between `<!-- sense:start -->`
+and `<!-- sense:end -->` markers, and skills and agents are overwritten. Your
+`configure` must hold this line; the tests below enforce it.
+
+### Before you start
+
+```bash
+git clone https://github.com/luuuc/sense.git
+cd sense
+./scripts/fetch-deps.sh --local   # ONNX runtime + model, required once
+make build
+```
+
+---
+
+## Tuning what tools are told (no new tool)
+
+- **Change the guidance every tool receives** (the table of tools, the MUST-NOT
+  rules, when not to use Sense): edit `guidanceMarkdown` in
+  [`marker.go`](internal/setup/marker.go). One edit, every tool updated on the
+  next `sense setup`. Keep it **tool-agnostic**: do not name one tool's UI. A
+  test (`TestGuidanceMarkdownContent`) fails if a tool-specific phrase leaks in,
+  and another (`TestGuidanceMarkdownIsSingleSource`) asserts every instructions
+  file carries this exact block.
+- **Change the MCP protocol instructions**: edit `mcpio.ServerInstructions` in
+  [`internal/mcpio/types.go`](internal/mcpio/types.go).
+- **Change a skill or agent's content**: edit the `skills` or `agents` slices in
+  [`skills.go`](internal/setup/skills.go) or [`agents.go`](internal/setup/agents.go).
+- **Change only one tool's files** (for example, add a hook to Claude Code): edit
+  that tool's `configure` function in its file.
+
+Then regenerate and eyeball the output:
+
+```bash
+go test ./internal/setup/
+go build -o /tmp/sense . && (cd "$(mktemp -d)" && /tmp/sense setup --tools claude-code && cat CLAUDE.md)
+```
+
+---
+
+## Adding a new tool
+
+The running example is **Aider**. Substitute your tool's real name and config
+paths. The one thing you must research up front is **how your tool consumes an
+MCP server and project instructions**, because that decides which files
+`configure` writes. The three existing tools already cover the common shapes;
+find which yours matches.
+
+### Step 1. Research the tool's config surface
+
+Answer three questions from the tool's own documentation before writing code:
+
+1. **How does it register an MCP server?** A JSON file with an `mcpServers`
+   object (Claude Code's `.mcp.json`, Cursor's `.cursor/mcp.json`)? A different
+   key or schema (OpenCode's `opencode.json` uses an `mcp` key with
+   `{type, command, enabled}`)? A non-JSON format? If the tool has no MCP
+   support, it cannot use Sense's tools and is not a candidate.
+2. **Where does it read project instructions?** A Markdown file the model is
+   given each session (`CLAUDE.md`, `.cursorrules`, `AGENTS.md`). Many tools now
+   read `AGENTS.md`; reuse it if so.
+3. **Does it support hooks, skills, or agents?** Optional. Claude Code is the only
+   current tool wiring hooks; skills are written for Claude Code and OpenCode.
+
+If two of your answers match an existing tool, your `configure` is mostly a copy
+of that tool's writers with different paths.
+
+### Step 2. Add the `Tool` constant
+
+In [`internal/setup/detect.go`](internal/setup/detect.go), add a constant. The
+string value **is** the `--tools` flag name, so make it the canonical lowercase
+id:
+
+```go
+const (
+    ToolClaudeCode Tool = "claude-code"
+    // ...
+    ToolAider      Tool = "aider"
+)
+```
+
+`ParseTools`, the `--tools` help text, and the error message all derive from the
+registry, so this is the only constant you add.
+
+### Step 3. Create the tool's file
+
+Create `internal/setup/aider.go` holding **the detector and the configurer**,
+mirroring [`cursor.go`](internal/setup/cursor.go) (the smallest example) or
+[`claude.go`](internal/setup/claude.go) (the fullest):
+
+```go
+package setup
+
+import (
+    "fmt"
+    "os"
+    "os/exec"
+    "path/filepath"
+)
+
+// detectAider looks for evidence that Aider is installed. The signals run
+// most-specific first: a session env var, the binary on PATH, a config dir.
+func detectAider() DetectResult {
+    r := DetectResult{Tool: ToolAider}
+    if _, err := exec.LookPath("aider"); err == nil {
+        r.Found = true
+        r.Evidence = "aider on PATH"
+        return r
+    }
+    if home, err := os.UserHomeDir(); err == nil {
+        if _, err := os.Stat(filepath.Join(home, ".aider")); err == nil {
+            r.Found = true
+            r.Evidence = "~/.aider/ directory"
+            return r
+        }
+    }
+    return r
+}
+
+// configureAider writes Aider's MCP config and the AGENTS.md guidance it reads.
+// Each writer returns (wrote bool, err); append the relative path on success so
+// the run summary lists it.
+func configureAider(root string) (*ToolResult, error) {
+    tr := &ToolResult{Tool: ToolAider}
+
+    if wrote, err := writeMCPJSON(root); err != nil {       // reuse the .mcp.json writer if the schema matches
+        return nil, fmt.Errorf("write .mcp.json: %w", err)
+    } else if wrote {
+        tr.Files = append(tr.Files, ".mcp.json")
+    }
+
+    if wrote, err := writeAgentsMD(root); err != nil {      // reuse the AGENTS.md writer (guidanceMarkdown)
+        return nil, fmt.Errorf("write AGENTS.md: %w", err)
+    } else if wrote {
+        tr.Files = append(tr.Files, "AGENTS.md")
+    }
+
+    return tr, nil
+}
+```
+
+**Reuse before you write.** If your tool's MCP schema matches `.mcp.json`, call
+`writeMCPJSON`. If it reads `AGENTS.md`, call `writeAgentsMD`. Only write a new
+`writeAiderJSON` when the schema genuinely differs (as `writeOpencodeJSON` does
+for OpenCode's `mcp`-keyed shape). When you do, always go through
+`readJSONFile` and `writeJSONFile` so you deep-merge rather than clobber a config
+the user already has.
+
+**Guidance is never inlined.** A guidance file is always
+`writeMarkerFile(path, guidanceMarkdown)`. Do not paste the guidance text into
+your file; the single-source test will fail and the next person editing the
+prompt will miss your copy.
+
+### Step 4. Register the tool
+
+Add one line to `registry()` in
+[`internal/setup/registry.go`](internal/setup/registry.go), in display order:
+
+```go
+func registry() []tool {
+    return []tool{
+        {id: ToolClaudeCode, displayName: "Claude Code", detect: detectClaudeCode, configure: configureClaudeCode},
+        // ...
+        {id: ToolAider, displayName: "Aider", detect: detectAider, configure: configureAider},
+    }
+}
+```
+
+That is the whole wiring. `AllTools`, `DetectAll`, `Detect`, `configureTool`,
+`ParseTools`, and `DisplayName` now all include Aider with no further edits.
+
+### Step 5. Add tests
+
+The setup tests are plain Go tests in
+[`internal/setup/setup_test.go`](internal/setup/setup_test.go) (no golden files).
+Add these, mirroring the `Cursor` and `Opencode` cases:
+
+1. **Creates files.** Run `Run(root, buf, &Options{Tools: []Tool{ToolAider}})`,
+   then assert each expected path exists.
+2. **Idempotent.** Run it twice; assert the instructions file is byte-identical
+   and contains exactly one `markerStart`.
+3. **Preserves user content.** Pre-write the instructions file with a user
+   heading, run setup, assert the heading survives and the Sense section is
+   appended once (see `TestOpencodeAgentsMDMergeOverUserContent`).
+4. **MCP merge preserves other servers.** Pre-write the JSON config with a
+   non-Sense server, run setup, assert both entries exist (see
+   `TestMCPJSONPreservesExistingServers`).
+5. **Error paths.** Every `return nil, err` branch in your writers needs a test
+   that triggers it (make the target path a directory, or pre-write invalid
+   JSON). The existing `*Error` tests show the technique; you need these to clear
+   the coverage floor.
+
+```bash
+go test ./internal/setup/
+```
+
+### Step 6. Verify the whole path
+
+```bash
+make ci      # build + cover (per-file ≥92% line AND func) + lint
+make smoke
+```
+
+The per-file coverage gate (see [`CONTRIBUTING.md`](CONTRIBUTING.md)) applies to
+`aider.go` automatically: it is a new production file, gated with no allow-list
+to opt into. Cover every writer branch, including the error returns.
+
+---
+
+## Reference: the existing tools
+
+| Tool | MCP config | Instructions | Extras |
+|---|---|---|---|
+| Claude Code | `.mcp.json` (`mcpServers`, with `serverInstructions`) | `CLAUDE.md` | `.claude/settings.json` hooks and perms, skills, agents |
+| Cursor | `.cursor/mcp.json` (`mcpServers`) | `.cursorrules` | none |
+| Codex CLI | `.mcp.json` (shared with Claude Code) | `AGENTS.md` | none |
+| OpenCode | `opencode.json` (`mcp` key, `{type, command, enabled}`) | `AGENTS.md` | skills as `.opencode/skills/<name>/SKILL.md` |
+
+---
+
+## When you get stuck
+
+If a step here does not match what you see in the repo, the **doc** is wrong, not
+you. Open an issue or PR against this file. This guide is meant to be followable
+end-to-end with zero gaps; a gap a newcomer hits is a bug in the guide.

--- a/CONTRIBUTING-AN-AI-TOOL.md
+++ b/CONTRIBUTING-AN-AI-TOOL.md
@@ -34,8 +34,14 @@ type tool struct {
     displayName string
     detect      func() DetectResult        // is this tool installed?
     configure   func(root string) (*ToolResult, error) // write its files
+    currentEnv  []string                   // env vars that mean "running inside this tool now"
 }
 ```
+
+`currentEnv` feeds `DetectCurrent`, which `sense scan` uses on first run to
+configure only the tool the user is currently inside. It is optional: a tool with
+no live-session env var still detects and configures normally, it just never wins
+`DetectCurrent` (which falls back to Claude Code).
 
 Every public entry point loops over that slice, so the registry is the only place
 the tool list is enumerated:
@@ -237,15 +243,19 @@ Add one line to `registry()` in
 ```go
 func registry() []tool {
     return []tool{
-        {id: ToolClaudeCode, displayName: "Claude Code", detect: detectClaudeCode, configure: configureClaudeCode},
+        {id: ToolClaudeCode, displayName: "Claude Code", detect: detectClaudeCode, configure: configureClaudeCode, currentEnv: []string{"CLAUDE_CODE"}},
         // ...
-        {id: ToolAider, displayName: "Aider", detect: detectAider, configure: configureAider},
+        {id: ToolAider, displayName: "Aider", detect: detectAider, configure: configureAider, currentEnv: []string{"AIDER"}},
     }
 }
 ```
 
 That is the whole wiring. `AllTools`, `DetectAll`, `Detect`, `configureTool`,
-`ParseTools`, and `DisplayName` now all include Aider with no further edits.
+`ParseTools`, `DisplayName`, and `DetectCurrent` now all include Aider with no
+further edits. Set `currentEnv` to the env var(s) the tool sets in its own
+sessions (omit the field if it has none); that is what makes the
+"one file plus one registry line" promise literally true, including for
+`sense scan`'s current-tool first-run path.
 
 ### Step 5. Add tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,33 @@
 # Contributing to Sense
 
+## What we accept
+
+Sense is feature-complete for v1. To keep it focused and maintainable, outside
+contributions are accepted in **three areas only**:
+
+1. **New languages and frameworks.** A tree-sitter-backed language, or framework
+   support on top of an existing one. Start with
+   [`CONTRIBUTING-A-LANGUAGE.md`](CONTRIBUTING-A-LANGUAGE.md); for a framework on
+   a language Sense already parses, go straight to
+   [`CONTRIBUTING-A-FRAMEWORK.md`](CONTRIBUTING-A-FRAMEWORK.md).
+2. **Dead-code fine-graining.** Teaching the dead-code analyzer about a language
+   or framework's invisible-reach idioms (decorators, routes, associations, FFI
+   exports) so those symbols are not falsely flagged dead. This is one half of
+   framework support and lives in the dead-code section of
+   [`CONTRIBUTING-A-FRAMEWORK.md`](CONTRIBUTING-A-FRAMEWORK.md).
+3. **AI-tool integration.** Adding or tuning an AI coding tool (Claude Code,
+   Cursor, Codex, Opencode, Aider, ...). See
+   [`CONTRIBUTING-AN-AI-TOOL.md`](CONTRIBUTING-AN-AI-TOOL.md).
+
+Bug fixes for existing behavior are always welcome.
+
+**Everything else we are not taking**, even if well-built: new commands, new
+query or output formats, configuration knobs, performance rewrites, dependency
+swaps, and net-new features. The query surface and CLI are deliberately small
+and considered done. Please open an issue before investing time in anything
+outside the three lanes above; an unsolicited feature PR will be closed with
+thanks rather than merged. This is not a judgement of the work, only of scope.
+
 ## Dev setup
 
 Requires Go 1.25+.
@@ -63,12 +91,20 @@ chore(ci): pin golangci-lint version
 
 Fill out the PR template: what changed, how you tested, and which issue (if any) the work addresses.
 
-## Adding a language
+## The contribution guides
 
-Adding support for a new programming language has its own step-by-step guide:
-[`CONTRIBUTING-A-LANGUAGE.md`](CONTRIBUTING-A-LANGUAGE.md). It covers both the
-standard tier (a ~30-line table-driven declaration) and the full tier (a bespoke
-extractor), from vendoring the tree-sitter grammar to generating goldens.
+Each accepted lane has its own step-by-step guide, written to be followed
+literally by an AI agent or a human with no prior knowledge of the codebase:
+
+- [`CONTRIBUTING-A-LANGUAGE.md`](CONTRIBUTING-A-LANGUAGE.md) for a new language.
+  It covers the standard tier (a ~30-line table-driven declaration) and the full
+  tier (a bespoke extractor), from vendoring the tree-sitter grammar to
+  generating goldens.
+- [`CONTRIBUTING-A-FRAMEWORK.md`](CONTRIBUTING-A-FRAMEWORK.md) for framework
+  support on a language Sense already parses, plus the dead-code fine-graining
+  that keeps a framework's invisibly-reached symbols out of the dead report.
+- [`CONTRIBUTING-AN-AI-TOOL.md`](CONTRIBUTING-AN-AI-TOOL.md) for a new AI coding
+  tool integration, or tuning the guidance an existing one receives.
 
 ## Larger changes
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-O'Saasy License
+MIT License
 
 Copyright © 2026, Luc B. Perussault-Diallo.
 
@@ -7,16 +7,10 @@ of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+furnished to do so, subject to the following condition:
 
-1. The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
-
-2. No licensee or downstream recipient may use the Software (including any
-   modified or derivative versions) to directly compete with the original
-   Licensor by offering it to third parties as a hosted, managed, or
-   Software-as-a-Service (SaaS) product or cloud service where the primary
-   value of the service is the functionality of the Software itself.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -25,10 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
----
-
-About this license: O'Saasy is the MIT do-whatever-you-want license with the
-commercial SaaS rights reserved for the copyright holder. Run it, ship it,
-fork it, embed it, modify it — but don't resell it as a hosted service that
-competes with the original. See https://osaasy.dev for the canonical text.

--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ Parses your code with tree-sitter, extracts symbols and relationships, embeds ev
 cd /path/to/project && sense setup
 ```
 
-Auto-detects installed AI tools (Claude Code, Cursor, Codex CLI) and writes integration configs:
+Auto-detects installed AI tools (Claude Code, Cursor, Codex CLI, and OpenCode) and writes each one's integration configs:
 
-- **`.mcp.json`**, MCP server config (Claude Code, Cursor, any MCP client)
+- **`.mcp.json`** / **`.cursor/mcp.json`** / **`opencode.json`**, the MCP server entry for the detected tool (or any MCP client)
+- **`CLAUDE.md`** / **`.cursorrules`** / **`AGENTS.md`**, routing guidance with a tool substitution table, written from a single shared source
 - **`.claude/settings.json`**, lifecycle hooks that nudge Claude toward Sense tools
-- **`CLAUDE.md`**, routing guidance with a substitution table
-- **`.claude/skills/`**, workflow skills for exploration, impact analysis, and conventions
+- **`.claude/skills/`** and **`.opencode/skills/`**, workflow skills for exploration, impact analysis, and conventions
 
 No manual setup. Run `sense setup` and your AI has structural understanding.
 
@@ -190,7 +190,7 @@ Sense uses tree-sitter for parsing. It ships with extractors for 13 languages ac
 | **PHP** | Classes, interfaces, traits (`\` scoping) |
 | **Scala** | Classes, traits, objects |
 
-Standard-tier languages use a table-driven generic extractor. Each is ~25 lines of config, not a handwritten walker. See [CONTRIBUTING-A-LANGUAGE.md](CONTRIBUTING-A-LANGUAGE.md) for how to add a new language or framework.
+Standard-tier languages use a table-driven generic extractor. Each is ~25 lines of config, not a handwritten walker. See [CONTRIBUTING-A-LANGUAGE.md](CONTRIBUTING-A-LANGUAGE.md) to add a new language, and [CONTRIBUTING-A-FRAMEWORK.md](CONTRIBUTING-A-FRAMEWORK.md) to add framework support (plus the dead-code fine-graining that goes with it).
 
 ## Feedback
 
@@ -205,6 +205,14 @@ make lint     # run linters
 make ci       # all of the above
 ```
 
+## Contributing
+
+Sense is feature-complete for v1. Outside contributions are accepted in three areas: new languages and frameworks, dead-code fine-graining for a language or framework, and AI-tool integrations. Bug fixes are always welcome; net-new features are not. The full scope and step-by-step guides are in [CONTRIBUTING.md](CONTRIBUTING.md):
+
+- [CONTRIBUTING-A-LANGUAGE.md](CONTRIBUTING-A-LANGUAGE.md), a new language.
+- [CONTRIBUTING-A-FRAMEWORK.md](CONTRIBUTING-A-FRAMEWORK.md), framework support and dead-code fine-graining.
+- [CONTRIBUTING-AN-AI-TOOL.md](CONTRIBUTING-AN-AI-TOOL.md), a new AI coding tool integration.
+
 ## License
 
-O'Saasy. MIT-style with SaaS-competition rights reserved. See [LICENSE](LICENSE).
+MIT. See [LICENSE](LICENSE).

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -11,7 +11,7 @@ import (
 const setupHelp = `usage: sense setup [flags]
 
 Configure AI tool integrations for this project. Auto-detects installed
-tools (Claude Code, Cursor, Codex CLI) and writes integration files.
+tools (Claude Code, Cursor, Codex CLI, Opencode) and writes integration files.
 
 Flags:
   --tools   comma-separated list of tools to configure (overrides detection)
@@ -19,7 +19,7 @@ Flags:
 Examples:
   sense setup                           # auto-detect and configure all
   sense setup --tools cursor            # configure Cursor only
-  sense setup --tools claude-code,codex-cli
+  sense setup --tools claude-code,codex-cli,opencode
 `
 
 // RunSetup configures AI tool integrations for the project.
@@ -27,7 +27,7 @@ func RunSetup(args []string, cio IO) int {
 	fs := flag.NewFlagSet("sense setup", flag.ContinueOnError)
 	fs.SetOutput(cio.Stderr)
 	fs.Usage = func() { _, _ = fmt.Fprint(cio.Stderr, setupHelp) }
-	toolsFlag := fs.String("tools", "", "comma-separated list of tools to configure (claude-code,cursor,codex-cli)")
+	toolsFlag := fs.String("tools", "", "comma-separated list of tools to configure (claude-code,cursor,codex-cli,opencode)")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return ExitSuccess

--- a/internal/setup/claude.go
+++ b/internal/setup/claude.go
@@ -1,0 +1,191 @@
+package setup
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/luuuc/sense/internal/mcpio"
+)
+
+// This file is the complete Claude Code integration: how Sense detects it
+// (detectClaudeCode) and what files it writes (configureClaudeCode plus its
+// writers). Adding a new tool means adding a sibling file shaped like this one
+// and a single line in registry().
+
+// detectClaudeCode looks for evidence that Claude Code is installed.
+func detectClaudeCode() DetectResult {
+	r := DetectResult{Tool: ToolClaudeCode}
+	if os.Getenv("CLAUDE_CODE") != "" {
+		r.Found = true
+		r.Evidence = "CLAUDE_CODE env var set"
+		return r
+	}
+	if _, err := exec.LookPath("claude"); err == nil {
+		r.Found = true
+		r.Evidence = "claude on PATH"
+		return r
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		if _, err := os.Stat(filepath.Join(home, ".claude")); err == nil {
+			r.Found = true
+			r.Evidence = "~/.claude/ directory"
+			return r
+		}
+	}
+	return r
+}
+
+// configureClaudeCode writes every Claude Code integration file: the MCP server
+// entry, hook + permission settings, the CLAUDE.md guidance section, and the
+// skill and agent files.
+func configureClaudeCode(root string) (*ToolResult, error) {
+	tr := &ToolResult{Tool: ToolClaudeCode}
+
+	if wrote, err := writeMCPJSON(root); err != nil {
+		return nil, fmt.Errorf("write .mcp.json: %w", err)
+	} else if wrote {
+		tr.Files = append(tr.Files, ".mcp.json")
+	}
+
+	if wrote, err := writeClaudeSettings(root); err != nil {
+		return nil, fmt.Errorf("write .claude/settings.json: %w", err)
+	} else if wrote {
+		tr.Files = append(tr.Files, ".claude/settings.json")
+	}
+
+	if wrote, err := writeClaudeMD(root); err != nil {
+		return nil, fmt.Errorf("write CLAUDE.md: %w", err)
+	} else if wrote {
+		tr.Files = append(tr.Files, "CLAUDE.md")
+	}
+
+	n, err := writeSkills(root)
+	if err != nil {
+		return nil, fmt.Errorf("write .claude/skills: %w", err)
+	}
+	if n > 0 {
+		tr.Files = append(tr.Files, fmt.Sprintf("%d skill files in .claude/skills/", n))
+	}
+
+	na, err := writeAgents(root)
+	if err != nil {
+		return nil, fmt.Errorf("write .claude/agents: %w", err)
+	}
+	if na > 0 {
+		tr.Files = append(tr.Files, fmt.Sprintf("%d agent files in .claude/agents/", na))
+	}
+
+	return tr, nil
+}
+
+// writeClaudeMD creates or updates the Sense guidance section in CLAUDE.md.
+func writeClaudeMD(root string) (bool, error) {
+	return writeMarkerFile(filepath.Join(root, "CLAUDE.md"), guidanceMarkdown)
+}
+
+// writeMCPJSON creates or merges the Sense MCP server entry into .mcp.json.
+// Shared with Codex CLI, which reads the same project-local file.
+func writeMCPJSON(root string) (bool, error) {
+	path := filepath.Join(root, ".mcp.json")
+
+	senseCfg := map[string]any{
+		"command":            "sense",
+		"args":               []any{"mcp"},
+		"serverInstructions": mcpio.ServerInstructions,
+	}
+
+	existing, err := readJSONFile(path)
+	if err != nil {
+		return false, err
+	}
+
+	servers, _ := existing["mcpServers"].(map[string]any)
+	if servers == nil {
+		servers = map[string]any{}
+	}
+	servers["sense"] = senseCfg
+	existing["mcpServers"] = servers
+
+	if err := writeJSONFile(path, existing); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// writeClaudeSettings creates or merges hook config and permissions
+// into .claude/settings.json.
+func writeClaudeSettings(root string) (bool, error) {
+	dir := filepath.Join(root, ".claude")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return false, err
+	}
+	path := filepath.Join(dir, "settings.json")
+
+	existing, err := readJSONFile(path)
+	if err != nil {
+		return false, err
+	}
+
+	hooks := map[string]any{
+		"PreToolUse": []any{
+			map[string]any{
+				"matcher": "Grep|Glob|Agent|Bash",
+				"hooks": []any{
+					map[string]any{
+						"type":    "command",
+						"command": "sense hook pre-tool-use",
+						"timeout": 5000,
+					},
+				},
+			},
+		},
+		"PreCompact": []any{
+			map[string]any{
+				"hooks": []any{
+					map[string]any{
+						"type":    "command",
+						"command": "sense hook pre-compact",
+						"timeout": 5000,
+					},
+				},
+			},
+		},
+		"SubagentStart": []any{
+			map[string]any{
+				"hooks": []any{
+					map[string]any{
+						"type":    "command",
+						"command": "sense hook subagent-start",
+						"timeout": 5000,
+					},
+				},
+			},
+		},
+		"SessionStart": []any{
+			map[string]any{
+				"hooks": []any{
+					map[string]any{
+						"type":    "command",
+						"command": "sense hook session-start",
+						"timeout": 5000,
+					},
+				},
+			},
+		},
+	}
+
+	mergeHooks(existing, hooks)
+	// Retire the synchronous PostToolUse re-index hook (pitch 26-01): the
+	// embedded watcher in `sense mcp` plus per-query read-repair now keep
+	// the index fresh off the agent's critical path. Strip any Sense entry
+	// an earlier setup wrote so re-running setup migrates old configs.
+	removeRetiredHook(existing, "PostToolUse")
+	mergePermissions(existing, []string{"mcp__sense__*"})
+
+	if err := writeJSONFile(path, existing); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/internal/setup/codex.go
+++ b/internal/setup/codex.go
@@ -1,30 +1,52 @@
 package setup
 
-import "path/filepath"
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
 
-const agentsMD = `<!-- sense:start -->
-## Sense — codebase understanding
+// detectCodexCLI looks for evidence that the Codex CLI is installed.
+func detectCodexCLI() DetectResult {
+	r := DetectResult{Tool: ToolCodexCLI}
+	if _, err := exec.LookPath("codex"); err == nil {
+		r.Found = true
+		r.Evidence = "codex on PATH"
+		return r
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		if _, err := os.Stat(filepath.Join(home, ".codex")); err == nil {
+			r.Found = true
+			r.Evidence = "~/.codex/ directory"
+			return r
+		}
+	}
+	return r
+}
 
-This project has a Sense index. Sense gives you structural understanding of the codebase — symbols, relationships, patterns — without reading dozens of files.
+// configureCodexCLI writes the shared .mcp.json server entry and the AGENTS.md
+// guidance Codex reads.
+func configureCodexCLI(root string) (*ToolResult, error) {
+	tr := &ToolResult{Tool: ToolCodexCLI}
 
-**Use Sense MCP tools for ALL codebase understanding:**
+	if wrote, err := writeMCPJSON(root); err != nil {
+		return nil, fmt.Errorf("write .mcp.json: %w", err)
+	} else if wrote {
+		tr.Files = append(tr.Files, ".mcp.json")
+	}
 
-| Question | Tool |
-|---|---|
-| Who calls X? What does X call? | sense_graph |
-| Find code related to a concept | sense_search |
-| What breaks if I change X? | sense_blast |
-| What patterns does this project follow? | sense_conventions |
-| Index health, what's indexed | sense_status |
+	if wrote, err := writeAgentsMD(root); err != nil {
+		return nil, fmt.Errorf("write AGENTS.md: %w", err)
+	} else if wrote {
+		tr.Files = append(tr.Files, "AGENTS.md")
+	}
 
-**When NOT to use Sense** (use grep instead):
-- Exact text/string search (regex, log messages, string literals)
-- Reading file contents → use your file reading tool
-- Editing code → Sense is read-only
-<!-- sense:end -->`
+	return tr, nil
+}
 
 // writeAgentsMD creates or updates the Sense section in AGENTS.md.
 // Uses the same marker-comment strategy as CLAUDE.md.
 func writeAgentsMD(root string) (bool, error) {
-	return writeMarkerFile(filepath.Join(root, "AGENTS.md"), agentsMD)
+	return writeMarkerFile(filepath.Join(root, "AGENTS.md"), guidanceMarkdown)
 }

--- a/internal/setup/cursor.go
+++ b/internal/setup/cursor.go
@@ -30,10 +30,14 @@ func detectCursor() DetectResult {
 	return r
 }
 
-// hasCursorEnv reports whether a Cursor session env var is set. Shared by
-// detectCursor and DetectCurrent.
+// cursorSessionEnvs are the env vars whose presence means the user is running
+// inside Cursor right now. Single source: detectCursor reads them via
+// hasCursorEnv, and the registry exposes them to DetectCurrent as currentEnv.
+var cursorSessionEnvs = []string{"CURSOR_TRACE_ID", "CURSOR_SESSION_ID"}
+
+// hasCursorEnv reports whether a Cursor session env var is set.
 func hasCursorEnv() bool {
-	for _, key := range []string{"CURSOR_TRACE_ID", "CURSOR_SESSION_ID"} {
+	for _, key := range cursorSessionEnvs {
 		if os.Getenv(key) != "" {
 			return true
 		}

--- a/internal/setup/cursor.go
+++ b/internal/setup/cursor.go
@@ -1,30 +1,64 @@
 package setup
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 )
 
-const cursorrules = `<!-- sense:start -->
-## Sense — codebase understanding
+// detectCursor looks for evidence that Cursor is installed.
+func detectCursor() DetectResult {
+	r := DetectResult{Tool: ToolCursor}
+	if hasCursorEnv() {
+		r.Found = true
+		r.Evidence = "CURSOR_* env var set"
+		return r
+	}
+	if _, err := exec.LookPath("cursor"); err == nil {
+		r.Found = true
+		r.Evidence = "cursor on PATH"
+		return r
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		if _, err := os.Stat(filepath.Join(home, ".cursor")); err == nil {
+			r.Found = true
+			r.Evidence = "~/.cursor/ directory"
+			return r
+		}
+	}
+	return r
+}
 
-This project has a Sense index. Sense gives you structural understanding of the codebase — symbols, relationships, patterns — without reading dozens of files.
+// hasCursorEnv reports whether a Cursor session env var is set. Shared by
+// detectCursor and DetectCurrent.
+func hasCursorEnv() bool {
+	for _, key := range []string{"CURSOR_TRACE_ID", "CURSOR_SESSION_ID"} {
+		if os.Getenv(key) != "" {
+			return true
+		}
+	}
+	return false
+}
 
-**Use Sense MCP tools for ALL codebase understanding:**
+// configureCursor writes Cursor's MCP config and its .cursorrules guidance.
+func configureCursor(root string) (*ToolResult, error) {
+	tr := &ToolResult{Tool: ToolCursor}
 
-| Question | Tool |
-|---|---|
-| Who calls X? What does X call? | sense_graph |
-| Find code related to a concept | sense_search |
-| What breaks if I change X? | sense_blast |
-| What patterns does this project follow? | sense_conventions |
-| Index health, what's indexed | sense_status |
+	if wrote, err := writeCursorMCPJSON(root); err != nil {
+		return nil, fmt.Errorf("write .cursor/mcp.json: %w", err)
+	} else if wrote {
+		tr.Files = append(tr.Files, ".cursor/mcp.json")
+	}
 
-**When NOT to use Sense** (use grep instead):
-- Exact text/string search (regex, log messages, string literals)
-- Reading file contents → use your file reading tool
-- Editing code → Sense is read-only
-<!-- sense:end -->`
+	if wrote, err := writeCursorRules(root); err != nil {
+		return nil, fmt.Errorf("write .cursorrules: %w", err)
+	} else if wrote {
+		tr.Files = append(tr.Files, ".cursorrules")
+	}
+
+	return tr, nil
+}
 
 // writeCursorMCPJSON creates or merges the Sense MCP server entry into
 // .cursor/mcp.json (Cursor's MCP config location).
@@ -61,5 +95,5 @@ func writeCursorMCPJSON(root string) (bool, error) {
 // writeCursorRules creates or updates the Sense section in .cursorrules.
 // Uses the same marker-comment strategy as CLAUDE.md for idempotent merges.
 func writeCursorRules(root string) (bool, error) {
-	return writeMarkerFile(filepath.Join(root, ".cursorrules"), cursorrules)
+	return writeMarkerFile(filepath.Join(root, ".cursorrules"), guidanceMarkdown)
 }

--- a/internal/setup/detect.go
+++ b/internal/setup/detect.go
@@ -35,18 +35,16 @@ func DetectAll() []DetectResult {
 	return results
 }
 
-// DetectCurrent returns the tool the user is currently running inside,
-// based on environment variables. Falls back to Claude Code as the
-// default consumer.
+// DetectCurrent returns the tool the user is currently running inside, based on
+// each tool's live-session env vars (registry currentEnv), in display order.
+// Falls back to Claude Code as the default consumer when no signal is present.
 func DetectCurrent() Tool {
-	if os.Getenv("CLAUDE_CODE") != "" {
-		return ToolClaudeCode
-	}
-	if hasCursorEnv() {
-		return ToolCursor
-	}
-	if os.Getenv("OPENCODE") != "" {
-		return ToolOpencode
+	for _, t := range registry() {
+		for _, key := range t.currentEnv {
+			if os.Getenv(key) != "" {
+				return t.id
+			}
+		}
 	}
 	return ToolClaudeCode
 }

--- a/internal/setup/detect.go
+++ b/internal/setup/detect.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
-	"path/filepath"
 )
 
-// Tool identifies an AI coding tool that Sense can integrate with.
+// Tool identifies an AI coding tool that Sense can integrate with. Its string
+// value is also the --tools flag name (see ParseTools). Detection, configure
+// dispatch, and display names all live in the registry (registry.go); the
+// per-tool detect/configure pair lives in that tool's own file.
 type Tool string
 
 const (
@@ -17,27 +18,6 @@ const (
 	ToolCodexCLI   Tool = "codex-cli"
 	ToolOpencode   Tool = "opencode"
 )
-
-// AllTools returns every tool Sense knows how to configure, in display order.
-func AllTools() []Tool {
-	return []Tool{ToolClaudeCode, ToolCursor, ToolCodexCLI, ToolOpencode}
-}
-
-// DisplayName returns the human-readable name for a tool.
-func (t Tool) DisplayName() string {
-	switch t {
-	case ToolClaudeCode:
-		return "Claude Code"
-	case ToolCursor:
-		return "Cursor"
-	case ToolCodexCLI:
-		return "Codex CLI"
-	case ToolOpencode:
-		return "Opencode"
-	default:
-		return string(t)
-	}
-}
 
 // DetectResult holds whether a tool was found and what evidence was seen.
 type DetectResult struct {
@@ -53,22 +33,6 @@ func DetectAll() []DetectResult {
 		results = append(results, Detect(t))
 	}
 	return results
-}
-
-// Detect checks for evidence of a single tool's installation.
-func Detect(t Tool) DetectResult {
-	switch t {
-	case ToolClaudeCode:
-		return detectClaudeCode()
-	case ToolCursor:
-		return detectCursor()
-	case ToolCodexCLI:
-		return detectCodexCLI()
-	case ToolOpencode:
-		return detectOpencode()
-	default:
-		return DetectResult{Tool: t}
-	}
 }
 
 // DetectCurrent returns the tool the user is currently running inside,
@@ -87,67 +51,6 @@ func DetectCurrent() Tool {
 	return ToolClaudeCode
 }
 
-func detectClaudeCode() DetectResult {
-	r := DetectResult{Tool: ToolClaudeCode}
-	if os.Getenv("CLAUDE_CODE") != "" {
-		r.Found = true
-		r.Evidence = "CLAUDE_CODE env var set"
-		return r
-	}
-	if _, err := exec.LookPath("claude"); err == nil {
-		r.Found = true
-		r.Evidence = "claude on PATH"
-		return r
-	}
-	if home, err := os.UserHomeDir(); err == nil {
-		if _, err := os.Stat(filepath.Join(home, ".claude")); err == nil {
-			r.Found = true
-			r.Evidence = "~/.claude/ directory"
-			return r
-		}
-	}
-	return r
-}
-
-func detectCursor() DetectResult {
-	r := DetectResult{Tool: ToolCursor}
-	if hasCursorEnv() {
-		r.Found = true
-		r.Evidence = "CURSOR_* env var set"
-		return r
-	}
-	if _, err := exec.LookPath("cursor"); err == nil {
-		r.Found = true
-		r.Evidence = "cursor on PATH"
-		return r
-	}
-	if home, err := os.UserHomeDir(); err == nil {
-		if _, err := os.Stat(filepath.Join(home, ".cursor")); err == nil {
-			r.Found = true
-			r.Evidence = "~/.cursor/ directory"
-			return r
-		}
-	}
-	return r
-}
-
-func detectCodexCLI() DetectResult {
-	r := DetectResult{Tool: ToolCodexCLI}
-	if _, err := exec.LookPath("codex"); err == nil {
-		r.Found = true
-		r.Evidence = "codex on PATH"
-		return r
-	}
-	if home, err := os.UserHomeDir(); err == nil {
-		if _, err := os.Stat(filepath.Join(home, ".codex")); err == nil {
-			r.Found = true
-			r.Evidence = "~/.codex/ directory"
-			return r
-		}
-	}
-	return r
-}
-
 // PrintDetection writes a summary of detected tools to out.
 func PrintDetection(out io.Writer) {
 	results := DetectAll()
@@ -160,35 +63,4 @@ func PrintDetection(out io.Writer) {
 		}
 	}
 	_, _ = fmt.Fprintln(out, "")
-}
-
-func detectOpencode() DetectResult {
-	r := DetectResult{Tool: ToolOpencode}
-	if os.Getenv("OPENCODE") != "" {
-		r.Found = true
-		r.Evidence = "OPENCODE env var set"
-		return r
-	}
-	if _, err := exec.LookPath("opencode"); err == nil {
-		r.Found = true
-		r.Evidence = "opencode on PATH"
-		return r
-	}
-	if home, err := os.UserHomeDir(); err == nil {
-		if _, err := os.Stat(filepath.Join(home, ".config", "opencode")); err == nil {
-			r.Found = true
-			r.Evidence = "~/.config/opencode/ directory"
-			return r
-		}
-	}
-	return r
-}
-
-func hasCursorEnv() bool {
-	for _, key := range []string{"CURSOR_TRACE_ID", "CURSOR_SESSION_ID"} {
-		if os.Getenv(key) != "" {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/setup/detect_test.go
+++ b/internal/setup/detect_test.go
@@ -225,6 +225,20 @@ func TestDetectCursorHomeDir(t *testing.T) {
 	}
 }
 
+func TestDetectCodexCLIPath(t *testing.T) {
+	binDir := t.TempDir()
+	t.Setenv("PATH", binDir)
+	_ = os.WriteFile(filepath.Join(binDir, "codex"), []byte("#!/bin/sh\n"), 0o755)
+
+	result := detectCodexCLI()
+	if !result.Found {
+		t.Error("expected Found=true for codex on PATH")
+	}
+	if result.Evidence != "codex on PATH" {
+		t.Errorf("expected PATH evidence, got %q", result.Evidence)
+	}
+}
+
 func TestDetectCodexCLIHomeDir(t *testing.T) {
 	t.Setenv("PATH", "")
 	home := t.TempDir()

--- a/internal/setup/marker.go
+++ b/internal/setup/marker.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"io/fs"
 	"os"
-	"path/filepath"
 	"strings"
 )
 
@@ -13,28 +12,34 @@ const (
 	markerEnd   = "<!-- sense:end -->"
 )
 
-const senseSection = `<!-- sense:start -->
-## IMPORTANT: This project has a Sense index — you MUST use it
+// guidanceMarkdown is the single source of truth for the Sense routing guidance
+// every tool's instructions file receives (CLAUDE.md, .cursorrules, AGENTS.md).
+// One source keeps the message consistent across tools; to tune what every AI
+// tool is told, edit this block. It is tool-agnostic on purpose: a phrasing
+// that only makes sense for one tool does not belong here.
+//
+// The one guidance surface NOT defined here is the MCP `serverInstructions`
+// string sent to a client at connect time. That lives in mcpio.ServerInstructions
+// because the running `sense mcp` server also sends it; setup only forwards it
+// (see writeMCPJSON). Keep the two in spirit, not in lockstep: this block is
+// the in-repo prompt, ServerInstructions is the protocol-level one-liner.
+const guidanceMarkdown = `<!-- sense:start -->
+## Use the Sense index for codebase understanding
 
-Sense tools are loaded at session start. Use them for ALL codebase understanding.
+Sense gives you structural understanding of the codebase (symbols, relationships, patterns) without reading dozens of files. Prefer it over grep, glob, and file-walking for any structural or semantic question.
 
 | Question | Tool |
 |---|---|
-| Who calls X? What does X call? | ` + "`sense_graph symbol=\"X\"`" + ` |
-| Find code related to a concept | ` + "`sense_search query=\"description\"`" + ` |
-| What breaks if I change X? | ` + "`sense_blast symbol=\"X\"`" + ` |
-| What patterns does this project follow? | ` + "`sense_conventions`" + ` |
+| Who calls X? What does X call? | sense_graph |
+| Find code related to a concept | sense_search |
+| What breaks if I change X? | sense_blast |
+| What patterns does this project follow? | sense_conventions |
+| Index health, what's indexed | sense_status |
 
-**You MUST NOT:** spawn Explore/deep-explore agents, use grep/glob for symbol lookup, or skip Sense because tools are deferred.
+**You MUST NOT** use grep/glob for symbol lookup, or skip Sense because its tools load on demand. For list outputs (dead code, blast radius, callers), spot-check a sample with grep before relying on them.
 
-**Verify list results:** For list outputs (dead code, blast radius, callers), verify a sample with grep before finalizing.
+**When NOT to use Sense** (use grep instead): exact text/string search, reading file contents, editing code (Sense is read-only).
 <!-- sense:end -->`
-
-// writeClaudeMD creates or updates the Sense section in CLAUDE.md.
-// Uses marker comments for idempotent updates.
-func writeClaudeMD(root string) (bool, error) {
-	return writeMarkerFile(filepath.Join(root, "CLAUDE.md"), senseSection)
-}
 
 // writeMarkerFile creates or updates a marker-delimited Sense section
 // in the file at path. If the file already contains markers, the section

--- a/internal/setup/opencode.go
+++ b/internal/setup/opencode.go
@@ -3,31 +3,36 @@ package setup
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 )
 
-const opencodeAgentsMD = `<!-- sense:start -->
-## Sense — codebase understanding
+// detectOpencode looks for evidence that OpenCode is installed.
+func detectOpencode() DetectResult {
+	r := DetectResult{Tool: ToolOpencode}
+	if os.Getenv("OPENCODE") != "" {
+		r.Found = true
+		r.Evidence = "OPENCODE env var set"
+		return r
+	}
+	if _, err := exec.LookPath("opencode"); err == nil {
+		r.Found = true
+		r.Evidence = "opencode on PATH"
+		return r
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		if _, err := os.Stat(filepath.Join(home, ".config", "opencode")); err == nil {
+			r.Found = true
+			r.Evidence = "~/.config/opencode/ directory"
+			return r
+		}
+	}
+	return r
+}
 
-This project has a Sense index. Sense gives you structural understanding of the codebase — symbols, relationships, patterns — without reading dozens of files.
-
-**Use Sense MCP tools for ALL codebase understanding:**
-
-| Question | Tool |
-|---|---|
-| Who calls X? What does X call? | sense_graph |
-| Find code related to a concept | sense_search |
-| What breaks if I change X? | sense_blast |
-| What patterns does this project follow? | sense_conventions |
-| Index health, what's indexed | sense_status |
-
-**When NOT to use Sense** (use grep instead):
-- Exact text/string search (regex, log messages, string literals)
-- Reading file contents → use your file reading tool
-- Editing code → Sense is read-only
-<!-- sense:end -->`
-
+// configureOpencode writes OpenCode's project-local MCP config, the AGENTS.md
+// guidance, and the per-skill SKILL.md tree OpenCode expects.
 func configureOpencode(root string) (*ToolResult, error) {
 	tr := &ToolResult{Tool: ToolOpencode}
 
@@ -88,7 +93,7 @@ func writeOpencodeJSON(root string) (bool, error) {
 
 // writeOpencodeAgentsMD creates or updates the Sense section in AGENTS.md.
 func writeOpencodeAgentsMD(root string) (bool, error) {
-	return writeMarkerFile(filepath.Join(root, "AGENTS.md"), opencodeAgentsMD)
+	return writeMarkerFile(filepath.Join(root, "AGENTS.md"), guidanceMarkdown)
 }
 
 // writeOpencodeSkills creates skill files in .opencode/skills/.

--- a/internal/setup/registry.go
+++ b/internal/setup/registry.go
@@ -21,18 +21,28 @@ type tool struct {
 	// twice produces the same result (JSON is deep-merged, Markdown uses
 	// marker comments, skills/agents are overwritten).
 	configure func(root string) (*ToolResult, error)
+	// currentEnv lists env vars whose presence means the user is running inside
+	// this tool right now. DetectCurrent uses it to pick the active tool for
+	// scan first-run. Leave empty when the tool exposes no live-session signal
+	// (a tool with none can still be detected and configured; it just never
+	// wins DetectCurrent, which falls back to Claude Code).
+	currentEnv []string
 }
 
 // registry returns every tool Sense knows how to configure, in display order.
 // To add a tool, append one entry here and implement its detect/configure pair
 // in a new file (see claude.go as the template, CONTRIBUTING-AN-AI-TOOL.md for
 // the walkthrough).
+//
+// The slice is rebuilt on each call rather than memoized: the set is tiny and
+// callers are not hot, so a fresh slice keeps the function pure and dodges
+// init-order questions. Do not "optimize" it into a package var.
 func registry() []tool {
 	return []tool{
-		{id: ToolClaudeCode, displayName: "Claude Code", detect: detectClaudeCode, configure: configureClaudeCode},
-		{id: ToolCursor, displayName: "Cursor", detect: detectCursor, configure: configureCursor},
+		{id: ToolClaudeCode, displayName: "Claude Code", detect: detectClaudeCode, configure: configureClaudeCode, currentEnv: []string{"CLAUDE_CODE"}},
+		{id: ToolCursor, displayName: "Cursor", detect: detectCursor, configure: configureCursor, currentEnv: cursorSessionEnvs},
 		{id: ToolCodexCLI, displayName: "Codex CLI", detect: detectCodexCLI, configure: configureCodexCLI},
-		{id: ToolOpencode, displayName: "Opencode", detect: detectOpencode, configure: configureOpencode},
+		{id: ToolOpencode, displayName: "Opencode", detect: detectOpencode, configure: configureOpencode, currentEnv: []string{"OPENCODE"}},
 	}
 }
 

--- a/internal/setup/registry.go
+++ b/internal/setup/registry.go
@@ -1,0 +1,108 @@
+package setup
+
+import (
+	"fmt"
+	"strings"
+)
+
+// tool is one AI coding tool Sense can integrate with. The registry of these
+// values is the single source of truth: detection, display names, the --tools
+// flag, and the configure dispatch all derive from it, so adding a tool is a
+// new per-tool file (detectX + configureX) plus one entry here, with no switch
+// statements to update.
+type tool struct {
+	id          Tool
+	displayName string
+	// detect reports whether this tool is installed, with human-readable
+	// evidence. It reads the environment and filesystem only.
+	detect func() DetectResult
+	// configure writes every integration file this tool needs into root and
+	// returns the relative paths written. It must be idempotent: running it
+	// twice produces the same result (JSON is deep-merged, Markdown uses
+	// marker comments, skills/agents are overwritten).
+	configure func(root string) (*ToolResult, error)
+}
+
+// registry returns every tool Sense knows how to configure, in display order.
+// To add a tool, append one entry here and implement its detect/configure pair
+// in a new file (see claude.go as the template, CONTRIBUTING-AN-AI-TOOL.md for
+// the walkthrough).
+func registry() []tool {
+	return []tool{
+		{id: ToolClaudeCode, displayName: "Claude Code", detect: detectClaudeCode, configure: configureClaudeCode},
+		{id: ToolCursor, displayName: "Cursor", detect: detectCursor, configure: configureCursor},
+		{id: ToolCodexCLI, displayName: "Codex CLI", detect: detectCodexCLI, configure: configureCodexCLI},
+		{id: ToolOpencode, displayName: "Opencode", detect: detectOpencode, configure: configureOpencode},
+	}
+}
+
+// lookup returns the registry entry for an id, or false if none matches.
+func lookup(id Tool) (tool, bool) {
+	for _, t := range registry() {
+		if t.id == id {
+			return t, true
+		}
+	}
+	return tool{}, false
+}
+
+// AllTools returns every tool Sense knows how to configure, in display order.
+func AllTools() []Tool {
+	reg := registry()
+	ids := make([]Tool, len(reg))
+	for i, t := range reg {
+		ids[i] = t.id
+	}
+	return ids
+}
+
+// DisplayName returns the human-readable name for a tool.
+func (t Tool) DisplayName() string {
+	if e, ok := lookup(t); ok {
+		return e.displayName
+	}
+	return string(t)
+}
+
+// Detect checks for evidence of a single tool's installation.
+func Detect(t Tool) DetectResult {
+	if e, ok := lookup(t); ok {
+		return e.detect()
+	}
+	return DetectResult{Tool: t}
+}
+
+// configureTool writes the integration files for a single tool.
+func configureTool(root string, t Tool) (*ToolResult, error) {
+	if e, ok := lookup(t); ok {
+		return e.configure(root)
+	}
+	return nil, fmt.Errorf("unknown tool: %s", t)
+}
+
+// ParseTools parses a comma-separated list of tool names into Tool values.
+// Returns an error if any name is unrecognized.
+func ParseTools(s string) ([]Tool, error) {
+	if s == "" {
+		return nil, nil
+	}
+	var tools []Tool
+	for _, name := range strings.Split(s, ",") {
+		id := Tool(strings.TrimSpace(name))
+		if _, ok := lookup(id); !ok {
+			return nil, fmt.Errorf("unknown tool %q (valid: %s)", id, strings.Join(toolNames(), ", "))
+		}
+		tools = append(tools, id)
+	}
+	return tools, nil
+}
+
+// toolNames returns the registry's tool ids as strings, for help and error text.
+func toolNames() []string {
+	reg := registry()
+	names := make([]string, len(reg))
+	for i, t := range reg {
+		names[i] = string(t.id)
+	}
+	return names
+}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -3,6 +3,12 @@
 // routing guidance, hooks, skills) so that AI tools discover and
 // prefer Sense without manual configuration.
 //
+// The set of tools is a registry (registry.go): each tool is one entry
+// pairing a detector with a configurer, and each tool's files live in
+// its own file (claude.go, cursor.go, codex.go, opencode.go). Adding a
+// tool touches a new file plus one registry line; see
+// CONTRIBUTING-AN-AI-TOOL.md.
+//
 // All writes are idempotent: JSON files are deep-merged, Markdown
 // files use marker comments, skill files are overwritten. Running
 // setup twice produces the same result.
@@ -11,11 +17,7 @@ package setup
 import (
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 	"strings"
-
-	"github.com/luuuc/sense/internal/mcpio"
 )
 
 // Options controls which tools setup configures.
@@ -77,97 +79,6 @@ func resolveTools(opts *Options) []Tool {
 	return tools
 }
 
-func configureTool(root string, t Tool) (*ToolResult, error) {
-	switch t {
-	case ToolClaudeCode:
-		return configureClaudeCode(root)
-	case ToolCursor:
-		return configureCursor(root)
-	case ToolCodexCLI:
-		return configureCodexCLI(root)
-	case ToolOpencode:
-		return configureOpencode(root)
-	default:
-		return nil, fmt.Errorf("unknown tool: %s", t)
-	}
-}
-
-func configureClaudeCode(root string) (*ToolResult, error) {
-	tr := &ToolResult{Tool: ToolClaudeCode}
-
-	if wrote, err := writeMCPJSON(root); err != nil {
-		return nil, fmt.Errorf("write .mcp.json: %w", err)
-	} else if wrote {
-		tr.Files = append(tr.Files, ".mcp.json")
-	}
-
-	if wrote, err := writeClaudeSettings(root); err != nil {
-		return nil, fmt.Errorf("write .claude/settings.json: %w", err)
-	} else if wrote {
-		tr.Files = append(tr.Files, ".claude/settings.json")
-	}
-
-	if wrote, err := writeClaudeMD(root); err != nil {
-		return nil, fmt.Errorf("write CLAUDE.md: %w", err)
-	} else if wrote {
-		tr.Files = append(tr.Files, "CLAUDE.md")
-	}
-
-	n, err := writeSkills(root)
-	if err != nil {
-		return nil, fmt.Errorf("write .claude/skills: %w", err)
-	}
-	if n > 0 {
-		tr.Files = append(tr.Files, fmt.Sprintf("%d skill files in .claude/skills/", n))
-	}
-
-	na, err := writeAgents(root)
-	if err != nil {
-		return nil, fmt.Errorf("write .claude/agents: %w", err)
-	}
-	if na > 0 {
-		tr.Files = append(tr.Files, fmt.Sprintf("%d agent files in .claude/agents/", na))
-	}
-
-	return tr, nil
-}
-
-func configureCursor(root string) (*ToolResult, error) {
-	tr := &ToolResult{Tool: ToolCursor}
-
-	if wrote, err := writeCursorMCPJSON(root); err != nil {
-		return nil, fmt.Errorf("write .cursor/mcp.json: %w", err)
-	} else if wrote {
-		tr.Files = append(tr.Files, ".cursor/mcp.json")
-	}
-
-	if wrote, err := writeCursorRules(root); err != nil {
-		return nil, fmt.Errorf("write .cursorrules: %w", err)
-	} else if wrote {
-		tr.Files = append(tr.Files, ".cursorrules")
-	}
-
-	return tr, nil
-}
-
-func configureCodexCLI(root string) (*ToolResult, error) {
-	tr := &ToolResult{Tool: ToolCodexCLI}
-
-	if wrote, err := writeMCPJSON(root); err != nil {
-		return nil, fmt.Errorf("write .mcp.json: %w", err)
-	} else if wrote {
-		tr.Files = append(tr.Files, ".mcp.json")
-	}
-
-	if wrote, err := writeAgentsMD(root); err != nil {
-		return nil, fmt.Errorf("write AGENTS.md: %w", err)
-	} else if wrote {
-		tr.Files = append(tr.Files, "AGENTS.md")
-	}
-
-	return tr, nil
-}
-
 func printSetupSummary(out io.Writer, res *Result) {
 	if len(res.Tools) == 0 {
 		return
@@ -200,133 +111,4 @@ func joinNames(names []string) string {
 	default:
 		return strings.Join(names[:len(names)-1], ", ") + ", and " + names[len(names)-1]
 	}
-}
-
-// writeMCPJSON creates or merges the Sense MCP server entry into .mcp.json.
-func writeMCPJSON(root string) (bool, error) {
-	path := filepath.Join(root, ".mcp.json")
-
-	senseCfg := map[string]any{
-		"command":            "sense",
-		"args":               []any{"mcp"},
-		"serverInstructions": mcpio.ServerInstructions,
-	}
-
-	existing, err := readJSONFile(path)
-	if err != nil {
-		return false, err
-	}
-
-	servers, _ := existing["mcpServers"].(map[string]any)
-	if servers == nil {
-		servers = map[string]any{}
-	}
-	servers["sense"] = senseCfg
-	existing["mcpServers"] = servers
-
-	if err := writeJSONFile(path, existing); err != nil {
-		return false, err
-	}
-	return true, nil
-}
-
-// writeClaudeSettings creates or merges hook config and permissions
-// into .claude/settings.json.
-func writeClaudeSettings(root string) (bool, error) {
-	dir := filepath.Join(root, ".claude")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return false, err
-	}
-	path := filepath.Join(dir, "settings.json")
-
-	existing, err := readJSONFile(path)
-	if err != nil {
-		return false, err
-	}
-
-	hooks := map[string]any{
-		"PreToolUse": []any{
-			map[string]any{
-				"matcher": "Grep|Glob|Agent|Bash",
-				"hooks": []any{
-					map[string]any{
-						"type":    "command",
-						"command": "sense hook pre-tool-use",
-						"timeout": 5000,
-					},
-				},
-			},
-		},
-		"PreCompact": []any{
-			map[string]any{
-				"hooks": []any{
-					map[string]any{
-						"type":    "command",
-						"command": "sense hook pre-compact",
-						"timeout": 5000,
-					},
-				},
-			},
-		},
-		"SubagentStart": []any{
-			map[string]any{
-				"hooks": []any{
-					map[string]any{
-						"type":    "command",
-						"command": "sense hook subagent-start",
-						"timeout": 5000,
-					},
-				},
-			},
-		},
-		"SessionStart": []any{
-			map[string]any{
-				"hooks": []any{
-					map[string]any{
-						"type":    "command",
-						"command": "sense hook session-start",
-						"timeout": 5000,
-					},
-				},
-			},
-		},
-	}
-
-	mergeHooks(existing, hooks)
-	// Retire the synchronous PostToolUse re-index hook (pitch 26-01): the
-	// embedded watcher in `sense mcp` plus per-query read-repair now keep
-	// the index fresh off the agent's critical path. Strip any Sense entry
-	// an earlier setup wrote so re-running setup migrates old configs.
-	removeRetiredHook(existing, "PostToolUse")
-	mergePermissions(existing, []string{"mcp__sense__*"})
-
-	if err := writeJSONFile(path, existing); err != nil {
-		return false, err
-	}
-	return true, nil
-}
-
-// ParseTools parses a comma-separated list of tool names into Tool values.
-// Returns an error if any name is unrecognized.
-func ParseTools(s string) ([]Tool, error) {
-	if s == "" {
-		return nil, nil
-	}
-	var tools []Tool
-	for _, name := range strings.Split(s, ",") {
-		name = strings.TrimSpace(name)
-		switch name {
-		case "claude-code":
-			tools = append(tools, ToolClaudeCode)
-		case "cursor":
-			tools = append(tools, ToolCursor)
-		case "codex-cli":
-			tools = append(tools, ToolCodexCLI)
-		case "opencode":
-			tools = append(tools, ToolOpencode)
-		default:
-			return nil, fmt.Errorf("unknown tool %q (valid: claude-code, cursor, codex-cli, opencode)", name)
-		}
-	}
-	return tools, nil
 }

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -740,34 +740,52 @@ func TestResolveToolsDefaultsToClaudeCode(t *testing.T) {
 	}
 }
 
-func TestSenseSectionContent(t *testing.T) {
-	if !strings.Contains(senseSection, "sense_graph") {
-		t.Error("senseSection must include tool table with sense_graph")
+func TestGuidanceMarkdownContent(t *testing.T) {
+	for _, tool := range []string{"sense_graph", "sense_search", "sense_blast", "sense_conventions", "sense_status"} {
+		if !strings.Contains(guidanceMarkdown, tool) {
+			t.Errorf("guidanceMarkdown must include %s in the tool table", tool)
+		}
 	}
-	if !strings.Contains(senseSection, "sense_search") {
-		t.Error("senseSection must include tool table with sense_search")
+	if !strings.Contains(guidanceMarkdown, "MUST NOT") {
+		t.Error("guidanceMarkdown must include MUST NOT rules")
 	}
-	if !strings.Contains(senseSection, "sense_blast") {
-		t.Error("senseSection must include tool table with sense_blast")
+	if strings.Contains(guidanceMarkdown, "FIRST action in every conversation") {
+		t.Error("guidanceMarkdown must not include cold-start protocol (now handled by SessionStart hook)")
 	}
-	if !strings.Contains(senseSection, "sense_conventions") {
-		t.Error("senseSection must include tool table with sense_conventions")
+	if strings.Contains(guidanceMarkdown, "sense_orient") || strings.Contains(guidanceMarkdown, "sense.orient") {
+		t.Error("guidanceMarkdown must not reference the removed orient tool")
 	}
-	if !strings.Contains(senseSection, "MUST NOT") {
-		t.Error("senseSection must include MUST NOT rules")
-	}
-	if strings.Contains(senseSection, "FIRST action in every conversation") {
-		t.Error("senseSection must not include cold-start protocol (now handled by SessionStart hook)")
-	}
-	if strings.Contains(senseSection, "sense_orient") || strings.Contains(senseSection, "sense.orient") {
-		t.Error("senseSection must not reference the removed orient tool")
+	// The guidance is tool-agnostic on purpose: a single source feeds every
+	// tool's instructions file, so it must not name one tool's UI.
+	for _, leak := range []string{"Explore/deep-explore", ".cursorrules", "Claude Code"} {
+		if strings.Contains(guidanceMarkdown, leak) {
+			t.Errorf("guidanceMarkdown must stay tool-agnostic, found %q", leak)
+		}
 	}
 	if strings.Contains(mcpio.ServerInstructions, "sense.orient") {
 		t.Error("ServerInstructions must not reference the removed orient tool")
 	}
-	lines := strings.Count(senseSection, "\n")
-	if lines > 20 {
-		t.Errorf("senseSection should be ≤20 lines (cold-start protocol removed), got %d", lines)
+	if lines := strings.Count(guidanceMarkdown, "\n"); lines > 20 {
+		t.Errorf("guidanceMarkdown should be ≤20 lines, got %d", lines)
+	}
+}
+
+// TestGuidanceMarkdownIsSingleSource asserts every tool's instructions file
+// receives the same guidance body, so tuning it is a one-place edit.
+func TestGuidanceMarkdownIsSingleSource(t *testing.T) {
+	root := t.TempDir()
+	opts := &Options{Tools: []Tool{ToolClaudeCode, ToolCursor, ToolCodexCLI, ToolOpencode}}
+	if _, err := Run(root, &bytes.Buffer{}, opts); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	for _, rel := range []string{"CLAUDE.md", ".cursorrules", "AGENTS.md"} {
+		data, err := os.ReadFile(filepath.Join(root, rel))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		if !strings.Contains(string(data), guidanceMarkdown) {
+			t.Errorf("%s does not contain the canonical guidanceMarkdown", rel)
+		}
 	}
 }
 

--- a/mcpb/manifest.template.json
+++ b/mcpb/manifest.template.json
@@ -16,7 +16,7 @@
   "homepage": "https://luuuc.github.io/sense/",
   "documentation": "https://github.com/luuuc/sense/blob/main/README.md",
   "support": "https://github.com/luuuc/sense/issues",
-  "license": "Other",
+  "license": "MIT",
   "keywords": [
     "mcp",
     "mcp-server",


### PR DESCRIPTION
## Problem

Sense is approaching v1 and wants outside help on a narrow set of surfaces (new languages and frameworks, dead-code fine-graining, AI-tool integrations) without inviting feature creep. Today there is no contribution policy, no guide for two of those three lanes, and the AI-tool setup code is not modular enough to follow: adding a tool means editing seven switch sites and five duplicated guidance blobs. The license also carries a non-standard SaaS-competition clause that complicates open contribution.

## Summary

Make Sense contributor-ready: add a contribution charter and per-lane guides, refactor the AI-tool setup into a registry with a single guidance source, and relicense to standard MIT.

## Changes

- **Contribution policy and guides**: a "what we accept" charter in `CONTRIBUTING.md` naming the three accepted lanes and declining net-new features; new `CONTRIBUTING-A-FRAMEWORK.md` (framework edges plus the dead-code fine-graining that goes with them) and `CONTRIBUTING-AN-AI-TOOL.md`; the language guide and README point at the full set.
- **setup registry refactor (behavior-preserving)**: replace the per-tool switch statements (detect, configure, parse, display name, current-session) with one registry and one file per tool; collapse five duplicated routing-guidance blobs into a single shared source asserted by a test; correct the CLI help and README to include OpenCode.
- **MIT relicense**: replace the O'Saasy license with the standard MIT License (same copyright holder) and update the MCPB manifest `license` field.

## Architecture Highlights

- Adding an AI tool is now a new file (a detect/configure pair) plus one registry line, including the live-session detection path via the `currentEnv` field.
- One `guidanceMarkdown` source feeds every tool's instructions file (CLAUDE.md, .cursorrules, AGENTS.md); a test pins that they stay identical.

## Notes

- The unified guidance block written to CLAUDE.md is tool-agnostic, so it drops the previous Claude-specific phrasing (for example the "spawn Explore agents" prohibition). File-generation behavior is unchanged; only the guidance content differs.
- The license change is a loosening (pure MIT), so it is not a breaking change for consumers, but downstream users should note the reserved SaaS-competition clause is gone.

## Test Plan

- [x] `make ci` passes: per-file coverage gate (>=92% line and function, 95.0% total), golangci-lint 0 issues, complexity ledger 0
- [x] sense binary builds cleanly
- [x] `sense setup` is idempotent and preserves existing user content and non-Sense MCP servers (existing setup tests)
- [x] `DetectCurrent` selects the active tool from its session env var (registry-driven)
- [x] Manual: `sense setup --tools claude-code,cursor,codex-cli,opencode` writes each tool's files in a scratch repo
