### PR TITLE
fix(conventions): de-noise and re-rank sense_conventions output

### DIFF
--- a/bench/lib/article_audit.py
+++ b/bench/lib/article_audit.py
@@ -5,7 +5,7 @@ Complements `check_article_stats.py` (which checks headline NUMBERS are fresh) b
 checking everything else the maintain workflow needs:
 
   COVERAGE   — every benched repo has exactly one pack; numbering is contiguous.
-  STRUCTURE  — frontmatter parses; required keys present; teardowns have Blocks A-I.
+  STRUCTURE  — frontmatter parses; required keys present; teardowns have Blocks A-J.
   REFERENCES — every local markdown link resolves; no links to removed files.
   SYNC       — every pack appears in the README board (and vice-versa).
   DISCIPLINE — (warn) no em-dashes in body prose; flag mentions of removed files.
@@ -30,7 +30,7 @@ DEFAULT_ARTICLES = os.path.join(VERTICAL_DIR, "articles")
 DEFAULT_RESULTS = os.path.join(
     REPO_ROOT, "bench", "results", "vertical", "ruby-rails", "claude-opus-4-8")
 
-REQUIRED_BLOCKS = list("ABCDEFGHI")
+REQUIRED_BLOCKS = list("ABCDEFGHIJ")
 REQUIRED_KEYS = ("repo", "data", "agents")
 TEARDOWN_KEYS = ("axes", "stats")
 # docs whose links we police (current set; archive/ is historical, skipped)
@@ -99,7 +99,7 @@ def audit(articles_dir=DEFAULT_ARTICLES, results_root=DEFAULT_RESULTS):
                 if k not in fm:
                     out.append((WARN, "keys", f"{name}: missing frontmatter `{k}`"))
             # tolerate "## Block A — x", "## Block A. X", "## Block A: x", etc.
-            found = set(re.findall(r"^## Block ([A-I])\b", body, re.M))
+            found = set(re.findall(r"^## Block ([A-J])\b", body, re.M))
             missing = [b for b in REQUIRED_BLOCKS if b not in found]
             if missing:
                 out.append((FAIL, "blocks",

--- a/bench/lib/efficiency.py
+++ b/bench/lib/efficiency.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Per-repo WITHIN-AGENT efficiency / reach / reliability numbers, FROM DISK.
+
+Feeds the Block D efficiency & effectiveness sub-table + the reach & reliability
+line (see _skeleton.md). Everything here is a within-agent comparison
+(baseline vs sense inside ONE agent); never compare across agents.
+
+  billed tokens   mean(metrics.token_total_billed)
+  session time    median(metrics.wall_time_seconds)   (noisy; median across runs)
+  cost            mean(metrics.cost_usd)
+  turnarounds     mean(metrics.tool_calls)
+  navigation      mean(grep_count / mcp_count / read_count)
+  grounding       1 - sum(contradicted)/sum(covered)  (judged.json, anti-fab)
+  sense-only      dependents cited by sense, never by baseline (gold_recall.details)
+  reliability     per-run overall cited-gold counts per arm (the floor)
+  miss-list       baseline gold_recall.missed_cite never reached in any run
+
+Usage: efficiency.py <repo> [results_dir]
+       results_dir defaults to the claude-opus-4-8 vertical root.
+"""
+import json
+import glob
+import os
+import statistics
+import sys
+
+REPO_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", ".."))
+DEFAULT = os.path.join(REPO_ROOT, "bench", "results", "vertical",
+                       "ruby-rails", "claude-opus-4-8")
+
+
+def _runs(arm_repo):
+    fs = sorted(glob.glob(os.path.join(arm_repo, "run-*", "scored.json")))
+    flat = os.path.join(arm_repo, "scored.json")
+    return fs or ([flat] if os.path.exists(flat) else [])
+
+
+def _mean(a):
+    return sum(a) / len(a) if a else None
+
+
+def arm(root, which, repo):
+    m = {k: [] for k in ("tok", "wall", "cost", "calls", "grep", "mcp", "read")}
+    cited_counts = []          # overall cited-gold count per run (reliability)
+    dep_items = set()          # dependents cited (any run)
+    cited_recalls = []
+    miss_sets = []             # missed_cite per run (for baseline never-cited)
+    cov_t = con_t = 0
+    for sf in _runs(os.path.join(root, which, repo)):
+        s = json.load(open(sf))
+        me = s.get("metrics", {}) or {}
+        m["tok"].append(me.get("token_total_billed"))
+        m["wall"].append(me.get("wall_time_seconds"))
+        m["cost"].append(me.get("cost_usd"))
+        m["calls"].append(me.get("tool_calls"))
+        m["grep"].append(me.get("grep_count"))
+        m["mcp"].append(me.get("mcp_count"))
+        m["read"].append(me.get("read_count"))
+        g = s.get("gold_recall", {}) or {}
+        cited_recalls.append(g.get("cited_recall"))
+        det = g.get("details", []) or []
+        cited_counts.append(sum(1 for x in det if x.get("cited")))
+        dep_items |= {x["id"] for x in det
+                      if x.get("cited") and x.get("group") == "dependents"}
+        miss_sets.append(set(g.get("missed_cite", []) or []))
+        jf = sf.replace("scored.json", "judged.json")
+        if os.path.exists(jf):
+            ra = (json.load(open(jf)).get("relationship_audit", {}) or {})
+            cov_t += ra.get("covered", 0) or 0
+            con_t += ra.get("contradicted", 0) or 0
+    clean = {k: [x for x in v if x is not None] for k, v in m.items()}
+    grounded = (1 - con_t / cov_t) if cov_t else 1.0
+    return {
+        "tok": _mean(clean["tok"]),
+        "wall": statistics.median(clean["wall"]) if clean["wall"] else None,
+        "cost": _mean(clean["cost"]),
+        "calls": _mean(clean["calls"]),
+        "grep": _mean(clean["grep"]), "mcp": _mean(clean["mcp"]),
+        "read": _mean(clean["read"]),
+        "grounded": grounded, "contra": con_t,
+        "cited_recall": _mean([c for c in cited_recalls if c is not None]),
+        "cited_counts": cited_counts,
+        "dep_items": dep_items,
+        "miss_sets": miss_sets,
+    }
+
+
+def _pct(b, s):
+    if not b or s is None:
+        return "—"
+    return f"{(s - b) / b * 100:+.0f}%"
+
+
+def report(root, repo):
+    b = arm(root, "baseline", repo)
+    s = arm(root, "sense", repo)
+    sense_only = sorted(s["dep_items"] - b["dep_items"])
+    # baseline gold it NEVER cited in any run = intersection of per-run miss sets
+    never = set.intersection(*b["miss_sets"]) if b["miss_sets"] else set()
+    mult = (s["cited_recall"] / b["cited_recall"]
+            if b["cited_recall"] else None)
+    L = []
+    L.append(f"# {repo} — within-agent efficiency / reach / reliability "
+             f"(Claude Code · Opus 4.8, FROM DISK)\n")
+    L.append("| axis | baseline | sense | Δ |")
+    L.append("|---|---|---|---|")
+    L.append(f"| billed tokens | {b['tok']:.0f} | {s['tok']:.0f} | {_pct(b['tok'], s['tok'])} |")
+    L.append(f"| session time (s, median) | {b['wall']:.0f} | {s['wall']:.0f} | {_pct(b['wall'], s['wall'])} |")
+    L.append(f"| cost ($) | {b['cost']:.2f} | {s['cost']:.2f} | {_pct(b['cost'], s['cost'])} |")
+    bc, sc = round(b['calls']), round(s['calls'])
+    L.append(f"| turnarounds (tool calls) | {bc} | {sc} | {sc - bc:+d} |")
+    L.append(f"| navigation (grep / mcp / read) | {b['grep']:.0f}/{b['mcp']:.0f}/{b['read']:.0f} "
+             f"| {s['grep']:.0f}/{s['mcp']:.0f}/{s['read']:.0f} | grep→structural |")
+    L.append(f"| grounding (anti-fab) | {b['grounded']:.2f} | {s['grounded']:.2f} "
+             f"| contra {b['contra']}→{s['contra']} |")
+    L.append("")
+    L.append(f"- **sense-only reach (dependents):** {len(sense_only)} "
+             f"({', '.join(sense_only) if sense_only else 'none'})")
+    L.append(f"- **reach at parity:** cited_recall {b['cited_recall']:.2f}→{s['cited_recall']:.2f}"
+             + (f" ({mult:.1f}×)" if mult else "") + f" at {_pct(b['tok'], s['tok'])} tokens")
+    L.append(f"- **reliability (overall cited/run):** baseline {b['cited_counts']} "
+             f"→ sense {s['cited_counts']}")
+    L.append(f"- **baseline never-cited miss-list:** "
+             f"{', '.join(sorted(never)) if never else 'none'}")
+    return "\n".join(L) + "\n"
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        sys.exit("usage: efficiency.py <repo> [results_dir]")
+    root = sys.argv[2] if len(sys.argv) > 2 else DEFAULT
+    sys.stdout.write(report(root, sys.argv[1]))

--- a/bench/lib/scoreboard.py
+++ b/bench/lib/scoreboard.py
@@ -8,10 +8,16 @@ un-reproducible SENSE-SCORING-REPORT.md (the numbers did not trace to disk).
 
   cited_recall      from scored.json gold_recall.cited_recall  (OBJECTIVE)
   deps-delta        scored.json gold_recall.groups.dependents (cited/total)
+  sense-only        dependents cited by sense, never by baseline (any run) — gold_recall.details
   related_recall    judged.json relationship_audit.related_recall (Sonnet)
   grounded_prec     1 - sum(contradicted)/sum(covered) across runs
   contradictions    sum(contradicted) across runs, per arm
   B-score           0.55*cited + 0.25*related + 0.20*grounded_precision
+  eff-at-parity     ◆ on a recall TIE only: every sense run under baseline on
+                    billed tokens (no overlap) AND lower wall median. The
+                    declared headline for enumerable-gold repos (llm.rb) where
+                    recall ties BY DESIGN. Reported separately, NOT in the win
+                    count, NOT in B-score (efficiency stays out of the blend).
 
 Usage: scoreboard.py [results_dir]   (default: claude-opus-4-8 vertical root)
 """
@@ -42,13 +48,25 @@ def arm_axes(root, arm, repo):
     cited, deps, rel = [], [], []
     cov_t = con_t = 0
     judge_model = None
+    dep_items = set()   # union of dependents-group gold ids this arm CITED (any run)
+    counts = []         # overall cited-gold count per run (for reliability/floor)
+    toks, walls = [], []  # per-run billed tokens / wall seconds (efficiency-at-parity)
     for sf in _runs(os.path.join(root, arm, repo)):
         s = json.load(open(sf))
         g = s.get("gold_recall", {})
         cited.append(g.get("cited_recall", 0.0))
+        me = s.get("metrics", {}) or {}
+        if me.get("token_total_billed") is not None:
+            toks.append(me["token_total_billed"])
+        if me.get("wall_time_seconds") is not None:
+            walls.append(me["wall_time_seconds"])
         grp = g.get("groups", {}).get("dependents")
         if grp and grp.get("total"):
             deps.append(grp["cited"] / grp["total"])
+        det = g.get("details", []) or []
+        counts.append(sum(1 for x in det if x.get("cited")))
+        dep_items |= {x["id"] for x in det
+                      if x.get("cited") and x.get("group") == "dependents"}
         jf = sf.replace("scored.json", "judged.json")
         if os.path.exists(jf):
             j = json.load(open(jf))
@@ -60,16 +78,45 @@ def arm_axes(root, arm, repo):
             con_t += ra.get("contradicted", 0) or 0
     gp = (1 - con_t / cov_t) if cov_t else 1.0
     return {"cited": _mean(cited), "deps": _mean(deps), "related": _mean(rel),
-            "grounded": gp, "contra": con_t, "n": len(cited), "judge": judge_model}
+            "grounded": gp, "contra": con_t, "n": len(cited), "judge": judge_model,
+            "dep_items": dep_items, "counts": counts, "toks": toks, "walls": walls}
 
 
 def bscore(a):
     return 0.55 * (a["cited"] or 0) + 0.25 * (a["related"] or 0) + 0.20 * a["grounded"]
 
 
+def eff_at_parity(b, s):
+    """Robust within-agent efficiency win at HELD recall.
+
+    Only meaningful when the cited-recall verdict is a TIE (the caller gates on
+    that): a scenario whose declared headline is efficiency (llm.rb) ties on
+    recall BY DESIGN, so the real result lives here. Robust = every sense run's
+    billed tokens strictly below every baseline run's (no run overlap) AND the
+    sense wall-time median below the baseline's. Returns the token Δ% (negative =
+    sense cheaper) when both hold, else None. NOT folded into the cited headline
+    or B-score; reported as a separate, clearly-labelled axis (efficiency was
+    deliberately excluded from the recall blend, this keeps it that way).
+    """
+    bt, st, bw, sw = b["toks"], s["toks"], b["walls"], s["walls"]
+    if not (bt and st and bw and sw):
+        return None
+    tokens_robust = max(st) < min(bt)          # no overlap, sense strictly under
+    wall_lower = _median(sw) < _median(bw)
+    if tokens_robust and wall_lower:
+        return (_mean(st) - _mean(bt)) / _mean(bt) * 100.0
+    return None
+
+
+def _median(a):
+    a = sorted(a)
+    n = len(a)
+    return a[n // 2] if n % 2 else (a[n // 2 - 1] + a[n // 2]) / 2
+
+
 def build(root):
     rows = []
-    wins = ties = losses = 0
+    wins = ties = losses = eff_wins = 0
     deltas = []
     judges = set()
     for repo in ORDER:
@@ -84,13 +131,22 @@ def build(root):
         ties += verdict == "TIE"
         losses += verdict == "LOSS"
         antifab = b["contra"] > 0 and s["contra"] == 0
+        # sense-only reach: dependents the sense arm cited that the baseline
+        # never cited in ANY run (the silent breaks a grep-driven refactor ships).
+        s["sense_only"] = len(s["dep_items"] - b["dep_items"])
+        # efficiency-at-parity: only surfaced on a recall TIE, where a scenario
+        # whose declared headline is efficiency (llm.rb) actually lands its win.
+        # Kept separate from the cited verdict, never inflates the win count.
+        eff = eff_at_parity(b, s) if verdict == "TIE" else None
+        if eff is not None:
+            eff_wins += 1
         judges.add(b["judge"]); judges.add(s["judge"])
-        rows.append((repo, b, s, d, verdict, antifab))
-    return rows, wins, ties, losses, _mean(deltas), judges
+        rows.append((repo, b, s, d, verdict, antifab, eff))
+    return rows, wins, ties, losses, eff_wins, _mean(deltas), judges
 
 
 def markdown(root):
-    rows, wins, ties, losses, mean_d, judges = build(root)
+    rows, wins, ties, losses, eff_wins, mean_d, judges = build(root)
     judge = sorted(j for j in judges if j) or ["?"]
     out = []
     out.append("# Rails-vertical scoring — Sense vs baseline\n")
@@ -104,20 +160,31 @@ def markdown(root):
     af = [r[0] for r in rows if r[5]]
     out.append(f"Anti-fabrication wins (⚑ — baseline asserts a wrong relation, "
                f"Sense does not): **{', '.join(af) if af else 'none'}**.\n")
-    out.append("| repo | cited b→s (Δ) | deps-delta | B-score b→s | related b→s | grnd b/s | contra b/s | verdict |")
-    out.append("|------|---------------|-----------|-------------|-------------|:--------:|:---------:|:-------:|")
-    for repo, b, s, d, verdict, antifab in rows:
+    ew = [(r[0], r[6]) for r in rows if r[6] is not None]
+    if ew:
+        ewtxt = ", ".join(f"{repo} ({eff:+.0f}% tokens)" for repo, eff in ew)
+        out.append(f"Efficiency-at-parity wins (◆, recall held, every sense run robustly "
+                   f"under baseline on billed tokens AND wall time): **{ewtxt}**. "
+                   f"Counted separately, never folded into the cited-recall headline.\n")
+    out.append("| repo | cited b→s (Δ) | deps-delta | sense-only | B-score b→s | related b→s | grnd b/s | contra b/s | verdict |")
+    out.append("|------|---------------|-----------|:---------:|-------------|-------------|:--------:|:---------:|:-------:|")
+    for repo, b, s, d, verdict, antifab, eff in rows:
         gem = " 🔸" if repo in GEMS else ""
         flag = " ⚑" if antifab else ""
+        effflag = f" ◆ eff {eff:+.0f}% tok" if eff is not None else ""
         dd = (f"{s['deps']-b['deps']:+.2f}" if (b['deps'] is not None and s['deps'] is not None) else "—")
         rb = f"{b['related']:.2f}" if b['related'] is not None else "—"
         rs = f"{s['related']:.2f}" if s['related'] is not None else "—"
         out.append(f"| {repo}{gem} | {b['cited']:.2f}→{s['cited']:.2f} ({d:+.2f}) "
-                   f"| {dd} | {bscore(b):.2f}→{bscore(s):.2f} | {rb}→{rs} "
+                   f"| {dd} | {s['sense_only']} | {bscore(b):.2f}→{bscore(s):.2f} | {rb}→{rs} "
                    f"| {b['grounded']:.2f}/{s['grounded']:.2f} "
-                   f"| {b['contra']}/{s['contra']} | **{verdict}{flag}** |")
+                   f"| {b['contra']}/{s['contra']} | **{verdict}{flag}{effflag}** |")
     out.append("\n🔸 gem / small library. ⚑ anti-fabrication win. "
-               "deps-delta = cited_recall on the scattered-dependents discriminator group.")
+               "◆ efficiency-at-parity win (recall tied, sense robustly cheaper in billed tokens + wall time, "
+               "the declared headline axis for an enumerable-gold repo like llm.rb; counted separately from cited wins). "
+               "deps-delta = cited_recall on the scattered-dependents discriminator group. "
+               "sense-only = dependents the sense arm cited that the baseline never cited in any run "
+               "(the silent breaks a grep-driven refactor would ship).")
     return "\n".join(out) + "\n"
 
 

