### PR TITLE
feat(resolve): trace worker enqueue and inheritance chains in blast

### DIFF
--- a/internal/blast/enqueue_closure_test.go
+++ b/internal/blast/enqueue_closure_test.go
@@ -1,0 +1,174 @@
+package blast_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/luuuc/sense/internal/blast"
+	"github.com/luuuc/sense/internal/index"
+	"github.com/luuuc/sense/internal/scan"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// TestEnqueueHierarchyClosure is the cross-card acceptance gate for 29-01: a
+// scan of a fixture mirroring mastodon's delivery hierarchy, then a single
+// blast on the terminal worker, must reach every emitter — direct, wrapped via
+// an own-#perform worker, via a `super`-delegating subclass, and via a subclass
+// with NO own #perform (inherited-method resolution). None of these emitters
+// names the terminal worker, so grep cannot assemble them.
+func TestEnqueueHierarchyClosure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("scans a fixture; run without -short")
+	}
+	files := map[string]string{
+		// Terminal worker — the blast subject.
+		"app/workers/delivery_worker.rb": `class DeliveryWorker
+  include Sidekiq::Worker
+  def perform(json, inbox_url)
+  end
+end`,
+		// Base wrapper: own #perform → distribute! → DeliveryWorker.push_bulk.
+		"app/workers/raw_distribution_worker.rb": `class RawDistributionWorker
+  include Sidekiq::Worker
+  def perform(json, account_id)
+    distribute!
+  end
+
+  def distribute!
+    DeliveryWorker.push_bulk(inboxes) do |inbox_url|
+      [payload, inbox_url]
+    end
+  end
+end`,
+		// Own-#perform wrapper that includes Sidekiq directly (not a subclass).
+		"app/workers/move_distribution_worker.rb": `class MoveDistributionWorker
+  include Sidekiq::Worker
+  def perform(migration_id)
+    DeliveryWorker.push_bulk(inboxes) do |inbox_url|
+      [payload, inbox_url]
+    end
+  end
+end`,
+		// Subclass with its own #perform delegating via super.
+		"app/workers/collection_raw_distribution_worker.rb": `class CollectionRawDistributionWorker < RawDistributionWorker
+  def perform(json, collection_id)
+    super(json, account_id)
+  end
+end`,
+		// Subclass with NO own #perform — purely inherits the run method.
+		"app/workers/account_raw_distribution_worker.rb": `class AccountRawDistributionWorker < RawDistributionWorker
+  def inboxes
+    @inboxes ||= reach
+  end
+end`,
+		// Emitters — none references DeliveryWorker.
+		"app/services/move_service.rb": `class MoveService
+  def call
+    MoveDistributionWorker.perform_async(migration_id)
+  end
+end`,
+		"app/services/add_to_collection_service.rb": `class AddToCollectionService
+  def call
+    CollectionRawDistributionWorker.perform_async(json, collection_id)
+  end
+end`,
+		"app/services/remove_featured_tag_service.rb": `class RemoveFeaturedTagService
+  def call
+    AccountRawDistributionWorker.perform_async(json, account_id)
+  end
+end`,
+	}
+
+	repo := t.TempDir()
+	for rel, content := range files {
+		writeFixture(t, repo, rel, content)
+	}
+
+	senseDir := t.TempDir()
+	ctx := context.Background()
+	if _, err := scan.Run(ctx, scan.Options{
+		Root:     repo,
+		Sense:    senseDir,
+		Output:   &bytes.Buffer{},
+		Warnings: io.Discard,
+	}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+
+	dbPath := filepath.Join(senseDir, "index.db")
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	all, err := adapter.Query(ctx, index.Filter{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	idOf := map[string]int64{}
+	for _, s := range all {
+		idOf[s.Qualified] = s.ID
+	}
+	subjectID := idOf["DeliveryWorker"]
+	if subjectID == 0 {
+		t.Fatal("DeliveryWorker symbol missing from index")
+	}
+
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	out, err := blast.Compute(ctx, db, []int64{subjectID}, blast.Options{MaxHops: 6})
+	if err != nil {
+		t.Fatalf("blast.Compute: %v", err)
+	}
+
+	reached := map[string]bool{}
+	for _, c := range out.DirectCallers {
+		reached[c.Qualified] = true
+	}
+	for _, h := range out.IndirectCallers {
+		reached[h.Symbol.Qualified] = true
+	}
+
+	// The four enqueueing service methods must all be in the blast closure.
+	want := []string{
+		"MoveService#call",              // own-#perform wrapper
+		"AddToCollectionService#call",   // super-delegating subclass
+		"RemoveFeaturedTagService#call", // no-own-#perform subclass (inherited resolution)
+	}
+	for _, q := range want {
+		if !reached[q] {
+			t.Errorf("blast closure missing emitter %q\nreached: %v", q, keys(reached))
+		}
+	}
+}
+
+func writeFixture(t *testing.T, root, rel, content string) {
+	t.Helper()
+	full := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("mkdir for %s: %v", rel, err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/blast/enqueue_closure_test.go
+++ b/internal/blast/enqueue_closure_test.go
@@ -84,6 +84,13 @@ end`,
     AccountRawDistributionWorker.perform_async(json, account_id)
   end
 end`,
+		// Direct enqueue of the base wrapper — gates the intra-class
+		// perform → distribute! → push_bulk chain on its own.
+		"app/services/pin_service.rb": `class PinService
+  def call
+    RawDistributionWorker.perform_async(json, account_id)
+  end
+end`,
 	}
 
 	repo := t.TempDir()
@@ -146,6 +153,7 @@ end`,
 		"MoveService#call",              // own-#perform wrapper
 		"AddToCollectionService#call",   // super-delegating subclass
 		"RemoveFeaturedTagService#call", // no-own-#perform subclass (inherited resolution)
+		"PinService#call",               // base wrapper, intra-class perform → distribute! → push_bulk
 	}
 	for _, q := range want {
 		if !reached[q] {

--- a/internal/extract/ruby/calls.go
+++ b/internal/extract/ruby/calls.go
@@ -29,6 +29,10 @@ func (w *walker) emitCall(n *sitter.Node, source string, scope []string, localTy
 		return nil
 	}
 
+	if handled, err := w.tryEmitEnqueueEdge(n, methodName, source, scope, localTypes, ivarTypes); handled {
+		return err
+	}
+
 	switch methodName {
 	case "send", "public_send", "__send__":
 		target, ok := literalSendTarget(n, w.source)
@@ -79,6 +83,10 @@ func (w *walker) emitCallWithConfidence(n *sitter.Node, source string, scope []s
 	if methodName == "" {
 		return nil
 	}
+
+	if handled, err := w.tryEmitEnqueueEdge(n, methodName, source, scope, localTypes, ivarTypes); handled {
+		return err
+	}
 	line := extract.Line(n.StartPosition())
 
 	switch methodName {
@@ -124,27 +132,31 @@ func (w *walker) emitCallWithConfidence(n *sitter.Node, source string, scope []s
 		return err
 	}
 
-	// If this call has a block, infer block parameter types from the
-	// receiver's collection type and walk the block body with an
-	// augmented local type map. When inference is not possible (non-
-	// collection method, destructuring params, unknown receiver type),
-	// we still walk the block so calls inside are not lost.
-	if block := n.ChildByFieldName("block"); block != nil {
-		paramTypes := w.inferBlockParamTypes(n, scope, localTypes, ivarTypes)
-		blockTypes := localTypes
-		if paramTypes != nil {
-			blockTypes = mergeMaps(localTypes, paramTypes)
-		}
-		if err := extract.WalkNamedDescendants(block, "call", func(c *sitter.Node) error {
-			if isInsideNestedBlock(c, block) {
-				return nil
-			}
-			return w.emitCall(c, source, scope, blockTypes, ivarTypes)
-		}); err != nil {
-			return err
-		}
+	return w.walkBlockCalls(n, source, scope, localTypes, ivarTypes)
+}
+
+// walkBlockCalls walks a call's block body (`foo(x) do |y| ... end`) for
+// nested call edges. Block parameter types are inferred from the receiver's
+// collection type when possible; when inference is not possible (non-
+// collection method, destructuring params, unknown receiver type) the block
+// is still walked so calls inside are not lost. A call with no block is a
+// no-op.
+func (w *walker) walkBlockCalls(n *sitter.Node, source string, scope []string, localTypes, ivarTypes map[string]string) error {
+	block := n.ChildByFieldName("block")
+	if block == nil {
+		return nil
 	}
-	return nil
+	paramTypes := w.inferBlockParamTypes(n, scope, localTypes, ivarTypes)
+	blockTypes := localTypes
+	if paramTypes != nil {
+		blockTypes = mergeMaps(localTypes, paramTypes)
+	}
+	return extract.WalkNamedDescendants(block, "call", func(c *sitter.Node) error {
+		if isInsideNestedBlock(c, block) {
+			return nil
+		}
+		return w.emitCall(c, source, scope, blockTypes, ivarTypes)
+	})
 }
 
 // coreNoiseMethods are ubiquitous core-Ruby / ActiveSupport methods

--- a/internal/extract/ruby/enqueue.go
+++ b/internal/extract/ruby/enqueue.go
@@ -1,0 +1,95 @@
+package ruby
+
+import (
+	"strings"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/model"
+)
+
+// enqueueMethods are the Sidekiq / ActiveJob enqueue entrypoints. A call to
+// one of these on a worker/job class ultimately runs that class's #perform —
+// an edge that does not exist in the greppable text, because the call names
+// the enqueue method, not #perform. Matching on the framework's enqueue API
+// (not on a `*Worker` name convention) is the structural signal that the
+// receiver is a worker: only a Sidekiq worker responds to perform_async /
+// push_bulk, only an ActiveJob job to perform_later.
+var enqueueMethods = map[string]bool{
+	// Sidekiq
+	"perform_async": true,
+	"perform_in":    true,
+	"perform_at":    true,
+	"perform_bulk":  true,
+	"push_bulk":     true,
+	// ActiveJob
+	"perform_later": true,
+}
+
+// enqueueTarget returns the worker run-method target (`Receiver#perform`) for
+// an enqueue call, or "" when the call is not an enqueue of a constant-named
+// worker. The receiver must be a constant or scope_resolution
+// (`DeliveryWorker`, `ActivityPub::DeliveryWorker`); a dynamic receiver
+// (variable, self, or receiverless) cannot be tied to a worker class
+// statically, so no edge is emitted rather than a guessed one.
+func enqueueTarget(n *sitter.Node, methodName string, source []byte) string {
+	if !enqueueMethods[methodName] {
+		return ""
+	}
+	recv := n.ChildByFieldName("receiver")
+	if recv == nil {
+		return ""
+	}
+	switch recv.Kind() {
+	case "constant", "scope_resolution":
+		// A constant/scope_resolution node always carries source text, so the
+		// trimmed receiver is non-empty by construction. Every method in
+		// enqueueMethods runs the worker's `#perform`; if a future entry runs a
+		// differently-named method, this target must become table-driven.
+		return strings.TrimSpace(extract.Text(recv, source)) + "#perform"
+	}
+	return ""
+}
+
+// tryEmitEnqueueEdge handles a Sidekiq/ActiveJob enqueue call
+// (`Worker.perform_async(...)`, `Worker.push_bulk(...) do ... end`,
+// `Job.perform_later(...)`) by emitting a calls edge from the enclosing method
+// to the worker's run method `Worker#perform` at convention confidence (0.9):
+// the edge is inferred from the enqueue convention, never certain, so it is
+// never stamped 1.0. The enqueue API is itself the structural worker/job
+// marker — no `*Worker` name match.
+//
+// Safety of the receiver guess is empirical, not structural: the enqueue API
+// names (perform_async/push_bulk/perform_later/…) are near-unique to Sidekiq/
+// ActiveJob, so a `Const.perform_async` whose `Const` is *not* a worker is
+// vanishingly rare. When it does happen and `Const` defines (or inherits) an
+// unrelated `#perform`, the edge resolves to it at 0.9 — a wrong edge. We
+// accept that residual risk because the enqueue-API names make it negligible in
+// practice; a receiver with no `#perform` anywhere simply drops at resolution.
+//
+// Returns handled=true when the call was an enqueue of a constant-named
+// worker, so the caller skips the (unresolvable) `Worker.perform_async`
+// target edge it would otherwise emit. A block argument (push_bulk's
+// `do |x| ... end`) is still walked so real calls inside it — e.g.
+// `build_json(follow)` in suspend_account_service — are not lost.
+//
+// methodName is the already-extracted call method name (both callers extract
+// it before dispatching), passed in to avoid re-reading the method node.
+func (w *walker) tryEmitEnqueueEdge(n *sitter.Node, methodName, source string, scope []string, localTypes, ivarTypes map[string]string) (bool, error) {
+	target := enqueueTarget(n, methodName, w.source)
+	if target == "" {
+		return false, nil
+	}
+	line := extract.Line(n.StartPosition())
+	if err := w.emit.Edge(extract.EmittedEdge{
+		SourceQualified: source,
+		TargetQualified: target,
+		Kind:            model.EdgeCalls,
+		Line:            &line,
+		Confidence:      extract.ConfidenceConvention,
+	}); err != nil {
+		return true, err
+	}
+	return true, w.walkBlockCalls(n, source, scope, localTypes, ivarTypes)
+}

--- a/internal/extract/ruby/enqueue_test.go
+++ b/internal/extract/ruby/enqueue_test.go
@@ -1,0 +1,160 @@
+package ruby
+
+import (
+	"testing"
+
+	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/model"
+)
+
+// enqueueEdge finds the calls edge a `*.perform_async`-style call should emit
+// from sourceMethod to `<worker>#perform`.
+func enqueueEdge(r *recorder, sourceMethod, worker string) *extract.EmittedEdge {
+	return findEdge(r, sourceMethod, worker+"#perform", string(model.EdgeCalls))
+}
+
+func TestEnqueuePerformAsyncEmitsRunMethodEdge(t *testing.T) {
+	src := `class FollowService
+  def call
+    DeliveryWorker.perform_async(payload)
+  end
+end`
+	r := parseRuby(t, src)
+	e := enqueueEdge(r, "FollowService#call", "DeliveryWorker")
+	if e == nil {
+		t.Fatal("perform_async should emit a calls edge to DeliveryWorker#perform")
+	}
+	if e.Confidence != extract.ConfidenceConvention {
+		t.Errorf("enqueue edge confidence = %v, want %v (inferred, never 1.0)", e.Confidence, extract.ConfidenceConvention)
+	}
+	// The unresolvable Worker.perform_async target must NOT also be emitted.
+	if findEdge(r, "FollowService#call", "DeliveryWorker.perform_async", string(model.EdgeCalls)) != nil {
+		t.Error("the literal Worker.perform_async target edge should be suppressed")
+	}
+}
+
+func TestEnqueueNamespacedReceiver(t *testing.T) {
+	src := `module ActivityPub
+  class RawDistributionWorker
+    def distribute!
+      ActivityPub::DeliveryWorker.push_bulk(inboxes) do |inbox_url|
+        [payload, inbox_url]
+      end
+    end
+  end
+end`
+	r := parseRuby(t, src)
+	if enqueueEdge(r, "ActivityPub::RawDistributionWorker#distribute!", "ActivityPub::DeliveryWorker") == nil {
+		t.Fatal("push_bulk on a namespaced worker should emit edge to ActivityPub::DeliveryWorker#perform")
+	}
+}
+
+func TestEnqueueActiveJobPerformLater(t *testing.T) {
+	src := `class Mailer
+  def deliver
+    NotificationJob.perform_later(user_id)
+  end
+end`
+	r := parseRuby(t, src)
+	if enqueueEdge(r, "Mailer#deliver", "NotificationJob") == nil {
+		t.Fatal("perform_later should emit a calls edge to NotificationJob#perform")
+	}
+}
+
+func TestEnqueueAllSidekiqVariants(t *testing.T) {
+	for _, m := range []string{"perform_async", "perform_in", "perform_at", "perform_bulk", "push_bulk"} {
+		src := `class S
+  def go
+    MyWorker.` + m + `(arg)
+  end
+end`
+		r := parseRuby(t, src)
+		if enqueueEdge(r, "S#go", "MyWorker") == nil {
+			t.Errorf("%s should emit a calls edge to MyWorker#perform", m)
+		}
+	}
+}
+
+func TestEnqueuePushBulkBlockCallsStillEmitted(t *testing.T) {
+	// suspend_account_service's `push_bulk(follows) do |follow| [build_json(follow)] end`
+	// — the enqueue edge AND the nested build_json call edge must both survive.
+	src := `class SuspendAccountService
+  def call
+    DeliveryWorker.push_bulk(follows) do |follow|
+      [build_json(follow), follow.account_id]
+    end
+  end
+
+  def build_json(follow)
+  end
+end`
+	r := parseRuby(t, src)
+	if enqueueEdge(r, "SuspendAccountService#call", "DeliveryWorker") == nil {
+		t.Error("push_bulk enqueue edge missing")
+	}
+	// build_json is a bare/self call inside the block; it resolves to self.build_json.
+	if findEdge(r, "SuspendAccountService#call", "self.build_json", string(model.EdgeCalls)) == nil {
+		t.Error("nested call inside the push_bulk block was lost")
+	}
+}
+
+func TestEnqueueNonEnqueueCallNoPerformEdge(t *testing.T) {
+	// A plain class-method call must NOT be rewritten to a #perform edge.
+	src := `class C
+  def go
+    Math.sqrt(2)
+    Foo.bar(x)
+  end
+end`
+	r := parseRuby(t, src)
+	if findEdge(r, "C#go", "Math#perform", string(model.EdgeCalls)) != nil {
+		t.Error("Math.sqrt must not emit a #perform edge")
+	}
+	if findEdge(r, "C#go", "Foo#perform", string(model.EdgeCalls)) != nil {
+		t.Error("Foo.bar must not emit a #perform edge")
+	}
+}
+
+func TestEnqueueBareReceiverSkipped(t *testing.T) {
+	// A receiverless enqueue call (`perform_async` with no constant receiver,
+	// e.g. inside the worker calling itself) cannot name a worker class — no
+	// edge.
+	src := `class C
+  def go
+    perform_async(arg)
+  end
+end`
+	r := parseRuby(t, src)
+	for _, e := range r.edges {
+		if e.TargetQualified == "#perform" || e.TargetQualified == "self#perform" {
+			t.Errorf("bare perform_async should emit no enqueue edge, got %s", e.TargetQualified)
+		}
+	}
+}
+
+func TestEnqueueEmitErrorPropagates(t *testing.T) {
+	// A failing edge emit inside the enqueue path must propagate out, not be
+	// swallowed.
+	err := parseWithEmitter(t, "class C\n  def go\n    DeliveryWorker.perform_async(x)\n  end\nend",
+		&failAfterN{symbolsLeft: 100, edgesLeft: 0})
+	if err == nil {
+		t.Error("expected the failing enqueue edge emit to propagate")
+	}
+}
+
+func TestEnqueueDynamicReceiverSkipped(t *testing.T) {
+	// A variable receiver cannot be tied to a worker class statically — emit
+	// no guessed edge rather than a wrong one.
+	src := `class C
+  def go(klass)
+    worker = klass
+    worker.perform_async(arg)
+  end
+end`
+	r := parseRuby(t, src)
+	for _, e := range r.edges {
+		if e.SourceQualified == "C#go" && len(e.TargetQualified) > 8 && e.TargetQualified[len(e.TargetQualified)-8:] == "#perform" {
+			t.Errorf("dynamic receiver should emit no enqueue edge, got %s", e.TargetQualified)
+		}
+	}
+}

--- a/internal/extract/ruby/ruby.go
+++ b/internal/extract/ruby/ruby.go
@@ -67,6 +67,7 @@ func (Extractor) Extract(tree *sitter.Tree, source []byte, filePath string, emit
 		emittedSynthetics: make(map[string]bool),
 		pkgBindings:       make(map[string]string),
 		methodVisibility:  make(map[string]string),
+		classSuperclass:   make(map[string]string),
 	}
 	w.collectConstants(tree.RootNode(), nil)
 	if err := w.walk(tree.RootNode(), nil); err != nil {
@@ -115,6 +116,7 @@ type walker struct {
 	emittedSynthetics  map[string]bool              // dedup synthetic base symbols (ruby-core:Struct/Data) per file
 	pkgBindings        map[string]string            // unqualified name → qualified name for file-level constants
 	methodVisibility   map[string]string            // method_qualified → public/private/protected, from the per-class pre-pass
+	classSuperclass    map[string]string            // class_qualified → superclass name as written, for `super` edges
 }
 
 // walk visits node and its children under the given class/module scope.

--- a/internal/extract/ruby/super_test.go
+++ b/internal/extract/ruby/super_test.go
@@ -100,6 +100,26 @@ end`
 	}
 }
 
+func TestSuperNotAttributedAcrossNestedDef(t *testing.T) {
+	// A `super` inside a nested method definition belongs to that nested method,
+	// not the outer one. The outer method (no super of its own) must emit no
+	// super edge.
+	src := `class Sub < Base
+  def perform
+    define_singleton_method(:inner) do
+    end
+
+    def helper
+      super
+    end
+  end
+end`
+	r := parseRuby(t, src)
+	if superEdge(r, "Sub#perform", "Base#perform") != nil {
+		t.Error("outer #perform has no super of its own; the nested def's super must not be attributed to it")
+	}
+}
+
 func TestSuperAbsentNoEdge(t *testing.T) {
 	src := `class Sub < Base
   def perform

--- a/internal/extract/ruby/super_test.go
+++ b/internal/extract/ruby/super_test.go
@@ -1,0 +1,113 @@
+package ruby
+
+import (
+	"testing"
+
+	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/model"
+)
+
+func superEdge(r *recorder, sourceMethod, target string) *extract.EmittedEdge {
+	return findEdge(r, sourceMethod, target, string(model.EdgeCalls))
+}
+
+func TestSuperBareEmitsParentMethodEdge(t *testing.T) {
+	src := `class Sub < Base
+  def perform(x)
+    setup
+    super
+  end
+end`
+	r := parseRuby(t, src)
+	e := superEdge(r, "Sub#perform", "Base#perform")
+	if e == nil {
+		t.Fatal("bare super should emit a calls edge to Base#perform")
+	}
+	if e.Confidence != extract.ConfidenceConvention {
+		t.Errorf("super edge confidence = %v, want %v", e.Confidence, extract.ConfidenceConvention)
+	}
+}
+
+func TestSuperWithArgsEmitsParentMethodEdge(t *testing.T) {
+	src := `class Sub < Base
+  def perform(json, id)
+    super(json, id)
+  end
+end`
+	r := parseRuby(t, src)
+	if superEdge(r, "Sub#perform", "Base#perform") == nil {
+		t.Fatal("super(args) should emit a calls edge to Base#perform")
+	}
+}
+
+func TestSuperNamespacedSuperclass(t *testing.T) {
+	// Mirrors mastodon: CollectionRawDistributionWorker < ActivityPub::RawDistributionWorker.
+	src := `class ActivityPub::CollectionRawDistributionWorker < ActivityPub::RawDistributionWorker
+  def perform(json, collection_id)
+    super(json, account_id)
+  end
+end`
+	r := parseRuby(t, src)
+	if superEdge(r, "ActivityPub::CollectionRawDistributionWorker#perform", "ActivityPub::RawDistributionWorker#perform") == nil {
+		t.Fatal("super should target the fully-qualified superclass run method")
+	}
+}
+
+func TestSuperOnlyOneEdgePerMethod(t *testing.T) {
+	src := `class Sub < Base
+  def perform
+    super
+    super()
+  end
+end`
+	r := parseRuby(t, src)
+	count := 0
+	for _, e := range r.edges {
+		if e.SourceQualified == "Sub#perform" && e.TargetQualified == "Base#perform" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly one super edge per method, got %d", count)
+	}
+}
+
+func TestSuperSingletonUsesDotSeparator(t *testing.T) {
+	src := `class Sub < Base
+  def self.build(x)
+    super
+  end
+end`
+	r := parseRuby(t, src)
+	if superEdge(r, "Sub.build", "Base.build") == nil {
+		t.Fatal("super in a singleton method should target Base.build (dot separator)")
+	}
+}
+
+func TestSuperNoSuperclassNoEdge(t *testing.T) {
+	// A class with no superclass: `super` would be a runtime NoMethodError, but
+	// we must emit no guessed edge.
+	src := `class Standalone
+  def perform
+    super
+  end
+end`
+	r := parseRuby(t, src)
+	for _, e := range r.edges {
+		if e.SourceQualified == "Standalone#perform" && e.TargetQualified == "#perform" {
+			t.Error("a class with no superclass must emit no super edge")
+		}
+	}
+}
+
+func TestSuperAbsentNoEdge(t *testing.T) {
+	src := `class Sub < Base
+  def perform
+    do_work
+  end
+end`
+	r := parseRuby(t, src)
+	if superEdge(r, "Sub#perform", "Base#perform") != nil {
+		t.Error("a method without super must emit no super edge")
+	}
+}

--- a/internal/extract/ruby/symbols.go
+++ b/internal/extract/ruby/symbols.go
@@ -186,7 +186,7 @@ func (w *walker) handleMethod(n *sitter.Node, scope []string, singleton bool) er
 	if err := w.emitBareIdentifierCalls(body, qualified, extract.ConfidenceDynamic, methodParamNames(n, w.source)); err != nil {
 		return err
 	}
-	if err := w.emitSuperEdge(body, parent, qualified, name, singleton); err != nil {
+	if err := w.emitSuperEdge(n, parent, qualified, name, singleton); err != nil {
 		return err
 	}
 	return w.collectConstRefs(body, qualified, false)
@@ -204,8 +204,12 @@ func (w *walker) handleMethod(n *sitter.Node, scope []string, singleton bool) er
 // inheritance but module prepends/MRO can intervene, so it is never 1.0. A
 // method whose class has no recorded superclass (top-level, module, or no
 // superclass) emits nothing rather than a guess.
-func (w *walker) emitSuperEdge(body *sitter.Node, parent, qualified, methodName string, singleton bool) error {
-	if body == nil || parent == "" {
+func (w *walker) emitSuperEdge(methodNode *sitter.Node, parent, qualified, methodName string, singleton bool) error {
+	if methodNode == nil || parent == "" {
+		return nil
+	}
+	body := methodNode.ChildByFieldName("body")
+	if body == nil {
 		return nil
 	}
 	superclass := w.classSuperclass[parent]
@@ -213,7 +217,13 @@ func (w *walker) emitSuperEdge(body *sitter.Node, parent, qualified, methodName 
 		return nil
 	}
 	hasSuper := false
-	if err := extract.WalkNamedDescendants(body, "super", func(*sitter.Node) error {
+	if err := extract.WalkNamedDescendants(body, "super", func(s *sitter.Node) error {
+		// Skip a `super` that belongs to a nested method definition inside this
+		// body — its `super` dispatches to the nested method's parent, not this
+		// method's. Attributing it here would be a false edge.
+		if !superBelongsToMethod(s, methodNode) {
+			return nil
+		}
 		hasSuper = true
 		return nil
 	}); err != nil {
@@ -234,6 +244,21 @@ func (w *walker) emitSuperEdge(body *sitter.Node, parent, qualified, methodName 
 		Line:            &line,
 		Confidence:      extract.ConfidenceConvention,
 	})
+}
+
+// superBelongsToMethod reports whether a `super` node is part of methodNode
+// itself, rather than a method nested inside its body. The nearest enclosing
+// `method`/`singleton_method` ancestor of the super is the method it dispatches
+// from; the super belongs here only when that ancestor is methodNode (compared
+// by byte range — go-tree-sitter returns fresh node structs, so pointer
+// identity can't be used).
+func superBelongsToMethod(super, methodNode *sitter.Node) bool {
+	for p := super.Parent(); p != nil; p = p.Parent() {
+		if k := p.Kind(); k == "method" || k == "singleton_method" {
+			return p.StartByte() == methodNode.StartByte() && p.EndByte() == methodNode.EndByte()
+		}
+	}
+	return false
 }
 
 // isTestSuperclass returns true if the superclass name indicates a test base class.

--- a/internal/extract/ruby/symbols.go
+++ b/internal/extract/ruby/symbols.go
@@ -81,6 +81,10 @@ func (w *walker) emitInheritanceEdges(n *sitter.Node, qualified string) error {
 	if target == "" {
 		return nil
 	}
+	// Record the superclass so a `super` call inside one of this class's
+	// methods can resolve to the parent's same-named method (the worker
+	// run-method hierarchy chains through `super`).
+	w.classSuperclass[qualified] = target
 	line := extract.Line(sup.StartPosition())
 	if err := w.emit.Edge(extract.EmittedEdge{
 		SourceQualified: qualified,
@@ -182,7 +186,54 @@ func (w *walker) handleMethod(n *sitter.Node, scope []string, singleton bool) er
 	if err := w.emitBareIdentifierCalls(body, qualified, extract.ConfidenceDynamic, methodParamNames(n, w.source)); err != nil {
 		return err
 	}
+	if err := w.emitSuperEdge(body, parent, qualified, name, singleton); err != nil {
+		return err
+	}
 	return w.collectConstRefs(body, qualified, false)
+}
+
+// emitSuperEdge emits a calls edge from a method to its superclass's same-named
+// method when the body contains a `super` call. `super` (bare or `super(args)`)
+// dispatches to the parent's method of the same name — the link a worker
+// subclass uses to reach an inherited run method (`CollectionRawDistributionWorker#perform`
+// → `RawDistributionWorker#perform`). The target is built from the enclosing
+// class's recorded superclass and the method's own name; the dispatch separator
+// (`#` instance, `.` singleton) matches the method's receiver. One edge per
+// method regardless of how many `super` calls appear. Emitted at convention
+// confidence (0.9): super-to-direct-superclass is reliable in single
+// inheritance but module prepends/MRO can intervene, so it is never 1.0. A
+// method whose class has no recorded superclass (top-level, module, or no
+// superclass) emits nothing rather than a guess.
+func (w *walker) emitSuperEdge(body *sitter.Node, parent, qualified, methodName string, singleton bool) error {
+	if body == nil || parent == "" {
+		return nil
+	}
+	superclass := w.classSuperclass[parent]
+	if superclass == "" {
+		return nil
+	}
+	hasSuper := false
+	if err := extract.WalkNamedDescendants(body, "super", func(*sitter.Node) error {
+		hasSuper = true
+		return nil
+	}); err != nil {
+		return err
+	}
+	if !hasSuper {
+		return nil
+	}
+	sep := "#"
+	if singleton {
+		sep = "."
+	}
+	line := extract.Line(body.StartPosition())
+	return w.emit.Edge(extract.EmittedEdge{
+		SourceQualified: qualified,
+		TargetQualified: superclass + sep + methodName,
+		Kind:            model.EdgeCalls,
+		Line:            &line,
+		Confidence:      extract.ConfidenceConvention,
+	})
 }
 
 // isTestSuperclass returns true if the superclass name indicates a test base class.

--- a/internal/resolve/inherited_test.go
+++ b/internal/resolve/inherited_test.go
@@ -1,0 +1,181 @@
+package resolve_test
+
+import (
+	"testing"
+
+	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/resolve"
+)
+
+// workerRefs models the mastodon run-method hierarchy: a base worker defining
+// #perform/#distribute!, plus subclasses — one inheriting #perform wholesale
+// (AccountRaw), one two hops deep (StatusUpdate < Distribution < RawDist).
+func workerRefs() []model.SymbolRef {
+	return []model.SymbolRef{
+		{ID: 1, Qualified: "AP::RawDistributionWorker", FileID: 1, Language: "ruby"},
+		{ID: 2, Qualified: "AP::RawDistributionWorker#perform", FileID: 1, Language: "ruby", Receiver: extract.ReceiverInstance},
+		{ID: 3, Qualified: "AP::RawDistributionWorker#distribute!", FileID: 1, Language: "ruby", Receiver: extract.ReceiverInstance},
+		{ID: 4, Qualified: "AP::AccountRawDistributionWorker", FileID: 2, Language: "ruby"},
+		{ID: 5, Qualified: "AP::DistributionWorker", FileID: 3, Language: "ruby"},
+		{ID: 6, Qualified: "AP::DistributionWorker#perform", FileID: 3, Language: "ruby", Receiver: extract.ReceiverInstance},
+		{ID: 7, Qualified: "AP::StatusUpdateDistributionWorker", FileID: 4, Language: "ruby"},
+	}
+}
+
+func workerAncestry() map[string][]string {
+	return map[string][]string{
+		"AP::AccountRawDistributionWorker":   {"AP::RawDistributionWorker"},
+		"AP::DistributionWorker":             {"AP::RawDistributionWorker"},
+		"AP::StatusUpdateDistributionWorker": {"AP::DistributionWorker"},
+	}
+}
+
+func TestInheritedResolvesNoOwnPerform(t *testing.T) {
+	// AccountRaw has no own #perform — an enqueue edge to its #perform resolves
+	// to the inherited RawDistributionWorker#perform.
+	ix := resolve.NewIndex(workerRefs()).WithInheritance(workerAncestry())
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "AP::AccountRawDistributionWorker#perform",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   99,
+		BaseConfidence: extract.ConfidenceConvention,
+	})
+	if !ok {
+		t.Fatal("expected inherited resolution to RawDistributionWorker#perform")
+	}
+	if r.SymbolID != 2 {
+		t.Errorf("SymbolID = %d, want 2 (AP::RawDistributionWorker#perform)", r.SymbolID)
+	}
+	if r.Confidence != extract.ConfidenceConvention {
+		t.Errorf("Confidence = %v, want %v (unique ancestor keeps base)", r.Confidence, extract.ConfidenceConvention)
+	}
+}
+
+func TestInheritedWalksMultipleHops(t *testing.T) {
+	// StatusUpdate < Distribution < RawDist. StatusUpdate#distribute! resolves
+	// two hops up to RawDistributionWorker#distribute!.
+	ix := resolve.NewIndex(workerRefs()).WithInheritance(workerAncestry())
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "AP::StatusUpdateDistributionWorker#distribute!",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   99,
+		BaseConfidence: 1.0,
+	})
+	if !ok {
+		t.Fatal("expected resolution two hops up the chain")
+	}
+	if r.SymbolID != 3 {
+		t.Errorf("SymbolID = %d, want 3 (RawDistributionWorker#distribute!)", r.SymbolID)
+	}
+}
+
+func TestInheritedPrefersNearestAncestor(t *testing.T) {
+	// When both an intermediate and a base ancestor define the method, the
+	// nearest one wins. DistributionWorker defines its own #perform, so
+	// StatusUpdate#perform resolves to DistributionWorker#perform, not RawDist's.
+	ix := resolve.NewIndex(workerRefs()).WithInheritance(workerAncestry())
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "AP::StatusUpdateDistributionWorker#perform",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   99,
+		BaseConfidence: extract.ConfidenceConvention,
+	})
+	if !ok {
+		t.Fatal("expected resolution to the nearest ancestor's #perform")
+	}
+	if r.SymbolID != 6 {
+		t.Errorf("SymbolID = %d, want 6 (DistributionWorker#perform, nearest)", r.SymbolID)
+	}
+}
+
+func TestInheritedNoEdgeWhenMethodUndefinedInChain(t *testing.T) {
+	// A method no ancestor defines must NOT resolve via inheritance.
+	ix := resolve.NewIndex(workerRefs()).WithInheritance(workerAncestry())
+	_, ok := ix.Resolve(resolve.Request{
+		Target:         "AP::AccountRawDistributionWorker#nonexistent_method",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   99,
+		BaseConfidence: extract.ConfidenceConvention,
+	})
+	if ok {
+		t.Error("a method defined in no ancestor must not resolve via inheritance")
+	}
+}
+
+func TestInheritedNoEdgeForNonSubclassReceiver(t *testing.T) {
+	// A receiver with no ancestry entry (e.g. a gem/stdlib class) is never
+	// guessed at. RawDistributionWorker has no parent in the map.
+	ix := resolve.NewIndex(workerRefs()).WithInheritance(workerAncestry())
+	_, ok := ix.Resolve(resolve.Request{
+		Target:         "AP::RawDistributionWorker#totally_made_up",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   99,
+		BaseConfidence: 1.0,
+	})
+	if ok {
+		t.Error("a receiver with no recorded superclass must not resolve via inheritance")
+	}
+}
+
+func TestInheritedOnlyMethodDispatch(t *testing.T) {
+	// A `::` namespace target must not trigger inherited resolution — it carries
+	// no receiver type to inherit through.
+	rs := append(workerRefs(), model.SymbolRef{ID: 20, Qualified: "AP::RawDistributionWorker::CONST", FileID: 1, Language: "ruby"})
+	anc := workerAncestry()
+	anc["AP::AccountRawDistributionWorker::CONST"] = []string{"AP::RawDistributionWorker::CONST"} // nonsense, must be ignored
+	ix := resolve.NewIndex(rs).WithInheritance(anc)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "AP::AccountRawDistributionWorker::CONST",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   99,
+		BaseConfidence: 1.0,
+	})
+	// The leaf fallback may still bind `::CONST` to the coincidental constant,
+	// but only at the demoted name-collision confidence. The inherited step
+	// (which would keep BaseConfidence 1.0) must NOT have fired.
+	if ok && r.Confidence >= 1.0 {
+		t.Errorf("`::` namespace target must not resolve via the inherited-method step; got confidence %v", r.Confidence)
+	}
+}
+
+func TestInheritedNoOpWithoutAncestryMap(t *testing.T) {
+	// Without WithInheritance (the default NewIndex), the step is inert — a
+	// no-own-method call falls through to the existing leaf fallback / drop.
+	ix := resolve.NewIndex(workerRefs())
+	_, ok := ix.Resolve(resolve.Request{
+		Target:         "AP::AccountRawDistributionWorker#perform",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   99,
+		BaseConfidence: extract.ConfidenceConvention,
+	})
+	// byName["perform"] has two instance candidates (RawDist, Distribution) →
+	// ambiguous leaf fallback, which is name-collision (below floor) but still
+	// resolves. The point: it did NOT take the precise inherited path.
+	if ok {
+		// If it resolved, it must be the demoted name-collision, not the precise 0.9.
+		r, _ := ix.Resolve(resolve.Request{Target: "AP::AccountRawDistributionWorker#perform", Kind: model.EdgeCalls, SourceFileID: 99, BaseConfidence: extract.ConfidenceConvention})
+		if r.Confidence >= extract.ConfidenceConvention {
+			t.Errorf("without ancestry, resolution must not reach inherited-path confidence; got %v", r.Confidence)
+		}
+	}
+}
+
+func TestInheritedSingletonDispatch(t *testing.T) {
+	// Class-method (`.`) inheritance: Sub.build resolves to Base.build.
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "Base", FileID: 1, Language: "ruby"},
+		{ID: 2, Qualified: "Base.build", FileID: 1, Language: "ruby", Receiver: extract.ReceiverSingleton},
+		{ID: 3, Qualified: "Sub", FileID: 2, Language: "ruby"},
+	}
+	ix := resolve.NewIndex(rs).WithInheritance(map[string][]string{"Sub": {"Base"}})
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "Sub.build",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   99,
+		BaseConfidence: extract.ConfidenceConvention,
+	})
+	if !ok || r.SymbolID != 2 {
+		t.Fatalf("Sub.build should resolve to Base.build (id 2); got ok=%v id=%d", ok, r.SymbolID)
+	}
+}

