### PR TITLE
feat(blast): right-size sense_blast MCP output

### DIFF
--- a/bench/opencode-run.sh
+++ b/bench/opencode-run.sh
@@ -42,9 +42,9 @@ source "$BENCH_DIR/lib/bench-paths.sh"
 LIB_DIR="$BENCH_DIR/lib"
 SENSE_BENCH_ROOT="${SENSE_BENCH_ROOT:-$(cd "$PROJECT_ROOT/.." && pwd)/sense-benchmark}"
 
-TOOLS_CSV="baseline,sense"; REPO=""; MODEL="ollama-cloud/deepseek-v4-pro"
+TOOLS_CSV="baseline,sense"; REPO=""; MODEL="kimi-for-coding/k2p7"
 SESSION_TIMEOUT=""; KEEP_RAW=0
-# Stability knobs (ollama-cloud over opencode is flaky). See the watchdog below.
+# Stability knobs (cloud/subscription providers over opencode can be flaky). See the watchdog below.
 OPENCODE_MAX_SECS="${OPENCODE_MAX_SECS:-1200}"     # hard ceiling floor (was a flat 600 that killed slow-but-working sense runs)
 OPENCODE_FIRST_GRACE="${OPENCODE_FIRST_GRACE:-240}" # allow this long for the FIRST streamed byte (MCP cold start); 0 bytes past it = a hang
 OPENCODE_STALL_IDLE="${OPENCODE_STALL_IDLE:-150}"   # after output starts, kill only if the stream goes silent this long (stuck mid-run)
@@ -244,11 +244,11 @@ meta = {
     "tool": tool, "repo": repo, "scenario": scen,
     "wall_time_seconds": int(wall), "model": model,
     "repo_commit": commit or None, "tool_version": ver or None,
-    "harness": "opencode", "provider": "ollama-cloud",
+    "harness": "opencode", "provider": (model.split("/", 1)[0] if "/" in model else "opencode"),
     "auth_mode": "opencode_cli", "mode": "single_prompt",
     "opencode_exit_code": rc, "attempts": int(attempts), "output_tokens": otok,
     "answer_chars": achars,
-    "cost_usd_note": "ollama-cloud bills off-platform; per-token cost left null",
+    "cost_usd_note": "opencode subscription bills off-platform; per-token cost left null",
 }
 kind = KIND.get(rc, "opencode_session_failed")
 if kind:

--- a/bench/runs-variance.sh
+++ b/bench/runs-variance.sh
@@ -58,7 +58,8 @@ for m in $MODELS; do
   # RUNS times and file each invocation's flat output into a run-N/ subdir, giving
   # variance-row.py / pergroup.py the same run-N shape on every harness.
   case "$m" in