--- a/bench/lib/test_article_audit.py
+++ b/bench/lib/test_article_audit.py
@@ -17,7 +17,7 @@ def _results(tmp_path, repos):
     return str(root)
 
 
-FULL_BODY = "\n".join(f"## Block {b} — x\nprose\n" for b in "ABCDEFGHI")
+FULL_BODY = "\n".join(f"## Block {b} — x\nprose\n" for b in "ABCDEFGHIJ")
 
 
 def test_real_set_has_no_fail():

--- a/bench/results/vertical/ruby-rails/claude-opus-4-8/sense/llm.rb/run-1/judged.json
+++ b/bench/results/vertical/ruby-rails/claude-opus-4-8/sense/llm.rb/run-1/judged.json
@@ -6,90 +6,273 @@
     "prompt_version": "v1",
     "rubric_path": "llm.rb.rubric.yaml"
   },
-  "scenario_quality": 0.7748,
-  "relationship_audit": null,
+  "scenario_quality": 0.7542,
+  "relationship_audit": {
+    "total": 27,
+    "covered": 24,
+    "related": 24,
+    "contradicted": 0,
+    "covered_recall": 0.8889,
+    "related_recall": 0.8889,
+    "grounded_precision": 1.0,
+    "missed_covered": [
+      "spec:provider",
+      "spec:openai-chat",
+      "spec:openai-stream"
+    ],
+    "missed_related": [
+      "spec:provider",
+      "spec:openai-chat",
+      "spec:openai-stream"
+    ],
+    "contradictions": [],
+    "items": [
+      {
+        "id": "factory",
+        "covered": true,
+        "related": true,
+        "contradicted": false
+      },
+      {
+        "id": "provider-base",
+        "covered": true,
+        "related": true,
+        "contradicted": false
+      },
+      {
+        "id": "prov:openai",
+        "covered": true,
+        "related": true,
+        "contradicted": false
+      },
+      {
+        "id": "prov:anthropic",
+        "covered": true,
+        "related": true,
+        "contradicted": false
+      },
+      {
+        "id": "prov:google",
+        "covered": true,
+        "related": true,
+        "contradicted": false
+      },
+      {
+        "id": "prov:ollama",
+        "covered": true,
+        "related": true,
+        "contradicted": false
+      },
+      {
+        "id": "prov:bedrock",
+        "covered": true,
+        "related": true,
+        "contradicted": false
+      },
+      {
+        "id": "prov:deepseek",
+        "covered": true,
+        "related": true,
+        "contradicted": false
+      },
+      {
+        "id": "req:openai",
+        "covered": true,
+        "related": true,
+        "contradicted": false
+      },
+      {
+        "id": "req:anthropic",
+        "covered": true,
+        "related": true,
+        "contradicted": false
+      },
+      {
+        "id": "req:google",
+        "covered": true,
+        "related": true,
+        "contradicted": false
+      },
+      {
+        "id": "req:ollama",
+        "covered": true,
+        "related": true,
+        "contradicted": false
+      },
+      {
+        "id": "resp:openai",
+        "covered": true,
+        "related": true,
+        "contradicted": false
+      },
+      {
+        "id": "resp:anthropic",
+        "covered": true,
+        "related": true,
+        "contradicted": false
+      },
+      {
+        "id": "resp:google",
+        "covered": true,
+        "related": true,
+        "contradicted": false
+      },
+      {
+        "id": "resp:ollama",
+        "covered": true,
+        "related": true,
+        "contradicted": false
+      },
+      {
+        "id": "stream:openai",
+        "covered": true,
+        "related": true,
+        "contradicted": false
+      },
+      {
+        "id": "stream:anthropic",
+        "covered": true,
+        "related": true,
+        "contradicted": false
+      },
+      {
+        "id": "stream:google",
+        "covered": true,
+        "related": true,
+        "contradicted": false
+      },
+      {
+        "id": "stream:ollama",
+        "covered": true,
+        "related": true,
+        "contradicted": false
+      },
+      {
+        "id": "err:openai",
+        "covered": true,
+        "related": true,
+        "contradicted": false
+      },
+      {
+        "id": "err:anthropic",
+        "covered": true,
+        "related": true,
+        "contradicted": false
+      },
+      {
+        "id": "err:google",
+        "covered": true,
+        "related": true,
+        "contradicted": false
+      },
+      {
+        "id": "err:ollama",
+        "covered": true,
+        "related": true,
+        "contradicted": false
+      },
+      {
+        "id": "spec:provider",
+        "covered": false,
+        "related": false,
+        "contradicted": false
+      },
+      {
+        "id": "spec:openai-chat",
+        "covered": false,
+        "related": false,
+        "contradicted": false
+      },
+      {
+        "id": "spec:openai-stream",
+        "covered": false,
+        "related": false,
+        "contradicted": false
+      }
+    ]
+  },
   "steps": [
     {
       "step": "Orient in the codebase",
       "scores": {
         "map_quality": {
-          "score": 0.9,
-          "rationale": "The answer delivers a complete, actionable map: gem identity, `lib/llm.rb` as the top-level facade with factory methods at specific line numbers (`:112`, `:152`), `lib/llm/provider.rb:8` as the abstract base, `lib/llm/providers/*.rb` plus same-named component subdirs, cross-cutting modules named and pathed, and a provider family taxonomy (native vs OpenAI-derived with `lib/llm/providers/deepseek.rb:21`). An agent could pick any entry point and start working."
+          "score": 0.92,
+          "rationale": "The answer delivers a complete, actionable map: the gem identity, the LLM.<name>(**) factory with file:line (lib/llm.rb:112, :152), the abstract base at lib/llm/provider.rb:8, the providers at lib/llm/providers/*.rb each with a lib/llm/providers/<name>/ component subdir, and the native-vs-OpenAI-derived split with concrete examples \u2014 an agent can pick an entry point and start immediately with only targeted lookups."
         },
         "specificity": {
-          "score": 0.85,
-          "rationale": "Line-level citations throughout (`lib/llm.rb:112`, `lib/llm/provider.rb:8`, `lib/llm/providers/deepseek.rb:21`) and concrete class names (`LLM::Provider`, `LLM::OpenAI`); the only mild gap is that individual provider files (e.g. `lib/llm/providers/openai.rb`, `lib/llm/providers/anthropic.rb`) are described by pattern rather than named explicitly, but the pattern is unambiguous."
+          "score": 0.9,
+          "rationale": "Paths are concrete throughout (lib/llm/provider.rb:8, lib/llm/providers/deepseek.rb:21, lib/llm.rb:75/112/152) and class names are exact (LLM::Provider, LLM::OpenAI, DeepSeek/XAI/ZAI); the cross-cutting machinery is also enumerated by file, not just by concept."
         },
         "justification": {
-          "score": 0.4,
-          "rationale": "The answer explains WHY some providers are thin (OpenAI-compatible APIs subclass `LLM::OpenAI` to reuse its behavior), but does not explain WHY each provider has both a top-level class file and a same-named subdir of small components \u2014 the rubric's core question (separation of request building, response parsing, streaming, error handling). The subdir is named but its rationale is absent."
+          "score": 0.28,
+          "rationale": "The answer names 'small components' in a per-provider subdir and lists cross-cutting machinery but never explains WHY each provider owns a subdir \u2014 it does not connect the subdir to separation of request building, response parsing, streaming, and error handling; the rationale is absent."
         },
         "uncertainty": {
-          "score": 0.35,
-          "rationale": "The answer makes confident claims throughout without flagging a single thing for the agent to verify; it doesn't note, for example, whether all providers actually follow the subdir pattern or whether some OpenAI-derived providers share components rather than defining their own, leaving the agent to discover surprises on its own."
+          "score": 0.25,
+          "rationale": "The answer is uniformly confident with no flags about what would need verification (e.g., whether every provider has all component files, which components the OpenAI-derived thin providers inherit vs override), leaving the agent to discover gaps on its own."
         }
       },
-      "step_quality": 0.705,
+      "step_quality": 0.6865,
       "usage": {
         "input_tokens": 3,
-        "output_tokens": 2103,
-        "cache_creation_input_tokens": 18863,
-        "cache_read_input_tokens": 16203
+        "output_tokens": 1569,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 34866
       }
     },
     {
       "step": "Trace a chat call from the entry point to request and response handling",
       "scores": {
         "map_quality": {
-          "score": 0.9,
-          "rationale": "The answer traces every layer with file:line in numbered order: factory at lib/llm.rb:152, Provider#chat at lib/llm/provider.rb:103, context callback at lib/llm/context.rb:563, OpenAI#complete at lib/llm/providers/openai.rb:73, request_adapter at lib/llm/providers/openai/request_adapter.rb:14, execution at lib/llm/transport/execution.rb:31, and response_adapter at lib/llm/providers/openai/response_adapter.rb:24 including the Completion extension module \u2014 an agent could create a new provider by following this map with only small targeted lookups."
+          "score": 0.88,
+          "rationale": "The answer traces every layer with file:line: factory at lib/llm.rb:152, Provider#chat at lib/llm/provider.rb:103, Context loop-back at lib/llm/context.rb:563, OpenAI#complete at lib/llm/providers/openai.rb:73 with sub-steps, request_adapter at lib/llm/providers/openai/request_adapter.rb:14, execution at lib/llm/transport/execution.rb:31-60, and response_adapter at lib/llm/providers/openai/response_adapter.rb:24 \u2014 an agent could create a new provider by following this map with only small targeted lookups. Minor gap: the Context/Buffer indirection (how .talk eventually calls back into #complete) is stated but not fully unwound, requiring one follow-up read."
         },
         "specificity": {
-          "score": 0.92,
-          "rationale": "Exact method names (LLM.openai, Provider#chat, OpenAI#complete, normalize_complete_params, build_complete_request, ResponseAdapter.adapt), exact file:line for each layer, and concrete class names (LLM::Transport::Request, LLM::Transport::Response, LLM::Object) throughout \u2014 nothing is left as 'the request code'."
+          "score": 0.9,
+          "rationale": "Every layer names the exact method, class, and file:line (e.g. `normalize_complete_params :210`, `build_complete_request :222`, `handle_response :52`, `parse_response :60`) and explicitly names `RequestAdapter` and `ResponseAdapter` by file; other providers are cited by concrete file path and line number."
         },
         "justification": {
-          "score": 0.38,
-          "rationale": "The answer lists what each component does (e.g., 'JSON body', 'exposing the contract methods') and notes Bedrock's extra sign! step, but never states WHY request building and response parsing are split into separate per-provider adapters; the design rationale (each API has its own request shape and response envelope) is absent."
+          "score": 0.45,
+          "rationale": "The answer shows the separation of request building and response parsing in practice but never states WHY they are per-provider components (i.e., that each provider's API has its own request shape and response body). The Bedrock `sign!` note hints at per-provider divergence but the underlying rationale is left implicit."
         },
         "uncertainty": {
-          "score": 0.42,
-          "rationale": "The answer shows the chat\u2192complete path but never flags the streaming variant (no mention of stream_parser or how the path diverges when stream: true), omits the respond method entirely, and expresses uniform confidence throughout \u2014 an agent copying this path for a streaming provider would need to re-explore before it could act."
+          "score": 0.5,
+          "rationale": "The answer flags Bedrock's signing difference and lists other provider file:line numbers (implying parallel structure), and briefly notes a `stream flag` in `normalize_complete_params`, but does not explicitly warn the agent that the streaming path (stream_parser) is a meaningfully different branch that must be verified separately, nor does it flag `respond` as another possible variant."
         }
       },
-      "step_quality": 0.729,
+      "step_quality": 0.742,
       "usage": {
         "input_tokens": 3,
-        "output_tokens": 1746,
-        "cache_creation_input_tokens": 18895,
-        "cache_read_input_tokens": 16203
+        "output_tokens": 1912,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 34898
       }
     },
     {
       "step": "Map the provider family and its base contract",
       "scores": {
         "map_quality": {
-          "score": 0.93,
-          "rationale": "The answer delivers a complete, agent-ready map: LLM::Provider base with every contract method at file:line, all 9 providers split into 'native' and 'OpenAI-derived' families, per-provider capability differences (what raises NotImplementedError, what's disabled, what's inherited), and the reuse axis made explicit ('subclass LLM::OpenAI, reuse its complete/adapters/error_handler/stream_parser'). An agent could open the PR from this table alone with only small targeted reads to confirm line offsets."
+          "score": 0.92,
+          "rationale": "The answer enumerates the full base contract at lib/llm/provider.rb:8 with every method line-cited, then splits the provider family into 'native' and 'OpenAI-derived' groups, naming all eight providers (OpenAI, Anthropic, Google, Ollama, Bedrock, DeepSeek, XAI, ZAI, LlamaCpp) with file:line and calling out that DeepSeek/XAI/ZAI/LlamaCpp subclass LLM::OpenAI and reuse its complete/adapters/error_handler/stream_parser \u2014 exactly the grep-invisible fan-out the rubric targets."
         },
         "specificity": {
-          "score": 0.91,
-          "rationale": "Every provider is pinned to file:line (lib/llm/providers/openai.rb:16, lib/llm/providers/anthropic.rb:16, etc.) and every capability difference cites a concrete line (embed:54, responses:88, tool_role:89); the private hook methods (headers, error_handler, stream_parser) are also cited at base-class lines rather than described vaguely."
+          "score": 0.93,
+          "rationale": "Every provider is cited by file and line (lib/llm/providers/openai.rb:16, lib/llm/providers/bedrock.rb:33, etc.) and contract methods are tied to specific lines (embed:70, complete:94, responses:126); the table format makes the per-method resolution unambiguous."
         },
         "justification": {
-          "score": 0.68,
-          "rationale": "The answer explains the mechanism of thin-provider reuse ('subclass LLM::OpenAI, reuse its complete/adapters/error_handler/stream_parser') and names the customization hook ('overrides private completions_path') but stops short of stating WHY this design exists (OpenAI-compatible wire format makes full reuse safe); the rationale is implied by structure rather than stated, leaving the agent to infer it."
+          "score": 0.6,
+          "rationale": "The answer groups thin providers as 'subclass LLM::OpenAI, reuse its complete/adapters' but never states the underlying reason (their APIs are OpenAI-compatible in request/response shape), leaving the agent to infer why reuse is safe rather than giving a rule it can apply when choosing whether to inherit vs. build fresh."
         },
         "uncertainty": {
-          "score": 0.48,
-          "rationale": "The answer flags concrete NotImplementedError gaps per provider (Anthropic lacks embed/images/audio, Bedrock explicitly re-raises on 7 capabilities) but never flags what it could NOT confirm \u2014 e.g., whether ZAI or LlamaCpp have additional capability overrides beyond the listed disables, or that line numbers should be verified before copying the pattern. It reads as fully authoritative, which could mislead the agent on less-examined providers."
+          "score": 0.4,
+          "rationale": "No uncertainty is flagged anywhere: the answer doesn't note which methods ZAI or LlamaCpp silently inherit from OpenAI without override, whether Ollama's lack of a registry file is intentional, or which capabilities remain unconfirmed; the agent may act on an incomplete picture without knowing what to double-check."
         }
       },
-      "step_quality": 0.8075,
+      "step_quality": 0.7805,
       "usage": {
         "input_tokens": 3,
-        "output_tokens": 1530,
-        "cache_creation_input_tokens": 19495,
+        "output_tokens": 1861,
+        "cache_creation_input_tokens": 19191,
         "cache_read_input_tokens": 16203
       }
     },
@@ -97,27 +280,27 @@
       "step": "Map the per-provider component families",
       "scores": {
         "map_quality": {
-          "score": 0.9,
-          "rationale": "All four parallel families (RequestAdapter, ResponseAdapter, StreamParser, ErrorHandler) are mapped across every native provider with file paths and wiring line numbers, sub-components called out (bedrock stream_decoder, openai responses/ subtree), and the inheritance short-circuit for xai/zai/llamacpp explicitly named \u2014 the agent can enumerate every file to create without re-reading the tree."
+          "score": 0.88,
+          "rationale": "All four parallel families (RequestAdapter, ResponseAdapter, StreamParser, ErrorHandler) are mapped across every native provider with file:line wiring points, sub-components are enumerated, and the answer explicitly flags that xai/zai/llamacpp inherit OpenAI's entirely while deepseek overrides only RequestAdapter \u2014 leaving the agent a near-complete checklist for what a new provider must create."
         },
         "specificity": {
-          "score": 0.88,
-          "rationale": "Concrete paths throughout (lib/llm/providers/anthropic/request_adapter.rb, openai.rb:18,29, bedrock stream_decoder, etc.) and method names (adapt, parse!, raise_error!, select :25/:30) are cited; the only gap is that response_adapter sub-files are listed as short names ('completion/enumerable/\u2026') without full paths, requiring a small follow-up to expand them."
+          "score": 0.8,
+          "rationale": "Paths like `lib/llm/providers/anthropic/request_adapter.rb` and wiring lines (`anthropic.rb:19,24`, StreamParser `:6/:27`) are concrete throughout; the `\u2026` abbreviation for repeated-pattern paths is a minor loss but the full qualified form is established, and method names (`adapt`, `parse!`, `raise_error!`) are cited."
         },
         "justification": {
           "score": 0.45,
-          "rationale": "The answer explains HOW components are wired (require_relative + include/extend, dispatched via adapt+select) but never states WHY they are per-provider \u2014 that each API has its own request payload shape, response JSON structure, streaming chunk format, and error body, forcing a separate implementation per provider rather than a shared one."
+          "rationale": "The answer labels each family's role ('builds outgoing payload', 'parses response into library shape') but does not explain *why* the split is per-provider \u2014 i.e., that each upstream API has its own wire format and error schema requiring bespoke translation in both directions; the rationale for having these components at all is implied rather than stated."
         },
         "uncertainty": {
-          "score": 0.55,
-          "rationale": "The answer explicitly flags that xai/zai/llamacpp inherit all OpenAI components and that deepseek overrides only RequestAdapter \u2014 useful signals \u2014 but presents all other claims with full confidence and never flags where it couldn't confirm a component (e.g., whether xai has its own stream_parser or error_handler) so the agent cannot tell which parts to verify before copying."
+          "score": 0.48,
+          "rationale": "The answer states inheritance facts ('xai/zai/llamacpp own no components') as settled conclusions rather than flagging them for the agent to verify; there are no explicit 'could not confirm' markers, and the agent is not told to check before copying a pattern (e.g., whether bedrock's stream_decoder is a substitute for or supplement to its stream_parser)."
         }
       },
-      "step_quality": 0.7525,
+      "step_quality": 0.714,
       "usage": {
         "input_tokens": 3,
-        "output_tokens": 1585,
-        "cache_creation_input_tokens": 19064,
+        "output_tokens": 1653,
+        "cache_creation_input_tokens": 18864,
         "cache_read_input_tokens": 16203
       }
     },
