### PR TITLE
fix(blast): surface reverse-composition dependents for ORM models

### DIFF
--- a/internal/blast/engine.go
+++ b/internal/blast/engine.go
@@ -187,9 +187,12 @@ type Result struct {
 	// view-helper or Stimulus-dispatched symbol's view reachability surfaces.
 	ViewReached bool
 
-	// Edge-kind groups: filtered views over the same nodes that appear
-	// in DirectCallers/IndirectCallers. A node appears in at most one
-	// group (the edge kind that discovered it first in BFS order).
+	// Edge-kind groups. A node appears in at most one group. Subclasses and
+	// includes are filtered views over the capped DirectCallers/IndirectCallers,
+	// bucketed by the edge kind that discovered each node first in BFS order.
+	// AffectedViaComposition is computed independently from the edge table (the
+	// complete reverse-composition set), so it may surface composers the result
+	// cap evicted from the caller lists — that is the point on high-fan-out hubs.
 	AffectedSubclasses     []model.Symbol
 	AffectedViaComposition []model.Symbol
 	AffectedViaIncludes    []model.Symbol
@@ -249,6 +252,10 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 	}
 	directIDs, indirectIDs := state.partition(seedSet)
 	totalAffectedCount := len(directIDs) + len(indirectIDs)
+	// Snapshot the uncapped affected set so reverse-composition dependents the BFS
+	// pruned by confidence (surfaced below from the edge table) can be reconciled
+	// into total_affected rather than appearing only in the composition list.
+	affectedSet := idSet(directIDs, indirectIDs)
 	directIDs, indirectIDs = state.capResults(directIDs, indirectIDs, opts.MaxResults)
 
 	symbolsByID, err := state.hydrate(ctx, db, subject, directIDs, indirectIDs)
@@ -271,7 +278,23 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 
 	risk, reasons := classifyRisk(len(directCallers), hasTemporal(directTemporalIDs, indirectCallers))
 	symbolTiers := state.buildTiers(directIDs, indirectIDs, symbolsByID, isSelf)
