### PR TITLE
fix(benchmark): report live heap for query serving, not alloc churn

### DIFF
--- a/internal/benchmark/benchmark.go
+++ b/internal/benchmark/benchmark.go
@@ -54,6 +54,11 @@ type IndexMetrics struct {
 }
 
 type MemoryMetrics struct {
+	// QueryLiveBytes is the live heap retained after the query suite settles
+	// (post-GC HeapInuse). It is the resident-set proxy for query serving.
+	QueryLiveBytes uint64
+	// QueryAllocBytes is the cumulative heap allocated during the query suite
+	// (TotalAlloc delta). It is allocation churn, not resident memory.
 	QueryAllocBytes uint64
 }
 
@@ -145,6 +150,15 @@ func Run(ctx context.Context, dir string, opts Options) (*Report, error) {
 		}
 	}
 
+	// Measure query-serving memory here, while the index and query structures
+	// are still live but before scan/cold-start allocate (and free) unrelated
+	// memory. GC first so HeapInuse reflects retained working set, not garbage.
+	runtime.GC()
+	var memAfter runtime.MemStats
+	runtime.ReadMemStats(&memAfter)
+	report.Memory.QueryLiveBytes = memAfter.HeapInuse
+	report.Memory.QueryAllocBytes = memAfter.TotalAlloc - memBefore.TotalAlloc
+
 	report.Index = measureIndex(dir, report.SymbolCount)
 
 	if opts.Binary != "" {
@@ -154,10 +168,6 @@ func Run(ctx context.Context, dir string, opts Options) (*Report, error) {
 	if !opts.SkipScan {
 		report.Scan = measureScan(ctx, dir)
 	}
-
-	var memAfter runtime.MemStats
-	runtime.ReadMemStats(&memAfter)
-	report.Memory.QueryAllocBytes = memAfter.TotalAlloc - memBefore.TotalAlloc
 
 	return report, nil
 }

--- a/internal/benchmark/format.go
+++ b/internal/benchmark/format.go
@@ -60,6 +60,7 @@ type JSONIndex struct {
 }
 
 type JSONMemory struct {
+	QueryLiveBytes  uint64 `json:"query_live_bytes"`
 	QueryAllocBytes uint64 `json:"query_alloc_bytes"`
 }
 
@@ -91,6 +92,7 @@ func MarshalJSON(r *Report) ([]byte, error) {
 			BytesPerSymbol: r.Index.BytesPerSymbol,
 		},
 		Memory: JSONMemory{
+			QueryLiveBytes:  r.Memory.QueryLiveBytes,
 			QueryAllocBytes: r.Memory.QueryAllocBytes,
 		},
 		Iterations: r.Iterations,
@@ -148,7 +150,8 @@ func WriteHuman(w io.Writer, r *Report) {
 	_, _ = fmt.Fprintln(w)
 
 	_, _ = fmt.Fprintf(w, "\nMemory\n")
-	_, _ = fmt.Fprintf(w, "  RSS (query serving) .... %s\n", fmtBytes(int64(r.Memory.QueryAllocBytes)))
+	_, _ = fmt.Fprintf(w, "  live heap (serving) .... %s\n", fmtBytes(int64(r.Memory.QueryLiveBytes)))
+	_, _ = fmt.Fprintf(w, "  alloc churn (queries) .. %s\n", fmtBytes(int64(r.Memory.QueryAllocBytes)))
 }
 
 func printLatency(w io.Writer, label string, l Latency) {

--- a/internal/benchmark/format_test.go
+++ b/internal/benchmark/format_test.go
@@ -158,6 +158,33 @@ func TestMarshalJSONOptionalFields(t *testing.T) {
 	}
 }
 
+func TestMarshalJSONMemory(t *testing.T) {
+	r := &Report{
+		Dir: "/tmp/test",
+		Memory: MemoryMetrics{
+			QueryLiveBytes:  1048576,
+			QueryAllocBytes: 5242880,
+		},
+	}
+
+	data, err := MarshalJSON(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var parsed JSONReport
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatal(err)
+	}
+
+	if parsed.Memory.QueryLiveBytes != 1048576 {
+		t.Errorf("QueryLiveBytes = %d, want 1048576", parsed.Memory.QueryLiveBytes)
+	}
+	if parsed.Memory.QueryAllocBytes != 5242880 {
+		t.Errorf("QueryAllocBytes = %d, want 5242880", parsed.Memory.QueryAllocBytes)
+	}
+}
+
 func TestWriteHuman(t *testing.T) {
 	r := &Report{
 		Dir:         "/tmp/test",
@@ -186,6 +213,7 @@ func TestWriteHuman(t *testing.T) {
 			BytesPerSymbol: 10240,
 		},
 		Memory: MemoryMetrics{
+			QueryLiveBytes:  1048576,
 			QueryAllocBytes: 5242880,
 		},
 	}
@@ -215,7 +243,8 @@ func TestWriteHuman(t *testing.T) {
 		"Index",
 		"database size",
 		"Memory",
-		"RSS (query serving)",
+		"live heap (serving)",
+		"alloc churn (queries)",
 	}
 
 	for _, s := range want {


### PR DESCRIPTION
## Problem
The benchmark's `Memory` section printed `RSS (query serving)`, but the number behind it was `memAfter.TotalAlloc - memBefore.TotalAlloc`. `TotalAlloc` is Go's monotonic lifetime allocation counter, so the delta measured total allocation churn over the run (mostly transient garbage that was already collected), not resident memory. The measurement window also spanned `measureIndex`, cold-start, and the full re-scan, folding scan allocations into a figure labeled "query serving". The result was wildly inflated numbers (e.g. 6 GB) that did not reflect actual serving footprint.

## Summary
Measure the live heap retained after the query suite settles and report it honestly, with the churn figure kept as a separate, correctly labeled line.

## Changes
- Take the memory snapshot immediately after the query suite, before scan/cold-start allocate unrelated memory, with a `runtime.GC()` first so the reading reflects retained working set
- Report `HeapInuse` as `live heap (serving)` (resident-set proxy)
- Keep the `TotalAlloc` delta but relabel it `alloc churn (queries)` so the allocation-pressure signal is preserved without masquerading as RSS
- Add `query_live_bytes` to JSON output alongside `query_alloc_bytes`

## Test Plan
- [x] `go test ./internal/benchmark/` passes (added `TestMarshalJSONMemory`, updated human-output assertions)
- [x] `make ci` fully green (95.0% total coverage, lint clean, ledger empty)
- [x] sense binary builds cleanly