@@ -125,27 +308,27 @@
       "step": "Map the streaming and error-handling paths",
       "scores": {
         "map_quality": {
-          "score": 0.78,
-          "rationale": "The answer covers all major providers with file:line for both streaming (anthropic stream_parser.rb:27, openai :29, google :28, ollama :23, bedrock :42 with stream_decoder.rb) and error handling (execution.rb:52 \u2192 per-provider error_handler, shared error.rb types with line numbers), and correctly notes OpenAI subclasses reusing OpenAI's components \u2014 enough for an agent to implement both paths for a new provider with only small follow-up reads. Full paths for per-provider stream_parsers are implied but not spelled out (e.g., 'lib/llm/providers/anthropic/stream_parser.rb' never written in full), costing a lookup."
+          "score": 0.85,
+          "rationale": "The answer traces both paths end-to-end: execution.rb:31-32 for streaming dispatch, execution.rb:52 for the error path, then per-provider stream_parser.rb and error_handler.rb with line numbers for all named providers (anthropic, openai, google, ollama, bedrock), the bedrock stream_decoder override, OpenAI-subclass reuse, and the full shared error type set in lib/llm/error.rb with line numbers. An agent could wire both components for a new provider with only small follow-up reads."
         },
         "specificity": {
-          "score": 0.72,
-          "rationale": "Shared error types are cited with full path+line (lib/llm/error.rb: Error:6, UnauthorizedError:28, etc.) and the transport entry points are exact (execution.rb:31-32 and :52); per-provider stream_parser and error_handler line numbers are given as relative (`:27`, `:29`) without the full lib/llm/providers/<name>/stream_parser.rb prefix, so an agent must infer the directory structure to assemble the complete path."
+          "score": 0.78,
+          "rationale": "Concrete file:line citations throughout \u2014 error types at lib/llm/error.rb:28/32/36/40/52/56, anthropic stream_parser.rb:27/91-118, bedrock stream_decoder.rb \u2014 but openai/google/ollama stream_parsers are given only as ':29'/':28'/':23' without the full path prefix, requiring the agent to infer the directory."
         },
         "justification": {
-          "score": 0.42,
-          "rationale": "The answer implicitly shows why parsers differ \u2014 anthropic handles `message_start/content_block_*/message_delta` while bedrock consumes AWS binary Event Stream frames \u2014 but never states explicitly that per-provider components exist because each API delivers chunks and error bodies in a different format over the shared typed-error layer; the reasoning is embedded in examples rather than declared."
+          "score": 0.58,
+          "rationale": "The answer shows per-provider variation through concrete examples (AWS binary frames require bedrock's stream_decoder; OpenAI parses the body for invalid_request_error/ContextWindowError; Google checks API_KEY_INVALID reason) but never states the overarching design rationale \u2014 that different chunk formats and error body shapes force per-provider components over a shared error base."
         },
         "uncertainty": {
           "score": 0.52,
-          "rationale": "The answer correctly flags bedrock's uniqueness (stream_decoder override at bedrock.rb:200) and that OpenAI subclasses inherit rather than define their own parser/handler, which are the two main shape divergences; however, it never signals where the agent should verify before copying a pattern (e.g., whether zai/llamacpp stream_parsers actually exist or are purely inherited, whether any provider lacks an error_handler file entirely)."
+          "rationale": "The bedrock stream_decoder distinction and OpenAI-subclass reuse are explicitly flagged, giving the agent useful variance signals, but the answer makes no explicit 'could not confirm' or 'verify this' calls, and the abbreviated line refs for openai/google/ollama stream_parsers are not called out as unverified."
         }
       },
