### PR TITLE
feat(mcp): completeness verdict + per-result relation for blast/graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,4 @@ bench/bench-sense-local.sh
 # reworking a seam (e.g. forem.embed.yaml.bak before the reaction rewrite).
 bench/lib/.coverage
 bench/scenarios/*.bak
+.local/

--- a/bench/index-state.json
+++ b/bench/index-state.json
@@ -32,9 +32,9 @@
     "symbols": "177929"
   },
   "langchainrb": {
-    "built_at": "2026-06-19T06:02:01Z",
+    "built_at": "2026-06-19T08:44:47Z",
     "edges": "2277",
-    "fingerprint": "3a93dc8afe70c89a|schema v5, embeddings: all-MiniLM-L6-v2-ctx1",
+    "fingerprint": "0bbf6f3aba24f37e|schema v5, embeddings: all-MiniLM-L6-v2-ctx1",
     "git_head": "",
     "sense_version": "",
     "symbols": "247"

--- a/bench/lib/reporter.py
+++ b/bench/lib/reporter.py
@@ -26,10 +26,12 @@ SCENARIO_DESCRIPTIONS = {
 
 
 METRIC_DIRECTIONS = {
-    "fairness": ("higher", "Combined fairness score — 0.10·keyword_coverage + 0.55·llm_quality + 0.15·citation_grounding + 0.20·efficiency. Shown as `—` if judge.sh has not run yet."),
+    "cited_recall": ("higher", "HEADLINE (Judging Contract rule 1): objective cited-recall vs the authored must-find set. Ranks the report."),
+    "relationship_audit": ("higher", "HEADLINE: reference-aware audit — fraction of the must-find set the answer covered, graded vs the authored relations. The omission-proof judge signal."),
+    "fairness": ("higher", "DIAGNOSTIC ONLY (not the headline): 0.10·keyword_coverage + 0.55·llm_quality + 0.15·citation_grounding + 0.20·efficiency. Omission-blind — see Judging Contract."),
     "adoption": ("higher", "Adoption score — tool fluency + discoverability, for code-intel comparisons only"),
     "keyword_coverage": ("higher", "Hit rate across keyword smoke-test checks (sum of hits / sum of totals; bonus weighted 0.5). Now a 10% smoke test, not the headline."),
-    "llm_quality": ("higher", "Judge-rated answer quality, per-scenario mean of step_quality. 0.55 weight in fairness — the headline."),
+    "llm_quality": ("higher", "DIAGNOSTIC ONLY: reference-blind judge prose-quality, mean of step_quality. Blind to omission (rates a 60%-recall answer ~0.84); NEVER the headline — use cited_recall/relationship_audit."),
     "efficiency": ("higher", "Half token efficiency + half time efficiency, each calibrated per repo"),
     "tokens": ("lower", "Billed tokens (uncached) — lower is better (cheaper)"),
     "wall_time": ("lower", "Wall-clock time — lower is better, folded into efficiency"),
@@ -62,6 +64,11 @@ def _attach_fairness(result, result_dir):
     )
     if judged is not None:
         result["_judge_steps"] = judged.get("steps", [])
+        # Reference-aware audit (graded vs the authored must-find set) is the
+        # HEADLINE-grade judge signal — extract its covered-recall so the
+        # aggregate can rank on it instead of the omission-blind llm_quality.
+        ra = judged.get("relationship_audit") or {}
+        result["relationship_audit"] = ra.get("covered_recall") if isinstance(ra, dict) else None
 
 
 def load_results(results_dir):
@@ -199,11 +206,20 @@ def build_aggregate(results):
         def avg(lst):
             return sum(lst) / len(lst) if lst else 0.0
 
+        # Headline axes (Judging Contract rule 1): objective cited-recall and the
+        # reference-aware relationship audit. These rank the report; the blind
+        # composite (avg_fairness/avg_llm_quality) is a trailing diagnostic only.
+        recalls = [r2.get("gold_recall", {}).get("cited_recall") for r2 in runs
+                   if r2.get("gold_recall", {}).get("cited_recall") is not None]
+        rel_audits = [r2.get("relationship_audit") for r2 in runs if r2.get("relationship_audit") is not None]
+
         failures = sum(1 for r2 in runs if r2.get("failed"))
         agg.append({
             "tool": tool_name,
             "scenarios": n,
             "failures": failures,
+            "avg_cited_recall": round(avg(recalls), 4) if recalls else None,
+            "avg_relationship_audit": round(avg(rel_audits), 4) if rel_audits else None,
             "avg_fairness": round(avg(fairness_scores), 4) if fairness_scores else None,
             "avg_adoption": round(avg(adoption), 4) if adoption else None,
             "avg_keyword_coverage": round(avg(keyword), 4) if keyword else None,
@@ -217,7 +233,10 @@ def build_aggregate(results):
             "cites_hallucinated": hallucinated_cites,
             "avg_grounding": round(grounded_cites / total_cites, 4) if total_cites > 0 else None,
         })
-    agg.sort(key=lambda r2: (r2["avg_fairness"] or 0), reverse=True)
+    # Judging Contract rule 1: rank by the objective headline (cited-recall, then
+    # the reference-aware audit), NEVER by the omission-blind fairness composite.
+    # Guarded by test_reporter_ranks_by_recall.
+    agg.sort(key=lambda r2: (r2["avg_cited_recall"] or 0, r2["avg_relationship_audit"] or 0), reverse=True)
     return agg
 
 
@@ -499,8 +518,8 @@ def format_markdown(tables, aggregate, header):
     lines.append("")
     lines.append("Failed runs count as fairness 0 in the average. The `Failures` column shows how many scenarios the tool could not complete. Costs marked with `*` are estimated from per-message token usage in the partial transcript, because the session never emitted a final cost event.")
     lines.append("")
-    lines.append("| Rank | Tool | Scenarios | Failures | Avg Fairness | Avg Adoption | Avg Keyword Cov. | Avg LLM Quality | Avg Efficiency | Avg Tokens | Avg Time | Total Cost | Avg Grounding |")
-    lines.append("|-----:|------|----------:|--------:|------------:|-----------:|---------------:|---------------:|--------------:|-----------:|--------:|-----------:|--------------:|")
+    lines.append("| Rank | Tool | Scenarios | Failures | **Cited Recall** | **Rel Audit** | Avg Fairness | Avg Adoption | Avg Keyword Cov. | Avg LLM Quality | Avg Efficiency | Avg Tokens | Avg Time | Total Cost | Avg Grounding |")
+    lines.append("|-----:|------|----------:|--------:|---------------:|-----------:|------------:|-----------:|---------------:|---------------:|--------------:|-----------:|--------:|-----------:|--------------:|")
     for i, row in enumerate(aggregate):
         badge = _rank_badge(i)
         af = f"{row['avg_fairness']:.4f}" if row["avg_fairness"] is not None else "—"
@@ -518,8 +537,10 @@ def format_markdown(tables, aggregate, header):
             ag = "—"
         fails = row.get("failures", 0)
         fail_cell = f"**{fails}**" if fails else "0"
+        acr = f"{row['avg_cited_recall']:.4f}" if row.get("avg_cited_recall") is not None else "—"
+        ara = f"{row['avg_relationship_audit']:.4f}" if row.get("avg_relationship_audit") is not None else "—"
         lines.append(
-            f"| {i+1} | {row['tool']}{badge} | {row['scenarios']} | {fail_cell} | {af} | {aa} | {akw} | {alq} | {ae} |"
+            f"| {i+1} | {row['tool']}{badge} | {row['scenarios']} | {fail_cell} | {acr} | {ara} | {af} | {aa} | {akw} | {alq} | {ae} |"
             f" {row['avg_tokens']:,} | {at} | {co} | {ag} |"
         )
     lines.append("")

--- a/bench/lib/test_reporter.py
+++ b/bench/lib/test_reporter.py
@@ -130,3 +130,35 @@ class FormatMarkdownSmokeTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class RankByRecallHeadline(unittest.TestCase):
+    """Judging Contract rule 1: the aggregate ranks by objective cited-recall +
+    relationship_audit, NEVER by the omission-blind fairness/llm_quality. This
+    guards against the regression where the blind composite (which rated the
+    chatwoot +0.44 win as a tie) drives the headline ranking."""
+
+    def test_ranks_by_recall_not_blind_fairness(self):
+        # baseline: high blind fairness, low recall. sense: low fairness, high recall.
+        # The blind composite would rank baseline first; recall must rank sense first.
+        results = [
+            {"tool": "baseline", "fairness_score": 0.90, "llm_quality": 0.90,
+             "gold_recall": {"cited_recall": 0.40}, "relationship_audit": 0.40, "metrics": {}},
+            {"tool": "sense", "fairness_score": 0.50, "llm_quality": 0.50,
+             "gold_recall": {"cited_recall": 0.90}, "relationship_audit": 0.95, "metrics": {}},
+        ]
+        agg = reporter.build_aggregate(results)
+        self.assertEqual(agg[0]["tool"], "sense",
+                         "ranking must follow cited_recall, not the blind fairness composite")
+        self.assertAlmostEqual(agg[0]["avg_cited_recall"], 0.90)
+        self.assertAlmostEqual(agg[0]["avg_relationship_audit"], 0.95)
+
+    def test_headline_columns_present_in_markdown(self):
+        results = [
+            {"tool": "sense", "fairness_score": 0.5, "llm_quality": 0.5,
+             "gold_recall": {"cited_recall": 0.9}, "relationship_audit": 0.9, "metrics": {}},
+        ]
+        agg = reporter.build_aggregate(results)
+        md = reporter.format_markdown([], agg, {"total": 1})
+        self.assertIn("Cited Recall", md)
+        self.assertIn("Rel Audit", md)

--- a/bench/opencode-run.sh
+++ b/bench/opencode-run.sh
@@ -49,6 +49,10 @@ OPENCODE_MAX_SECS="${OPENCODE_MAX_SECS:-1200}"     # hard ceiling floor (was a f
 OPENCODE_FIRST_GRACE="${OPENCODE_FIRST_GRACE:-240}" # allow this long for the FIRST streamed byte (MCP cold start); 0 bytes past it = a hang
 OPENCODE_STALL_IDLE="${OPENCODE_STALL_IDLE:-150}"   # after output starts, kill only if the stream goes silent this long (stuck mid-run)
 OPENCODE_RETRIES="${OPENCODE_RETRIES:-1}"           # extra attempts for a TRUE no-output hang (total attempts = retries+1)
+OPENCODE_MIN_ANSWER_CHARS="${OPENCODE_MIN_ANSWER_CHARS:-200}" # a run whose final assistant text is shorter than this is a
+                                                    # truncated/empty-stream artifact, not a real answer: retry it, and flag
+                                                    # it as invalid if it stays empty (the audit answers run ~4000+ chars, so
+                                                    # 200 is far below any real answer yet catches the 0/94-char degenerate runs)
 while [[ $# -gt 0 ]]; do case "$1" in
   --tool) TOOLS_CSV="$2"; shift 2;;
   --repo) REPO="$2"; shift 2;;
@@ -146,7 +150,7 @@ for tool in "${TOOLS[@]}"; do
   fi
 
   raw="$out/opencode-raw.jsonl"; LOGFILE="$out/opencode.log"; : > "$LOGFILE"
-  attempts=$((OPENCODE_RETRIES + 1)); start=$(date +%s); rc=0; otok=0
+  attempts=$((OPENCODE_RETRIES + 1)); start=$(date +%s); rc=0; otok=0; achars=0
   for attempt in $(seq 1 "$attempts"); do
     git -C "$repo_dir" checkout -- . 2>/dev/null || true   # reset tracked edits between attempts (keeps untracked sense surface)
     ( cd "$repo_dir" && PATH="$run_path" run_guarded "$raw" \
@@ -167,14 +171,50 @@ try:
     u=d.get('usage') or {}; t+=int(u.get('output_tokens') or 0)
 except FileNotFoundError: pass
 print(t)" 2>/dev/null || echo 0)
-    # Accept any run that produced a real answer (rc 0, or output even if capped:
-    # a slow sense run that streamed 14k tokens is a valid, if truncated, datum,
-    # NOT a failure). Retry ONLY a true no-output hang (rc!=0 AND 0 tokens).
-    if [ "$rc" -eq 0 ] || [ "${otok:-0}" -gt 0 ]; then
-      [ "$attempt" -gt 1 ] && echo "[opencode]   recovered on attempt $attempt (rc=$rc, out_tok=$otok)" >&2
+    # Inspect the FINAL assistant answer, built exactly like the scorer's
+    # read_answer_text (concatenated assistant text blocks). Emits two values:
+    #   achars = answer length. A run can stream tokens (otok>0) yet leave an
+    #            empty/near-empty final answer when the stream truncates -- a
+    #            failed datum, not a real 0.0.
+    #   perr   = 1 if the "answer" is actually an ollama-cloud provider error
+    #            (the 94-char `{"error":{"type":"llm_call_failed",...Operation
+    #            not allowed...}}` blob = a rate-limit/session cap, NOT a model
+    #            answer). Classified separately so cap hits are legible vs plain
+    #            truncations.
+    read achars perr < <(python3 -c "
+import json
+parts=[]
+try:
+  for l in open('$out/transcript.json'):
+    l=l.strip()
+    if not l: continue
+    try: d=json.loads(l)
+    except: continue
+    e=d.get('event', d)
+    if e.get('type') != 'assistant': continue
+    for b in e.get('message', {}).get('content', []):
+      if b.get('type') == 'text' and b.get('text'): parts.append(b['text'])
+except FileNotFoundError: pass
+ans='\n'.join(parts)
+perr = 1 if ('llm_call_failed' in ans or 'Operation not allowed' in ans) else 0
+print(len(ans), perr)" 2>/dev/null || echo "0 0")
+    achars="${achars:-0}"; perr="${perr:-0}"
+    # Accept a run only if it produced a REAL answer: tokens streamed AND a
+    # final answer of usable length AND not a provider error. Retry everything
+    # else: a true no-output hang (otok=0), an empty/truncated answer (achars <
+    # min), or a provider cap error (perr=1) -- all were previously scored 0.0.
+    if [ "${otok:-0}" -gt 0 ] && [ "${achars:-0}" -ge "$OPENCODE_MIN_ANSWER_CHARS" ] && [ "$perr" -eq 0 ]; then
+      [ "$attempt" -gt 1 ] && echo "[opencode]   recovered on attempt $attempt (rc=$rc, out_tok=$otok, answer_chars=$achars)" >&2
       break
     fi
-    echo "[opencode]   attempt $attempt/$attempts: no output (rc=$rc, 0 tok) -- $([ "$attempt" -lt "$attempts" ] && echo retrying || echo 'giving up')" >&2
+    if [ "$perr" -eq 1 ]; then
+      reason="provider error (llm_call_failed / 'Operation not allowed' -- likely an ollama-cloud cap)"
+    elif [ "${otok:-0}" -gt 0 ] && [ "${achars:-0}" -lt "$OPENCODE_MIN_ANSWER_CHARS" ]; then
+      reason="empty/truncated answer (out_tok=$otok, answer_chars=$achars < $OPENCODE_MIN_ANSWER_CHARS)"
+    else
+      reason="no output (rc=$rc, 0 tok)"
+    fi
+    echo "[opencode]   attempt $attempt/$attempts: $reason -- $([ "$attempt" -lt "$attempts" ] && echo retrying || echo 'giving up')" >&2
   done
   wall=$(( $(date +%s) - start ))
 
@@ -193,10 +233,10 @@ print(t)" 2>/dev/null || echo 0)
 
   commit=$(git -C "$repo_dir" rev-parse --short HEAD 2>/dev/null || echo "")
   ver=""; [[ "$tool" == sense ]] && ver="$SVER"
-  python3 - "$tool" "$REPO" "$SCEN_NAME" "$wall" "$MODEL" "$commit" "$ver" "$rc" "$attempts" "$otok" > "$out/run_meta.json" <<'PY'
+  python3 - "$tool" "$REPO" "$SCEN_NAME" "$wall" "$MODEL" "$commit" "$ver" "$rc" "$attempts" "$otok" "$achars" "$OPENCODE_MIN_ANSWER_CHARS" "$perr" > "$out/run_meta.json" <<'PY'
 import json, sys
-tool, repo, scen, wall, model, commit, ver, rc, attempts, otok = sys.argv[1:11]
-rc = int(rc); otok = int(otok)
+tool, repo, scen, wall, model, commit, ver, rc, attempts, otok, achars, min_chars, perr = sys.argv[1:14]
+rc = int(rc); otok = int(otok); achars = int(achars); min_chars = int(min_chars); perr = int(perr)
 # Classify the watchdog exit so the contaminated-vs-real distinction is legible
 # downstream (124 hard cap / 125 stalled / 126 cold-start hang).
 KIND = {0: None, 124: "hard_cap_timeout", 125: "stalled_midrun", 126: "no_first_output_hang"}
@@ -207,20 +247,38 @@ meta = {
     "harness": "opencode", "provider": "ollama-cloud",
     "auth_mode": "opencode_cli", "mode": "single_prompt",
     "opencode_exit_code": rc, "attempts": int(attempts), "output_tokens": otok,
+    "answer_chars": achars,
     "cost_usd_note": "ollama-cloud bills off-platform; per-token cost left null",
 }
 kind = KIND.get(rc, "opencode_session_failed")
 if kind:
     meta["watchdog_kind"] = kind
-# Only a TRUE no-output hang is a failed run; a capped/stalled run that still
-# streamed tokens is a valid (truncated) datum, not a 0.
-if rc != 0 and otok == 0:
+# Failure classes that are NOT real 0.0 data and must be flagged so they are not
+# trusted as genuine ties: (1) a provider cap error (the answer IS an
+# `llm_call_failed`/"Operation not allowed" blob = ollama-cloud rate-limit/session
+# cap; re-run the repo after reset), (2) a true no-output hang (rc!=0 AND 0
+# tokens), and (3) an empty/truncated final answer (tokens streamed but the
+# answer text is below min_chars -- the 0-char degenerate runs). A capped/stalled
+# run that DID leave a long real answer stays a valid (truncated) datum.
+# Check provider-error FIRST: its blob is ~94 chars so it also trips the
+# min_chars gate, but the cap diagnosis is the more actionable one.
+if perr == 1:
+    meta["error"] = "provider_cap_error"
+    meta["watchdog_kind"] = "provider_cap_error"
+    meta["note"] = "final answer was an ollama-cloud provider error (llm_call_failed / 'Operation not allowed'); likely a rate-limit/session cap -- re-run this repo after the cap resets, do NOT score as a 0.0"
+elif achars < min_chars:
+    meta["error"] = "empty_final_answer"
+    meta["note"] = f"final answer only {achars} chars (< {min_chars}); truncated/empty stream, retried and still short -- not a real 0.0"
+elif rc != 0 and otok == 0:
     meta["error"] = "opencode_session_failed"
 elif rc != 0:
-    meta["note"] = f"watchdog stopped ({kind}) but produced {otok} output tokens; kept as a truncated-but-valid run"
+    meta["note"] = f"watchdog stopped ({kind}) but produced {otok} output tokens and a {achars}-char answer; kept as a truncated-but-valid run"
 print(json.dumps(meta, indent=2))
 PY
-  echo "[opencode]   $tool rc=$rc wall=${wall}s attempts=$attempts out_tok=$otok" >&2
+  if [ "${perr:-0}" -eq 1 ]; then flag=" *** INVALID: provider cap error (Operation not allowed) -- re-run after reset ***";
+  elif [ "${achars:-0}" -lt "$OPENCODE_MIN_ANSWER_CHARS" ]; then flag=" *** INVALID: empty/truncated answer ***";
+  else flag=""; fi
+  echo "[opencode]   $tool rc=$rc wall=${wall}s attempts=$attempts out_tok=$otok answer_chars=$achars$flag" >&2
 done
 
 SJ=(--tool "$TOOLS_CSV" --repo "$REPO")

--- a/bench/scenarios/vertical/ruby-rails/llm.rb.providers-recall.20260619.bak
+++ b/bench/scenarios/vertical/ruby-rails/llm.rb.providers-recall.20260619.bak
@@ -1,0 +1,232 @@
+name: llm.rb work session - add support for a new LLM provider
+repo: llm.rb
+# Single-prompt session bench (run via bench/bench-sense-local.sh): all steps are
+# presented in ONE prompt and worked in order, so context accumulates the way a
+# real work session does. Rendered to the agent: the description + each step's
+# name and prompt ONLY (checks/gold are NOT shown). Everything rendered is kept
+# NEUTRAL, it states the task, never the answer's shape, file paths, class or
+# method names, counts, or which tool to reach for. This is a SMALL gem, so it
+# goes DEEPER than "list the providers": each provider is a Provider subclass plus
+# a factory method (LLM.openai) AND a parallel set of components in its own subdir
+#, request_adapter (build the HTTP request), response_adapter (parse it),
+# stream_parser (parse streamed chunks), error_handler (map HTTP errors to typed
+# errors), models. A new provider must add an entry in EACH parallel family; thin
+# providers (DeepSeek) reuse a richer one's components by inheritance, a
+# grep-invisible reuse. The Provider base blast is 44. The headline is CUMULATIVE
+# efficiency (tool calls, billed + context tokens, time) at held accuracy.
+description: 'You are a maintainer about to add support for a new external LLM
+  provider to this library, mirroring how the existing providers are built. Work
+  through the tasks below one at a time; each builds on what you learned in the
+  previous one. Keep every answer concrete with file:line so the next step (and a
+  teammate opening the PR) can act without re-exploring the codebase.'
+steps:
+- name: Orient in the codebase
+  prompt: "Task: orient yourself. In a few sentences plus file paths, what is this
+    project, how is the code organized, and where do the integrations with external
+    LLM providers live along with the shared machinery they are built on, including
+    how a caller obtains a specific provider? Hand the next agent a map so they can
+    act with small, targeted lookups, not a fresh exploration of the codebase. No
+    Explore agents.
+    "
+  checks:
+  - type: word
+    value: Provider
+    required: true
+  - type: word
+    value: provider
+    required: false
+  - type: response_richness
+    value: '3'
+    required: false
+  - type: mcp_tool_used
+    value: sense_search
+    required: false
+    layer: adoption
+  - type: mcp_tool_used
+    value: sense_conventions
+    required: false
+    layer: adoption
+- name: Trace a chat call from the entry point to request and response handling
+  prompt: "Task: trace how a single chat or completion call is routed to a concrete
+    provider and turned into an outgoing request and then a parsed result. Start
+    from how a caller gets a provider and follow it down to where that provider's
+    request is built and its response is parsed. Give file:line for each layer and
+    the order they run.
+    "
+  checks:
+  - type: word
+    value: Provider
+    required: true
+  - type: word
+    value: complete
+    required: false
+    description: Reached a concrete provider contract call
+  - type: response_richness
+    value: '4'
+    required: true
+  - type: mcp_tool_used
+    value: sense_graph
+    required: false
+    layer: adoption
+- name: Map the provider family and its base contract
+  prompt: "Task: a new provider will be built on the same shared base the existing
+    providers use, then customize a few pieces. Map the shared contract such a
+    provider must implement (completion, chat, embeddings, and the capability
+    accessors) and which existing providers customize it and how each differs,
+    including any provider that reuses another's behavior. Be complete with
+    file:line; a missed method is a capability the new provider silently won't
+    support.
+    "
+  checks:
+  - type: word
+    value: Provider
+    required: true
+  - type: word
+    value: complete
+    required: true
+    description: Anchored on a concrete contract method every provider implements
+  - type: response_richness
+    value: '6'
+    required: true
+    description: Enumerated the shared base plus the per-provider customizations
+  - type: contains
+    value: provider.rb
+    required: false
+  - type: no_grep
+    value: no_grep
+    required: false
+    layer: adoption
+  - type: mcp_tool_used
+    value: sense_graph
+    required: false
+    layer: adoption
+- name: Map the per-provider component families
+  prompt: "Task: each provider owns a parallel set of small components, one that
+    builds its outgoing request, one that parses its response into the library's
+    shape, and others. Map these component families and the per-provider
+    implementation of each, and tie each provider's components together. Be
+    complete with file:line; a missed component is a piece the new provider won't
+    have.
+    "
+  checks:
+  - type: word
+    value: adapter
+    required: true
+    description: Found the request/response component families
+  - type: word
+    value: response
+    required: false
+  - type: response_richness
+    value: '6'
+    required: true
+    description: Enumerated the parallel component families across providers
+  - type: mcp_tool_used
+    value: sense_graph
+    required: false
+    layer: adoption
+- name: Map the streaming and error-handling paths
+  prompt: "Task: providers also stream partial results and turn failed HTTP
+    responses into typed errors. Map, per provider, how a streamed response is
+    parsed incrementally and how an HTTP failure becomes a typed error, plus the
+    shared error types they map onto. Be complete with file:line.
+    "
+  checks:
+  - type: word
+    value: stream
+    required: true
+  - type: word
+    value: error
+    required: false
+  - type: response_richness
+    value: '4'
+    required: true
+  - type: mcp_tool_used
+    value: sense_graph
+    required: false
+    layer: adoption
+- name: Find every site that must change to add a new provider
+  prompt: "Task: you will add the new provider. Find every place in the codebase
+    that must change for it to be obtainable, perform requests, parse responses,
+    stream, handle errors, and be tested, including where the shared base is
+    depended on and where a caller obtains it. Be complete and use file:line; a
+    missed site means the new provider is unreachable or untested.
+    "
+  checks:
+  - type: word
+    value: Provider
+    required: true
+  - type: response_richness
+    value: '6'
+    required: true
+    description: Reached the factory, the component families, and the specs
+  - type: contains
+    value: spec
+    required: false
+  - type: mcp_tool_used
+    value: sense_blast
+    required: false
+    layer: adoption
+- name: Produce the edit map
+  prompt: "Task: produce the complete edit map for adding the new provider: which
+    files to create and which to change across each area you explored (the provider
+    class and where a caller obtains it, the request and response components, the
+    streaming and error components), and which specs to add. Use file:line
+    throughout, so a teammate could open the PR from your map alone.
+    "
+  checks:
+  - type: response_richness
+    value: '6'
+    required: true
+  - type: contains
+    value: spec
+    required: false
+  - type: contains
+    value: adapter
+    required: false
+scoring:
+  weights:
+    correctness: 0.70
+    efficiency: 0.30
+# Gold is the multi-component per-provider fan-out, the heart of the task: a new
+# provider needs a Provider subclass, a factory entry, and an entry in EACH
+# parallel component family, request_adapter, response_adapter, stream_parser,
+# error_handler, under its own subdir. Nothing but the provider-name convention
+# links these files, and thin providers reuse a richer one's components by
+# inheritance, so completeness here is exactly what grep misses and Sense's
+# inheritance graph captures. All targets are file-path matched so both mention and
+# cited are scored. Headline is CUMULATIVE efficiency at held accuracy.
+gold:
+  # dispatch, the factory that hands back a provider + the shared base
+  - {id: factory,         group: dispatch,   match: [lib/llm.rb]}
+  - {id: provider-base,   group: dispatch,   match: [lib/llm/provider.rb]}
+  # the provider fan-out (subclasses of LLM::Provider)
+  - {id: prov:openai,     group: providers,  match: [providers/openai.rb]}
+  - {id: prov:anthropic,  group: providers,  match: [providers/anthropic.rb]}
+  - {id: prov:google,     group: providers,  match: [providers/google.rb]}
+  - {id: prov:ollama,     group: providers,  match: [providers/ollama.rb]}
+  - {id: prov:bedrock,    group: providers,  match: [providers/bedrock.rb]}
+  - {id: prov:deepseek,   group: providers,  match: [providers/deepseek.rb]}
+  # request-builder component family
+  - {id: req:openai,      group: request,    match: [providers/openai/request_adapter.rb]}
+  - {id: req:anthropic,   group: request,    match: [providers/anthropic/request_adapter.rb]}
+  - {id: req:google,      group: request,    match: [providers/google/request_adapter.rb]}
+  - {id: req:ollama,      group: request,    match: [providers/ollama/request_adapter.rb]}
+  # response-parser component family
+  - {id: resp:openai,     group: response,   match: [providers/openai/response_adapter.rb]}
+  - {id: resp:anthropic,  group: response,   match: [providers/anthropic/response_adapter.rb]}
+  - {id: resp:google,     group: response,   match: [providers/google/response_adapter.rb]}
+  - {id: resp:ollama,     group: response,   match: [providers/ollama/response_adapter.rb]}
+  # streaming component family
+  - {id: stream:openai,   group: streaming,  match: [providers/openai/stream_parser.rb]}
+  - {id: stream:anthropic,group: streaming,  match: [providers/anthropic/stream_parser.rb]}
+  - {id: stream:google,   group: streaming,  match: [providers/google/stream_parser.rb]}
+  - {id: stream:ollama,   group: streaming,  match: [providers/ollama/stream_parser.rb]}
+  # error-handling component family
+  - {id: err:openai,      group: errors,     match: [providers/openai/error_handler.rb]}
+  - {id: err:anthropic,   group: errors,     match: [providers/anthropic/error_handler.rb]}
+  - {id: err:google,      group: errors,     match: [providers/google/error_handler.rb]}
+  - {id: err:ollama,      group: errors,     match: [providers/ollama/error_handler.rb]}
+  # test matrix, the provider contract spec + per-provider behavior specs
+  - {id: spec:provider,   group: specs,      match: [spec/provider_spec.rb]}
+  - {id: spec:openai-chat,group: specs,      match: [openai/chat_spec.rb]}
+  - {id: spec:openai-stream,group: specs,    match: [openai/stream_parser_spec.rb]}

--- a/bench/scenarios/vertical/ruby-rails/llm.rb.rubric.providers-recall.20260619.bak
+++ b/bench/scenarios/vertical/ruby-rails/llm.rb.rubric.providers-recall.20260619.bak
@@ -1,0 +1,226 @@
+# Per-scenario rubric for the LLM judge layer.
+#
+# Audience block is shared across all steps. Per-step rubrics use the same four
+# criteria (map_quality, specificity, justification, uncertainty) with the
+# canonical 40/25/20/15 weights. The judge scores the answer text first;
+# side-context (wall_time, tokens, completed/failed) is provided for the criteria
+# it bears on, map_quality (did this save downstream exploration?) and
+# uncertainty (was confidence calibrated against effort?).
+#
+# Step names MUST match scenarios/llm.rb.yaml exactly (the judge pairs by name).
+
+audience: |
+  An AI coding agent that will use this answer to add a new external LLM provider
+  to the llm.rb gem with only small, targeted follow-up lookups, not a fresh
+  exploration of the codebase. Score for that audience, not a human reader, not a
+  docs page. A perfect answer leaves the agent ready to create the provider class,
+  its factory entry, and its request/response/stream/error components; a weak
+  answer forces the agent to re-explore the codebase before it can act.
+
+steps:
+  - name: Orient in the codebase
+    criteria:
+      map_quality:
+        weight: 0.40
+        question: |
+          Does the answer hand the agent a usable map: that this is the llm.rb gem,
+          and where providers live, the base (lib/llm/provider.rb), the concrete
+          providers (lib/llm/providers/<name>.rb) each with a subdir of components
+          (lib/llm/providers/<name>/), and the factory methods that hand back a
+          provider (LLM.openai etc. in lib/llm.rb)? Could the agent pick an entry
+          point and start working with only small, targeted lookups?
+      specificity:
+        weight: 0.25
+        question: |
+          Are the cited paths concrete (lib/llm/provider.rb,
+          lib/llm/providers/openai.rb, lib/llm.rb) rather than vague ("the provider
+          layer")? Are abstractions tied to actual files and class names?
+      justification:
+        weight: 0.20
+        question: |
+          Does the answer explain WHY each provider has both a class and a subdir of
+          small components (separation of request building, response parsing,
+          streaming, errors), not just NAME the pieces?
+      uncertainty:
+        weight: 0.15
+        question: |
+          Where the answer is unsure how the provider, components, and factory
+          connect, does it flag that so the agent doesn't act blindly?
+
+  - name: Trace a chat call from the entry point to request and response handling
+    criteria:
+      map_quality:
+        weight: 0.40
+        question: |
+          Does the answer trace the path with file:line: from the factory (LLM.x in
+          lib/llm.rb) returning a provider, through the provider's
+          complete/chat/respond (lib/llm/provider.rb and the concrete provider), into
+          that provider's request_adapter (builds the request) and response_adapter
+          (parses the result)? Could the agent follow the same path for a new
+          provider?
+      specificity:
+        weight: 0.25
+        question: |
+          Are the pieces named exactly (LLM.openai, Provider#complete,
+          request_adapter, response_adapter) with file:line, rather than "the
+          request code"?
+      justification:
+        weight: 0.20
+        question: |
+          Does the answer explain WHY request building and response parsing are
+          separate per-provider components (provider APIs differ in both
+          directions), not just LIST the call chain?
+      uncertainty:
+        weight: 0.15
+        question: |
+          Does the answer flag where the path varies (chat vs complete vs respond,
+          streaming vs buffered) so the agent verifies?
+
+  - name: Map the provider family and its base contract
+    criteria:
+      map_quality:
+        weight: 0.40
+        question: |
+          Does the answer enumerate the shared base (LLM::Provider in
+          lib/llm/provider.rb: the name / complete / chat / embed / respond /
+          responses / images / audio contract raising NotImplementedError) AND the
+          existing providers that implement it (OpenAI, Anthropic, Google, Ollama,
+          Bedrock, DeepSeek, xAI, ...), with file:line and how each differs,
+          including that a thin provider (DeepSeek) reuses a richer one's behavior?
+          This inheritance fan-out is grep-invisible; a strong answer names that
+          breadth and the reuse so the agent knows what to implement vs inherit.
+      specificity:
+        weight: 0.25
+        question: |
+          Are the providers named concretely by file (providers/openai.rb,
+          providers/anthropic.rb) and the contract methods (complete, chat, embed)
+          cited, rather than "the providers"?
+      justification:
+        weight: 0.20
+        question: |
+          Does the answer explain WHY some providers are thin (OpenAI-compatible
+          APIs reuse OpenAI's components), not just LIST the classes?
+      uncertainty:
+        weight: 0.15
+        question: |
+          Does the answer flag any contract method or reuse it could not confirm
+          (a capability a provider lacks, what DeepSeek inherits) so the agent
+          checks?
+
+  - name: Map the per-provider component families
+    criteria:
+      map_quality:
+        weight: 0.40
+        question: |
+          Does the answer map the parallel component families with file:line: the
+          request builders (providers/<name>/request_adapter.rb) and the response
+          parsers (providers/<name>/response_adapter.rb) across providers (OpenAI,
+          Anthropic, Google, Ollama, ...), and tie each provider's components
+          together? A strong answer makes the per-provider component correspondence
+          explicit so the agent creates every piece a new provider needs.
+      specificity:
+        weight: 0.25
+        question: |
+          Are the components named concretely by file
+          (providers/openai/request_adapter.rb,
+          providers/anthropic/response_adapter.rb) rather than "the adapters"?
+      justification:
+        weight: 0.20
+        question: |
+          Does the answer explain WHY these components are per-provider (each API
+          has its own request and response shape), not just LIST them?
+      uncertainty:
+        weight: 0.15
+        question: |
+          Does the answer flag any component it could not confirm (a provider
+          missing one, or reusing another's) so the agent checks before copying a
+          pattern?
+
+  - name: Map the streaming and error-handling paths
+    criteria:
+      map_quality:
+        weight: 0.40
+        question: |
+          Does the answer map, per provider with file:line, the streaming parser
+          (providers/<name>/stream_parser.rb) that handles incremental chunks AND
+          the error handler (providers/<name>/error_handler.rb) that maps HTTP
+          failures to the library's shared typed errors? Could the agent give the
+          new provider correct streaming and error handling without re-reading every
+          file?
+      specificity:
+        weight: 0.25
+        question: |
+          Are the components named exactly (stream_parser, error_handler per
+          provider) with file:line, rather than "the streaming and error code"?
+      justification:
+        weight: 0.20
+        question: |
+          Does the answer explain WHY streaming and error mapping are per-provider
+          (different chunk formats and error bodies) over a shared error type set,
+          not just NAME the pieces?
+      uncertainty:
+        weight: 0.15
+        question: |
+          Does the answer flag where a provider's streaming/error shape differs (a
+          provider with a stream_decoder or no stream parser) so the agent verifies?
+
+  - name: Find every site that must change to add a new provider
+    criteria:
+      map_quality:
+        weight: 0.40
+        question: |
+          Does the answer enumerate the full fan-out: the new provider class
+          (providers/<name>.rb subclassing LLM::Provider, blast 44), the factory
+          method in lib/llm.rb, and the per-provider components
+          (request_adapter, response_adapter, stream_parser, error_handler, models
+          under providers/<name>/), plus the spec matrix? A new provider touches a
+          class, a factory entry, and several parallel component families; a strong
+          answer names that breadth with file:line. Could the agent open the PR from
+          this list?
+      specificity:
+        weight: 0.25
+        question: |
+          Are the sites named concretely (a new providers/<name>.rb, the LLM.<name>
+          factory method, the component files under providers/<name>/) rather than
+          "add the provider and tests"?
+      justification:
+        weight: 0.20
+        question: |
+          Does the answer explain WHY each site is affected (class vs factory vs
+          each component family vs tests), not just LIST them?
+      uncertainty:
+        weight: 0.15
+        question: |
+          Does the answer acknowledge what static reading can miss (which
+          components can be reused vs must be new, the factory registration, fixtures)
+          so the agent knows to verify?
+
+  - name: Produce the edit map
+    criteria:
+      map_quality:
+        weight: 0.40
+        question: |
+          Does the answer produce a complete, actionable edit map: the new files to
+          create (providers/<name>.rb plus the component files under
+          providers/<name>/) and the existing files to change (the LLM.<name>
+          factory in lib/llm.rb, anything the base contract requires) plus the
+          specs, with file:line throughout? Could a teammate open the PR from this
+          map alone?
+      specificity:
+        weight: 0.25
+        question: |
+          Are the files and insertion points concrete (the provider class, the
+          factory method, request_adapter/response_adapter/stream_parser/
+          error_handler files, a spec) rather than "create the provider and add
+          tests"?
+      justification:
+        weight: 0.20
+        question: |
+          Does the answer explain WHY each file is in the map (class vs factory vs
+          which component family), not just LIST files?
+      uncertainty:
+        weight: 0.15
+        question: |
+          Does the answer flag the parts it is least sure about (which components to
+          reuse, the provider's streaming/error shape, fixtures) so the agent
+          confirms before committing?

--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -63,6 +63,11 @@ func ApplyBlastBudget(resp *BlastResponse, budget int) {
 		resp.DirectCallers = resp.DirectCallers[:n-trimStep(n-1)]
 		resp.Truncated = true
 	}
+	// Budget trimming may have dropped callers — recompute the verdict so
+	// "complete" never survives a trim that actually shed dependents.
+	if resp.Completeness != nil {
+		resp.Completeness = blastCompleteness(resp, resp.TotalAffected)
+	}
 }
 
 // trimStep returns how many trailing items to drop this iteration —
@@ -104,6 +109,7 @@ func BuildBlastResponse(ctx context.Context, r blast.Result, files FileLookup, s
 		entry := BlastCaller{
 			Symbol:      qualifiedOrName(c),
 			File:        file,
+			Relation:    "calls " + r.Symbol.Name,
 			LineStart:   c.LineStart,
 			LineEnd:     c.LineEnd,
 			Ref:         FormatRef(file, c.LineStart),
@@ -158,7 +164,7 @@ func BuildBlastResponse(ctx context.Context, r blast.Result, files FileLookup, s
 		if path, ok := files(s.FileID); ok {
 			file = path
 		}
-		entry := BlastCaller{Symbol: qualifiedOrName(s), File: file, LineStart: s.LineStart, LineEnd: s.LineEnd, Ref: FormatRef(file, s.LineStart)}
+		entry := BlastCaller{Symbol: qualifiedOrName(s), File: file, Relation: "inherits " + r.Symbol.Name, LineStart: s.LineStart, LineEnd: s.LineEnd, Ref: FormatRef(file, s.LineStart)}
 		resp.AffectedSubclasses = append(resp.AffectedSubclasses, entry)
 		tier2All = append(tier2All, entry)
 	}
@@ -167,7 +173,7 @@ func BuildBlastResponse(ctx context.Context, r blast.Result, files FileLookup, s
 		if path, ok := files(s.FileID); ok {
 			file = path
 		}
-		entry := BlastCaller{Symbol: qualifiedOrName(s), File: file, LineStart: s.LineStart, LineEnd: s.LineEnd, Ref: FormatRef(file, s.LineStart)}
+		entry := BlastCaller{Symbol: qualifiedOrName(s), File: file, Relation: "composes " + r.Symbol.Name, LineStart: s.LineStart, LineEnd: s.LineEnd, Ref: FormatRef(file, s.LineStart)}
 		resp.AffectedViaComposition = append(resp.AffectedViaComposition, entry)
 		tier2All = append(tier2All, entry)
 	}
@@ -176,7 +182,7 @@ func BuildBlastResponse(ctx context.Context, r blast.Result, files FileLookup, s
 		if path, ok := files(s.FileID); ok {
 			file = path
 		}
-		entry := BlastCaller{Symbol: qualifiedOrName(s), File: file, LineStart: s.LineStart, LineEnd: s.LineEnd, Ref: FormatRef(file, s.LineStart)}
+		entry := BlastCaller{Symbol: qualifiedOrName(s), File: file, Relation: "includes " + r.Symbol.Name, LineStart: s.LineStart, LineEnd: s.LineEnd, Ref: FormatRef(file, s.LineStart)}
 		resp.AffectedViaIncludes = append(resp.AffectedViaIncludes, entry)
 		tier2All = append(tier2All, entry)
 	}
@@ -218,7 +224,44 @@ func BuildBlastResponse(ctx context.Context, r blast.Result, files FileLookup, s
 		EstimatedFileReadsAvoided: uniqueFiles,
 		EstimatedTokensSaved:      uniqueFiles * AvgTokensPerFile,
 	}
+	resp.Completeness = blastCompleteness(&resp, r.TotalAffected)
 	return resp
+}
+
+// blastCompleteness builds the consolidated stop/verify verdict.
+// "complete" means the enumerated set IS the full
+// statically-resolvable dependent set — the agent should act on it and
+// NOT re-grep. It is deliberately conservative: any budget trim, a hit on
+// the direct-caller cap, or affected symbols left un-enumerated downgrades
+// to "partial". Dynamic-dispatch residual is left to index_caveat and
+// never folded into "complete", so the verdict can't over-claim into a
+// duck-typed gap (the Lobsters failure mode).
+func blastCompleteness(resp *BlastResponse, totalAffected int) *Completeness {
+	// total_affected is the engine's count of the direct+indirect caller union.
+	// The inherit/include/compose groups are a re-classification of those SAME
+	// caller IDs by edge kind, not additional symbols, so they must NOT be summed
+	// in — doing so would understate `hidden` and let "complete" mask callers the
+	// tier cap or a trim dropped. Count only the caller union, matching the
+	// denomination of total_affected.
+	enumerated := len(resp.DirectCallers) + len(resp.IndirectCallers)
+	hidden := totalAffected - enumerated
+	if hidden < 0 {
+		hidden = 0
+	}
+	capped := len(resp.DirectCallers) >= tier1Cap
+	if hidden > 0 || capped {
+		return &Completeness{
+			Verdict:  "partial",
+			Resolved: enumerated,
+			Hidden:   hidden,
+			Advice:   "Partial: total_affected is the true count. Narrow with a direction or query a specific name for the rest.",
+		}
+	}
+	return &Completeness{
+		Verdict:  "complete",
+		Resolved: enumerated,
+		Advice:   "Complete resolvable dependent set — act on it, do not re-grep. Dynamic-dispatch residual, if any, is in index_caveat.",
+	}
 }
 
 // BuildDiffBlastResponse assembles one BlastResponse from many

--- a/internal/mcpio/completeness_test.go
+++ b/internal/mcpio/completeness_test.go
@@ -1,0 +1,172 @@
+package mcpio
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/internal/blast"
+	"github.com/luuuc/sense/internal/model"
+)
+
+func TestBlastCompletenessComplete(t *testing.T) {
+	// total_affected counts the direct+indirect caller union. The inherit/
+	// include/compose groups are subset views of those same callers, so they
+	// must NOT inflate the enumerated count — only direct+indirect do.
+	resp := &BlastResponse{
+		DirectCallers:      []BlastCaller{{}, {}, {}, {}, {}},
+		AffectedSubclasses: []BlastCaller{{}, {}}, // a view into DirectCallers, not extra
+	}
+	c := blastCompleteness(resp, 5) // 5 direct enumerated == total
+	if c.Verdict != "complete" {
+		t.Fatalf("verdict = %q, want complete", c.Verdict)
+	}
+	if c.Resolved != 5 {
+		t.Errorf("resolved = %d, want 5 (direct+indirect only)", c.Resolved)
+	}
+	if c.Hidden != 0 {
+		t.Errorf("hidden = %d, want 0", c.Hidden)
+	}
+	if !strings.Contains(c.Advice, "do not re-grep") {
+		t.Errorf("advice missing stop signal: %q", c.Advice)
+	}
+}
+
+// The kind groups must not be summed into the enumerated count — if they were,
+// hidden would be understated and "complete" could mask dropped callers.
+func TestBlastCompletenessIgnoresKindGroupsInCount(t *testing.T) {
+	resp := &BlastResponse{
+		DirectCallers:          []BlastCaller{{}, {}}, // only 2 callers enumerated
+		AffectedSubclasses:     []BlastCaller{{}, {}}, // subset views — must not add
+		AffectedViaIncludes:    []BlastCaller{{}},     // to the count
+		AffectedViaComposition: []BlastCaller{{}},
+	}
+	c := blastCompleteness(resp, 6) // 2 callers vs 6 affected -> 4 hidden
+	if c.Verdict != "partial" {
+		t.Fatalf("verdict = %q, want partial (kind groups must not mask the 4 hidden)", c.Verdict)
+	}
+	if c.Hidden != 4 {
+		t.Errorf("hidden = %d, want 4", c.Hidden)
+	}
+}
+
+func TestBlastCompletenessPartialHidden(t *testing.T) {
+	resp := &BlastResponse{DirectCallers: []BlastCaller{{}, {}}}
+	c := blastCompleteness(resp, 5) // 2 enumerated, 5 affected -> 3 hidden
+	if c.Verdict != "partial" {
+		t.Fatalf("verdict = %q, want partial", c.Verdict)
+	}
+	if c.Hidden != 3 {
+		t.Errorf("hidden = %d, want 3", c.Hidden)
+	}
+}
+
+func TestBlastCompletenessPartialCapped(t *testing.T) {
+	callers := make([]BlastCaller, tier1Cap)
+	resp := &BlastResponse{DirectCallers: callers}
+	// total == enumerated (no hidden), but the cap was hit -> partial.
+	c := blastCompleteness(resp, tier1Cap)
+	if c.Verdict != "partial" {
+		t.Fatalf("verdict = %q, want partial (cap hit)", c.Verdict)
+	}
+}
+
+func TestGraphCompletenessComplete(t *testing.T) {
+	c := graphCompleteness(&GraphResponse{}, 4)
+	if c.Verdict != "complete" {
+		t.Fatalf("verdict = %q, want complete", c.Verdict)
+	}
+	if c.Resolved != 4 {
+		t.Errorf("resolved = %d, want 4", c.Resolved)
+	}
+}
+
+func TestGraphCompletenessPartialLowConfidence(t *testing.T) {
+	c := graphCompleteness(&GraphResponse{LowConfidenceHidden: 2}, 3)
+	if c.Verdict != "partial" {
+		t.Fatalf("verdict = %q, want partial", c.Verdict)
+	}
+	if c.Hidden != 2 {
+		t.Errorf("hidden = %d, want 2", c.Hidden)
+	}
+	if !strings.Contains(c.Advice, "min_confidence") {
+		t.Errorf("advice should point at min_confidence: %q", c.Advice)
+	}
+}
+
+func TestGraphCompletenessPartialOmitted(t *testing.T) {
+	c := graphCompleteness(&GraphResponse{OmittedEdges: 3}, 10)
+	if c.Verdict != "partial" {
+		t.Fatalf("verdict = %q, want partial", c.Verdict)
+	}
+	if !strings.Contains(c.Advice, "token budget") {
+		t.Errorf("advice should mention token budget: %q", c.Advice)
+	}
+}
+
+func TestGraphCompletenessPartialTruncated(t *testing.T) {
+	c := graphCompleteness(&GraphResponse{Truncated: true}, 10)
+	if c.Verdict != "partial" {
+		t.Fatalf("verdict = %q, want partial", c.Verdict)
+	}
+}
+
+// BuildBlastResponse should stamp a per-caller relation reflecting the edge
+// kind of the bucket each affected symbol came from.
+func TestBuildBlastResponseRelation(t *testing.T) {
+	r := blast.Result{
+		Symbol:                 model.Symbol{ID: 1, Name: "Hub", Qualified: "Hub"},
+		Risk:                   blast.RiskLow,
+		DirectCallers:          []model.Symbol{{ID: 10, Qualified: "Caller", FileID: 2}},
+		AffectedSubclasses:     []model.Symbol{{ID: 11, Qualified: "Sub", FileID: 2}},
+		AffectedViaIncludes:    []model.Symbol{{ID: 12, Qualified: "Inc", FileID: 2}},
+		AffectedViaComposition: []model.Symbol{{ID: 13, Qualified: "Comp", FileID: 2}},
+		AffectedTests:          []string{},
+		TotalAffected:          4,
+	}
+	files := func(id int64) (string, bool) {
+		if id == 2 {
+			return "x.rb", true
+		}
+		return "", false
+	}
+	resp := BuildBlastResponse(context.Background(), r, files, nil)
+
+	if got := resp.DirectCallers[0].Relation; got != "calls Hub" {
+		t.Errorf("direct relation = %q, want %q", got, "calls Hub")
+	}
+	if got := resp.AffectedSubclasses[0].Relation; got != "inherits Hub" {
+		t.Errorf("subclass relation = %q, want %q", got, "inherits Hub")
+	}
+	if got := resp.AffectedViaIncludes[0].Relation; got != "includes Hub" {
+		t.Errorf("include relation = %q, want %q", got, "includes Hub")
+	}
+	if got := resp.AffectedViaComposition[0].Relation; got != "composes Hub" {
+		t.Errorf("composition relation = %q, want %q", got, "composes Hub")
+	}
+	if resp.Completeness == nil {
+		t.Error("completeness should be set on every blast response")
+	}
+}
+
+// A budget trim that drops callers must downgrade a "complete" verdict so it
+// never survives a trim that actually shed dependents.
+func TestApplyBlastBudgetDowngradesCompleteness(t *testing.T) {
+	var callers []BlastCaller
+	for i := 0; i < 50; i++ {
+		callers = append(callers, BlastCaller{Symbol: "C", File: "f.rb", Relation: "calls Hub"})
+	}
+	resp := &BlastResponse{
+		Symbol:        "Hub",
+		DirectCallers: callers,
+		TotalAffected: 50,
+		Completeness:  &Completeness{Verdict: "complete", Resolved: 50},
+	}
+	ApplyBlastBudget(resp, 200) // tiny budget forces a caller trim
+	if !resp.Truncated {
+		t.Fatal("expected Truncated after trim")
+	}
+	if resp.Completeness.Verdict != "partial" {
+		t.Errorf("verdict = %q, want partial after trim", resp.Completeness.Verdict)
+	}
+}

--- a/internal/mcpio/graph.go
+++ b/internal/mcpio/graph.go
@@ -249,7 +249,30 @@ func BuildGraphResponse(ctx context.Context, sc *model.SymbolContext, files File
 		EstimatedFileReadsAvoided: uniqueFiles,
 		EstimatedTokensSaved:      uniqueFiles * AvgTokensPerFile,
 	}
+	resp.Completeness = graphCompleteness(&resp, symbolsReturned)
 	return resp
+}
+
+// graphCompleteness builds the consolidated stop/verify verdict for a
+// graph response, reusing the existing
+// low_confidence_hidden / omitted_edges / truncated signals so the agent
+// can branch on ONE field. "complete" means nothing was filtered or
+// dropped; otherwise "partial" with the hidden count and how to widen.
+// Dynamic-dispatch residual stays in index_caveat, never folded in here.
+func graphCompleteness(resp *GraphResponse, symbolsReturned int) *Completeness {
+	hidden := resp.LowConfidenceHidden + resp.OmittedEdges
+	if resp.Truncated || hidden > 0 {
+		advice := "Partial: re-run with min_confidence=0.3 or a specific direction to see the rest."
+		if resp.OmittedEdges > 0 {
+			advice = "Partial: edges dropped for token budget — narrow with a direction or a specific symbol."
+		}
+		return &Completeness{Verdict: "partial", Resolved: symbolsReturned, Hidden: hidden, Advice: advice}
+	}
+	return &Completeness{
+		Verdict:  "complete",
+		Resolved: symbolsReturned,
+		Advice:   "Complete resolvable edge set — act on it, do not re-grep. Dynamic-dispatch residual, if any, is in index_caveat.",
+	}
 }
 
 // BuildFullGraphResponse builds the complete response for a multi-hop
@@ -276,6 +299,9 @@ func BuildFullGraphResponse(ctx context.Context, gr *model.GraphResult, files Fi
 		resp.SenseMetrics.EstimatedFileReadsAvoided = uniqueFiles
 		resp.SenseMetrics.EstimatedTokensSaved = uniqueFiles * AvgTokensPerFile
 	}
+	// Layer truncation is known only here — recompute the verdict so a
+	// multi-hop trim downgrades "complete" honestly.
+	resp.Completeness = graphCompleteness(&resp, resp.SenseMetrics.SymbolsReturned)
 	return resp
 }
 

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -115,6 +115,8 @@ type GraphResponse struct {
 	CoverageNote string `json:"coverage_note,omitempty"`
 	VerifyHint   string `json:"verify_hint,omitempty"`
 	IndexCaveat  string `json:"index_caveat,omitempty"`
+	// Completeness is the consolidated stop/verify verdict.
+	Completeness *Completeness `json:"completeness,omitempty"`
 	// ViewEdges is the per-subject view-reachability signal: "present" when a
 	// view template reaches this symbol, "none" when view-dispatch is a live
 	// question for it but no view edge exists, "" (omitted) otherwise. See
@@ -314,6 +316,8 @@ type BlastResponse struct {
 
 	VerifyHint  string `json:"verify_hint,omitempty"`
 	IndexCaveat string `json:"index_caveat,omitempty"`
+	// Completeness is the consolidated stop/verify verdict.
+	Completeness *Completeness `json:"completeness,omitempty"`
 	// ViewEdges is the per-subject view-reachability signal: "present" when a
 	// view template reaches this symbol, "none" when view-dispatch is a live
 	// question for it but no view edge exists, "" (omitted) otherwise. See
@@ -333,13 +337,40 @@ type BlastTierSummary struct {
 
 // BlastCaller is the shape of a direct_callers entry.
 type BlastCaller struct {
-	Symbol      string    `json:"symbol"`
-	File        string    `json:"file"`
+	Symbol string `json:"symbol"`
+	File   string `json:"file"`
+	// Relation is a one-line "how this reaches the subject" phrase
+	// (calls / inherits / includes / composes <subject>), so the agent
+	// knows the edge kind per entry without re-opening the file. The kind
+	// is already known from which bucket the entry came from; surfacing it
+	// inline is what lets the agent act without a follow-up read.
+	Relation    string    `json:"relation,omitempty"`
 	LineStart   int       `json:"line_start,omitempty"`
 	LineEnd     int       `json:"line_end,omitempty"`
 	Ref         string    `json:"ref,omitempty"`
 	ViaTemporal bool      `json:"via_temporal,omitempty"`
 	CallSite    *CallSite `json:"call_site,omitempty"`
+}
+
+// Completeness is a single, machine-branchable verdict on whether the
+// returned set is the full *statically resolvable* dependent set, so the
+// agent can decide to STOP searching vs verify specific names. "complete"
+// deliberately covers ONLY resolvable static edges — dynamic-dispatch
+// residual is reported separately in index_caveat and is NEVER folded into
+// "complete", so the verdict can't over-claim into a duck-typed gap.
+//
+// It is the DERIVED top-level branch point, computed from the granular
+// signals that still ship alongside it (low_confidence_hidden, omitted_edges,
+// truncated for graph; total_affected and the tier cap for blast). Those
+// remain because they carry detail the verdict collapses (which floor, how
+// many, why); Completeness is the one field a consumer should branch on.
+// Resolved is "items enumerated in this response": direct+indirect callers
+// for blast, edges returned for graph.
+type Completeness struct {
+	Verdict  string `json:"verdict"`          // "complete" | "partial"
+	Resolved int    `json:"resolved"`         // edges enumerated in this response
+	Hidden   int    `json:"hidden,omitempty"` // affected symbols not enumerated (budget/cap)
+	Advice   string `json:"advice"`
 }
 
 // BlastIndirect is the shape of an indirect_callers entry. Via names

--- a/internal/mcpserver/oracle_test.go
+++ b/internal/mcpserver/oracle_test.go
@@ -163,7 +163,9 @@ func oracleDigest(t *testing.T, calls []labeledCall) (string, []string) {
 // detectors, so the `conventions` response's structure line moved from counting
 // the fixture's test function to domain-only (internal/auth/ "3 of 6"). No other
 // response changed.
-const oracleGolden = "131642008d18c908ba84202b29570a7822c92b80dbbaa4e2c2231e9519b4a181"
+// Added the `completeness` verdict to blast/graph responses and per-caller
+// `relation` to blast callers (terminal payloads) — digest moved.
+const oracleGolden = "250acefd023052c452684b7c0f1dc344e9c9c42c3aad39358511d8b81659851b"
 
 func TestMCPServerResponseOracle(t *testing.T) {
 	got, content := oracleDigest(t, collectOracleCalls(t))


### PR DESCRIPTION
## Problem
`sense_blast`/`sense_graph` returned the resolved dependent set but gave the agent no signal of whether that set was *complete*, and no per-result indication of *how* each result reaches the subject. So the agent treated results as new leads — re-grepping and re-reading files it already had structurally — which made Sense cost more than it should on tasks where it was already correct.

## Summary
Make the responses terminal: add a single `completeness` verdict the agent can branch on (stop vs verify) and a per-caller `relation` naming the edge kind, so the agent acts on the resolved set instead of re-exploring.

## Changes
- **`completeness` block** on blast and graph: `verdict` (`complete`|`partial`), `resolved`/`hidden` counts, and `advice`. `complete` is conservative — it covers only the statically resolvable set and never folds in dynamic-dispatch residual (that stays in `index_caveat`), so it cannot over-claim into a duck-typed gap.
- `hidden` is computed from the direct+indirect caller union (matching `total_affected`); the inherit/include/compose groups are subset views and are not double-counted, so a trimmed or capped response correctly degrades to `partial` (recomputed after budget trimming).
- **Per-result `relation`** on blast callers (`calls`/`inherits`/`includes`/`composes <subject>`) so the edge kind is explicit without opening the file.
- **Bench reporter** ranks results by objective `cited_recall` + reference-aware `relationship_audit` instead of the omission-blind `fairness`/`llm_quality` composite (which had rated a +0.44 recall win as a tie); blind composite relabeled diagnostic-only, with a guard test.
- chore: gitignore the built bench binary; opencode stall/short-answer retry guard; fixture + scenario-backup refresh.

## Test Plan
- [x] `make ci` green (race-coverage 95%, 0 lint, ledger 0)
- [x] `internal/mcpio` unit tests cover both verdict branches (complete / hidden / capped), the relation stamping, and the budget-trim downgrade
- [x] response oracle digest updated for the new fields
- [x] `python3 -m pytest bench/lib/test_reporter.py` (incl. the rank-by-recall guard)
- [x] `sense blast`/`sense graph` verified to emit the new fields on a live index