### PR TITLE
feat(resolve): resolve relatively-named superclasses via lexical scope

### DIFF
--- a/internal/extract/ruby/inheritance_test.go
+++ b/internal/extract/ruby/inheritance_test.go
@@ -31,3 +31,62 @@ func TestBareIdentifierCallEdgeEmitError(t *testing.T) {
 		t.Error("expected error from failing bare-identifier calls edge to propagate")
 	}
 }
+
+// TestRelativeSuperclassEmitsBareAncestorName pins the namespaced-inheritance
+// gap (the root cause of `blast Shop::Base` missing its subclasses). A subclass
+// nested two modules deep that names its superclass *relatively* (`< Base`,
+// where the real base is `Shop::Base` one level up) emits the inherits target as
+// the bare written text "Base" — superclassName returns the raw source text with
+// no lexical-scope qualification. Because the resolver matches inherits by exact
+// qualified name only (it is not a gated kind, so there is no leaf fallback),
+// that bare "Base" never binds to the `Shop::Base` symbol and the edge is
+// dropped (target_id is NOT NULL). Collision-free fixture: a single Base, a
+// single Widget, so nothing here can resolve by coincidence.
+func TestRelativeSuperclassEmitsBareAncestorName(t *testing.T) {
+	src := `module Shop
+  class Base
+  end
+  module Items
+    class Widget < Base
+    end
+  end
+end`
+	r := parseRuby(t, src)
+
+	if findSymbol(r, "Shop::Base") == nil {
+		t.Fatal("expected base symbol Shop::Base to be recorded")
+	}
+	if findSymbol(r, "Shop::Items::Widget") == nil {
+		t.Fatal("expected subclass symbol Shop::Items::Widget to be recorded")
+	}
+
+	// The gap: inherits target is the bare "Base", which cannot exact-match the
+	// recorded "Shop::Base".
+	if findEdge(r, "Shop::Items::Widget", "Base", string(model.EdgeInherits)) == nil {
+		t.Fatal(`expected inherits edge with bare target "Base" (the namespaced-inheritance gap)`)
+	}
+	// And it was NOT qualified to the resolvable name. If this ever fires, the
+	// extractor began qualifying ancestors — flip this test to assert resolution.
+	if findEdge(r, "Shop::Items::Widget", "Shop::Base", string(model.EdgeInherits)) != nil {
+		t.Error("extractor unexpectedly qualified the ancestor to Shop::Base — gap may be fixed; update this test")
+	}
+}
+
+// TestQualifiedSuperclassEmitsResolvableName is the contrast: the same class
+// written with a fully-qualified ancestor emits the full path, which exact-
+// matches and resolves. This is why `< Spree::Base` resolves while `< Base`
+// does not.
+func TestQualifiedSuperclassEmitsResolvableName(t *testing.T) {
+	src := `module Shop
+  class Base
+  end
+  module Items
+    class Widget < Shop::Base
+    end
+  end
+end`
+	r := parseRuby(t, src)
+	if findEdge(r, "Shop::Items::Widget", "Shop::Base", string(model.EdgeInherits)) == nil {
+		t.Fatal(`expected inherits edge with fully-qualified target "Shop::Base"`)
+	}
+}

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -171,6 +171,19 @@ func (ix *Index) Resolve(req Request) (Result, bool) {
 		return r, ok
 	}
 
+	// Step 2b: inherits lexical-scope resolution. A superclass written relative to
+	// the subclass's namespace (`class Sub < Base` where the real base is
+	// `Outer::Base`) is emitted as the bare written text and misses the exact
+	// match; resolve it the way Ruby/Rust constant lookup does, by walking the
+	// subclass's enclosing scopes outward. inherits is not a gated kind, so this
+	// is its only resolution path past the exact match — and it repairs the
+	// `inherits` edges the ancestry map (resolveInherited) is built from.
+	if req.Kind == model.EdgeInherits {
+		if r, ok := ix.resolveLexicalInherits(target, req); ok {
+			return r, true
+		}
+	}
+
 	// Step 2.5: inherited-method resolution (gated kinds only — method dispatch,
 	// same as the leaf fallback below). A `Sub#m` / `Sub.m` dispatch with no own
 	// `Sub#m` symbol resolves to the nearest `Ancestor#m` up the class chain —
@@ -267,6 +280,57 @@ func (ix *Index) resolveInherited(target string, req Request) (Result, bool) {
 		frontier = next
 	}
 	return Result{}, false