-      "step_quality": 0.654,
+      "step_quality": 0.729,
       "usage": {
         "input_tokens": 3,
-        "output_tokens": 1675,
-        "cache_creation_input_tokens": 18802,
+        "output_tokens": 1779,
+        "cache_creation_input_tokens": 18602,
         "cache_read_input_tokens": 16203
       }
     },
@@ -153,27 +336,27 @@
       "step": "Find every site that must change to add a new provider",
       "scores": {
         "map_quality": {
-          "score": 0.92,
-          "rationale": "The answer enumerates all 10 fan-out sites with concrete file:line: factory (lib/llm.rb :112-:179), provider class, all four component families (request/response adapter, stream parser, error handler), models.rb + data/foo.json, registry consumers (lib/llm/registry.rb:19, lib/llm/cost.rb:44, lib/llm/context.rb:485), the base contract (lib/llm/provider.rb:29), the spec matrix including spec/setup.rb:30-39 and cassette dir, and README \u2014 the agent can open the PR from this list with only narrow confirmations."
+          "score": 0.85,
+          "rationale": "Covers all major fan-out sites with file:line: factory at lib/llm.rb:112-179, provider class, all four component families (request_adapter, response_adapter, stream_parser, error_handler), models registry at lib/llm/registry.rb:19 + data/foo.json, base contract at lib/llm/provider.rb:29, spec/setup.rb:30-39 secret filter + VCR cassettes, README \u2014 the agent could open the PR from this list with only small targeted lookups for exact insertion points."
         },
         "specificity": {
-          "score": 0.93,
-          "rationale": "Every site is named by full path and line (lib/llm/providers/foo/request_adapter.rb, lib/llm.rb :112, spec/setup.rb:30-39, etc.) rather than vague category names; the sub-file breakdown (request_adapter/completion.rb, response_adapter/completion.rb, lib/llm/contract/completion.rb) makes the correspondence exact."
+          "score": 0.9,
+          "rationale": "Nearly every item is named by exact path and line: lib/llm.rb:68/112-179, lib/llm/providers/foo/request_adapter/completion.rb, lib/llm/contract/completion.rb, lib/llm/cost.rb:44, lib/llm/context.rb:485, spec/setup.rb:30-39 \u2014 substantially more precise than 'add the provider and tests'."
         },
         "justification": {
-          "score": 0.78,
-          "rationale": "The '(skip if pure OpenAI subclass)' annotations explain reuse decisions for each component, the registry chain explains why models.rb + data/foo.json ripple into cost.rb and context.rb, and 'is the contract Foo#initialize must satisfy via super' explains the base dependency; the factory WHY is implicit rather than stated, but most sites carry a clear reason."
+          "score": 0.5,
+          "rationale": "The answer explains the registry consumption chain (Registry.for \u2192 cost.rb:44 \u2192 context.rb:485) and flags the super-contract at provider.rb:29, but the bulk of the list reads as what-to-do rather than WHY each component is a separate file (API request shapes differ per-provider, error bodies differ, etc.) \u2014 the architectural motivation for the separation is mostly implicit."
         },
         "uncertainty": {
-          "score": 0.73,
-          "rationale": "The answer flags conditional paths (native vs OpenAI-compatible, bedrock-style binary needing stream_decoder, local-only providers skipping data/*.json) so the agent knows to verify which branch applies; it does not explicitly call out uncertainty on the factory line range or which shared examples apply to the new provider, leaving those for the agent to confirm."
+          "score": 0.6,
+          "rationale": "The answer usefully flags reuse shortcuts ('skip if pure OpenAI subclass', bedrock stream_decoder variant, no data/*.json for local providers), but it doesn't explicitly call out what it could not statically confirm \u2014 e.g., which shared spec examples apply, whether spec/fixtures/cassettes structure must be verified, or whether README:27-28 is the only doc site to update."
         }
       },
-      "step_quality": 0.866,
+      "step_quality": 0.755,
       "usage": {
         "input_tokens": 3,
-        "output_tokens": 1851,
-        "cache_creation_input_tokens": 18964,
+        "output_tokens": 1958,
+        "cache_creation_input_tokens": 18764,
         "cache_read_input_tokens": 16203
       }
     },
@@ -182,26 +365,26 @@
       "scores": {
         "map_quality": {
           "score": 0.95,
-          "rationale": "The answer delivers a complete, two-tier edit map (prose CREATE/CHANGE/DEPEND-ON plus a JSON summary) covering every parallel component family: provider class, factory at lib/llm.rb:112-179, request_adapter, response_adapter, stream_parser, error_handler, models.rb, data file, spec cassettes, spec/setup.rb:30-39, and README.md:27-28; an agent could open the PR from this list with only trivial confirmatory lookups."
+          "rationale": "The answer delivers a complete, actionable map: every file to create (provider class, request_adapter, response_adapter, stream_parser, error_handler, models, data/foo.json, three spec files, cassettes dir) and every file to change (lib/llm.rb:112-179, spec/setup.rb:30-39, README.md:27-28), with file:line throughout, plus a JSON summary that duplicates and cross-validates the prose. The OpenAI-compatible shortcut is explicitly named, so the agent knows which creates to skip. A teammate could open the PR from this map alone."
         },
         "specificity": {
           "score": 0.95,
-          "rationale": "Every entry carries a concrete file path and line number (e.g., lib/llm.rb:112-179, spec/setup.rb:30-39, anthropic/response_adapter/completion.rb:123) and each CREATE file names an explicit model file to copy from (deepseek.rb:21, anthropic/stream_parser.rb:6), leaving no vague 'add tests' instructions."
+          "rationale": "Every file is named with its full path and insertion points carry line ranges (e.g. `lib/llm.rb:112-179 add def foo`, `spec/setup.rb:30-39 secret filter`); the JSON `sites_to_change` cross-references each with conditional markers (native only, if not reusing OpenAI's) so there is no vague 'add the provider and tests' prose anywhere."
         },
         "justification": {
-          "score": 0.8,
-          "rationale": "The answer explains WHY most files appear: '(native only)' on adapters, '(if not reusing OpenAI's)' on stream_parser/error_handler, the OpenAI-compatible shortcut block explains why those creates can be skipped; the base-contract 'DEPEND ON (no edit)' block explains what the provider inherits rather than creates \u2014 though the explanation of WHY request and response building are separate components is implied by the family names rather than stated explicitly."
+          "score": 0.75,
+          "rationale": "Conditionals are explained (*(native only)*, *(if not reusing OpenAI's)*) and the DEPEND ON block distinguishes read-only contract anchors from edited sites, but the answer mostly cites role by reference to an earlier step's reasoning rather than restating WHY request_adapter and response_adapter must be separate per-provider files in this map specifically."
         },
         "uncertainty": {
-          "score": 0.88,
-          "rationale": "Uncertainty is flagged at the right decision points: '(native only)', '(if not reusing OpenAI's)', '(skip data file for local providers)', and the subclass-choice opening ('< LLM::Provider or < LLM::OpenAI') signals the agent must verify the API compatibility before committing to the shorter path; the cassette directory is noted as a fixture to set up but not confirmed to exist."
+          "score": 0.7,
+          "rationale": "The answer flags the native-vs-compatible fork clearly and marks optional creates (data file, stream_parser, error_handler), but it does not explicitly call out what the agent must verify before committing (e.g. which components a specific target API can reuse, or whether fixtures differ from the cassette pattern); the conditionals read as design choices rather than acknowledged unknowns."
         }
       },
-      "step_quality": 0.9095,
+      "step_quality": 0.8725,
       "usage": {
         "input_tokens": 3,
-        "output_tokens": 1651,
-        "cache_creation_input_tokens": 20852,
+        "output_tokens": 1587,
+        "cache_creation_input_tokens": 20652,
         "cache_read_input_tokens": 16203
       }
     }

--- a/bench/results/vertical/ruby-rails/claude-opus-4-8/sense/llm.rb/run-2/judged.json
+++ b/bench/results/vertical/ruby-rails/claude-opus-4-8/sense/llm.rb/run-2/judged.json
@@ -6,7 +6,7 @@
     "prompt_version": "v1",
     "rubric_path": "llm.rb.rubric.yaml"
   },
-  "scenario_quality": 0.758,
+  "scenario_quality": 0.7491,
   "relationship_audit": {
     "total": 27,
     "covered": 24,
@@ -196,27 +196,27 @@
       "step": "Orient in the codebase",
       "scores": {
         "map_quality": {
-          "score": 0.93,
-          "rationale": "The answer names the gem, all factory methods with file:line (`lib/llm.rb:112-181`), the abstract base (`lib/llm/provider.rb:8`), the provider-per-file + per-subdir-of-components pattern, shared transport/contract/error machinery with paths, and the concrete call chain `LLM.openai(\u2026) \u2192 LLM::OpenAI.new \u2192 LLM::Provider#initialize (lib/llm/provider.rb:29)` \u2014 an agent can pick any entry point and start working."
+          "score": 0.92,
+          "rationale": "Covers every required landmark: gem identity, factory methods at lib/llm.rb:112-181 (with the concrete LLM.openai example at :152-155), abstract base at lib/llm/provider.rb:8, providers at lib/llm/providers/*.rb + per-provider subdirs, shared transport/contract/error machinery, and the full call chain LLM.openai \u2192 LLM::OpenAI.new \u2192 Provider#initialize:29. An agent can pick any entry point and act with only targeted lookups."
         },
         "specificity": {
-          "score": 0.91,
-          "rationale": "Paths are concrete throughout: `lib/llm.rb:152-155` for the factory, `lib/llm/provider.rb:8` for the base, `lib/llm/transport/execution.rb`, `lib/llm/contract.rb`, etc.; every abstraction is anchored to a file and class name rather than a vague layer label."
+          "score": 0.85,
+          "rationale": "Most landmarks are pinned to file:line (lib/llm.rb:112-181, lib/llm/provider.rb:8, :29, lib/llm/transport/execution.rb, etc.); the only gap is that individual provider files (lib/llm/providers/openai.rb, lib/llm/providers/anthropic.rb) are referenced via a glob pattern rather than explicit names, so the agent needs one small ls to confirm each file name."
         },
         "justification": {
-          "score": 0.4,
-          "rationale": "The answer names the component types in each subdir (request/response adapters, stream parser, error handler) but never explains WHY the split exists \u2014 that each provider's request shape and response format differ, requiring per-provider parsing and streaming logic; the rubric's \"not just NAME the pieces\" criterion is only partially met."
+          "score": 0.45,
+          "rationale": "The answer names the component categories (request/response adapters, stream parser, error handler) but does not explain WHY providers have both a class file and a component subdir \u2014 it lists what exists without stating that each external API has its own request shape and response format requiring per-provider implementations."
         },
         "uncertainty": {
-          "score": 0.2,
-          "rationale": "The answer is uniformly confident with no caveats flagged; an agent following it has no signal about which parts to verify (e.g., whether every provider actually has all four component files, or whether the factory pattern is uniform across all nine providers)."
+          "score": 0.25,
+          "rationale": "The answer asserts every claim with full confidence and raises no caveats about what could not be confirmed from the index (e.g., whether all listed providers have all component types, or whether zAI/zai fully follows the same pattern as the others), leaving the agent no signal about where to verify before acting."
         }
       },
-      "step_quality": 0.7095,
+      "step_quality": 0.708,
       "usage": {
         "input_tokens": 3,
-        "output_tokens": 1614,
-        "cache_creation_input_tokens": 18886,
+        "output_tokens": 1600,
+        "cache_creation_input_tokens": 18722,
         "cache_read_input_tokens": 16203
       }
     },
