### PR TITLE
feat(blast): collapse already-seen callers in sense_blast (graph/blast session dedup)

### DIFF
--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -107,13 +107,37 @@ func trimStep(n int) int {
 	return 1
 }
 
+// SeenFunc reports whether a symbol id was already returned to this MCP
+// session by an earlier sense_graph/sense_blast call. A nil SeenFunc (the
+// CLI path and most tests) means "nothing seen yet" — every caller is
+// enumerated, so output is byte-identical to the un-deduplicated build.
+type SeenFunc func(int64) bool
+
+// seen is the nil-safe predicate: a nil SeenFunc reports false for every id.
+func (f SeenFunc) seen(id int64) bool { return f != nil && f(id) }
+
 // BuildBlastResponse assembles a wire BlastResponse from the blast
 // engine's Result plus a file-path lookup for caller symbols. Results
 // are partitioned by relevance tier:
 //   - Tier 1 (breaks): full detail, capped at 200 items
 //   - Tier 2 (references): count + top 5 examples
 //   - Tier 3 (tests): count only
+//
+// This is the CLI/test entry point — it enumerates every caller. The MCP
+// handler calls BuildBlastResponseSeen to collapse callers the session
+// already received from an earlier sense_graph/sense_blast call.
 func BuildBlastResponse(ctx context.Context, r blast.Result, files FileLookup, snippets *SnippetReader) BlastResponse {
+	return BuildBlastResponseSeen(ctx, r, files, snippets, nil)
+}
+
+// BuildBlastResponseSeen is BuildBlastResponse plus per-session deduplication:
+// a tier-1 direct caller whose id satisfies seen is dropped from the inline
+// direct_callers enumeration and counted into seen_elsewhere instead. The
+// magnitude fields (total_affected, direct_callers_by_area) and the
+// completeness verdict are computed from the FULL caller set, so the collapse
+// saves tokens without hiding radius — the agent already holds the collapsed
+// callers from the prior call.
+func BuildBlastResponseSeen(ctx context.Context, r blast.Result, files FileLookup, snippets *SnippetReader, seen SeenFunc) BlastResponse {
 	resp := BlastResponse{
 		Symbol:             qualifiedOrName(r.Symbol),
 		Risk:               r.Risk,
@@ -130,6 +154,8 @@ func BuildBlastResponse(ctx context.Context, r blast.Result, files FileLookup, s
 	var tier2All []BlastCaller
 
 	var tier1Direct []rankedCaller
+	seenCount := 0
+	var seenFiles []string
 
 	for _, c := range r.DirectCallers {
 		var file string
@@ -149,10 +175,21 @@ func BuildBlastResponse(ctx context.Context, r blast.Result, files FileLookup, s
 
 		if !hasTiers || r.SymbolTiers[c.ID] == blast.TierBreaks {
 			// Every tier-1 direct caller feeds the by-area map (the true
-			// structural shape), but only directEnumCap are enumerated
-			// inline (the actionable subset).
+			// structural shape) and the directTier1 magnitude count, but only
+			// directEnumCap are enumerated inline (the actionable subset).
+			// Both run BEFORE the seen-collapse so the magnitude reflects the
+			// full set regardless of how many callers the session already has.
 			addArea(&resp.DirectCallersByArea, file)
 			directTier1++
+			// Collapse a caller the session already received from an earlier
+			// sense_graph/sense_blast call: count it for seen_elsewhere and
+			// skip the inline enumeration. Only this specific id is collapsed
+			// — never the whole list — so unseen callers stay fully listed.
+			if seen.seen(c.ID) {
+				seenCount++
+				seenFiles = append(seenFiles, file)
+				continue
+			}
 			tier1Direct = append(tier1Direct, rankedCaller{entry: entry, area: areaOf(file), id: c.ID, conf: r.DirectConfidence[c.ID]})
 		} else {
 			tier2All = append(tier2All, entry)
@@ -173,6 +210,16 @@ func BuildBlastResponse(ctx context.Context, r blast.Result, files FileLookup, s
 	// fully deterministic. The by-area map and total_affected still carry
 	// the full magnitude.
 	resp.DirectCallers = enumerateByArea(tier1Direct, directEnumCap)
+	if seenCount > 0 {
+		note := fmt.Sprintf("%d of %d direct callers were already returned by an earlier sense_graph/sense_blast call on this symbol; only new callers are listed.",
+			seenCount, directTier1)
+		if seenCount == directTier1 {
+			// All direct callers were already shown — there is no "new" subset.
+			note = fmt.Sprintf("all %d direct callers were already returned by an earlier sense_graph/sense_blast call on this symbol; see that response for the list.",
+				directTier1)
+		}
+		resp.SeenVia = &BlastSeenSummary{Count: seenCount, Note: note}
+	}
 	// Charge the full tier-1 direct count against the shared tier1Cap so
 	// indirect enumeration keeps its prior ceiling even though only the top
 	// directEnumCap direct callers are enumerated inline. Indirect callers
@@ -271,7 +318,7 @@ func BuildBlastResponse(ctx context.Context, r blast.Result, files FileLookup, s
 		resp.ViewEdges = viewEdgesSignal(subjectFile, r.ViewReached)
 	}
 
-	uniqueFiles := countUniqueBlastFiles(resp)
+	uniqueFiles := countUniqueBlastFiles(resp, seenFiles...)
 	resp.AffectedFiles = uniqueFiles
 	resp.SenseMetrics = BlastMetrics{
 		SymbolsTraversed:          1 + len(r.DirectCallers) + len(r.IndirectCallers),
@@ -291,22 +338,31 @@ func BuildBlastResponse(ctx context.Context, r blast.Result, files FileLookup, s
 // never folded into "complete", so the verdict can't over-claim into a
 // duck-typed gap (the Lobsters failure mode).
 func blastCompleteness(resp *BlastResponse, totalAffected int) *Completeness {
+	// Direct callers collapsed into seen_elsewhere are NOT hidden: the agent
+	// already received them from an earlier call this session, so they count
+	// as resolved. Folding the seen count into `resolved` keeps a complete
+	// verdict complete (the seen-collapse is a dedup, not a truncation) and
+	// keeps the cap check honest (the full set is still accounted for).
+	seenCollapsed := 0
+	if resp.SeenVia != nil {
+		seenCollapsed = resp.SeenVia.Count
+	}
 	// total_affected is the engine's count of the direct+indirect caller union.
 	// The inherit/include/compose groups are a re-classification of those SAME
 	// caller IDs by edge kind, not additional symbols, so they must NOT be summed
 	// in — doing so would understate `hidden` and let "complete" mask callers the
 	// tier cap or a trim dropped. Count only the caller union, matching the
 	// denomination of total_affected.
-	enumerated := len(resp.DirectCallers) + len(resp.IndirectCallers)
+	enumerated := len(resp.DirectCallers) + len(resp.IndirectCallers) + seenCollapsed
 	hidden := totalAffected - enumerated
 	if hidden < 0 {
 		hidden = 0
 	}
 	// The enumerated direct_callers are capped at directEnumCap; the by-area
 	// map carries the full tier-1 direct count. If more direct callers exist
-	// than were enumerated, the response is partial even when total_affected
-	// happens to match (e.g. all callers are direct and there are >cap of them).
-	capped := sumAreas(resp.DirectCallersByArea) > len(resp.DirectCallers)
+	// than were enumerated (or collapsed as already-seen), the response is
+	// partial even when total_affected happens to match.
+	capped := sumAreas(resp.DirectCallersByArea) > len(resp.DirectCallers)+seenCollapsed
 	if hidden > 0 || capped {
 		return &Completeness{
 			Verdict:  "partial",
@@ -337,6 +393,14 @@ func blastCompleteness(resp *BlastResponse, totalAffected int) *Completeness {
 // diff shape; reusing the same response type keeps 01-05's MCP
 // surface one tool, one response.
 func BuildDiffBlastResponse(ctx context.Context, ref string, results []blast.Result, files FileLookup, snippets *SnippetReader) BlastResponse {
+	return BuildDiffBlastResponseSeen(ctx, ref, results, files, snippets, nil)
+}
+
+// BuildDiffBlastResponseSeen is BuildDiffBlastResponse plus per-session
+// deduplication: a direct caller whose id satisfies seen is collapsed into
+// seen_elsewhere instead of being enumerated. total_affected still counts the
+// full deduplicated caller union, so the radius is unchanged.
+func BuildDiffBlastResponseSeen(ctx context.Context, ref string, results []blast.Result, files FileLookup, snippets *SnippetReader, seen SeenFunc) BlastResponse {
 	resp := BlastResponse{
 		Symbol: "diff:" + ref,
 	}
@@ -346,6 +410,9 @@ func BuildDiffBlastResponse(ctx context.Context, ref string, results []blast.Res
 	testsSeen := map[string]struct{}{}
 	risk := blast.RiskLow
 	totalEdges := 0
+	directTotal := 0
+	seenCount := 0
+	var seenFiles []string
 
 	for _, r := range results {
 		totalEdges += r.EdgesTraversed
@@ -357,9 +424,17 @@ func BuildDiffBlastResponse(ctx context.Context, ref string, results []blast.Res
 				continue
 			}
 			directSeen[c.ID] = struct{}{}
+			// Count every unique direct caller toward the radius BEFORE the
+			// seen-collapse, then collapse the ones the session already holds.
+			directTotal++
 			var file string
 			if path, ok := files(c.FileID); ok {
 				file = path
+			}
+			if seen.seen(c.ID) {
+				seenCount++
+				seenFiles = append(seenFiles, file)
+				continue
 			}
 			resp.DirectCallers = append(resp.DirectCallers, BlastCaller{
 				Symbol:    qualifiedOrName(c),
@@ -397,22 +472,32 @@ func BuildDiffBlastResponse(ctx context.Context, ref string, results []blast.Res
 		}
 	}
 
+	if seenCount > 0 {
+		resp.SeenVia = &BlastSeenSummary{
+			Count: seenCount,
+			Note: fmt.Sprintf("%d of %d direct callers were already returned by an earlier sense_graph/sense_blast call on this symbol; only new callers are listed.",
+				seenCount, directTotal),
+		}
+	}
+
 	resp.Risk = risk
 	resp.TestsAffectedCount = len(resp.AffectedTests)
-	resp.TotalAffected = len(resp.DirectCallers) + len(resp.IndirectCallers)
+	// directTotal, not the post-collapse enumeration length, so total_affected
+	// and the risk-factor count report the full deduplicated radius.
+	resp.TotalAffected = directTotal + len(resp.IndirectCallers)
 	resp.AffectedSymbols = resp.TotalAffected
 	resp.GraphEdgesTraversed = totalEdges
 	resp.Note = "affected_symbols counts unique symbols in the blast radius — not source-level references or graph edges traversed. total_affected is an alias for affected_symbols."
 	resp.RiskFactors = []string{
-		fmt.Sprintf("%d modified symbols; %d direct callers", len(results), len(resp.DirectCallers)),
+		fmt.Sprintf("%d modified symbols; %d direct callers", len(results), directTotal),
 	}
 
 	segmentBlastCallers(&resp)
 
-	uniqueFiles := countUniqueBlastFiles(resp)
+	uniqueFiles := countUniqueBlastFiles(resp, seenFiles...)
 	resp.AffectedFiles = uniqueFiles
 	resp.SenseMetrics = BlastMetrics{
-		SymbolsTraversed:          len(results) + len(resp.DirectCallers) + len(resp.IndirectCallers),
+		SymbolsTraversed:          len(results) + directTotal + len(resp.IndirectCallers),
 		EstimatedFileReadsAvoided: uniqueFiles,
 		EstimatedTokensSaved:      uniqueFiles * AvgTokensPerFile,
 	}
@@ -541,7 +626,12 @@ func sumAreas(m map[string]int) int {
 	return n
 }
 
-func countUniqueBlastFiles(resp BlastResponse) int {
+// countUniqueBlastFiles counts the distinct files across the enumerated
+// direct callers and affected tests, plus any extra paths supplied. The
+// extra paths carry the files of callers collapsed by the seen-dedup, so
+// affected_files reports the same magnitude whether or not a caller was
+// already returned earlier this session.
+func countUniqueBlastFiles(resp BlastResponse, extra ...string) int {
 	seen := map[string]struct{}{}
 	for _, c := range resp.DirectCallers {
 		if c.File != "" {
@@ -550,6 +640,11 @@ func countUniqueBlastFiles(resp BlastResponse) int {
 	}
 	for _, t := range resp.AffectedTests {
 		seen[t] = struct{}{}
+	}
+	for _, f := range extra {
+		if f != "" {
+			seen[f] = struct{}{}
+		}
 	}
 	return len(seen)
 }

--- a/internal/mcpio/blast_test.go
+++ b/internal/mcpio/blast_test.go
@@ -2,7 +2,9 @@ package mcpio
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/luuuc/sense/internal/blast"
@@ -1379,5 +1381,208 @@ func TestRiskRank(t *testing.T) {
 		if got := riskRank(c.risk); got != c.want {
 			t.Errorf("riskRank(%q) = %d, want %d", c.risk, got, c.want)
 		}
+	}
+}
+
+// --- Per-session seen-caller deduplication (option B) -----------------------
+
+// seenSet is a SeenFunc backed by a set literal — the test-side stand-in for
+// the handler's per-session seenSymbols map.
+func seenSet(ids ...int64) SeenFunc {
+	m := map[int64]bool{}
+	for _, id := range ids {
+		m[id] = true
+	}
+	return func(id int64) bool { return m[id] }
+}
+
+// blastFixture builds a small high-tier blast.Result with N direct callers,
+// one per area, so each enumerated caller maps to a distinct file/area.
+func seenBlastFixture(n int) (blast.Result, FileLookup) {
+	var callers []model.Symbol
+	tiers := map[int64]blast.Tier{}
+	conf := map[int64]float64{}
+	paths := map[int64]string{}
+	for i := int64(1); i <= int64(n); i++ {
+		callers = append(callers, model.Symbol{ID: i, Qualified: fmt.Sprintf("C%d", i), FileID: i})
+		tiers[i] = blast.TierBreaks
+		conf[i] = 1.0
+		paths[i] = fmt.Sprintf("area%03d/file.rb", i)
+	}
+	r := blast.Result{
+		Symbol:           model.Symbol{ID: 0, Qualified: "Subject"},
+		DirectCallers:    callers,
+		AffectedTests:    []string{},
+		TotalAffected:    n,
+		SymbolTiers:      tiers,
+		DirectConfidence: conf,
+		Risk:             blast.RiskLow,
+	}
+	files := func(fid int64) (string, bool) { p, ok := paths[fid]; return p, ok }
+	return r, files
+}
+
+// TestBuildBlastResponseSeenNilIsByteIdentical pins the single-call-safe
+// invariant: a nil SeenFunc (CLI path, empty seen-set) collapses nothing, so
+// the response equals the un-deduplicated build exactly.
+func TestBuildBlastResponseSeenNilIsByteIdentical(t *testing.T) {
+	r, files := seenBlastFixture(5)
+	plain := BuildBlastResponse(context.Background(), r, files, nil)
+	seenNil := BuildBlastResponseSeen(context.Background(), r, files, nil, nil)
+
+	if seenNil.SeenVia != nil {
+		t.Errorf("nil seen-set must not set seen_elsewhere, got %+v", seenNil.SeenVia)
+	}
+	pj, _ := json.Marshal(plain)
+	sj, _ := json.Marshal(seenNil)
+	if string(pj) != string(sj) {
+		t.Errorf("nil SeenFunc must be byte-identical to BuildBlastResponse\nplain: %s\nseen:  %s", pj, sj)
+	}
+}
+
+// TestBuildBlastResponseSeenCollapsesPerID pins that ONLY the specific seen
+// ids are collapsed — unseen callers stay fully enumerated, and the collapsed
+// count is summarised in seen_elsewhere.
+func TestBuildBlastResponseSeenCollapsesPerID(t *testing.T) {
+	r, files := seenBlastFixture(5)
+	// Mark 3 of the 5 direct callers as already returned this session.
+	resp := BuildBlastResponseSeen(context.Background(), r, files, nil, seenSet(1, 2, 3))
+
+	if len(resp.DirectCallers) != 2 {
+		t.Errorf("enumerated direct_callers = %d, want 2 (only the 2 unseen)", len(resp.DirectCallers))
+	}
+	for _, c := range resp.DirectCallers {
+		if id := symbolID(c.Symbol); id == 1 || id == 2 || id == 3 {
+			t.Errorf("seen caller C%d must not be enumerated", id)
+		}
+	}
+	if resp.SeenVia == nil || resp.SeenVia.Count != 3 {
+		t.Fatalf("seen_elsewhere = %+v, want count 3", resp.SeenVia)
+	}
+	if !strings.Contains(resp.SeenVia.Note, "3 of 5") {
+		t.Errorf("seen_elsewhere note = %q, want it to mention 3 of 5", resp.SeenVia.Note)
+	}
+}
+
+// TestBuildBlastResponseSeenPreservesMagnitude pins that the collapse leaves
+// total_affected, affected_symbols, affected_files, and direct_callers_by_area
+// reporting the TRUE full set — the by-area map is computed before collapse.
+func TestBuildBlastResponseSeenPreservesMagnitude(t *testing.T) {
+	r, files := seenBlastFixture(5)
+	full := BuildBlastResponse(context.Background(), r, files, nil)
+	collapsed := BuildBlastResponseSeen(context.Background(), r, files, nil, seenSet(1, 2, 3))
+
+	if collapsed.TotalAffected != full.TotalAffected {
+		t.Errorf("total_affected = %d, want %d (unchanged by collapse)", collapsed.TotalAffected, full.TotalAffected)
+	}
+	if collapsed.AffectedSymbols != full.AffectedSymbols {
+		t.Errorf("affected_symbols = %d, want %d", collapsed.AffectedSymbols, full.AffectedSymbols)
+	}
+	if collapsed.AffectedFiles != full.AffectedFiles {
+		t.Errorf("affected_files = %d, want %d (collapsed callers' files still counted)", collapsed.AffectedFiles, full.AffectedFiles)
+	}
+	if sumAreas(collapsed.DirectCallersByArea) != sumAreas(full.DirectCallersByArea) {
+		t.Errorf("by_area sum = %d, want %d (full set, computed before collapse)",
+			sumAreas(collapsed.DirectCallersByArea), sumAreas(full.DirectCallersByArea))
+	}
+	if len(collapsed.DirectCallersByArea) != len(full.DirectCallersByArea) {
+		t.Errorf("by_area areas = %d, want %d", len(collapsed.DirectCallersByArea), len(full.DirectCallersByArea))
+	}
+}
+
+// TestBuildBlastResponseSeenKeepsCompleteVerdict pins the load-bearing
+// invariant: collapsing already-seen callers is a dedup, not a truncation, so
+// a response that was "complete" stays "complete" even when every direct
+// caller is collapsed.
+func TestBuildBlastResponseSeenKeepsCompleteVerdict(t *testing.T) {
+	r, files := seenBlastFixture(5)
+	// Without collapse this fixture is complete (5 callers, all enumerated).
+	full := BuildBlastResponse(context.Background(), r, files, nil)
+	if full.Completeness == nil || full.Completeness.Verdict != "complete" {
+		t.Fatalf("precondition: full build must be complete, got %+v", full.Completeness)
+	}
+
+	// Collapse ALL five — the agent already holds them from the prior call.
+	resp := BuildBlastResponseSeen(context.Background(), r, files, nil, seenSet(1, 2, 3, 4, 5))
+	if len(resp.DirectCallers) != 0 {
+		t.Fatalf("all callers seen, enumerated should be 0, got %d", len(resp.DirectCallers))
+	}
+	if resp.Completeness == nil || resp.Completeness.Verdict != "complete" {
+		t.Errorf("verdict = %+v, want complete (seen-collapse is not truncation)", resp.Completeness)
+	}
+	if resp.Truncated {
+		t.Error("Truncated must stay false — collapse is not a budget trim")
+	}
+	if resp.Completeness.Hidden != 0 {
+		t.Errorf("hidden = %d, want 0 (collapsed callers are in the agent's context, not hidden)", resp.Completeness.Hidden)
+	}
+}
+
+// TestBuildBlastResponseSeenLeavesNonCallerSetsAlone pins that the collapse
+// never touches the inherit/include/compose affected sets or indirect callers:
+// those may NOT have appeared in the prior graph response, so they stay fully
+// enumerated even when their ids coincide with the seen set.
+func TestBuildBlastResponseSeenLeavesNonCallerSetsAlone(t *testing.T) {
+	r := blast.Result{
+		Symbol:        model.Symbol{ID: 0, Qualified: "Subject"},
+		DirectCallers: []model.Symbol{{ID: 1, Qualified: "C1", FileID: 1}},
+		IndirectCallers: []blast.CallerHop{
+			{Symbol: model.Symbol{ID: 2, Qualified: "I2", FileID: 2}, Via: model.Symbol{ID: 1, Qualified: "C1"}, Hops: 2},
+		},
+		AffectedSubclasses:     []model.Symbol{{ID: 3, Qualified: "Sub3", FileID: 3}},
+		AffectedViaComposition: []model.Symbol{{ID: 4, Qualified: "Comp4", FileID: 4}},
+		AffectedViaIncludes:    []model.Symbol{{ID: 5, Qualified: "Inc5", FileID: 5}},
+		AffectedTests:          []string{},
+		TotalAffected:          2, // direct + indirect union
+	}
+	// Mark every id seen — even the indirect/subclass/compose/include ids.
+	resp := BuildBlastResponseSeen(context.Background(), r, noFiles, nil, seenSet(1, 2, 3, 4, 5))
+
+	if len(resp.DirectCallers) != 0 || resp.SeenVia == nil || resp.SeenVia.Count != 1 {
+		t.Errorf("direct caller C1 should collapse: callers=%d seen=%+v", len(resp.DirectCallers), resp.SeenVia)
+	}
+	// Only DIRECT callers collapse; the other relations are untouched.
+	if len(resp.IndirectCallers) != 1 {
+		t.Errorf("indirect_callers = %d, want 1 (never collapsed)", len(resp.IndirectCallers))
+	}
+	if len(resp.AffectedSubclasses) != 1 {
+		t.Errorf("affected_subclasses = %d, want 1 (never collapsed)", len(resp.AffectedSubclasses))
+	}
+	if len(resp.AffectedViaComposition) != 1 {
+		t.Errorf("affected_via_composition = %d, want 1 (never collapsed)", len(resp.AffectedViaComposition))
+	}
+	if len(resp.AffectedViaIncludes) != 1 {
+		t.Errorf("affected_via_includes = %d, want 1 (never collapsed)", len(resp.AffectedViaIncludes))
+	}
+}
+
+// TestBuildDiffBlastResponseSeenCollapses pins the same dedup on the diff
+// builder: a seen direct caller is collapsed, magnitude (total_affected, the
+// risk-factor count) reflects the full deduplicated union, not the remainder.
+func TestBuildDiffBlastResponseSeenCollapses(t *testing.T) {
+	results := []blast.Result{
+		{
+			Symbol: model.Symbol{ID: 1, Qualified: "A"},
+			Risk:   blast.RiskLow,
+			DirectCallers: []model.Symbol{
+				{ID: 10, Qualified: "Seen", FileID: 1},
+				{ID: 11, Qualified: "New", FileID: 2},
+			},
+			AffectedTests: []string{},
+		},
+	}
+	resp := BuildDiffBlastResponseSeen(context.Background(), "HEAD~1", results, noFiles, nil, seenSet(10))
+
+	if len(resp.DirectCallers) != 1 || resp.DirectCallers[0].Symbol != "New" {
+		t.Errorf("direct_callers = %+v, want only the unseen 'New'", resp.DirectCallers)
+	}
+	if resp.SeenVia == nil || resp.SeenVia.Count != 1 {
+		t.Fatalf("seen_elsewhere = %+v, want count 1", resp.SeenVia)
+	}
+	if resp.TotalAffected != 2 {
+		t.Errorf("total_affected = %d, want 2 (full dedup union, not the remainder)", resp.TotalAffected)
+	}
+	if !strings.Contains(resp.RiskFactors[0], "2 direct callers") {
+		t.Errorf("risk factor = %q, want it to report 2 direct callers (full magnitude)", resp.RiskFactors[0])
 	}
 }

--- a/internal/mcpio/graph.go
+++ b/internal/mcpio/graph.go
@@ -348,6 +348,7 @@ func categorizeEdges(ctx context.Context, outbound, inbound []model.EdgeRef, fil
 				}
 				fp := fileRefOrNil(e.Target.FileID, files)
 				edges.Calls = append(edges.Calls, CallEdgeRef{
+					ID:         e.Target.ID,
 					Symbol:     qualifiedOrName(e.Target),
 					File:       fp,
 					LineStart:  e.Target.LineStart,
@@ -430,6 +431,7 @@ func categorizeEdges(ctx context.Context, outbound, inbound []model.EdgeRef, fil
 					}
 				}
 				edges.CalledBy = append(edges.CalledBy, CallEdgeRef{
+					ID:         e.Target.ID,
 					Symbol:     sym,
 					File:       fp,
 					LineStart:  lineStart,

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -192,6 +192,11 @@ type GraphEdges struct {
 // may have no indexed file — the documented example includes
 // `"file": null` for exactly that case.
 type CallEdgeRef struct {
+	// ID is the target symbol's id, kept off the wire (json:"-"). It rides
+	// through segmentation and the budget trim so the handler can mark the
+	// FINAL rendered called_by set seen — a later sense_blast then collapses
+	// only callers the model actually received, never ones the budget dropped.
+	ID           int64      `json:"-"`
 	Symbol       string     `json:"symbol"`
 	File         *string    `json:"file"`
 	LineStart    int        `json:"line_start,omitempty"`
@@ -331,10 +336,26 @@ type BlastResponse struct {
 	// view template reaches this symbol, "none" when view-dispatch is a live
 	// question for it but no view edge exists, "" (omitted) otherwise. See
 	// viewedges.go for the full contract.
-	ViewEdges    string       `json:"view_edges,omitempty"`
-	SenseMetrics BlastMetrics `json:"-"`
-	Freshness    *Freshness   `json:"freshness,omitempty"`
-	NextSteps    []NextStep   `json:"next_steps"`
+	ViewEdges string `json:"view_edges,omitempty"`
+	// SeenVia summarises the direct callers collapsed out of the enumerated
+	// list because an earlier sense_graph/sense_blast call already returned
+	// them to this session. It is a token-saving deduplication, not a
+	// truncation: the data is already in the agent's context, so the magnitude
+	// fields (total_affected, direct_callers_by_area) and the completeness
+	// verdict are unaffected. Present only when at least one caller was
+	// collapsed.
+	SeenVia      *BlastSeenSummary `json:"seen_elsewhere,omitempty"`
+	SenseMetrics BlastMetrics      `json:"-"`
+	Freshness    *Freshness        `json:"freshness,omitempty"`
+	NextSteps    []NextStep        `json:"next_steps"`
+}
+
+// BlastSeenSummary collapses direct callers already returned earlier this
+// session into a single count + note, instead of re-enumerating them. Count
+// is how many enumerated direct callers were omitted; Note explains why.
+type BlastSeenSummary struct {
+	Count int    `json:"count"`
+	Note  string `json:"note"`
 }
 
 // BlastTierSummary holds a count plus a capped set of examples for

--- a/internal/mcpserver/blast.go
+++ b/internal/mcpserver/blast.go
@@ -12,6 +12,7 @@ import (
 	"github.com/luuuc/sense/internal/blast"
 	"github.com/luuuc/sense/internal/cli"
 	"github.com/luuuc/sense/internal/mcpio"
+	"github.com/luuuc/sense/internal/model"
 )
 
 func (h *handlers) handleBlast(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -328,7 +329,21 @@ func (h *handlers) blastSymbol(ctx context.Context, symbol, fileHint string, opt
 		return p, ok
 	}
 
-	return mcpio.BuildBlastResponse(ctx, blastResult, lookup, snippets), nil
+	resp := mcpio.BuildBlastResponseSeen(ctx, blastResult, lookup, snippets, h.seenPredicate())
+	// Symmetry: record every direct caller so a later sense_graph/sense_blast
+	// dedups against this blast, exactly as graph records its edge targets.
+	h.markSeen(directCallerIDs(blastResult.DirectCallers))
+	return resp, nil
+}
+
+// directCallerIDs extracts the symbol ids of a blast result's direct callers,
+// the set marked seen after a blast so later calls can dedup against it.
+func directCallerIDs(callers []model.Symbol) []int64 {
+	ids := make([]int64, len(callers))
+	for i, c := range callers {
+		ids[i] = c.ID
+	}
+	return ids
 }
 
 func (h *handlers) blastDiff(ctx context.Context, ref string, opts blast.Options, snippets *mcpio.SnippetReader) (mcpio.BlastResponse, error) {
@@ -364,5 +379,9 @@ func (h *handlers) blastDiff(ctx context.Context, ref string, opts blast.Options
 		return p, ok
 	}
 
-	return mcpio.BuildDiffBlastResponse(ctx, ref, results, lookup, snippets), nil
+	resp := mcpio.BuildDiffBlastResponseSeen(ctx, ref, results, lookup, snippets, h.seenPredicate())
+	for _, r := range results {
+		h.markSeen(directCallerIDs(r.DirectCallers))
+	}
+	return resp, nil
 }

--- a/internal/mcpserver/blastdiff_test.go
+++ b/internal/mcpserver/blastdiff_test.go
@@ -107,9 +107,10 @@ func setupGitRepo(t *testing.T) (dir string, h *handlers, cleanup func()) {
 	}
 
 	engine := &handlers{
-		adapter: adapter,
-		db:      adapter.DB(),
-		dir:     dir,
+		adapter:     adapter,
+		db:          adapter.DB(),
+		dir:         dir,
+		seenSymbols: make(map[int64]bool),
 	}
 
 	cleanup = func() {

--- a/internal/mcpserver/dispatch_test.go
+++ b/internal/mcpserver/dispatch_test.go
@@ -295,7 +295,8 @@ func TestAppendDispatchCallers(t *testing.T) {
 	}
 	directCallers := map[string]struct{}{"pkg.Dup": {}}
 
-	got := appendDispatchCallers(nil, inbound, "pkg.S.M", directCallers, lookup)
+	var ids []int64
+	got := appendDispatchCallers(nil, &ids, inbound, "pkg.S.M", directCallers, lookup)
 	if len(got) != 1 {
 		t.Fatalf("want 1 appended (non-call and dup skipped), got %d: %+v", len(got), got)
 	}
@@ -305,10 +306,15 @@ func TestAppendDispatchCallers(t *testing.T) {
 	if got[0].File == nil || *got[0].File != "caller.go" {
 		t.Errorf("want file caller.go from lookup, got %v", got[0].File)
 	}
+	// Only the emitted (non-skipped) caller's id is collected.
+	if len(ids) != 1 {
+		t.Errorf("collected ids = %v, want exactly the emitted caller", ids)
+	}
 
 	// At the per-query cap, further callers are not appended.
 	full := make([]mcpio.DispatchInferredRef, maxDispatchInferred)
-	capped := appendDispatchCallers(full,
+	var overflowIDs []int64
+	capped := appendDispatchCallers(full, &overflowIDs,
 		[]model.EdgeRef{{Edge: model.Edge{Kind: model.EdgeCalls}, Target: model.Symbol{Qualified: "pkg.Overflow"}}},
 		"pkg.S.M", map[string]struct{}{}, lookup)
 	if len(capped) != maxDispatchInferred {

--- a/internal/mcpserver/graph.go
+++ b/internal/mcpserver/graph.go
@@ -181,10 +181,6 @@ func (h *handlers) shapeGraphResponse(ctx context.Context, resp *mcpio.GraphResp
 		compactDispatchInferred(resp.DispatchInferred)
 	}
 
-	h.seenMu.Lock()
-	h.seenSymbols[gr.Root.Symbol.ID] = true
-	h.seenMu.Unlock()
-
 	h.tracker.Record("sense_graph", p.symbol,
 		resp.SenseMetrics.EstimatedFileReadsAvoided, resp.SenseMetrics.EstimatedTokensSaved, false)
 
@@ -198,6 +194,15 @@ func (h *handlers) shapeGraphResponse(ctx context.Context, resp *mcpio.GraphResp
 	// Keep hub responses within the MCP token budget — sheds deeper layers
 	// and trims the longest edge list, recording the count in OmittedEdges.
 	mcpio.ApplyGraphBudget(resp, h.defaults.GraphTokenBudget)
+
+	// Mark the root AND the FINAL rendered called_by callers seen — AFTER the
+	// budget trim, so a later sense_blast collapses ONLY callers the model
+	// actually received, never ones the budget dropped (collapsing an unshown
+	// caller would silently lose it). The rendered called_by set is exactly
+	// blast's depth-1 direct-caller set; inherit/include/compose and indirect
+	// callers are not marked — blast lists those separately. Test callers,
+	// segmented into their own bucket, are intentionally left un-collapsed.
+	h.markSeen(append(renderedCallerIDs(resp), gr.Root.Symbol.ID))
 }
 
 const (
@@ -283,6 +288,7 @@ func (h *handlers) resolveDispatchCallers(ctx context.Context, root *model.Symbo
 	}
 
 	var inferred []mcpio.DispatchInferredRef
+	var inferredIDs []int64
 	for _, eqID := range equivIDs {
 		if len(inferred) >= maxDispatchInferred {
 			break
@@ -292,15 +298,19 @@ func (h *handlers) resolveDispatchCallers(ctx context.Context, root *model.Symbo
 			continue
 		}
 		via := qualifiedOrNameRef(eqSym.Symbol)
-		inferred = appendDispatchCallers(inferred, eqSym.Inbound, via, directCallers, lookup)
+		inferred = appendDispatchCallers(inferred, &inferredIDs, eqSym.Inbound, via, directCallers, lookup)
 	}
+	// Dispatch-inferred callers reach the subject via interface dispatch — a
+	// later sense_blast counts them among its direct callers, so record them
+	// here to dedup that re-dump.
+	h.markSeen(inferredIDs)
 	return inferred
 }
 
 // appendDispatchCallers folds one dispatch-equivalent method's inbound call
 // edges into inferred, skipping callers already seen (direct or via an earlier
 // equivalent) and stopping once the per-query cap is reached.
-func appendDispatchCallers(inferred []mcpio.DispatchInferredRef, inbound []model.EdgeRef, via string, directCallers map[string]struct{}, lookup mcpio.FileLookup) []mcpio.DispatchInferredRef {
+func appendDispatchCallers(inferred []mcpio.DispatchInferredRef, ids *[]int64, inbound []model.EdgeRef, via string, directCallers map[string]struct{}, lookup mcpio.FileLookup) []mcpio.DispatchInferredRef {
 	for _, e := range inbound {
 		if e.Edge.Kind != model.EdgeCalls {
 			continue
@@ -313,6 +323,7 @@ func appendDispatchCallers(inferred []mcpio.DispatchInferredRef, inbound []model
 			continue
 		}
 		directCallers[callerName] = struct{}{}
+		*ids = append(*ids, e.Target.ID)
 
 		var filePath *string
 		if p, ok := lookup(e.Target.FileID); ok {
@@ -329,6 +340,25 @@ func appendDispatchCallers(inferred []mcpio.DispatchInferredRef, inbound []model
 		})
 	}
 	return inferred
+}
+
+// renderedCallerIDs collects the symbol ids of the callers the graph response
+// ACTUALLY rendered in its
+// called_by bucket, read after segmentation and the budget trim. These are
+// exactly the depth-1 callers the model received and exactly blast's direct-
+// caller set, so a later sense_blast can collapse them with no risk of hiding
+// a caller that was never shown. Test callers (segmented into their own
+// bucket) and indirect/inherit/include/compose targets are deliberately not
+// returned — blast enumerates those separately. IDs of 0 (unresolved-source
+// view edges) are skipped: they carry no symbol blast could match.
+func renderedCallerIDs(resp *mcpio.GraphResponse) []int64 {
+	ids := make([]int64, 0, len(resp.Edges.CalledBy))
+	for _, c := range resp.Edges.CalledBy {
+		if c.ID != 0 {
+			ids = append(ids, c.ID)
+		}
+	}
+	return ids
 }
 
 func qualifiedOrNameRef(s model.Symbol) string {

--- a/internal/mcpserver/oracle_test.go
+++ b/internal/mcpserver/oracle_test.go
@@ -169,7 +169,16 @@ func oracleDigest(t *testing.T, calls []labeledCall) (string, []string) {
 // across subsystems) and emitted area-clustered, so the fixture's two
 // callers reorder by area name (internal/auth before internal/handler)
 // instead of by symbol ID — digest moved.
-const oracleGolden = "b0342fc640957d5d134c63d2a807242141bde4a618f5c409843c723e2f3cb9f9"
+// Per-session blast dedup: the three graph calls on auth.Verify earlier in
+// this sequence mark its call-edge targets seen, so the blast on auth.Verify
+// now collapses both already-returned direct callers into seen_elsewhere
+// (direct_callers: [], seen_elsewhere.count: 2). Magnitude (total_affected,
+// direct_callers_by_area, affected_files) and the "complete" verdict are
+// unchanged — only the duplicate enumeration is gone — so the digest moved.
+// All direct callers of auth.Verify are collapsed (count == directTier1), so
+// the seen_elsewhere note now uses the "all N … see that response" phrasing
+// instead of "only new callers are listed" — digest moved.
+const oracleGolden = "62793f531d39e5a80e6c8a1189b5a713d9970dc57595324dcc1f522af1d1e0f5"
 
 func TestMCPServerResponseOracle(t *testing.T) {
 	got, content := oracleDigest(t, collectOracleCalls(t))

--- a/internal/mcpserver/seen.go
+++ b/internal/mcpserver/seen.go
@@ -1,0 +1,46 @@
+package mcpserver
+
+import "github.com/luuuc/sense/internal/mcpio"
+
+// Per-session seen-symbol dedup. The handler tracks every symbol id it has
+// already returned to this MCP session (search results, graph edge targets,
+// blast callers) in seenSymbols. A later tool collapses entries the session
+// already holds instead of re-sending them: sense_search blanks the snippet
+// (search.go), sense_blast collapses already-seen direct callers into a
+// seen_elsewhere summary (blast.go). This file is the one home for the read
+// (seenPredicate) and write (markSeen) sides of that shared state.
+
+// seenPredicate returns a SeenFunc the mcpio blast builders consult to decide
+// which direct callers were already returned this session. The predicate
+// locks per lookup, so it reflects the set as it stands when the builder runs
+// — a blast records its own callers only afterwards (markSeen), so it never
+// collapses against itself.
+func (h *handlers) seenPredicate() mcpio.SeenFunc {
+	return func(id int64) bool {
+		h.seenMu.Lock()
+		defer h.seenMu.Unlock()
+		return h.seenSymbols[id]
+	}
+}
+
+// markSeen records ids as returned to this session so a later collapsing tool
+// dedups against them. The dedup is directional: sense_graph and sense_blast
+// MARK what they return, but only sense_blast COLLAPSES already-seen direct
+// callers (and sense_search blanks already-seen snippets) — graph never
+// collapses. So the practical flows are graph→blast and blast→blast; a blast
+// after a graph is the common one. A nil seenSymbols map (a handler built
+// without session tracking) disables the dedup rather than panicking — the
+// zero value is "track nothing".
+func (h *handlers) markSeen(ids []int64) {
+	if len(ids) == 0 {
+		return
+	}
+	h.seenMu.Lock()
+	defer h.seenMu.Unlock()
+	if h.seenSymbols == nil {
+		return
+	}
+	for _, id := range ids {
+		h.seenSymbols[id] = true
+	}
+}

--- a/internal/mcpserver/seen_test.go
+++ b/internal/mcpserver/seen_test.go
@@ -1,0 +1,195 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/luuuc/sense/internal/mcpio"
+)
+
+// TestSeenPredicateAndMarkSeen pins the read/write sides of the per-session
+// dedup state: markSeen records ids, seenPredicate reports them, and a handler
+// with no seenSymbols map degrades to "track nothing" instead of panicking.
+func TestSeenPredicateAndMarkSeen(t *testing.T) {
+	h := &handlers{seenSymbols: map[int64]bool{}}
+	pred := h.seenPredicate()
+
+	if pred(7) {
+		t.Error("nothing marked yet — id 7 must not be seen")
+	}
+	h.markSeen([]int64{7, 9})
+	if !pred(7) || !pred(9) {
+		t.Error("markSeen([7,9]) must make both seen")
+	}
+	if pred(8) {
+		t.Error("id 8 was never marked — must not be seen")
+	}
+
+	// markSeen with no ids is a no-op (no panic, no entries).
+	h.markSeen(nil)
+
+	// A handler without a seen-set disables dedup gracefully.
+	nilH := &handlers{}
+	nilH.markSeen([]int64{1}) // must not panic
+	if nilH.seenPredicate()(1) {
+		t.Error("a nil seen-set must report nothing as seen")
+	}
+}
+
+// TestSeenDedupCollapsesOnlyRenderedCallers is the LEAK regression. graph marks
+// the FINAL rendered called_by (post budget-trim), never the pre-trim query set
+// — collapsing a caller the model never received would silently drop it (the
+// bug that once leaked 27 unshown callers). It is a differential: a graph whose
+// called_by the budget TRIMMED must make a later blast collapse STRICTLY FEWER
+// callers than an untrimmed graph. If the marking ever reverts to the untrimmed
+// query, both runs mark the same full set, the counts converge, and this fails.
+func TestSeenDedupCollapsesOnlyRenderedCallers(t *testing.T) {
+	ctx := context.Background()
+	const sym = "auth.Verify" // a fixture symbol with two static callers
+
+	seenAfterGraph := func(graphBudget int) int {
+		// Fresh server → fresh seen-set. graph then blast in ONE session: graph
+		// marks its rendered callers, blast collapses the ones it also lists.
+		ts := setupTestServer(t)
+		ts.handlers.defaults.GraphTokenBudget = graphBudget
+		if _, err := ts.handlers.handleGraph(ctx, toolReq(map[string]any{"symbol": sym, "direction": "callers"})); err != nil {
+			t.Fatalf("handleGraph(budget=%d): %v", graphBudget, err)
+		}
+		result, err := ts.handlers.handleBlast(ctx, toolReq(map[string]any{"symbol": sym}))
+		if err != nil {
+			t.Fatalf("handleBlast(budget=%d): %v", graphBudget, err)
+		}
+		var resp mcpio.BlastResponse
+		if err := json.Unmarshal([]byte(resultText(t, result)), &resp); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if resp.SeenVia == nil {
+			return 0
+		}
+		return resp.SeenVia.Count
+	}
+
+	trimmed := seenAfterGraph(1)      // budget=1 trims called_by to ~one entry
+	full := seenAfterGraph(1_000_000) // no trim: every rendered caller marked
+
+	if full < 2 {
+		t.Skipf("fixture symbol %q collapses only %d callers at full budget — too few to test the differential", sym, full)
+	}
+	if full <= trimmed {
+		t.Fatalf("blast collapsed %d callers after a TRIMMED graph and %d after a FULL graph; "+
+			"a trimmed graph renders fewer callers so it must collapse strictly fewer — equal/greater "+
+			"means the marking ignored the budget trim and leaked unshown callers", trimmed, full)
+	}
+}
+
+// TestRenderedCallerIDs pins that only the callers the graph response actually
+// rendered in called_by are collected (so blast collapses only what the model
+// received), and that unresolved-source view edges (ID 0) are skipped.
+func TestRenderedCallerIDs(t *testing.T) {
+	resp := &mcpio.GraphResponse{
+		Edges: mcpio.GraphEdges{
+			CalledBy: []mcpio.CallEdgeRef{
+				{ID: 1, Symbol: "A#m"},
+				{ID: 2, Symbol: "B#n"},
+				{ID: 0, Symbol: "app/views/x.erb"}, // unresolved view edge — skip
+				{ID: 3, Symbol: "C#o"},
+			},
+			// Calls (callees) and other buckets must NOT be collected — they are
+			// not blast direct callers.
+			Calls: []mcpio.CallEdgeRef{{ID: 88, Symbol: "callee"}},
+		},
+	}
+
+	got := renderedCallerIDs(resp)
+	want := map[int64]bool{1: true, 2: true, 3: true}
+	if len(got) != len(want) {
+		t.Fatalf("renderedCallerIDs = %v, want the 3 rendered called_by ids {1,2,3}", got)
+	}
+	for _, id := range got {
+		if !want[id] {
+			t.Errorf("collected id %d — only rendered called_by ids should be marked seen", id)
+		}
+	}
+}
+
+// parseBlast unmarshals a blast tool result into the fields the dedup tests
+// assert on. Keeps the test focused on the dedup contract.
+type blastView struct {
+	DirectCallers       []map[string]any `json:"direct_callers"`
+	TotalAffected       int              `json:"total_affected"`
+	DirectCallersByArea map[string]int   `json:"direct_callers_by_area"`
+	SeenVia             *struct {
+		Count int `json:"count"`
+	} `json:"seen_elsewhere"`
+	Completeness *struct {
+		Verdict string `json:"verdict"`
+	} `json:"completeness"`
+}
+
+func runBlast(t *testing.T, h *handlers, symbol string) blastView {
+	t.Helper()
+	res, err := h.handleBlast(context.Background(), toolReq(map[string]any{"symbol": symbol}))
+	if err != nil {
+		t.Fatalf("handleBlast: %v", err)
+	}
+	var v blastView
+	if err := json.Unmarshal([]byte(resultText(t, res)), &v); err != nil {
+		t.Fatalf("parse blast: %v", err)
+	}
+	return v
+}
+
+// TestBlastSingleCallIsFullThenGraphDedups pins order-independence end to end:
+//  1. A blast in a FRESH session enumerates every direct caller (empty seen-set
+//     ⇒ no collapse), recording them as seen.
+//  2. A graph on the same symbol next would dedup against blast's recorded ids
+//     (the symmetric direction). We assert the recording half here.
+//  3. A SECOND blast on the same symbol collapses the callers the first blast
+//     recorded — proving the dedup is order-independent and blast records its
+//     own callers for later calls.
+func TestBlastSingleCallIsFullThenGraphDedups(t *testing.T) {
+	ts := setupTestServer(t)
+	h := ts.handlers
+
+	// 1. Fresh session: blast on auth.Verify enumerates its callers in full.
+	first := runBlast(t, h, "auth.Verify")
+	if first.SeenVia != nil {
+		t.Errorf("fresh-session blast must collapse nothing, got seen_elsewhere=%+v", first.SeenVia)
+	}
+	if len(first.DirectCallers) == 0 {
+		t.Fatal("fresh blast should enumerate at least one direct caller")
+	}
+	if first.Completeness == nil || first.Completeness.Verdict != "complete" {
+		t.Fatalf("fresh blast verdict = %+v, want complete", first.Completeness)
+	}
+	firstCount := len(first.DirectCallers)
+	fullArea := sumIntMap(first.DirectCallersByArea)
+
+	// 2+3. Second blast on the same symbol: the callers recorded by the first
+	// blast are now collapsed, but the radius is preserved.
+	second := runBlast(t, h, "auth.Verify")
+	if second.SeenVia == nil || second.SeenVia.Count != firstCount {
+		t.Errorf("second blast seen_elsewhere = %+v, want count %d (all callers already returned)", second.SeenVia, firstCount)
+	}
+	if len(second.DirectCallers) != 0 {
+		t.Errorf("second blast enumerated %d callers, want 0 (all already seen)", len(second.DirectCallers))
+	}
+	if second.TotalAffected != first.TotalAffected {
+		t.Errorf("total_affected drifted: %d vs %d (magnitude must survive collapse)", second.TotalAffected, first.TotalAffected)
+	}
+	if sumIntMap(second.DirectCallersByArea) != fullArea {
+		t.Errorf("by_area sum drifted: %d vs %d", sumIntMap(second.DirectCallersByArea), fullArea)
+	}
+	if second.Completeness == nil || second.Completeness.Verdict != "complete" {
+		t.Errorf("second blast verdict = %+v, want complete (dedup is not truncation)", second.Completeness)
+	}
+}
+
+func sumIntMap(m map[string]int) int {
+	n := 0
+	for _, v := range m {
+		n += v
+	}
+	return n
+}

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -247,6 +247,9 @@ func TestMCPIntegration(t *testing.T) {
 			Risk          string `json:"risk"`
 			DirectCallers []any  `json:"direct_callers"`
 			TotalAffected int    `json:"total_affected"`
+			SeenVia       *struct {
+				Count int `json:"count"`
+			} `json:"seen_elsewhere"`
 		}
 		if err := json.Unmarshal([]byte(text), &blastResp); err != nil {
 			t.Fatalf("parse blast JSON: %v\n%s", err, text)
@@ -259,8 +262,22 @@ func TestMCPIntegration(t *testing.T) {
 		default:
 			t.Errorf("risk = %q, want low/medium/high", blastResp.Risk)
 		}
-		if len(blastResp.DirectCallers) < 5 {
-			t.Errorf("direct_callers = %d, want >= 5", len(blastResp.DirectCallers))
+		// Earlier subtests already ran sense_graph on extract.Register in this
+		// same session, so the call-edge targets are marked seen and this blast
+		// collapses them into seen_elsewhere rather than re-dumping them. The
+		// radius is unchanged: total_affected still reports the full set, and
+		// the enumerated direct callers plus the collapsed count cover it.
+		enumerated := len(blastResp.DirectCallers)
+		collapsed := 0
+		if blastResp.SeenVia != nil {
+			collapsed = blastResp.SeenVia.Count
+		}
+		if blastResp.TotalAffected < 5 {
+			t.Errorf("total_affected = %d, want >= 5 (magnitude must survive seen-collapse)", blastResp.TotalAffected)
+		}
+		if enumerated+collapsed < 5 {
+			t.Errorf("direct_callers(%d) + seen_elsewhere(%d) = %d, want >= 5",
+				enumerated, collapsed, enumerated+collapsed)
 		}
 	})
 


### PR DESCRIPTION
## Summary
When an MCP session calls `sense_graph` then `sense_blast` on the same symbol, blast re-dumped the caller set graph already returned — roughly 2x the token weight for no new information. blast now collapses the direct callers the session already received into a `seen_elsewhere` summary, freeing its enumeration budget to surface NEW callers instead.

Magnitude (`total_affected`, `direct_callers_by_area`, `affected_files`) and the completeness verdict are computed from the FULL set, so the collapse saves tokens without hiding radius.

## Safety
The dedup keys on the FINAL rendered `called_by` (post token-budget trim) via a wire-invisible id on `CallEdgeRef` — never the pre-trim query set — so it can only collapse callers the model actually received. CLI output is unchanged (a nil `SeenFunc` enumerates everything).

## Measured impact (bench, Opus 4.8 x3)
- **discourse**: Sense tokens into context ~21k -> ~13k; distinct callers visible 117 -> 148; dependents cited-recall 0.958 -> 0.979 (held/improved).
- **gitlabhq**: cache-write -31%, billed -13%; dependents cited-recall 0.750 -> 0.771.
- Zero leak (every collapsed caller was actually rendered), verified over MCP stdio.

## Tests
- **Leak regression**: a budget-trimmed graph must collapse strictly fewer callers than a full graph — fails if marking ever reverts to the pre-trim query.
- blast->blast order-independence; magnitude + completeness invariants survive the collapse; oracle digest updated.

`make ci` green: coverage 95% (floor 92%), lint 0 issues, complexity ledger 0.