-    *:cloud|ollama-cloud/*|ollama/*) runner=(bash bench/opencode-run.sh --tool baseline,sense --repo "$REPO" --model "$m"); per_run=1 ;;
+    kimi-for-coding/*|zai-coding-plan/*|zhipuai-coding-plan/*|minimax-coding-plan/*|minimax-cn-coding-plan/*|alibaba-coding-plan/*|alibaba-coding-plan-cn/*|moonshotai/*|moonshotai-cn/*|*:cloud|ollama-cloud/*|ollama/*) \
+                                     runner=(bash bench/opencode-run.sh --tool baseline,sense --repo "$REPO" --model "$m"); per_run=1 ;;
     codex:*)                         runner=(bash bench/codex-run.sh    --tool baseline,sense --repo "$REPO" --model "${m#codex:}"); per_run=1 ;;
     gpt-*|o3*|o4*)                   runner=(bash bench/codex-run.sh    --tool baseline,sense --repo "$REPO" --model "$m"); per_run=1 ;;
     *)                               runner=(bash bench/bench-sense-local.sh --tool baseline,sense --repo "$REPO" --no-build --model "$m" --runs "$RUNS"); per_run=0 ;;

--- a/bench/sweep-rails.sh
+++ b/bench/sweep-rails.sh
@@ -55,7 +55,7 @@ for m in $MODELS; do
     #   codex ids (gpt-5.x, or a codex: prefix) -> codex
     #   everything else (claude-*) -> the subscription Claude runner
     case "$m" in
-      *:cloud|ollama-cloud/*|ollama/*)
+      kimi-for-coding/*|zai-coding-plan/*|zhipuai-coding-plan/*|minimax-coding-plan/*|minimax-cn-coding-plan/*|alibaba-coding-plan/*|alibaba-coding-plan-cn/*|moonshotai/*|moonshotai-cn/*|*:cloud|ollama-cloud/*|ollama/*)
         run=(bash bench/opencode-run.sh --tool baseline,sense --repo "$r" --model "$m") ;;
       codex:*)
         run=(bash bench/codex-run.sh --tool baseline,sense --repo "$r" --model "${m#codex:}") ;;

--- a/internal/blast/engine.go
+++ b/internal/blast/engine.go
@@ -169,6 +169,15 @@ type Result struct {
 	// keyed by symbol ID. Used for call-site snippet generation.
 	DirectEdgeSites map[int64]EdgeSite
 
+	// DirectConfidence records the cumulative path confidence for each
+	// direct caller, keyed by symbol ID. This is the same score the
+	// engine ranks by at the MaxResults cap boundary (capResults). Response
+	// shapers use it to enumerate the highest-confidence subset inline when
+	// the full direct list is capped: only enumerated callers carry
+	// file:line and are citable, so the enumerated slice must be the most
+	// relevant callers, not an arbitrary (ID-ordered) prefix.
+	DirectConfidence map[int64]float64
+
 	EdgesTraversed    int
 	SubjectHasCallees bool
 	// ViewReached is true when a view template (ERB) reaches the subject via a
@@ -248,7 +257,7 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 	}
 
 	isSelf := selfMethodPredicate(subject, seedSet)
-	directCallers, directTemporalIDs, directEdgeSites, excludedD := state.buildDirectCallers(directIDs, symbolsByID, isSelf)
+	directCallers, directTemporalIDs, directEdgeSites, directConfidence, excludedD := state.buildDirectCallers(directIDs, symbolsByID, isSelf)
 	indirectCallers, excludedI := state.buildIndirectCallers(indirectIDs, symbolsByID, isSelf)
 	totalAffectedCount -= excludedD + excludedI
 
@@ -277,6 +286,7 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 		ViewReached:            viewReached,
 		DirectTemporalIDs:      directTemporalIDs,
 		DirectEdgeSites:        directEdgeSites,
+		DirectConfidence:       directConfidence,
 		AffectedSubclasses:     subclasses,
 		AffectedViaComposition: viaComposition,
 		AffectedViaIncludes:    viaIncludes,
@@ -607,14 +617,16 @@ func selfMethodPredicate(subject model.Symbol, seedSet map[int64]struct{}) selfM
 }
 
 // buildDirectCallers hydrates the direct-caller IDs into symbols (skipping the
-// subject's own members), recording which were reached via a temporal edge and
-// each one's edge site. Returns the callers, the temporal-ID set, the edge-site
-// map, and the count excluded as self-members.
-func (s *bfsState) buildDirectCallers(directIDs []int64, symbolsByID map[int64]model.Symbol, isSelf selfMethodFn) ([]model.Symbol, map[int64]bool, map[int64]EdgeSite, int) {
+// subject's own members), recording which were reached via a temporal edge,
+// each one's edge site, and its cumulative path confidence. Returns the
+// callers, the temporal-ID set, the edge-site map, the confidence map, and the
+// count excluded as self-members.
+func (s *bfsState) buildDirectCallers(directIDs []int64, symbolsByID map[int64]model.Symbol, isSelf selfMethodFn) ([]model.Symbol, map[int64]bool, map[int64]EdgeSite, map[int64]float64, int) {
 	excluded := 0
 	callers := make([]model.Symbol, 0, len(directIDs))
 	temporalIDs := map[int64]bool{}
 	edgeSites := make(map[int64]EdgeSite, len(directIDs))
+	confidence := make(map[int64]float64, len(directIDs))
 	for _, id := range directIDs {
 		sym, ok := symbolsByID[id]
 		if !ok {
@@ -631,9 +643,10 @@ func (s *bfsState) buildDirectCallers(directIDs []int64, symbolsByID map[int64]m
 		if es, ok := s.edgeSites[id]; ok {
 			edgeSites[id] = es
 		}
+		confidence[id] = s.pathConf[id]
 	}
 	sortSymbolsByID(callers)
-	return callers, temporalIDs, edgeSites, excluded
+	return callers, temporalIDs, edgeSites, confidence, excluded
 }
 
 // buildIndirectCallers hydrates the indirect-caller IDs into CallerHops

--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -3,12 +3,39 @@ package mcpio
 import (
 	"context"
 	"fmt"
+	"path"
+	"sort"
 
 	"github.com/luuuc/sense/internal/blast"
 )
 
 const (
-	tier1Cap         = 200
+	tier1Cap = 200
+	// directEnumCap bounds how many direct callers are enumerated inline.
+	// On a high-fan-out hub a flat dump of all (up to tier1Cap) direct
+	// callers is ~9k tokens in one tool result; the agent rarely needs the
+	// full list as line-addressable entries. direct_callers_by_area carries
+	// the true magnitude and structural shape, total_affected the true
+	// count, so enumerating only the top slice keeps the response small
+	// without hiding how big the radius is. The enumerated entries are the
+	// actionable subset; the by-area map is the map of the rest. The
+	// enumerated subset is the highest-confidence slice (see
+	// BuildBlastResponse), so a modest cap still surfaces the most relevant
+	// callers, still far under tier1Cap. 60 was chosen to hold recall: it
+	// kept Opus's discourse cited-recall flat across three runs (30 was too
+	// aggressive and dropped it). The weak/throttled-model case is NOT
+	// proven safe — that bench scenario is too noisy to discriminate (see
+	// the project memory on the small-subscription bench). directEnumCap and
+	// BlastTokenBudget are two distinct knobs: this caps the COUNT of
+	// enumerated callers; the budget is the token backstop that trims
+	// further only when the enumerated subset (with its snippets) is itself
+	// large enough to exceed the budget — at this cap it rarely fires.
+	directEnumCap = 60
+	// indirectEnumCap bounds the enumerated indirect_callers list. Indirect
+	// callers are the weakest "what breaks?" signal (reached via N hops);
+	// capping them keeps a high-fan-out blast small. total_affected still
+	// reports every indirect caller in the radius.
+	indirectEnumCap  = 20
 	tier2ExamplesCap = 5
 	// blastTestExamplesCap bounds the affected-test sample kept when a
 	// response must be trimmed to fit a token budget. tests_affected_count
@@ -99,7 +126,10 @@ func BuildBlastResponse(ctx context.Context, r blast.Result, files FileLookup, s
 
 	hasTiers := len(r.SymbolTiers) > 0
 	tier1Count := 0
+	directTier1 := 0
 	var tier2All []BlastCaller
+
+	var tier1Direct []rankedCaller
 
 	for _, c := range r.DirectCallers {
 		var file string
@@ -118,17 +148,41 @@ func BuildBlastResponse(ctx context.Context, r blast.Result, files FileLookup, s
 		}
 
 		if !hasTiers || r.SymbolTiers[c.ID] == blast.TierBreaks {
-			if tier1Count < tier1Cap {
-				resp.DirectCallers = append(resp.DirectCallers, entry)
-				tier1Count++
-			}
+			// Every tier-1 direct caller feeds the by-area map (the true
+			// structural shape), but only directEnumCap are enumerated
+			// inline (the actionable subset).
+			addArea(&resp.DirectCallersByArea, file)
+			directTier1++
+			tier1Direct = append(tier1Direct, rankedCaller{entry: entry, area: areaOf(file), id: c.ID, conf: r.DirectConfidence[c.ID]})
 		} else {
 			tier2All = append(tier2All, entry)
 		}
 	}
+
+	// Enumerate inline breadth-first across areas. Only the enumerated
+	// callers carry file:line and are citable, so the subset must span the
+	// blast radius rather than sample one corner of it. On a high-fan-out
+	// hub every direct caller often has confidence 1.0, so a flat conf-DESC
+	// rank degenerates to id-ASC, and IDs cluster by scan directory — the
+	// top-cap slice ends up entirely in one big low-ID area while every
+	// scattered area is crowded out. Instead: group by area, then round-
+	// robin so each area surfaces its best exemplar before any area
+	// surfaces a second. Within an area the exemplar is the existing signal
+	// (confidence DESC, then ID ASC); areas are visited by descending area
+	// count, tiebreak area-name ASC, so the selection and its order are
+	// fully deterministic. The by-area map and total_affected still carry
+	// the full magnitude.
+	resp.DirectCallers = enumerateByArea(tier1Direct, directEnumCap)
+	// Charge the full tier-1 direct count against the shared tier1Cap so
+	// indirect enumeration keeps its prior ceiling even though only the top
+	// directEnumCap direct callers are enumerated inline. Indirect callers
+	// are additionally bounded by indirectEnumCap: on a high-fan-out hub they
+	// must not expand to fill the room freed by capping the direct list, or
+	// the response stays large for the weakest signal.
+	tier1Count = directTier1
 	for _, hop := range r.IndirectCallers {
 		if !hasTiers || r.SymbolTiers[hop.Symbol.ID] == blast.TierBreaks {
-			if tier1Count < tier1Cap {
+			if tier1Count < tier1Cap && len(resp.IndirectCallers) < indirectEnumCap {
 				var file string
 				if path, ok := files(hop.Symbol.FileID); ok {
 					file = path
@@ -248,7 +302,11 @@ func blastCompleteness(resp *BlastResponse, totalAffected int) *Completeness {
 	if hidden < 0 {
 		hidden = 0
 	}
-	capped := len(resp.DirectCallers) >= tier1Cap
+	// The enumerated direct_callers are capped at directEnumCap; the by-area
+	// map carries the full tier-1 direct count. If more direct callers exist
+	// than were enumerated, the response is partial even when total_affected
+	// happens to match (e.g. all callers are direct and there are >cap of them).
+	capped := sumAreas(resp.DirectCallersByArea) > len(resp.DirectCallers)
 	if hidden > 0 || capped {
 		return &Completeness{
 			Verdict:  "partial",
@@ -359,6 +417,128 @@ func BuildDiffBlastResponse(ctx context.Context, ref string, results []blast.Res
 		EstimatedTokensSaved:      uniqueFiles * AvgTokensPerFile,
 	}
 	return resp
+}
+
+// rankedCaller pairs a tier-1 direct caller's wire entry with the keys
+// that drive area-stratified enumeration: area groups callers into
+// subsystems, conf/id pick the exemplar within an area.
+type rankedCaller struct {
+	entry BlastCaller
+	area  string
+	id    int64
+	conf  float64
+}
+
+// areaOf returns the subsystem key for a file — its parent directory,
+// the same key addArea tallies. An unresolved file falls under ".".
+func areaOf(file string) string {
+	if file == "" {
+		return "."
+	}
+	return path.Dir(file)
+}
+
+// enumerateByArea selects up to cap direct callers breadth-first across
+// areas. Each area contributes its best exemplar before any area
+// contributes a second, so a small scattered area (lib/email) surfaces a
+// citable exemplar instead of being crowded out by a big low-ID area.
+// Areas are visited by descending member count, tiebreak area-name ASC;
+// within an area the exemplar order is the existing signal (confidence
+// DESC, then ID ASC). The returned slice is area-clustered in that same
+// visitation order, so the reader sees the enumerated callers by
+// subsystem. Selection and order are deterministic across builds.
+//
+// When the callers span MORE areas than limit, round-robin seats one per
+// area, so the most-populated limit areas each get an exemplar and the
+// smaller tail is represented only in direct_callers_by_area — summarised,
+// never hidden (see TestBuildBlastResponseMoreAreasThanCap). Descending
+// count means a bigger (more-affected) subsystem is never dropped for a
+// one-off; the long tail loses its inline exemplar but keeps its true
+// count in by_area, which is what makes that tradeoff acceptable.
+func enumerateByArea(callers []rankedCaller, limit int) []BlastCaller {
+	if len(callers) == 0 || limit <= 0 {
+		return nil
+	}
+
+	// Bucket by area, then rank within each bucket by the existing signal.
+	buckets := map[string][]rankedCaller{}
+	for _, rc := range callers {
+		buckets[rc.area] = append(buckets[rc.area], rc)
+	}
+	areas := make([]string, 0, len(buckets))
+	for area, b := range buckets {
+		sort.SliceStable(b, func(i, j int) bool {
+			if b[i].conf != b[j].conf {
+				return b[i].conf > b[j].conf
+			}
+			return b[i].id < b[j].id
+		})
+		buckets[area] = b
+		areas = append(areas, area)
+	}
+	// Deterministic area visitation: most-populated first (its breadth is
+	// most worth sampling), tiebreak by area name so two equal-count areas
+	// always order the same way.
+	sort.SliceStable(areas, func(i, j int) bool {
+		if len(buckets[areas[i]]) != len(buckets[areas[j]]) {
+			return len(buckets[areas[i]]) > len(buckets[areas[j]])
+		}
+		return areas[i] < areas[j]
+	})
+
+	// Round-robin: rank r takes the r-th exemplar from every area in turn,
+	// so each area surfaces its best before any surfaces a second. Stop at
+	// cap. Areas that received a slot in this pass are emitted
+	// area-clustered (in visitation order) so the reader groups them by
+	// subsystem; the round-robin only decides WHICH callers are chosen.
+	chosen := map[string][]BlastCaller{}
+	picked := 0
+	for rank := 0; picked < limit; rank++ {
+		progressed := false
+		for _, area := range areas {
+			b := buckets[area]
+			if rank >= len(b) {
+				continue
+			}
+			progressed = true
+			chosen[area] = append(chosen[area], b[rank].entry)
+			picked++
+			if picked >= limit {
+				break
+			}
+		}
+		if !progressed {
+			break // every area exhausted
+		}
+	}
+
+	out := make([]BlastCaller, 0, picked)
+	for _, area := range areas {
+		out = append(out, chosen[area]...)
+	}
+	return out
+}
+
+// addArea increments the by-area tally for a caller's file directory.
+// The area is the file's parent directory — coarse enough to name a
+// subsystem (app/models, app/jobs) yet fine enough to distinguish them.
+// A file at the repo root, or a caller with no resolved file, falls under
+// ".". The map is lazily allocated so a zero-caller blast omits the field.
+func addArea(m *map[string]int, file string) {
+	if *m == nil {
+		*m = make(map[string]int)
+	}
+	(*m)[areaOf(file)]++
+}
+
+// sumAreas totals the by-area direct-caller tally — the true tier-1
+// direct count, even when direct_callers enumerates only the top slice.
+func sumAreas(m map[string]int) int {
+	n := 0
+	for _, v := range m {
+		n += v
+	}
+	return n
 }
 
 func countUniqueBlastFiles(resp BlastResponse) int {

--- a/internal/mcpio/blast_test.go
+++ b/internal/mcpio/blast_test.go
@@ -148,9 +148,10 @@ func TestBuildBlastResponseViaTemporal(t *testing.T) {
 	}
 }
 
-func TestBuildBlastResponseTier1Cap(t *testing.T) {
-	// Build a Result with 250 Tier-1 (calls-edge) direct callers.
-	// The response should cap at 200.
+func TestBuildBlastResponseDirectEnumCap(t *testing.T) {
+	// Build a Result with 250 Tier-1 (calls-edge) direct callers. The
+	// enumerated direct_callers list is bounded at directEnumCap, but the
+	// by-area map and total_affected preserve the true magnitude.
 	var directCallers []model.Symbol
 	tiers := make(map[int64]blast.Tier)
 	for i := int64(1); i <= 250; i++ {
@@ -173,11 +174,379 @@ func TestBuildBlastResponseTier1Cap(t *testing.T) {
 
 	resp := BuildBlastResponse(context.Background(), r, noFiles, nil)
 
-	if len(resp.DirectCallers) != 200 {
-		t.Errorf("DirectCallers = %d, want 200 (tier1 cap)", len(resp.DirectCallers))
+	if len(resp.DirectCallers) != directEnumCap {
+		t.Errorf("DirectCallers = %d, want %d (direct enum cap)", len(resp.DirectCallers), directEnumCap)
+	}
+	// by-area carries the full tier-1 direct count even though only the top
+	// slice is enumerated. noFiles → all callers fall under the "." area.
+	if got := sumAreas(resp.DirectCallersByArea); got != 250 {
+		t.Errorf("by-area sum = %d, want 250 (full direct count preserved)", got)
 	}
 	if resp.TotalAffected != 250 {
 		t.Errorf("TotalAffected = %d, want 250 (pre-cap count preserved)", resp.TotalAffected)
+	}
+}
+
+func TestBuildBlastResponseByAreaTruthful(t *testing.T) {
+	// 40 direct callers across three subsystems: 30 under app/models,
+	// 7 under app/jobs, 3 under lib/foo. Only directEnumCap are enumerated
+	// inline, but the by-area map must report all 40 grouped by directory so
+	// the agent sees the structural shape and true total.
+	type area struct {
+		dir string
+		n   int
+	}
+	areas := []area{{"app/models", 70}, {"app/jobs", 7}, {"lib/foo", 3}}
+	var directCallers []model.Symbol
+	tiers := make(map[int64]blast.Tier)
+	paths := map[int64]string{}
+	var id int64
+	for _, a := range areas {
+		for i := 0; i < a.n; i++ {
+			id++
+			directCallers = append(directCallers, model.Symbol{ID: id, Qualified: fmt.Sprintf("C%d", id), FileID: id})
+			tiers[id] = blast.TierBreaks
+			paths[id] = fmt.Sprintf("%s/file%d.rb", a.dir, i)
+		}
+	}
+	files := func(fid int64) (string, bool) { p, ok := paths[fid]; return p, ok }
+
+	r := blast.Result{
+		Symbol:        model.Symbol{ID: 0, Qualified: "Subject"},
+		DirectCallers: directCallers,
+		AffectedTests: []string{},
+		TotalAffected: 30,
+		SymbolTiers:   tiers,
+	}
+
+	resp := BuildBlastResponse(context.Background(), r, files, nil)
+
+	if len(resp.DirectCallers) != directEnumCap {
+		t.Errorf("enumerated direct_callers = %d, want %d", len(resp.DirectCallers), directEnumCap)
+	}
+	want := map[string]int{"app/models": 70, "app/jobs": 7, "lib/foo": 3}
+	for dir, n := range want {
+		if resp.DirectCallersByArea[dir] != n {
+			t.Errorf("by_area[%q] = %d, want %d", dir, resp.DirectCallersByArea[dir], n)
+		}
+	}
+	if got := sumAreas(resp.DirectCallersByArea); got != 80 {
+		t.Errorf("by_area sum = %d, want 80 (true direct count)", got)
+	}
+	if resp.Completeness == nil || resp.Completeness.Verdict != "partial" {
+		t.Errorf("verdict = %v, want partial (more direct callers than enumerated)", resp.Completeness)
+	}
+}
+
+func TestBuildBlastResponseEnumeratesHighestConfidence(t *testing.T) {
+	// 80 tier-1 direct callers in ID order (> directEnumCap so the cap
+	// bites), with confidence deliberately NOT monotonic in ID: caller i
+	// gets confidence that peaks in the middle of the ID range. The
+	// enumerated subset must be the highest-confidence callers (DESC),
+	// tie-broken by ID ASC — NOT the lowest-ID prefix the engine's
+	// determinism sort yields.
+	const n = 80
+	var directCallers []model.Symbol
+	tiers := make(map[int64]blast.Tier)
+	conf := map[int64]float64{}
+	for i := int64(1); i <= n; i++ {
+		directCallers = append(directCallers, model.Symbol{
+			ID: i, Qualified: fmt.Sprintf("Caller%02d", i), FileID: 100,
+		})
+		tiers[i] = blast.TierBreaks
+		// Tent function over [1,n]: confidence rises then falls, so the
+		// top-confidence callers cluster around the middle IDs, far from
+		// the lowest-ID prefix.
+		if i <= n/2 {
+			conf[i] = float64(i) / 100.0
+		} else {
+			conf[i] = float64(n-i+1) / 100.0
+		}
+	}
+
+	r := blast.Result{
+		Symbol:           model.Symbol{ID: 0, Qualified: "Subject"},
+		DirectCallers:    directCallers,
+		AffectedTests:    []string{},
+		TotalAffected:    n,
+		SymbolTiers:      tiers,
+		DirectConfidence: conf,
+	}
+
+	resp := BuildBlastResponse(context.Background(), r, noFiles, nil)
+
+	if len(resp.DirectCallers) != directEnumCap {
+		t.Fatalf("enumerated direct_callers = %d, want %d", len(resp.DirectCallers), directEnumCap)
+	}
+
+	// Expected enumerated set: the directEnumCap highest-confidence IDs,
+	// ordered by confidence DESC then ID ASC. Reconstruct independently.
+	type rc struct {
+		id   int64
+		conf float64
+	}
+	var ranked []rc
+	for id, c := range conf {
+		ranked = append(ranked, rc{id, c})
+	}
+	sortRanked := func(a, b rc) bool {
+		if a.conf != b.conf {
+			return a.conf > b.conf
+		}
+		return a.id < b.id
+	}
+	// simple insertion sort to avoid pulling in sort just for the oracle
+	for i := 1; i < len(ranked); i++ {
+		for j := i; j > 0 && sortRanked(ranked[j], ranked[j-1]); j-- {
+			ranked[j], ranked[j-1] = ranked[j-1], ranked[j]
+		}
+	}
+
+	// The enumerated entries must be confidence-DESC (highest first) and
+	// match the expected top-cap IDs.
+	prev := 2.0
+	for i, c := range resp.DirectCallers {
+		gotConf := conf[symbolID(c.Symbol)]
+		if gotConf > prev {
+			t.Errorf("enumerated[%d] conf %.3f > previous %.3f — not confidence-descending", i, gotConf, prev)
+		}
+		prev = gotConf
+		wantID := ranked[i].id
+		if symbolID(c.Symbol) != wantID {
+			t.Errorf("enumerated[%d] = %s (conf %.3f), want id %d (conf %.3f)", i, c.Symbol, gotConf, wantID, ranked[i].conf)
+		}
+	}
+
+	// Determinism: a second build produces a byte-identical enumerated set.
+	resp2 := BuildBlastResponse(context.Background(), r, noFiles, nil)
+	if len(resp2.DirectCallers) != len(resp.DirectCallers) {
+		t.Fatalf("non-deterministic length: %d vs %d", len(resp2.DirectCallers), len(resp.DirectCallers))
+	}
+	for i := range resp.DirectCallers {
+		if resp.DirectCallers[i].Symbol != resp2.DirectCallers[i].Symbol {
+			t.Errorf("non-deterministic at %d: %q vs %q", i, resp.DirectCallers[i].Symbol, resp2.DirectCallers[i].Symbol)
+		}
+	}
+
+	// by_area sum and total stay truthful over the FULL set.
+	if got := sumAreas(resp.DirectCallersByArea); got != n {
+		t.Errorf("by_area sum = %d, want %d", got, n)
+	}
+	if resp.TotalAffected != n {
+		t.Errorf("TotalAffected = %d, want %d", resp.TotalAffected, n)
+	}
+}
+
+// TestBuildBlastResponseMoreAreasThanCap pins the behaviour when a symbol's
+// callers span MORE distinct areas than directEnumCap. Round-robin can seat
+// only one caller per area, so exactly directEnumCap areas get a citable
+// exemplar (most-populated area first, name-tiebroken). The remaining areas
+// are NOT hidden — every one still appears in direct_callers_by_area with
+// its true count. This is the antirez/Kent "long tail" case: it must be
+// summarised, never silently dropped.
+func TestBuildBlastResponseMoreAreasThanCap(t *testing.T) {
+	const nAreas = 70 // > directEnumCap
+	var directCallers []model.Symbol
+	tiers := make(map[int64]blast.Tier)
+	paths := map[int64]string{}
+	for i := int64(1); i <= nAreas; i++ {
+		directCallers = append(directCallers, model.Symbol{ID: i, Qualified: fmt.Sprintf("C%d", i), FileID: i})
+		tiers[i] = blast.TierBreaks
+		paths[i] = fmt.Sprintf("area%03d/file.rb", i) // one caller, one area
+	}
+	files := func(fid int64) (string, bool) { p, ok := paths[fid]; return p, ok }
+
+	r := blast.Result{
+		Symbol:        model.Symbol{ID: 0, Qualified: "Subject"},
+		DirectCallers: directCallers,
+		AffectedTests: []string{},
+		TotalAffected: nAreas,
+		SymbolTiers:   tiers,
+	}
+	resp := BuildBlastResponse(context.Background(), r, files, nil)
+
+	// Exactly cap callers, each from a distinct area (one-per-area: here one
+	// file per area, so distinct files prove distinct areas).
+	if len(resp.DirectCallers) != directEnumCap {
+		t.Fatalf("enumerated = %d, want %d (cap)", len(resp.DirectCallers), directEnumCap)
+	}
+	seenFile := map[string]bool{}
+	for _, c := range resp.DirectCallers {
+		if seenFile[c.File] {
+			t.Errorf("file %q enumerated twice — round-robin must seat one per area when areas exceed the cap", c.File)
+		}
+		seenFile[c.File] = true
+	}
+	// The un-enumerated tail is summarised, not hidden: by_area carries EVERY area.
+	if len(resp.DirectCallersByArea) != nAreas {
+		t.Errorf("by_area areas = %d, want %d (every area incl. the un-enumerated tail)", len(resp.DirectCallersByArea), nAreas)
+	}
+	if got := sumAreas(resp.DirectCallersByArea); got != nAreas {
+		t.Errorf("by_area sum = %d, want %d (true direct count)", got, nAreas)
+	}
+	if resp.Completeness == nil || resp.Completeness.Verdict != "partial" {
+		t.Errorf("verdict = %v, want partial (more areas than enumerated)", resp.Completeness)
+	}
+
+	// Deterministic: a second build yields the identical enumerated set.
+	resp2 := BuildBlastResponse(context.Background(), r, files, nil)
+	if len(resp2.DirectCallers) != len(resp.DirectCallers) {
+		t.Fatalf("non-deterministic length: %d vs %d", len(resp2.DirectCallers), len(resp.DirectCallers))
+	}
+	for i := range resp.DirectCallers {
+		if resp.DirectCallers[i].Symbol != resp2.DirectCallers[i].Symbol {
+			t.Errorf("non-deterministic at %d: %q vs %q", i, resp.DirectCallers[i].Symbol, resp2.DirectCallers[i].Symbol)
+		}
+	}
+}
+
+// symbolID parses the trailing integer from a "CallerNN" qualified name,
+// the oracle the confidence-ranking test uses to map a wire entry back to
+// its fixture ID.
+func symbolID(qualified string) int64 {
+	var id int64
+	// names are "CallerNN"; scan the digit suffix.
+	for i := 0; i < len(qualified); i++ {
+		if qualified[i] >= '0' && qualified[i] <= '9' {
+			_, _ = fmt.Sscanf(qualified[i:], "%d", &id)
+			break
+		}
+	}
+	return id
+}
+
+func TestBuildBlastResponseEnumeratesBreadthAcrossAreas(t *testing.T) {
+	// One big area swamps the ID range, plus many small scattered areas.
+	// A flat conf-DESC/id-ASC rank (every conf 1.0 → pure id-ASC) would
+	// fill the enumerated set entirely from the big low-ID area and crowd
+	// out every scattered area. Breadth-first enumeration must surface a
+	// citable exemplar from each scattered area before the big area takes a
+	// second slot.
+	bigArea := "app/models"
+	scattered := []string{
+		"lib/email", "lib/backup_restore", "lib/file_store",
+		"lib/cooked", "lib/auth", "lib/jobs", "lib/search",
+		"lib/tasks", "lib/validators", "lib/serializers",
+	}
+
+	var directCallers []model.Symbol
+	tiers := make(map[int64]blast.Tier)
+	conf := map[int64]float64{}
+	paths := map[int64]string{}
+	var id int64
+
+	// 60 callers in the big area, all the lowest IDs (scan-order clustering).
+	for i := 0; i < 60; i++ {
+		id++
+		directCallers = append(directCallers, model.Symbol{ID: id, Qualified: fmt.Sprintf("Big%d", id), FileID: id})
+		tiers[id] = blast.TierBreaks
+		conf[id] = 1.0
+		paths[id] = fmt.Sprintf("%s/file%d.rb", bigArea, i)
+	}
+	// One caller in each scattered area, all at higher IDs.
+	for _, area := range scattered {
+		id++
+		directCallers = append(directCallers, model.Symbol{ID: id, Qualified: fmt.Sprintf("S_%s_%d", area, id), FileID: id})
+		tiers[id] = blast.TierBreaks
+		conf[id] = 1.0
+		paths[id] = fmt.Sprintf("%s/file.rb", area)
+	}
+	files := func(fid int64) (string, bool) { p, ok := paths[fid]; return p, ok }
+
+	total := len(directCallers)
+	r := blast.Result{
+		Symbol:           model.Symbol{ID: 0, Qualified: "Upload"},
+		DirectCallers:    directCallers,
+		AffectedTests:    []string{},
+		TotalAffected:    total,
+		SymbolTiers:      tiers,
+		DirectConfidence: conf,
+	}
+
+	resp := BuildBlastResponse(context.Background(), r, files, nil)
+
+	if len(resp.DirectCallers) != directEnumCap {
+		t.Fatalf("enumerated = %d, want %d", len(resp.DirectCallers), directEnumCap)
+	}
+
+	// (a) Breadth: EVERY scattered area must have a citable exemplar, and
+	// the big area must not monopolize the enumerated set.
+	enumAreas := map[string]int{}
+	for _, c := range resp.DirectCallers {
+		enumAreas[areaOf(c.File)]++
+	}
+	for _, area := range scattered {
+		if enumAreas[area] == 0 {
+			t.Errorf("scattered area %q has no enumerated exemplar (crowded out)", area)
+		}
+	}
+	if enumAreas[bigArea] >= directEnumCap {
+		t.Errorf("big area %q monopolized the enumerated set (%d of %d)", bigArea, enumAreas[bigArea], directEnumCap)
+	}
+	// 10 scattered areas each get a slot; the big area takes the remaining
+	// 20. No single area exceeds the big area's share.
+	if enumAreas[bigArea] != directEnumCap-len(scattered) {
+		t.Errorf("big area got %d slots, want %d (cap minus scattered)", enumAreas[bigArea], directEnumCap-len(scattered))
+	}
+
+	// (d) by_area sum + total stay truthful over the FULL set.
+	if got := sumAreas(resp.DirectCallersByArea); got != total {
+		t.Errorf("by_area sum = %d, want %d", got, total)
+	}
+	if resp.TotalAffected != total {
+		t.Errorf("TotalAffected = %d, want %d", resp.TotalAffected, total)
+	}
+
+	// (c) Determinism: a second build is identical entry-for-entry.
+	resp2 := BuildBlastResponse(context.Background(), r, files, nil)
+	if len(resp2.DirectCallers) != len(resp.DirectCallers) {
+		t.Fatalf("non-deterministic length: %d vs %d", len(resp2.DirectCallers), len(resp.DirectCallers))
+	}
+	for i := range resp.DirectCallers {
+		if resp.DirectCallers[i].Symbol != resp2.DirectCallers[i].Symbol {
+			t.Errorf("non-deterministic at %d: %q vs %q", i, resp.DirectCallers[i].Symbol, resp2.DirectCallers[i].Symbol)
+		}
+	}
+}
+
+func TestBuildBlastResponseAreaExemplarIsHighestConfidence(t *testing.T) {
+	// (b) Within an area, the chosen exemplar is the highest-confidence
+	// caller, NOT the lowest-ID one. Two areas, each with three callers
+	// whose top-confidence member is at the HIGHEST id (so id-ASC would
+	// pick the wrong one). With cap=2, each area contributes exactly its
+	// best exemplar.
+	type caller struct {
+		id   int64
+		conf float64
+		area string
+	}
+	callers := []caller{
+		{1, 0.3, "app/a"}, {2, 0.5, "app/a"}, {3, 0.9, "app/a"}, // best is id 3
+		{4, 0.4, "app/b"}, {5, 0.95, "app/b"}, {6, 0.6, "app/b"}, // best is id 5
+	}
+
+	// Drive enumerateByArea directly with a tight cap so each area yields
+	// exactly its best exemplar.
+	var ranked []rankedCaller
+	for _, c := range callers {
+		ranked = append(ranked, rankedCaller{
+			entry: BlastCaller{Symbol: fmt.Sprintf("C%d", c.id)},
+			area:  c.area, id: c.id, conf: c.conf,
+		})
+	}
+	got := enumerateByArea(ranked, 2)
+	gotSet := map[string]bool{}
+	for _, e := range got {
+		gotSet[e.Symbol] = true
+	}
+	if !gotSet["C3"] {
+		t.Errorf("app/a exemplar should be C3 (conf 0.9), got %v", got)
+	}
+	if !gotSet["C5"] {
+		t.Errorf("app/b exemplar should be C5 (conf 0.95), got %v", got)
+	}
+	if len(got) != 2 {
+		t.Errorf("enumerated = %d, want 2 (one exemplar per area)", len(got))
 	}
 }
 
@@ -430,13 +799,19 @@ func TestBlastResponseRefField(t *testing.T) {
 
 	resp := BuildBlastResponse(context.Background(), r, files, nil)
 
-	// DirectCallers — with file
-	if resp.DirectCallers[0].Ref != "lib/caller.rb:25" {
-		t.Errorf("DirectCallers[0].Ref = %q, want %q", resp.DirectCallers[0].Ref, "lib/caller.rb:25")
+	// Look the entries up by symbol — area-stratified enumeration clusters
+	// by directory, so the Ref assertions must not assume input order.
+	refBySymbol := map[string]string{}
+	for _, c := range resp.DirectCallers {
+		refBySymbol[c.Symbol] = c.Ref
 	}
-	// DirectCallers — no file (lookup miss)
-	if resp.DirectCallers[1].Ref != "" {
-		t.Errorf("DirectCallers[1].Ref = %q, want empty (no file)", resp.DirectCallers[1].Ref)
+	// DirectCaller — with file
+	if got := refBySymbol["DirectCaller"]; got != "lib/caller.rb:25" {
+		t.Errorf("DirectCaller.Ref = %q, want %q", got, "lib/caller.rb:25")
+	}
+	// DirectCaller — no file (lookup miss)
+	if got := refBySymbol["NoFileCaller"]; got != "" {
+		t.Errorf("NoFileCaller.Ref = %q, want empty (no file)", got)
 	}
 
 	// IndirectCallers

--- a/internal/mcpio/completeness_test.go
+++ b/internal/mcpio/completeness_test.go
@@ -62,12 +62,18 @@ func TestBlastCompletenessPartialHidden(t *testing.T) {
 }
 
 func TestBlastCompletenessPartialCapped(t *testing.T) {
-	callers := make([]BlastCaller, tier1Cap)
-	resp := &BlastResponse{DirectCallers: callers}
-	// total == enumerated (no hidden), but the cap was hit -> partial.
-	c := blastCompleteness(resp, tier1Cap)
+	// Enumerated direct_callers are capped at directEnumCap, but the by-area
+	// map records more direct callers than were enumerated. total ==
+	// enumerated so `hidden` is 0, yet the response is partial because the
+	// inline list does not show every direct caller.
+	callers := make([]BlastCaller, directEnumCap)
+	resp := &BlastResponse{
+		DirectCallers:       callers,
+		DirectCallersByArea: map[string]int{"app/models": 200},
+	}
+	c := blastCompleteness(resp, directEnumCap)
 	if c.Verdict != "partial" {
-		t.Fatalf("verdict = %q, want partial (cap hit)", c.Verdict)
+		t.Fatalf("verdict = %q, want partial (enum cap hit, by-area carries the rest)", c.Verdict)
 	}
 }
 

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -298,6 +298,15 @@ type BlastResponse struct {
 	GraphEdgesTraversed int             `json:"graph_edges_traversed"`
 	TotalAffected       int             `json:"total_affected"`
 
+	// DirectCallersByArea groups EVERY direct caller by its file's
+	// directory, e.g. {"app/models": 40, "app/jobs": 18}. It is computed
+	// from the full caller set before direct_callers is capped, so it
+	// reports the true magnitude and structural shape (which subsystems
+	// depend on the subject) even when direct_callers enumerates only the
+	// top slice. The values sum to the true direct-caller count; pair it
+	// with total_affected for the full radius.
+	DirectCallersByArea map[string]int `json:"direct_callers_by_area,omitempty"`
+
 	AffectedSubclasses     []BlastCaller `json:"affected_subclasses"`
 	AffectedViaComposition []BlastCaller `json:"affected_via_composition"`
 	AffectedViaIncludes    []BlastCaller `json:"affected_via_includes"`

--- a/internal/mcpserver/oracle_test.go
+++ b/internal/mcpserver/oracle_test.go
@@ -165,7 +165,11 @@ func oracleDigest(t *testing.T, calls []labeledCall) (string, []string) {
 // response changed.
 // Added the `completeness` verdict to blast/graph responses and per-caller
 // `relation` to blast callers (terminal payloads) — digest moved.
-const oracleGolden = "250acefd023052c452684b7c0f1dc344e9c9c42c3aad39358511d8b81659851b"
+// blast direct_callers are now enumerated area-stratified (breadth-first
+// across subsystems) and emitted area-clustered, so the fixture's two
+// callers reorder by area name (internal/auth before internal/handler)
+// instead of by symbol ID — digest moved.
+const oracleGolden = "b0342fc640957d5d134c63d2a807242141bde4a618f5c409843c723e2f3cb9f9"
 
 func TestMCPServerResponseOracle(t *testing.T) {
 	got, content := oracleDigest(t, collectOracleCalls(t))

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -198,8 +198,14 @@ func DefaultParams() Defaults {
 		BlastMaxHops:           5,
 		BlastMinConfidence:     0.3,
 		BlastResultCap:         200,
-		BlastTokenBudget:       12000,
-		GraphTokenBudget:       12000,
-		GraphSegmentCallers:    false,
+		// Blast got the full right-sizing treatment (area-stratified
+		// enumeration + direct_callers_by_area), validated to hold recall.
+		// Graph received only this budget reduction (12000->8000) — the
+		// stratification/by-area work was NOT applied to graph and graph was
+		// not benched; trimming there is still ApplyGraphBudget's
+		// least-relevant-first edge drop.
+		BlastTokenBudget:    8000,
+		GraphTokenBudget:    8000,
+		GraphSegmentCallers: false,
 	}
 }

--- a/internal/profile/profile_test.go
+++ b/internal/profile/profile_test.go
@@ -52,8 +52,8 @@ func TestDefaultParams(t *testing.T) {
 		BlastMaxHops:           5,
 		BlastMinConfidence:     0.3,
 		BlastResultCap:         200,
-		BlastTokenBudget:       12000,
-		GraphTokenBudget:       12000,
+		BlastTokenBudget:       8000,
+		GraphTokenBudget:       8000,
 		GraphSegmentCallers:    false,
 	}
 	if d != want {


### PR DESCRIPTION
## Problem
`sense_blast` on a high-fan-out symbol returned **all ~156 direct callers (~37KB / ~9k tokens)** in a single tool result. That flat list is more than an agent can act on: it bloats context, inflates cost and latency, and on token-metered clients it is the request most likely to cross a throttle. The agent rarely needs every caller as a line-addressable entry, but it loses the structural shape in the noise.

## Summary
Right-size the blast MCP response: cap the enumerated callers, add a per-subsystem summary computed over the full set, and lower the token budgets — ~45% smaller payload with truthful totals and no recall regression.

## Changes
- **Cap enumerated direct callers at 60** (`directEnumCap`), selected **breadth-first across subsystems** so each affected area surfaces a citable exemplar instead of a single low-ID cluster. Within an area, the exemplar is ranked by confidence DESC then id ASC (`DirectConfidence` plumbed from the blast engine).
- **Add `direct_callers_by_area`** — a per-subsystem tally computed over the **full** caller set. `total_affected` and `completeness` stay truthful; when callers span more areas than the cap, the un-enumerated long tail is **summarised in `by_area`, never hidden**.
- **Lower the blast and graph MCP token budgets** 12000 → 8000.
- Graph received only the budget reduction; the stratification / by-area work is blast-only, and graph was not benched.

## Validation
- ~45% smaller on a high-fan-out blast (37KB → 20KB).
- **No recall regression**: Opus cited-recall held flat across three runs. The weak/throttled-model case is **noted as unverified** — that bench scenario is too noisy to discriminate.
- `make ci` green: coverage **95.0%** (floor 92%), lint clean, complexity ledger clean.
- Reviewed via the code-review council.

Note: `bench/results/` data is intentionally not included in this PR.

## Test Plan
- [x] `make ci` (build + coverage + lint + ledger) passes
- [x] New tests: area-stratified breadth, within-area confidence ranking, areas-over-cap long-tail (summarised not hidden), determinism across builds, `by_area` truthfulness over the full set
- [x] Coverage gate ≥92% (95.0%)
- [x] sense binary builds cleanly