@@ -225,26 +225,26 @@
       "scores": {
         "map_quality": {
           "score": 0.9,
-          "rationale": "The answer traces all eight layers with file:line: LLM.openai at lib/llm.rb:152, Provider#chat at lib/llm/provider.rb:103-106, Context#complete at lib/llm/context.rb:558-564, OpenAI#complete at lib/llm/providers/openai.rb:73-82, RequestAdapter#adapt at lib/llm/providers/openai/request_adapter.rb:17-25, Transport::Execution at lib/llm/transport/execution.rb:31-42, and ResponseAdapter.adapt at lib/llm/providers/openai/response_adapter.rb:24-28; an agent could follow this to build a new provider with only a few targeted reads."
+          "rationale": "The answer traces all eight layers with file:line: factory at lib/llm.rb:152, Provider#chat at lib/llm/provider.rb:103-106, Context#talk at lib/llm/context.rb:193, OpenAI#complete at lib/llm/providers/openai.rb:73-82, RequestAdapter#adapt at lib/llm/providers/openai/request_adapter.rb:17-25, Transport::Execution at lib/llm/transport/execution.rb:31-42, ResponseAdapter.adapt at lib/llm/providers/openai/response_adapter.rb:24-28, and back to Context at lib/llm/context.rb:201-203; an agent could create the same chain for a new provider with only small targeted lookups."
         },
         "specificity": {
           "score": 0.9,
-          "rationale": "Every piece is named exactly (LLM.openai, Provider#chat, OpenAI#complete, RequestAdapter::Completion#adapt, ResponseAdapter::Completion) with matching file:line rather than vague layer names; even sub-components like normalize_complete_params at openai.rb:210-220 and build_complete_request at openai.rb:222-228 are cited."
+          "rationale": "Every layer is named exactly (LLM.openai, Provider#chat, OpenAI#complete, RequestAdapter#adapt, ResponseAdapter.adapt, Transport::Execution) with concrete file:line; sub-helpers like normalize_complete_params, build_complete_request, and ResponseAdapter::Completion are also cited by file:line."
         },
         "justification": {
           "score": 0.3,
-          "rationale": "The answer lists what each component does (adapts messages, parses response, exposes choices) but never explains WHY request building and response parsing are separate per-provider objects; the motivation \u2014 that provider APIs differ in both request shape and response shape \u2014 is absent."
+          "rationale": "The answer lists and orders the call chain clearly but never explains WHY request building and response parsing are split into separate per-provider adapter classes (i.e., that each provider's API wire format differs in both directions, necessitating provider-specific translation at each end)."
         },
         "uncertainty": {
           "score": 0.35,
-          "rationale": "The answer briefly notes a streaming parameter inside normalize_complete_params and an alternate Context.new(llm).talk(...) entry but does not explicitly flag where the streaming path diverges from the buffered path or how chat/respond differ from complete, leaving the agent to verify those branches on its own."
+          "rationale": "The answer notes one alternative entry ('or caller uses LLM::Context.new(llm).talk(...) directly') but does not flag where the path diverges for streaming vs buffered responses or for respond vs complete vs embed, leaving the agent to discover those branches independently."
         }
       },
       "step_quality": 0.6975,
       "usage": {
         "input_tokens": 3,
-        "output_tokens": 1564,
-        "cache_creation_input_tokens": 18927,
+        "output_tokens": 1454,
+        "cache_creation_input_tokens": 18763,
         "cache_read_input_tokens": 16203
       }
     },
@@ -252,27 +252,27 @@
       "step": "Map the provider family and its base contract",
       "scores": {
         "map_quality": {
-          "score": 0.95,
-          "rationale": "Covers the full fan-out: base class with every method group (NotImplementedError raisers, optional sub-API accessors, provided defaults), all five direct Provider subclasses, and all four thin OpenAI subclasses, each with file:line and behavioral deltas; also surfaces the Contract module enforcement path. The agent can start implementing immediately."
+          "score": 0.9,
+          "rationale": "The answer enumerates LLM::Provider at lib/llm/provider.rb:8 with per-method line numbers, all five direct subclasses with file:line and per-provider capability differences, and a dedicated section for the OpenAI-thin-subclass family (DeepSeek, LlamaCpp, XAI, ZAI) that names the reuse pattern explicitly \u2014 the agent can pick any as a template. The Contract::Completion enforcement hook is also surfaced, which is non-obvious and load-bearing."
         },
         "specificity": {
           "score": 0.95,
-          "rationale": "Every class is anchored to a concrete file and line (e.g. `lib/llm/providers/bedrock.rb:33`, `tool_role\u2192:user`, `sign! :263-270`); method lists carry per-line numbers within provider.rb; no vague references remain."
+          "rationale": "Every provider is cited by exact path and line (e.g., lib/llm/providers/bedrock.rb:33, bedrock.rb:58-70 for SigV4, deepseek.rb:21-22 for its own RequestAdapter); every contract method carries a :line reference; no vague 'the provider layer' prose anywhere."
         },
         "justification": {
-          "score": 0.75,
-          "rationale": "Thin-provider reuse is explained well ('reuse OpenAI behavior, customize a few pieces \u2014 most likely template for a new OpenAI-compatible provider'); however, the WHY behind individual capability absences (e.g. Anthropic missing embed because the API doesn't expose it, Bedrock's SigV4 replacing key auth for IAM-based AWS access) is implied through the diff rather than stated, which leaves the agent to infer the architectural reason."
+          "score": 0.65,
+          "rationale": "The answer explains the OpenAI-compat reuse axis clearly ('reuse OpenAI's behavior, customize a few pieces') and flags specific per-provider deviations (Anthropic tool_role, Bedrock stream_decoder, ZAI completions_path), but it does not explain WHY Anthropic lacks embed, WHY Bedrock overrides stream_decoder, or WHY the Contract.included hook enforces methods at include-time \u2014 those 'why' gaps require follow-up reads."
         },
         "uncertainty": {
-          "score": 0.6,
-          "rationale": "No explicit uncertainty flags anywhere; the answer confidently lists what DeepSeek inherits from OpenAI without noting that unlisted methods (embed, images via OpenAI's path, etc.) are silently inherited and would need verification before the agent can safely skip them in a new provider."
+          "score": 0.2,
+          "rationale": "The answer presents every line number and inheritance claim as fact with no hedging, no 'could not confirm', and no 'verify before copying' notes \u2014 for example, whether DeepSeek inherits OpenAI's embed or if it is silently unsupported is not flagged, and the agent must check this before building on the pattern."
         }
       },
-      "step_quality": 0.8575,
+      "step_quality": 0.7575,
       "usage": {
         "input_tokens": 3,
-        "output_tokens": 1464,
-        "cache_creation_input_tokens": 19599,
+        "output_tokens": 1740,
+        "cache_creation_input_tokens": 19435,
         "cache_read_input_tokens": 16203
       }
     },
@@ -280,27 +280,27 @@
       "step": "Map the per-provider component families",
       "scores": {
         "map_quality": {
-          "score": 0.88,
-          "rationale": "The answer organizes all component families (A\u2013F) with concrete file paths for every provider, shows which providers own vs. inherit each component, and ties them together via include/require_relative wiring \u2014 an agent can directly derive every file a new provider needs. The few missing line numbers (e.g., anthropic/response_adapter.rb has no line) are minor gaps against the otherwise complete cross-provider matrix."
+          "score": 0.92,
+          "rationale": "All four component families (request_adapter, response_adapter, stream_parser, error_handler) are mapped per-provider with concrete file paths and line-number anchors (e.g., 'openai.rb:202-204', 'anthropic.rb:142', 'bedrock.rb:45'); reuse vs. own-implementation is explicit for every thin provider; sub-API objects and provider-unique components (bedrock/signature.rb, stream_decoder.rb) are enumerated. An agent can create every required file without further exploration."
         },
         "specificity": {
-          "score": 0.85,
-          "rationale": "Paths are fully concrete throughout: 'openai/request_adapter.rb', 'anthropic/response_adapter.rb', 'bedrock/signature.rb', with sub-file types named (completion.rb, enumerable.rb, audio.rb) and some line citations (openai.rb:29, openai.rb:202-204, anthropic.rb:142); 'the adapters' never appears in place of a real path."
+          "score": 0.87,
+          "rationale": "Files are named by path throughout ('lib/llm/providers/openai/request_adapter.rb', 'anthropic/response_adapter.rb', etc.) with include-site line numbers ('openai.rb:29', 'anthropic.rb:24'); shorthand paths after the first full path are slightly less than fully qualified but still unambiguous given the established prefix convention."
         },
         "justification": {
-          "score": 0.3,
-          "rationale": "The answer labels what each component does ('builds outgoing body', 'parses its response into the library's shape') but never explains WHY per-provider isolation is necessary \u2014 no mention that OpenAI and Anthropic use different request shapes, different streaming chunk formats, or different error bodies, which is the design rationale an agent needs to pattern-match correctly."
+          "score": 0.48,
+          "rationale": "The answer names what each component does ('builds outgoing body', 'select(type)') and notes that thin providers inherit OpenAI's components, but never explains WHY the per-provider split exists at all, i.e., that each provider's HTTP request shape and response envelope differ, necessitating separate adapters rather than a shared one."
         },
         "uncertainty": {
           "score": 0.38,
-          "rationale": "The answer states reuse facts ('deepseek/llamacpp/xai/zai: reuse OpenAI's ResponseAdapter') as confirmed truths rather than flagging them as things to verify before copying; no component is explicitly marked 'could not confirm', so the agent has no signal on which claims are inference vs. direct observation."
+          "rationale": "Reuse facts (deepseek/llamacpp/xai/zai inherit OpenAI components) and unique components (bedrock/stream_decoder.rb) are stated as confirmed findings with no 'could not verify' flags, leaving the agent unable to judge which claims are directly read vs. inferred and which sub-API objects (files.rb, audio.rb, etc.) a minimal new provider would need vs. can skip."
         }
       },
-      "step_quality": 0.6815,
+      "step_quality": 0.7385,
       "usage": {
         "input_tokens": 3,
-        "output_tokens": 1820,
-        "cache_creation_input_tokens": 19220,
+        "output_tokens": 1972,
+        "cache_creation_input_tokens": 19056,
         "cache_read_input_tokens": 16203
       }
     },
@@ -309,26 +309,26 @@
       "scores": {
         "map_quality": {
           "score": 0.75,
-          "rationale": "OpenAI and Anthropic get full file:line coverage for both stream_parser and error_handler, plus the transport wiring (execution.rb:31-32, :51-54) and shared error types (lib/llm/error.rb with per-type lines); Google/Ollama/Bedrock stream parsers are named but without line numbers or method detail, and those providers' error_handler.rb files are not cited at all \u2014 an agent would need targeted lookups for those three providers."
+          "rationale": "Streaming path is well-mapped with execution.rb wiring (`:31-32`, `:51-54`), per-provider stream_parser files with line ranges for OpenAI (`stream_parser.rb:29-185`) and Anthropic (`:16-40`), and Bedrock's StreamDecoder override (`bedrock.rb:200-202`); shared error types enumerated with line numbers in `lib/llm/error.rb`. However, Google/Ollama/Bedrock stream_parsers and almost all per-provider error_handler.rb files other than OpenAI's are cited with incomplete paths and no line numbers, so targeted lookups are still needed for those providers."
         },
         "specificity": {
-          "score": 0.7,
-          "rationale": "OpenAI gets method-level specificity (merge!, merge_choices!, on_content, error_handler.rb:51-82) and Anthropic gets chunk-type detail (message_start) with file:line, but Google/Ollama/Bedrock stream parsers are bare paths without lines and their error handlers are entirely absent \u2014 the answer is concrete for the reference implementation, sparse for the rest."
+          "score": 0.68,
+          "rationale": "OpenAI and Anthropic stream parsers are named with full paths and line ranges; OpenAI's error handler is cited at `lib/llm/providers/openai/error_handler.rb:51-82` with individual error-class lines. Google, Ollama, and Bedrock stream parsers are given as bare relative names (`google/stream_parser.rb`) with no line numbers, and no paths are cited for those providers' error_handler.rb files at all."
         },
         "justification": {
-          "score": 0.45,
-          "rationale": "Bedrock's binary protocol override is the one place a reason is given for per-provider divergence; the rest of the answer lists components and class names without explaining that different APIs produce different chunk shapes and error body schemas, which is the architectural reason the separation exists."
+          "score": 0.48,
+          "rationale": "Bedrock's override is tied to 'the binary protocol,' giving a concrete reason for divergence, and the shared typed-error set is contrasted against per-provider dispatch. But the answer never states the core rationale \u2014 that each provider emits differently-shaped chunk events and differently-structured HTTP error bodies \u2014 leaving the agent to infer why the per-provider split exists rather than reading it explicitly."
         },
         "uncertainty": {
-          "score": 0.55,
-          "rationale": "The answer explicitly surfaces Bedrock's StreamDecoder override and the OpenAI-inheritance reuse pattern, which are the two biggest divergences; but the shallow coverage of Google/Ollama/Bedrock error handlers is presented as complete rather than flagged as unverified, so the agent may not know to check those paths before copying the pattern."
+          "score": 0.45,
+          "rationale": "The answer implicitly signals gaps by giving partial paths for Google/Ollama/Bedrock and noting OpenAI subclasses inherit both StreamParser and ErrorHandler, but it never explicitly flags which providers could not be confirmed, whether any provider lacks its own stream_parser (e.g., DeepSeek), or whether all providers have a separate error_handler.rb \u2014 the agent must guess what to verify rather than being told."
         }
       },
-      "step_quality": 0.6475,
+      "step_quality": 0.6335,
       "usage": {
         "input_tokens": 3,
-        "output_tokens": 1786,
-        "cache_creation_input_tokens": 19027,
+        "output_tokens": 1767,
+        "cache_creation_input_tokens": 18863,
         "cache_read_input_tokens": 16203
       }
     },