--- a/internal/resolve/inherited_test.go
+++ b/internal/resolve/inherited_test.go
@@ -2,6 +2,7 @@ package resolve_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/luuuc/sense/internal/extract"
 	"github.com/luuuc/sense/internal/model"
@@ -158,6 +159,65 @@ func TestInheritedNoOpWithoutAncestryMap(t *testing.T) {
 		if r.Confidence >= extract.ConfidenceConvention {
 			t.Errorf("without ancestry, resolution must not reach inherited-path confidence; got %v", r.Confidence)
 		}
+	}
+}
+
+func TestInheritedTerminatesOnCycle(t *testing.T) {
+	// A cyclic inherits graph (A < B, B < A) must not hang. The method is
+	// defined nowhere, so resolution fails — the point is that it returns.
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "A", FileID: 1, Language: "ruby"},
+		{ID: 2, Qualified: "B", FileID: 2, Language: "ruby"},
+	}
+	ix := resolve.NewIndex(rs).WithInheritance(map[string][]string{
+		"A": {"B"},
+		"B": {"A"},
+	})
+	done := make(chan struct{})
+	go func() {
+		ix.Resolve(resolve.Request{
+			Target:         "A#whatever",
+			Kind:           model.EdgeCalls,
+			SourceFileID:   99,
+			BaseConfidence: 1.0,
+		})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("resolveInherited did not terminate on a cyclic inherits graph")
+	}
+}
+
+func TestInheritedMultiParentSameDepthIsAmbiguous(t *testing.T) {
+	// A class recorded with two superclasses both defining the method (reopened
+	// class with divergent superclass clauses) is an ambiguous pick: the result
+	// must be flagged Ambiguous and confidence clamped, not silently confident.
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "Sub", FileID: 1, Language: "ruby"},
+		{ID: 2, Qualified: "ParentA", FileID: 2, Language: "ruby"},
+		{ID: 3, Qualified: "ParentA#perform", FileID: 2, Language: "ruby", Receiver: extract.ReceiverInstance},
+		{ID: 4, Qualified: "ParentB", FileID: 3, Language: "ruby"},
+		{ID: 5, Qualified: "ParentB#perform", FileID: 3, Language: "ruby", Receiver: extract.ReceiverInstance},
+	}
+	ix := resolve.NewIndex(rs).WithInheritance(map[string][]string{
+		"Sub": {"ParentA", "ParentB"},
+	})
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "Sub#perform",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   99,
+		BaseConfidence: extract.ConfidenceConvention,
+	})
+	if !ok {
+		t.Fatal("expected resolution to one of the two parents")
+	}
+	if !r.Ambiguous {
+		t.Errorf("two ancestors at the same depth defining the method must flag Ambiguous; got %+v", r)
+	}
+	if r.Confidence > 0.8 {
+		t.Errorf("ambiguous inherited pick must clamp confidence to <=0.8, got %v", r.Confidence)
 	}
 }
 

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -36,6 +36,13 @@ type Index struct {
 	// a coincidental same-named symbol that lives in a test file. Built from the
 	// same SymbolRefs; a file id absent from the map is treated as non-test.
 	fileIsTest map[int64]bool
+	// ancestry maps a class's qualified name to its direct superclass qualified
+	// names (as written on the `inherits` edge). It powers inherited-method
+	// resolution: a call to `Sub#m` with no own `Sub#m` resolves to the nearest
+	// `Ancestor#m` up the class chain. Empty (the default from NewIndex) makes
+	// that step a no-op; WithInheritance populates it from the scan's pending
+	// inherits edges.
+	ancestry map[string][]string
 }
 
 // NewIndex builds an Index from the bulk SymbolRefs output. The input
