### PR TITLE
fix(mcp): close the Sense adoption gate and harden the bench

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,8 @@ bench/results/report-*.md
 bench/results/report-for-humans-*.md
 bench/bench-sense-local.sh
 /bench/embed-recall
+
+# Local scratch: Python coverage DB and scenario backups taken while
+# reworking a seam (e.g. forem.embed.yaml.bak before the reaction rewrite).
+bench/lib/.coverage
+bench/scenarios/*.bak

--- a/bench/lib/gold.py
+++ b/bench/lib/gold.py
@@ -19,18 +19,41 @@ Each gold item (a dict, or a bare string shorthand):
   - group: optional bucket for per-group recall (e.g. "providers")
   - match: list of case-insensitive substrings; the target is MENTIONED if any
            appears. A pattern that looks like a file (has "/" and "." or a code
-           extension) also drives the CITED check: the target is cited when that
-           path is followed by `:<line>` in the answer. Items with no file-like
-           pattern (pure symbol names) treat cited == mentioned.
+           extension) also drives the CITED check: the target is cited when a
+           location pin for that path appears in the answer (see _cited for the
+           accepted forms). Items with no file-like pattern (pure symbol names)
+           treat cited == mentioned.
+
+The cited check accepts any of the location-pin forms agents actually use, not
+just a contiguous `path:N`. The old matcher demanded the full gold path be
+immediately followed by `:<line>`, which under-credited a baseline that named
+the path but pinned the line a different way, and so manufactured fake
+"sense-only cited" wins. The accepted forms are:
+  1. `path:N`                      — gold path immediately followed by a line.
+  2. `path (line N)`               — line in a trailing parenthetical.
+  3. `path` ... `"line": N`        — the JSON-object form, where the line is a
+                                     sibling field within a small same-object
+                                     window (e.g. {"file": "...rb", "line": 5}).
+  4. `<basename>:N`                — a short basename + line, e.g.
+                                     `benefit.rb:260`, ONLY when that basename is
+                                     unambiguous among the gold file paths (no two
+                                     targets share it), so a basename pin can never
+                                     double-count two distinct targets.
 
 Returns None when the scenario declares no gold — older scenarios and
 competitor runs are unaffected.
 """
 
+import os
 import re
 
 _CODE_EXT = (".rb", ".py", ".go", ".ts", ".tsx", ".js", ".jsx", ".rs", ".java",
              ".kt", ".cs", ".cpp", ".cc", ".c", ".php", ".scala", ".erb")
+
+# How far past a path a sibling `"line": N` JSON field may sit and still count
+# as the same object's location pin. Small enough to stay inside one object's
+# adjacent fields; `{`/`}`/newline are hard stops regardless (see _cited).
+_LINE_FIELD_WINDOW = 60
 
 
 def _is_file_like(p):
@@ -38,15 +61,61 @@ def _is_file_like(p):
     return pl.endswith(_CODE_EXT) or ("/" in p and "." in p)
 
 
-def _cited(pattern, hay):
-    # path immediately followed by a line locator, e.g. "providers/anthropic.rb:24"
-    return bool(re.search(re.escape(pattern.lower()) + r":\d+", hay))
+def _cited(pattern, hay, basename=None):
+    """Is this gold file path pinned to a line anywhere in the answer?
+
+    `pattern` and `hay` are already lower-cased by the caller. `basename`, when
+    given, is the path's unambiguous basename (unique among the gold file
+    paths) and enables the short-basename form; pass None to disable it.
+    """
+    esc = re.escape(pattern)
+    # 1. path immediately followed by a line, e.g. "anthropic.rb:24" or ":49-63".
+    if re.search(esc + r":\d+", hay):
+        return True
+    # 2. path then a trailing parenthetical, e.g. "anthropic.rb (line 24)".
+    if re.search(esc + r"\s*\(line\s+\d+\)", hay):
+        return True
+    # 3. path then a sibling "line": N JSON field within the same object, e.g.
+    #    {"file": "...benefit.rb", "line": 260}. The [^\n{}] class keeps the
+    #    match from crossing a newline or an object boundary, so it cannot bind
+    #    a path to a *different* object's line field.
+    if re.search(esc + r'[^\n{}]{0,%d}?"line"\s*:\s*\d+' % _LINE_FIELD_WINDOW, hay):
+        return True
+    # 4. unambiguous basename + line, e.g. "benefit.rb:260" when the full path
+    #    was named but the line pinned via the basename. The (?<!\w) guard stops
+    #    a basename from matching inside a longer sibling path (so "product.rb"
+    #    does NOT match inside "line_item_product.rb").
+    if basename and re.search(r'(?<!\w)' + re.escape(basename) + r":\d+", hay):
+        return True
+    return False
+
+
+def _gold_basenames(gold):
+    """Map each gold file path -> its basename IFF that basename is unique.
+
+    A basename shared by two or more gold file paths is omitted, so the
+    short-basename cited form can never credit the wrong target (or both).
+    Keys and values are lower-cased to match the lower-cased haystack.
+    """
+    counts = {}
+    paths = []
+    for item in gold:
+        if isinstance(item, str):
+            item = {"match": [item]}
+        for p in item.get("match") or []:
+            sp = str(p).lower()
+            if _is_file_like(sp):
+                bn = os.path.basename(sp)
+                paths.append((sp, bn))
+                counts[bn] = counts.get(bn, 0) + 1
+    return {sp: bn for sp, bn in paths if counts.get(bn, 0) == 1}
 
 
 def score_gold_recall(answer_text, gold):
     if not gold:
         return None
     hay = (answer_text or "").lower()
+    unique_basenames = _gold_basenames(gold)
     details, groups = [], {}
     men_total = cit_total = 0
     for item in gold:
@@ -56,11 +125,17 @@ def score_gold_recall(answer_text, gold):
         grp = item.get("group", "_")
         pats = item.get("match") or [gid]
         mentioned = any(str(p).lower() in hay for p in pats)
-        file_pats = [p for p in pats if _is_file_like(str(p))]
+        file_pats = [str(p).lower() for p in pats if _is_file_like(str(p))]
         if file_pats:
-            cited = any(_cited(str(p), hay) for p in file_pats)
+            cited = any(_cited(p, hay, unique_basenames.get(p)) for p in file_pats)
         else:
             cited = mentioned  # pure symbol target: mention is the best we can verify
+        # cited ⇒ mentioned. A target pinned only by its (unambiguous) basename
+        # + line — e.g. "async_adapter.rb:50" without the full gold path — is
+        # genuinely referenced, so it counts as mentioned too. Without this,
+        # cited_recall could exceed mention_recall, which is incoherent (you
+        # cannot cite a reference you never surfaced).
+        mentioned = mentioned or cited
         men_total += 1 if mentioned else 0
         cit_total += 1 if cited else 0
         details.append({"id": gid, "group": grp, "mentioned": mentioned, "cited": cited})

--- a/bench/lib/reporter.py
+++ b/bench/lib/reporter.py
@@ -126,6 +126,7 @@ def build_per_scenario_table(results):
             m = r.get("metrics", {})
 
             cg = r.get("citation_grounding") or {}
+            gr = r.get("gold_recall") or {}
             rows.append({
                 "tool": tool,
                 "fairness_score": r.get("fairness_score"),
@@ -135,6 +136,17 @@ def build_per_scenario_table(results):
                 "llm_quality": r.get("llm_quality"),
                 "efficiency": r.get("efficiency"),
                 "tokens": m.get("token_total_billed", m.get("token_total", 0)),
+                # Billed-context axis — first-class headline. token_total_billed
+                # is input+output billed; token_input_uncached is the uncached
+                # prompt tokens (what a code map saves by not re-reading files).
+                "billed": m.get("token_total_billed", m.get("token_total", 0)),
+                "uncached_in": m.get("token_input_uncached"),
+                # Gold recall — the two split precision/completeness axes.
+                "mention_recall": gr.get("mention_recall"),
+                "cited_recall": gr.get("cited_recall"),
+                "gold_mentioned": gr.get("mentioned"),
+                "gold_cited": gr.get("cited"),
+                "gold_total": gr.get("total"),
                 "wall_time": m.get("wall_time_seconds"),
                 "cost_usd": m.get("cost_usd"),
                 "cost_estimated": bool(m.get("cost_estimated")),
@@ -265,6 +277,58 @@ def _fmt_cites(row, width=7):
     return f"{s:>{width}}"
 
 
+def _fmt_recall(recall, hit, total):
+    """`83% (10/12)` for a gold-recall cell, `—` when no gold declared."""
+    if recall is None:
+        return "—"
+    if hit is not None and total:
+        return f"{recall:.0%} ({hit}/{total})"
+    return f"{recall:.0%}"
+
+
+def _fmt_billed_delta(rows):
+    """baseline→sense billed-context delta as a signed percent, or None.
+
+    Negative = Sense loaded less context (the win). Needs exactly the two
+    arms present with positive baseline billed tokens.
+    """
+    by_tool = {r["tool"]: r for r in rows}
+    b, s = by_tool.get("baseline"), by_tool.get("sense")
+    if not (b and s):
+        return None
+    bb, sb = b.get("billed"), s.get("billed")
+    if not bb or sb is None:
+        return None
+    return (sb - bb) / bb
+
+
+def _headline_table_md(rows):
+    """The PRIMARY per-repo table: mention / cited / billed context.
+
+    Rows alphabetical by tool so baseline sits above sense and the comparison
+    reads top-to-bottom; a trailing delta line states the billed-context gap.
+    """
+    out = []
+    out.append("| Tool | Mention recall | Cited recall (fixed) | Billed ctx | Uncached in |")
+    out.append("|------|---------------:|---------------------:|-----------:|------------:|")
+    for row in sorted(rows, key=lambda r: r["tool"]):
+        tool = row["tool"]
+        if row.get("failed"):
+            out.append(f"| {tool} | **FAILED** | — | — | — |")
+            continue
+        men = _fmt_recall(row.get("mention_recall"), row.get("gold_mentioned"), row.get("gold_total"))
+        cit = _fmt_recall(row.get("cited_recall"), row.get("gold_cited"), row.get("gold_total"))
+        billed = f"{row['billed']:,}" if row.get("billed") else "—"
+        unc = f"{row['uncached_in']:,}" if row.get("uncached_in") else "—"
+        out.append(f"| {tool} | {men} | {cit} | {billed} | {unc} |")
+    delta = _fmt_billed_delta(rows)
+    if delta is not None:
+        direction = "Sense loads less" if delta < 0 else "Sense loads more"
+        out.append("")
+        out.append(f"_Billed-context Δ (sense vs baseline): **{delta:+.0%}** — {direction}._")
+    return out
+
+
 def _rank_badge(i):
     if i == 0:
         return " :1st_place_medal:"
@@ -351,9 +415,15 @@ def format_markdown(tables, aggregate, header):
     lines.append("")
     lines.append(f"Results: {len(aggregate)} tools × {len(tables)} scenarios")
     lines.append("")
-    lines.append("Two-layer scoring: **Fairness** = 0.10·keyword_coverage + 0.55·llm_quality + 0.15·citation_grounding + 0.20·efficiency. The judge layer (llm_quality) is the 55% headline — keyword overlap dropped to a 10% smoke test. Fairness cells render `—` if `judge.sh` has not been run on a result. **Adoption** (tool fluency + discoverability) is for code-intel-vs-code-intel comparisons only.")
+    lines.append("**The headline is three separated axes, not the composite.** Each repo leads with a PRIMARY table reporting the axes that actually decompose Sense's value:")
     lines.append("")
-    lines.append("**Citations** are `file.ext:line` or `file.ext:Symbol` references the assistant printed in its answer. The scorer checks each one against the repo at `run_meta.repo_commit`. A `0/0` Cites cell means the answer had no structured citations to verify — neither penalized nor rewarded; prose-only claims are scored by `llm_quality` instead. The full list of ungrounded citations lives in [`citation-hallucinations.md`](citation-hallucinations.md).")
+    lines.append("- **Mention recall** — share of the gold reference set the answer named at all (completeness of the map).")
+    lines.append("- **Cited recall** — share pinned to an exact location (`path:line`, `path (line N)`, a `\"line\": N` field, or an unambiguous basename+line). Precision: an agent can jump straight there. This is the FIXED metric — the old `_cited` demanded a contiguous `path:N` and under-credited baseline.")
+    lines.append("- **Billed context** — `token_total_billed` (input+output billed) with `token_input_uncached` alongside. Same answer reached with less context loaded is the one scorer-independent Sense win (lobsters −34%). Lower is better.")
+    lines.append("")
+    lines.append("The locked **fairness composite** (`0.10·keyword_coverage + 0.55·llm_quality + 0.15·citation_grounding + 0.20·efficiency`) is reported **as a secondary table per repo** — its 30%-effective efficiency weight masks precision, so it is no longer the headline. The formula is unchanged. **Adoption** (tool fluency + discoverability) is for code-intel-vs-code-intel comparisons only.")
+    lines.append("")
+    lines.append("**Citations** (in the secondary table) are `file.ext:line` or `file.ext:Symbol` references the assistant printed in its answer. The scorer checks each one against the repo at `run_meta.repo_commit`. A `0/0` Cites cell means the answer had no structured citations to verify. The full list of ungrounded citations lives in [`citation-hallucinations.md`](citation-hallucinations.md).")
     lines.append("")
 
     lines.append("### Reading the scores")
@@ -373,6 +443,17 @@ def format_markdown(tables, aggregate, header):
         if desc:
             lines.append(f"> {desc}")
             lines.append("")
+
+        # PRIMARY — the three separated axes. Tools alphabetical (baseline,
+        # sense) so the baseline→sense comparison reads top-to-bottom, with a
+        # billed-context delta when both arms are present.
+        lines.extend(_headline_table_md(table["rows"]))
+        lines.append("")
+
+        # SECONDARY — the locked fairness composite and its components, kept
+        # intact but demoted. Ranked by fairness as before.
+        lines.append("<details><summary>Secondary — locked fairness composite & components</summary>")
+        lines.append("")
         lines.append("| Rank | Tool | Fairness | Adoption | Keyword Cov. | LLM Quality | Efficiency | Tokens | Time | Cost | Cites |")
         lines.append("|-----:|------|--------:|---------:|------------:|------------:|---------:|-------:|-----:|-----:|------:|")
 
@@ -402,6 +483,8 @@ def format_markdown(tables, aggregate, header):
             lines.append(
                 f"| {i+1} | {row['tool']}{badge} | {fa} | {ad} | {kw} | {lq} | {ef} | {tk} | {wt} | {co} | {ci} |"
             )
+        lines.append("")
+        lines.append("</details>")
         lines.append("")
 
     lines.append("### Aggregate")

--- a/bench/lib/test_gold.py
+++ b/bench/lib/test_gold.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Unit tests for gold.py — gold-target recall scoring.
+
+Run from anywhere:
+    python3 -m unittest bench.lib.test_gold
+
+Or directly:
+    python3 bench/lib/test_gold.py
+
+The cited-recall snippets are lifted verbatim from real baseline answers in
+results/baseline/{rails,solidus}/ — the formats a real Opus 4.6 run actually
+used to pin a line. The point of these tests is that every one of those forms
+earns cited credit, so baseline stops being under-credited and the
+"sense-only cited" artifact disappears.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import gold  # noqa: E402
+from scorer import read_transcript_texts  # noqa: E402
+
+
+class IsFileLikeTest(unittest.TestCase):
+    def test_code_extension(self):
+        self.assertTrue(gold._is_file_like("anthropic.rb"))
+        self.assertTrue(gold._is_file_like("queue_adapters/async_adapter.rb"))
+
+    def test_path_with_dot(self):
+        self.assertTrue(gold._is_file_like("a/b.conf"))
+
+    def test_pure_symbol_is_not_file_like(self):
+        self.assertFalse(gold._is_file_like("TopicCreator"))
+        self.assertFalse(gold._is_file_like("parse_error"))
+
+
+class CitedFormsTest(unittest.TestCase):
+    """Each accepted location-pin form, lower-cased like the real caller."""
+
+    def test_path_colon_line(self):
+        # Form 1 — full gold path immediately followed by a line (rails used
+        # this for one adapter via "file_line").
+        hay = '"file_line": "activejob/lib/active_job/queue_adapters/abstract_adapter.rb:9-23",'.lower()
+        self.assertTrue(gold._cited("queue_adapters/abstract_adapter.rb", hay))
+
+    def test_path_paren_line(self):
+        # Form 2 — trailing "(line N)" parenthetical.
+        hay = "see providers/anthropic.rb (line 24) for the mapping".lower()
+        self.assertTrue(gold._cited("providers/anthropic.rb", hay))
+
+    def test_path_then_json_line_field(self):
+        # Form 3 — JSON sibling "line" field (solidus used this for the
+        # *_level_condition concerns).
+        hay = (
+            '{"name": "OrderLevelCondition", '
+            '"file": "promotions/app/models/concerns/solidus_promotions/conditions/order_level_condition.rb", '
+            '"line": 5, "note": "Deprecated"}'
+        ).lower()
+        self.assertTrue(gold._cited("conditions/order_level_condition.rb", hay))
+
+    def test_json_line_field_does_not_cross_object_boundary(self):
+        # The path's own object has no line; a *different* object right after
+        # carries one. The } between them must block the match.
+        hay = (
+            '{"file": "promotions/app/models/solidus_promotions/order_adjuster.rb"}, '
+            '{"other": "x", "line": 5}'
+        ).lower()
+        self.assertFalse(gold._cited("solidus_promotions/order_adjuster.rb", hay))
+
+    def test_json_line_field_window_is_bounded(self):
+        # A "line" field far past the path (beyond the window) is not its pin.
+        far = "x" * 200
+        hay = f'"file": "lib/foo.rb", "{far}": 1, "line": 5'.lower()
+        self.assertFalse(gold._cited("lib/foo.rb", hay))
+
+    def test_unique_basename_line(self):
+        # Form 4 — basename + line when the full path was named but the line
+        # pinned via the basename (solidus: "reads at benefit.rb:260").
+        hay = (
+            '"benefit_base_class": "promotions/app/models/solidus_promotions/benefit.rb"\n'
+            '"note": "what benefit#available_calculators reads at benefit.rb:260."'
+        ).lower()
+        self.assertTrue(gold._cited("solidus_promotions/benefit.rb", hay, basename="benefit.rb"))
+
+    def test_basename_disabled_when_not_passed(self):
+        # Same haystack, no basename allowed -> not cited (the full path has no
+        # adjacent line of its own).
+        hay = '"file": "promotions/app/models/solidus_promotions/benefit.rb"\nreads at benefit.rb:260.'.lower()
+        self.assertFalse(gold._cited("solidus_promotions/benefit.rb", hay))
+
+    def test_basename_guard_rejects_longer_sibling_path(self):
+        # basename "product.rb" must NOT match inside "line_item_product.rb:6".
+        hay = '"file": "conditions/line_item_product.rb:6"'.lower()
+        self.assertFalse(gold._cited("conditions/product.rb", hay, basename="product.rb"))
+
+    def test_full_path_named_but_never_pinned_is_not_cited(self):
+        hay = '"file": "promotions/app/models/solidus_promotions/order_adjuster.rb",'.lower()
+        self.assertFalse(gold._cited("solidus_promotions/order_adjuster.rb", hay, basename="order_adjuster.rb"))
+
+
+class GoldBasenamesTest(unittest.TestCase):
+    def test_unique_basenames_kept(self):
+        g = [
+            {"match": ["queue_adapters/async_adapter.rb"]},
+            {"match": ["queue_adapters/inline_adapter.rb"]},
+        ]
+        m = gold._gold_basenames(g)
+        self.assertEqual(m["queue_adapters/async_adapter.rb"], "async_adapter.rb")
+        self.assertEqual(m["queue_adapters/inline_adapter.rb"], "inline_adapter.rb")
+
+    def test_shared_basename_dropped(self):
+        # Two distinct gold targets ending in the same basename -> neither may
+        # use the short-basename cited form.
+        g = [
+            {"match": ["a/foo.rb"]},
+            {"match": ["b/foo.rb"]},
+        ]
+        m = gold._gold_basenames(g)
+        self.assertNotIn("a/foo.rb", m)
+        self.assertNotIn("b/foo.rb", m)
+
+    def test_string_shorthand_and_symbol_ignored(self):
+        g = ["TopicCreator", {"match": ["lib/x.rb"]}]
+        m = gold._gold_basenames(g)
+        self.assertEqual(m, {"lib/x.rb": "x.rb"})
+
+
+class ScoreGoldRecallTest(unittest.TestCase):
+    def test_none_gold_returns_none(self):
+        self.assertIsNone(gold.score_gold_recall("anything", None))
+        self.assertIsNone(gold.score_gold_recall("anything", []))
+
+    def test_pure_symbol_cited_equals_mentioned(self):
+        r = gold.score_gold_recall("we call TopicCreator here", ["TopicCreator"])
+        self.assertEqual(r["mention_recall"], 1.0)
+        self.assertEqual(r["cited_recall"], 1.0)
+
+    def test_symbol_missing_is_zero(self):
+        r = gold.score_gold_recall("nothing here", ["TopicCreator"])
+        self.assertEqual(r["mention_recall"], 0.0)
+        self.assertEqual(r["cited_recall"], 0.0)
+        self.assertEqual(r["missed_mention"], ["TopicCreator"])
+        self.assertEqual(r["missed_cite"], ["TopicCreator"])
+
+    def test_mentioned_but_not_cited(self):
+        g = [{"id": "adapter", "group": "g", "match": ["queue_adapters/async_adapter.rb"]}]
+        r = gold.score_gold_recall('"file": "lib/queue_adapters/async_adapter.rb",', g)
+        self.assertEqual(r["mention_recall"], 1.0)
+        self.assertEqual(r["cited_recall"], 0.0)
+        self.assertEqual(r["missed_cite"], ["adapter"])
+
+    def test_groups_breakdown(self):
+        g = [
+            {"id": "a", "group": "adapters", "match": ["x/async_adapter.rb"]},
+            {"id": "b", "group": "adapters", "match": ["x/inline_adapter.rb"]},
+        ]
+        text = '"x/async_adapter.rb:1" and "x/inline_adapter.rb"'
+        r = gold.score_gold_recall(text, g)
+        grp = r["groups"]["adapters"]
+        self.assertEqual(grp["total"], 2)
+        self.assertEqual(grp["mention_recall"], 1.0)
+        self.assertEqual(grp["cited_recall"], 0.5)
+
+    def test_cited_implies_mentioned_via_basename(self):
+        # Regression: an answer that pins a target only by basename+line
+        # ("async_adapter.rb:50") without the full gold path must count as BOTH
+        # cited and mentioned — cited_recall can never exceed mention_recall.
+        g = [{"id": "async", "group": "adapters",
+              "match": ["queue_adapters/async_adapter.rb"]}]
+        r = gold.score_gold_recall("see async_adapter.rb:50 for enqueue", g)
+        self.assertTrue(r["details"][0]["cited"])
+        self.assertTrue(r["details"][0]["mentioned"])
+        self.assertEqual(r["mention_recall"], 1.0)
+        self.assertEqual(r["cited_recall"], 1.0)
+
+    def test_cited_never_exceeds_mention_across_set(self):
+        g = [
+            {"id": "a", "group": "g", "match": ["queue_adapters/async_adapter.rb"]},
+            {"id": "b", "group": "g", "match": ["queue_adapters/inline_adapter.rb"]},
+            {"id": "c", "group": "g", "match": ["queue_adapters/resque_adapter.rb"]},
+        ]
+        # basenames+lines for a,b; nothing for c
+        r = gold.score_gold_recall("async_adapter.rb:1 inline_adapter.rb:2", g)
+        self.assertLessEqual(r["cited_recall"], r["mention_recall"])
+        self.assertEqual(r["cited"], 2)
+        self.assertEqual(r["mentioned"], 2)
+
+    def test_shared_basename_targets_do_not_double_count(self):
+        # Two gold targets share basename foo.rb; the answer pins only a/foo.rb.
+        # b/foo.rb must NOT also score cited off the shared basename.
+        g = [
+            {"id": "a", "group": "g", "match": ["a/foo.rb"]},
+            {"id": "b", "group": "g", "match": ["b/foo.rb"]},
+        ]
+        r = gold.score_gold_recall('"a/foo.rb:12" named; b/foo.rb has no line', g)
+        self.assertEqual(r["cited"], 1)
+        self.assertEqual(r["missed_cite"], ["b"])
+
+
+class RealBaselineSnippetTest(unittest.TestCase):
+    """End-to-end on the actual baseline answers the fix was diagnosed from.
+
+    Skips cleanly when results/ is absent (clean checkout / CI).
+    """
+
+    def _answer(self, repo):
+        path = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            "..", "results", "baseline", repo, "transcript.json",
+        )
+        if not os.path.exists(path):
+            self.skipTest(f"results/baseline/{repo} not present")
+        answer, _ = read_transcript_texts(path)
+        return answer
+
+    def test_rails_adapters_now_cited(self):
+        # Form 1+4: rails baseline named all 8 adapter paths and pinned several
+        # via basename (async_adapter.rb:64-67). Old matcher scored these 0.
+        answer = self._answer("rails")
+        g = [
+            {"id": "async", "group": "adapters", "match": ["queue_adapters/async_adapter.rb"]},
+            {"id": "abstract", "group": "adapters", "match": ["queue_adapters/abstract_adapter.rb"]},
+        ]
+        r = gold.score_gold_recall(answer, g)
+        self.assertEqual(r["mention_recall"], 1.0)
+        self.assertEqual(r["cited_recall"], 1.0, r["missed_cite"])
+
+    def test_solidus_benefit_now_cited(self):
+        # Form 4: solidus baseline named the full benefit.rb path and pinned the
+        # line as "benefit.rb:260".
+        answer = self._answer("solidus")
+        g = [{"id": "benefit", "group": "registry", "match": ["solidus_promotions/benefit.rb"]}]
+        r = gold.score_gold_recall(answer, g)
+        self.assertTrue(r["details"][0]["mentioned"])
+        self.assertTrue(r["details"][0]["cited"], "benefit.rb:260 should now count")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bench/lib/test_reporter.py
+++ b/bench/lib/test_reporter.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Unit tests for reporter.py — the split-axes headline rendering.
+
+Run directly:
+    python3 bench/lib/test_reporter.py
+
+Covers the headline table (mention / fixed-cited / billed-context) and the
+billed-context delta, plus the secondary fairness table still rendering.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import reporter  # noqa: E402
+
+
+class FmtRecallTest(unittest.TestCase):
+    def test_none_is_dash(self):
+        self.assertEqual(reporter._fmt_recall(None, None, None), "—")
+
+    def test_with_counts(self):
+        self.assertEqual(reporter._fmt_recall(0.7778, 14, 18), "78% (14/18)")
+
+    def test_recall_only_when_counts_missing(self):
+        self.assertEqual(reporter._fmt_recall(0.5, None, None), "50%")
+        self.assertEqual(reporter._fmt_recall(0.5, 3, 0), "50%")
+
+
+class FmtBilledDeltaTest(unittest.TestCase):
+    def test_sense_loads_less(self):
+        rows = [
+            {"tool": "baseline", "billed": 28226},
+            {"tool": "sense", "billed": 18671},
+        ]
+        self.assertAlmostEqual(reporter._fmt_billed_delta(rows), -0.3385, places=3)
+
+    def test_sense_loads_more(self):
+        rows = [
+            {"tool": "baseline", "billed": 9474},
+            {"tool": "sense", "billed": 12393},
+        ]
+        self.assertGreater(reporter._fmt_billed_delta(rows), 0)
+
+    def test_missing_arm_returns_none(self):
+        self.assertIsNone(reporter._fmt_billed_delta([{"tool": "sense", "billed": 5}]))
+
+    def test_zero_baseline_returns_none(self):
+        rows = [{"tool": "baseline", "billed": 0}, {"tool": "sense", "billed": 5}]
+        self.assertIsNone(reporter._fmt_billed_delta(rows))
+
+
+class HeadlineTableTest(unittest.TestCase):
+    def _rows(self):
+        return [
+            {"tool": "baseline", "mention_recall": 0.92, "cited_recall": 0.92,
+             "gold_mentioned": 11, "gold_cited": 11, "gold_total": 12,
+             "billed": 28226, "uncached_in": 8140},
+            {"tool": "sense", "mention_recall": 1.0, "cited_recall": 0.833,
+             "gold_mentioned": 12, "gold_cited": 10, "gold_total": 12,
+             "billed": 18671, "uncached_in": 23},
+        ]
+
+    def test_renders_both_arms_and_delta(self):
+        md = "\n".join(reporter._headline_table_md(self._rows()))
+        self.assertIn("Mention recall", md)
+        self.assertIn("Cited recall (fixed)", md)
+        self.assertIn("92% (11/12)", md)   # baseline mention
+        self.assertIn("83% (10/12)", md)   # sense cited
+        self.assertIn("28,226", md)        # billed
+        self.assertIn("-34%", md)          # billed delta
+        self.assertIn("Sense loads less", md)
+
+    def test_alphabetical_order_baseline_first(self):
+        rows = list(reversed(self._rows()))  # feed sense-first
+        out = reporter._headline_table_md(rows)
+        body = [l for l in out if l.startswith("| ") and "Tool" not in l and "---" not in l]
+        self.assertTrue(body[0].startswith("| baseline"))
+        self.assertTrue(body[1].startswith("| sense"))
+
+    def test_failed_row_and_no_gold(self):
+        rows = [
+            {"tool": "baseline", "failed": True},
+            {"tool": "sense", "mention_recall": None, "cited_recall": None,
+             "billed": None, "uncached_in": None},
+        ]
+        md = "\n".join(reporter._headline_table_md(rows))
+        self.assertIn("**FAILED**", md)
+        self.assertIn("| sense | — | — | — | — |", md)
+        # No delta line when an arm is missing usable billed tokens.
+        self.assertNotIn("Billed-context Δ", md)
+
+
+class FormatMarkdownSmokeTest(unittest.TestCase):
+    """End-to-end render of one repo so format_markdown's new branches run."""
+
+    def test_primary_and_secondary_tables_present(self):
+        tables = [{
+            "repo": "lobsters",
+            "rows": [
+                {"tool": "baseline", "fairness_score": 0.767, "fairness_complete": True,
+                 "adoption_score": 0.4, "keyword_coverage": 1.0, "llm_quality": 0.85,
+                 "efficiency": 0.5, "tokens": 28226, "billed": 28226, "uncached_in": 8140,
+                 "mention_recall": 0.92, "cited_recall": 0.92, "gold_mentioned": 11,
+                 "gold_cited": 11, "gold_total": 12, "wall_time": 120.0, "cost_usd": 1.0,
+                 "cites_grounded": 5, "cites_total": 5, "cites_hallucinated": 0},
+                {"tool": "sense", "fairness_score": 0.774, "fairness_complete": True,
+                 "adoption_score": 0.7, "keyword_coverage": 1.0, "llm_quality": 0.86,
+                 "efficiency": 0.6, "tokens": 18671, "billed": 18671, "uncached_in": 23,
+                 "mention_recall": 1.0, "cited_recall": 0.833, "gold_mentioned": 12,
+                 "gold_cited": 10, "gold_total": 12, "wall_time": 100.0, "cost_usd": 0.9,
+                 "cites_grounded": 4, "cites_total": 4, "cites_hallucinated": 0},
+            ],
+        }]
+        aggregate = [{
+            "tool": "sense", "scenarios": 1, "failures": 0, "avg_fairness": 0.774,
+            "avg_adoption": 0.7, "avg_keyword_coverage": 1.0, "avg_llm_quality": 0.86,
+            "avg_efficiency": 0.6, "avg_tokens": 18671, "avg_time": 100.0,
+            "total_cost": 0.9, "cites_grounded": 4, "cites_total": 4,
+            "cites_hallucinated": 0, "avg_grounding": 1.0,
+        }]
+        md = reporter.format_markdown(tables, aggregate, {"total": 1})
+        self.assertIn("Cited recall (fixed)", md)            # primary table
+        self.assertIn("Secondary — locked fairness", md)      # secondary table
+        self.assertIn("0.774", md)                            # fairness preserved
+        self.assertIn("-34%", md)                             # billed delta
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bench/scenarios/chatwoot.rubric.yaml
+++ b/bench/scenarios/chatwoot.rubric.yaml
@@ -10,13 +10,13 @@
 # Step names MUST match scenarios/chatwoot.yaml exactly (the judge pairs by name).
 
 audience: |
-  An AI coding agent that will use this answer to add a new messaging channel (a
-  new external provider customers can be reached over) to Chatwoot with only
-  small, targeted follow-up lookups, not a fresh exploration of the codebase.
-  Score for that audience, not a human reader, not a docs page. A perfect answer
-  leaves the agent ready to create the channel model, its outgoing sender, its
-  incoming-message handling, register the routing, and add specs; a weak answer
-  forces the agent to re-explore the codebase before it can act.
+  An AI coding agent that will use this answer to safely rework the Inbox model's
+  teardown contract in Chatwoot with only small, targeted follow-up lookups, not a
+  fresh exploration of the codebase. Score for that audience, not a human reader,
+  not a docs page. A perfect answer leaves the agent able to change the Inbox
+  contract knowing every dependent that must be reviewed; a weak answer forces the
+  agent to re-grep a very common token and re-read the codebase before it can act
+  safely.
 
 steps:
   - name: Orient in the codebase
@@ -26,222 +26,207 @@ steps:
         question: |
           Does the answer hand the agent a usable map: that this is Chatwoot (a
           customer-support / messaging platform), how the Rails app is organized
-          (app/models, app/services, app/jobs), and specifically where messaging
-          channels live, the channel models (app/models/channel/, the Channelable
-          concern), the outgoing senders (app/services/<provider>/, the
-          Base::SendOnChannelService base) and the inbound webhook handling
-          (app/jobs/webhooks/)? Could the agent pick an entry point and start
-          working with only small, targeted lookups?
+          (app/models, app/services, app/jobs, lib/, the enterprise/ overlay), and
+          specifically where the Inbox model sits, the thing a channel hangs off
+          and that conversations and contacts attach to? Could the agent pick an
+          entry point and start working with only small, targeted lookups?
       specificity:
         weight: 0.25
         question: |
-          Are the cited paths concrete (app/models/channel/whatsapp.rb,
-          app/models/concerns/channelable.rb, app/jobs/send_reply_job.rb) rather
-          than vague ("the channel layer")? Are abstractions tied to actual files
-          and class names?
+          Are the cited paths concrete (app/models/inbox.rb, app/models/channel/,
+          app/models/concerns/) rather than vague ("the model layer")? Are
+          abstractions tied to actual files and class names?
       justification:
         weight: 0.20
         question: |
-          Does the answer explain WHY the architecture is shaped this way (a
-          channel is a model bound to an Inbox via a shared concern, outgoing
-          sends are routed to a per-provider service, incoming messages arrive via
-          per-provider webhooks), not just NAME the pieces?
+          Does the answer explain WHY the architecture is shaped this way (an Inbox
+          is the hub a channel hangs off, with conversations/contacts attached via
+          associations and behavior pulled in through concerns), not just NAME the
+          pieces?
       uncertainty:
         weight: 0.15
         question: |
-          Where the answer is unsure about how the layers connect or what a new
-          channel must implement, does it flag that so the agent doesn't act
-          blindly?
+          Where the answer is unsure about how the layers connect, does it flag
+          that so the agent doesn't act blindly?
 
-  - name: Trace an outgoing reply to its channel-specific sender
+  - name: Map the Inbox contract and what it is built on
     criteria:
       map_quality:
         weight: 0.40
         question: |
-          Does the answer trace the routing path with file:line, in order: from
-          where an outgoing message is picked up into SendReplyJob, through the
-          CHANNEL_SERVICES dispatch table that maps the inbox's channel class to a
-          per-provider sender, into that sender (a Base::SendOnChannelService
-          subclass) and its #perform / #perform_reply? Could the agent follow the
-          same path to route a new channel's outgoing replies?
+          Does the answer map the Inbox model's contract with file:line: the
+          concerns it includes (e.g. cache_keys and other shared model behavior),
+          the associations records hang off it through (channel polymorphic
+          association, conversations, contact_inboxes), and the enterprise overlay
+          that reopens it? Could the agent know what a change to the model has to
+          preserve?
       specificity:
         weight: 0.25
         question: |
-          Are the dispatch pieces named exactly (SendReplyJob, CHANNEL_SERVICES,
-          the SendOn<Provider>Service, perform_reply) with file:line, rather than
-          "the send code"?
+          Are the contract pieces named concretely by file
+          (app/models/concerns/cache_keys.rb, app/models/contact_inbox.rb,
+          enterprise/app/models/enterprise/inbox.rb) rather than "the concerns and
+          associations"?
       justification:
         weight: 0.20
         question: |
-          Does the answer explain WHY delivery is a per-channel service chosen by
-          a dispatch table (so a new provider is added by registering a sender,
-          not by editing the job body), and note the special-cased channels
-          (FacebookPage), not just LIST the call chain?
+          Does the answer explain WHY the contract is shaped this way (behavior
+          shared through concerns, other records related through associations, the
+          paid tier reopening the class), not just LIST the pieces?
       uncertainty:
         weight: 0.15
         question: |
-          Does the answer flag where the path is asynchronous or special-cased
-          (job queue, FacebookPage handled separately, channels mapped to a shared
-          notification service) so the agent verifies before relying on it?
+          Does the answer flag any part of the contract it could not confirm (a
+          concern method or association it didn't open) so the agent checks before
+          relying on it?
 
-  - name: Map the channel family and the shared contracts
+  - name: Trace how an inbox and its attached data are torn down
     criteria:
       map_quality:
         weight: 0.40
         question: |
-          Does the answer enumerate BOTH shared contracts, the Channelable
-          concern (app/models/concerns/channelable.rb) that every channel model
-          includes, and the Base::SendOnChannelService
-          (app/services/base/send_on_channel_service.rb) outbound base whose
-          subclasses must implement channel_class and perform_reply, AND the
-          existing channels that customize them (WhatsApp, Telegram, Line, SMS,
-          Twilio, Instagram, TikTok, Email, Twitter, WebWidget, API, FacebookPage,
-          each in app/models/channel/ with a matching sender), with file:line and
-          how each differs? This include / inheritance fan-out is grep-invisible
-          (the shared-contract relationship is structural, not a shared string); a
-          strong answer names that breadth so the agent knows exactly what to
-          include, subclass, and override.
+          Does the answer trace the teardown path with file:line, in order: from
+          where a destroy is triggered through the heavy cleanup of associated
+          records (the async DeleteObjectJob#heavy_associations path), naming which
+          associated records are cleaned up asynchronously versus inline? Could the
+          agent follow the same path to change teardown safely?
       specificity:
         weight: 0.25
         question: |
-          Are the customizing channels named concretely by file
-          (channel/whatsapp.rb, send_on_telegram_service.rb) and the override
-          points (channel_class, perform_reply, the concern's required methods)
-          cited, rather than "some channels customize it"?
+          Are the teardown pieces named exactly (DeleteObjectJob, the
+          heavy-associations cleanup, the destroy callbacks) with file:line, rather
+          than "the delete code"?
       justification:
         weight: 0.20
         question: |
-          Does the answer explain WHY there are two shared contracts (one for the
-          stored channel via a concern, one for outbound delivery via a service
-          base), not just LIST the classes?
+          Does the answer explain WHY heavy association cleanup is pushed to a
+          background job (to avoid a slow/locking inline destroy), not just LIST the
+          call chain?
       uncertainty:
         weight: 0.15
         question: |
-          Does the answer flag any customization it could not confirm (a channel
-          that overrides a concern method or sender behavior it didn't open) so
-          the agent checks before copying a pattern?
+          Does the answer flag where the teardown is asynchronous or relies on
+          dependent: destroy semantics it didn't fully open, so the agent verifies?
 
-  - name: Trace an incoming provider message to a stored message
+  - name: Audit every dependent of the Inbox contract
     criteria:
       map_quality:
         weight: 0.40
         question: |
-          Does the answer trace the inbound path with file:line, in order: from
-          the provider's webhook (the webhooks controller / the per-provider
-          events job in app/jobs/webhooks/<provider>_events_job.rb) into the
-          per-provider IncomingMessageService
-          (app/services/<provider>/incoming_message_service.rb) where the contact,
-          conversation, and message are created? Could the agent follow the same
-          path to handle a new channel's incoming messages?
+          Does the answer enumerate the FULL scattered dependent set of the Inbox
+          model, grouped by area: request handling (the accounts / dashboard /
+          widget-tests controllers), background work (assignment, IMAP fetch, stale
+          notification, delete-object jobs), shared model behavior (the cache_keys
+          concern, the assignee activity-message handler), provider services
+          (Twitter webhook subscribe, WhatsApp channel creation), library /
+          integration code (chatwoot_hub, the Slack link-unfurl formatter) and the
+          enterprise overlay? This fan-out is the heart of the ticket and is
+          grep-hostile, most dependents reach Inbox through an association or a
+          concern, and the bare token appears across the whole messaging app, so a
+          text search both misses some and drowns the rest. A strong answer names
+          that breadth with file:line so the agent can review every dependent.
       specificity:
         weight: 0.25
         question: |
-          Are the inbound pieces named exactly (<Provider>EventsJob,
-          <Provider>::IncomingMessageService) with file:line, rather than "the
-          webhook handler"?
+          Are the dependents named concretely by file and symbol
+          (app/jobs/delete_object_job.rb, app/models/concerns/cache_keys.rb,
+          app/services/whatsapp/channel_creation_service.rb) with file:line and one
+          phrase on how each uses the inbox, rather than "various controllers and
+          jobs"?
       justification:
         weight: 0.20
         question: |
-          Does the answer explain WHY inbound is split into a webhook-receiving
-          job and a per-provider builder service (decoupling delivery from
-          message construction), not just LIST the call chain?
+          Does the answer explain WHY each dependent is affected (operates on the
+          inbox, caches off it, cleans it up, creates it, reads it for metrics),
+          grouping by area rather than just LISTING files?
       uncertainty:
         weight: 0.15
         question: |
-          Does the answer flag where inbound shapes differ per provider (payload
-          formats, base/helper services it didn't open) so the agent verifies?
+          Does the answer acknowledge what a static pass can miss (dependents that
+          reach the inbox only through an association or polymorphic relation, the
+          enterprise overlay, indirect callers) so the agent knows to verify?
 
-  - name: Trace how sends and incoming notifications are validated
+  - name: Trace how inbox availability and identity are guarded
     criteria:
       map_quality:
         weight: 0.40
         question: |
-          Does the answer give file:line for both guards: the outbound checks in
-          Base::SendOnChannelService (validate_target_channel, outgoing_message?,
-          invalid_message?, skipping private notes, loops, wrong channel) AND how
-          inbound webhooks confirm authenticity before processing (the provider's
-          signature/verify-token check in its controller/job)? Could the agent give
-          the new channel correct guards without re-reading every file?
+          Does the answer give file:line for how background work confirms it is
+          operating on a real, current inbox before acting (existence/availability
+          checks in the assignment, IMAP-fetch and maintenance jobs, and any shared
+          guard)? Could the agent give a reworked teardown the right guards without
+          re-reading every file?
       specificity:
         weight: 0.25
         question: |
-          Are the guards named exactly (validate_target_channel, invalid_message?,
-          the inbound verification method) with file:line, rather than "the
+          Are the guards named exactly (the job-level presence/availability checks,
+          the methods that confirm the inbox) with file:line, rather than "the
           validation code"?
       justification:
         weight: 0.20
         question: |
-          Does the answer explain WHY outbound validates the target channel (to
-          avoid loops and cross-channel sends) and WHY inbound must verify the
-          sender, not just NAME the pieces?
+          Does the answer explain WHY background work must re-confirm the inbox (it
+          may have been torn down between enqueue and run), not just NAME the
+          pieces?
       uncertainty:
         weight: 0.15
         question: |
-          Does the answer flag where verification is provider-specific (each
-          provider signs/verifies differently) so the agent verifies before
-          shipping?
+          Does the answer flag where a guard is missing or implicit (a job that
+          assumes the inbox still exists) so the agent verifies before relying on
+          it?
 
-  - name: Find every site that must change to add a new channel
+  - name: Assess the blast radius of the contract change
     criteria:
       map_quality:
         weight: 0.40
         question: |
-          Does the answer enumerate the full fan-out of adding a channel: the new
-          channel model under app/models/channel/ (including Channelable, whose
-          blast surface shows what the concern touches), the outgoing sender
-          subclassing Base::SendOnChannelService plus its registration in
-          SendReplyJob::CHANNEL_SERVICES, the inbound events job under
-          app/jobs/webhooks/ and its IncomingMessageService, and the spec matrix
-          (spec/models/channel/, spec/services/<provider>/, send_reply_job_spec)?
-          A new channel touches several disjoint areas; a strong answer names that
-          breadth with file:line. Could the agent open the PR from this list?
+          Does the answer assess the full blast radius of changing the Inbox
+          teardown contract: which dependents are at risk across every area
+          (request handling, jobs, concerns, provider services, lib integrations,
+          enterprise overlay), which are most likely to break, and what must be
+          re-verified, with file:line and a risk ranking? This is the change-impact
+          question a structural blast answers directly and a hand audit under-covers.
       specificity:
         weight: 0.25
         question: |
-          Are the sites named concretely (a new channel/<provider>.rb, a
-          send_on_<provider>_service.rb plus the CHANNEL_SERVICES line, a
-          webhooks/<provider>_events_job.rb, a spec) rather than "wire it in and
-          add tests"?
+          Are the at-risk dependents named concretely by file with a stated reason
+          for the risk level, rather than "several things might break"?
       justification:
         weight: 0.20
         question: |
-          Does the answer explain WHY each site is affected (stored model vs
-          outbound routing vs inbound handling vs shared contract vs test matrix),
-          not just LIST them?
+          Does the answer explain WHY a given dependent is high vs low risk (it
+          mutates inbox associations on teardown vs merely reads a cache key), not
+          just LIST them?
       uncertainty:
         weight: 0.15
         question: |
-          Does the answer acknowledge what static reading can miss (senders reached
-          only through the dispatch table, routes/config for the webhook endpoint,
-          provider fixtures/cassettes) so the agent knows to verify?
+          Does the answer flag the dependents it is least sure about (indirect or
+          association-reached, only surfaced structurally) so the agent confirms?
 
-  - name: Produce the edit map
+  - name: Produce the change + verification map
     criteria:
       map_quality:
         weight: 0.40
         question: |
-          Does the answer produce a complete, actionable edit map: the new files
-          to create (the channel/<provider>.rb model, the
-          send_on_<provider>_service.rb sender, the inbound events job + incoming
-          message service) and the existing files/lines to change (the
-          CHANNEL_SERVICES registration, the Channelable concern if the contract
-          extends, the webhook routes, validation guards) plus the specs and
-          fixtures, with file:line throughout? Could a teammate open the PR from
-          this map alone?
+          Does the answer produce a complete, actionable map: the model and shared
+          pieces to edit (inbox.rb, the relevant concerns, the teardown job), every
+          dependent that must be reviewed grouped by area, and the specs/fixtures to
+          update or add for the teardown behavior, with file:line throughout? Could
+          a teammate land the change from this map alone?
       specificity:
         weight: 0.25
         question: |
-          Are the files and insertion points concrete (new channel/<provider>.rb,
-          the CHANNEL_SERVICES line in send_reply_job.rb, a sender, a webhook job,
-          a spec) rather than "create the channel and add tests"?
+          Are the files and insertion points concrete (app/models/inbox.rb,
+          app/jobs/delete_object_job.rb, the affected concerns, the specs under
+          spec/models and spec/jobs) rather than "edit the model and add tests"?
       justification:
         weight: 0.20
         question: |
-          Does the answer explain WHY each file is in the map (which area it
-          belongs to and what the new channel needs there), not just LIST files?
+          Does the answer explain WHY each file is in the map (which area it belongs
+          to and what the teardown change does to it), not just LIST files?
       uncertainty:
         weight: 0.15
         question: |
-          Does the answer flag the parts it is least sure about (the inbound
-          payload shape, the provider's auth/verification, fixture generation) so
-          the agent confirms before committing?
+          Does the answer flag the parts it is least sure about (association cleanup
+          semantics, the enterprise overlay, fixtures) so the agent confirms before
+          committing?

--- a/bench/scenarios/chatwoot.yaml
+++ b/bench/scenarios/chatwoot.yaml
@@ -1,43 +1,48 @@
-name: Chatwoot work session - add support for a new messaging channel
+name: Chatwoot work session - audit the Inbox contract before a teardown rework
 repo: chatwoot
 # Single-prompt session bench (run via bench/bench-sense-local.sh): all steps are
 # presented in ONE prompt and worked in order, so context accumulates the way a
 # real work session does. Rendered to the agent: the description + each step's
 # name and prompt ONLY (checks/gold are NOT shown). Everything rendered is kept
 # NEUTRAL, it states the task, never the answer's shape, file paths, class or
-# method names, counts, or which tool to reach for. The recurring real task this
-# mirrors is "add a new messaging channel" (a WhatsApp/Telegram/Line-style
-# provider), Chatwoot's most iconic contribution, which naturally walks the
-# channel model + the Channelable concern, the outbound dispatch table in
-# SendReplyJob + the Base::SendOnChannelService contract and its per-channel
-# subclasses, the inbound webhook jobs + per-channel IncomingMessageService, the
-# send/webhook validation guards, and the spec matrix. The headline is CUMULATIVE
-# efficiency (tool calls, billed + context tokens, time) at held accuracy: across
-# these areas the baseline re-derives the structure each step while the map is
-# queried once and reused.
-description: 'You are a maintainer about to add support for a new messaging channel
-  to this platform, so agents can converse with customers over a new provider,
-  mirroring how the existing channels are built. Work through the tasks below one
-  at a time; each builds on what you learned in the previous one. Keep every answer
-  concrete with file:line so the next step (and a teammate opening the PR) can act
-  without re-exploring the codebase.'
+# method names, counts, or which tool to reach for.
+#
+# This is a CHANGE-IMPACT ticket, not an add-by-copying ticket. The recurring
+# real task it mirrors: a maintainer about to change how an Inbox (and all the
+# data attached to it) is torn down has to first audit EVERY place that depends
+# on the Inbox model before touching it. The must-find answer is the scattered
+# dependent set, callers spread across controllers, jobs, model concerns,
+# provider services, lib integrations and the enterprise overlay, most of them
+# reaching Inbox through an association or a shared concern, not by listing one
+# directory. The headline is whether the agent can assemble that fan-out
+# completely and cheaply: a structural query returns the resolved dependent set
+# in one shot, whereas reconstructing it by hand means grepping a very common
+# token (inbox appears across the whole messaging app) and reading to filter
+# signal from noise.
+description: 'You are a maintainer about to rework how an Inbox and everything
+  attached to it is handled when it (or its account) is torn down. Before touching
+  the model, you need a complete audit of what depends on the Inbox contract today,
+  so the rework does not silently break a dependent. Work through the tasks below
+  one at a time; each builds on what you learned in the previous one. Keep every
+  answer concrete with file:line so the next step (and a teammate opening the PR)
+  can act without re-exploring the codebase.'
 steps:
 - name: Orient in the codebase
   prompt: "Task: orient yourself. In a few sentences plus file paths, what is this
-    project, how is the code organized, and where does the machinery that lets
-    agents send and receive messages over the different external providers live,
-    along with the shared pieces it is built on? Hand the next agent a map so they
-    can act with small, targeted lookups, not a fresh exploration of the codebase.
-    No Explore agents.
+    project, how is the code organized, and where does the model you are about to
+    rework sit, the thing an external messaging channel hangs off and that
+    conversations and contacts are attached to, along with the shared pieces it is
+    built on? Hand the next agent a map so they can act with small, targeted
+    lookups, not a fresh exploration of the codebase. No Explore agents.
     "
   checks:
   - type: word
-    value: Channel
+    value: Inbox
     required: true
   - type: word
-    value: Inbox
+    value: Channel
     required: false
-    description: Reached the inbox the channels hang off, not just the channel
+    description: Reached the channel the inbox hangs off, not just the inbox
   - type: response_richness
     value: '3'
     required: false
@@ -49,21 +54,43 @@ steps:
     value: sense_conventions
     required: false
     layer: adoption
-- name: Trace an outgoing reply to its channel-specific sender
-  prompt: "Task: trace how a single outgoing reply is routed to the concrete object
-    that delivers it over the right external provider. Start from where an outgoing
-    message is picked up and follow it down through to where the provider-specific
-    sender is selected and run. Give file:line for each layer and the order they
-    run.
+- name: Map the Inbox contract and what it is built on
+  prompt: "Task: map the contract of the model you are about to change. What does it
+    expose and what shared behavior does it pull in (the concerns it includes, the
+    associations other records hang off it through), and what does a teammate need
+    to know about that contract before changing it? Give file:line for the model and
+    each shared piece.
     "
   checks:
   - type: word
-    value: SendReplyJob
-    required: true
-    description: Found the dispatch that maps a channel to its sender
-  - type: word
-    value: perform_reply
+    value: concern
     required: false
+  - type: response_richness
+    value: '4'
+    required: true
+  - type: contains
+    value: inbox.rb
+    required: false
+  - type: mcp_tool_used
+    value: sense_conventions
+    required: false
+    layer: adoption
+  - type: mcp_tool_used
+    value: sense_graph
+    required: false
+    layer: adoption
+- name: Trace how an inbox and its attached data are torn down
+  prompt: "Task: trace what happens to an inbox and everything attached to it when
+    it is destroyed. Start from where a destroy is triggered and follow it through
+    the heavy cleanup of its associated records. Give file:line for each layer and
+    the order they run, and note which associated records are cleaned up
+    asynchronously versus inline.
+    "
+  checks:
+  - type: word
+    value: DeleteObject
+    required: false
+    description: Found the async heavy-association cleanup
   - type: response_richness
     value: '4'
     required: true
@@ -71,70 +98,37 @@ steps:
     value: sense_graph
     required: false
     layer: adoption
-- name: Map the channel family and the shared contracts
-  prompt: "Task: a new channel will be built on the same shared pieces the existing
-    channels are built on, then customize a few things. Map the shared behavior a
-    channel inherits, both as a stored channel and as an outgoing sender, and,
-    crucially, which existing channels customize that shared behavior and how each
-    one differs. Be complete with file:line; a missed customization point is
-    behavior the new channel silently won't have.
+- name: Audit every dependent of the Inbox contract
+  prompt: "Task: this is the core of the ticket. Find EVERY place in the codebase
+    that depends on the Inbox model, so the rework cannot silently break one. Be
+    exhaustive and group them by area (request handling, background work, shared
+    model behavior, provider-specific services, library/integration code, and any
+    paid-tier overlay). Many depend on it indirectly, through an association or a
+    shared concern rather than by naming the class, so a surface text search will
+    miss some and drown the rest in unrelated matches. For each dependent give
+    file:line and one phrase on how it uses the inbox. A missed dependent is a
+    regression shipped.
     "
   checks:
-  - type: word
-    value: Channelable
-    required: true
-  - type: word
-    value: SendOnChannelService
-    required: true
-    description: Anchored on the outbound contract every sender implements
   - type: response_richness
     value: '6'
     required: true
-    description: Enumerated the shared contracts plus the per-channel customizations
-  - type: contains
-    value: channelable.rb
-    required: false
+    description: Enumerated the scattered dependent set across disjoint areas
   - type: no_grep
     value: no_grep
     required: false
     layer: adoption
   - type: mcp_tool_used
-    value: sense_graph
+    value: sense_blast
     required: false
     layer: adoption
-- name: Trace an incoming provider message to a stored message
-  prompt: "Task: trace how a message arriving from an external provider becomes a
-    stored conversation message. Start from where the provider's incoming
-    notification is received and follow it down through to where the conversation
-    and message are created for that specific provider. Give file:line for each
-    layer and the order they run.
+- name: Trace how inbox availability and identity are guarded
+  prompt: "Task: when work runs against an inbox in the background (assignment,
+    fetching, periodic maintenance), how does the code confirm it is operating on a
+    real, current inbox before acting? Trace where those guards live and what they
+    check. Give file:line throughout.
     "
   checks:
-  - type: word
-    value: IncomingMessage
-    required: true
-    description: Found the per-provider service that builds the stored message
-  - type: word
-    value: webhook
-    required: false
-  - type: response_richness
-    value: '4'
-    required: true
-  - type: mcp_tool_used
-    value: sense_graph
-    required: false
-    layer: adoption
-- name: Trace how sends and incoming notifications are validated
-  prompt: "Task: not every message is delivered or accepted. Trace how an outgoing
-    send checks it is targeting the right channel and is allowed to send, and how
-    an incoming notification confirms it really came from the provider before it is
-    processed. Give file:line throughout.
-    "
-  checks:
-  - type: word
-    value: validate
-    required: true
-    description: Found the outbound target-channel guard
   - type: response_richness
     value: '3'
     required: false
@@ -142,36 +136,29 @@ steps:
     value: sense_graph
     required: false
     layer: adoption
-- name: Find every site that must change to add a new channel
-  prompt: "Task: you will add the new channel. Find every place in the codebase
-    that must change for it to be stored, to send outgoing replies, to receive
-    incoming messages, and to be tested, including where the shared contracts are
-    depended on and where outgoing delivery is routed by channel. Be complete and
-    use file:line; a missed site means the new channel silently can't send or
-    receive.
+- name: Assess the blast radius of the contract change
+  prompt: "Task: you are about to change the Inbox contract (how teardown and a
+    couple of its associations behave). Assess the full blast radius: which
+    dependents are at risk, which are most likely to break, and what must be
+    re-verified after the change, across every area you found. Be complete and use
+    file:line; rank by risk. A missed high-risk dependent is the one that pages
+    someone.
     "
   checks:
-  - type: word
-    value: Channelable
-    required: true
   - type: response_richness
     value: '6'
     required: true
-    description: Reached the dispatch table and the spec matrix, not just the channel model
-  - type: contains
-    value: spec
-    required: false
+    description: Ranked the scattered dependents by risk, not just relisted them
   - type: mcp_tool_used
     value: sense_blast
     required: false
     layer: adoption
-- name: Produce the edit map
-  prompt: "Task: produce the complete edit map for adding the new channel: which
-    files to create and which to change across each area you explored (the stored
-    channel and its shared concern, the outgoing sender and the routing that
-    selects it, the incoming-message handling, the validation guards), and which
-    specs and fixtures to add. Use file:line throughout, so a teammate could open
-    the PR from your map alone.
+- name: Produce the change + verification map
+  prompt: "Task: produce the complete map for landing this safely: the model and
+    shared pieces you will edit, every dependent that must be reviewed or touched
+    grouped by area, and the specs/fixtures that must be updated or added to cover
+    the teardown behavior. Use file:line throughout, so a teammate could land the
+    change from your map alone.
     "
   checks:
   - type: response_richness
@@ -179,57 +166,40 @@ steps:
     required: true
   - type: contains
     value: spec
-    required: false
-  - type: contains
-    value: service
     required: false
 scoring:
   weights:
     correctness: 0.70
     efficiency: 0.30
-# Gold spans the areas the "add a channel" session walks. The discriminator is the
-# twin fan-out: the `channels` group (12 channel models that all include the
-# Channelable concern, a grep-invisible include relationship, blast 12) and the
-# `outbound` group (per-channel senders subclassing Base::SendOnChannelService,
-# each in its own provider namespace, selected by the CHANNEL_SERVICES dispatch
-# table in send_reply_job.rb). The `dispatch` group is the grep-hard routing seam.
-# All targets are file-path matched so both mention (is it on the map?) and cited
-# (pinned to path:line?) are scored. The session headline is CUMULATIVE efficiency
-# at held accuracy.
+# Gold is the must-find audit: the scattered dependent set of the Inbox model plus
+# the contract pieces a teammate must know before changing it. The discriminator is
+# NOT an enumerable directory, it is the fan-out of resolved dependents spread
+# across controllers, background jobs, model concerns, provider services, lib
+# integrations and the enterprise overlay, most reaching Inbox through an
+# association or a shared concern. A structural impact query returns this set
+# directly; reconstructing it by hand means grepping a token (`inbox`) that appears
+# across the entire messaging app and reading to filter. Pure seeder/test-data
+# inbox builders (all in one lib/seeders dir, an `ls` away) are deliberately
+# EXCLUDED, they are the enumerable half grep does well. All targets are file-path
+# matched so both mention (is it on the map?) and cited (pinned to path:line?) score.
 gold:
-  # dispatch / shared contracts, outgoing routing + the two shared bases + the hub
-  - {id: send-reply-job,       group: dispatch, match: [send_reply_job.rb]}
-  - {id: send-on-channel-base, group: dispatch, match: [base/send_on_channel_service.rb]}
-  - {id: channelable-concern,  group: dispatch, match: [concerns/channelable.rb]}
-  - {id: inbox-hub,            group: dispatch, match: [models/inbox.rb]}
-  # the channel fan-out (12 models, all include Channelable, grep-invisible include)
-  - {id: channel:api,          group: channels, match: [models/channel/api.rb]}
-  - {id: channel:email,        group: channels, match: [models/channel/email.rb]}
-  - {id: channel:facebook,     group: channels, match: [models/channel/facebook_page.rb]}
-  - {id: channel:instagram,    group: channels, match: [models/channel/instagram.rb]}
-  - {id: channel:line,         group: channels, match: [models/channel/line.rb]}
-  - {id: channel:sms,          group: channels, match: [models/channel/sms.rb]}
-  - {id: channel:telegram,     group: channels, match: [models/channel/telegram.rb]}
-  - {id: channel:tiktok,       group: channels, match: [models/channel/tiktok.rb]}
-  - {id: channel:twilio,       group: channels, match: [models/channel/twilio_sms.rb]}
-  - {id: channel:twitter,      group: channels, match: [models/channel/twitter_profile.rb]}
-  - {id: channel:webwidget,    group: channels, match: [models/channel/web_widget.rb]}
-  - {id: channel:whatsapp,     group: channels, match: [models/channel/whatsapp.rb]}
-  # outbound senders, per-channel subclasses of Base::SendOnChannelService
-  - {id: send:whatsapp,        group: outbound, match: [send_on_whatsapp_service.rb]}
-  - {id: send:telegram,        group: outbound, match: [send_on_telegram_service.rb]}
-  - {id: send:line,            group: outbound, match: [send_on_line_service.rb]}
-  - {id: send:sms,             group: outbound, match: [send_on_sms_service.rb]}
-  - {id: send:twilio,          group: outbound, match: [send_on_twilio_service.rb]}
-  - {id: send:instagram,       group: outbound, match: [instagram/send_on_instagram_service.rb]}
-  # inbound, provider webhook jobs + per-channel incoming-message services
-  - {id: in:whatsapp-job,      group: inbound,  match: [jobs/webhooks/whatsapp_events_job.rb]}
-  - {id: in:telegram-job,      group: inbound,  match: [webhooks/telegram_events_job.rb]}
-  - {id: in:line-job,          group: inbound,  match: [webhooks/line_events_job.rb]}
-  - {id: in:instagram-job,     group: inbound,  match: [webhooks/instagram_events_job.rb]}
-  - {id: in:whatsapp-svc,      group: inbound,  match: [whatsapp/incoming_message_service.rb]}
-  - {id: in:telegram-svc,      group: inbound,  match: [telegram/incoming_message_service.rb]}
-  # test matrix, the dispatch job spec + per-channel model/sender specs
-  - {id: spec:send-reply,      group: specs,    match: [send_reply_job_spec.rb]}
-  - {id: spec:channel-whatsapp,group: specs,    match: [channel/whatsapp_spec.rb]}
-  - {id: spec:send-whatsapp,   group: specs,    match: [send_on_whatsapp_service_spec.rb]}
+  # the contract itself + the shared pieces a change must reckon with
+  - {id: inbox-model,          group: contract,   match: [app/models/inbox.rb]}
+  - {id: cache-keys-concern,   group: contract,   match: [models/concerns/cache_keys.rb]}
+  - {id: channelable-concern,  group: contract,   match: [models/concerns/channelable.rb]}
+  - {id: contact-inbox,        group: contract,   match: [models/contact_inbox.rb]}
+  - {id: enterprise-inbox,     group: contract,   match: [enterprise/app/models/enterprise/inbox.rb]}
+  # the teardown path the rework centers on
+  - {id: delete-object-job,    group: teardown,   match: [app/jobs/delete_object_job.rb]}
+  # scattered dependents reached through associations / concerns (the grep-noisy fan-out)
+  - {id: dep:accounts-ctrl,    group: dependents, match: [api/v1/accounts_controller.rb]}
+  - {id: dep:dashboard-ctrl,   group: dependents, match: [super_admin/dashboard_controller.rb]}
+  - {id: dep:widget-tests,     group: dependents, match: [widget_tests_controller.rb]}
+  - {id: dep:assignment-job,   group: dependents, match: [auto_assignment/assignment_job.rb]}
+  - {id: dep:imap-fetch-job,   group: dependents, match: [inboxes/fetch_imap_email_inboxes_job.rb]}
+  - {id: dep:stale-notif-job,  group: dependents, match: [migration/remove_stale_notifications_job.rb]}
+  - {id: dep:assignee-handler, group: dependents, match: [concerns/assignee_activity_message_handler.rb]}
+  - {id: dep:twitter-webhook,  group: dependents, match: [twitter/webhook_subscribe_service.rb]}
+  - {id: dep:whatsapp-create,  group: dependents, match: [whatsapp/channel_creation_service.rb]}
+  - {id: dep:chatwoot-hub,     group: dependents, match: [lib/chatwoot_hub.rb]}
+  - {id: dep:slack-unfurl,     group: dependents, match: [integrations/slack/link_unfurl_formatter.rb]}

--- a/bench/scenarios/forem.rubric.yaml
+++ b/bench/scenarios/forem.rubric.yaml
@@ -10,13 +10,17 @@
 # Step names MUST match scenarios/forem.yaml exactly (the judge pairs by name).
 
 audience: |
-  An AI coding agent that will use this answer to add a new inline content embed
-  (a Liquid tag for an external service) to Forem with only small, targeted
-  follow-up lookups, not a fresh exploration of the codebase. Score for that
-  audience, not a human reader, not a docs page. A perfect answer leaves the agent
-  ready to create the new embed's renderer class, its view partial, register its
-  link pattern, and add specs; a weak answer forces the agent to re-explore the
-  codebase before it can act.
+  An AI coding agent that will use this answer to add a new reaction category (a
+  new way readers react to a post) to Forem with only small, targeted follow-up
+  lookups, not a fresh exploration of the codebase. Score for that audience, not
+  a human reader, not a docs page. A perfect answer leaves the agent ready to
+  declare the new category, give it the right scoring/caching/moderation/
+  notification behavior the existing categories have, and add specs; a weak
+  answer forces the agent to re-explore the codebase before it can act. Reactions
+  are a polymorphic, callback-driven hub: the high-value parts of the map are the
+  effects a reaction triggers and the dependents that read it, which are
+  scattered across services and workers in different namespaces and cannot be
+  found by listing one directory.
 
 steps:
   - name: Orient in the codebase
@@ -26,217 +30,239 @@ steps:
         question: |
           Does the answer hand the agent a usable map: that this is Forem (a
           community/blogging platform), how the Rails app is organized, and
-          specifically where inline embeds live, the embed renderers
-          (app/liquid_tags/, the LiquidTagBase base) and the dispatch that turns
-          a link into a renderer (app/liquid_tags/unified_embed/)? Could the agent
-          pick an entry point and start working with only small, targeted lookups?
+          specifically where reactions live, the Reaction model
+          (app/models/reaction.rb), the polymorphic reactable association
+          (app/models/concerns/reactable.rb), the category type
+          (app/models/reaction_category.rb), and the write path
+          (app/services/reaction_handler.rb, the reactions controller)? Could the
+          agent pick an entry point and start working with only small, targeted
+          lookups?
       specificity:
         weight: 0.25
         question: |
-          Are the cited paths concrete (app/liquid_tags/liquid_tag_base.rb,
-          app/liquid_tags/unified_embed/registry.rb, app/views/liquids/) rather
-          than vague ("the embed layer")? Are abstractions tied to actual files
-          and class names?
+          Are the cited paths concrete (app/models/reaction.rb,
+          app/models/concerns/reactable.rb, app/services/reaction_handler.rb)
+          rather than vague ("the reactions layer")? Are abstractions tied to
+          actual files and class names?
       justification:
         weight: 0.20
         question: |
-          Does the answer explain WHY the architecture is shaped this way (embeds
-          are Liquid tags subclassing a shared base, a registry maps a URL to the
-          right embed, each renders a view partial), not just NAME the pieces?
+          Does the answer explain WHY the architecture is shaped this way
+          (reactions are a polymorphic join recorded by a service, categories are
+          declared centrally, behavior is driven by model callbacks), not just
+          NAME the pieces?
       uncertainty:
         weight: 0.15
         question: |
           Where the answer is unsure about how the layers connect or what a new
-          embed must implement, does it flag that so the agent doesn't act blindly?
+          category must implement, does it flag that so the agent doesn't act
+          blindly?
 
-  - name: Trace an embed from post markup to its renderer
+  - name: Trace a reaction from user action to stored record
     criteria:
       map_quality:
         weight: 0.40
         question: |
-          Does the answer trace the routing path with file:line, in order: from
-          the embed markup an author writes through the unified embed tag
-          (UnifiedEmbed::Tag in app/liquid_tags/unified_embed/tag.rb) into the
-          registry (UnifiedEmbed::Registry#find_liquid_tag_for in
-          unified_embed/registry.rb) that regexp-matches the link to a concrete
-          embed class, and finally that class's #render? Could the agent follow
-          the same path to route a new embed?
+          Does the answer trace the write path with file:line, in order: from the
+          reader's action through the controller (ReactionsController in
+          app/controllers/reactions_controller.rb) into the service that creates
+          or toggles the reaction (ReactionHandler in
+          app/services/reaction_handler.rb) and finally the Reaction record and
+          its validations? Could the agent follow the same path to create a
+          reaction of the new category?
       specificity:
         weight: 0.25
         question: |
-          Are the dispatch methods named exactly (UnifiedEmbed::Registry,
-          find_liquid_tag_for / find_handler_for, #render) with file:line, rather
-          than "the routing code"?
+          Are the layers named exactly (ReactionsController, ReactionHandler,
+          Reaction) with file:line, rather than "the controller and the model"?
       justification:
         weight: 0.20
         question: |
-          Does the answer explain WHY dispatch is a regexp-keyed registry (so a
-          new embed is selected by registering a URL pattern, not by editing a
-          dispatcher) and why OpenGraphTag is the fallback, not just LIST the call
-          chain?
+          Does the answer explain WHY a service object mediates the write (toggle
+          semantics, validation, contradictory-reaction handling), not just LIST
+          the call chain?
       uncertainty:
         weight: 0.15
         question: |
-          Does the answer flag where the path is dynamic (registry consulted at
-          render time, first-matching-regexp wins, special-cased local URLs) so
-          the agent verifies before relying on it?
+          Does the answer flag where the path branches (create vs destroy/toggle,
+          admin vs public vs API controllers) so the agent verifies before
+          relying on it?
 
-  - name: Map the embed family and the shared contract
+  - name: Map what defines a reaction category
     criteria:
       map_quality:
         weight: 0.40
         question: |
-          Does the answer enumerate the shared base (LiquidTagBase in
-          app/liquid_tags/liquid_tag_base.rb: the initialize(tag_name, token,
-          parse_context) contract, the abstract #render, the LiquidTagHelpers
-          concern, the user_authorization_method_name hook) AND the existing
-          embeds that subclass and customize it (YouTube, Vimeo, GitHub, CodePen,
-          Gist, Instagram, Reddit, Spotify, Bluesky, ... each in
-          app/liquid_tags/<service>_tag.rb), with file:line and how each differs
-          (its regexp, its parse, its partial)? This inheritance fan-out is
-          grep-invisible (the subclass relationship is structural, not a shared
-          string); a strong answer names that breadth so the agent knows exactly
-          what to inherit and what to override.
+          Does the answer locate, with file:line, the category type
+          (ReactionCategory in app/models/reaction_category.rb), where the full
+          set of categories is declared (config/reactions.yml loaded by
+          config/initializers/load_reaction_category_list.rb into
+          REACTION_CATEGORY_LIST), and the attributes/conventions a category
+          carries (slug, score, position, privileged, published, icon) plus where
+          Reaction validates category inclusion? Could the agent declare a new
+          valid category from this?
       specificity:
         weight: 0.25
         question: |
-          Are the customizing embeds named concretely by file (youtube_tag.rb,
-          vimeo_tag.rb, codepen_tag.rb, gist_tag.rb) and the override points
-          (initialize, render, REGISTRY_REGEXP, PARTIAL) cited, rather than "some
-          embeds customize it"?
+          Are the pieces named exactly (ReactionCategory, REACTION_CATEGORY_LIST,
+          config/reactions.yml, the slug/score/privileged attributes) with
+          file:line, rather than "the category config"?
       justification:
         weight: 0.20
         question: |
-          Does the answer explain WHY the base is shared and subclassed (one
-          contract for all embeds, per-service behavior via a subclass that parses
-          its link and renders its partial), not just LIST the classes?
+          Does the answer explain WHY categories are data-declared centrally (so a
+          new one is added by configuration plus behavior, not by editing every
+          consumer) and what each attribute controls, not just NAME the file?
       uncertainty:
         weight: 0.15
         question: |
-          Does the answer flag any customization it could not confirm (an embed
-          that overrides a helper or renders differently than it opened) so the
-          agent checks before copying a pattern?
+          Does the answer flag attributes whose effect it could not confirm
+          (privileged, score, published) so the agent checks before setting them?
 
-  - name: Map how each embed declares which links it handles
+  - name: Map everything that happens when a reaction is created or removed
     criteria:
       map_quality:
         weight: 0.40
         question: |
-          Does the answer locate, with file:line, where each embed declares the
-          links it handles (a REGISTRY_REGEXP constant per embed class), where it
-          is registered (UnifiedEmbed.register and Liquid::Template.register_tag
-          calls, typically at the bottom of each embed file), and where the
-          registry is consulted to choose one for an incoming link
-          (UnifiedEmbed::Registry#find_handler_for / find_liquid_tag_for)? Could
-          the agent register a new embed's link pattern from this?
+          Does the answer enumerate the create/destroy cascade with file:line, the
+          callbacks in app/models/reaction.rb (assign_points, update_reactable,
+          bust_reactable_cache, async_bust, check_for_reaction_ring,
+          enqueue_article_activity_update, enqueue_update_user_interest_embedding,
+          record_field_test_event, the vomit slack notify) AND the concrete jobs
+          each enqueues, which live in DIFFERENT namespaces:
+          Reactions::UpdateRelevantScoresWorker,
+          Reactions::BustReactableCacheWorker,
+          Reactions::BustHomepageCacheWorker, ReactionCounterSyncWorker,
+          Spam::ReactionRingDetectionWorker,
+          Articles::UpdateArticleActivityWorker,
+          UpdateUserInterestEmbeddingWorker, and the notification worker? This
+          cascade is grep-invisible (effects are dispatched through callbacks to
+          workers in five different directories, not a shared string); a strong
+          answer names that breadth so the agent knows every effect the new
+          category must participate in. A thin answer that names only one or two
+          effects should score low here.
       specificity:
         weight: 0.25
         question: |
-          Are the registration calls named exactly (UnifiedEmbed.register(klass,
-          regexp:), Liquid::Template.register_tag, REGISTRY_REGEXP) with file:line,
-          rather than "it gets registered somewhere"?
+          Are the effects and their jobs named concretely
+          (Reactions::UpdateRelevantScoresWorker in
+          app/workers/reactions/update_relevant_scores_worker.rb,
+          Spam::ReactionRingDetectionWorker in
+          app/workers/spam/reaction_ring_detection_worker.rb) with file:line,
+          rather than "it busts some caches and updates scores"?
       justification:
         weight: 0.20
         question: |
-          Does the answer explain WHY registration is distributed (each embed owns
-          its own URL pattern and self-registers) and consumed centrally (one
-          registry scans patterns), not just NAME the calls?
+          Does the answer explain WHY the work is deferred to background jobs and
+          WHY each effect exists (scoring, caching, anti-abuse, activity feed,
+          recommendations), not just LIST the callbacks?
       uncertainty:
         weight: 0.15
         question: |
-          Does the answer flag where matching is order-sensitive or pattern-fragile
-          (first matching regexp wins, overlapping patterns) so the agent verifies
-          its new pattern does not collide?
+          Does the answer flag effects gated by a condition (vomit-only,
+          article-only, public-only) or any it could not fully trace, so the agent
+          verifies before assuming the new category triggers them?
 
-  - name: Trace how an embed validates input and restricts access
+  - name: Trace how a reaction feeds scoring and moderation
     criteria:
       map_quality:
         weight: 0.40
         question: |
-          Does the answer give file:line for input validation (LiquidTagHelpers in
-          app/liquid_tags/concerns/liquid_tag_helpers.rb: parse_options,
-          validate_url! raising on a bad scheme) AND per-embed authorization
-          (LiquidTagPolicy in app/policies/liquid_tag_policy.rb, the
-          user_authorization_method_name hook on the base)? Could the agent give
-          the new embed correct validation and access control without re-reading
-          every file?
+          Does the answer give file:line for BOTH directions: how a reaction
+          changes the reactable's standing (update_reactable ->
+          Reactions::UpdateRelevantScoresWorker -> Article#update_score in
+          app/models/article.rb and User#calculate_score in app/models/user.rb),
+          AND how moderation/anti-abuse treats particular reactions (the vomit
+          category, Spam::Handler in app/services/spam/handler.rb,
+          Spam::ReactionRingDetector, Moderator::BanishUser#delete_vomit_reactions
+          in app/services/moderator/banish_user.rb, Users::ConfirmFlagReactions)?
+          Could the agent decide what scoring and moderation behavior the new
+          category needs?
       specificity:
         weight: 0.25
         question: |
-          Are the methods/classes named exactly (validate_url!, parse_options,
-          LiquidTagPolicy, user_authorization_method_name) with file:line, rather
-          than "the validation code"?
+          Are the scoring and moderation entry points named exactly
+          (Article#update_score, User#calculate_score, Spam::Handler,
+          Moderator::BanishUser, the vomit category) with file:line, rather than
+          "it affects scoring and moderation"?
       justification:
         weight: 0.20
         question: |
-          Does the answer explain WHY validation lives in a shared concern and WHY
-          authorization is a policy keyed on a per-class method, not just NAME the
-          pieces?
+          Does the answer explain WHY scoring is recomputed off reactions and WHY
+          some reactions are privileged/negative and moderation-relevant, not just
+          NAME the methods?
       uncertainty:
         weight: 0.15
         question: |
-          Does the answer flag where an embed needs custom validation or
-          restricted access (a tag that overrides the auth hook) so the agent
-          verifies before shipping?
+          Does the answer flag where the scoring or moderation behavior is
+          category-dependent (privileged, negative, vomit) so the agent verifies
+          how the new category should participate?
 
-  - name: Find every site that must change to add a new embed
+  - name: Find every place that depends on the reaction contract
     criteria:
       map_quality:
         weight: 0.40
         question: |
-          Does the answer enumerate the full fan-out of adding an embed: the new
-          renderer class under app/liquid_tags/ (subclassing LiquidTagBase, whose
-          97-caller blast surface shows what the contract touches), its view
-          partial under app/views/liquids/, the two registrations
-          (Liquid::Template.register_tag + UnifiedEmbed.register with a regexp),
-          and the spec matrix (spec/liquid_tags/, the unified_embed registry/tag
-          specs)? A new embed touches several disjoint areas; a strong answer
-          names that breadth with file:line. Could the agent open the PR from this
-          list?
+          Does the answer enumerate the blast radius of the reaction contract, the
+          scattered dependents that read, create, or react to reactions across
+          DISJOINT areas: the cascade workers, the scoring models, the moderation
+          and spam services (Spam::Handler, Moderator::BanishUser,
+          Users::ConfirmFlagReactions), the notification path
+          (Notifications::Reactions::Send), and the reactable models (Article,
+          Comment, User via app/models/concerns/reactable.rb)? This dependent set
+          is grep-invisible (reached through the polymorphic association and
+          callbacks, not a shared literal; a plain grep for "reaction"
+          over-collects unrelated files); a strong answer assembles that breadth
+          with file:line so the agent knows what a contract change touches. Could
+          the agent revisit every dependent from this list?
       specificity:
         weight: 0.25
         question: |
-          Are the sites named concretely (a new <service>_tag.rb, a
-          liquids/_<service>.html.erb partial, the register lines, a
-          <service>_tag_spec.rb) rather than "create the embed and add tests"?
+          Are the dependents named concretely (Spam::Handler in
+          app/services/spam/handler.rb, the Reactions::* workers, the reactable
+          concern) rather than "lots of things use reactions"?
       justification:
         weight: 0.20
         question: |
-          Does the answer explain WHY each site is affected (renderer vs template
-          vs registration vs shared-base contract vs test matrix), not just LIST
-          them?
+          Does the answer explain WHY each dependent is coupled to the contract
+          (it reads category/points, it is enqueued by a callback, it is
+          polymorphic on reactable), not just LIST them?
       uncertainty:
         weight: 0.15
         question: |
-          Does the answer acknowledge what static reading can miss (embeds reached
-          only through the registry regexp, fixtures/cassettes for the embed's
-          HTTP calls) so the agent knows to verify?
+          Does the answer acknowledge what static reading can miss (dependents
+          reached only through the polymorphic association or a background job) so
+          the agent knows to verify?
 
   - name: Produce the edit map
     criteria:
       map_quality:
         weight: 0.40
         question: |
-          Does the answer produce a complete, actionable edit map: the new files
-          to create (the <service>_tag.rb renderer, its liquids/_<service>.html.erb
-          partial) and the existing files/lines to change (the two registrations,
-          the shared base if the contract extends, validation/authorization if the
-          embed needs it) plus the specs and fixtures, with file:line throughout?
-          Could a teammate open the PR from this map alone?
+          Does the answer produce a complete, actionable edit map: the
+          configuration to add (the new category in config/reactions.yml with its
+          attributes), the existing behaviors to extend or verify so the new
+          category is scored, cached, moderated, and notified like the others (the
+          cascade callbacks/workers, the scoring path, the moderation/notification
+          services as relevant), and the specs and fixtures to add, all with
+          file:line? Could a teammate open the PR from this map alone?
       specificity:
         weight: 0.25
         question: |
-          Are the files and insertion points concrete (new <service>_tag.rb with
-          REGISTRY_REGEXP + render, the partial, the register lines, a spec under
-          spec/liquid_tags/) rather than "create the embed and add tests"?
+          Are the files and insertion points concrete (the reactions.yml entry,
+          the specific workers/services to touch, a spec under
+          spec/models/reaction_spec.rb or spec/services/) rather than "configure
+          the category and add tests"?
       justification:
         weight: 0.20
         question: |
-          Does the answer explain WHY each file is in the map (which area it
-          belongs to and what the new embed needs there), not just LIST files?
+          Does the answer explain WHY each file is in the map (which behavior the
+          new category needs there: scoring, caching, moderation, notification,
+          validation, tests), not just LIST files?
       uncertainty:
         weight: 0.15
         question: |
-          Does the answer flag the parts it is least sure about (the exact URL
-          regexp, whether the embed needs authorization, fixture generation) so
-          the agent confirms before committing?
+          Does the answer flag the parts it is least sure about (the right score
+          or privileged setting, whether the category should be notifiable or
+          moderation-relevant, fixture generation) so the agent confirms before
+          committing?

--- a/bench/scenarios/forem.yaml
+++ b/bench/scenarios/forem.yaml
@@ -1,42 +1,61 @@
-name: Forem work session - add support for a new inline content embed
+name: Forem work session - add a new reaction category
 repo: forem
 # Single-prompt session bench (run via bench/bench-sense-local.sh): all steps are
 # presented in ONE prompt and worked in order, so context accumulates the way a
 # real work session does. Rendered to the agent: the description + each step's
 # name and prompt ONLY (checks/gold are NOT shown). Everything rendered is kept
 # NEUTRAL, it states the task, never the answer's shape, file paths, class or
-# method names, counts, or which tool to reach for. The recurring real task this
-# mirrors is "add a new inline embed" (a YouTube/CodePen/Bluesky-style embed),
-# one of Forem's most common contributions, which naturally walks the embed
-# markup, the UnifiedEmbed dispatch + Registry that maps a URL to a renderer, the
-# shared LiquidTagBase and its ~60+ subclasses, the per-embed URL regexp +
-# registration, the view partial each renders, the input-validation + per-embed
-# authorization guards, and the spec matrix. The headline is CUMULATIVE
-# efficiency (tool calls, billed + context tokens, time) at held accuracy: across
-# these areas the baseline re-derives the structure each step while the map is
-# queried once and reused.
-description: 'You are a maintainer about to add support for embedding content from
-  a new external service inline in posts, mirroring how the existing inline embeds
-  are built. Work through the tasks below one at a time; each builds on what you
-  learned in the previous one. Keep every answer concrete with file:line so the
-  next step (and a teammate opening the PR) can act without re-exploring the
-  codebase.'
+# method names, counts, or which tool to reach for.
+#
+# WHY THIS SEAM (and not the earlier "add an inline embed" version, kept as
+# *.embed.*.bak): the embed fan-out is grep's home turf. The ~60 embed renderers
+# all live in ONE directory (app/liquid_tags/*_tag.rb) and inherit via a literal
+# `< LiquidTagBase` string, so `ls app/liquid_tags/` + `grep '< LiquidTagBase'`
+# reconstructs the whole answer. A single Opus-4.6 run tied (fairness 0.828 both
+# arms) and the sense arm never needed graph/blast. That is the enumerable-fact
+# trap the runbook warns about.
+#
+# The REACTION system is the opposite: a Reaction (app/models/reaction.rb) is a
+# polymorphic `reactable` hub whose behavior is a dense callback cascade and
+# whose ~49 dependents are SCATTERED across disjoint namespaces grep cannot
+# cleanly enumerate. Creating/destroying a reaction fans out (via after_commit /
+# before_destroy callbacks, no shared literal string) into scoring
+# (Reactions::UpdateRelevantScoresWorker -> Article#update_score /
+# User#calculate_score), cache busts (Reactions::Bust{Reactable,Homepage}Cache,
+# ReactionCounterSync), anti-abuse (Spam::ReactionRingDetectionWorker), activity
+# (Articles::UpdateArticleActivityWorker), embeddings
+# (UpdateUserInterestEmbeddingWorker), field tests, and notifications
+# (Notifications::NewReactionWorker -> Notifications::Reactions::Send). On the
+# read side, moderation (Spam::Handler, Moderator::BanishUser#delete_vomit_,
+# Users::ConfirmFlagReactions) and analytics/badges depend on the contract.
+# `grep -rl reaction app/` over-collects 119 noisy files; `sense_blast Reaction`
+# resolves 49 direct / 152 total; `sense_graph Reaction` lists the scattered
+# consumers. That is where the map pays for itself. The session headline is
+# CUMULATIVE efficiency at held accuracy plus the cited-recall (precision) of the
+# scattered web.
+description: 'You are a maintainer about to add a new reaction category to Forem
+  (a new way readers can react to a post, alongside the ones that already exist),
+  and before writing it you need to understand how reactions work today so the new
+  one behaves consistently with everything a reaction already does. Work through
+  the tasks below one at a time; each builds on what you learned in the previous
+  one. Keep every answer concrete with file:line so the next step (and a teammate
+  opening the PR) can act without re-exploring the codebase.'
 steps:
 - name: Orient in the codebase
   prompt: "Task: orient yourself. In a few sentences plus file paths, what is this
-    project, how is the code organized, and where does the machinery that turns an
-    inline embed written in a post into rendered HTML live, along with the shared
-    pieces it is built on? Hand the next agent a map so they can act with small,
-    targeted lookups, not a fresh exploration of the codebase. No Explore agents.
+    project, how is the code organized, and where does the machinery that records
+    a reader's reaction to a post live, along with the shared pieces it is built
+    on? Hand the next agent a map so they can act with small, targeted lookups,
+    not a fresh exploration of the codebase. No Explore agents.
     "
   checks:
   - type: word
-    value: embed
+    value: reaction
     required: true
   - type: word
-    value: Liquid
+    value: polymorphic
     required: false
-    description: Named the templating layer the embeds are built on
+    description: Noted the reactable association is polymorphic
   - type: response_richness
     value: '3'
     required: false
@@ -48,22 +67,19 @@ steps:
     value: sense_conventions
     required: false
     layer: adoption
-- name: Trace an embed from post markup to its renderer
-  prompt: "Task: trace how a single inline embed written in a post is routed to the
-    concrete object that renders that specific service. Start from the markup an
-    author writes and follow it down through to where the right renderer is chosen
-    and run. Give file:line for each layer and the order they run.
+- name: Trace a reaction from user action to stored record
+  prompt: "Task: trace how a reader's reaction to a post becomes a stored record.
+    Start from the action the reader takes and follow it down through to where the
+    reaction is created and persisted. Give file:line for each layer and the order
+    they run.
     "
   checks:
   - type: word
-    value: Registry
+    value: ReactionHandler
     required: true
-    description: Found the registry that maps a link to its renderer
+    description: Found the service that creates the reaction
   - type: word
-    value: UnifiedEmbed
-    required: true
-  - type: word
-    value: render
+    value: ReactionsController
     required: false
   - type: response_richness
     value: '4'
@@ -72,28 +88,48 @@ steps:
     value: sense_graph
     required: false
     layer: adoption
-- name: Map the embed family and the shared contract
-  prompt: "Task: a new embed will be built on the same shared base that the existing
-    embeds are built on, then customize a few pieces. Map the shared behavior such
-    an embed inherits and, crucially, which existing embeds customize that shared
-    behavior and how each one differs. Be complete with file:line; a missed
-    customization point is behavior the new embed silently won't have.
+- name: Map what defines a reaction category
+  prompt: "Task: the new reaction is a new category of the same kind the existing
+    reactions are. Map what a reaction category is, where the full set of
+    categories is declared, and what attributes and conventions a new one must
+    follow to be valid and behave like the others. Be complete with file:line.
     "
   checks:
   - type: word
-    value: LiquidTagBase
+    value: ReactionCategory
     required: true
   - type: word
-    value: render
+    value: category
+    required: false
+  - type: response_richness
+    value: '4'
     required: true
-    description: Anchored on the shared contract method every embed implements
+  - type: mcp_tool_used
+    value: sense_conventions
+    required: false
+    layer: adoption
+  - type: mcp_tool_used
+    value: sense_search
+    required: false
+    layer: adoption
+- name: Map everything that happens when a reaction is created or removed
+  prompt: "Task: when a reaction is saved or removed, other parts of the system run
+    as a result. Map every one of those effects and, crucially, where each one
+    runs. Be complete with file:line; a missed effect is behavior the new category
+    silently will not get.
+    "
+  checks:
+  - type: word
+    value: Worker
+    required: true
+    description: Named the background jobs the cascade enqueues
+  - type: contains
+    value: reaction.rb
+    required: false
   - type: response_richness
     value: '6'
     required: true
-    description: Enumerated the shared base plus the per-embed customizations
-  - type: contains
-    value: liquid_tag_base.rb
-    required: false
+    description: Enumerated the scattered cascade, not just one or two effects
   - type: no_grep
     value: no_grep
     required: false
@@ -102,20 +138,22 @@ steps:
     value: sense_graph
     required: false
     layer: adoption
-- name: Map how each embed declares which links it handles
-  prompt: "Task: a new embed should only render for the links it owns, the way the
-    existing embeds do. Map how an embed declares which links it is responsible
-    for, and how the system selects the right embed to handle a given link. Be
-    complete with file:line.
+- name: Trace how a reaction feeds scoring and moderation
+  prompt: "Task: trace two things a reaction affects beyond itself. First, how a
+    reaction changes the standing of the thing it is attached to (its score or
+    rank). Second, how moderation and anti-abuse paths treat particular reactions:
+    where certain reactions are flagged, removed, or acted on. Give file:line
+    throughout.
     "
   checks:
   - type: word
-    value: register
+    value: score
     required: true
+    description: Found that reactions feed the reactable's score
   - type: word
-    value: regexp
+    value: vomit
     required: false
-    description: Found that the link-to-embed match is pattern-based
+    description: Found the moderation/abuse reaction path
   - type: response_richness
     value: '5'
     required: true
@@ -123,61 +161,34 @@ steps:
     value: sense_graph
     required: false
     layer: adoption
+- name: Find every place that depends on the reaction contract
+  prompt: "Task: you will change what a reaction stores and does. Find every place
+    in the codebase that reads, creates, or reacts to reactions and would need
+    revisiting, including the parts that are not obvious from the reaction file
+    itself. Be complete and use file:line; a missed dependent is a silent break.
+    "
+  checks:
+  - type: word
+    value: reactable
+    required: true
+  - type: response_richness
+    value: '6'
+    required: true
+    description: Reached the scattered dependents across services, workers, and controllers
   - type: mcp_tool_used
     value: sense_blast
     required: false
     layer: adoption
-- name: Trace how an embed validates input and restricts access
-  prompt: "Task: not every embed input is accepted. Trace how an embed validates the
-    input it is given and how access to certain embeds is restricted: where the
-    input and its links are checked, what happens on bad input, and where per-embed
-    authorization is enforced. Give file:line throughout.
-    "
-  checks:
-  - type: word
-    value: Policy
-    required: true
-    description: Found the per-embed authorization layer
-  - type: word
-    value: validate
-    required: false
-  - type: response_richness
-    value: '3'
-    required: false
   - type: mcp_tool_used
     value: sense_graph
     required: false
     layer: adoption
-- name: Find every site that must change to add a new embed
-  prompt: "Task: you will add the new embed. Find every place in the codebase that
-    must change for it to be recognized, routed, rendered, and tested, including
-    where embeds are registered, where the shared base is depended on, the template
-    that turns it into HTML, and where the existing embeds are covered by tests. Be
-    complete and use file:line; a missed site means the new embed is silently
-    ignored or untested.
-    "
-  checks:
-  - type: word
-    value: LiquidTagBase
-    required: true
-  - type: response_richness
-    value: '6'
-    required: true
-    description: Reached the registration and the spec matrix, not just the obvious file
-  - type: contains
-    value: spec
-    required: false
-  - type: mcp_tool_used
-    value: sense_blast
-    required: false
-    layer: adoption
 - name: Produce the edit map
-  prompt: "Task: produce the complete edit map for adding the new embed: which files
-    to create and which to change across each area you explored (the renderer class
-    and its template, the registration that maps links to it, the shared base it
-    depends on, the input validation and access checks), and which specs and
-    fixtures to add. Use file:line throughout, so a teammate could open the PR from
-    your map alone.
+  prompt: "Task: produce the complete edit map for adding the new reaction category:
+    what to configure, which existing behaviors and effects you mapped above the
+    new category must extend or be verified against so it behaves consistently
+    with the existing ones, and which specs and fixtures to add. Use file:line
+    throughout, so a teammate could open the PR from your map alone.
     "
   checks:
   - type: response_richness
@@ -186,59 +197,59 @@ steps:
   - type: contains
     value: spec
     required: false
-  - type: contains
-    value: liquid
+  - type: word
+    value: category
     required: false
 scoring:
   weights:
     correctness: 0.70
     efficiency: 0.30
-# Gold spans the areas the "add an inline embed" session walks. The discriminator
-# is the `embeds` group: a new embed inherits the shared LiquidTagBase
-# (app/liquid_tags/liquid_tag_base.rb) which is SUBCLASSED by ~60+ existing embeds
-# and selected by a regexp-keyed Registry (app/liquid_tags/unified_embed/), an
-# inheritance + regexp-dispatch fan-out grep cannot cleanly resolve (the subclass
-# relationship and the 97-caller blast radius of LiquidTagBase, not a string, is
-# what matters; you cannot grep "which class renders a vimeo URL"). The `dispatch`
-# group is the other grep-hard seam (markup -> UnifiedEmbed::Tag -> Registry
-# regexp match -> renderer). All targets are file-path matched so both mention (is
-# it on the map?) and cited (pinned to path:line?) are scored. The session
-# headline is CUMULATIVE efficiency at held accuracy.
+# Gold spans the areas the "add a reaction category" session walks. The
+# discriminator is the SCATTERED, grep-invisible web: the `cascade` group (the
+# side effects fired by Reaction's create/destroy callbacks, eight background
+# workers in five disjoint namespaces reached through callbacks, not a literal
+# call), plus `moderation` and `notification` (read-side dependents in
+# app/services/spam, app/services/moderator, app/services/notifications). These
+# cannot be produced by `ls` one directory or one grep; they require resolving
+# callback dispatch and polymorphic blast (sense_graph Reaction / sense_blast
+# Reaction = 49 direct / 152 total). The `config` + `contract` groups are the
+# convention a new category must follow (orient/convention steps); `scoring` is
+# symbol-matched (mention only) because the scoring methods live in god-object
+# models cited for many reasons. All path targets are file-path matched so both
+# mention (is it on the map?) and cited (pinned to path:line?) are scored.
 gold:
-  # dispatch / routing, markup down to the chosen renderer (regexp-keyed, grep-invisible)
-  - {id: unified-embed-tag,     group: dispatch,   match: [unified_embed/tag.rb]}
-  - {id: unified-embed-registry,group: dispatch,   match: [unified_embed/registry.rb]}
-  - {id: liquid-tag-base,       group: dispatch,   match: [liquid_tag_base.rb]}
-  - {id: opengraph-fallback,    group: dispatch,   match: [open_graph_tag.rb]}
-  # the embed fan-out (subclasses of the shared base, grep-invisible inheritance + regexp dispatch)
-  - {id: embed:youtube,         group: embeds,     match: [youtube_tag.rb]}
-  - {id: embed:vimeo,           group: embeds,     match: [vimeo_tag.rb]}
-  - {id: embed:github,          group: embeds,     match: [github_tag.rb]}
-  - {id: embed:gist,            group: embeds,     match: [gist_tag.rb]}
-  - {id: embed:codepen,         group: embeds,     match: [codepen_tag.rb]}
-  - {id: embed:codesandbox,     group: embeds,     match: [codesandbox_tag.rb]}
-  - {id: embed:instagram,       group: embeds,     match: [instagram_tag.rb]}
-  - {id: embed:tweet,           group: embeds,     match: [tweet_tag.rb]}
-  - {id: embed:twitter-timeline,group: embeds,     match: [twitter_timeline_tag.rb]}
-  - {id: embed:reddit,          group: embeds,     match: [reddit_tag.rb]}
-  - {id: embed:spotify,         group: embeds,     match: [spotify_tag.rb]}
-  - {id: embed:soundcloud,      group: embeds,     match: [soundcloud_tag.rb]}
-  - {id: embed:slideshare,      group: embeds,     match: [slideshare_tag.rb]}
-  - {id: embed:speakerdeck,     group: embeds,     match: [speakerdeck_tag.rb]}
-  - {id: embed:stackblitz,      group: embeds,     match: [stackblitz_tag.rb]}
-  - {id: embed:replit,          group: embeds,     match: [replit_tag.rb]}
-  - {id: embed:glitch,          group: embeds,     match: [glitch_tag.rb]}
-  - {id: embed:bluesky,         group: embeds,     match: [bluesky_tag.rb]}
-  # the HTML template each embed renders (a new embed needs its own partial)
-  - {id: view:youtube,          group: views,      match: [liquids/_youtube.html.erb]}
-  - {id: view:vimeo,            group: views,      match: [liquids/_vimeo.html.erb]}
-  - {id: view:codepen,          group: views,      match: [liquids/_codepen.html.erb]}
-  # input validation + per-embed authorization (what rejects bad input / restricts access)
-  - {id: liquid-tag-helpers,    group: validation, match: [concerns/liquid_tag_helpers.rb]}
-  - {id: liquid-tag-policy,     group: validation, match: [liquid_tag_policy.rb]}
-  # test matrix, the registry/dispatch specs + the per-embed spec set
-  - {id: registry-spec,         group: specs,      match: [unified_embed/registry_spec.rb]}
-  - {id: unified-tag-spec,      group: specs,      match: [unified_embed/tag_spec.rb]}
-  - {id: spec:youtube,          group: specs,      match: [youtube_tag_spec.rb]}
-  - {id: spec:vimeo,            group: specs,      match: [vimeo_tag_spec.rb]}
-  - {id: spec:codepen,          group: specs,      match: [codepen_tag_spec.rb]}
+  # the shared contract a new category is built on (the model + concern + category type)
+  - {id: reaction-model,        group: contract,     match: [models/reaction.rb]}
+  - {id: reactable-concern,     group: contract,     match: [concerns/reactable.rb]}
+  - {id: reaction-category,     group: contract,     match: [reaction_category.rb]}
+  # where the set of categories is declared (the convention a new one follows)
+  - {id: reactions-yml,         group: config,       match: [config/reactions.yml]}
+  - {id: category-initializer,  group: config,       match: [load_reaction_category_list.rb]}
+  # the write path: how a reaction is created
+  - {id: reaction-handler,      group: write-path,   match: [reaction_handler.rb]}
+  - {id: reactions-controller,  group: write-path,   match: [controllers/reactions_controller.rb]}
+  # THE discriminator: the create/destroy cascade, scattered workers across disjoint namespaces
+  - {id: w:update-scores,       group: cascade,      match: [reactions/update_relevant_scores_worker.rb]}
+  - {id: w:bust-reactable,      group: cascade,      match: [reactions/bust_reactable_cache_worker.rb]}
+  - {id: w:bust-homepage,       group: cascade,      match: [reactions/bust_homepage_cache_worker.rb]}
+  - {id: w:counter-sync,        group: cascade,      match: [reaction_counter_sync_worker.rb]}
+  - {id: w:ring-detection,      group: cascade,      match: [spam/reaction_ring_detection_worker.rb]}
+  - {id: w:article-activity,    group: cascade,      match: [articles/update_article_activity_worker.rb]}
+  - {id: w:interest-embedding,  group: cascade,      match: [update_user_interest_embedding_worker.rb]}
+  - {id: w:new-reaction-notif,  group: cascade,      match: [notifications/new_reaction_worker.rb]}
+  # how a reaction feeds the reactable's score (reached via update_reactable; symbol-matched, mention)
+  - {id: score:article,         group: scoring,      match: [update_score]}
+  - {id: score:user,            group: scoring,      match: [calculate_score]}
+  # moderation / anti-abuse dependents (scattered, grep-invisible read side)
+  - {id: mod:spam-handler,      group: moderation,   match: [spam/handler.rb]}
+  - {id: mod:banish-user,       group: moderation,   match: [moderator/banish_user.rb]}
+  - {id: mod:confirm-flags,     group: moderation,   match: [users/confirm_flag_reactions.rb]}
+  - {id: mod:ring-detector,     group: moderation,   match: [spam/reaction_ring_detector.rb]}
+  # how a reaction notifies
+  - {id: notif:send,            group: notification, match: [notifications/reactions/send.rb]}
+  - {id: notif:data,            group: notification, match: [notifications/reactions/reaction_data.rb]}
+  # the test matrix
+  - {id: spec:reaction,         group: specs,        match: [models/reaction_spec.rb]}
+  - {id: spec:handler,          group: specs,        match: [reaction_handler_spec.rb]}
+  - {id: spec:scores-worker,    group: specs,        match: [update_relevant_scores_worker_spec.rb]}
+  - {id: spec:requests,         group: specs,        match: [requests/reactions_spec.rb]}

--- a/bench/scenarios/lobsters.yaml
+++ b/bench/scenarios/lobsters.yaml
@@ -184,27 +184,29 @@ scoring:
     correctness: 0.70
     efficiency: 0.30
 # Lobsters is small, so gold is the must-find RELATIONAL set, not a wide
-# enumeration. The discriminator is the `votable` contract (Story AND Comment both
-# implement update_score_and_recalculate!, a polymorphic contract grep cannot tie
-# together) plus the transitive `ranking`/consumer fan-out (paginator, hydrator,
-# feeds) that reads score/hotness with no shared string. All targets are file-path
-# matched so both mention and cited are scored. Headline is CUMULATIVE efficiency
-# at held accuracy.
+# enumeration. It is the verified scattered dependent set of the vote/score
+# contract (from `sense blast Vote`), NOT an ls-able directory. The discriminator
+# is twofold: (1) the polymorphic `votable` contract (Story AND Comment both
+# implement update_score_and_recalculate!, grep cannot tie them together by string)
+# and (2) the transitive consumer fan-out that reads votes/score without sharing a
+# clean token — the paginator's vote cache, the comment-vote hydrator, the stats
+# graph cache, the search controller, the story_finder concern. To assemble this by
+# hand a maintainer greps `vote` (very common across the app) and must recognise
+# each indirect consumer; a structural impact query returns the resolved set. Pure
+# spec twins (both arms miss them in a 7-step session) are dropped. All targets are
+# file-path matched so both mention and cited are scored.
 gold:
-  # vote recording + author reputation
-  - {id: vote-model,    group: vote-flow, match: [models/vote.rb]}
-  - {id: user-karma,    group: vote-flow, match: [models/user.rb]}
-  - {id: inbox-vote,    group: vote-flow, match: [controllers/inbox_controller.rb]}
-  # HTTP entry points where votes/flags are cast
-  - {id: stories-ctrl,  group: entry,     match: [controllers/stories_controller.rb]}
-  - {id: comments-ctrl, group: entry,     match: [controllers/comments_controller.rb]}
-  # the shared votable contract (both implement update_score_and_recalculate!)
-  - {id: story-votable, group: votable,   match: [models/story.rb]}
-  - {id: comment-votable,group: votable,  match: [models/comment.rb]}
-  # ranking + display consumers of score/hotness/votes
-  - {id: paginator,     group: ranking,   match: [models/stories_paginator.rb]}
-  - {id: vote-hydrator, group: ranking,   match: [models/comment_vote_hydrator.rb]}
-  - {id: home-feeds,    group: ranking,   match: [controllers/home_controller.rb]}
-  # tests of the vote/score behavior
-  - {id: spec:vote,     group: specs,     match: [models/vote_spec.rb]}
-  - {id: spec:story,    group: specs,     match: [models/story_spec.rb]}
+  # the contract: the polymorphic votable pair + the vote record + author reputation
+  - {id: vote-model,     group: contract,   match: [models/vote.rb]}
+  - {id: story-votable,  group: contract,   match: [models/story.rb]}
+  - {id: comment-votable,group: contract,   match: [models/comment.rb]}
+  - {id: user-karma,     group: contract,   match: [models/user.rb]}
+  # HTTP entry points where votes/flags are cast (the obvious half, grep finds these)
+  - {id: stories-ctrl,   group: entry,      match: [controllers/stories_controller.rb]}
+  - {id: comments-ctrl,  group: entry,      match: [controllers/comments_controller.rb]}
+  # scattered consumers reached without a clean shared token (the grep-hostile half)
+  - {id: paginator,      group: consumers,  match: [models/stories_paginator.rb]}
+  - {id: vote-hydrator,  group: consumers,  match: [models/comment_vote_hydrator.rb]}
+  - {id: stats-cache,    group: consumers,  match: [models/stats.rb]}
+  - {id: search-ctrl,    group: consumers,  match: [controllers/search_controller.rb]}
+  - {id: story-finder,   group: consumers,  match: [controllers/concerns/story_finder.rb]}

--- a/bench/scenarios/mastodon.rubric.yaml
+++ b/bench/scenarios/mastodon.rubric.yaml
@@ -1,22 +1,15 @@
-# Per-scenario rubric for the LLM judge layer.
-#
-# Audience block is shared across all steps. Per-step rubrics use the same four
-# criteria (map_quality, specificity, justification, uncertainty) with the
-# canonical 40/25/20/15 weights. The judge scores the answer text first;
-# side-context (wall_time, tokens, completed/failed) is provided for the criteria
-# it bears on, map_quality (did this save downstream exploration?) and
-# uncertainty (was confidence calibrated against effort?).
-#
-# Step names MUST match scenarios/mastodon.yaml exactly (the judge pairs by name).
+# Per-scenario rubric for the LLM judge layer. Audience block shared across steps;
+# per-step criteria use the canonical map_quality 0.40 / specificity 0.25 /
+# justification 0.20 / uncertainty 0.15 weights. Step names MUST match
+# scenarios/mastodon.yaml exactly (the judge pairs by name).
 
 audience: |
-  An AI coding agent that will use this answer to add a new inbound federation
-  (ActivityPub) activity type to Mastodon with only small, targeted follow-up
-  lookups, not a fresh exploration of the codebase. Score for that audience, not
-  a human reader, not a docs page. A perfect answer leaves the agent ready to
-  create the new handler, wire it into dispatch, emit and deliver the outgoing
-  counterpart, and add specs; a weak answer forces the agent to re-explore the
-  codebase before it can act.
+  An AI coding agent that will use this answer to safely change Mastodon's outbound
+  ActivityPub delivery contract with only small, targeted follow-up lookups, not a
+  fresh exploration of the codebase. Score for that audience, not a human reader. A
+  perfect answer leaves the agent able to change delivery knowing every emitter that
+  must keep federating across both enqueue paths; a weak answer forces the agent to
+  re-grep several worker names and re-read the codebase before it can act safely.
 
 steps:
   - name: Orient in the codebase
@@ -25,226 +18,192 @@ steps:
         weight: 0.40
         question: |
           Does the answer hand the agent a usable map: that this is Mastodon (a
-          federated social server), how the Rails app is organized
-          (app/controllers, app/services, app/workers, app/lib, app/serializers),
-          and specifically where inbound federation lives, the inbox controller
-          (app/controllers/activitypub/inboxes_controller.rb), the processing
-          worker, the collection service, and the ActivityPub::Activity base and
-          its handlers (app/lib/activitypub/activity.rb, activity/)? Could the
-          agent pick an entry point and start working with only small, targeted
-          lookups?
+          federated social server), how the Rails app is organized (app/services,
+          app/workers, app/lib/activitypub), and where outbound delivery to remote
+          servers lives, the delivery worker(s) and how a payload is built and
+          signed? Could the agent pick an entry point with only small lookups?
       specificity:
         weight: 0.25
         question: |
-          Are the cited paths concrete (activitypub/inboxes_controller.rb,
-          app/lib/activitypub/activity.rb, app/services/activitypub/) rather than
-          vague ("the federation layer")? Are abstractions tied to actual files
-          and class names?
+          Are the cited paths concrete (app/workers/activitypub/delivery_worker.rb,
+          app/lib/activitypub/, the Payloadable concern) rather than vague ("the
+          federation layer")?
       justification:
         weight: 0.20
         question: |
-          Does the answer explain WHY the architecture is shaped this way (inbox
-          accepts and enqueues, processing happens async in a worker, a factory
-          dispatches each activity to a per-kind handler), not just NAME the
-          pieces?
+          Does the answer explain WHY delivery is shaped this way (async workers,
+          signed payloads, a single-destination delivery vs a fan-out to followers),
+          not just NAME the pieces?
       uncertainty:
         weight: 0.15
         question: |
-          Where the answer is unsure about how the layers connect or what a new
-          activity type must implement, does it flag that so the agent doesn't act
-          blindly?
+          Where unsure how the layers connect, does the answer flag it so the agent
+          doesn't act blindly?
 
-  - name: Trace an incoming activity to its concrete handler
+  - name: Map the delivery contract and what it is built on
     criteria:
       map_quality:
         weight: 0.40
         question: |
-          Does the answer trace the routing path with file:line, in order: from
-          the public endpoint (ActivityPub::InboxesController#create) through the
-          async worker (ActivityPub::ProcessingWorker) to the collection service
-          (ActivityPub::ProcessCollectionService#process_item) and into the
-          dispatch (ActivityPub::Activity.factory / klass_for) that selects the
-          per-kind handler and runs #perform? Could the agent follow the same path
-          to register and route a new activity type?
+          Does the answer map the delivery contract with file:line: the low-level
+          DeliveryWorker (one destination) versus the DistributionWorker /
+          RawDistributionWorker fan-out (many destinations), and the Payloadable
+          concern that builds and signs the payload? Could the agent know what a
+          change has to preserve across both layers?
       specificity:
         weight: 0.25
         question: |
-          Are the lookup/selection methods named exactly (ProcessCollectionService
-          #process_item, Activity.factory, klass_for, #perform) with file:line,
-          rather than "the routing code"?
+          Are the pieces named concretely by file (delivery_worker.rb,
+          distribution_worker.rb, concerns/payloadable.rb) rather than "the delivery
+          workers"?
       justification:
         weight: 0.20
         question: |
-          Does the answer explain WHY dispatch is a factory keyed on the activity
-          type (so a new kind is handled by adding a branch + a handler class, not
-          by editing the inbox), not just LIST the call chain?
+          Does the answer explain WHY there are two delivery layers (a single push
+          vs a fan-out that itself enqueues many single pushes) and what the shared
+          payload concern provides, not just LIST the classes?
       uncertainty:
         weight: 0.15
         question: |
-          Does the answer flag where the path is asynchronous or dynamic (work
-          deferred to Sidekiq, type-string keyed dispatch) so the agent verifies
-          before relying on it?
+          Does the answer flag any part of the contract it could not confirm so the
+          agent checks before relying on it?
 
-  - name: Map the handler family and the shared contract
+  - name: Trace one user action to an outbound delivery
     criteria:
       map_quality:
         weight: 0.40
         question: |
-          Does the answer enumerate the shared base (ActivityPub::Activity in
-          app/lib/activitypub/activity.rb: the initialize/@object/@account
-          contract, the abstract #perform, the protected helpers and included
-          concerns) AND the existing handlers that subclass and customize it
-          (Create, Announce, Delete, Follow, Like, Block, Update, Undo, Accept,
-          Reject, Flag, Add, Remove, Move, QuoteRequest, FeatureRequest, each in
-          app/lib/activitypub/activity/), with file:line and how each differs?
-          This inheritance + dispatch fan-out is grep-invisible (the subclass
-          relationship is structural, not a shared string); a strong answer names
-          that breadth so the agent knows exactly what to inherit and what to
-          override.
+          Does the answer trace one action (follow / favourite / post) with
+          file:line from its service down to where the delivery is queued, naming
+          whether it delivers directly or via a fan-out worker? Could the agent
+          follow the same path for another action?
       specificity:
         weight: 0.25
         question: |
-          Are the customizing handlers named concretely by file
-          (activity/create.rb, activity/announce.rb, activity/undo.rb,
-          activity/quote_request.rb) and the override/helper points cited, rather
-          than "some handlers customize it"?
+          Are the layers named exactly (the service, the worker, the enqueue call)
+          with file:line, rather than "the follow code"?
       justification:
         weight: 0.20
         question: |
-          Does the answer explain WHY the base is shared and subclassed (one
-          contract for all inbound activities, per-kind behavior via a subclass
-          implementing #perform plus shared protected helpers), not just LIST the
-          classes?
+          Does the answer explain WHY the action federates the way it does (direct
+          delivery to a single inbox vs fan-out to all followers), not just LIST the
+          chain?
       uncertainty:
         weight: 0.15
         question: |
-          Does the answer flag any customization it could not confirm (a handler
-          that overrides a helper it didn't open) so the agent checks before
-          copying a pattern?
+          Does the answer flag where the path is async or branches by case so the
+          agent verifies?
 
-  - name: Map the outbound counterpart for the same activities
+  - name: Audit every emitter of an outbound delivery
     criteria:
       map_quality:
         weight: 0.40
         question: |
-          Does the answer connect each inbound activity to its outbound emission:
-          the ActivityPub serializers that build the outgoing JSON
-          (app/serializers/activitypub/, e.g. create_note_serializer.rb,
-          announce_note_serializer.rb, delete_note_serializer.rb) and the
-          distribution workers that deliver it (ActivityPub::DistributionWorker /
-          RawDistributionWorker in app/workers/activitypub/), with file:line?
-          Tying inbound handler to outbound serializer is a semantic correspondence
-          with no shared string, so a strong answer pays off here.
+          Does the answer enumerate the FULL emitter set across BOTH enqueue paths:
+          the services that queue a delivery directly (follow, unfollow, block,
+          favourite, vote, report, delete/suspend account, authorize/reject follow,
+          remove status), the services that go through a *DistributionWorker fan-out
+          (post status, reblog, move, collection changes), the fan-out workers
+          themselves, and any model/scheduled emitter (relay)? This two-path fan-out
+          is the heart of the ticket and is grep-hostile: a hand audit must chase
+          several distinct worker names and read a large file union. A strong answer
+          names that breadth with file:line so no action silently stops federating.
       specificity:
         weight: 0.25
         question: |
-          Are the serializers and workers named concretely by file
-          (create_note_serializer.rb, distribution_worker.rb) rather than "the
-          serializer layer"?
+          Are the emitters named concretely by file and symbol
+          (app/services/follow_service.rb, app/services/post_status_service.rb,
+          app/workers/activitypub/distribution_worker.rb) with file:line and one
+          phrase on what each federates, rather than "the various services"?
       justification:
         weight: 0.20
         question: |
-          Does the answer explain WHY emission is split into serialize (build the
-          payload) and distribute (sign + deliver to followers/inboxes), not just
-          NAME the files?
+          Does the answer explain WHY there are two emit paths (direct vs fan-out)
+          and group the emitters accordingly, not just LIST files?
       uncertainty:
         weight: 0.15
         question: |
-          Does the answer flag where an inbound activity has no symmetric outbound
-          path (or vice versa) so the agent does not assume a counterpart exists?
+          Does the answer acknowledge what a static pass can miss (emitters reached
+          only through a wrapping fan-out worker, scheduled jobs) so the agent
+          verifies?
 
-  - name: Trace how malformed or unauthorized activities are rejected
+  - name: Trace how a delivery target and payload are validated
     criteria:
       map_quality:
         weight: 0.40
         question: |
-          Does the answer give file:line for the rejection path: the
-          sender-signature verification (SignatureVerification /
-          SignatureAuthentication concerns, the inbox before_actions
-          require_actor_signature! / skip_large_payload / skip_unknown_actor_activity)
-          AND what happens to an unrecognized type (factory/klass_for returns nil
-          so the activity is dropped; SUPPORTED_TYPES / CONVERTED_TYPES)? Could the
-          agent give the new activity correct guard behavior without re-reading
-          every file?
+          Does the answer give file:line for how a destination is judged eligible
+          (not blocked, not local, a real remote inbox) and how the payload is
+          built/signed before sending? Could the agent give a reworked delivery the
+          right guards?
       specificity:
         weight: 0.25
         question: |
-          Are the guards/concerns named exactly (signature_verification.rb,
-          require_actor_signature!, klass_for returning nil) with file:line, rather
-          than "the validation code"?
+          Are the guards named exactly (the inbox/domain eligibility checks, the
+          signing in the payload concern) with file:line rather than "the validation
+          code"?
       justification:
         weight: 0.20
         question: |
-          Does the answer explain WHY verification happens at the inbox before
-          async processing and WHY an unknown type is silently dropped rather than
-          erroring, not just NAME the pieces?
+          Does the answer explain WHY delivery must validate the target and sign the
+          payload (avoid sending to blocked/local domains, prove authenticity), not
+          just NAME the pieces?
       uncertainty:
         weight: 0.15
         question: |
-          Does the answer flag where guard behavior is conditional (per-type early
-          returns, payload size limits) so the agent verifies before shipping?
+          Does the answer flag where eligibility/signing is implicit or shared so
+          the agent verifies?
 
-  - name: Find every site that must change to add a new incoming activity type
+  - name: Assess the blast radius of the delivery change
     criteria:
       map_quality:
         weight: 0.40
         question: |
-          Does the answer enumerate the full fan-out of adding an inbound activity
-          type: the dispatch branch (Activity.klass_for in
-          app/lib/activitypub/activity.rb), the new handler subclass under
-          app/lib/activitypub/activity/, the shared base it depends on (the
-          53-caller blast surface of ActivityPub::Activity), the outbound
-          serializer + distribution if it is emitted, and the spec matrix
-          (spec/lib/activitypub/activity/, process_collection_service_spec.rb)? A
-          new type touches several disjoint areas; a strong answer names that
-          breadth with file:line. Could the agent open the PR from this list?
+          Does the answer assess the full blast radius of changing the delivery
+          contract: which emitters are at risk across both paths, which are most
+          likely to break, and what must be re-verified, with file:line and a risk
+          ranking? This is the change-impact question a structural blast answers
+          directly and a hand audit under-covers.
       specificity:
         weight: 0.25
         question: |
-          Are the sites named concretely (the klass_for case in activity.rb, a new
-          activity/<kind>.rb, activity/<kind>_spec.rb) rather than "wire it in and
-          add tests"?
+          Are the at-risk emitters named concretely by file with a stated reason for
+          the risk level, rather than "several things might break"?
       justification:
         weight: 0.20
         question: |
-          Does the answer explain WHY each site is affected (dispatch branch vs
-          handler implementation vs shared-base contract vs test matrix), not just
-          LIST them?
+          Does the answer explain WHY a given emitter is high vs low risk (relies on
+          the fan-out path being preserved vs a single direct push), not just LIST
+          them?
       uncertainty:
         weight: 0.15
         question: |
-          Does the answer acknowledge what static reading can miss (handlers
-          reached only through the factory, fixtures/JSON-LD test payloads) so the
-          agent knows to verify?
+          Does the answer flag the emitters it is least sure about (reached only via
+          a fan-out worker, only surfaced structurally) so the agent confirms?
 
-  - name: Produce the edit map
+  - name: Produce the change + verification map
     criteria:
       map_quality:
         weight: 0.40
         question: |
-          Does the answer produce a complete, actionable edit map: the new files
-          to create (the handler class under activity/, possibly an outbound
-          serializer) and the existing files to change across every area (the
-          klass_for dispatch in activity.rb, the shared base if the contract
-          extends, the distribution wiring, the signature/validation guards) plus
-          the specs and JSON-LD fixtures, with file:line throughout? Could a
-          teammate open the PR from this map alone?
+          Does the answer produce a complete, actionable map: the delivery worker(s)
+          and payload concern to edit, every emitter to review grouped by path, and
+          the specs/fixtures to update for both the direct and fan-out paths, with
+          file:line throughout? Could a teammate land the change from this map alone?
       specificity:
         weight: 0.25
         question: |
-          Are the files and insertion points concrete (new activity/<kind>.rb, the
-          klass_for branch in activity.rb, a spec under
-          spec/lib/activitypub/activity/) rather than "create the handler and add
-          tests"?
+          Are the files and insertion points concrete (delivery_worker.rb, the
+          distribution workers, the emitting services, the relevant specs) rather
+          than "edit delivery and add tests"?
       justification:
         weight: 0.20
         question: |
-          Does the answer explain WHY each file is in the map (which area it
-          belongs to and what the new activity type needs there), not just LIST
-          files?
+          Does the answer explain WHY each file is in the map (which path/area it
+          belongs to and what the change does to it), not just LIST files?
       uncertainty:
         weight: 0.15
         question: |
-          Does the answer flag the parts it is least sure about (whether the new
-          type needs an outbound counterpart, which protected helpers it must
-          override, fixture generation) so the agent confirms before committing?
+          Does the answer flag the parts it is least sure about (the fan-out
+          enqueue, payload signing, fixtures) so the agent confirms before
+          committing?

--- a/bench/scenarios/mastodon.yaml
+++ b/bench/scenarios/mastodon.yaml
@@ -1,43 +1,43 @@
-name: Mastodon work session - add support for a new incoming federation activity
+name: Mastodon work session - audit outbound federation before changing delivery
 repo: mastodon
 # Single-prompt session bench (run via bench/bench-sense-local.sh): all steps are
 # presented in ONE prompt and worked in order, so context accumulates the way a
 # real work session does. Rendered to the agent: the description + each step's
-# name and prompt ONLY (checks/gold are NOT shown). Everything rendered is kept
-# NEUTRAL, it states the task, never the answer's shape, file paths, class or
-# method names, counts, or which tool to reach for. The recurring real task this
-# mirrors is "add a new inbound ActivityPub activity type" (QuoteRequest and
-# FeatureRequest were both added this way recently), which naturally walks the
-# inbox endpoint, the Sidekiq processing worker, the collection service, the
-# `ActivityPub::Activity.factory` dispatch, the shared `ActivityPub::Activity`
-# base and its 16 handler subclasses, the outbound serializers + distribution
-# workers, the sender-signature verification guards, and the spec matrix. The
-# headline is CUMULATIVE efficiency (tool calls, billed + context tokens, time)
-# at held accuracy: across these areas the baseline re-derives the structure each
-# step while the map is queried once and reused.
-description: 'You are a maintainer about to add support for a new kind of incoming
-  federation activity to this server, mirroring how the existing activity handling
-  is built. Work through the tasks below one at a time; each builds on what you
-  learned in the previous one. Keep every answer concrete with file:line so the
-  next step (and a teammate opening the PR) can act without re-exploring the
-  codebase.'
+# name and prompt ONLY (checks/gold are NOT shown), kept NEUTRAL — it states the
+# task, never the answer's shape, file paths, class/method names, counts, or which
+# tool to reach for.
+#
+# CHANGE-IMPACT ticket, not add-by-copying. The recurring real task: a maintainer
+# about to change how Mastodon delivers an activity to remote servers (the outbound
+# federation contract) must first audit EVERY place that emits a federated
+# delivery. The must-find answer is the scattered emitter set spread across
+# app/services and app/workers, reached through TWO enqueue paths — the low-level
+# delivery worker AND the higher-level distribution fan-out workers that wrap it —
+# so a maintainer auditing by hand has to grep multiple worker names and read a
+# large union of files to separate real emitters from noise. A structural impact
+# query returns the resolved emitter set in one shot. The headline is whether the
+# agent assembles that two-path fan-out completely and cheaply.
+description: 'You are a maintainer about to change how this server delivers activities
+  to other servers it federates with (the outbound delivery contract — batching,
+  retries, and the payload envelope). Before touching it, you need a complete audit
+  of everything that emits an outbound federated delivery today, so the change does
+  not silently stop some action from federating. Work through the tasks below one at
+  a time; each builds on what you learned in the previous one. Keep every answer
+  concrete with file:line so the next step (and a teammate opening the PR) can act
+  without re-exploring the codebase.'
 steps:
 - name: Orient in the codebase
   prompt: "Task: orient yourself. In a few sentences plus file paths, what is this
-    project, how is the code organized, and where does the machinery that receives
-    and processes incoming federation activities from other servers live, along
-    with the shared pieces it is built on? Hand the next agent a map so they can
-    act with small, targeted lookups, not a fresh exploration of the codebase.
-    No Explore agents.
+    project, how is the code organized, and where does the machinery that delivers
+    activities to other servers live, along with the shared pieces it is built on
+    (how an outgoing payload is built and signed, and how a delivery is queued)?
+    Hand the next agent a map so they can act with small, targeted lookups, not a
+    fresh exploration of the codebase. No Explore agents.
     "
   checks:
   - type: word
     value: ActivityPub
     required: true
-  - type: word
-    value: inbox
-    required: false
-    description: Named the inbound entry point, not just the protocol
   - type: response_richness
     value: '3'
     required: false
@@ -49,23 +49,39 @@ steps:
     value: sense_conventions
     required: false
     layer: adoption
-- name: Trace an incoming activity to its concrete handler
-  prompt: "Task: trace how a single incoming activity is routed to the concrete
-    object that processes that specific kind of activity. Start from the public
-    HTTP endpoint that receives it and follow it down through to where the right
-    handler is chosen and run. Give file:line for each layer and the order they
-    run.
+- name: Map the delivery contract and what it is built on
+  prompt: "Task: map the contract you are about to change. How is an outgoing
+    delivery queued, what is the difference between delivering to a single
+    destination and fanning out to many, and what shared piece builds and wraps the
+    payload that gets delivered? Give file:line for the worker(s) and the shared
+    payload-building behavior, and explain how they relate.
     "
   checks:
   - type: word
-    value: factory
+    value: DeliveryWorker
     required: true
-    description: Found the dispatch that selects the handler by activity kind
-  - type: word
-    value: ProcessCollectionService
+    description: Found the low-level delivery worker
+  - type: response_richness
+    value: '4'
     required: true
+  - type: mcp_tool_used
+    value: sense_conventions
+    required: false
+    layer: adoption
+  - type: mcp_tool_used
+    value: sense_graph
+    required: false
+    layer: adoption
+- name: Trace one user action to an outbound delivery
+  prompt: "Task: pick a single user action that must reach other servers (for
+    instance following, favouriting, or posting) and trace it from the service that
+    performs it down to where the delivery is actually queued. Give file:line for
+    each layer and the order they run, and note whether it delivers directly or goes
+    through a fan-out step.
+    "
+  checks:
   - type: word
-    value: perform
+    value: Service
     required: false
   - type: response_richness
     value: '4'
@@ -74,75 +90,37 @@ steps:
     value: sense_graph
     required: false
     layer: adoption
-- name: Map the handler family and the shared contract
-  prompt: "Task: a new handler will be built on the same shared base that the
-    existing activity handlers are built on, then customize a few pieces. Map the
-    shared behavior such a handler inherits and, crucially, which existing handlers
-    customize that shared behavior and how each one differs. Be complete with
-    file:line; a missed customization point is behavior the new handler silently
-    won't have.
+- name: Audit every emitter of an outbound delivery
+  prompt: "Task: this is the core of the ticket. Find EVERY place that emits an
+    outbound federated delivery, so the change cannot silently stop one from
+    federating. There is more than one path: some emit a delivery directly, others
+    go through a higher-level fan-out step that wraps it. Be exhaustive across both
+    paths and group the emitters by area (the services that perform user actions,
+    the fan-out workers, and any model or scheduled job that originates a delivery).
+    For each give file:line and one phrase on what action it federates. A surface
+    text search has to chase several different worker names and wade through a large
+    set of files; a missed emitter is an action that silently stops federating.
     "
   checks:
-  - type: word
-    value: Activity
-    required: true
-  - type: word
-    value: perform
-    required: true
-    description: Anchored on the shared contract method every handler implements
   - type: response_richness
     value: '6'
     required: true
-    description: Enumerated the shared base plus the per-handler customizations
-  - type: contains
-    value: activitypub/activity.rb
-    required: false
+    description: Enumerated the two-path emitter set across services + workers
   - type: no_grep
     value: no_grep
     required: false
     layer: adoption
   - type: mcp_tool_used
-    value: sense_graph
+    value: sense_blast
     required: false
     layer: adoption
-- name: Map the outbound counterpart for the same activities
-  prompt: "Task: for the kinds of activities you just mapped on the way in, find how
-    this server emits the corresponding activity outward to other servers: where
-    the outgoing payload is built and where it is delivered. Tie each incoming
-    activity to its outgoing counterpart, with file:line.
+- name: Trace how a delivery target and payload are validated
+  prompt: "Task: not every delivery is sent. Before an activity goes out, how does
+    the code decide a destination is eligible (not blocked, not the local domain,
+    actually a remote inbox) and that the payload is well-formed and signed? Trace
+    where those checks live. Give file:line throughout.
     "
   checks:
-  - type: word
-    value: Serializer
-    required: true
-  - type: word
-    value: Distribution
-    required: false
-    description: Reached the delivery worker, not just the payload builder
-  - type: response_richness
-    value: '4'
-    required: true
-  - type: contains
-    value: serializer
-    required: false
-  - type: mcp_tool_used
-    value: sense_search
-    required: false
-    layer: adoption
-  - type: mcp_tool_used
-    value: sense_graph
-    required: false
-    layer: adoption
-- name: Trace how malformed or unauthorized activities are rejected
-  prompt: "Task: not every incoming activity is processed. Trace how this server
-    rejects or drops an activity it should not act on: how it verifies the sender,
-    what guards run before processing, and what happens to an activity whose kind
-    is not recognized. Give file:line throughout.
-    "
-  checks:
-  - type: word
-    value: signature
-    required: true
   - type: response_richness
     value: '3'
     required: false
@@ -150,36 +128,28 @@ steps:
     value: sense_graph
     required: false
     layer: adoption
-- name: Find every site that must change to add a new incoming activity type
-  prompt: "Task: you will add the new kind of activity. Find every place in the
-    codebase that must change for the server to recognize, route, process, emit,
-    and test it, including where handlers are selected, where the shared base is
-    depended on, and where the existing activity handling is covered by tests. Be
-    complete and use file:line; a missed site means the new activity is silently
-    ignored or untested.
+- name: Assess the blast radius of the delivery change
+  prompt: "Task: you are about to change the outbound delivery contract. Assess the
+    full blast radius: which emitters are at risk across both enqueue paths, which
+    are most likely to break, and what must be re-verified after the change. Be
+    complete and use file:line; rank by risk. A missed high-risk emitter is an
+    action that silently stops reaching other servers.
     "
   checks:
-  - type: word
-    value: Activity
-    required: true
   - type: response_richness
     value: '6'
     required: true
-    description: Reached the dispatch and the spec matrix, not just the obvious handler file
-  - type: contains
-    value: spec
-    required: false
+    description: Ranked the scattered emitters by risk across both paths
   - type: mcp_tool_used
     value: sense_blast
     required: false
     layer: adoption
-- name: Produce the edit map
-  prompt: "Task: produce the complete edit map for adding the new kind of activity:
-    which files to create and which to change across each area you explored (the
-    routing/dispatch, the shared base and its handlers, the outgoing serialization
-    and delivery, the sender-verification and validation guards), and which specs
-    and fixtures to add. Use file:line throughout, so a teammate could open the PR
-    from your map alone.
+- name: Produce the change + verification map
+  prompt: "Task: produce the complete map for landing this safely: the delivery
+    worker(s) and shared payload piece you will edit, every emitter that must be
+    reviewed grouped by path/area, and the specs/fixtures that must be updated to
+    cover both the direct and the fan-out delivery paths. Use file:line throughout,
+    so a teammate could land the change from your map alone.
     "
   checks:
   - type: response_richness
@@ -187,58 +157,41 @@ steps:
     required: true
   - type: contains
     value: spec
-    required: false
-  - type: contains
-    value: serializer
     required: false
 scoring:
   weights:
     correctness: 0.70
     efficiency: 0.30
-# Gold spans the areas the "add an inbound activity type" session walks. The
-# discriminator is the `handlers` group: a new handler inherits the shared
-# `ActivityPub::Activity` base (app/lib/activitypub/activity.rb) which is
-# SUBCLASSED by 16 existing handlers and dispatched by a private `klass_for`
-# case, an inheritance + dispatch fan-out grep cannot cleanly resolve (the
-# relationship and the 53-caller blast radius, not a string, is what matters).
-# The `dispatch` group is the other grep-hard seam (the route from inbox HTTP
-# endpoint to handler hops controller -> worker -> service -> factory across four
-# dirs). All targets are file-path matched so both mention (is it on the map?)
-# and cited (pinned to path:line?) are scored. The session headline is CUMULATIVE
-# efficiency at held accuracy.
+# Gold is the must-find audit: every emitter of an outbound federated delivery,
+# across BOTH enqueue paths (the direct DeliveryWorker and the *DistributionWorker
+# fan-out layer), plus the delivery/payload contract pieces. The discriminator is
+# NOT the inbound activity-handler directory (the old enumerable trap, now dropped),
+# it is the two-path emitter fan-out scattered across app/services and app/workers.
+# Assembling it by hand means grepping several distinct worker names and reading a
+# ~75-file union to filter real emitters; a structural blast returns the resolved
+# set. All targets are file-path matched so both mention and cited score.
 gold:
-  # dispatch / routing, inbox HTTP endpoint down to handler selection (multi-hop, grep-tedious)
-  - {id: inbox-controller,   group: dispatch,  match: [activitypub/inboxes_controller.rb]}
-  - {id: processing-worker,  group: dispatch,  match: [activitypub/processing_worker.rb]}
-  - {id: process-collection, group: dispatch,  match: [process_collection_service.rb]}
-  - {id: activity-factory,   group: dispatch,  match: [activitypub/activity.rb]}
-  # the inbound handler fan-out (16 subclasses of the shared base, grep-invisible inheritance)
-  - {id: handler:create,     group: handlers,  match: [activity/create.rb]}
-  - {id: handler:announce,   group: handlers,  match: [activity/announce.rb]}
-  - {id: handler:delete,     group: handlers,  match: [activity/delete.rb]}
-  - {id: handler:follow,     group: handlers,  match: [activity/follow.rb]}
-  - {id: handler:like,       group: handlers,  match: [activity/like.rb]}
-  - {id: handler:block,      group: handlers,  match: [activity/block.rb]}
-  - {id: handler:update,     group: handlers,  match: [activity/update.rb]}
-  - {id: handler:undo,       group: handlers,  match: [activity/undo.rb]}
-  - {id: handler:accept,     group: handlers,  match: [activity/accept.rb]}
-  - {id: handler:reject,     group: handlers,  match: [activity/reject.rb]}
-  - {id: handler:flag,       group: handlers,  match: [activity/flag.rb]}
-  - {id: handler:add,        group: handlers,  match: [activity/add.rb]}
-  - {id: handler:remove,     group: handlers,  match: [activity/remove.rb]}
-  - {id: handler:move,       group: handlers,  match: [activity/move.rb]}
-  - {id: handler:quotereq,   group: handlers,  match: [activity/quote_request.rb]}
-  - {id: handler:featurereq, group: handlers,  match: [activity/feature_request.rb]}
-  # outbound counterpart, serializers build the payload, distribution workers deliver it
-  - {id: create-note-ser,    group: outbound,  match: [create_note_serializer.rb]}
-  - {id: announce-note-ser,  group: outbound,  match: [announce_note_serializer.rb]}
-  - {id: delete-note-ser,    group: outbound,  match: [delete_note_serializer.rb]}
-  - {id: distribution-worker,group: outbound,  match: [activitypub/distribution_worker.rb]}
-  # sender verification / validation guards (what drops an activity before processing)
-  - {id: sig-verification,   group: rejection, match: [signature_verification.rb]}
-  - {id: sig-authentication, group: rejection, match: [signature_authentication.rb]}
-  # test matrix, the per-handler spec set + the collection-processing spec
-  - {id: process-collection-spec, group: specs, match: [process_collection_service_spec.rb]}
-  - {id: spec:create,        group: specs,     match: [activity/create_spec.rb]}
-  - {id: spec:announce,      group: specs,     match: [activity/announce_spec.rb]}
-  - {id: spec:follow,        group: specs,     match: [activity/follow_spec.rb]}
+  # the contract: the two delivery layers + the shared payload-building concern
+  - {id: delivery-worker,      group: contract,  match: [activitypub/delivery_worker.rb]}
+  - {id: distribution-worker,  group: contract,  match: [activitypub/distribution_worker.rb]}
+  - {id: raw-distribution,     group: contract,  match: [activitypub/raw_distribution_worker.rb]}
+  - {id: payloadable,          group: contract,  match: [concerns/payloadable.rb]}
+  # direct-path emitters (services that queue a delivery themselves)
+  - {id: emit:follow,          group: direct,    match: [services/follow_service.rb]}
+  - {id: emit:unfollow,        group: direct,    match: [services/unfollow_service.rb]}
+  - {id: emit:block,           group: direct,    match: [services/block_service.rb]}
+  - {id: emit:favourite,       group: direct,    match: [services/favourite_service.rb]}
+  - {id: emit:vote,            group: direct,    match: [services/vote_service.rb]}
+  - {id: emit:report,          group: direct,    match: [services/report_service.rb]}
+  - {id: emit:delete-account,  group: direct,    match: [services/delete_account_service.rb]}
+  - {id: emit:suspend-account, group: direct,    match: [services/suspend_account_service.rb]}
+  - {id: emit:authorize-follow,group: direct,    match: [services/authorize_follow_service.rb]}
+  - {id: emit:reject-follow,   group: direct,    match: [services/reject_follow_service.rb]}
+  - {id: emit:remove-status,   group: direct,    match: [services/remove_status_service.rb]}
+  - {id: emit:relay,           group: direct,    match: [models/relay.rb]}
+  # fan-out-path emitters (services that go through a *DistributionWorker)
+  - {id: emit:post-status,     group: fanout,    match: [services/post_status_service.rb]}
+  - {id: emit:reblog,          group: fanout,    match: [services/reblog_service.rb]}
+  - {id: emit:move,            group: fanout,    match: [services/move_service.rb]}
+  - {id: emit:delete-collection, group: fanout,  match: [services/delete_collection_service.rb]}
+  - {id: emit:add-to-collection, group: fanout,  match: [services/add_account_to_collection_service.rb]}

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -157,8 +157,13 @@ func TestSessionStartReturnsStats(t *testing.T) {
 	if !strings.Contains(resp.Message, "Sense index:") {
 		t.Errorf("message = %q, expected 'Sense index:' prefix", resp.Message)
 	}
-	if !strings.Contains(resp.Message, "ToolSearch") {
-		t.Errorf("message = %q, expected ToolSearch directive", resp.Message)
+	// The tools are pre-loaded (alwaysLoad), so the message must NOT revive the
+	// retired ToolSearch gate; it should point at the loaded tools directly.
+	if strings.Contains(resp.Message, "ToolSearch") {
+		t.Errorf("message = %q, should not instruct ToolSearch (tools are pre-loaded)", resp.Message)
+	}
+	if !strings.Contains(resp.Message, "sense_graph") {
+		t.Errorf("message = %q, expected the loaded-tools hint", resp.Message)
 	}
 }
 
@@ -247,8 +252,11 @@ func TestSubagentStartReturnsGuidance(t *testing.T) {
 	if !strings.Contains(ctx, "Sense index") {
 		t.Errorf("context = %q, expected sense guidance", ctx)
 	}
-	if !strings.Contains(ctx, "ToolSearch") {
-		t.Error("expected ToolSearch command in guidance")
+	if strings.Contains(ctx, "ToolSearch") {
+		t.Error("guidance should not revive the ToolSearch gate — tools are pre-loaded")
+	}
+	if !strings.Contains(ctx, "loaded and callable") {
+		t.Error("expected the pre-loaded-tools hint in guidance")
 	}
 	if !strings.Contains(ctx, "sense_graph") {
 		t.Error("expected sense_graph in guidance")

--- a/internal/hook/pre_tool_use.go
+++ b/internal/hook/pre_tool_use.go
@@ -112,8 +112,7 @@ func handleGrep(ctx context.Context, req preToolUseInput, adapter *sqlite.Adapte
 	if err != nil || len(symbols) == 0 {
 		if isMultiWordPattern(pattern) {
 			ctx := fmt.Sprintf(
-				"Consider sense_search query=%q for semantic code search. "+
-					"Load tools first: %s", pattern, toolSearchCmd)
+				"Consider sense_search query=%q for semantic code search (it's loaded and ready).", pattern)
 			return nudge("Sense can do semantic code search — consider sense_search instead of grep.", ctx), nil
 		}
 		return nil, nil
@@ -144,13 +143,12 @@ func handleAgent(ctx context.Context, req preToolUseInput, adapter *sqlite.Adapt
 	}
 
 	reason := fmt.Sprintf(
-		"This project has a Sense index (%d symbols). Use Sense MCP tools instead of agents for codebase understanding:\n"+
+		"This project has a Sense index (%d symbols). The Sense MCP tools are loaded and callable now — prefer them over agents for codebase understanding:\n"+
 			"- sense_graph for symbol relationships (callers, callees, inheritance)\n"+
 			"- sense_search for semantic code search\n"+
 			"- sense_blast for impact analysis\n"+
-			"- sense_conventions for project patterns\n"+
-			"Load tools first: %s",
-		count, toolSearchCmd,
+			"- sense_conventions for project patterns",
+		count,
 	)
 
 	tip := "Sense has this project indexed — use Sense MCP tools instead of agents for codebase questions."
@@ -163,6 +161,10 @@ func handleAgent(ctx context.Context, req preToolUseInput, adapter *sqlite.Adapt
 func handleBash(ctx context.Context, req preToolUseInput, adapter *sqlite.Adapter) (any, error) {
 	cmd := req.Input.Command
 
+	// extractBashPattern returns a single whitespace-split token, so the
+	// pattern here is never multi-word (unlike handleGrep, whose pattern comes
+	// straight from the Grep tool input). Only the symbol-shaped single-token
+	// case can fire; the multi-word semantic-search nudge lives in handleGrep.
 	pattern := extractBashPattern(cmd)
 	if pattern != "" && isSymbolShaped(pattern) {
 		symbols, err := adapter.Query(ctx, index.Filter{Name: pattern, Limit: 5})
@@ -172,17 +174,10 @@ func handleBash(ctx context.Context, req preToolUseInput, adapter *sqlite.Adapte
 				buildContext(len(symbols), pattern, "bash grep"),
 			), nil
 		}
-		if isMultiWordPattern(pattern) {
-			ctx := fmt.Sprintf(
-				"Consider sense_search query=%q for semantic code search. "+
-					"Load tools first: %s", pattern, toolSearchCmd)
-			return nudge("Sense can do semantic code search — consider sense_search instead of grep.", ctx), nil
-		}
 	}
 
 	if isExplorationCommand(cmd) {
-		ctx := "Sense can answer codebase understanding questions without reading individual files. " +
-			"Load tools first: " + toolSearchCmd
+		ctx := "Sense can answer codebase understanding questions without reading individual files — its tools are loaded and ready."
 		return nudge("Sense has this project indexed — consider Sense tools instead of reading files manually.", ctx), nil
 	}
 
@@ -194,7 +189,7 @@ func buildContext(count int, pattern, source string) string {
 	fmt.Fprintf(&sb, "Sense has %d indexed symbol(s) matching %q. Consider Sense MCP tools instead of %s:\n", count, pattern, source)
 	fmt.Fprintf(&sb, "- sense_graph symbol=%q for callers/callees\n", pattern)
 	fmt.Fprintf(&sb, "- sense_search query=%q for semantic matches\n", pattern)
-	fmt.Fprintf(&sb, "Load tools first: %s", toolSearchCmd)
+	sb.WriteString("(The Sense tools are loaded and callable now.)")
 	return sb.String()
 }
 

--- a/internal/hook/response.go
+++ b/internal/hook/response.go
@@ -1,7 +1,5 @@
 package hook
 
-const toolSearchCmd = `ToolSearch("select:mcp__sense__sense_graph,mcp__sense__sense_search,mcp__sense__sense_blast,mcp__sense__sense_conventions")`
-
 type hookResponse struct {
 	AdditionalContext string `json:"additionalContext,omitempty"`
 }

--- a/internal/hook/session_start.go
+++ b/internal/hook/session_start.go
@@ -138,9 +138,14 @@ func handleSessionStart(ctx context.Context, _ json.RawMessage, adapter *sqlite.
 		fmt.Fprintf(&sb, " %s", freshness)
 	}
 	sb.WriteByte('\n')
-	fmt.Fprintf(&sb, "REQUIRED: Your FIRST tool call MUST be %s to load Sense tools.\n", toolSearchCmd)
-	sb.WriteString("Do NOT call sense_status — index health was verified at session start.\n")
-	sb.WriteString("Use Sense MCP tools for ALL codebase understanding — do not use grep, glob, Read, Bash, or agents before loading Sense.")
+	// A light, task-layer hint — NOT an imperative gate. The Sense tools are
+	// pre-loaded (alwaysLoad in .mcp.json), so there is no ToolSearch hop to
+	// require and nothing to "load first". We just point at the resolved code
+	// map and let the model reach for it; grep/ls stay available for the cases
+	// where they genuinely fit.
+	sb.WriteString("A resolved code map for this repo is already loaded: sense_search, sense_graph, sense_blast, sense_conventions are callable now (no setup call needed).\n")
+	sb.WriteString("For structural questions — who calls X, what breaks if X changes, how symbols relate, what conventions to follow — these are faster and more complete than grep/glob/file-walking.\n")
+	sb.WriteString("Index health was verified at session start, so there is no need to call sense_status.")
 
 	summaryPath := filepath.Join(dir, ".sense", "summary.md")
 	if summary, err := os.ReadFile(summaryPath); err == nil && len(bytes.TrimSpace(summary)) > 0 {

--- a/internal/hook/session_start_test.go
+++ b/internal/hook/session_start_test.go
@@ -193,10 +193,10 @@ func TestSessionStartNoSenseStatusInstruction(t *testing.T) {
 	}
 	msg := resp["message"]
 	if strings.Contains(msg, "sense_status\"") {
-		t.Error("ToolSearch command should not include sense_status")
+		t.Error("tool hint should not include sense_status")
 	}
-	if !strings.Contains(msg, "Do NOT call sense_status") {
-		t.Error("message should instruct LLM not to call sense_status")
+	if !strings.Contains(msg, "no need to call sense_status") {
+		t.Error("message should steer the LLM away from a wasted sense_status call")
 	}
 }
 

--- a/internal/hook/subagent_start.go
+++ b/internal/hook/subagent_start.go
@@ -22,8 +22,7 @@ func handleSubagentStart(ctx context.Context, _ json.RawMessage, adapter *sqlite
 
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "This project has a Sense index (%d symbols, %d edges).\n\n", symbolCount, edgeCount)
-	sb.WriteString("Before using grep/find/file-walking, load Sense tools:\n")
-	sb.WriteString(toolSearchCmd + "\n\n")
+	sb.WriteString("The Sense tools are loaded and callable now — prefer them over grep/find/file-walking for structural questions:\n")
 	sb.WriteString("- Who calls X? What does X depend on? → sense_graph\n")
 	sb.WriteString("- Find code related to a concept → sense_search\n")
 	sb.WriteString("- What breaks if I change X? → sense_blast\n")

--- a/internal/setup/claude.go
+++ b/internal/setup/claude.go
@@ -94,6 +94,16 @@ func writeMCPJSON(root string) (bool, error) {
 		"command":            "sense",
 		"args":               []any{"mcp"},
 		"serverInstructions": mcpio.ServerInstructions,
+		// Pre-load Sense's tools into the initial tool set instead of letting
+		// Claude Code defer them behind ToolSearch. Deferred MCP tools are
+		// only callable after the model first invokes ToolSearch to load their
+		// schemas; in practice the model skips that hop whenever an obvious
+		// grep/ls target exists, so the structural tools (sense_graph,
+		// sense_blast) never ran. alwaysLoad makes them callable from turn 1,
+		// so reaching for Sense is the path of least resistance, not an extra
+		// step. Claude Code reads this per-server field (v2.1.121+); other MCP
+		// clients ignore the unknown key.
+		"alwaysLoad": true,
 	}
 
 	existing, err := readJSONFile(path)

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -117,6 +117,30 @@ func TestMCPJSONPreservesExistingServers(t *testing.T) {
 	}
 }
 
+// The Sense server entry must carry alwaysLoad:true so Claude Code pre-loads
+// the tools into the initial set instead of deferring them behind ToolSearch
+// (the adoption gate the model kept skipping).
+func TestMCPJSONSenseAlwaysLoad(t *testing.T) {
+	root := t.TempDir()
+	if _, err := Run(root, &bytes.Buffer{}, claudeCodeOnly()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	data, _ := os.ReadFile(filepath.Join(root, ".mcp.json"))
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("parse .mcp.json: %v", err)
+	}
+	servers, _ := m["mcpServers"].(map[string]any)
+	sense, _ := servers["sense"].(map[string]any)
+	if sense == nil {
+		t.Fatal("sense server not added")
+	}
+	if al, ok := sense["alwaysLoad"].(bool); !ok || !al {
+		t.Errorf("sense.alwaysLoad = %v, want true", sense["alwaysLoad"])
+	}
+}
+
 func TestSettingsPreservesExistingHooks(t *testing.T) {
 	root := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(root, ".claude"), 0o755); err != nil {


### PR DESCRIPTION
## Problem
Sense's MCP tools were registered as deferred, so they were only callable after the model first invoked `ToolSearch` to load their schemas. In practice the model skipped that hop whenever an obvious grep/ls target existed, so the structural tools (`sense_graph`, `sense_blast`) effectively never ran. The benchmark that was supposed to catch this masked it twice: the `_cited` scorer demanded a contiguous `path:line`, under-crediting baselines that pinned the line another way and manufacturing fake "sense-only cited" wins, and several scenarios scored an enumerable directory listing that a plain grep reconstructs, so the arms tied and Sense never needed its structural tools.

## Summary
Pre-load the Sense tools so they are callable from turn 1, then fix the bench so it measures the real value (precision + context saved) instead of artifacts.

## Changes
- **mcp / hooks**: set `alwaysLoad: true` on the Sense server entry so the tools load into the initial set; rewrite session-start, subagent-start, and pre-tool-use (grep/bash/agent) guidance from "load tools first" imperatives into light "tools are loaded and ready" hints.
- **bench scorer**: `_cited` now credits the four location-pin forms agents actually use (`path:N`, `path (line N)`, sibling `"line": N` JSON field, and unambiguous basename+line), and enforces `cited ⇒ mentioned`.
- **bench report**: lead each repo with a primary table of three separated axes (mention recall, fixed cited recall, billed context with uncached-in) plus a billed-context delta; demote the locked fairness composite to a secondary table, formula unchanged.
- **bench scenarios**: pivot chatwoot, forem, and mastodon off enumerable seams onto scattered polymorphic hubs, and refine lobsters' gold to the verified scattered vote/score dependent set.
- **tests**: new `test_gold.py` (25 cases, snippets lifted from real baseline answers) and `test_reporter.py` (11 cases); Go hook/setup tests updated to assert the ToolSearch gate is gone.
- **chore**: gitignore the Python coverage DB and scenario `.bak` backups.

## Architecture Highlights
- `alwaysLoad` is a per-server field Claude Code reads (v2.1.121+); other MCP clients ignore the unknown key, so the change is backward-compatible.

## Test Plan
- [x] `go test ./internal/hook/ ./internal/setup/` passes
- [x] `go build ./...` succeeds
- [x] `python3 bench/lib/test_gold.py` — 25 cases pass
- [x] `python3 bench/lib/test_reporter.py` — 11 cases pass
- [x] `sense setup` writes `.mcp.json` with `alwaysLoad: true` on the sense server
- [x] Re-run a session scenario and confirm `sense_graph`/`sense_blast` fire without a ToolSearch hop
