### PR TITLE
feat(ruby): resolve class_name_attribute config-string edges

### DIFF
--- a/internal/extract/ruby/class_name_attribute_test.go
+++ b/internal/extract/ruby/class_name_attribute_test.go
@@ -1,0 +1,219 @@
+package ruby
+
+import (
+	"testing"
+
+	"errors"
+
+	"github.com/luuuc/sense/internal/extract"
+)
+
+// The class_name_attribute macro (solidus/Spree) declares a reconfigurable
+// class accessor whose default names a class via a string literal. The
+// extractor indexes the accessor as a symbol and, for a static string default
+// that parses as a constant path, emits a calls edge to that constant so the
+// config-string applier becomes reachable (the seam grep cannot follow).
+
+func TestClassNameAttributeEmitsAccessorAndEdge(t *testing.T) {
+	r := parseRubyWithPath(t, `module SolidusLegacyPromotions
+  class Configuration < Spree::Preferences::Configuration
+    class_name_attribute :order_adjuster_class, default: "Spree::Promotion::OrderAdjustmentsRecalculator"
+  end
+end
+`, "configuration.rb")
+
+	accessor := "SolidusLegacyPromotions::Configuration.order_adjuster_class"
+	sym := findSymbol(r, accessor)
+	if sym == nil {
+		t.Fatalf("missing accessor symbol %q", accessor)
+	}
+	if sym.Name != "order_adjuster_class" {
+		t.Errorf("accessor Name = %q, want order_adjuster_class", sym.Name)
+	}
+	if sym.ParentQualified != "SolidusLegacyPromotions::Configuration" {
+		t.Errorf("accessor ParentQualified = %q", sym.ParentQualified)
+	}
+
+	edge := findEdge(r, accessor, "Spree::Promotion::OrderAdjustmentsRecalculator", "calls")
+	if edge == nil {
+		t.Fatal("missing config-string calls edge to the applier class")
+	}
+	if edge.Confidence != extract.ConfidenceConvention {
+		t.Errorf("edge confidence = %v, want %v (convention)", edge.Confidence, extract.ConfidenceConvention)
+	}
+}
+
+// The reopened-namespace form (`module Spree; class AppConfiguration`) must
+// compose the full accessor path and resolve the default just like the nested
+// form — this is the actual app_configuration.rb shape.
+func TestClassNameAttributeReopenedNamespace(t *testing.T) {
+	r := parseRubyWithPath(t, `module Spree
+  class AppConfiguration
+    class_name_attribute :order_recalculator_class, default: "Spree::OrderUpdater"
+  end
+end
+`, "app_configuration.rb")
+
+	accessor := "Spree::AppConfiguration.order_recalculator_class"
+	if findSymbol(r, accessor) == nil {
+		t.Fatalf("missing accessor symbol %q", accessor)
+	}
+	if findEdge(r, accessor, "Spree::OrderUpdater", "calls") == nil {
+		t.Error("missing config-string calls edge Spree::AppConfiguration.order_recalculator_class -> Spree::OrderUpdater")
+	}
+}
+
+// Leading `::` (absolute constant path) is trimmed and still resolves.
+func TestClassNameAttributeAbsolutePath(t *testing.T) {
+	r := parseRuby(t, `class C
+  class_name_attribute :impl, default: "::Foo::Bar"
+end
+`)
+	if findEdge(r, "C.impl", "Foo::Bar", "calls") == nil {
+		t.Error("absolute-path default ::Foo::Bar should resolve to Foo::Bar")
+	}
+}
+
+// Negative cases: the accessor symbol is always emitted (so `graph <name>`
+// resolves), but NO edge is emitted when the default is absent, dynamic, a
+// lambda, or not a constant path. A wrong high-confidence edge misleads worse
+// than a missing one.
+func TestClassNameAttributeNoEdgeCases(t *testing.T) {
+	cases := []struct {
+		name string
+		decl string
+	}{
+		{"no default", `class_name_attribute :impl`},
+		{"interpolated default", "class_name_attribute :impl, default: \"Spree::#{flavor}\""},
+		{"lambda default", `class_name_attribute :impl, default: -> { resolve_class }`},
+		{"constant default (not a string)", `class_name_attribute :impl, default: Spree::OrderUpdater`},
+		{"non-constant string", `class_name_attribute :impl, default: "not a class name"`},
+		{"lowercase string", `class_name_attribute :impl, default: "spree/order_updater"`},
+		{"empty string", `class_name_attribute :impl, default: ""`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := parseRuby(t, "class C\n  "+tc.decl+"\nend\n")
+			if findSymbol(r, "C.impl") == nil {
+				t.Error("accessor symbol C.impl should still be emitted")
+			}
+			for _, e := range r.edges {
+				if e.SourceQualified == "C.impl" && string(e.Kind) == "calls" {
+					t.Errorf("expected no config-string edge, got %s -> %s", e.SourceQualified, e.TargetQualified)
+				}
+			}
+		})
+	}
+}
+
+// A non-symbol first argument is not a valid accessor declaration — emit
+// nothing rather than a malformed symbol.
+func TestClassNameAttributeNonSymbolArg(t *testing.T) {
+	r := parseRuby(t, `class C
+  class_name_attribute "impl", default: "Spree::OrderUpdater"
+end
+`)
+	for _, s := range r.symbols {
+		if s.Name == "impl" {
+			t.Error("should not emit accessor symbol for non-symbol first argument")
+		}
+	}
+}
+
+// Documented limitation: only the first accessor symbol is handled. solidus
+// declares one accessor per call, so a multi-symbol form is out of scope — the
+// second name yields no symbol and the default binds to the first only. This
+// test pins that contract so a future change is a deliberate decision.
+func TestClassNameAttributeOnlyFirstSymbol(t *testing.T) {
+	r := parseRuby(t, `class C
+  class_name_attribute :a, :b, default: "Spree::OrderUpdater"
+end
+`)
+	if findSymbol(r, "C.a") == nil {
+		t.Error("first accessor C.a should be emitted")
+	}
+	if findSymbol(r, "C.b") != nil {
+		t.Error("second accessor C.b is out of scope and should not be emitted")
+	}
+	if findEdge(r, "C.a", "Spree::OrderUpdater", "calls") == nil {
+		t.Error("default should bind to the first accessor C.a")
+	}
+}
+
+// A bare `class_name_attribute` with no arguments is malformed — emit nothing.
+func TestClassNameAttributeNoArgs(t *testing.T) {
+	r := parseRuby(t, `class C
+  class_name_attribute
+end
+`)
+	for _, e := range r.edges {
+		if e.SourceQualified == "C.impl" || string(e.Kind) == "calls" && e.SourceQualified == "C" {
+			t.Errorf("should not emit edge for argument-less class_name_attribute, got %s -> %s", e.SourceQualified, e.TargetQualified)
+		}
+	}
+	for _, s := range r.symbols {
+		if s.ParentQualified == "C" && s.Kind == "method" {
+			t.Errorf("should not emit accessor symbol for argument-less class_name_attribute, got %q", s.Qualified)
+		}
+	}
+}
+
+// Empty-parens `class_name_attribute()` parses as a call with an empty
+// argument list — emit nothing.
+func TestClassNameAttributeEmptyArgs(t *testing.T) {
+	r := parseRuby(t, `class C
+  class_name_attribute()
+end
+`)
+	for _, s := range r.symbols {
+		if s.ParentQualified == "C" && s.Kind == "method" {
+			t.Errorf("should not emit accessor symbol for empty-args class_name_attribute, got %q", s.Qualified)
+		}
+	}
+}
+
+// The accessor-symbol and config-string-edge emits must propagate emitter
+// errors. `class C` emits the class (Symbol #1), then the accessor (Symbol #2)
+// and its calls edge (Edge #1).
+func TestClassNameAttributeEmitterErrorsPropagate(t *testing.T) {
+	src := "class C\n  class_name_attribute :impl, default: \"Spree::OrderUpdater\"\nend\n"
+	cases := []struct {
+		name string
+		emit *errEmit
+	}{
+		{"accessor symbol", &errEmit{failSymbolAt: 2}},
+		{"config-string edge", &errEmit{failEdgeAt: 1}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if err := runWithEmitter(t, src, c.emit); !errors.Is(err, errBoom) {
+				t.Errorf("expected errBoom to propagate, got %v", err)
+			}
+		})
+	}
+}
+
+func TestLooksLikeConstantPath(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"Spree::Promotion::OrderAdjustmentsRecalculator", true},
+		{"Foo", true},
+		{"Foo::Bar2", true},
+		{"My_Class", true},
+		{"", false},
+		{"foo", false},
+		{"Foo::bar", false},
+		{"Foo::", false},
+		{"::Foo", false}, // caller trims the leading "::" before this check
+		{"2Foo", false},
+		{"Foo Bar", false},
+		{"spree/order_updater", false},
+	}
+	for _, tc := range cases {
+		if got := looksLikeConstantPath(tc.in); got != tc.want {
+			t.Errorf("looksLikeConstantPath(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/extract/ruby/rails.go
+++ b/internal/extract/ruby/rails.go
@@ -262,6 +262,181 @@ func (w *walker) emitScopeEdge(n *sitter.Node, scope []string) error {
 	})
 }
 
+// classNameAttributeMacros are class-body DSL macros that declare a
+// configurable class accessor whose shipped default names a class via a
+// string literal. solidus/Spree's `class_name_attribute` is the canonical
+// case:
+//
+//	class_name_attribute :order_adjuster_class,
+//	  default: "Spree::Promotion::OrderAdjustmentsRecalculator"
+//
+// The macro defines a reader/writer (so the applier is reconfigurable at
+// runtime) whose default is the named class. Recognising it as a declarative
+// idiom — a table entry plus emitClassNameAttribute, sibling to the scope /
+// callback / association handlers — keeps the rule narrow and extensible: add
+// a sibling macro name here as one surfaces, never a per-framework branch.
+var classNameAttributeMacros = map[string]bool{
+	"class_name_attribute": true,
+}
+
+// emitClassNameAttribute handles a `class_name_attribute :name, default: "A::B"`
+// declaration. It emits the accessor as a KindMethod symbol (so
+// `graph <name>` resolves instead of "No symbol matches") and, when `default:`
+// is a static string literal that parses as a Ruby constant path, a calls edge
+// from the accessor to that constant. The edge target is the constant's
+// surface text; the resolver's existing exact-qualified match binds it to the
+// real class symbol when one is indexed (no new resolver machinery — a static
+// literal needs none; 29-03 generalizes the dynamic string-built case).
+//
+// Precision over recall: no edge is emitted when the default is absent,
+// dynamic (interpolated/computed), a lambda, or not a constant path. A missing
+// edge is cheaper than a wrong high-confidence one (see staticConstantKeywordArg).
+// Only the first accessor symbol is handled — solidus declares one per call.
+func (w *walker) emitClassNameAttribute(n *sitter.Node, scope []string) error {
+	args := n.ChildByFieldName("arguments")
+	if args == nil || args.NamedChildCount() == 0 {
+		return nil
+	}
+	first := args.NamedChild(0)
+	if first == nil || first.Kind() != "simple_symbol" {
+		return nil
+	}
+	name := strings.TrimPrefix(extract.Text(first, w.source), ":")
+	if name == "" {
+		return nil
+	}
+
+	source := strings.Join(scope, "::")
+	accessor := source + "." + name
+	line := extract.Line(n.StartPosition())
+
+	if err := w.emit.Symbol(extract.EmittedSymbol{
+		Name:            name,
+		Qualified:       accessor,
+		Kind:            model.KindMethod,
+		ParentQualified: source,
+		LineStart:       line,
+		LineEnd:         line,
+		Docstring:       docstringFor(n, w.source),
+	}); err != nil {
+		return err
+	}
+
+	target, ok := staticConstantKeywordArg(args, "default", w.source)
+	if !ok {
+		return nil
+	}
+	return w.emit.Edge(extract.EmittedEdge{
+		SourceQualified: accessor,
+		TargetQualified: target,
+		Kind:            model.EdgeCalls,
+		Line:            &line,
+		Confidence:      extract.ConfidenceConvention,
+	})
+}
+
+// staticConstantKeywordArg reads a keyword argument whose value is a static
+// string literal naming a Ruby constant (`default: "A::B::C"`) and returns the
+// constant path. It returns ok=false — emit no edge — when the key is absent,
+// the value is not a plain string literal (a lambda, a bare constant, an
+// interpolated or computed string), or the string does not parse as a constant
+// path. This is the precision gate: only a statically-known class name
+// produces an edge.
+//
+// A wrapped literal — `default: "A::B".freeze`, `default: ("A::B")` — parses as
+// a call/parenthesized node rather than a bare `string`, so it is treated as
+// dynamic and yields no edge. That under-recalls rather than risk a wrong edge;
+// solidus writes the bare literal.
+func staticConstantKeywordArg(args *sitter.Node, key string, source []byte) (string, bool) {
+	count := args.NamedChildCount()
+	for i := uint(0); i < count; i++ {
+		arg := args.NamedChild(i)
+		if arg == nil || arg.Kind() != "pair" {
+			continue
+		}
+		k := arg.ChildByFieldName("key")
+		v := arg.ChildByFieldName("value")
+		if k == nil || v == nil || extract.Text(k, source) != key {
+			continue
+		}
+		s, ok := staticStringLiteral(v, source)
+		if !ok {
+			return "", false
+		}
+		path := strings.TrimPrefix(s, "::")
+		if !looksLikeConstantPath(path) {
+			return "", false
+		}
+		return path, true
+	}
+	return "", false
+}
+
+// staticStringLiteral returns the content of a plain string literal node, with
+// ok=true only when the string is fully static: a single `string_content`
+// named child with no interpolation or escape sequence. An interpolated string
+// (`"Spree::#{x}"`) carries an `interpolation` child and returns ok=false — its
+// runtime value is not statically known, so it must not produce an edge.
+func staticStringLiteral(n *sitter.Node, source []byte) (string, bool) {
+	if n == nil || n.Kind() != "string" {
+		return "", false
+	}
+	content := ""
+	seen := false
+	count := n.NamedChildCount()
+	for i := uint(0); i < count; i++ {
+		c := n.NamedChild(i)
+		if c == nil {
+			continue
+		}
+		if c.Kind() != "string_content" || seen {
+			// interpolation, escape_sequence, or a second fragment — not a
+			// simple static literal.
+			return "", false
+		}
+		content = extract.Text(c, source)
+		seen = true
+	}
+	return content, seen
+}
+
+// looksLikeConstantPath reports whether s is a Ruby constant path: one or more
+// `::`-separated segments, each starting with an uppercase letter and otherwise
+// containing only identifier characters (`Spree::Promotion::OrderAdjuster`). It
+// rejects method names, file paths, and anything lowercase-leading so a
+// non-class default string never produces a spurious constant edge.
+func looksLikeConstantPath(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, seg := range strings.Split(s, "::") {
+		if !isConstantSegment(seg) {
+			return false
+		}
+	}
+	return true
+}
+
+// isConstantSegment reports whether seg is a single Ruby constant name:
+// uppercase first letter, identifier characters thereafter.
+func isConstantSegment(seg string) bool {
+	if seg == "" {
+		return false
+	}
+	for i, r := range seg {
+		switch {
+		case i == 0:
+			if r < 'A' || r > 'Z' {
+				return false
+			}
+		case r >= 'A' && r <= 'Z', r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '_':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 // resourceActions is the set of RESTful actions for `resources`.
 var resourceActions = []string{"index", "show", "new", "create", "edit", "update", "destroy"}
 

--- a/internal/extract/ruby/ruby.go
+++ b/internal/extract/ruby/ruby.go
@@ -213,6 +213,9 @@ func (w *walker) dispatchClassBodyCall(n *sitter.Node, scope []string, methodNam
 	case "scope":
 		return true, w.emitScopeEdge(n, scope)
 	}
+	if classNameAttributeMacros[methodName] {
+		return true, w.emitClassNameAttribute(n, scope)
+	}
 	if model.RailsCallbackNames[methodName] {
 		return true, w.emitCallbackEdges(n, scope, methodName)
 	}


### PR DESCRIPTION
## Problem
On deeply-configured Rails/Solidus engines, the class that actually does the work is often selected by a config-string default rather than named at the call site — e.g. `class_name_attribute :order_adjuster_class, default: "Spree::Promotion::OrderAdjustmentsRecalculator"`. The applier name never appears where the recalculation runs, so `grep` cannot connect the two, and the accessor itself was never indexed (`graph order_adjuster_class` returned "No symbol matches").

## Summary
Teach the Ruby extractor the `class_name_attribute` macro as a declarative class-body idiom: index the accessor as a symbol, and resolve its static string default to the named class via a `calls` edge.

## Changes
- **`internal/extract/ruby/rails.go`** — `classNameAttributeMacros` table + `emitClassNameAttribute` handler (sibling to the existing `scope` / callback / association handlers), plus `staticStringLiteral`, `staticConstantKeywordArg`, and `looksLikeConstantPath` precision helpers.
- **`internal/extract/ruby/ruby.go`** — wired the macro into `dispatchClassBodyCall` (purely additive: a new branch gated on the macro name; no existing path changes).
- **`internal/extract/ruby/class_name_attribute_test.go`** — positive cases (nested, reopened namespace, absolute path), the full negative matrix (absent / interpolated / lambda / bare-constant / non-constant / empty defaults), guards (non-symbol arg, empty args), emitter-error propagation, the documented first-symbol-only limitation, and a `looksLikeConstantPath` table.

## Architecture Highlights
- A **static** string literal binds via the existing exact-match resolver — no new resolver machinery. The dynamic string-built case (`camelize.constantize`, interpolation) is intentionally left to a later change.
- **Precision over recall:** the edge is emitted only when `default:` is a static string literal that parses as a constant path. Absent / interpolated / lambda / wrapped (`.freeze`) / non-constant defaults emit the accessor symbol but no edge — a missing edge is cheaper than a wrong high-confidence one.
- The config-string edge carries convention confidence `0.9` (never `1.0`): it asserts the shipped default, which the accessor exists to let an extension override at runtime.

## Test Plan
- [x] `make ci` green — per-file coverage gate PASS, total 95.0%, 0 lint issues, complexity ledger clean
- [x] New extractor unit tests cover the positive cases and the full no-edge negative matrix
- [x] Verified on a real Solidus scan: `graph order_adjuster_class` resolves and shows `calls Spree::Promotion::OrderAdjustmentsRecalculator (0.9)`; `blast Spree::OrderUpdater` surfaces the real production consumer
- [x] Grep litmus: the applier name is absent from the file where the recalculation runs — a genuine Sense-only result