### PR TITLE
fix(hook): nudge toward Sense on cd-prefixed and quoted greps

### DIFF
--- a/bench/lib/loopA-scan.sh
+++ b/bench/lib/loopA-scan.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# loopA-scan.sh — the Loop-A (PRODUCT-gap detection) pass over a vertical.
+#
+# Loop A ≠ Loop B. The bench (runs-variance.sh + pergroup/scorer/judge) is the
+# value-PROOF instrument (Loop B). This is the gap-DETECTOR (Loop A): it is
+# ADVISORY ONLY — it writes a report and NEVER gates a bench, blocks a sweep, or
+# touches a score. Two free passes, no LLM, no new bench tokens:
+#
+#   preflight  resolve_oracle.py — live `sense` CLI vs the gold discriminator.
+#              Run it at SCOUT time (after the index builds, while authoring gold):
+#              catches ambiguous symbols needing --file, budget-cap eviction, and
+#              gold that blast can't retrieve (manifesto §8.3/§10 "gold must be
+#              default-blast-retrievable") — BEFORE you pay for a sweep.
+#   harvest    transcript_miss.py — mines the ×N transcripts a sweep already paid
+#              for (cited-not-returned / fallback-reads / empty returns). Run it
+#              AFTER a sweep to bank the Loop-A signal for free.
+#
+# Output is appended (never overwritten) to results/loopA-gaps/<stack>.md so the
+# product-gap log accumulates across repos and verticals. A FAIL in the oracle is
+# a fix CANDIDATE for the NEXT vertical's pre-bench window, not a reason to stop —
+# fixing the product mid-vertical invalidates that vertical's frozen numbers.
+#
+# Usage:
+#   bash bench/lib/loopA-scan.sh preflight <stack> [repo]
+#   bash bench/lib/loopA-scan.sh harvest   <stack> [model]
+#   bash bench/lib/loopA-scan.sh both      <stack>           # preflight + harvest
+set -uo pipefail
+
+BENCH_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+LIB="$BENCH_DIR/lib"
+MODE="${1:?usage: loopA-scan.sh <preflight|harvest|both> <stack> [repo|model]}"
+STACK="${2:?usage: loopA-scan.sh <mode> <stack> [arg]}"
+ARG="${3:-}"
+
+LOGDIR="$BENCH_DIR/results/loopA-gaps"
+mkdir -p "$LOGDIR"
+LOG="$LOGDIR/$STACK.md"
+STAMP="$(date -u +%Y-%m-%dT%H:%MZ)"
+
+append() { tee -a "$LOG"; }
+
+run_preflight() {
+  local repo_flag=()
+  [ -n "$ARG" ] && repo_flag=(--repo "$ARG")
+  {
+    echo ""
+    echo "## [$STAMP] PREFLIGHT resolve_oracle — stack=$STACK ${ARG:+repo=$ARG}"
+    echo '```'
+  } | append
+  # advisory: capture exit but do NOT propagate as a wrapper failure.
+  # ${arr[@]+...} guards the empty-array case under `set -u` on bash 3.2 (macOS).
+  python3 "$LIB/resolve_oracle.py" --stack "$STACK" ${repo_flag[@]+"${repo_flag[@]}"} 2>&1 | append
+  echo '```' | append
+}
+
+run_harvest() {
+  local model_flag=()
+  [ -n "$ARG" ] && model_flag=(--model "$ARG")
+  {
+    echo ""
+    echo "## [$STAMP] HARVEST transcript_miss — stack=$STACK ${ARG:+model=$ARG}"
+    echo '```'
+  } | append
+  python3 "$LIB/transcript_miss.py" --stack "$STACK" ${model_flag[@]+"${model_flag[@]}"} 2>&1 | append
+  echo '```' | append
+}
+
+case "$MODE" in
+  preflight) run_preflight ;;
+  harvest)   run_harvest ;;
+  both)      run_preflight; run_harvest ;;
+  *) echo "unknown mode: $MODE (preflight|harvest|both)" >&2; exit 64 ;;
+esac
+
+echo ""
+echo "Loop-A scan appended to $LOG (advisory — no bench was gated)."