+}
+
+// resolveLexicalInherits resolves an `inherits` target that missed the exact
+// match by walking the subclass's enclosing scopes outward, mirroring Ruby/Rust
+// constant lookup. A superclass named relative to the subclass's namespace
+// (`class Sub < Base` two modules deep, where the real base is `Outer::Base`) is
+// emitted by the extractor as the bare written text "Base", so the exact
+// byQualified lookup misses. Trying `<enclosing-scope><sep>Base` from the
+// innermost enclosing scope outward binds the same symbol the language would —
+// the innermost match wins (Ruby's rule), and a name that exists at no enclosing
+// scope resolves to nothing rather than a fabricated base (a wrong base misleads
+// blast worse than a gap).
+//
+// Scoped to inherits on purpose: gated kinds already have resolveByLeaf, and a
+// general scope walk for calls/references would reintroduce exactly the
+// cross-scope guessing isUnverifiedCrossScope exists to demote. The separator is
+// derived from the source's own qualified name so the walk stays language-
+// agnostic; when it cannot be determined (no enclosing scope, e.g. a top-level
+// subclass) the step is a no-op and the edge stays unresolved.
+func (ix *Index) resolveLexicalInherits(target string, req Request) (Result, bool) {
+	sep := separator(req.SourceQualified, req.SourceParentQualified)
+	if sep == "" {
+		return Result{}, false
+	}
+	// An absolute reference (leading separator, e.g. Ruby's `::Foo`) forces
+	// top-level lookup: try the bare form only, never prepend an enclosing scope.
+	if strings.HasPrefix(target, sep) {
+		bare := target[len(sep):]
+		if m := ix.byQualified[bare]; len(m) > 0 {
+			return pickBest(m, req.SourceFileID, req.BaseConfidence), true
+		}
+		return Result{}, false
+	}
+	// Walk the enclosing scopes outward, innermost first. The bare-target case
+	// (the "" scope) was already tried by the exact match, so it is skipped here.
+	for scope := req.SourceParentQualified; scope != ""; scope = trimLastSegment(scope, sep) {
+		if m := ix.byQualified[scope+sep+target]; len(m) > 0 {
+			return pickBest(m, req.SourceFileID, req.BaseConfidence), true
+		}
+	}
+	return Result{}, false
+}
+
+// trimLastSegment drops the trailing `<sep>segment` of a qualified name, or
+// returns "" when no separator remains — one step in walking enclosing scopes
+// outward.
+func trimLastSegment(qualified, sep string) string {
+	if i := strings.LastIndex(qualified, sep); i >= 0 {
+		return qualified[:i]
+	}
+	return ""
 }
 
 // resolveQualified attempts an exact byQualified match. The bool done reports

--- a/internal/resolve/resolver_test.go
+++ b/internal/resolve/resolver_test.go
@@ -859,3 +859,99 @@ func TestResolveCrossNamespaceColonColonDemotedBelowFloor(t *testing.T) {
 		t.Error("single match should not be flagged ambiguous")
 	}
 }