@@ -61,6 +68,22 @@ func NewIndex(refs []model.SymbolRef) *Index {
 	}
 	return ix
 }
+
+// WithInheritance attaches a class-ancestry map (child qualified name → direct
+// superclass qualified names, as written on `inherits` edges) and returns the
+// Index for chaining. It enables inherited-method resolution; passing nil or
+// omitting the call leaves that step a no-op. Built by the scan harness from
+// the pending inherits edges before the resolve pass.
+func (ix *Index) WithInheritance(ancestry map[string][]string) *Index {
+	ix.ancestry = ancestry
+	return ix
+}
+
+// maxAncestryDepth bounds the superclass walk in inherited-method resolution.
+// Real Ruby class chains are shallow (mastodon's deepest worker chain is
+// StatusUpdate < Distribution < RawDistribution, depth 2); the cap is a
+// cycle/runaway guard, not a real limit.
+const maxAncestryDepth = 16
 
 // Request carries everything the resolver needs to turn one pending
 // edge's target-name string into a symbol_id. SourceQualified and
@@ -138,6 +161,17 @@ func (ix *Index) Resolve(req Request) (Result, bool) {
 		return r, ok
 	}
 
+	// Step 2.5: inherited-method resolution. A `Sub#m` / `Sub.m` dispatch with
+	// no own `Sub#m` symbol resolves to the nearest `Ancestor#m` up the class
+	// chain — the real method the call runs (a worker subclass reaching an
+	// inherited run method, e.g. `AccountRawDistributionWorker#perform` ⇒
+	// `RawDistributionWorker#perform`). Verified against the actual `inherits`
+	// chain, so it is a real edge, not a same-name guess — preferred over the
+	// leaf fallback below, which would demote it as cross-scope.
+	if r, ok := ix.resolveInherited(target, req); ok {
+		return r, true
+	}
+
 	// Step 3: unqualified leaf fallback, gated kinds only.
 	if gatedKind {
 		if r, ok := ix.resolveByLeaf(target, req); ok {
@@ -145,6 +179,60 @@ func (ix *Index) Resolve(req Request) (Result, bool) {
 		}
 	}
 
+	return Result{}, false
+}
+
+// resolveInherited resolves a method-dispatch target (`Sub#m` / `Sub.m`) whose
+// exact qualified form missed, by walking Sub's class-ancestry chain and
+// binding to the nearest ancestor that defines the method. This is real Ruby
+// (and general single-inheritance) method lookup: the call dispatches to the
+// inherited definition. It is intentionally narrow:
+//
+//   - Only `#` (instance) and `.` (singleton) dispatch — never `::` namespace
+//     or a bare leaf, which carry no receiver type to inherit through.
+//   - Only when the receiver type is a known class in the ancestry map; a
+//     receiver with no recorded superclass (or a non-class) yields nothing,
+//     so a call into a gem/stdlib type is never guessed at.
+//   - The first ancestor (nearest in MRO order) that defines `<sep>m` wins;
+//     candidates are language/test-gated exactly like the exact-match path, and
+//     confidence follows pickBest (a unique ancestor keeps BaseConfidence — the
+//     dispatch is as certain as the inherits chain).
+//
+// Returns ok=false when no ancestor defines the method, leaving the leaf
+// fallback to try a same-name match.
+func (ix *Index) resolveInherited(target string, req Request) (Result, bool) {
+	if len(ix.ancestry) == 0 {
+		return Result{}, false
+	}
+	leaf, sep := unqualifiedNameSep(target)
+	if sep != "#" && sep != "." {
+		return Result{}, false
+	}
+	recvType := strings.TrimSuffix(target, sep+leaf)
+	if recvType == "" || len(ix.ancestry[recvType]) == 0 {
+		return Result{}, false
+	}
+
+	// Breadth-first walk up the superclass chain, nearest ancestor first.
+	seen := map[string]bool{recvType: true}
+	frontier := ix.ancestry[recvType]
+	for depth := 0; depth < maxAncestryDepth && len(frontier) > 0; depth++ {
+		var next []string
+		for _, anc := range frontier {
+			if seen[anc] {
+				continue
+			}
+			seen[anc] = true
+			matches := ix.byQualified[anc+sep+leaf]
+			matches = filterByLanguage(matches, ix.fileLang[req.SourceFileID])
+			matches = filterByTestDirection(matches, ix.fileIsTest[req.SourceFileID], ix.fileIsTest)
+			if len(matches) > 0 {
+				return pickBest(matches, req.SourceFileID, req.BaseConfidence), true
+			}
+			next = append(next, ix.ancestry[anc]...)
+		}
+		frontier = next
+	}
 	return Result{}, false
 }
 

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -132,6 +132,7 @@ const nameCollisionConfidence = extract.ConfidenceNameCollision
 //
 //  1. Apply receiver rewrite (`self.` / `Self::` ⇒ parent-prefixed)
 //     when the source symbol has a parent qualified name.