-	subclasses, viaComposition, viaIncludes := state.buildEdgeKindGroups(directIDs, indirectIDs, symbolsByID, isSelf)
+	subclasses, viaIncludes := state.buildEdgeKindGroups(directIDs, indirectIDs, symbolsByID, isSelf)
+
+	// Composition is derived from the edge table directly rather than from the
+	// capped/visitedKind-bucketed callers: on a high-fan-out hub the reverse
+	// composers (e.g. every Django model holding a ForeignKey to this one) ride
+	// low-confidence composes edges that capResults evicts beneath the 1.0
+	// call/test callers, and a composer that also calls the subject is recorded
+	// under the calls edge and never bucketed here. excludeGrouped keeps the
+	// one-node-one-group invariant against the inherits/includes buckets above.
+	excludeGrouped := symbolIDSet(subclasses, viaIncludes)
+	viaComposition, err := state.loadReverseComposition(ctx, db, symbolIDs, seedSet, excludeGrouped, isSelf, opts.MaxResults)
+	if err != nil {
+		return Result{}, fmt.Errorf("blast: reverse composition: %w", err)
+	}
+	// Count any composer the BFS did not visit (pruned by confidence) into the
+	// total so total_affected never under-reports what the response surfaces.
+	totalAffectedCount += countUnvisited(viaComposition, affectedSet)
 
 	return Result{
 		Symbol:                 subject,
@@ -718,10 +741,50 @@ func (s *bfsState) buildTiers(directIDs, indirectIDs []int64, symbolsByID map[in
 	return tiers
 }
 
+// idSet collects two id slices into a membership set.
+func idSet(a, b []int64) map[int64]struct{} {
+	set := make(map[int64]struct{}, len(a)+len(b))
+	for _, id := range a {
+		set[id] = struct{}{}
+	}
+	for _, id := range b {
+		set[id] = struct{}{}
+	}
+	return set
+}
+
+// symbolIDSet collects the ids of two symbol slices into a membership set.
+func symbolIDSet(a, b []model.Symbol) map[int64]struct{} {
+	set := make(map[int64]struct{}, len(a)+len(b))
+	for _, sym := range a {
+		set[sym.ID] = struct{}{}
+	}
+	for _, sym := range b {
+		set[sym.ID] = struct{}{}
+	}
+	return set
+}
+
+// countUnvisited returns how many of syms are absent from visited — the
+// composers the BFS pruned by confidence but the edge-table query still surfaced.
+func countUnvisited(syms []model.Symbol, visited map[int64]struct{}) int {
+	n := 0
+	for _, sym := range syms {
+		if _, seen := visited[sym.ID]; !seen {
+			n++
+		}
+	}
+	return n
+}
+
 // buildEdgeKindGroups partitions the affected callers (skipping self-members)
-// into the structural edge-kind views — subclasses (inherits), composition,
-// and includes — by the edge kind that first discovered each node.
-func (s *bfsState) buildEdgeKindGroups(directIDs, indirectIDs []int64, symbolsByID map[int64]model.Symbol, isSelf selfMethodFn) (subclasses, viaComposition, viaIncludes []model.Symbol) {
+// into the structural edge-kind views — subclasses (inherits) and includes — by
+// the edge kind that first discovered each node. Composition is NOT derived here:
+// the visitedKind bucketing under-reports it (a composer also reached by a
+// higher-confidence calls edge is recorded as a caller, and low-confidence
+// composers are evicted by the result cap), so it is computed separately from
+// the edge table — see loadReverseComposition.
+func (s *bfsState) buildEdgeKindGroups(directIDs, indirectIDs []int64, symbolsByID map[int64]model.Symbol, isSelf selfMethodFn) (subclasses, viaIncludes []model.Symbol) {
 	for _, idSlice := range [2][]int64{directIDs, indirectIDs} {
 		for _, id := range idSlice {
 			sym, ok := symbolsByID[id]
@@ -731,14 +794,12 @@ func (s *bfsState) buildEdgeKindGroups(directIDs, indirectIDs []int64, symbolsBy
 			switch s.visitedKind[id] {
 			case "inherits":
 				subclasses = append(subclasses, sym)
-			case "composes":
-				viaComposition = append(viaComposition, sym)
 			case "includes":
 				viaIncludes = append(viaIncludes, sym)
 			}
 		}
 	}
-	return subclasses, viaComposition, viaIncludes
+	return subclasses, viaIncludes
 }
 
 // edgePair is the (source, target) shape one BFS hop returns. source

--- a/internal/blast/engine_test.go
+++ b/internal/blast/engine_test.go
@@ -1188,6 +1188,186 @@ func TestDoubleReachableAppearsInFirstGroup(t *testing.T) {
 	}
 }
 
+// TestReverseCompositionSurfacesMaskedComposer covers the visitedKind-masking
+// fix: a dependent that both calls and composes the subject is recorded under
+// the higher-confidence calls edge, so the old visitedKind bucketing never
+// listed it as a composer. The edge-table-derived set must still surface it.
+func TestReverseCompositionSurfacesMaskedComposer(t *testing.T) {
+	fix := newFixtureDB(t)
+	base := fix.addSymbol(t, "Base")
+	dep := fix.addSymbol(t, "Dependent")
+	fix.addEdge(t, dep, base, model.EdgeCalls, 1.0)
+	fix.addEdge(t, dep, base, model.EdgeComposes, 0.5)
+
+	res, err := blast.Compute(context.Background(), fix.db, []int64{base}, blast.Options{MaxHops: 1, MinConfidence: 0.1})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+
+	found := false
+	for _, s := range res.AffectedViaComposition {
+		if s.ID == dep {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("AffectedViaComposition = %+v, want Dependent (a composer masked by a calls edge must still surface)", res.AffectedViaComposition)
+	}
+}
+
+// TestReverseCompositionSurvivesResultCap covers the capResults-eviction fix:
+// strong 1.0 callers fill the result cap and evict the low-confidence composer
+// from the caller lists, but it must remain in the reverse-composition set —
+// the whole point on a high-fan-out hub like a Django model.
+func TestReverseCompositionSurvivesResultCap(t *testing.T) {
+	fix := newFixtureDB(t)
+	base := fix.addSymbol(t, "Base")
+	c1 := fix.addSymbol(t, "Caller1")
+	c2 := fix.addSymbol(t, "Caller2")
+	fix.addEdge(t, c1, base, model.EdgeCalls, 1.0)
+	fix.addEdge(t, c2, base, model.EdgeCalls, 1.0)
+	comp := fix.addSymbol(t, "Composer")
+	fix.addEdge(t, comp, base, model.EdgeComposes, 0.5)
+
+	res, err := blast.Compute(context.Background(), fix.db, []int64{base}, blast.Options{MaxHops: 1, MinConfidence: 0.1, MaxResults: 1})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+
+	inCallers := false
+	for _, c := range res.DirectCallers {
+		if c.ID == comp {
+			inCallers = true
+		}
+	}
+	if inCallers {
+		t.Fatal("setup invalid: the composer was meant to be evicted by the result cap")
+	}
+	found := false
+	for _, s := range res.AffectedViaComposition {
+		if s.ID == comp {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("AffectedViaComposition = %+v, want Composer (a cap-evicted composer must still surface)", res.AffectedViaComposition)
+	}
+}
+
+// TestReverseCompositionRespectsCap covers the maxResults trim on the
+// reverse-composition set itself.
+func TestReverseCompositionRespectsCap(t *testing.T) {
+	fix := newFixtureDB(t)
+	base := fix.addSymbol(t, "Base")
+	c1 := fix.addSymbol(t, "Composer1")
+	c2 := fix.addSymbol(t, "Composer2")
+	fix.addEdge(t, c1, base, model.EdgeComposes, 0.9)
+	fix.addEdge(t, c2, base, model.EdgeComposes, 0.9)
+
+	res, err := blast.Compute(context.Background(), fix.db, []int64{base}, blast.Options{MaxHops: 1, MinConfidence: 0.1, MaxResults: 1})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	if len(res.AffectedViaComposition) != 1 {
+		t.Errorf("AffectedViaComposition = %d, want 1 (capped to MaxResults)", len(res.AffectedViaComposition))
+	}
+	if !res.Truncated {
+		t.Error("Truncated = false, want true (the reverse-composition set was capped — silent truncation breaks the audit-completeness promise)")
+	}
+}
+
+// TestReverseCompositionReconcilesTotalAffected covers the total_affected
+// reconciliation: a composer reachable only by a composes edge the BFS prunes by
+// confidence still surfaces in the composition set AND is counted in the total,
+// so the response never under-reports what it returns.
+func TestReverseCompositionReconcilesTotalAffected(t *testing.T) {
+	fix := newFixtureDB(t)
+	base := fix.addSymbol(t, "Base")
+	comp := fix.addSymbol(t, "Composer")
+	fix.addEdge(t, comp, base, model.EdgeComposes, 0.5) // decays below the floor
+
+	res, err := blast.Compute(context.Background(), fix.db, []int64{base}, blast.Options{MaxHops: 1, MinConfidence: 0.9})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	found := false
+	for _, s := range res.AffectedViaComposition {
+		if s.ID == comp {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("AffectedViaComposition = %+v, want the BFS-pruned composer", res.AffectedViaComposition)
+	}
+	if res.TotalAffected < 1 {
+		t.Errorf("TotalAffected = %d, want >= 1 (a composer surfaced in the response must be counted)", res.TotalAffected)
+	}
+}
+
+// TestReverseCompositionDedupsAcrossSeeds locks the set-dedup behavior: one
+// composer that holds an FK to two different seeds appears exactly once.
+func TestReverseCompositionDedupsAcrossSeeds(t *testing.T) {
+	fix := newFixtureDB(t)
+	base1 := fix.addSymbol(t, "Base1")
+	base2 := fix.addSymbol(t, "Base2")
+	comp := fix.addSymbol(t, "Composer")
+	fix.addEdge(t, comp, base1, model.EdgeComposes, 0.9)
+	fix.addEdge(t, comp, base2, model.EdgeComposes, 0.9)
+
+	res, err := blast.Compute(context.Background(), fix.db, []int64{base1, base2}, blast.Options{MaxHops: 1, MinConfidence: 0.1})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	seen := 0
+	for _, s := range res.AffectedViaComposition {
+		if s.ID == comp {
+			seen++
+		}
+	}
+	if seen != 1 {
+		t.Errorf("Composer appears %d times in AffectedViaComposition, want exactly 1", seen)
+	}
+}
+
+// TestReverseCompositionExcludesSelfSeed covers the seed-skip filter: a seed that
+// composes itself must not list itself as its own dependent.
+func TestReverseCompositionExcludesSelfSeed(t *testing.T) {
+	fix := newFixtureDB(t)
+	base := fix.addSymbol(t, "Base")
+	dep := fix.addSymbol(t, "Dependent")
+	fix.addEdge(t, base, base, model.EdgeComposes, 0.9) // self-loop seed
+	fix.addEdge(t, dep, base, model.EdgeComposes, 0.9)
+
+	res, err := blast.Compute(context.Background(), fix.db, []int64{base}, blast.Options{MaxHops: 1, MinConfidence: 0.1})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	for _, s := range res.AffectedViaComposition {
+		if s.ID == base {
+			t.Errorf("AffectedViaComposition contains the seed itself (%d); a self-compose must be skipped", base)
+		}
+	}
+}
+
+// TestReverseCompositionExcludesOwnMember covers the childSet-skip filter: a
+// member of the subject is not one of the subject's external dependents.
+func TestReverseCompositionExcludesOwnMember(t *testing.T) {
+	fix := newFixtureDB(t)
+	base := fix.addSymbol(t, "Base")
+	member := fix.addSymbolWith(t, "Base#field", model.KindMethod, &base)
+	fix.addEdge(t, member, base, model.EdgeComposes, 0.9)
+
+	res, err := blast.Compute(context.Background(), fix.db, []int64{base}, blast.Options{MaxHops: 1, MinConfidence: 0.1})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	for _, s := range res.AffectedViaComposition {
+		if s.ID == member {
+			t.Errorf("AffectedViaComposition contains the subject's own member (%d); members must be skipped", member)
+		}
+	}
+}
+
 // --- Pitch 15-02 fixture tests ---
 
 func TestTierClassification(t *testing.T) {

--- a/internal/blast/symbols.go
+++ b/internal/blast/symbols.go
@@ -137,6 +137,106 @@ func SiblingSymbolIDs(ctx context.Context, db *sql.DB, symbolID int64) ([]int64,
 	return ids, rows.Err()
 }
 
+// loadReverseComposition returns the symbols that declare a `composes` edge
+// directly onto one of the seed symbols — the reverse-composition dependents
+// ("what composes the subject"). For a Django model this is every model that
+// holds a ForeignKey / OneToOne / ManyToMany to it, scattered across apps.
+//
+// It reads the edge table directly instead of bucketing the BFS callers, because
+// on a high-fan-out hub the composers are buried: they ride low-confidence
+// composes edges that capResults evicts beneath the 1.0 call/test callers, and a
+// composer that also calls the subject is recorded under the calls edge, never
+// bucketed as a composer. Because it selects `composes` edges only, the test
+// call-sites that dominate the caller list (calls/tests edges) are excluded by
+// construction. Seeds, the subject's own members (childSet / isSelf), and ids
+// already placed in another edge-kind group (excludeGrouped) are skipped; output
+// is ordered by id and capped to maxResults.
+func (s *bfsState) loadReverseComposition(ctx context.Context, db *sql.DB, seedIDs []int64, seedSet, excludeGrouped map[int64]struct{}, isSelf selfMethodFn, maxResults int) ([]model.Symbol, error) {
+	composerIDs, err := inboundComposers(ctx, db, seedIDs)
+	if err != nil {
+		return nil, err
+	}
+	kept := make([]int64, 0, len(composerIDs))
+	for _, id := range composerIDs {
+		if _, isSeed := seedSet[id]; isSeed {
+			continue
+		}
+		if _, isChild := s.childSet[id]; isChild {
+			continue
+		}
+		if _, grouped := excludeGrouped[id]; grouped {
+			continue
+		}
+		kept = append(kept, id)
+	}
+	if len(kept) > maxResults {
+		// Signal the cap so the response is not read as a complete dependent set —
+		// "audit every dependent" depends on the agent knowing it was truncated.
+		s.truncated = true
+		kept = kept[:maxResults]
+	}
+	syms, err := loadSymbols(ctx, db, kept)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]model.Symbol, 0, len(kept))
+	for _, id := range kept {
+		if sym, ok := syms[id]; ok && !isSelf(sym) {
+			out = append(out, sym)
+		}
+	}
+	sortSymbolsByID(out)
+	return out, nil
+}
+
+// inboundComposers returns the distinct source symbol ids of `composes` edges
+// whose target is any of ids, ordered ascending. These are the symbols that
+// compose (hold a structural has-a relationship to) one of the seeds. The set
+// dedups sources that compose more than one seed; chunking keeps the IN clause
+// under SQLITE_MAX_VARIABLE_NUMBER on a wide seed set.
+func inboundComposers(ctx context.Context, db *sql.DB, ids []int64) ([]int64, error) {
+	set := make(map[int64]struct{}, len(ids))
+	const chunk = 500
+	for start := 0; start < len(ids); start += chunk {
+		end := start + chunk
+		if end > len(ids) {
+			end = len(ids)
+		}
+		batch := ids[start:end]
+		placeholders := strings.Repeat("?,", len(batch))
+		placeholders = placeholders[:len(placeholders)-1]
+		q := `SELECT DISTINCT source_id FROM sense_edges
+		      WHERE target_id IN (` + placeholders + `) AND kind = 'composes' AND source_id IS NOT NULL`
+		args := make([]any, len(batch))
+		for i, id := range batch {
+			args[i] = id
+		}
+		rows, err := db.QueryContext(ctx, q, args...)
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			var id int64
+			if err := rows.Scan(&id); err != nil {
+				_ = rows.Close()
+				return nil, err
+			}
+			set[id] = struct{}{}
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		_ = rows.Close()
+	}
+	out := make([]int64, 0, len(set))
+	for id := range set {
+		out = append(out, id)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out, nil
+}
+
 func filterIDs(ids []int64, keep map[int64]struct{}) []int64 {
 	out := make([]int64, 0, len(ids))
 	for _, id := range ids {

--- a/internal/blast/symbols_faults_test.go
+++ b/internal/blast/symbols_faults_test.go
@@ -240,3 +240,45 @@ func TestSiblingSymbolIDsScanError(t *testing.T) {
 		t.Fatal("SiblingSymbolIDs: expected row scan error, got nil")
 	}
 }
+
+func TestInboundComposersQueryError(t *testing.T) {
+	db := openBlastFaultDB(t)
+	armBlastQueryFault("kind = 'composes'")
+	t.Cleanup(disarmBlastFaults)
+	if _, err := inboundComposers(context.Background(), db, []int64{1, 2}); err == nil {
+		t.Fatal("inboundComposers: expected query error, got nil")
+	}
+}
+
+func TestInboundComposersScanError(t *testing.T) {
+	db := openBlastFaultDB(t)
+	armBlastRowsFault("kind = 'composes'", blastRowsBadValue)
+	t.Cleanup(disarmBlastFaults)
+	if _, err := inboundComposers(context.Background(), db, []int64{1, 2}); err == nil {
+		t.Fatal("inboundComposers: expected row scan error, got nil")
+	}
+}
+
+func TestInboundComposersRowsIterationError(t *testing.T) {
+	db := openBlastFaultDB(t)
+	armBlastRowsFault("kind = 'composes'", blastRowsNext)
+	t.Cleanup(disarmBlastFaults)
+	if _, err := inboundComposers(context.Background(), db, []int64{1, 2}); err == nil {
+		t.Fatal("inboundComposers: expected rows.Err iteration error, got nil")
+	}
+}
+
+// TestLoadReverseCompositionPropagatesQueryError covers the error return after
+// inboundComposers fails inside the method.
+func TestLoadReverseCompositionPropagatesQueryError(t *testing.T) {
+	db := openBlastFaultDB(t)
+	armBlastQueryFault("kind = 'composes'")
+	t.Cleanup(disarmBlastFaults)
+	s := &bfsState{childSet: map[int64]struct{}{}}
+	noSelf := func(model.Symbol) bool { return false }
+	_, err := s.loadReverseComposition(context.Background(), db, []int64{1, 2},
+		map[int64]struct{}{}, map[int64]struct{}{}, noSelf, 100)
+	if err == nil {
+		t.Fatal("loadReverseComposition: expected propagated query error, got nil")
+	}
+}

--- a/internal/cli/blast.go
+++ b/internal/cli/blast.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/luuuc/sense/internal/blast"
 	"github.com/luuuc/sense/internal/mcpio"
+	"github.com/luuuc/sense/internal/model"
 )
 
 // blastHelp mirrors the `sense blast` example block in
@@ -254,21 +255,30 @@ func runBlastSymbol(cio IO, opts blastOptions) int {
 }
 
 // collectBlastFileIDs returns the unique file ids referenced by the
-// blast Result's direct + indirect callers. Batched so the caller
-// hydrates paths in one query.
+// blast Result's direct + indirect callers and its structural edge-kind
+// groups. Batched so the caller hydrates paths in one query. The
+// edge-kind groups matter because AffectedViaComposition is computed
+// from the edge table independently of the capped caller lists, so it
+// can carry composers whose files no caller references — without them
+// here those dependents would render with an empty path.
 func CollectBlastFileIDs(r blast.Result) []int64 {
 	seen := map[int64]struct{}{r.Symbol.FileID: {}}
 	ids := []int64{r.Symbol.FileID}
-	for _, c := range r.DirectCallers {
-		if _, ok := seen[c.FileID]; !ok {
-			seen[c.FileID] = struct{}{}
-			ids = append(ids, c.FileID)
+	note := func(fileID int64) {
+		if _, ok := seen[fileID]; !ok {
+			seen[fileID] = struct{}{}
+			ids = append(ids, fileID)
 		}
 	}
+	for _, c := range r.DirectCallers {
+		note(c.FileID)
+	}
 	for _, hop := range r.IndirectCallers {
-		if _, ok := seen[hop.Symbol.FileID]; !ok {
-			seen[hop.Symbol.FileID] = struct{}{}
-			ids = append(ids, hop.Symbol.FileID)
+		note(hop.Symbol.FileID)
+	}
+	for _, group := range [][]model.Symbol{r.AffectedSubclasses, r.AffectedViaComposition, r.AffectedViaIncludes} {
+		for _, sym := range group {
+			note(sym.FileID)
 		}
 	}
 	return ids

--- a/internal/cli/blast_test.go
+++ b/internal/cli/blast_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/luuuc/sense/internal/blast"
 	"github.com/luuuc/sense/internal/mcpio"
 	"github.com/luuuc/sense/internal/model"
 	"github.com/luuuc/sense/internal/sqlite"
@@ -111,6 +112,31 @@ func degradeIndexColumn(t *testing.T, dir, table, column string) {
 	}
 	if _, err := db.ExecContext(ctx, fmt.Sprintf("PRAGMA user_version = %d", sqlite.SchemaVersion)); err != nil {
 		t.Fatalf("stamp user_version: %v", err)
+	}
+}
+
+// TestCollectBlastFileIDsIncludesEdgeKindGroups guards the empty-path
+// regression: AffectedViaComposition is computed from the edge table
+// independently of the capped caller lists, so a composer's file may be
+// referenced by no caller. CollectBlastFileIDs must still gather it, or that
+// dependent renders with an empty path and loses its citation.
+func TestCollectBlastFileIDsIncludesEdgeKindGroups(t *testing.T) {
+	r := blast.Result{
+		Symbol:        model.Symbol{ID: 1, FileID: 1},
+		DirectCallers: []model.Symbol{{ID: 2, FileID: 2}},
+		// a composer whose file (99) appears nowhere in the caller lists
+		AffectedViaComposition: []model.Symbol{{ID: 9, FileID: 99}},
+		AffectedSubclasses:     []model.Symbol{{ID: 8, FileID: 88}},
+		AffectedViaIncludes:    []model.Symbol{{ID: 7, FileID: 77}},
+	}
+	got := map[int64]bool{}
+	for _, id := range CollectBlastFileIDs(r) {
+		got[id] = true
+	}
+	for _, want := range []int64{1, 2, 99, 88, 77} {
+		if !got[want] {
+			t.Errorf("CollectBlastFileIDs missing file id %d (edge-kind group file not collected)", want)
+		}
 	}
 }
 

--- a/internal/mcpio/graph.go
+++ b/internal/mcpio/graph.go
@@ -49,6 +49,7 @@ func trimLongestEdgeList(e *GraphEdges, resp *GraphResponse) bool {
 		{len(e.CalledBy), func(k int) { e.CalledBy = e.CalledBy[:len(e.CalledBy)-k] }},
 		{len(e.Calls), func(k int) { e.Calls = e.Calls[:len(e.Calls)-k] }},
 		{len(e.Composes), func(k int) { e.Composes = e.Composes[:len(e.Composes)-k] }},
+		{len(e.ComposedBy), func(k int) { e.ComposedBy = e.ComposedBy[:len(e.ComposedBy)-k] }},
 		{len(e.Inherits), func(k int) { e.Inherits = e.Inherits[:len(e.Inherits)-k] }},
 		{len(e.Includes), func(k int) { e.Includes = e.Includes[:len(e.Includes)-k] }},
 		{len(e.Imports), func(k int) { e.Imports = e.Imports[:len(e.Imports)-k] }},
@@ -465,8 +466,12 @@ func categorizeEdges(ctx context.Context, outbound, inbound []model.EdgeRef, fil
 					Ref:       FormatRefPtr(fp, e.Target.LineStart),
 				})
 			case model.EdgeComposes:
+				// Inbound: a symbol that composes THIS one (holds a has-a
+				// relationship to it). Routed to ComposedBy, distinct from the
+				// outbound Composes bucket, so the reverse fan-out a Django model's
+				// FK dependents form is not conflated with what the model owns.
 				fp := fileRefOrNil(e.Target.FileID, files)
-				edges.Composes = append(edges.Composes, ComposeEdgeRef{
+				edges.ComposedBy = append(edges.ComposedBy, ComposeEdgeRef{
 					Symbol:    qualifiedOrName(e.Target),
 					File:      fp,
 					LineStart: e.Target.LineStart,
@@ -518,7 +523,7 @@ func qualifiedOrName(s model.Symbol) string {
 
 func countEdgeSymbols(edges GraphEdges) int {
 	return len(edges.Calls) + len(edges.CalledBy) +
-		len(edges.Inherits) + len(edges.Composes) +
+		len(edges.Inherits) + len(edges.Composes) + len(edges.ComposedBy) +
 		len(edges.Includes) + len(edges.Imports) +
 		len(edges.Tests) + len(edges.Temporal)
 }
@@ -554,6 +559,11 @@ func collectEdgeFiles(edges GraphEdges, seen map[string]struct{}) {
 		}
 	}
 	for _, e := range edges.Composes {
+		if e.File != nil {
+			seen[*e.File] = struct{}{}
+		}
+	}
+	for _, e := range edges.ComposedBy {
 		if e.File != nil {
 			seen[*e.File] = struct{}{}
 		}

--- a/internal/mcpio/graph_test.go
+++ b/internal/mcpio/graph_test.go
@@ -154,14 +154,23 @@ func TestBuildGraphResponseComposesEdges(t *testing.T) {
 
 	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{})
 
-	if len(resp.Edges.Composes) != 3 {
-		t.Fatalf("Composes = %d, want 3 (2 outbound + 1 inbound)", len(resp.Edges.Composes))
+	// Outbound composes ("what User owns") land in Composes; the inbound composer
+	// ("what owns User") lands in ComposedBy — the two directions are no longer
+	// conflated.
+	if len(resp.Edges.Composes) != 2 {
+		t.Fatalf("Composes = %d, want 2 (outbound only)", len(resp.Edges.Composes))
 	}
 	if resp.Edges.Composes[0].Symbol != "Order" {
 		t.Errorf("Composes[0].Symbol = %q, want %q", resp.Edges.Composes[0].Symbol, "Order")
 	}
 	if resp.Edges.Composes[0].File == nil {
 		t.Error("Composes[0].File = nil, want non-nil")
+	}
+	if len(resp.Edges.ComposedBy) != 1 {
+		t.Fatalf("ComposedBy = %d, want 1 (the inbound composer)", len(resp.Edges.ComposedBy))
+	}
+	if resp.Edges.ComposedBy[0].Symbol != "Order" {
+		t.Errorf("ComposedBy[0].Symbol = %q, want %q", resp.Edges.ComposedBy[0].Symbol, "Order")
 	}
 }
 
@@ -288,14 +297,24 @@ func TestBuildGraphResponseComposesDirection(t *testing.T) {
 	}
 	files := func(int64) (string, bool) { return "", false }
 
+	// Callees = outbound only: the owned Order surfaces in Composes; the inbound
+	// composer is out of scope.
 	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{Direction: model.DirectionCallees})
 	if len(resp.Edges.Composes) != 1 || resp.Edges.Composes[0].Symbol != "Order" {
-		t.Errorf("callees direction: want only outbound Order, got %v", resp.Edges.Composes)
+		t.Errorf("callees direction: want only outbound Order in Composes, got %v", resp.Edges.Composes)
+	}
+	if len(resp.Edges.ComposedBy) != 0 {
+		t.Errorf("callees direction: want empty ComposedBy, got %v", resp.Edges.ComposedBy)
 	}
 
+	// Callers = inbound only: the composer Profile surfaces in ComposedBy; the
+	// outbound Composes bucket is out of scope.
 	resp = BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{Direction: model.DirectionCallers})
-	if len(resp.Edges.Composes) != 1 || resp.Edges.Composes[0].Symbol != "Profile" {
-		t.Errorf("callers direction: want only inbound Profile, got %v", resp.Edges.Composes)
+	if len(resp.Edges.ComposedBy) != 1 || resp.Edges.ComposedBy[0].Symbol != "Profile" {
+		t.Errorf("callers direction: want only inbound Profile in ComposedBy, got %v", resp.Edges.ComposedBy)
+	}
+	if len(resp.Edges.Composes) != 0 {
+		t.Errorf("callers direction: want empty Composes, got %v", resp.Edges.Composes)
 	}
 }
 

--- a/internal/mcpio/marshal.go
+++ b/internal/mcpio/marshal.go
@@ -60,19 +60,21 @@ func MarshalGraphCompactDirectional(r GraphResponse, direction model.Direction) 
 // table is derived from that logic. Returns nil for direction == Both
 // (or empty), meaning "render every bucket as today".
 //
-//	Callers — outbound (calls) excluded.
-//	Callees — inbound-only (called_by, tests) excluded.
-//	Inherits / Composes / Includes / Imports — populated by both
-//	paths (outbound = "what this inherits from / composes / etc.",
-//	inbound = "what inherits from / composes / etc. this"), never
-//	excluded.
+//	Callers — outbound (calls, composes) excluded.
+//	Callees — inbound-only (called_by, composed_by, tests) excluded.
+//	calls/called_by and composes/composed_by are directional pairs: the
+//	outbound member is dropped for a callers query, the inbound member for
+//	a callees query.
+//	Inherits / Includes / Imports — populated by both paths (outbound =
+//	"what this inherits from / includes / etc.", inbound = "what inherits
+//	from / includes / etc. this") into one bucket, never excluded.
 //	Temporal — bidirectional, never excluded.
 func outOfScopeEdgeBuckets(direction model.Direction) []string {
 	switch direction {
 	case model.DirectionCallers:
-		return []string{"calls"}
+		return []string{"calls", "composes"}
 	case model.DirectionCallees:
-		return []string{"called_by", "tests"}
+		return []string{"called_by", "composed_by", "tests"}
 	default:
 		return nil
 	}
@@ -177,6 +179,9 @@ func normalizeGraphResponse(r *GraphResponse) {
 	if r.Edges.Composes == nil {
 		r.Edges.Composes = []ComposeEdgeRef{}
 	}
+	if r.Edges.ComposedBy == nil {
+		r.Edges.ComposedBy = []ComposeEdgeRef{}
+	}
 	if r.Edges.Includes == nil {
 		r.Edges.Includes = []IncludeEdgeRef{}
 	}
@@ -234,6 +239,9 @@ func normalizeGraphEdgesScoped(e *GraphEdges, skip map[string]struct{}) {
 	}
 	if _, ok := skip["composes"]; !ok && e.Composes == nil {
 		e.Composes = []ComposeEdgeRef{}
+	}
+	if _, ok := skip["composed_by"]; !ok && e.ComposedBy == nil {
+		e.ComposedBy = []ComposeEdgeRef{}
 	}
 	if _, ok := skip["includes"]; !ok && e.Includes == nil {
 		e.Includes = []IncludeEdgeRef{}

--- a/internal/mcpio/marshal_test.go
+++ b/internal/mcpio/marshal_test.go
@@ -32,13 +32,14 @@ func TestMarshalGraphRoundTrip(t *testing.T) {
 				{Symbol: "PaymentGateway#charge", File: &filePath, Confidence: 1.0},
 				{Symbol: "Beacon.track", File: nil, Confidence: 0.9},
 			},
-			CalledBy: []CallEdgeRef{},
-			Inherits: []InheritEdgeRef{{Symbol: "ApplicationService", File: nil}},
-			Composes: []ComposeEdgeRef{},
-			Includes: []IncludeEdgeRef{},
-			Imports:  []ImportEdgeRef{},
-			Tests:    []TestEdgeRef{{File: "test/services/checkout_service_test.rb", Confidence: 0.8}},
-			Temporal: []TemporalEdgeRef{},
+			CalledBy:   []CallEdgeRef{},
+			Inherits:   []InheritEdgeRef{{Symbol: "ApplicationService", File: nil}},
+			Composes:   []ComposeEdgeRef{},
+			ComposedBy: []ComposeEdgeRef{},
+			Includes:   []IncludeEdgeRef{},
+			Imports:    []ImportEdgeRef{},
+			Tests:      []TestEdgeRef{{File: "test/services/checkout_service_test.rb", Confidence: 0.8}},
+			Temporal:   []TemporalEdgeRef{},
 		},
 		NextSteps: []NextStep{},
 	}
@@ -103,12 +104,12 @@ func TestMarshalZeroValueEmptySlices(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MarshalGraph: %v", err)
 	}
-	for _, field := range []string{`"calls": []`, `"called_by": []`, `"inherits": []`, `"composes": []`, `"includes": []`, `"imports": []`, `"tests": []`, `"temporal": []`, `"next_steps": []`} {
+	for _, field := range []string{`"calls": []`, `"called_by": []`, `"inherits": []`, `"composes": []`, `"composed_by": []`, `"includes": []`, `"imports": []`, `"tests": []`, `"temporal": []`, `"next_steps": []`} {
 		if !strings.Contains(string(graphBytes), field) {
 			t.Errorf("GraphResponse zero-value missing %s\ngot:\n%s", field, graphBytes)
 		}
 	}
-	for _, nullField := range []string{`"calls": null`, `"called_by": null`, `"inherits": null`, `"composes": null`, `"includes": null`, `"imports": null`, `"tests": null`, `"temporal": null`, `"next_steps": null`} {
+	for _, nullField := range []string{`"calls": null`, `"called_by": null`, `"inherits": null`, `"composes": null`, `"composed_by": null`, `"includes": null`, `"imports": null`, `"tests": null`, `"temporal": null`, `"next_steps": null`} {
 		if strings.Contains(string(graphBytes), nullField) {
 			t.Errorf("GraphResponse zero-value slice field should be []: %s\ngot:\n%s", nullField, graphBytes)
 		}

--- a/internal/mcpio/testdata/graph_checkout_service.json
+++ b/internal/mcpio/testdata/graph_checkout_service.json
@@ -45,6 +45,7 @@
       }
     ],
     "composes": [],
+    "composed_by": [],
     "includes": [],
     "imports": [],
     "tests": [

--- a/internal/mcpio/testdata/graph_empty.json
+++ b/internal/mcpio/testdata/graph_empty.json
@@ -13,6 +13,7 @@
     "called_by": [],
     "inherits": [],
     "composes": [],
+    "composed_by": [],
     "includes": [],
     "imports": [],
     "tests": [],

--- a/internal/mcpio/testdata/graph_with_freshness.json
+++ b/internal/mcpio/testdata/graph_with_freshness.json
@@ -45,6 +45,7 @@
       }
     ],
     "composes": [],
+    "composed_by": [],
     "includes": [],
     "imports": [],
     "tests": [

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -177,14 +177,23 @@ type GraphSymbol struct {
 // leave unrequested kinds as empty slices and callers must treat
 // `[]` as "none found" rather than "not provided."
 type GraphEdges struct {
-	Calls    []CallEdgeRef     `json:"calls"`
-	CalledBy []CallEdgeRef     `json:"called_by"`
-	Inherits []InheritEdgeRef  `json:"inherits"`
-	Composes []ComposeEdgeRef  `json:"composes"`
-	Includes []IncludeEdgeRef  `json:"includes"`
-	Imports  []ImportEdgeRef   `json:"imports"`
-	Tests    []TestEdgeRef     `json:"tests"`
-	Temporal []TemporalEdgeRef `json:"temporal"`
+	Calls    []CallEdgeRef    `json:"calls"`
+	CalledBy []CallEdgeRef    `json:"called_by"`
+	Inherits []InheritEdgeRef `json:"inherits"`
+	Composes []ComposeEdgeRef `json:"composes"`
+	// ComposedBy is the reverse-composition direction: the symbols that hold a
+	// has-a relationship TO this one (a Django model's ForeignKey / OneToOne /
+	// ManyToMany dependents). Kept distinct from Composes — "what I own" vs "what
+	// owns me" are different questions, and merging them hid the reverse fan-out
+	// a change-impact audit needs. Note: composes/composed_by are a directional
+	// pair (like calls/called_by), so a callers-direction query now returns
+	// inbound composers here, NOT in Composes; inherits/includes/imports stay
+	// merged into one bucket per kind.
+	ComposedBy []ComposeEdgeRef  `json:"composed_by"`
+	Includes   []IncludeEdgeRef  `json:"includes"`
+	Imports    []ImportEdgeRef   `json:"imports"`
+	Tests      []TestEdgeRef     `json:"tests"`
+	Temporal   []TemporalEdgeRef `json:"temporal"`
 }
 
 // CallEdgeRef is the shape of a calls / called_by edge entry. File

--- a/internal/mcpserver/oracle_test.go
+++ b/internal/mcpserver/oracle_test.go
@@ -182,7 +182,11 @@ func oracleDigest(t *testing.T, calls []labeledCall) (string, []string) {
 // project's own architecture (inheritance, framework, design-pattern, composition
 // lead; naming/structure/testing trail), so the fixture's key_types line now
 // precedes its structure line — digest moved.
-const oracleGolden = "60c3c73e13d7e50bcfa45a5f00e8e9239ebda0f8b4f0997954400d5949a3eb50"
+// sense_graph now splits inbound composition into its own `composed_by` bucket
+// (reverse-composition, distinct from outbound `composes`), so every graph
+// response gained an empty `composed_by` field and callees-direction responses
+// drop it — digest moved. No edge content changed.
+const oracleGolden = "83a83c93c603a6b1550af16056341c2c9f5769f5503edaf9fc895e564a716983"
 
 func TestMCPServerResponseOracle(t *testing.T) {
 	got, content := oracleDigest(t, collectOracleCalls(t))

--- a/internal/resolve/django.go
+++ b/internal/resolve/django.go
@@ -1,0 +1,76 @@
+package resolve
+
+import (
+	"strings"
+
+	"github.com/luuuc/sense/internal/model"
+)
+
+// Django-specific resolution refinement. Kept in its own file (not baked into
+// the generic resolver) so the framework convention lives beside the language it
+// belongs to, mirroring extract/python/django.go and model/rails.go. The generic
+// resolver only dispatches to the seams declared here.
+
+// isDjangoModelModuleRef reports whether a symbol belongs to a Python Django
+// "models" module, used by NewIndex to flag the source files where ORM
+// relations are declared. Only Python files qualify.
+func isDjangoModelModuleRef(r model.SymbolRef) bool {
+	return r.Language == "python" && isDjangoModelPath(r.Path)
+}
+
+// isDjangoModelPath reports whether a file path is a Django "models" module: a
+// `<app>/models.py` file or a `<app>/models/` package. Django ORM model classes
+// live there by convention, so the candidate in a models module is the real
+// referent of an ORM relation that collides with a same-named non-model symbol.
+func isDjangoModelPath(path string) bool {
+	if path == "models.py" || strings.HasPrefix(path, "models/") {
+		return true
+	}
+	return strings.HasSuffix(path, "/models.py") || strings.Contains(path, "/models/")
+}
+
+// preferDjangoModelComposes reorders a same-named candidate set for a Django ORM
+// `composes` edge so the symbols defined in a models module come first, when the
+// edge originates from one. A Django FK/O2O/M2M target string like
+// `"product.ProductVariant"` is emitted as the bare leaf `ProductVariant`
+// (see extract/python/django.go), which collides with same-named GraphQL types
+// and serializers. Those non-model symbols were winning the tie purely by lower
+// scan id (pickBest's lowest-id fallback), wiring the dependency to the wrong
+// node and hiding the reverse fan-out from blast/graph. Floating the
+// models-module candidates ahead of the rest makes pickBest land on the model.
+//
+// It is purely a tie-break refinement: the set is unchanged in length, so
+// pickBest still flags the collision ambiguous and clamps confidence exactly as
+// before — only which same-named symbol wins changes. pickBest's same-file
+// preference still takes precedence (order preserved within each partition), so
+// a genuine same-file match is never overridden.
+//
+// The gate is deliberately narrow so it touches only Django ORM relations: it
+// fires only for `composes` whose source file is itself a Python models module
+// (where ORM fields are declared), never a generic type-annotation compose, and
+// never another language's composes (Ruby `has_many`, Rust, TS). It is a no-op
+// unless it actually discriminates — it returns the input untouched when no
+// candidate is in a models module, or when every candidate already is.
+func (ix *Index) preferDjangoModelComposes(matches []model.SymbolRef, req Request) []model.SymbolRef {
+	if req.Kind != model.EdgeComposes || len(matches) < 2 {
+		return matches
+	}
+	if ix.fileLang[req.SourceFileID] != "python" || !ix.fileModelModule[req.SourceFileID] {
+		return matches
+	}
+	models := make([]model.SymbolRef, 0, len(matches))
+	rest := make([]model.SymbolRef, 0, len(matches))
+	for _, m := range matches {
+		if m.Language == "python" && isDjangoModelPath(m.Path) {
+			models = append(models, m)
+		} else {
+			rest = append(rest, m)
+		}
+	}
+	if len(models) == 0 || len(rest) == 0 {
+		return matches
+	}
+	// models was allocated with cap len(matches), but rest holds the remaining
+	// elements, so this append cannot alias or overwrite the input slice.
+	return append(models, rest...)
+}

--- a/internal/resolve/django_internal_test.go
+++ b/internal/resolve/django_internal_test.go
@@ -1,0 +1,68 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/luuuc/sense/internal/model"
+)
+
+func TestIsDjangoModelPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"saleor/product/models.py", true},                  // app/models.py
+		{"saleor/attribute/models/base.py", true},           // app/models/ package
+		{"saleor/attribute/models/__init__.py", true},       // package init
+		{"models.py", true},                                 // models.py at repo root
+		{"models/foo.py", true},                             // models/ package at repo root
+		{"saleor/graphql/product/types/products.py", false}, // GraphQL type, not a model
+		{"saleor/order/services.py", false},
+		{"saleor/product/managers.py", false}, // "models" substring absent
+		{"app/model.py", false},               // singular, not the convention
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := isDjangoModelPath(c.path); got != c.want {
+			t.Errorf("isDjangoModelPath(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}
+
+func TestIsDjangoModelModuleRef(t *testing.T) {
+	cases := []struct {
+		name string
+		ref  model.SymbolRef
+		want bool
+	}{
+		{"python model module", model.SymbolRef{Language: "python", Path: "saleor/product/models.py"}, true},
+		{"python non-model", model.SymbolRef{Language: "python", Path: "saleor/order/services.py"}, false},
+		{"ruby models path is not Django", model.SymbolRef{Language: "ruby", Path: "app/models/order.rb"}, false},
+		{"empty", model.SymbolRef{}, false},
+	}
+	for _, c := range cases {
+		if got := isDjangoModelModuleRef(c.ref); got != c.want {
+			t.Errorf("%s: isDjangoModelModuleRef = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// TestPreferDjangoModelComposesAllModels covers the branch where every candidate
+// is already in a models module: the gate must not narrow (there is nothing to
+// discriminate), leaving pickBest's lowest-id tie-break to stand.
+func TestPreferDjangoModelComposesAllModels(t *testing.T) {
+	refs := []model.SymbolRef{
+		{ID: 1, Qualified: "OrderLine", FileID: 1, Language: "python", Path: "saleor/order/models.py"},
+		// two same-named models in different apps' models modules
+		{ID: 2, Qualified: "Address", FileID: 2, Language: "python", Path: "saleor/account/models.py"},
+		{ID: 3, Qualified: "Address", FileID: 3, Language: "python", Path: "saleor/order/models/address.py"},
+	}
+	ix := NewIndex(refs)
+	matches := ix.byQualified["Address"]
+	got := ix.preferDjangoModelComposes(matches, Request{
+		Target: "Address", Kind: model.EdgeComposes, SourceFileID: 1, BaseConfidence: 0.9,
+	})
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d, want 2 (all-models candidate set must not be narrowed)", len(got))
+	}
+}

--- a/internal/resolve/django_test.go
+++ b/internal/resolve/django_test.go
@@ -1,0 +1,99 @@
+package resolve_test
+
+import (
+	"testing"
+
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/resolve"
+)
+
+// djangoRefs models the same-named ProductVariant collision that breaks the
+// Django reverse-FK fan-out: a GraphQL ObjectType (lower scan id) and the ORM
+// model (higher id) share the qualified name "ProductVariant". OrderLine is the
+// dependent declaring the FK, in an order/models.py models module. Extra
+// fixtures cover the no-op gates (a non-models source, an all-non-model
+// collision).
+func djangoRefs() []model.SymbolRef {
+	return []model.SymbolRef{
+		// dependent declaring the FK, in a models module
+		{ID: 50, Qualified: "OrderLine", FileID: 50, Language: "python", Path: "saleor/order/models.py"},
+		// a service in the same app but NOT a models module
+		{ID: 51, Qualified: "OrderService", FileID: 51, Language: "python", Path: "saleor/order/services.py"},
+		// the collision: GraphQL type at the LOWER id, ORM model at the higher id
+		{ID: 60, Qualified: "ProductVariant", FileID: 60, Language: "python", Path: "saleor/graphql/product/types/products.py"},
+		{ID: 61, Qualified: "ProductVariant", FileID: 61, Language: "python", Path: "saleor/product/models.py"},
+		// an all-non-model collision (two GraphQL-layer symbols, no models module)
+		{ID: 70, Qualified: "Money", FileID: 60, Language: "python", Path: "saleor/graphql/core/types/money.py"},
+		{ID: 71, Qualified: "Money", FileID: 62, Language: "python", Path: "saleor/graphql/order/types.py"},
+	}
+}
+
+func TestResolveComposesPrefersDjangoModel(t *testing.T) {
+	ix := resolve.NewIndex(djangoRefs())
+
+	// A composes edge from OrderLine (an order/models.py models module) to the
+	// colliding "ProductVariant" must bind to the ORM model (id 61), beating the
+	// GraphQL type (id 60) that would otherwise win by lowest id. Confidence is
+	// still clamped + flagged ambiguous: the gate picks the right candidate, it
+	// does not remove the ambiguity.
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "ProductVariant",
+		Kind:           model.EdgeComposes,
+		SourceFileID:   50,
+		BaseConfidence: 0.9,
+	})
+	if !ok {
+		t.Fatal("expected resolution")
+	}
+	if r.SymbolID != 61 {
+		t.Errorf("SymbolID = %d, want 61 (the ORM model, not the lower-id GraphQL type)", r.SymbolID)
+	}
+	if r.Confidence != 0.8 {
+		t.Errorf("Confidence = %v, want 0.8 (ambiguous clamp still applies)", r.Confidence)
+	}
+	if !r.Ambiguous {
+		t.Error("Ambiguous = false, want true (multiple candidates)")
+	}
+}
+
+func TestResolveComposesModelPreferenceNoOps(t *testing.T) {
+	ix := resolve.NewIndex(djangoRefs())
+
+	cases := []struct {
+		name   string
+		req    resolve.Request
+		wantID int64
+	}{
+		{
+			// Not a composes edge: the gate never fires, lowest id wins.
+			name:   "non-composes kind",
+			req:    resolve.Request{Target: "ProductVariant", Kind: model.EdgeInherits, SourceFileID: 50, BaseConfidence: 0.9},
+			wantID: 60,
+		},
+		{
+			// Source is order/services.py, not a models module: not an ORM
+			// relation, so no preference; lowest id wins.
+			name:   "source not a models module",
+			req:    resolve.Request{Target: "ProductVariant", Kind: model.EdgeComposes, SourceFileID: 51, BaseConfidence: 0.9},
+			wantID: 60,
+		},
+		{
+			// The collision has no models-module candidate (both GraphQL layer):
+			// nothing to prefer, lowest id stands.
+			name:   "no model candidate",
+			req:    resolve.Request{Target: "Money", Kind: model.EdgeComposes, SourceFileID: 50, BaseConfidence: 0.9},
+			wantID: 70,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r, ok := ix.Resolve(c.req)
+			if !ok {
+				t.Fatal("expected resolution")
+			}
+			if r.SymbolID != c.wantID {
+				t.Errorf("SymbolID = %d, want %d", r.SymbolID, c.wantID)
+			}
+		})
+	}
+}

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -36,6 +36,12 @@ type Index struct {
 	// a coincidental same-named symbol that lives in a test file. Built from the
 	// same SymbolRefs; a file id absent from the map is treated as non-test.
 	fileIsTest map[int64]bool
+	// fileModelModule flags files that are framework model-definition modules,
+	// populated by language-specific classifiers (see isDjangoModelModuleRef in
+	// django.go). It lets a `composes` edge prefer a model-definition target over
+	// a same-named non-model symbol; see preferDjangoModelComposes. A file id
+	// absent from the map is treated as not a model module.
+	fileModelModule map[int64]bool
 	// ancestry maps a class's qualified name to its direct superclass qualified
 	// names (as written on the `inherits` edge). It powers inherited-method
 	// resolution: a call to `Sub#m` with no own `Sub#m` resolves to the nearest
@@ -50,10 +56,11 @@ type Index struct {
 // preserved in each map bucket.
 func NewIndex(refs []model.SymbolRef) *Index {
 	ix := &Index{
-		byQualified: make(map[string][]model.SymbolRef, len(refs)),
-		byName:      make(map[string][]model.SymbolRef, len(refs)),
-		fileLang:    make(map[int64]string),
-		fileIsTest:  make(map[int64]bool),
+		byQualified:     make(map[string][]model.SymbolRef, len(refs)),
+		byName:          make(map[string][]model.SymbolRef, len(refs)),
+		fileLang:        make(map[int64]string),
+		fileIsTest:      make(map[int64]bool),
+		fileModelModule: make(map[int64]bool),
 	}
 	for _, r := range refs {
 		ix.byQualified[r.Qualified] = append(ix.byQualified[r.Qualified], r)
@@ -64,6 +71,9 @@ func NewIndex(refs []model.SymbolRef) *Index {
 		}
 		if r.Path != "" {
 			ix.fileIsTest[r.FileID] = isTestPath(r.Path)
+		}
+		if isDjangoModelModuleRef(r) {
+			ix.fileModelModule[r.FileID] = true
 		}
 	}
 	return ix
@@ -355,6 +365,7 @@ func (ix *Index) resolveQualified(target string, req Request, gatedKind bool) (R
 		matches = filterByTestDirection(matches, ix.fileIsTest[req.SourceFileID], ix.fileIsTest)
 	}
 	if len(matches) > 0 {
+		matches = ix.preferDjangoModelComposes(matches, req)
 		return pickBest(matches, req.SourceFileID, req.BaseConfidence), true, true
 	}
 	// The qualified name matched only cross-language or test-only symbols: a


### PR DESCRIPTION
## Problem

For a high-fan-out model, "what depends on me" is the set of models that hold a ForeignKey / OneToOne / ManyToMany to it — the reverse-composition fan-out. That set was invisible to `sense_blast` / `sense_graph`: they returned call-site callers (test functions on a heavily-tested repo), and Django FK strings even resolved to the wrong same-named symbol. An agent auditing a model before a change-impact edit could not see the dependents it would break, which is the whole point of the query.

## Summary

Close the gap end to end: bind FK strings to the real model, derive the reverse-composition set directly from the edge table, and expose it as its own direction in graph — with full `file:line` citations.

## Changes

- **resolver** — a Django FK-string target (`"app.Model"`) now resolves to the ORM model over a same-named GraphQL type / serializer. Kept in a per-language `internal/resolve/django.go` so the generic resolver stays framework-free; gated to `composes` edges from a Python models module, and a pure tie-break (set length, confidence clamp, and ambiguity flag unchanged).
- **blast** — `affected_via_composition` is computed from a direct inbound-`composes` edge query, independent of the result cap (which evicted low-confidence composers) and of edge-kind masking (a composer that also `calls` the subject was bucketed as a caller). Test call-sites are excluded by construction. Truncation is signaled and `total_affected` reconciled so the response never under-reports what it returns.
- **graph** — inbound composition is split into a new `composed_by` bucket, distinct from the outbound `composes` direction.
- **cli/mcp** — `CollectBlastFileIDs` now gathers the edge-kind groups' files, so cap-evicted composers keep their `file:line` citation instead of rendering an empty path.

Language-agnostic: the blast/graph half also surfaces the reverse-association fan-out on Rails models.

## Breaking Changes

⚠️ `composed_by` is additive, but inbound composers now appear there rather than in `composes` for a callers-direction `sense_graph` query (the two are now a directional pair like `calls`/`called_by`). `inherits`/`includes`/`imports` remain merged per kind.

## Test Plan

- [x] `make ci` green — 95.1% coverage, lint clean, complexity ledger clean
- [x] Saleor (Django) `blast ProductVariant`: `affected_via_composition` 0 → 14 with full `file:line`, covering every dependent group (OrderLine, CheckoutLine, Stock, Voucher/PromotionRule, the attribute join models, AttributeValue.reference_variant); `OrderLine` now composes the model, not the GraphQL type
- [x] Rails (lobsters) side-effect check: `blast Story` reverse-composition 0 → 16, `User` 2 → 23 — all real associations, `total_affected` unchanged, zero regression; the resolver change proven inert on Ruby
- [x] Unit tests for masking, cap eviction, truncation signal, total reconciliation, multi-seed dedup, self/member skips, the resolver tie-break and its no-ops, and the file-id collector