+
+// The four tests below are the fixture-first gate for the namespaced-inheritance
+// fix. The extractor emits an inherits edge with the bare ancestor "Base" (see
+// ruby.TestRelativeSuperclassEmitsBareAncestorName); the resolver must resolve it
+// by walking the source's enclosing scopes outward, mirroring Ruby/Rust constant
+// lookup. Collision-free: a single Base, a single Widget per case.
+
+// TestResolveInheritsRelativeAncestorViaLexicalScope — RED until resolveLexical
+// lands. A subclass nested in Shop::Items names its superclass relatively
+// (`< Base`); the real base is Shop::Base one level up. Resolution must try
+// Shop::Items::Base then Shop::Base and bind the first that exists.
+func TestResolveInheritsRelativeAncestorViaLexicalScope(t *testing.T) {
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "Shop::Base", FileID: 1},
+		{ID: 2, Qualified: "Shop::Items::Widget", FileID: 1},
+	}
+	ix := resolve.NewIndex(rs)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:                "Base",
+		Kind:                  model.EdgeInherits,
+		SourceFileID:          1,
+		SourceQualified:       "Shop::Items::Widget",
+		SourceParentQualified: "Shop::Items",
+		BaseConfidence:        1.0,
+	})
+	if !ok || r.SymbolID != 1 {
+		t.Fatalf("relative ancestor should resolve to Shop::Base (id 1) via lexical scope, got ok=%v id=%d", ok, r.SymbolID)
+	}
+	if r.Confidence != 1.0 {
+		t.Errorf("unique nesting hit should keep full confidence, got %v", r.Confidence)
+	}
+}
+
+// TestResolveInheritsRelativeAncestorInnermostWins — RED until the fix. When a
+// matching constant exists at more than one enclosing level, Ruby binds the
+// innermost; resolution must too.
+func TestResolveInheritsRelativeAncestorInnermostWins(t *testing.T) {
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "Shop::Base", FileID: 1},
+		{ID: 3, Qualified: "Shop::Items::Base", FileID: 1},
+		{ID: 2, Qualified: "Shop::Items::Widget", FileID: 1},
+	}
+	ix := resolve.NewIndex(rs)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:                "Base",
+		Kind:                  model.EdgeInherits,
+		SourceFileID:          1,
+		SourceQualified:       "Shop::Items::Widget",
+		SourceParentQualified: "Shop::Items",
+		BaseConfidence:        1.0,
+	})
+	if !ok || r.SymbolID != 3 {
+		t.Fatalf("innermost Shop::Items::Base (id 3) should win, got ok=%v id=%d", ok, r.SymbolID)
+	}
+}
+
+// TestResolveInheritsRelativeAncestorNoCandidateDropped — precision guard (green
+// today and after the fix). A relative ancestor with no matching symbol at ANY
+// enclosing level must NOT resolve: a known gap beats a fabricated base.
+func TestResolveInheritsRelativeAncestorNoCandidateDropped(t *testing.T) {
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "Shop::Base", FileID: 1},
+		{ID: 2, Qualified: "Shop::Items::Widget", FileID: 1},
+	}
+	ix := resolve.NewIndex(rs)
+	if _, ok := ix.Resolve(resolve.Request{
+		Target:                "Nonexistent",
+		Kind:                  model.EdgeInherits,
+		SourceFileID:          1,
+		SourceQualified:       "Shop::Items::Widget",
+		SourceParentQualified: "Shop::Items",
+		BaseConfidence:        1.0,
+	}); ok {
+		t.Error("a relative ancestor with no matching symbol must not resolve")
+	}
+}
+
+// TestResolveInheritsQualifiedAncestorExactMatch — no-regression: a fully-
+// qualified ancestor still resolves via the existing exact path at full
+// confidence (this is why `< Spree::Base` already works).
+func TestResolveInheritsQualifiedAncestorExactMatch(t *testing.T) {
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "Shop::Base", FileID: 1},
+		{ID: 2, Qualified: "Shop::Items::Widget", FileID: 1},
+	}
+	ix := resolve.NewIndex(rs)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "Shop::Base",
+		Kind:           model.EdgeInherits,
+		SourceFileID:   1,
+		BaseConfidence: 1.0,
+	})
+	if !ok || r.SymbolID != 1 {
+		t.Errorf("qualified ancestor should resolve to id 1, got ok=%v id=%d", ok, r.SymbolID)
+	}
+}


### PR DESCRIPTION
## Problem
`inherits` edges resolve by exact qualified-name match only. A subclass that
names its superclass *relative* to its namespace — `class Sub < Base` where the
real base is `Outer::Base` — is emitted as the bare text `"Base"`, misses the
exact lookup, and is dropped. On deeply-namespaced repos (Rails engines, STI
trees, namespaced error hierarchies) this makes whole inheritance fan-outs
invisible to `graph`/`blast`: a base class reports none of its subclasses.

## Summary
Resolve a relatively-named superclass the way Ruby/Rust constant lookup does —
walk the subclass's enclosing scopes outward and bind the first one that exists.

## Changes
- `internal/resolve/resolver.go`: add `resolveLexicalInherits` (+ `trimLastSegment`),
  invoked for `inherits` after the exact match misses. Walks enclosing scopes
  innermost-first (`Outer::Inner::Base` → `Outer::Base` → …) and binds the first
  indexed symbol.
- Tests: four resolver gate cases (lexical resolve, innermost-wins, no-candidate
  drop, qualified-ancestor no-regression) and extractor characterization tests
  pinning that the superclass is emitted as written.

## Architecture Highlights
- Scoped to `inherits` on exact-miss only; existing exact matches and all other
  edge kinds are untouched (purely additive).
- Precision-gated: a name that exists at no enclosing scope resolves to nothing
  rather than a fabricated base (a wrong base misleads `blast` worse than a gap);
  innermost match wins, mirroring language semantics; full confidence only on a
  unique nesting hit.
- Repairs the foundation the inherited-method ancestry walk is built from.

## Test Plan
- [x] Relative ancestor resolves via lexical scope; innermost wins; no-candidate
      drops (no false edge); fully-qualified ancestor still resolves unchanged.
- [x] End-to-end: rebuild a deeply-namespaced Ruby repo; `blast` on a base class
      returns its subclasses (verified: 0 → 24 on one engine's base class, all
      at confidence 1.0).
- [x] No-regression on an independent Ruby repo: non-`inherits` edge counts
      byte-identical; only correct `inherits` edges added, none lost.
- [x] `go test ./...` passes; `make ci` green (coverage floor + lint).
- [x] sense binary builds cleanly.