+//
 //  2. Exact match via byQualified. Single hit ⇒ BaseConfidence.
 //     Multiple ⇒ same-file preferred, else lowest-id; confidence
 //     clamped to ambiguousConfidence. For calls/tests/references the
@@ -141,6 +142,14 @@ const nameCollisionConfidence = extract.ConfidenceNameCollision
 //     emitted at ConfidenceUnresolved (receiver unknown) skips the exact
 //     shortcut entirely: its byQualified hit would be a leaf coincidence, so
 //     it goes straight to the gated fallback.
+//
+//     Inherited-method step (between 2 and 3; calls/tests/references only):
+//     a `Sub#m` / `Sub.m` dispatch with no own `Sub#m` resolves to the
+//     nearest `Ancestor#m` up the class `inherits` chain (resolveInherited).
+//     Verified against the real chain, so it is preferred over the leaf
+//     fallback, which would demote the same hit as a cross-scope guess.
+//     No-op without an ancestry map.
+//
 //  3. For calls, tests, and references edges, fall back to
 //     unqualified-name match via byName. Candidates in a different code
 //     language than the source are dropped (filterByLanguage), test-file
@@ -150,6 +159,7 @@ const nameCollisionConfidence = extract.ConfidenceNameCollision
 //     (the namespace or receiver type was discarded) is demoted below
 //     blast's floor as an unverified cross-scope guess unless the
 //     qualifier can be verified — see isUnverifiedCrossScope.