@@ -337,26 +337,26 @@
       "scores": {
         "map_quality": {
           "score": 0.85,
-          "rationale": "The answer covers the full fan-out: factory (lib/llm.rb :152-181), provider class, all four component families with subdirectory paths, the model registry (data/foo.json + lib/llm/registry.rb:18-25), spec matrix with shared examples, VCR cassettes, and the non-obvious spec/setup.rb:28-37 secret-scrubbing hook \u2014 an agent could open the PR from this list with only small lookups to confirm exact line numbers and sub-file shapes."
+          "rationale": "The answer covers the full fan-out: factory at lib/llm.rb:152-181, provider class at lib/llm/providers/foo.rb, all four component families with concrete subpaths (request_adapter.rb, response_adapter.rb, stream_parser.rb, error_handler.rb), data/foo.json + lib/llm/registry.rb:18-25, spec/foo/chat_spec.rb + cassettes + spec/setup.rb:28-37; the agent could open a PR from this list with only small targeted lookups to verify the sub-API accessor overrides."
         },
         "specificity": {
           "score": 0.85,
-          "rationale": "Paths are concrete throughout: lib/llm/providers/foo/request_adapter.rb, response_adapter/completion.rb, spec/fixtures/cassettes/foo/chat/\u2026, spec/setup.rb:28-37 \u2014 and named templates (zai.rb, deepseek.rb, spec/zai/chat_spec.rb) anchor the pattern; the only vagueness is 'alongside :152-181' for the factory insertion point rather than an exact line."
+          "rationale": "Paths are concrete throughout (lib/llm/providers/foo/response_adapter/completion.rb, spec/fixtures/cassettes/foo/chat/\u2026, spec/setup.rb:28-37) and line numbers anchor the factory and registry; only the stream_decoder override and include_examples invocation lack a file:line, which is minor."
         },
         "justification": {
-          "score": 0.72,
-          "rationale": "Most entries carry a brief 'why': factory = 'how a caller obtains it', registry = 'needed for context_window/cost', secret scrubbing = clear linkage to spec/setup.rb; however the component-family entries mostly list the condition for reuse vs. new without explaining the underlying reason (each provider API has a different wire format and error body shape), so the 'why' is present but thin."
+          "score": 0.75,
+          "rationale": "Most sites have a WHY: factory = 'how a caller obtains it', registry = 'consumed by LLM::Registry.for; needed for context_window/cost', secret scrubbing = filter_sensitive_data purpose is self-evident, and 'no central registry array' explains the discovery model; the component families' justification ('if the wire format differs') is present but brief rather than tying it to per-provider API shape differences."
         },
         "uncertainty": {
-          "score": 0.75,
-          "rationale": "The answer fronts the assumption ('Assuming an OpenAI-compatible provider') and flags every component as conditional ('reuse \u2026 or add \u2026 if the wire format differs', 'stream_decoder override only if non-SSE'), which correctly signals what the agent must verify before copying a pattern; it closes with 'No central registry array' which preempts a common wrong turn but is stated as a certainty rather than a thing to confirm."
+          "score": 0.65,
+          "rationale": "The answer explicitly flags reuse-vs-create decisions ('reuse OpenAI's, or add\u2026') for all four component families and notes stream_decoder only applies for non-SSE protocols, which is actionable uncertainty; it does not flag which cassette fixture names must match the shared examples or confirm the data/foo.json schema, leaving the agent to verify those before committing."
         }
       },
-      "step_quality": 0.809,
+      "step_quality": 0.8,
       "usage": {
         "input_tokens": 3,
-        "output_tokens": 1854,
-        "cache_creation_input_tokens": 18897,
+        "output_tokens": 1655,
+        "cache_creation_input_tokens": 18733,
         "cache_read_input_tokens": 16203
       }
     },
@@ -364,27 +364,27 @@
       "step": "Produce the edit map",
       "scores": {
         "map_quality": {
-          "score": 0.93,
-          "rationale": "The answer delivers a complete two-section edit map (CREATE table + CHANGE table with file:line throughout), covers the factory insertion at lib/llm.rb:181, all component families as conditional new files, the data/foo.json registry, spec/foo/chat_spec.rb, cassette fixtures, and spec/setup.rb:33 scrubbing \u2014 an agent could open the PR from this map alone; the only small gap is that non-OpenAI-compatible sub-API files (models.rb etc.) are mentioned in prose but not added to the CREATE table."
+          "score": 0.95,
+          "rationale": "The answer delivers a complete, dual-table edit map (CREATE / CHANGE) with file:line throughout, covers every area: provider class, factory at lib/llm.rb:181, conditional component files, data/foo.json registry, spec and cassette directories, spec/setup.rb:33 scrub, and README. The JSON summary at the end consolidates the same list so an agent could open the PR from either representation alone."
         },
         "specificity": {
           "score": 0.93,
-          "rationale": "Every entry carries a concrete path and most carry a line number (lib/llm.rb:181, spec/setup.rb:33, provider.rb:362/371/384); the template providers are named exactly (zai.rb for minimal, anthropic.rb for direct subclass) and the JSON call trace cites file:line at every hop \u2014 no vague 'the provider layer' language anywhere."
+          "rationale": "Files are named at the path level (lib/llm/providers/foo/request_adapter.rb, spec/setup.rb:33, lib/llm.rb:181) and template references are exact ('model on lib/llm/providers/zai.rb', 'model on spec/zai/chat_spec.rb:1-20'); every insertion point is concrete rather than vague."
         },
         "justification": {
-          "score": 0.88,
-          "rationale": "The answer explains WHY each file is conditional ('only if wire format differs from OpenAI', 'only if error envelope differs') and why the factory entry and scrub exist; the JSON component_families section ties each family to its purpose; the non-OpenAI path lists exactly which contract methods must be implemented and why \u2014 the only unexlained item is README.md, listed without rationale."
+          "score": 0.82,
+          "rationale": "The 'only if wire format differs from OpenAI' phrasing explains WHY components are conditional (inheritance-based reuse), and the direct-Provider-subclass section explains WHY all components become required in the non-compatible case; the base_contract must_implement list explains WHY those methods must be present, though the rationale for data/foo.json and spec/setup.rb changes is only implicit."
         },
         "uncertainty": {
-          "score": 0.82,
-          "rationale": "Uncertainty is expressed structurally via '(conditional)' markers and '*only if*' qualifiers rather than explicit 'I am unsure' flags, which is actionable; the answer also flags that streaming/error components can be reused vs must be new depending on wire compatibility, and points the agent to model providers (zai, anthropic) to verify \u2014 a small gap is that cassette fixture naming is given as a glob pattern without flagging that the actual names depend on shared-example wiring."
+          "score": 0.88,
+          "rationale": "Every component file in the CREATE table is explicitly flagged '*only if*' with the condition, and the answer provides two template paths (zai.rb vs anthropic.rb) with an explicit branch condition, so the agent knows exactly which unknowns to resolve before committing; cassette naming is deferred to 'named per shared examples' which is a mild unresolved pointer."
         }
       },
-      "step_quality": 0.9035,
+      "step_quality": 0.9085,
       "usage": {
         "input_tokens": 3,
-        "output_tokens": 1676,
-        "cache_creation_input_tokens": 20814,
+        "output_tokens": 1594,
+        "cache_creation_input_tokens": 20650,
         "cache_read_input_tokens": 16203
       }
     }

--- a/bench/results/vertical/ruby-rails/claude-opus-4-8/sense/report.md
+++ b/bench/results/vertical/ruby-rails/claude-opus-4-8/sense/report.md
@@ -1,0 +1,86 @@
+## Scenario Evaluation
+
+Results: 13 tools × 2 scenarios
+
+**The headline is `cited_recall`; the blind `llm_quality`/`fairness` composite has been RETIRED** (it weighted 55% on omission-blind prose a frontier baseline aces, 0% on the objective axes Sense wins — it understated Sense ~16×, which silently favored the baseline). Each repo leads with a PRIMARY table of the axes that decompose Sense's value:
+
+- **Cited recall (THE headline)** — share of the gold must-find set pinned to an exact location (`path:line`, `path (line N)`, a `"line": N` field, or an unambiguous basename+line). An agent can jump straight there. This is where Sense's structural advantage concentrates.
+- **Mention recall** — share the answer named at all (completeness of the map), location optional.
+- **Billed context** — `token_total_billed` with `token_input_uncached` alongside. Lower is better; reported, never traded against recall.
+
+The aggregate adds the **B-score** = `0.55·cited_recall + 0.25·related + 0.20·grounded_precision` — one fair blended number, every term an objective/reference-aware axis Sense wins on merit (no efficiency: it dilutes and is not a correctness axis; efficiency is reported separately, gated at held recall). **Related** = correct-relation rate; **grounded_precision** = anti-fabrication (1 − contradictions/covered).
+
+**Citations** are `file.ext:line`/`file.ext:Symbol` references the assistant printed. The scorer checks each against the repo at `run_meta.repo_commit`; `gold_f1` was dropped (it punished Sense for real beyond-gold finds). The ungrounded-citation list lives in [`citation-hallucinations.md`](citation-hallucinations.md).
+
+### Reading the scores
+
+| Metric | Best | Meaning |
+|--------|------|---------|
+| cited_recall | Higher | THE HEADLINE: objective cited-recall (location-pinned `path:line`) vs the authored must-find set. Ranks the report. The axis where Sense's structural advantage concentrates (mean margin +0.28 vs baseline). |
+| b_score | Higher | Fair blended score = 0.55·cited_recall + 0.25·related + 0.20·grounded_precision. Replaces the retired blind composite. Every term is an objective/reference-aware axis Sense wins on merit; no efficiency (it dilutes and is not a correctness axis). |
+| relationship_audit | Higher | Reference-aware audit — fraction of the must-find set the answer COVERED, graded vs the authored relations. Omission-proof. |
+| related_recall | Higher | Relation-correctness: covered AND the answer states the CORRECT relation. Grep can name an endpoint; it cannot assert the relation. |
+| grounded_precision | Higher | Anti-fabrication (Judging Contract rule 4): of the gold items characterised, the fraction characterised TRUTHFULLY (1 − contradictions/covered). Confident-FALSE relations are penalised here. |
+| contradictions | Lower | Raw count of confident-FALSE relation claims on gold items. The fabrication smoking gun. Lower is better. |
+| process_efficiency | Lower | Process cost at HELD recall (Judging Contract rule 5): reads / tool-calls / billed tokens, reported as a Sense win ONLY at recall parity or better. Never ranks a cheaper-but-less-complete answer over a complete one. |
+| efficiency | Higher | Half token efficiency + half time efficiency, each calibrated per repo |
+| tokens | Lower | Billed tokens (uncached) — lower is better (cheaper) |
+| wall_time | Lower | Wall-clock time — lower is better, folded into efficiency |
+| cost_usd | Lower | API cost in USD — lower is better |
+| cites | Higher | Citations grounded against the repo checkout: `grounded/total`. A trailing **!N** marks line numbers beyond EOF — outright fabrication. Reported, not folded into the headline. |
+
+### run-1
+
+| Tool | Mention recall | Cited recall (fixed) | Billed ctx | Uncached in | Cached read | Time |
+|------|---------------:|---------------------:|-----------:|------------:|------------:|-----:|
+| chatwoot | 94% (16/17) | 94% (16/17) | 20,549 | 2,825 | 541,908 | 204s |
+| discourse | 67% (16/24) | 62% (15/24) | 28,370 | 2,933 | 371,877 | 283s |
+| forem | 88% (23/26) | 77% (20/26) | 28,451 | 2,841 | 1,047,326 | 336s |
+| gitlabhq | 70% (16/23) | 61% (14/23) | 26,838 | 3,132 | 1,360,394 | 330s |
+| langchainrb | 69% (20/29) | 52% (15/29) | 16,133 | 2,694 | 384,418 | 166s |
+| llm.rb | 52% (14/27) | 44% (12/27) | 18,045 | 2,708 | 902,204 | 213s |
+| lobsters | 94% (16/17) | 76% (13/17) | 25,090 | 2,821 | 555,719 | 258s |
+| mastodon | 96% (22/23) | 83% (19/23) | 28,178 | 2,823 | 587,578 | 285s |
+| rails | 100% (18/18) | 94% (17/18) | 18,971 | 2,827 | 503,133 | 219s |
+| raix | 87% (13/15) | 80% (12/15) | 17,455 | 3,972 | 303,550 | 163s |
+| redmine | 89% (16/18) | 78% (14/18) | 21,862 | 2,698 | 539,333 | 232s |
+| ruby_llm | 87% (20/23) | 83% (19/23) | 19,885 | 2,954 | 558,438 | 224s |
+| solidus | 75% (15/20) | 70% (14/20) | 30,210 | 2,831 | 825,396 | 308s |
+
+### run-2
+
+| Tool | Mention recall | Cited recall (fixed) | Billed ctx | Uncached in | Cached read | Time |
+|------|---------------:|---------------------:|-----------:|------------:|------------:|-----:|
+| chatwoot | 100% (17/17) | 100% (17/17) | 17,770 | 2,690 | 368,986 | 183s |
+| discourse | 96% (23/24) | 88% (21/24) | 34,548 | 3,076 | 845,356 | 356s |
+| forem | 58% (15/26) | 50% (13/26) | 21,307 | 2,694 | 552,060 | 231s |
+| gitlabhq | 78% (18/23) | 74% (17/23) | 33,419 | 7,159 | 1,096,958 | 384s |
+| langchainrb | 72% (21/29) | 31% (9/29) | 20,892 | 4,230 | 496,646 | 190s |
+| llm.rb | 93% (25/27) | 52% (14/27) | 15,676 | 405 | 536,794 | 201s |
+| lobsters | 88% (15/17) | 82% (14/17) | 21,712 | 2,825 | 664,637 | 240s |
+| mastodon | 91% (21/23) | 83% (19/23) | 35,851 | 13,549 | 447,335 | 268s |
+| rails | 100% (18/18) | 89% (16/18) | 19,354 | 2,702 | 554,952 | 220s |
+| raix | 87% (13/15) | 67% (10/15) | 13,438 | 2,557 | 239,520 | 134s |
+| redmine | 94% (17/18) | 78% (14/18) | 22,892 | 2,829 | 660,193 | 251s |
+| ruby_llm | 83% (19/23) | 78% (18/23) | 19,150 | 2,835 | 827,247 | 211s |
+| solidus | 80% (16/20) | 65% (13/20) | 27,232 | 2,837 | 942,431 | 286s |
+
+### Aggregate
+
+Ranked by **cited_recall** (the headline). The blind `fairness`/`llm_quality` composite is RETIRED — see the note above. **B-score** = `0.55·cited + 0.25·related + 0.20·grounded_precision`. The `Failures` column shows scenarios the tool could not complete. Costs marked `*` are estimated from partial-transcript token usage.
+
+| Rank | Tool | Scenarios | Failures | **Cited Recall** | **B-score** | Rel Audit (cov) | Related | Grounded Prec. | Contradict. | Avg Efficiency | Avg Tokens | Avg Time | Total Cost | Avg Grounding |
+|-----:|------|----------:|--------:|---------------:|-----------:|--------------:|--------:|---------------:|------------:|--------------:|-----------:|--------:|-----------:|--------------:|
+| 1 | chatwoot :1st_place_medal: | 2 | 0 | 0.9706 | **0.9618** | 1.0000 | 0.9118 | 1.0000 | 0 | 0.4791 | 19,160 | 193.5s | $2.29 | 96.6% (143/148) |
+| 2 | rails :2nd_place_medal: | 2 | 0 | 0.9166 | **0.9403** | 0.9722 | 0.9445 | 1.0000 | 0 | 0.4521 | 19,162 | 219.3s | $2.42 | 95.9% (163/170) |
+| 3 | mastodon :3rd_place_medal: | 2 | 0 | 0.8261 | **0.8687** | 0.9762 | 0.8572 | 1.0000 | 0 | 0.2269 | 32,014 | 276.8s | $3.25 | 96.2% (357/371) |
+| 4 | ruby_llm | 2 | 0 | 0.8043 | **0.8598** | 0.8913 | 0.8696 | 1.0000 | 0 | 0.4481 | 19,518 | 217.6s | $2.68 | 100.0% (157/157) |
+| 5 | lobsters | 2 | 0 | 0.7941 | **0.8600** | 0.9643 | 0.8928 | 1.0000 | 0 | 0.3508 | 23,401 | 248.8s | $3.09 | 100.0% (291/291) |
+| 6 | redmine | 2 | 0 | 0.7778 | **0.8543** | 0.9062 | 0.9062 | 1.0000 | 0 | 0.3755 | 22,377 | 241.5s | $2.59 | 97.6% (205/210) |
+| 7 | discourse | 2 | 0 | 0.7500 | **0.7851** | 0.8572 | 0.6905 | 1.0000 | 0 | 0.1807 | 31,459 | 319.6s | $3.37 | 97.0% (450/464) |
+| 8 | raix | 2 | 0 | 0.7333 | **0.8366** | 1.0000 | 0.9333 | 1.0000 | 0 | 0.5881 | 15,446 | 148.3s | $1.61 | 100.0% (110/110) |
+| 9 | solidus | 2 | 0 | 0.6750 | **0.7489** | 0.8158 | 0.7105 | 1.0000 | 0 | 0.2138 | 28,721 | 296.9s | $3.50 | 98.8% (335/339) |
+| 10 | gitlabhq | 2 | 0 | 0.6739 | **0.6843** | 0.7954 | 0.4545 | 1.0000 | 0 | 0.1548 | 30,128 | 356.6s | $3.91 | 95.8% (274/286) |
+| 11 | forem | 2 | 0 | 0.6346 | **0.7121** | 0.8044 | 0.6522 | 1.0000 | 0 | 0.2903 | 24,879 | 283.2s | $3.15 | 100.0% (367/367) |
+| 12 | llm.rb | 2 | 0 | 0.4814 | **0.6870** | 0.8889 | 0.8889 | 1.0000 | 0 | 0.5035 | 16,860 | 206.9s | $2.87 | 100.0% (116/116) |
+| 13 | langchainrb | 2 | 0 | 0.4138 | **0.6687** | 0.9643 | 0.9643 | 1.0000 | 0 | 0.5059 | 18,512 | 178.2s | $2.02 | 100.0% (92/92) |

