### PR TITLE
feat(conventions): qualify colliding bases, exclude test scaffolding

### DIFF
--- a/internal/conventions/detectors_generic.go
+++ b/internal/conventions/detectors_generic.go
@@ -9,13 +9,44 @@ import (
 	"github.com/luuuc/sense/internal/mcpio"
 )
 
+// isTestFile reports whether the file with the given id is a test file. The
+// domain-structure detectors skip test files so test scaffolding (TestCase
+// subclasses, *_test.rb naming, test/ grouping) does not drown the real domain
+// patterns; test-file naming is reported separately by detectTesting.
+//
+// This intentionally uses the path predicate mcpio.IsTestPath directly, the same
+// signal detectKeyTypes trusts, rather than collectTestFileIDs' "tests"-edge set
+// (which detectTesting uses). The path predicate is the simpler, more complete
+// signal for exclusion: it catches every test file, not only those with a
+// resolved tests edge. The two notions can diverge in principle; for exclusion
+// the more inclusive one is the right default.
+func isTestFile(filePathByID map[int64]string, fileID int64) bool {
+	return mcpio.IsTestPath(filePathByID[fileID])
+}
+
+// domainKindCounts counts symbols per kind, excluding those in test files. It is
+// the denominator for the domain-structure detectors so test scaffolding does
+// not dilute the prevalence of domain conventions.
+func domainKindCounts(symbols []symbolRow, filePathByID map[int64]string) map[string]int {
+	counts := map[string]int{}
+	for _, s := range symbols {
+		if isTestFile(filePathByID, s.fileID) {
+			continue
+		}
+		counts[s.kind]++
+	}
+	return counts
+}
+
 func detectInheritance(symbols []symbolRow, edges []edgeRow, symbolByID map[int64]symbolRow, filePathByID map[int64]string) []Convention {
 
 	type inheritGroup struct {
-		targetName string
-		sourceKind string
-		count      int
-		examples   []Example
+		targetID        int64
+		targetName      string
+		targetQualified string
+		sourceKind      string
+		count           int
+		examples        []Example
 	}
 
 	type groupKey struct {
@@ -32,6 +63,9 @@ func detectInheritance(symbols []symbolRow, edges []edgeRow, symbolByID map[int6
 		if !ok {
 			continue
 		}
+		if isTestFile(filePathByID, src.fileID) {
+			continue
+		}
 		tgt, ok := symbolByID[e.targetID]
 		if !ok {
 			continue
@@ -42,42 +76,62 @@ func detectInheritance(symbols []symbolRow, edges []edgeRow, symbolByID map[int6
 			g.examples = append(g.examples, Example{Name: src.name, Path: filePathByID[src.fileID]})
 		} else {
 			groups[key] = &inheritGroup{
-				targetName: tgt.name,
-				sourceKind: src.kind,
-				count:      1,
-				examples:   []Example{{Name: src.name, Path: filePathByID[src.fileID]}},
+				targetID:        e.targetID,
+				targetName:      tgt.name,
+				targetQualified: tgt.qualified,
+				sourceKind:      src.kind,
+				count:           1,
+				examples:        []Example{{Name: src.name, Path: filePathByID[src.fileID]}},
 			}
 		}
 	}
 
-	kindCounts := map[string]int{}
-	for _, s := range symbols {
-		kindCounts[s.kind]++
+	kindCounts := domainKindCounts(symbols, filePathByID)
+
+	nameByID := map[int64]string{}
+	for _, g := range groups {
+		if g.count >= minInstances {
+			nameByID[g.targetID] = g.targetName
+		}
 	}
+	ambiguous := ambiguousTargetNames(nameByID)
 
 	var out []Convention
 	for _, g := range groups {
 		if g.count < minInstances {
 			continue
 		}
+		// total is always >= g.count here: every group source is a non-test
+		// symbol of g.sourceKind, so domainKindCounts has counted it. safeStrength
+		// keeps the ratio well-defined without an unreachable zero guard.
 		total := kindCounts[g.sourceKind]
-		if total == 0 {
-			continue
-		}
 		sortExamples(g.examples)
+		label := baseLabel(g.targetName, g.targetQualified, ambiguous)
 		out = append(out, Convention{
 			Category:    CategoryInheritance,
-			Description: fmt.Sprintf("%d %s extend %s as a base class (%s)", g.count, pluralize(g.sourceKind), g.targetName, topNames(g.examples)),
+			Description: fmt.Sprintf("%d %s extend %s as a base class (%s)", g.count, pluralize(g.sourceKind), label, topNames(g.examples)),
 			Instances:   g.count,
 			Total:       total,
-			Strength:    float64(g.count) / float64(total),
+			Strength:    safeStrength(g.count, total),
 			Examples:    g.examples,
 		})
 	}
 	return out
 }
 
+// detectNaming reports symbol-name and file-name suffix conventions. It is split
+// into the two passes so each stays within the complexity budget; both exclude
+// test files so test scaffolding does not dilute the domain naming patterns.
 func detectNaming(symbols []symbolRow, filePathByID map[int64]string) []Convention {
+	var out []Convention
+	out = append(out, detectSymbolSuffixNaming(symbols, filePathByID)...)
+	out = append(out, detectFileSuffixNaming(symbols, filePathByID)...)
+	return out
+}
+
+// detectSymbolSuffixNaming finds top-level symbols whose names share a CamelCase
+// or snake_case suffix (e.g. *Service), excluding test files.
+func detectSymbolSuffixNaming(symbols []symbolRow, filePathByID map[int64]string) []Convention {
 	type kindSuffix struct {
 		kind   string
 		suffix string
@@ -88,6 +142,9 @@ func detectNaming(symbols []symbolRow, filePathByID map[int64]string) []Conventi
 
 	for _, s := range symbols {
 		if s.parentID != nil {
+			continue
+		}
+		if isTestFile(filePathByID, s.fileID) {
 			continue
 		}
 		kindCounts[s.kind]++
@@ -101,35 +158,7 @@ func detectNaming(symbols []symbolRow, filePathByID map[int64]string) []Conventi
 		suffixExamples[ks] = append(suffixExamples[ks], Example{Name: s.name, Path: filePathByID[s.fileID]})
 	}
 
-	type kindFileSuffix struct {
-		kind   string
-		suffix string
-	}
-	fileSuffixCounts := map[kindFileSuffix]int{}
-	fileSuffixExamples := map[kindFileSuffix][]Example{}
-	kindFileCounts := map[string]int{}
-
-	for _, s := range symbols {
-		if s.parentID != nil {
-			continue
-		}
-		fp, ok := filePathByID[s.fileID]
-		if !ok {
-			continue
-		}
-		base := path.Base(fp)
-		kindFileCounts[s.kind]++
-		fileSuffix := extractFileSuffix(base)
-		if fileSuffix == "" {
-			continue
-		}
-		kfs := kindFileSuffix{kind: s.kind, suffix: fileSuffix}
-		fileSuffixCounts[kfs]++
-		fileSuffixExamples[kfs] = append(fileSuffixExamples[kfs], Example{Name: base, Path: fp})
-	}
-
 	var out []Convention
-
 	for ks, count := range suffixCounts {
 		if count < minInstances {
 			continue
@@ -149,7 +178,43 @@ func detectNaming(symbols []symbolRow, filePathByID map[int64]string) []Conventi
 			Examples:    ex,
 		})
 	}
+	return out
+}
 
+// detectFileSuffixNaming finds top-level symbols whose file basenames share a
+// suffix (e.g. *_controller.rb), excluding test files.
+func detectFileSuffixNaming(symbols []symbolRow, filePathByID map[int64]string) []Convention {
+	type kindFileSuffix struct {
+		kind   string
+		suffix string
+	}
+	fileSuffixCounts := map[kindFileSuffix]int{}
+	fileSuffixExamples := map[kindFileSuffix][]Example{}
+	kindFileCounts := map[string]int{}
+
+	for _, s := range symbols {
+		if s.parentID != nil {
+			continue
+		}
+		fp, ok := filePathByID[s.fileID]
+		if !ok {
+			continue
+		}
+		if isTestFile(filePathByID, s.fileID) {
+			continue
+		}
+		base := path.Base(fp)
+		kindFileCounts[s.kind]++
+		fileSuffix := extractFileSuffix(base)
+		if fileSuffix == "" {
+			continue
+		}
+		kfs := kindFileSuffix{kind: s.kind, suffix: fileSuffix}
+		fileSuffixCounts[kfs]++
+		fileSuffixExamples[kfs] = append(fileSuffixExamples[kfs], Example{Name: base, Path: fp})
+	}
+
+	var out []Convention
 	for kfs, count := range fileSuffixCounts {
 		if count < minInstances {
 			continue
@@ -169,7 +234,6 @@ func detectNaming(symbols []symbolRow, filePathByID map[int64]string) []Conventi
 			Examples:    ex,
 		})
 	}
-
 	return out
 }
 
@@ -188,6 +252,9 @@ func detectStructure(symbols []symbolRow, filePathByID map[int64]string) []Conve
 		}
 		fp, ok := filePathByID[s.fileID]
 		if !ok {
+			continue
+		}
+		if isTestFile(filePathByID, s.fileID) {
 			continue
 		}
 		dir := path.Dir(fp)
@@ -227,10 +294,12 @@ func detectComposition(symbols []symbolRow, edges []edgeRow, symbolByID map[int6
 		sourceKind string
 	}
 	type compGroup struct {
-		targetName string
-		sourceKind string
-		count      int
-		examples   []Example
+		targetID        int64
+		targetName      string
+		targetQualified string
+		sourceKind      string
+		count           int
+		examples        []Example
 	}
 	groups := map[groupKey]*compGroup{}
 
@@ -240,6 +309,9 @@ func detectComposition(symbols []symbolRow, edges []edgeRow, symbolByID map[int6
 		}
 		src, ok := symbolByID[e.sourceID]
 		if !ok {
+			continue
+		}
+		if isTestFile(filePathByID, src.fileID) {
 			continue
 		}
 		tgt, ok := symbolByID[e.targetID]
@@ -252,18 +324,25 @@ func detectComposition(symbols []symbolRow, edges []edgeRow, symbolByID map[int6
 			g.examples = append(g.examples, Example{Name: src.name, Path: filePathByID[src.fileID]})
 		} else {
 			groups[key] = &compGroup{
-				targetName: tgt.name,
-				sourceKind: src.kind,
-				count:      1,
-				examples:   []Example{{Name: src.name, Path: filePathByID[src.fileID]}},
+				targetID:        e.targetID,
+				targetName:      tgt.name,
+				targetQualified: tgt.qualified,
+				sourceKind:      src.kind,
+				count:           1,
+				examples:        []Example{{Name: src.name, Path: filePathByID[src.fileID]}},
 			}
 		}
 	}
 
-	kindCounts := map[string]int{}
-	for _, s := range symbols {
-		kindCounts[s.kind]++
+	kindCounts := domainKindCounts(symbols, filePathByID)
+
+	nameByID := map[int64]string{}
+	for _, g := range groups {
+		if g.count >= minInstances {
+			nameByID[g.targetID] = g.targetName
+		}
 	}
+	ambiguous := ambiguousTargetNames(nameByID)
 
 	var out []Convention
 	var serializerExamples []Example
@@ -271,21 +350,21 @@ func detectComposition(symbols []symbolRow, edges []edgeRow, symbolByID map[int6
 		if g.count < minInstances {
 			continue
 		}
+		// total is always >= g.count here (see detectInheritance): the group
+		// source is a counted non-test symbol, so safeStrength needs no zero guard.
 		total := kindCounts[g.sourceKind]
-		if total == 0 {
-			continue
-		}
 		sortExamples(g.examples)
 		if strings.HasSuffix(g.targetName, "Serializer") {
 			serializerExamples = append(serializerExamples, g.examples...)
 			continue
 		}
+		label := baseLabel(g.targetName, g.targetQualified, ambiguous)
 		out = append(out, Convention{
 			Category:    CategoryComposition,
-			Description: fmt.Sprintf("%d %s mix in %s for shared behavior (%s)", g.count, pluralize(g.sourceKind), g.targetName, topNames(g.examples)),
+			Description: fmt.Sprintf("%d %s mix in %s for shared behavior (%s)", g.count, pluralize(g.sourceKind), label, topNames(g.examples)),
 			Instances:   g.count,
 			Total:       total,
-			Strength:    float64(g.count) / float64(total),
+			Strength:    safeStrength(g.count, total),
 			Examples:    g.examples,
 		})
 	}

--- a/internal/conventions/domain_conventions_test.go
+++ b/internal/conventions/domain_conventions_test.go
@@ -1,0 +1,239 @@
+package conventions
+
+import (
+	"strings"
+	"testing"
+)
+
+// fileMap builds a filePathByID map from id->path pairs.
+func fileMap(pairs map[int64]string) map[int64]string {
+	out := make(map[int64]string, len(pairs))
+	for id, p := range pairs {
+		out[id] = p
+	}
+	return out
+}
+
+func TestAmbiguousTargetNames(t *testing.T) {
+	nameByID := map[int64]string{
+		1: "Base",  // collides with id 2
+		2: "Base",  // collides with id 1
+		3: "Order", // unique
+	}
+	got := ambiguousTargetNames(nameByID)
+	if !got["Base"] {
+		t.Error("Base shared by two distinct ids should be ambiguous")
+	}
+	if got["Order"] {
+		t.Error("Order is held by a single id and must not be ambiguous")
+	}
+}
+
+func TestBaseLabel(t *testing.T) {
+	ambiguous := map[string]bool{"Base": true}
+	// Ambiguous + distinct qualified -> qualify.
+	if got := baseLabel("Base", "Foo::Base", ambiguous); got != "Foo::Base" {
+		t.Errorf("ambiguous base label = %q, want Foo::Base", got)
+	}
+	// Ambiguous but no qualified name -> stay bare (cannot qualify).
+	if got := baseLabel("Base", "", ambiguous); got != "Base" {
+		t.Errorf("ambiguous base with empty qualified = %q, want Base", got)
+	}
+	// Ambiguous but qualified equals name -> stay bare (nothing to add).
+	if got := baseLabel("Base", "Base", ambiguous); got != "Base" {
+		t.Errorf("ambiguous base with qualified==name = %q, want Base", got)
+	}
+	// Not ambiguous -> stay bare even with a qualified name.
+	if got := baseLabel("Order", "App::Order", ambiguous); got != "Order" {
+		t.Errorf("unambiguous base label = %q, want Order", got)
+	}
+}
+
+func TestDomainKindCounts_ExcludesTestFiles(t *testing.T) {
+	symbols := []symbolRow{
+		{id: 1, fileID: 1, name: "A", kind: "class"},
+		{id: 2, fileID: 2, name: "B", kind: "class"},
+		{id: 3, fileID: 3, name: "ATest", kind: "class"}, // test file
+	}
+	paths := fileMap(map[int64]string{
+		1: "app/a.rb",
+		2: "app/b.rb",
+		3: "test/a_test.rb",
+	})
+	counts := domainKindCounts(symbols, paths)
+	if counts["class"] != 2 {
+		t.Errorf("class count = %d, want 2 (test class excluded)", counts["class"])
+	}
+}
+
+// TestDetectInheritance_QualifiesCollidingBasesAndExcludesTests pins both fixes:
+// two distinct "Base" classes are qualified so they do not read as duplicates,
+// and a base class inherited from a test file is not counted.
+func TestDetectInheritance_QualifiesCollidingBasesAndExcludesTests(t *testing.T) {
+	symbols := []symbolRow{
+		// Two distinct base classes sharing the bare name "Base".
+		{id: 100, fileID: 10, name: "Base", qualified: "Foo::Base", kind: "class"},
+		{id: 101, fileID: 11, name: "Base", qualified: "Bar::Base", kind: "class"},
+		// Foo family (3 domain subclasses).
+		{id: 1, fileID: 1, name: "FooA", kind: "class"},
+		{id: 2, fileID: 2, name: "FooB", kind: "class"},
+		{id: 3, fileID: 3, name: "FooC", kind: "class"},
+		// Bar family (3 domain subclasses).
+		{id: 4, fileID: 4, name: "BarA", kind: "class"},
+		{id: 5, fileID: 5, name: "BarB", kind: "class"},
+		{id: 6, fileID: 6, name: "BarC", kind: "class"},
+		// A test subclass that also extends Foo::Base — must be excluded.
+		{id: 200, fileID: 20, name: "FooTest", kind: "class"},
+	}
+	paths := fileMap(map[int64]string{
+		1: "app/foo_a.rb", 2: "app/foo_b.rb", 3: "app/foo_c.rb",
+		4: "app/bar_a.rb", 5: "app/bar_b.rb", 6: "app/bar_c.rb",
+		10: "lib/foo/base.rb", 11: "lib/bar/base.rb",
+		20: "test/foo_test.rb",
+	})
+	edges := []edgeRow{
+		{sourceID: 1, targetID: 100, kind: "inherits"},
+		{sourceID: 2, targetID: 100, kind: "inherits"},
+		{sourceID: 3, targetID: 100, kind: "inherits"},
+		{sourceID: 4, targetID: 101, kind: "inherits"},
+		{sourceID: 5, targetID: 101, kind: "inherits"},
+		{sourceID: 6, targetID: 101, kind: "inherits"},
+		{sourceID: 200, targetID: 100, kind: "inherits"}, // test source, excluded
+	}
+	convs := detectInheritance(symbols, edges, indexSymbols(symbols), paths)
+	if len(convs) != 2 {
+		t.Fatalf("expected 2 inheritance conventions, got %d: %v", len(convs), convs)
+	}
+	var foo, bar *Convention
+	for i := range convs {
+		switch {
+		case strings.Contains(convs[i].Description, "Foo::Base"):
+			foo = &convs[i]
+		case strings.Contains(convs[i].Description, "Bar::Base"):
+			bar = &convs[i]
+		}
+	}
+	if foo == nil || bar == nil {
+		t.Fatalf("expected qualified Foo::Base and Bar::Base descriptions, got: %v", convs)
+	}
+	// Test subclass excluded: Foo::Base has 3 instances, not 4.
+	if foo.Instances != 3 {
+		t.Errorf("Foo::Base instances = %d, want 3 (test subclass excluded)", foo.Instances)
+	}
+	// Denominator excludes the test class: 8 domain classes total.
+	if foo.Total != 8 {
+		t.Errorf("Foo::Base total = %d, want 8 (test class excluded from denominator)", foo.Total)
+	}
+}
+
+// TestDetectComposition_QualifiesCollidingMixinsAndExcludesTests mirrors the
+// inheritance test for the composition (include/compose) path.
+func TestDetectComposition_QualifiesCollidingMixinsAndExcludesTests(t *testing.T) {
+	symbols := []symbolRow{
+		{id: 100, fileID: 10, name: "Trackable", qualified: "Billing::Trackable", kind: "module"},
+		{id: 101, fileID: 11, name: "Trackable", qualified: "Audit::Trackable", kind: "module"},
+		{id: 1, fileID: 1, name: "Invoice", kind: "class"},
+		{id: 2, fileID: 2, name: "Payment", kind: "class"},
+		{id: 3, fileID: 3, name: "Refund", kind: "class"},
+		{id: 4, fileID: 4, name: "LoginEvent", kind: "class"},
+		{id: 5, fileID: 5, name: "LogoutEvent", kind: "class"},
+		{id: 6, fileID: 6, name: "ResetEvent", kind: "class"},
+		{id: 200, fileID: 20, name: "InvoiceTest", kind: "class"},
+	}
+	paths := fileMap(map[int64]string{
+		1: "app/invoice.rb", 2: "app/payment.rb", 3: "app/refund.rb",
+		4: "app/login_event.rb", 5: "app/logout_event.rb", 6: "app/reset_event.rb",
+		10: "lib/billing/trackable.rb", 11: "lib/audit/trackable.rb",
+		20: "test/invoice_test.rb",
+	})
+	edges := []edgeRow{
+		{sourceID: 1, targetID: 100, kind: "includes"},
+		{sourceID: 2, targetID: 100, kind: "includes"},
+		{sourceID: 3, targetID: 100, kind: "includes"},
+		{sourceID: 4, targetID: 101, kind: "includes"},
+		{sourceID: 5, targetID: 101, kind: "includes"},
+		{sourceID: 6, targetID: 101, kind: "includes"},
+		{sourceID: 200, targetID: 100, kind: "includes"}, // test source, excluded
+	}
+	convs := detectComposition(symbols, edges, indexSymbols(symbols), paths)
+	if len(convs) != 2 {
+		t.Fatalf("expected 2 composition conventions, got %d: %v", len(convs), convs)
+	}
+	gotBilling, gotAudit := false, false
+	for _, c := range convs {
+		if strings.Contains(c.Description, "Billing::Trackable") {
+			gotBilling = true
+			if c.Instances != 3 {
+				t.Errorf("Billing::Trackable instances = %d, want 3 (test includer excluded)", c.Instances)
+			}
+		}
+		if strings.Contains(c.Description, "Audit::Trackable") {
+			gotAudit = true
+		}
+	}
+	if !gotBilling || !gotAudit {
+		t.Errorf("expected qualified Billing::Trackable and Audit::Trackable, got: %v", convs)
+	}
+}
+
+func TestDetectNaming_ExcludesTestSymbols(t *testing.T) {
+	symbols := []symbolRow{
+		{id: 1, fileID: 1, name: "CheckoutService", kind: "class"},
+		{id: 2, fileID: 2, name: "PaymentService", kind: "class"},
+		{id: 3, fileID: 3, name: "ShippingService", kind: "class"},
+		// Three *Test classes in test files — must not form a naming convention.
+		{id: 4, fileID: 4, name: "CheckoutServiceTest", kind: "class"},
+		{id: 5, fileID: 5, name: "PaymentServiceTest", kind: "class"},
+		{id: 6, fileID: 6, name: "ShippingServiceTest", kind: "class"},
+	}
+	paths := fileMap(map[int64]string{
+		1: "app/checkout_service.rb", 2: "app/payment_service.rb", 3: "app/shipping_service.rb",
+		4: "test/checkout_service_test.rb", 5: "test/payment_service_test.rb", 6: "test/shipping_service_test.rb",
+	})
+	convs := detectNaming(symbols, paths)
+	for _, c := range convs {
+		if strings.Contains(c.Description, "*Test ") || strings.Contains(c.Description, "*_test.rb") {
+			t.Errorf("test-derived naming convention leaked into domain naming: %q", c.Description)
+		}
+	}
+	// The domain *Service convention should still be present.
+	hasService := false
+	for _, c := range convs {
+		if strings.Contains(c.Description, "*Service") {
+			hasService = true
+		}
+	}
+	if !hasService {
+		t.Errorf("expected domain *Service naming convention, got: %v", convs)
+	}
+}
+
+func TestDetectStructure_ExcludesTestDirs(t *testing.T) {
+	symbols := []symbolRow{
+		{id: 1, fileID: 1, name: "A", kind: "class"},
+		{id: 2, fileID: 2, name: "B", kind: "class"},
+		{id: 3, fileID: 3, name: "C", kind: "class"},
+		{id: 4, fileID: 4, name: "ATest", kind: "class"},
+		{id: 5, fileID: 5, name: "BTest", kind: "class"},
+		{id: 6, fileID: 6, name: "CTest", kind: "class"},
+	}
+	paths := fileMap(map[int64]string{
+		1: "app/models/a.rb", 2: "app/models/b.rb", 3: "app/models/c.rb",
+		4: "test/models/a_test.rb", 5: "test/models/b_test.rb", 6: "test/models/c_test.rb",
+	})
+	convs := detectStructure(symbols, paths)
+	for _, c := range convs {
+		if strings.Contains(c.Description, "test/models") {
+			t.Errorf("test directory leaked into structure conventions: %q", c.Description)
+		}
+	}
+	hasAppModels := false
+	for _, c := range convs {
+		if strings.Contains(c.Description, "app/models") {
+			hasAppModels = true
+		}
+	}
+	if !hasAppModels {
+		t.Errorf("expected app/models structure convention, got: %v", convs)
+	}
+}

--- a/internal/conventions/helpers.go
+++ b/internal/conventions/helpers.go
@@ -34,6 +34,38 @@ func extractSuffix(name string) string {
 	return ""
 }
 
+// ambiguousTargetNames returns the bare names shared by more than one distinct
+// target id. Such names need qualifying so the rendered conventions do not read
+// as duplicate lines (e.g. several "Base" classes in different namespaces each
+// inherited by a different family). nameByID holds one entry per distinct target.
+func ambiguousTargetNames(nameByID map[int64]string) map[string]bool {
+	counts := map[string]int{}
+	for _, name := range nameByID {
+		counts[name]++
+	}
+	out := map[string]bool{}
+	for name, n := range counts {
+		if n > 1 {
+			out[name] = true
+		}
+	}
+	return out
+}
+
+// baseLabel renders a base/mixin target name, qualifying it only when the bare
+// name is ambiguous (shared by several distinct targets) and a distinct qualified
+// name is available. This keeps the common case terse while disambiguating
+// collisions, so "extend Base" lines do not read as duplicates. In the rare case
+// where the qualified names also collide (two "Foo::Base" in different files), it
+// falls back to the bare name rather than render a misleading partial path; that
+// residual duplicate is accepted as not worth a path-suffix escalation here.
+func baseLabel(name, qualified string, ambiguous map[string]bool) string {
+	if ambiguous[name] && qualified != "" && qualified != name {
+		return qualified
+	}
+	return name
+}
+
 func categoryOrder(c Category) int {
 	switch c {
 	case CategoryInheritance:

--- a/internal/mcpserver/oracle_test.go
+++ b/internal/mcpserver/oracle_test.go
@@ -158,7 +158,12 @@ func oracleDigest(t *testing.T, calls []labeledCall) (string, []string) {
 // not computed at runtime: a behavior-preserving split must leave it unchanged.
 // When a response changes on purpose, run the test with -v, copy the logged
 // digest here, and update it in the same commit.
-const oracleGolden = "7700c81cb8b9eaf18bfc7e056000d66a8557b58667a68e1c72460a48e67b7559"
+//
+// Last bumped: conventions now exclude test-file symbols from the domain-structure
+// detectors, so the `conventions` response's structure line moved from counting
+// the fixture's test function to domain-only (internal/auth/ "3 of 6"). No other
+// response changed.
+const oracleGolden = "131642008d18c908ba84202b29570a7822c92b80dbbaa4e2c2231e9519b4a181"
 
 func TestMCPServerResponseOracle(t *testing.T) {
 	got, content := oracleDigest(t, collectOracleCalls(t))


### PR DESCRIPTION
## Problem
`sense conventions` was burying real domain patterns under noise. Two issues: distinct base classes that share a bare name (e.g. several `Base` classes in different namespaces) all rendered as identical `extend Base` lines, reading as duplicates; and test scaffolding (TestCase subclasses, `*_test.rb` files, `test/` grouping) was counted alongside domain code, diluting denominators and pushing test conventions to the top of the output. For the AI consumer asking "what patterns does this project follow," the signal was drowned.

## Summary
Disambiguate colliding base/mixin labels with their qualified name, and exclude test-path symbols from the domain-structure detectors so the output surfaces domain conventions. Test-file naming remains reported separately under the `testing` category.

## Changes
- **Label disambiguation** (`detectInheritance`, `detectComposition`): a base or mixin name is qualified (`Langchain::LLM::Base`) only when the bare name collides across distinct targets; unique names stay terse. Falls back to the bare name when qualified names also collide.
- **Test segmentation** (`detectInheritance`/`detectNaming`/`detectStructure`/`detectComposition`): skip test-path symbols in both numerator and denominator, reusing `mcpio.IsTestPath` — the same signal `detectKeyTypes` already trusts.
- `detectNaming` split into symbol-suffix and file-suffix passes (complexity budget); unreachable `total==0` guards in the inheritance/composition emitters replaced by `safeStrength`.
- Response-oracle golden bumped: the conventions structure line now counts domain symbols only. No other MCP response changes.

## Architecture Highlights
- Scope intentionally limited to the generic structural detectors; the framework/architecture detectors are left unchanged (they did not exhibit the noise).
- Query-layer only: no scanner/index changes, so existing indexes need no rebuild.

## Test Plan
- [x] New white-box tests pin both behaviors: qualified-when-colliding / bare-when-unique, and test-symbol exclusion from numerator and denominator.
- [x] Side-effect check across small/medium/large repos: `graph`/`blast`/`dead`/`search`/`status`/`summary.md` byte-identical vs `main`; only `conventions` changed, exactly as intended.
- [x] `make ci` green (per-file 92% line+function coverage gate, lint, ledger).
- [x] sense binary builds cleanly.