--- a/bench/lib/resolve_oracle.py
+++ b/bench/lib/resolve_oracle.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Tier-0 resolution oracle — deterministic, $0, no LLM, no scenario, no judge.
+
+The isolated product unit-test the vertical bench is too coarse to be. For each
+repo's CENTRAL contract symbol it runs the LIVE `sense` CLI against the repo's
+pinned `.sense` index and asserts two things mechanically:
+
+  COVERAGE — does `sense blast <symbol>` (default min_confidence 0.7, the agent's
+    default) actually return the gold DISCRIMINATOR dependents the scenario says it
+    must? Missing gold here is a LIVE-CONFIRMED resolver miss (stronger than the
+    transcript_miss inference, which only saw what the agent happened to query).
+
+  AMBIGUITY — does the naive `sense graph/blast <symbol>` (no --file) resolve, or
+    does it error/empty while the --file form returns a real set? That is the exact
+    gap transcript_miss surfaced (graph(Status)→0 vs graph(Status,file=)→111). When
+    the graph-disambiguation fix lands, this flag clears — so the oracle doubles as
+    the regression net for that fix.
+
+This is the unit the piking loop gates on: change Sense → re-run the oracle → a
+deterministic diff, for free, before any bench token is spent. It is a DETECTOR and
+a REGRESSION NET, never the ship gate (the differential bench stays that). Exit code
+is non-zero if any repo FAILs, so it can gate CI / the loop driver.
+
+Usage:
+  python3 bench/lib/resolve_oracle.py                  # all seeded repos
+  python3 bench/lib/resolve_oracle.py --repo chatwoot,mastodon
+  python3 bench/lib/resolve_oracle.py --json out.json
+"""
+import argparse
+import glob
+import json
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+import yaml  # noqa: E402
+
+SENSE_REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))  # oss/sense
+CLONES = os.path.join(os.path.dirname(SENSE_REPO), "sense-benchmark", "sense")     # per-repo clones + .sense
+SCEN = os.path.join(SENSE_REPO, "bench", "scenarios", "vertical")
+SENSE_BIN = os.environ.get("SENSE_BIN", os.path.expanduser("~/.local/bin/sense"))
+
+ANCHOR_GROUPS = {"contract", "context", "surface", "teardown"}
+COV_FAIL, COV_WARN = 0.50, 0.80   # blast coverage of the gold discriminator
+
+# (repo) -> {symbol, file?}. The contract symbol the scenario puts under change.
+# PREFERRED source is each gold yaml's top-level `contract_symbol:` (+ optional
+# `contract_file:`) — stack-agnostic, so a new vertical (Django) is picked up with
+# zero code edits. This hand-table is the rails-vintage FALLBACK for the frozen
+# yamls that predate the field. `file` is set only for AMBIGUOUS symbols.
+CONTRACTS = {
+    # big apps — high confidence (the discriminator wins live here)
+    "chatwoot":   {"symbol": "Inbox"},
+    "discourse":  {"symbol": "Upload"},
+    "forem":      {"symbol": "Article"},
+    "mastodon":   {"symbol": "Status", "file": "app/models/status.rb"},   # ambiguous: Ruby model vs JS
+    "gitlabhq":   {"symbol": "MergeRequest", "file": "app/models/merge_request.rb"},   # ambiguous
+    "solidus":    {"symbol": "Spree::Order", "file": "core/app/models/spree/order.rb"},  # re-opened
+    "rails":      {"symbol": "ActiveRecord::Relation", "file": "active_record/relation.rb"},  # re-opened
+    "redmine":    {"symbol": "Issue"},
+    "lobsters":   {"symbol": "Story"},
+    # gems — best-guess symbols (adoption-gapped in the bench; fix the symbol if "not found")
+    "ruby_llm":   {"symbol": "RubyLLM::Provider", "gem": True},
+    "langchainrb": {"symbol": "Langchain::LLM::Base", "gem": True},
+    "llm.rb":     {"symbol": "LLM::Provider", "gem": True},
+    "raix":       {"symbol": "Raix::ChatCompletion", "gem": True},
+}
+
+
+def discover_contracts(stack):
+    """Build {repo: {symbol, file?}}: gold yaml `contract_symbol:` wins (stack-agnostic,
+    Django-ready). The rails-vintage CONTRACTS hand-table is the fallback for ruby-rails
+    ONLY (its frozen yamls predate the field); other stacks rely on `contract_symbol:`."""
+    out = dict(CONTRACTS) if stack == "ruby-rails" else {}
+    for f in glob.glob(os.path.join(SCEN, stack, "*.yaml")):
+        if ".rubric" in os.path.basename(f):
+            continue
+        repo = os.path.basename(f)[:-5]
+        try:
+            doc = yaml.safe_load(open(f)) or {}
+        except yaml.YAMLError:
+            continue
+        sym = doc.get("contract_symbol")
+        if sym:
+            spec = {"symbol": sym}
+            if doc.get("contract_file"):
+                spec["file"] = doc["contract_file"]
+            if doc.get("gem"):
+                spec["gem"] = True
+            out[repo] = spec  # yaml-declared overrides the hand-table
+    return out
+
+
+def run_sense(clone, args):
+    """Run `sense <args>` in the clone. Returns (exit_code, parsed_json_or_None)."""
+    try:
+        p = subprocess.run([SENSE_BIN, *args], cwd=clone, capture_output=True,
+                           text=True, timeout=120)
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        return (-1, {"_error": str(e)})
+    out = p.stdout.strip()
+    if not out:
+        return (p.returncode, None)
+    try:
+        return (p.returncode, json.loads(out))
+    except json.JSONDecodeError:
+        return (p.returncode, None)
+
+
+def harvest_files(obj):
+    """Recursively collect every value under a 'file' key (repo-relative paths)."""
+    found = set()
+    if isinstance(obj, dict):
+        f = obj.get("file")
+        if isinstance(f, str) and "." in f:
+            found.add(f)
+        for v in obj.values():
+            found |= harvest_files(v)
+    elif isinstance(obj, list):
+        for v in obj:
+            found |= harvest_files(v)
+    return found
+
+
+def discriminator_gold(stack, repo):
+    """Expected files = the gold's discriminator group (largest non-anchor group)."""
+    f = os.path.join(SCEN, stack, f"{repo}.yaml")
+    if not os.path.exists(f):
+        return set(), "?"
+    doc = yaml.safe_load(open(f))
+    by_group = {}
+    for t in doc.get("gold", []):
+        m = t.get("match")
+        m = [m] if isinstance(m, str) else (m or [])
+        by_group.setdefault(t.get("group", "?"), []).extend(m)
+    disc = [g for g in by_group if g not in ANCHOR_GROUPS]
+    if not disc:  # gem scenarios sometimes have no anchor split
+        group = max(by_group, key=lambda g: len(by_group[g])) if by_group else "?"
+    else:
+        group = max(disc, key=lambda g: len(by_group[g]))
+    return {p for p in by_group.get(group, [])}, group
+
+
+def covered(expected, returned):
+    """suffix-tolerant set coverage."""
+    hit = set()
+    for e in expected:
+        if any(e == r or r.endswith("/" + e) or e.endswith("/" + r) for r in returned):
+            hit.add(e)
+    return hit
+
+
+def check_repo(stack, repo, spec):
+    clone = os.path.join(CLONES, repo)
+    if not os.path.isdir(os.path.join(clone, ".sense")):
+        return {"repo": repo, "status": "SKIP", "note": "no .sense index"}
+    symbol = spec["symbol"]
+    file_arg = spec.get("file")
+
+    # 1) canonical blast (with --file if the symbol is ambiguous) → coverage
+    blast_args = ["blast", symbol, "--json"]
+    if file_arg:
+        blast_args += ["--file", file_arg]
+    bcode, bjson = run_sense(clone, blast_args)
+    blast_files = harvest_files(bjson) if bjson else set()
+    direct = len(bjson.get("direct_callers", [])) if isinstance(bjson, dict) else 0
+
+    expected, group = discriminator_gold(stack, repo)
+
+    # 2) uncapped graph edges (--direction both) = the RESOLUTION-truth signal.
+    # blast's direct_callers are budget-capped (~60); graph called_by/composes/etc
+    # are not — so coverage must be measured against blast ∪ graph, else the cap
+    # gets misread as a resolver miss (two different product axes).
+    gboth_args = ["graph", symbol, "--direction", "both", "--json"]
+    if file_arg:
+        gboth_args += ["--file", file_arg]
+    _gc, gboth = run_sense(clone, gboth_args)
+    graph_files = harvest_files(gboth) if gboth else set()
+
+    resolved = blast_files | graph_files
+    hit_resolved = covered(expected, resolved)        # does Sense resolve it AT ALL?
+    hit_blast = covered(expected, blast_files)         # is it in the budgeted slice?
+    cov = len(hit_resolved) / len(expected) if expected else None
+    cov_blast = len(hit_blast) / len(expected) if expected else None
+    missing = sorted(expected - hit_resolved)          # GENUINE resolver-miss candidates
+    budget_evicted = sorted((hit_resolved - hit_blast)) # resolved but cap-evicted from blast
+
+    # 3) ambiguity probe — naive graph (no --file) vs disambiguated
+    gnaive_code, gnaive = run_sense(clone, ["graph", symbol, "--direction", "callers", "--json"])
+    naive_cb = len(gnaive.get("edges", {}).get("called_by", [])) if isinstance(gnaive, dict) else 0
+    if file_arg:
+        gdis_code, gdis = run_sense(clone, ["graph", symbol, "--direction", "callers",
+                                            "--file", file_arg, "--json"])
+        dis_cb = len(gdis.get("edges", {}).get("called_by", [])) if isinstance(gdis, dict) else 0
+    else:
+        gdis_code, dis_cb = gnaive_code, naive_cb
+    # AMBIGUOUS = naive errors/empties while a real set exists (disambiguated or blast)
+    ambiguous = (naive_cb == 0) and (dis_cb > 0 or direct > 0)
+
+    # verdict
+    status = "PASS"
+    flags = []
+    if bcode == 2 and not file_arg:
+        flags.append("BLAST_AMBIGUOUS")
+    if symbol and direct == 0 and not blast_files:
+        status, note = "FAIL", "symbol resolved to 0 callers/files (wrong symbol or resolver miss)"
+        flags.append("EMPTY_BLAST")
+    if ambiguous:
+        flags.append("GRAPH_AMBIGUOUS_EMPTY")  # the transcript_miss finding, live-confirmed
+    if budget_evicted:
+        flags.append(f"BUDGET_EVICTED×{len(budget_evicted)}")  # resolved but capped out of blast
+    if cov is not None:  # FAIL/WARN on RESOLVED coverage — a true resolver gap, not the cap
+        if cov < COV_FAIL:
+            status = "FAIL"
+        elif cov < COV_WARN and status != "FAIL":
+            status = "WARN"
+    if ambiguous and status == "PASS":
+        status = "WARN"
+
+    return {
+        "repo": repo, "symbol": symbol, "file": file_arg, "status": status,
+        "gem": spec.get("gem", False), "group": group,
+        "direct_callers": direct, "blast_files": len(blast_files),
+        "coverage": round(cov, 3) if cov is not None else None,
+        "coverage_blast_slice": round(cov_blast, 3) if cov_blast is not None else None,
+        "expected": len(expected), "covered": len(hit_resolved),
+        "missing_gold": missing, "budget_evicted": budget_evicted,
+        "graph_naive_callers": naive_cb, "graph_disambig_callers": dis_cb,
+        "flags": flags,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--stack", default="ruby-rails")
+    ap.add_argument("--repo", default="", help="comma-separated repo filter")
+    ap.add_argument("--json", default="")
+    args = ap.parse_args()
+    if not os.path.exists(SENSE_BIN):
+        sys.exit(f"sense binary not found at {SENSE_BIN} (set SENSE_BIN=)")
+
+    repo_filter = set(r.strip() for r in args.repo.split(",") if r.strip())
+    results = []
+    for repo, spec in discover_contracts(args.stack).items():
+        if repo_filter and repo not in repo_filter:
+            continue
+        results.append(check_repo(args.stack, repo, spec))
+
+    report(results, args.stack)
+    if args.json:
+        json.dump(results, open(args.json, "w"), indent=2)
+        print(f"\nwrote {args.json}")
+    sys.exit(1 if any(r["status"] == "FAIL" for r in results) else 0)
+
+
+def report(results, stack):
+    icon = {"PASS": "✅", "WARN": "🟡", "FAIL": "❌", "SKIP": "·"}
+    order = {"FAIL": 0, "WARN": 1, "PASS": 2, "SKIP": 3}
+    print(f"\n=== Tier-0 resolution oracle — stack={stack} "
+          f"(live `sense` vs gold discriminator, $0) ===\n")
+    for r in sorted(results, key=lambda x: order.get(x["status"], 9)):
+        if r["status"] == "SKIP":
+            print(f"{icon['SKIP']} {r['repo']:<12} SKIP — {r.get('note')}")
+            continue
+        cov = f"{r['coverage']*100:.0f}%" if r["coverage"] is not None else "n/a"
+        covb = f"{r['coverage_blast_slice']*100:.0f}%" if r.get("coverage_blast_slice") is not None else "n/a"
+        gem = " (gem)" if r["gem"] else ""
+        print(f"{icon[r['status']]} {r['repo']:<12}{gem}  {r['symbol']}"
+              + (f"  [file:{r['file']}]" if r['file'] else ""))
+        print(f"     resolved coverage {cov} ({r['covered']}/{r['expected']} gold '{r['group']}') | "
+              f"blast budgeted-slice {covb} ({r['direct_callers']} direct) | "
+              f"graph callers naive={r['graph_naive_callers']} disambig={r['graph_disambig_callers']}")
+        if r["flags"]:
+            print(f"     ⚑ {', '.join(r['flags'])}")
+        if r["missing_gold"]:
+            show = r["missing_gold"][:6]
+            more = "" if len(r["missing_gold"]) <= 6 else f"  (+{len(r['missing_gold'])-6} more)"
+            print(f"     UNRESOLVED gold (true resolver-miss candidates): {', '.join(show)}{more}")
+        if r["budget_evicted"]:
+            show = r["budget_evicted"][:4]
+            more = "" if len(r["budget_evicted"]) <= 4 else f"  (+{len(r['budget_evicted'])-4} more)"
+            print(f"     budget-evicted (resolved, but capped out of blast): {', '.join(show)}{more}")
+        print()
+    n = {k: sum(1 for r in results if r["status"] == k) for k in icon}
+    print(f"summary: {n['PASS']} pass · {n['WARN']} warn · {n['FAIL']} fail · {n['SKIP']} skip")
+    print("Tier-0 is a DETECTOR + REGRESSION NET. A FAIL/WARN is a fix candidate, not a verdict; "
+          "ship only behind a differential bench. GRAPH_AMBIGUOUS_EMPTY clears when graph mirrors "
+          "blast's disambiguation.")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/lib/transcript_miss.py
+++ b/bench/lib/transcript_miss.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Retroactive Sense-miss miner over already-paid bench transcripts ($0, read-only).
+
+The vertical bench is a value-PROOF instrument (Loop B). It is the wrong tool for
+DETECTING Sense product gaps (Loop A) — too slow, too noisy, too many tokens. But
+every sense-arm run already recorded, for free, exactly what we need to detect gaps:
+each `sense_blast`/`graph`/`search` call AND its full JSON response, then what the
+agent did next (Reads, greps) and which gold targets it ultimately cited.
+
+This script mines that corpus for three deterministic signals, no LLM, no re-bench:
+
+  1. CITED-NOT-RETURNED (resolver miss, highest value) — a gold file the sense arm
+     got credit for citing, that NONE of its Sense calls actually returned. Sense
+     got the answer DESPITE its own tool (via a read/grep). blast/graph should have
+     surfaced it. (This is the class that produced the acts_as + determinism fixes.)
+  2. FALLBACK-READS (coverage/trust gap) — files the agent Read that no Sense call
+     returned. High volume = Sense under-covered, the agent had to go find it itself.
+     (The chatwoot "1 blast then 18 Reads" signature.)
+  3. DEGENERATE-RETURN (resolution/ranking gap) — a blast/graph call that came back
+     empty or near-empty, plus cross-run NONDETERMINISM on the same symbol (the exact
+     signature of the high-fan-out blast bug we fixed once by hand).
+
+Output is a ranked gap list to react to BEFORE spending a single new bench token.
+
+Usage:
+  python3 bench/lib/transcript_miss.py                 # whole rails corpus, opus-4-8
+  python3 bench/lib/transcript_miss.py --model all      # every model dir
+  python3 bench/lib/transcript_miss.py --repo chatwoot,discourse
+  python3 bench/lib/transcript_miss.py --json out.json  # machine-readable dump
+"""
+import argparse
+import collections
+import glob
+import json
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+import yaml  # noqa: E402
+
+SENSE_REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))  # oss/sense
+RESULTS = os.path.join(SENSE_REPO, "bench", "results", "vertical")
+SCEN = os.path.join(SENSE_REPO, "bench", "scenarios", "vertical")
+
+SENSE_TOOLS = ("sense_blast", "sense_graph", "sense_search")
+# A gold group is a "discriminator" (the headline) unless it is one of the
+# anchor groups both arms are expected to get. cited-not-returned in a
+# discriminator group is the high-value product signal.
+ANCHOR_GROUPS = {"contract", "context", "surface", "teardown"}
+
+PATH_RE = re.compile(r'"(?:file|ref|path)"\s*:\s*"([^"]+?\.[a-zA-Z]{1,4})(?::\d+)?"')
+
+
+def _load_jsonl(path):
+    out = []
+    with open(path) as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                try:
+                    out.append(json.loads(line))
+                except json.JSONDecodeError:
+                    pass
+    return out
+
+
+def _blocks(rows):
+    """Yield every content block in transcript order."""
+    for r in rows:
+        msg = r.get("message", {})
+        if not isinstance(msg, dict):
+            continue
+        for b in msg.get("content") or []:
+            if isinstance(b, dict):
+                yield b
+
+
+def _result_text(block):
+    c = block.get("content")
+    if isinstance(c, str):
+        return c
+    if isinstance(c, list):
+        return " ".join(
+            (p.get("text", "") if isinstance(p, dict) else str(p)) for p in c
+        )
+    return json.dumps(c)
+
+
+def _rel(path, repo):
+    """Strip the clone prefix .../<repo>/ from an absolute Read path."""
+    marker = f"/{repo}/"
+    i = path.rfind(marker)
+    if i >= 0:
+        return path[i + len(marker):]
+    return path.lstrip("/")
+
+
+def analyze_run(run_dir, repo, gold_by_id):
+    tpath = os.path.join(run_dir, "transcript.json")
+    spath = os.path.join(run_dir, "scored.json")
+    if not os.path.exists(tpath):
+        return None
+    rows = _load_jsonl(tpath)
+
+    # Pair tool_use ids -> name/input; collect tool_results by id.
+    uses = {}
+    for b in _blocks(rows):
+        if b.get("type") == "tool_use":
+            uses[b.get("id")] = (b.get("name") or "", b.get("input") or {})
+
+    sense_calls = []          # [(short_tool, input, returned_files, n_returned)]
+    sense_files = set()       # every repo-rel path any Sense call returned
+    read_files = []           # repo-rel paths the agent Read
+    grep_calls = 0            # Bash greps/finds (text-search fallback)
+    structural_calls = 0      # blast/graph calls (the resolvers, not search/status)
+
+    for b in _blocks(rows):
+        if b.get("type") == "tool_use":
+            name, inp = b.get("name") or "", b.get("input") or {}
+            if name == "Read":
+                fp = inp.get("file_path") or ""
+                if fp:
+                    read_files.append(_rel(fp, repo))
+            elif name == "Bash":
+                cmd = (inp.get("command") or "")
+                if re.search(r"\b(grep|rg|find|ag|ack)\b", cmd):
+                    grep_calls += 1
+        elif b.get("type") == "tool_result":
+            tid = b.get("tool_use_id")
+            name, inp = uses.get(tid, ("", {}))
+            short = next((t for t in SENSE_TOOLS if t in name), None)
+            if not short:
+                continue
+            txt = _result_text(b)
+            files = set(m.group(1) for m in PATH_RE.finditer(txt))
+            # the symbol's own definition file isn't a "returned dependent"
+            files.discard(_symbol_self_file(inp, txt))
+            sense_calls.append((short, inp, files, len(files)))
+            sense_files |= files
+            if short in ("sense_blast", "sense_graph"):
+                structural_calls += 1
+
+    # scored.json: which gold ids the arm CITED, and the per-id group.
+    cited_ids = set()
+    if os.path.exists(spath):
+        try:
+            sc = json.load(open(spath))
+            for d in sc.get("gold_recall", {}).get("details", []):
+                if d.get("cited"):
+                    cited_ids.add(d.get("id"))
+        except (json.JSONDecodeError, KeyError):
+            pass
+
+    # SIGNAL 1: cited-not-returned (per cited gold id whose files Sense never returned)
+    cited_not_returned = []
+    for gid in cited_ids:
+        g = gold_by_id.get(gid)
+        if not g:
+            continue
+        matches = g["match"]
+        if not any(any(mf == sf or sf.endswith("/" + mf) or mf.endswith("/" + sf)
+                       for sf in sense_files) for mf in matches):
+            cited_not_returned.append(gid)
+
+    # SIGNAL 2: fallback reads (Read files no Sense call returned)
+    fallback_reads = [f for f in read_files if f not in sense_files
+                      and not any(f.endswith("/" + sf) or sf.endswith("/" + f)
+                                  for sf in sense_files)]
+    reread_sense = [f for f in read_files if f not in fallback_reads]
+
+    # SIGNAL 3: degenerate sense returns
+    degenerate = [(s, _symbol_of(inp), n) for (s, inp, files, n) in sense_calls
+                  if s in ("sense_blast", "sense_graph") and n == 0]
+
+    return {
+        "run": os.path.basename(run_dir),
+        "sense_call_count": len(sense_calls),
+        "structural_calls": structural_calls,   # blast/graph only
+        "sense_calls": [(s, _symbol_of(inp), n) for (s, inp, _f, n) in sense_calls],
+        "sense_files": sorted(sense_files),
+        "n_read": len(read_files),
+        "grep_calls": grep_calls,
+        # a cited-not-returned id is a RESOLVER-miss candidate only when the run
+        # actually exercised a structural resolver; otherwise it's an ADOPTION gap.
+        "cited_not_returned": cited_not_returned if structural_calls else [],
+        "adoption_gap": cited_not_returned if not structural_calls else [],
+        "fallback_reads": fallback_reads,
+        "reread_sense": reread_sense,
+        "degenerate": degenerate,
+    }
+
+
+def _symbol_of(inp):
+    return inp.get("symbol") or inp.get("query") or ""
+
+
+def _symbol_self_file(inp, txt):
+    # the queried symbol's own "file" appears once near the top of graph/blast output
+    m = re.search(r'"symbol"\s*:\s*\{[^}]*?"file"\s*:\s*"([^"]+)"', txt)
+    return m.group(1) if m else ""
+
+
+def load_gold(stack, repo):
+    f = os.path.join(SCEN, stack, f"{repo}.yaml")
+    if not os.path.exists(f):
+        return {}
+    doc = yaml.safe_load(open(f))
+    out = {}
+    for t in doc.get("gold", []):
+        matches = t.get("match")
+        if isinstance(matches, str):
+            matches = [matches]
+        out[t["id"]] = {
+            "group": t.get("group", "?"),
+            "match": matches or [],
+            "relation": t.get("relation", ""),
+        }
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--stack", default="ruby-rails")
+    ap.add_argument("--model", default="claude-opus-4-8",
+                    help="model dir under results/vertical/<stack>/, or 'all'")
+    ap.add_argument("--repo", default="", help="comma-separated repo filter")
+    ap.add_argument("--json", default="", help="write machine-readable dump here")
+    args = ap.parse_args()
+
+    stack_dir = os.path.join(RESULTS, args.stack)
+    if args.model == "all":
+        model_dirs = [d for d in glob.glob(os.path.join(stack_dir, "*")) if os.path.isdir(d)]
+    else:
+        model_dirs = [os.path.join(stack_dir, args.model)]
+    repo_filter = set(r.strip() for r in args.repo.split(",") if r.strip())
+
+    # repo -> aggregated signal
+    agg = {}
+    gold_cache = {}
+    n_runs = 0
+    for md in model_dirs:
+        sense_root = os.path.join(md, "sense")
+        if not os.path.isdir(sense_root):
+            continue
+        for repo_dir in sorted(glob.glob(os.path.join(sense_root, "*"))):
+            repo = os.path.basename(repo_dir)
+            if repo_filter and repo not in repo_filter:
+                continue
+            gold = gold_cache.setdefault(repo, load_gold(args.stack, repo))
+            for run_dir in sorted(glob.glob(os.path.join(repo_dir, "run-*"))):
+                res = analyze_run(run_dir, repo, gold)
+                if res is None:
+                    continue
+                n_runs += 1
+                a = agg.setdefault(repo, {
+                    "runs": 0, "cnr": collections.Counter(), "adopt_gap": collections.Counter(),
+                    "fallback": collections.Counter(), "degenerate": collections.Counter(),
+                    "grep_runs": 0, "noadopt_runs": 0, "sense_calls": 0, "reads": 0,
+                    "sense_symbols": collections.defaultdict(set),
+                })
+                a["runs"] += 1
+                a["noadopt_runs"] += 1 if not res["structural_calls"] else 0
+                a["cnr"].update(res["cited_not_returned"])
+                a["adopt_gap"].update(res["adoption_gap"])
+                a["fallback"].update(res["fallback_reads"])
+                a["degenerate"].update(f"{s}({sym})" for (s, sym, _n) in res["degenerate"])
+                a["grep_runs"] += 1 if res["grep_calls"] else 0
+                a["sense_calls"] += res["sense_call_count"]
+                a["reads"] += res["n_read"]
+                # nondeterminism tracking: symbol -> set of returned-count per run
+                for (s, sym, n) in res["sense_calls"]:
+                    if s in ("sense_blast", "sense_graph") and sym:
+                        a["sense_symbols"][f"{s}:{sym}"].add(n)
+
+    report(agg, gold_cache, n_runs, args)
+    if args.json:
+        dump_json(agg, gold_cache, args.json)
+
+
+def _severity(repo_agg, gold):
+    """Rank a cited-not-returned gold id: discriminator-group misses dominate."""
+    score = 0
+    for gid, cnt in repo_agg["cnr"].items():
+        g = gold.get(gid, {})
+        weight = 3 if g.get("group") not in ANCHOR_GROUPS else 1
+        score += cnt * weight
+    return score
+
+
+def report(agg, gold_cache, n_runs, args):
+    print(f"\n=== Sense-miss mine — stack={args.stack} model={args.model} "
+          f"({n_runs} sense runs over {len(agg)} repos) ===\n")
+    # rank repos by discriminator-weighted miss severity
+    ranked = sorted(agg.items(),
+                    key=lambda kv: _severity(kv[1], gold_cache.get(kv[0], {})),
+                    reverse=True)
+    for repo, a in ranked:
+        gold = gold_cache.get(repo, {})
+        runs = a["runs"]
+        nondet = {k: sorted(v) for k, v in a["sense_symbols"].items() if len(v) > 1}
+        sev = _severity(a, gold)
+        adopt = ""
+        if a["noadopt_runs"]:
+            adopt = f", ⚠ NO-STRUCTURAL-CALL in {a['noadopt_runs']}/{runs} (adoption, not resolver)"
+        print(f"## {repo}  ({runs} runs, resolver-sev={sev}, "
+              f"avg {a['sense_calls']/runs:.1f} sense-calls + {a['reads']/runs:.0f} reads/run, "
+              f"grep-fallback in {a['grep_runs']}/{runs}{adopt})")
+
+        if a["adopt_gap"]:
+            print(f"  [0] ADOPTION GAP — {a['noadopt_runs']}/{runs} runs made NO blast/graph call; "
+                  f"{len(a['adopt_gap'])} gold ids cited via reads only. (Fix the SCENARIO/steering, not the resolver.)")
+        if a["cnr"]:
+            print("  [1] CITED-NOT-RETURNED (resolver misses — blast/graph WAS called but never returned this file):")
+            for gid, cnt in sorted(a["cnr"].items(),
+                                   key=lambda x: (gold.get(x[0], {}).get("group") not in ANCHOR_GROUPS, x[1]),
+                                   reverse=True):
+                g = gold.get(gid, {})
+                disc = "★" if g.get("group") not in ANCHOR_GROUPS else " "
+                rel = (g.get("relation", "") or "")[:72]
+                print(f"      {disc} {gid:<26} {cnt}/{runs} runs  [{g.get('group','?')}]  {rel}")
+        if nondet:
+            print("  [3] NONDETERMINISTIC / DEGENERATE returns (same symbol, different return-counts across runs):")
+            for k, counts in nondet.items():
+                print(f"        {k}: returned {counts} across runs")
+        if a["degenerate"]:
+            empties = a["degenerate"].most_common()
+            print(f"  [3] EMPTY returns: " +
+                  ", ".join(f"{k}×{c}" for k, c in empties))
+        # top fallback reads (coverage signal)
+        top_fb = a["fallback"].most_common(6)
+        if top_fb:
+            tot = sum(a["fallback"].values())
+            print(f"  [2] FALLBACK READS ({tot} total over {runs} runs; files no Sense call returned). Top:")
+            for f, c in top_fb:
+                print(f"        {c}×  {f}")
+        print()
+
+    print("Legend: ★ = discriminator-group miss (high product value). "
+          "[1] resolver coverage · [2] under-coverage/trust · [3] resolution/determinism.\n"
+          "These are DETECTION signals over already-paid transcripts — confirm each against the "
+          "live index (resolve_oracle) before proposing a fix; ship only behind a differential bench.")
+
+
+def dump_json(agg, gold_cache, path):
+    out = {}
+    for repo, a in agg.items():
+        gold = gold_cache.get(repo, {})
+        out[repo] = {
+            "runs": a["runs"],
+            "severity": _severity(a, gold),
+            "cited_not_returned": [
+                {"id": gid, "runs": cnt, "group": gold.get(gid, {}).get("group"),
+                 "relation": gold.get(gid, {}).get("relation"),
+                 "match": gold.get(gid, {}).get("match")}
+                for gid, cnt in a["cnr"].most_common()
+            ],
+            "nondeterministic": {k: sorted(v) for k, v in a["sense_symbols"].items() if len(v) > 1},
+            "empty_returns": dict(a["degenerate"]),
+            "fallback_reads": dict(a["fallback"].most_common(20)),
+            "grep_fallback_runs": a["grep_runs"],
+        }
+    with open(path, "w") as fh:
+        json.dump(out, fh, indent=2)
+    print(f"\nwrote {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -467,11 +467,164 @@ func TestExtractBashPattern(t *testing.T) {
 		{"grep -rn UserService . && echo done", "UserService"},
 		{"grep -rn UserService ; echo done", "UserService"},
 		{"grep -rn UserService . || true", "UserService"},
+		// A search behind a cd prefix (the dominant real-world shape) is found.
+		{"cd /repo && grep -rn UserService .", "UserService"},
+		{"cd /repo ; grep -rn UserService .", "UserService"},
+		{"cd /a/b || true && grep UserService", "UserService"},
+		// Quoted multi-word patterns survive intact.
+		{`grep -rn "func Open" internal`, "func Open"},
+		{"cd /x && grep -rn 'func Open' internal", "func Open"},
+		// A grep that only filters piped output is not a code search.
+		{"cat foo.go | grep UserService", ""},
+		{"git status | grep '^??'", ""},
+		{"ls | grep -i foo", ""},
+		// Path-qualified search binaries are recognised by basename.
+		{"/usr/bin/grep -rn UserService .", "UserService"},
+		{"egrep -rn UserService .", "UserService"},
+		{"fgrep UserService .", "UserService"},
+		// A value-taking flag with no following value must not over-consume.
+		{"grep --include", ""},
+		// A single & (background) acts as a statement boundary.
+		{"echo a & grep UserService", "UserService"},
 	}
 	for _, tc := range cases {
 		if got := extractBashPattern(tc.cmd); got != tc.want {
 			t.Errorf("extractBashPattern(%q) = %q, want %q", tc.cmd, got, tc.want)
 		}
+	}
+}
+
+func TestSymbolFromPattern(t *testing.T) {
+	cases := []struct {
+		pattern string
+		want    string
+	}{
+		{"UserService", "UserService"},
+		{"Spree::Order", "Spree::Order"},
+		{"func Open", "Open"},
+		{"def perform", "perform"},
+		{"class User", "User"},
+		{"type Adapter", "Adapter"},
+		{"module Billing", "Billing"},
+		{"func Open(", "Open"},
+		{"the model file", ""}, // multi-word literal, not a definition form
+		{"a b c", ""},
+		{"", ""},
+		{"   ", ""},
+	}
+	for _, tc := range cases {
+		if got := symbolFromPattern(tc.pattern); got != tc.want {
+			t.Errorf("symbolFromPattern(%q) = %q, want %q", tc.pattern, got, tc.want)
+		}
+	}
+}
+
+func TestShellTokens(t *testing.T) {
+	// Quoted multi-word stays one word; operators are split out and flagged.
+	toks := shellTokens(`cd /x && grep -rn "func Open" . | head`)
+	var got []string
+	for _, tk := range toks {
+		if tk.op {
+			got = append(got, "op:"+tk.val)
+		} else {
+			got = append(got, tk.val)
+		}
+	}
+	want := []string{"cd", "/x", "op:&&", "grep", "-rn", "func Open", ".", "op:|", "head"}
+	if len(got) != len(want) {
+		t.Fatalf("shellTokens tokens = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("token[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	// Single quotes are literal; double-quote escapes are unwrapped.
+	if tk := shellTokens(`grep 'a;b'`); len(tk) != 2 || tk[1].val != "a;b" {
+		t.Errorf("single-quoted literal not preserved: %+v", tk)
+	}
+	if tk := shellTokens(`echo "a\"b"`); len(tk) != 2 || tk[1].val != `a"b` {
+		t.Errorf("escaped double-quote not unwrapped: %+v", tk)
+	}
+	// An unterminated quote extends to end-of-input instead of panicking.
+	if tk := shellTokens(`grep "foo`); len(tk) != 2 || tk[1].val != "foo" {
+		t.Errorf("unterminated quote not tolerated: %+v", tk)
+	}
+}
+
+func TestPreToolUseBashMalformedCommand(t *testing.T) {
+	dir := indexedDir(t)
+	// Malformed or adversarial shell must degrade to valid JSON output, never
+	// panic and never block the command. This hook runs on every Bash call, so
+	// "be invisible when unsure" is the contract.
+	cmds := []string{
+		`grep -rn "func Open`, // unterminated double quote
+		`grep -rn 'sym`,       // unterminated single quote
+		`grep foo\`,           // lone trailing backslash
+		`cd /x && grep "a\`,   // trailing backslash inside a quote
+		`;; && | grep`,        // operator soup, no real command
+		`grep`,                // search binary, no arguments
+	}
+	for _, cmd := range cmds {
+		payload, err := json.Marshal(map[string]any{
+			"tool_name":  "Bash",
+			"tool_input": map[string]any{"command": cmd},
+		})
+		if err != nil {
+			t.Fatalf("marshal payload: %v", err)
+		}
+		var buf bytes.Buffer
+		Run("pre-tool-use", dir, bytes.NewReader(payload), &buf)
+		if buf.Len() == 0 {
+			t.Errorf("command %q produced no output", cmd)
+			continue
+		}
+		var v map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &v); err != nil {
+			t.Errorf("command %q produced invalid JSON %q: %v", cmd, buf.String(), err)
+		}
+	}
+}
+
+func TestPreToolUseBashCdPrefixNudges(t *testing.T) {
+	dir := indexedDir(t)
+	input := `{"tool_name":"Bash","tool_input":{"command":"cd /tmp && grep -rn UserService ."}}`
+	var buf bytes.Buffer
+	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
+
+	var resp nudgeResponse
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if resp.AdditionalContext == "" || !strings.Contains(resp.AdditionalContext, "sense_graph") {
+		t.Errorf("cd-prefixed grep of known symbol should nudge, got %q", buf.String())
+	}
+}
+
+func TestPreToolUseBashQuotedDefNudges(t *testing.T) {
+	dir := indexedDir(t)
+	input := `{"tool_name":"Bash","tool_input":{"command":"grep -rn \"func UserService\" ."}}`
+	var buf bytes.Buffer
+	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
+
+	var resp nudgeResponse
+	if err := json.Unmarshal(buf.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if resp.AdditionalContext == "" || !strings.Contains(resp.AdditionalContext, "UserService") {
+		t.Errorf("quoted def-form grep should nudge for the declared symbol, got %q", buf.String())
+	}
+}
+
+func TestPreToolUseBashPipeFilterNoOp(t *testing.T) {
+	dir := indexedDir(t)
+	// grep here filters git's output; it is not a code search, so no nudge.
+	input := `{"tool_name":"Bash","tool_input":{"command":"git status | grep UserService"}}`
+	var buf bytes.Buffer
+	Run("pre-tool-use", dir, strings.NewReader(input), &buf)
+
+	if buf.String() != "{}\n" {
+		t.Errorf("pipe-filter grep should be no-op, got %q", buf.String())
 	}
 }
 

--- a/internal/hook/pre_tool_use.go
+++ b/internal/hook/pre_tool_use.go
@@ -161,17 +161,17 @@ func handleAgent(ctx context.Context, req preToolUseInput, adapter *sqlite.Adapt
 func handleBash(ctx context.Context, req preToolUseInput, adapter *sqlite.Adapter) (any, error) {
 	cmd := req.Input.Command
 
-	// extractBashPattern returns a single whitespace-split token, so the
-	// pattern here is never multi-word (unlike handleGrep, whose pattern comes
-	// straight from the Grep tool input). Only the symbol-shaped single-token
-	// case can fire; the multi-word semantic-search nudge lives in handleGrep.
-	pattern := extractBashPattern(cmd)
-	if pattern != "" && isSymbolShaped(pattern) {
-		symbols, err := adapter.Query(ctx, index.Filter{Name: pattern, Limit: 5})
+	// extractBashPattern finds the grep/rg/ag search even behind a `cd … &&`
+	// prefix or inside a pipeline, and keeps quoted multi-word patterns intact.
+	// symbolFromPattern then reduces a definition-form pattern ("func Open") to
+	// the bare symbol name before the index lookup.
+	symbol := symbolFromPattern(extractBashPattern(cmd))
+	if symbol != "" && isSymbolShaped(symbol) {
+		symbols, err := adapter.Query(ctx, index.Filter{Name: symbol, Limit: 5})
 		if err == nil && len(symbols) > 0 {
 			return nudge(
-				fmt.Sprintf("Sense has %d indexed symbol(s) matching %q — consider sense_graph or sense_search instead of bash grep.", len(symbols), pattern),
-				buildContext(len(symbols), pattern, "bash grep"),
+				fmt.Sprintf("Sense has %d indexed symbol(s) matching %q — consider sense_graph or sense_search instead of bash grep.", len(symbols), symbol),
+				buildContext(len(symbols), symbol, "bash grep"),
 			), nil
 		}
 	}
@@ -203,38 +203,109 @@ func extractPattern(req preToolUseInput) string {
 	return req.Input.Regex
 }
 
-// extractBashPattern extracts the search pattern from grep, rg, or ag
-// commands. Returns "" for non-search commands so the hook is a no-op.
-// Returns "" when -e/-f is used (explicit pattern flags, often regex).
-// Stops at shell operators (|, ;, &&, ||) to avoid treating the next
-// command's arguments as a pattern.
+// extractBashPattern extracts the search pattern from a grep, rg, or ag
+// command. It locates the search even when it is not the first word — behind a
+// `cd … &&`/`;` prefix or as a pipeline stage — but treats a grep that only
+// consumes piped input (`… | grep`) as a filter on another command's output,
+// not a code search, and skips it. Quotes are honoured, so a multi-word pattern
+// like "func Open" survives intact. Returns "" for non-search commands and when
+// -e/-f is used (explicit pattern flags, often regex).
 func extractBashPattern(cmd string) string {
-	fields := strings.Fields(cmd)
-	if len(fields) == 0 {
-		return ""
-	}
-
-	base := fields[0]
-	if base != "grep" && base != "rg" && base != "ag" {
-		return ""
-	}
-
-	for i := 1; i < len(fields); i++ {
-		arg := fields[i]
-
-		if arg == "|" || arg == ";" || arg == "&&" || arg == "||" {
-			break
+	toks := shellTokens(cmd)
+	prevOp := ";" // start of the line acts as a statement boundary
+	for i := 0; i < len(toks); {
+		t := toks[i]
+		if t.op {
+			prevOp = t.val
+			i++
+			continue
 		}
+		// A search command only counts when it starts a statement; a grep right
+		// after a pipe is filtering another command's output, not searching code.
+		standalone := prevOp != "|"
+		if standalone && isSearchBinary(baseName(t.val)) {
+			j := i + 1
+			var args []string
+			for j < len(toks) && !toks[j].op {
+				args = append(args, toks[j].val)
+				j++
+			}
+			if p := patternFromArgs(args); p != "" {
+				return p
+			}
+			i = j
+			continue
+		}
+		// Skip the rest of this command's words; the next operator updates prevOp.
+		j := i + 1
+		for j < len(toks) && !toks[j].op {
+			j++
+		}
+		i = j
+	}
+	return ""
+}
+
+// patternFromArgs returns the first non-flag argument (the search pattern) from
+// a search command's arguments, or "" when an explicit -e/-f pattern flag is
+// present (those are often regex, which isSymbolShaped would reject anyway).
+func patternFromArgs(args []string) string {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
 		if arg == "-e" || arg == "-f" {
 			return ""
 		}
 		if strings.HasPrefix(arg, "-") {
-			if needsValue(arg) && i+1 < len(fields) {
+			if needsValue(arg) && i+1 < len(args) {
 				i++
 			}
 			continue
 		}
-		return strings.Trim(arg, "'\"")
+		return arg
+	}
+	return ""
+}
+
+func isSearchBinary(base string) bool {
+	switch base {
+	case "grep", "egrep", "fgrep", "rg", "ag":
+		return true
+	}
+	return false
+}
+
+// baseName strips a leading path so /usr/bin/grep is recognised as grep.
+func baseName(s string) string {
+	if i := strings.LastIndexByte(s, '/'); i >= 0 {
+		return s[i+1:]
+	}
+	return s
+}
+
+// defKeywords are the definition-introducing keywords across the languages
+// Sense indexes; a grep for "<keyword> Name" is a lookup of the symbol Name.
+var defKeywords = map[string]bool{
+	"func": true, "def": true, "class": true, "type": true,
+	"interface": true, "struct": true, "module": true,
+	"fn": true, "impl": true, "trait": true, "const": true, "var": true,
+}
+
+// symbolFromPattern reduces a grep pattern to the symbol name worth looking up.
+// A single token is returned as-is ("ApplyBlastBudget"). A definition-form
+// pattern returns the declared name ("func Open" -> "Open", "class User" ->
+// "User"). Any other multi-word pattern is a literal string search, which is
+// grep's job, so it returns "".
+func symbolFromPattern(pattern string) string {
+	pattern = strings.TrimSpace(pattern)
+	if pattern == "" {
+		return ""
+	}
+	fields := strings.Fields(pattern)
+	if len(fields) == 1 {
+		return pattern
+	}
+	if len(fields) == 2 && defKeywords[fields[0]] {
+		return strings.Trim(fields[1], "*()")
 	}
 	return ""
 }
@@ -310,4 +381,86 @@ func hasCodeExtension(s string) bool {
 		}
 	}
 	return false
+}
+
+// shTok is a shell token: an operator (|, ||, &&, &, ;) or a word.
+type shTok struct {
+	op  bool
+	val string
+}
+
+// shellTokens splits a command line into words and shell operators, honouring
+// single and double quotes so a quoted pattern stays a single word. It is a
+// pragmatic tokenizer, not a full shell parser: it covers the command shapes
+// agents actually emit (cd prefixes, pipelines, &&/||/; chains) well enough to
+// find the search command and its pattern.
+//
+// Deliberately NOT handled, by design: backslash escapes outside quotes,
+// command substitution ($(...) and backticks), variable expansion ($VAR), and
+// glob expansion. These cause at most a missed nudge, never a wrong block, so
+// chasing them is not worth the complexity. Unterminated quotes are tolerated:
+// the quoted run simply extends to end-of-input.
+func shellTokens(cmd string) []shTok {
+	var toks []shTok
+	var b strings.Builder
+	flush := func() {
+		if b.Len() > 0 {
+			toks = append(toks, shTok{val: b.String()})
+			b.Reset()
+		}
+	}
+	for i := 0; i < len(cmd); {
+		c := cmd[i]
+		switch c {
+		case ' ', '\t', '\n', '\r':
+			flush()
+			i++
+		case '\'':
+			j := i + 1
+			for j < len(cmd) && cmd[j] != '\'' {
+				b.WriteByte(cmd[j])
+				j++
+			}
+			i = j + 1
+		case '"':
+			j := i + 1
+			for j < len(cmd) && cmd[j] != '"' {
+				if cmd[j] == '\\' && j+1 < len(cmd) {
+					b.WriteByte(cmd[j+1])
+					j += 2
+					continue
+				}
+				b.WriteByte(cmd[j])
+				j++
+			}
+			i = j + 1
+		case '|':
+			flush()
+			if i+1 < len(cmd) && cmd[i+1] == '|' {
+				toks = append(toks, shTok{op: true, val: "||"})
+				i += 2
+			} else {
+				toks = append(toks, shTok{op: true, val: "|"})
+				i++
+			}
+		case '&':
+			flush()
+			if i+1 < len(cmd) && cmd[i+1] == '&' {
+				toks = append(toks, shTok{op: true, val: "&&"})
+				i += 2
+			} else {
+				toks = append(toks, shTok{op: true, val: "&"})
+				i++
+			}
+		case ';':
+			flush()
+			toks = append(toks, shTok{op: true, val: ";"})
+			i++
+		default:
+			b.WriteByte(c)
+			i++
+		}
+	}
+	flush()
+	return toks
 }

--- a/internal/setup/marker.go
+++ b/internal/setup/marker.go
@@ -42,7 +42,7 @@ Sense gives you structural understanding of the codebase (symbols, relationships
 | What patterns does this project follow? | sense_conventions |
 | Index health, what's indexed | sense_status |
 
-**You MUST NOT** use grep/glob for symbol lookup, or skip Sense because its tools load on demand. For list outputs (dead code, blast radius, callers), spot-check a sample with grep before relying on them.
+**You MUST NOT** use grep/glob for symbol lookup, or skip Sense because its tools load on demand. **About to grep, rg, or find (including through Bash) to locate code?** Searching for a *name* (a function, method, type, or constant; who calls it; what it touches) is a Sense call first: sense_graph, sense_search, or sense_blast. Searching for a *literal* (an error string, log line, config key, TODO), grep is right, go ahead. One line: **grepping a name → Sense; grepping a string → grep.** For list outputs (dead code, blast radius, callers), spot-check a sample with grep before relying on them.
 
 **When NOT to use Sense** (use grep instead): exact text/string search, reading file contents, editing code (Sense is read-only).
 <!-- sense:end -->`

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -854,7 +854,10 @@ func TestGuidanceMarkdownContent(t *testing.T) {
 		}
 	}
 	if !strings.Contains(guidanceMarkdown, "MUST NOT") {
-		t.Error("guidanceMarkdown must include MUST NOT rules")
+		t.Error("guidanceMarkdown must include the MUST NOT rule")
+	}
+	if !strings.Contains(guidanceMarkdown, "grepping a name") {
+		t.Error("guidanceMarkdown must include the name-vs-string grep routing rule")
 	}
 	if strings.Contains(guidanceMarkdown, "FIRST action in every conversation") {
 		t.Error("guidanceMarkdown must not include cold-start protocol (now handled by SessionStart hook)")


### PR DESCRIPTION
## Problem
The pre-tool-use hook that nudges agents toward Sense on a symbol grep only fired when `grep`/`rg`/`ag` was the command's first word. The dominant real-world shape, `cd repo && grep -rn Foo`, and quoted multi-word patterns like `grep "func Open"` produced no nudge at all, so the feature was silently inert for the most common command an agent actually emits.

## Summary
Rewrite the bash pattern extraction around a small quote-aware tokenizer that locates the search command behind `cd` prefixes and pipeline stages and preserves quoted patterns, and reduce a definition form (`func Open`) to its symbol name before the index lookup.

## Changes
- `internal/hook/pre_tool_use.go`
  - Add `shellTokens`, a pragmatic quote-aware tokenizer (handles `cd` prefixes, `&&`/`||`/`;`/`|` chains, single/double quotes; documents its deliberate blind spots).
  - Rewrite `extractBashPattern` to find a standalone `grep`/`rg`/`ag` search anywhere in the command, while treating `... | grep` as a filter on another command's output (not a code search). Recognises path-qualified binaries by basename.
  - Add `symbolFromPattern` to map a definition-form pattern (`func Open`, `class User`) to the declared symbol before querying the index.
- `internal/setup/marker.go`
  - Refresh the setup guidance: keep the `MUST NOT` lead and add a name-vs-string routing rule that names Bash searches explicitly.
- Tests
  - Extend `TestExtractBashPattern`; add `TestSymbolFromPattern`, `TestShellTokens`, cd-prefix / quoted-def / pipe-filter behavior tests, and an adversarial-input test (unterminated quotes, lone backslashes, operator soup) asserting valid JSON output and no panic.

## Architecture Highlights
- The hook stays non-blocking and index-gated: it only nudges when the extracted symbol actually exists in the index, so worst case is a missed nudge, never a blocked command.
- `shellTokens` is intentionally a partial shell parser; escapes outside quotes, command substitution, variable and glob expansion are out of scope by design (documented in the code).

## Test Plan
- [x] `grep -rn UserService .` nudges (unchanged)
- [x] `cd /tmp && grep -rn UserService .` nudges (was silent)
- [x] `grep -rn "func UserService" .` nudges via the declared symbol (was silent)
- [x] `git status | grep UserService` stays silent (pipe filter)
- [x] `grep -rn "the model file" .` stays silent (literal string)
- [x] malformed commands degrade to valid JSON, no panic
- [x] `make ci` green (build, 95.0% coverage >= 92% floor, 0 lint issues, ledger clean)
- [x] sense binary builds cleanly