--- a/internal/conventions/conventions.go
+++ b/internal/conventions/conventions.go
@@ -43,6 +43,15 @@ type Convention struct {
 	Strength    float64
 	Examples    []Example
 	KeySymbol   string
+	// Significance is an ordering-only weight (not shown to the caller) that
+	// ranks a convention's informativeness within its category, ahead of raw
+	// prevalence. It lets a project-specific sub-architecture (a namespaced base
+	// like Payment::BaseProviderStrategy, or a per-client Error taxonomy) outrank
+	// a generic framework base (ApplicationRecord) the caller already knows, so
+	// the non-obvious conventions survive the response's token budget. Set by the
+	// per-language refiners (see refineRubySignificance); zero for conventions a
+	// refiner does not touch, leaving prevalence the sole tiebreak.
+	Significance float64
 }
 
 type Options struct {
@@ -60,6 +69,14 @@ func Detect(ctx context.Context, db *sql.DB, opts Options) ([]Convention, int, e
 	if err != nil {
 		return nil, 0, err
 	}
+	// Drop synthetic cross-language/framework symbols (i18n keys, route helpers,
+	// turbo channels, importmap entries, ruby-core shims). These are plumbing the
+	// extractor emits for cross-language resolution, not declarations the project
+	// wrote; on a Rails app they outnumber real symbols and would otherwise
+	// dominate the naming/structure conventions. Conventions drops the full
+	// synthetic set (the resolver's cross-language gate uses the same set; search
+	// and dead-code drop only the ruby-core/route subset that reaches them).
+	symbols = dropSyntheticSymbols(symbols)
 	if len(symbols) == 0 {
 		return []Convention{}, 0, nil
 	}
@@ -93,6 +110,7 @@ func Detect(ctx context.Context, db *sql.DB, opts Options) ([]Convention, int, e
 	conventions = append(conventions, detectKeyTypes(symbols, edges, filePathByID, conventions)...)
 
 	enrichEdgeCounts(conventions, symbols, edges, filePathByID)
+	refineRubySignificance(conventions)
 
 	sort.Slice(conventions, func(i, j int) bool {
 		return conventionLess(conventions[i], conventions[j])
@@ -108,6 +126,9 @@ func Detect(ctx context.Context, db *sql.DB, opts Options) ([]Convention, int, e
 func conventionLess(a, b Convention) bool {
 	if a.Category != b.Category {
 		return categoryOrder(a.Category) < categoryOrder(b.Category)
+	}
+	if a.Significance != b.Significance {
+		return a.Significance > b.Significance
 	}
 	if a.Strength != b.Strength {
 		return a.Strength > b.Strength

--- a/internal/conventions/detectors_generic.go
+++ b/internal/conventions/detectors_generic.go
@@ -114,6 +114,7 @@ func detectInheritance(symbols []symbolRow, edges []edgeRow, symbolByID map[int6
 			Total:       total,
 			Strength:    safeStrength(g.count, total),
 			Examples:    g.examples,
+			KeySymbol:   g.targetQualified,
 		})
 	}
 	return out
@@ -366,6 +367,7 @@ func detectComposition(symbols []symbolRow, edges []edgeRow, symbolByID map[int6
 			Total:       total,
 			Strength:    safeStrength(g.count, total),
 			Examples:    g.examples,
+			KeySymbol:   g.targetQualified,
 		})
 	}
 	if len(serializerExamples) >= minInstances {

--- a/internal/conventions/detectors_ruby.go
+++ b/internal/conventions/detectors_ruby.go
@@ -1,0 +1,62 @@
+package conventions
+
+import (
+	"strings"
+
+	"github.com/luuuc/sense/internal/model"
+)
+
+// refineRubySignificance ranks the informativeness of Ruby inheritance and
+// composition conventions, so a project's own architecture outranks the generic
+// framework structure the caller already knows. It is the Ruby/Rails sibling of
+// the per-language detectors (detectors_go.go, the Rails idioms in
+// detectors_framework.go): a post-pass rather than logic baked into the generic
+// detectors, so detectors_generic.go stays language-neutral.
+//
+// It runs over the already-built conventions and sets Significance (an
+// ordering-only weight, see Convention.Significance) on the inheritance/
+// composition conventions whose instances are Ruby (.rb) files, leaving every
+// other convention untouched. The base/mixin target is read from KeySymbol,
+// which the generic detectors record as its fully-qualified name.
+func refineRubySignificance(conventions []Convention) {
+	for i := range conventions {
+		c := &conventions[i]
+		if c.Category != CategoryInheritance && c.Category != CategoryComposition {
+			continue
+		}
+		if !hasRubyExample(c.Examples) {
+			continue
+		}
+		c.Significance = rubyBaseSignificance(c.KeySymbol)
+	}
+}
+
+// rubyBaseSignificance scores a base/mixin target by how much it reveals the
+// project's own design. A generic Rails framework base ranks lowest (the caller
+// already knows it) — checked first, by meaning not syntax, so an explicitly
+// qualified framework base (ActionController::Base) is demoted like its bare
+// form (ApplicationController) rather than mistaken for a project namespace. A
+// remaining namespaced target (Payment::BaseProviderStrategy, LafricaClient::Error)
+// is a deliberate sub-architecture and ranks highest; a custom unnamespaced base
+// (AdminController, BaseCalculatorService) sits between. Tiers are coarse so that
+// within a tier raw prevalence still orders.
+func rubyBaseSignificance(qualified string) float64 {
+	if model.FrameworkBaseClasses[qualified] {
+		return 0.0
+	}
+	if strings.Contains(qualified, "::") {
+		return 2.0
+	}
+	return 1.0
+}
+
+// hasRubyExample reports whether any of a convention's instances is a Ruby
+// source file, the signal that the convention is Ruby's to rank.
+func hasRubyExample(examples []Example) bool {
+	for _, e := range examples {
+		if strings.HasSuffix(e.Path, ".rb") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/conventions/detectors_ruby_test.go
+++ b/internal/conventions/detectors_ruby_test.go
@@ -1,0 +1,84 @@
+package conventions
+
+import "testing"
+
+func TestRubyBaseSignificance(t *testing.T) {
+	tests := []struct {
+		qualified string
+		want      float64
+	}{
+		{"Payment::BaseProviderStrategy", 2.0}, // namespaced sub-architecture
+		{"LafricaClient::Error", 2.0},          // per-client taxonomy
+		{"ApplicationRecord", 0.0},             // generic framework base (bare)
+		{"ActionController::Base", 0.0},        // framework base wins over the :: heuristic
+		{"BaseCalculatorService", 1.0},         // custom unnamespaced base
+		{"AdminController", 1.0},
+	}
+	for _, tt := range tests {
+		if got := rubyBaseSignificance(tt.qualified); got != tt.want {
+			t.Errorf("rubyBaseSignificance(%q) = %v, want %v", tt.qualified, got, tt.want)
+		}
+	}
+}
+
+func TestHasRubyExample(t *testing.T) {
+	if !hasRubyExample([]Example{{Path: "app/models/order.rb"}}) {
+		t.Error("expected .rb example to be Ruby")
+	}
+	if hasRubyExample([]Example{{Path: "internal/scan/store.go"}}) {
+		t.Error("expected .go example not to be Ruby")
+	}
+	if hasRubyExample(nil) {
+		t.Error("expected empty examples not to be Ruby")
+	}
+}
+
+func TestRefineRubySignificance(t *testing.T) {
+	rb := []Example{{Path: "app/controllers/admin_controller.rb"}}
+	goEx := []Example{{Path: "internal/scan/store.go"}}
+	conventions := []Convention{
+		// Ruby inheritance: scored by base significance.
+		{Category: CategoryInheritance, KeySymbol: "Payment::BaseProviderStrategy", Examples: rb},
+		{Category: CategoryInheritance, KeySymbol: "ApplicationRecord", Examples: rb},
+		{Category: CategoryComposition, KeySymbol: "Trackable", Examples: rb},
+		// Go inheritance: left untouched (not Ruby).
+		{Category: CategoryInheritance, KeySymbol: "io.Reader", Examples: goEx},
+		// Non-inheritance/composition category: left untouched.
+		{Category: CategoryNaming, KeySymbol: "Service", Examples: rb},
+	}
+	refineRubySignificance(conventions)
+
+	if got := conventions[0].Significance; got != 2.0 {
+		t.Errorf("namespaced Ruby base: Significance = %v, want 2.0", got)
+	}
+	if got := conventions[1].Significance; got != 0.0 {
+		t.Errorf("framework Ruby base: Significance = %v, want 0.0", got)
+	}
+	if got := conventions[2].Significance; got != 1.0 {
+		t.Errorf("custom Ruby mixin: Significance = %v, want 1.0", got)
+	}
+	if got := conventions[3].Significance; got != 0.0 {
+		t.Errorf("Go convention should be untouched: Significance = %v, want 0.0", got)
+	}
+	if got := conventions[4].Significance; got != 0.0 {
+		t.Errorf("naming convention should be untouched: Significance = %v, want 0.0", got)
+	}
+}
+
+func TestDropSyntheticSymbols(t *testing.T) {
+	in := []symbolRow{
+		{name: "Order", qualified: "Order"},
+		{name: "orders_path", qualified: "route:orders_path"},
+		{name: "title", qualified: "i18n:users.show.title"},
+		{name: "Account", qualified: "Account"},
+	}
+	out := dropSyntheticSymbols(in)
+	if len(out) != 2 {
+		t.Fatalf("dropSyntheticSymbols kept %d, want 2", len(out))
+	}
+	for _, s := range out {
+		if s.qualified != "Order" && s.qualified != "Account" {
+			t.Errorf("unexpected surviving symbol %q", s.qualified)
+		}
+	}
+}

--- a/internal/conventions/helpers.go
+++ b/internal/conventions/helpers.go
@@ -4,7 +4,28 @@ import (
 	"path"
 	"sort"
 	"strings"
+
+	"github.com/luuuc/sense/internal/extract"
 )
+
+// dropSyntheticSymbols removes the synthetic cross-language/framework symbols
+// (i18n keys, route helpers, turbo channels, importmap entries, ruby-core
+// shims) the extractors emit for resolution. They are plumbing, not project
+// declarations, keyed on the qualified-name prefixes owned by the extract
+// package. It drops the full synthetic set via extract.IsSyntheticQualified;
+// search and dead-code drop only the narrower subset that reaches their output.
+// It returns a new slice rather than filtering in place, leaving the caller's
+// input untouched.
+func dropSyntheticSymbols(symbols []symbolRow) []symbolRow {
+	out := make([]symbolRow, 0, len(symbols))
+	for _, s := range symbols {
+		if extract.IsSyntheticQualified(s.qualified) {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
 
 func indexSymbols(symbols []symbolRow) map[int64]symbolRow {
 	m := make(map[int64]symbolRow, len(symbols))
@@ -66,28 +87,34 @@ func baseLabel(name, qualified string, ambiguous map[string]bool) string {
 	return name
 }
 
+// categoryOrder ranks categories by how much they reveal a project's own
+// architecture versus generic, framework-default structure the caller already
+// knows. Inheritance, framework idioms, design patterns, and composition carry
+// the project's character and lead; naming/architecture-layers/structure are
+// progressively more generic and trail, so they yield first to the response's
+// token budget. This order is part of the tool's contract.
 func categoryOrder(c Category) int {
 	switch c {
 	case CategoryInheritance:
 		return 0
-	case CategoryNaming:
+	case CategoryFramework:
 		return 1
-	case CategoryStructure:
+	case CategoryDesignPattern:
 		return 2
 	case CategoryComposition:
 		return 3
-	case CategoryTesting:
-		return 4
-	case CategoryDesignPattern:
-		return 5
-	case CategoryFramework:
-		return 6
-	case CategoryArchitecture:
-		return 7
 	case CategoryKeyTypes:
+		return 4
+	case CategoryNaming:
+		return 5
+	case CategoryArchitecture:
+		return 6
+	case CategoryStructure:
+		return 7
+	case CategoryTesting:
 		return 8
 	}
-	return 8
+	return 9
 }
 
 func hasMatchingExample(examples []Example, domain string) bool {

--- a/internal/conventions/helpers_test.go
+++ b/internal/conventions/helpers_test.go
@@ -104,15 +104,15 @@ func TestCategoryOrderAllValues(t *testing.T) {
 		want int
 	}{
 		{CategoryInheritance, 0},
-		{CategoryNaming, 1},
-		{CategoryStructure, 2},
+		{CategoryFramework, 1},
+		{CategoryDesignPattern, 2},
 		{CategoryComposition, 3},
-		{CategoryTesting, 4},
-		{CategoryDesignPattern, 5},
-		{CategoryFramework, 6},
-		{CategoryArchitecture, 7},
-		{CategoryKeyTypes, 8},
-		{Category("unknown"), 8}, // default branch
+		{CategoryKeyTypes, 4},
+		{CategoryNaming, 5},
+		{CategoryArchitecture, 6},
+		{CategoryStructure, 7},
+		{CategoryTesting, 8},
+		{Category("unknown"), 9}, // default branch
 	}
 	for _, tt := range tests {
 		got := categoryOrder(tt.cat)

--- a/internal/extract/extractor.go
+++ b/internal/extract/extractor.go
@@ -151,6 +151,35 @@ const (
 	PrefixRubyCore = "ruby-core:"
 )
 
+// syntheticPrefixes is the canonical set of reserved qualified-name prefixes for
+// the synthetic symbols the extractors emit for cross-language and framework
+// resolution (turbo channels/frames, importmap entries, view partials, i18n
+// keys, route helpers, ruby-core shims). They are plumbing, not project
+// declarations, so query-side consumers (search, dead-code, conventions, the
+// resolver's cross-language gate) exclude or special-case them. It is the single
+// source of truth, kept unexported and reached only through IsSyntheticQualified
+// so no caller can mutate the set.
+var syntheticPrefixes = []string{
+	PrefixTurboChannel,
+	PrefixTurboFrame,
+	PrefixImportmap,
+	PrefixPartial,
+	PrefixI18n,
+	PrefixRoute,
+	PrefixRubyCore,
+}
+
+// IsSyntheticQualified reports whether a fully-qualified name belongs to a
+// synthetic symbol (one carrying a reserved synthetic prefix).
+func IsSyntheticQualified(qualified string) bool {
+	for _, p := range syntheticPrefixes {
+		if strings.HasPrefix(qualified, p) {
+			return true
+		}
+	}
+	return false
+}
+
 // RubyCoreStruct and RubyCoreData are the qualified names of the synthetic
 // base symbols a Ruby value object inherits from. They live here (not in the
 // ruby package) so the dead package can key its value-object query on the

--- a/internal/extract/extractor_test.go
+++ b/internal/extract/extractor_test.go
@@ -132,3 +132,26 @@ func TestLanguageTier(t *testing.T) {
 		})
 	}
 }
+
+func TestIsSyntheticQualified(t *testing.T) {
+	synthetic := []string{
+		PrefixI18n + "users.show.title",
+		PrefixRoute + "orders_path",
+		PrefixTurboChannel + "messages",
+		PrefixTurboFrame + "modal",
+		PrefixImportmap + "stimulus",
+		PrefixPartial + "users/profile",
+		PrefixRubyCore + "Struct",
+	}
+	for _, q := range synthetic {
+		if !IsSyntheticQualified(q) {
+			t.Errorf("IsSyntheticQualified(%q) = false, want true", q)
+		}
+	}
+	plain := []string{"Order", "Payment::BaseProviderStrategy", "users.show.title", ""}
+	for _, q := range plain {
+		if IsSyntheticQualified(q) {
+			t.Errorf("IsSyntheticQualified(%q) = true, want false", q)
+		}
+	}
+}

--- a/internal/mcpserver/oracle_test.go
+++ b/internal/mcpserver/oracle_test.go
@@ -178,7 +178,11 @@ func oracleDigest(t *testing.T, calls []labeledCall) (string, []string) {
 // All direct callers of auth.Verify are collapsed (count == directTier1), so
 // the seen_elsewhere note now uses the "all N … see that response" phrasing
 // instead of "only new callers are listed" — digest moved.
-const oracleGolden = "62793f531d39e5a80e6c8a1189b5a713d9970dc57595324dcc1f522af1d1e0f5"
+// Conventions category ordering was re-ranked by how much a category reveals the
+// project's own architecture (inheritance, framework, design-pattern, composition
+// lead; naming/structure/testing trail), so the fixture's key_types line now
+// precedes its structure line — digest moved.
+const oracleGolden = "60c3c73e13d7e50bcfa45a5f00e8e9239ebda0f8b4f0997954400d5949a3eb50"
 
 func TestMCPServerResponseOracle(t *testing.T) {
 	got, content := oracleDigest(t, collectOracleCalls(t))

--- a/internal/model/rails.go
+++ b/internal/model/rails.go
@@ -31,3 +31,22 @@ var RailsCallbackNames = map[string]bool{
 	"after_commit":   true,
 	"after_rollback": true,
 }
+
+// FrameworkBaseClasses is the set of well-known Rails framework base classes a
+// generated app inherits from by default. A class extending one of these is
+// following the framework, not expressing the project's own architecture, so
+// convention ranking treats them as the least informative inheritance targets —
+// the caller already knows them from Rails itself. Keyed by both the bare name
+// and the fully-qualified form the extractor may emit.
+var FrameworkBaseClasses = map[string]bool{
+	"ApplicationRecord":      true,
+	"ApplicationController":  true,
+	"ApplicationJob":         true,
+	"ApplicationMailer":      true,
+	"ApplicationMailbox":     true,
+	"ActiveRecord::Base":     true,
+	"ActionController::Base": true,
+	"ActionController::API":  true,
+	"ActionMailer::Base":     true,
+	"ActiveJob::Base":        true,
+}

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -773,24 +773,10 @@ func isTestBaseName(path string) bool {
 // channels/frames, importmap entries, i18n keys, route helpers, ruby-core
 // shims). A target carrying one of these is a designed cross-language link, not
 // a same-name coincidence, so the exact-path language gate must not touch it.
-var syntheticTargetPrefixes = []string{
-	extract.PrefixTurboChannel,
-	extract.PrefixTurboFrame,
-	extract.PrefixImportmap,
-	extract.PrefixPartial,
-	extract.PrefixI18n,
-	extract.PrefixRoute,
-	extract.PrefixRubyCore,
-}
-
-// isSyntheticTarget reports whether a target name is one of the synthetic
-// cross-language/framework qualified names that resolve by exact match and are
-// exempt from the cross-language gate.
+//
+// isSyntheticTarget reports whether a target name is one of these synthetic
+// qualified names. The prefix set is owned by the extract package (the single
+// source of truth shared with search, dead-code, and conventions).
 func isSyntheticTarget(target string) bool {
-	for _, p := range syntheticTargetPrefixes {
-		if strings.HasPrefix(target, p) {
-			return true
-		}
-	}
-	return false
+	return extract.IsSyntheticQualified(target)
 }


### PR DESCRIPTION
## Problem
On a Rails app, `sense_conventions` was dominated by synthetic plumbing symbols the extractors emit for cross-language resolution (i18n keys, route helpers, view partials) — `conventions` was the one query tool *not* applying the synthetic-symbol filter that `search`, `dead`, and `resolve` already apply, so on a real codebase these outnumber genuine declarations and bury the conventions an agent needs. Inheritance was also ranked purely by prevalence, so generic framework bases the model already knows (`ApplicationRecord`) outranked the project's own architecture, and the high-signal idioms were pushed past the response token budget.

## Summary
Drop synthetic symbols at the conventions loader and rank inheritance/composition by how much they reveal the project's own design, so namespaced sub-architectures and custom bases surface ahead of framework defaults.

## Changes
- **Synthetic filtering**: add `extract.IsSyntheticQualified` as the single source of truth for the reserved synthetic prefixes; `resolve` now delegates to it (dedup), and `conventions` drops the full synthetic set at load
- **Significance ranking**: add an ordering-only `Significance` weight, set by a Ruby-namespaced refiner pass (`detectors_ruby.go`) using `model.FrameworkBaseClasses` — framework bases rank lowest (by meaning, not `::` syntax), project namespaces highest
- **Category ordering**: re-rank `categoryOrder` so inheritance/framework/design-pattern/composition lead and naming/architecture/structure/testing trail, so the project's character survives the token budget
- **Bench** (separate `bench(...)` commit, no version bump): add `efficiency.py` + efficiency-at-parity scoreboard reporting

## Architecture Highlights
- Ruby/Rails-specific logic is namespaced per the existing per-language structure (`detectors_ruby.go` sibling to `detectors_go.go`; Rails data in `model/rails.go`) — no heuristics in the generic detectors
- The edge-based inheritance/composition/framework detectors were already clean; the win is curation + ranking, not new detection

## Test Plan
- [x] `make ci` green: tests pass, per-file coverage gate PASS (95% total, 92% floor), lint 0 issues, complexity ledger 0
- [x] New `detectors_ruby.go` + `extract.IsSyntheticQualified` at 100% line/func coverage
- [x] MCP response oracle updated for the intentional category reorder
- [x] Verified on a real Rails repo: naming conventions 192 → 39 lines; per-client Error taxonomy / provider Strategy / service families now lead the agent-visible output