+//
 //  4. No match ⇒ ok=false.
 func (ix *Index) Resolve(req Request) (Result, bool) {
 	target := rewriteReceiver(req.Target, req.SourceQualified, req.SourceParentQualified)
@@ -161,19 +171,20 @@ func (ix *Index) Resolve(req Request) (Result, bool) {
 		return r, ok
 	}
 
-	// Step 2.5: inherited-method resolution. A `Sub#m` / `Sub.m` dispatch with
-	// no own `Sub#m` symbol resolves to the nearest `Ancestor#m` up the class
-	// chain — the real method the call runs (a worker subclass reaching an
-	// inherited run method, e.g. `AccountRawDistributionWorker#perform` ⇒
+	// Step 2.5: inherited-method resolution (gated kinds only — method dispatch,
+	// same as the leaf fallback below). A `Sub#m` / `Sub.m` dispatch with no own
+	// `Sub#m` symbol resolves to the nearest `Ancestor#m` up the class chain —
+	// the real method the call runs (a worker subclass reaching an inherited run
+	// method, e.g. `AccountRawDistributionWorker#perform` ⇒
 	// `RawDistributionWorker#perform`). Verified against the actual `inherits`
 	// chain, so it is a real edge, not a same-name guess — preferred over the
 	// leaf fallback below, which would demote it as cross-scope.
-	if r, ok := ix.resolveInherited(target, req); ok {
-		return r, true
-	}
-
-	// Step 3: unqualified leaf fallback, gated kinds only.
 	if gatedKind {
+		if r, ok := ix.resolveInherited(target, req); ok {
+			return r, true
+		}
+
+		// Step 3: unqualified leaf fallback.
 		if r, ok := ix.resolveByLeaf(target, req); ok {
 			return r, true
 		}
@@ -198,6 +209,24 @@ func (ix *Index) Resolve(req Request) (Result, bool) {
 //     confidence follows pickBest (a unique ancestor keeps BaseConfidence — the
 //     dispatch is as certain as the inherits chain).
 //
+// The walk is breadth-first with a `seen` cycle guard because the ancestry map
+// is slice-valued: a class reopened across files with divergent superclass
+// clauses (rare, but real Ruby) yields multiple parents, and a future ancestry
+// source (module includes) would too. Single inheritance collapses it to a
+// linear walk. maxAncestryDepth bounds a pathological chain; `seen` handles
+// cycles (`class A < B` / `class B < A`).
+//
+// Known limits (a wrong edge here is bounded and accepted, never 1.0):
+//   - Ancestor names are matched as written on the `inherits` edge, so a parent
+//     referenced by a short name from inside a namespace
+//     (`class Foo < Bar` where the real parent is `NS::Bar`) won't match
+//     `byQualified` and the step no-ops — the same limitation the rest of the
+//     resolver carries. Fully-qualified superclasses (mastodon's `< AP::X`)
+//     resolve correctly.
+//   - Module `prepend`/MRO is not modelled: only class `inherits` ancestry is
+//     walked, so a method intercepted by a prepended module still resolves to
+//     the superclass definition.
+//
 // Returns ok=false when no ancestor defines the method, leaving the leaf
 // fallback to try a same-name match.
 func (ix *Index) resolveInherited(target string, req Request) (Result, bool) {
@@ -213,23 +242,27 @@ func (ix *Index) resolveInherited(target string, req Request) (Result, bool) {
 		return Result{}, false
 	}
 
-	// Breadth-first walk up the superclass chain, nearest ancestor first.
+	// Breadth-first walk up the superclass chain, nearest depth first. Matches
+	// are collected across the whole depth-level before deciding, so two parents
+	// at the same hop that both define the method resolve through pickBest as
+	// ambiguous (clamped + flagged) rather than silently taking the first.
 	seen := map[string]bool{recvType: true}
 	frontier := ix.ancestry[recvType]
 	for depth := 0; depth < maxAncestryDepth && len(frontier) > 0; depth++ {
+		var matches []model.SymbolRef
 		var next []string
 		for _, anc := range frontier {
 			if seen[anc] {
 				continue
 			}
 			seen[anc] = true
-			matches := ix.byQualified[anc+sep+leaf]
-			matches = filterByLanguage(matches, ix.fileLang[req.SourceFileID])
-			matches = filterByTestDirection(matches, ix.fileIsTest[req.SourceFileID], ix.fileIsTest)
-			if len(matches) > 0 {
-				return pickBest(matches, req.SourceFileID, req.BaseConfidence), true
-			}
+			matches = append(matches, ix.byQualified[anc+sep+leaf]...)
 			next = append(next, ix.ancestry[anc]...)
+		}
+		matches = filterByLanguage(matches, ix.fileLang[req.SourceFileID])
+		matches = filterByTestDirection(matches, ix.fileIsTest[req.SourceFileID], ix.fileIsTest)
+		if len(matches) > 0 {
+			return pickBest(matches, req.SourceFileID, req.BaseConfidence), true
 		}
 		frontier = next
 	}

--- a/internal/scan/ancestry_internal_test.go
+++ b/internal/scan/ancestry_internal_test.go
@@ -1,0 +1,43 @@
+package scan
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/luuuc/sense/internal/model"
+)
+
+func TestBuildAncestry(t *testing.T) {
+	h := &harness{
+		pendingEdges: []pendingEdge{
+			// inherits edges → recorded as child → [parent].
+			{SourceQualified: "Sub", TargetName: "Base", Kind: model.EdgeInherits},
+			{SourceQualified: "Sub2", TargetName: "Base", Kind: model.EdgeInherits},
+			// A reopened class with a divergent superclass yields a multi-parent
+			// slice (rare, but the map must hold it).
+			{SourceQualified: "Sub", TargetName: "OtherBase", Kind: model.EdgeInherits},
+			// Non-inherits edges are ignored.
+			{SourceQualified: "Sub", TargetName: "Mixin", Kind: model.EdgeIncludes},
+			{SourceQualified: "Caller#m", TargetName: "Base#perform", Kind: model.EdgeCalls},
+			// Edges with an empty endpoint are skipped.
+			{SourceQualified: "", TargetName: "Base", Kind: model.EdgeInherits},
+			{SourceQualified: "Sub3", TargetName: "", Kind: model.EdgeInherits},
+		},
+	}
+
+	got := h.buildAncestry()
+	want := map[string][]string{
+		"Sub":  {"Base", "OtherBase"},
+		"Sub2": {"Base"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildAncestry() = %#v, want %#v", got, want)
+	}
+}
+
+func TestBuildAncestryEmpty(t *testing.T) {
+	h := &harness{}
+	if got := h.buildAncestry(); len(got) != 0 {
+		t.Errorf("buildAncestry() on no edges = %#v, want empty", got)
+	}
+}

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -1123,6 +1123,21 @@ func (h *harness) removeStaleFiles() error {
 // single commit is reasonable at pitch-target sizes (≤30K symbols,
 // ≤120K edges ⇒ low-MB range, commits in milliseconds). Much larger
 // repos will want a batched commit strategy; not this card's job.
+// buildAncestry derives the class-ancestry map (child qualified name → direct
+// superclass qualified names) from the pending `inherits` edges, so the
+// resolver can bind an inherited-method call (`Sub#m` with no own `Sub#m`) to
+// the nearest `Ancestor#m`. Built from the in-memory edge buffer — no DB round
+// trip — and keyed by the same qualified names the targets carry.
+func (h *harness) buildAncestry() map[string][]string {
+	ancestry := make(map[string][]string)
+	for _, pe := range h.pendingEdges {
+		if pe.Kind == model.EdgeInherits && pe.SourceQualified != "" && pe.TargetName != "" {
+			ancestry[pe.SourceQualified] = append(ancestry[pe.SourceQualified], pe.TargetName)
+		}
+	}
+	return ancestry
+}
+
 func (h *harness) resolveAndWriteEdges() error {
 	if len(h.pendingEdges) == 0 {
 		return nil
@@ -1131,7 +1146,7 @@ func (h *harness) resolveAndWriteEdges() error {
 	if err != nil {
 		return fmt.Errorf("load symbols for edge resolution: %w", err)
 	}
-	resolver := resolve.NewIndex(refs)
+	resolver := resolve.NewIndex(refs).WithInheritance(h.buildAncestry())
 
 	var written, unresolved, ambiguous int
 	err = h.idx.InTx(h.ctx, func() error {

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -1099,6 +1099,21 @@ func (h *harness) removeStaleFiles() error {
 	return nil
 }
 
+// buildAncestry derives the class-ancestry map (child qualified name → direct
+// superclass qualified names) from the pending `inherits` edges, so the
+// resolver can bind an inherited-method call (`Sub#m` with no own `Sub#m`) to
+// the nearest `Ancestor#m`. Built from the in-memory edge buffer — no DB round
+// trip — and keyed by the same qualified names the targets carry.
+func (h *harness) buildAncestry() map[string][]string {
+	ancestry := make(map[string][]string)
+	for _, pe := range h.pendingEdges {
+		if pe.Kind == model.EdgeInherits && pe.SourceQualified != "" && pe.TargetName != "" {
+			ancestry[pe.SourceQualified] = append(ancestry[pe.SourceQualified], pe.TargetName)
+		}
+	}
+	return ancestry
+}
+
 // resolveAndWriteEdges is the resolve phase: after walkTree has
 // visited every file and written every symbol, drain pendingEdges
 // into sense_edges by feeding each pending edge through the
@@ -1123,21 +1138,6 @@ func (h *harness) removeStaleFiles() error {
 // single commit is reasonable at pitch-target sizes (≤30K symbols,
 // ≤120K edges ⇒ low-MB range, commits in milliseconds). Much larger
 // repos will want a batched commit strategy; not this card's job.
-// buildAncestry derives the class-ancestry map (child qualified name → direct
-// superclass qualified names) from the pending `inherits` edges, so the
-// resolver can bind an inherited-method call (`Sub#m` with no own `Sub#m`) to
-// the nearest `Ancestor#m`. Built from the in-memory edge buffer — no DB round
-// trip — and keyed by the same qualified names the targets carry.
-func (h *harness) buildAncestry() map[string][]string {
-	ancestry := make(map[string][]string)
-	for _, pe := range h.pendingEdges {
-		if pe.Kind == model.EdgeInherits && pe.SourceQualified != "" && pe.TargetName != "" {
-			ancestry[pe.SourceQualified] = append(ancestry[pe.SourceQualified], pe.TargetName)
-		}
-	}
-	return ancestry
-}
-
 func (h *harness) resolveAndWriteEdges() error {
 	if len(h.pendingEdges) == 0 {
 		return nil


### PR DESCRIPTION
## Problem
A maintainer about to change a worker contract (e.g. an outbound delivery worker) needs every site that *ultimately* triggers it. Today those edges exist at runtime but not in greppable text: a service enqueues a worker (`Worker.perform_async`), the worker reaches the contract through a fan-out wrapper, and subclasses reach it via `super` or pure inheritance. `blast` saw none of this — it returned only the sites that named the symbol directly, so impact analysis under-recalled exactly where it matters most.

## Summary
Resolve the three hidden edges so a single `blast` returns the full transitive closure across enqueue, wrapper, and inheritance hops — answers grep cannot assemble.

## Changes
- **Ruby extractor — enqueue edges:** Sidekiq/ActiveJob enqueue calls (`perform_async`/`perform_in`/`perform_at`/`perform_bulk`/`push_bulk`/`perform_later`) on a constant receiver emit `calls → Receiver#perform` at 0.9. A `push_bulk` block's nested calls are still walked (extracted `walkBlockCalls`).
- **Ruby extractor — super edges:** a method calling `super` emits `calls → Superclass#<same-method>` at 0.9, guarded against nested-`def` mis-attribution.
- **Resolver — inheritance-aware dispatch:** an exact-miss `Sub#m`/`Sub.m` resolves to the nearest `Ancestor#m` up the class chain (built from pending inherits edges), so a subclass with no own definition reaches its inherited method.

## Architecture Highlights
- All new edges are inferred, stamped 0.9 (never 1.0); a non-worker receiver drops at resolution rather than producing a false edge.
- Inheritance resolution is scoped for precision: gated kinds only, `#`/`.` dispatch, unique class-ancestry match, BFS with a cycle guard; same-depth multi-parent matches flag ambiguous and clamp. No blast-engine change.
- Known limits documented in code: module `prepend`/MRO is not modelled; ancestor names match as written on the inherits edge.

## Test Plan
- [x] Unit: enqueue/super/inheritance precision + false-edge cases (non-worker, bare/dynamic receiver, no-superclass, nested-`def`, cyclic ancestry, multi-parent ambiguity, `::`-namespace)
- [x] End-to-end: a fixture mirroring all four worker emitter shapes — one blast reaches every emitter (`internal/blast/enqueue_closure_test.go`)
- [x] Non-Ruby correctness-neutral: main-vs-branch edge digest over a Go corpus (4042 edges, zero delta)
- [x] `make ci` green (coverage 95.0%, lint 0 issues)
- [x] sense binary builds cleanly