### PR TITLE
fix(python): resolve celery task dispatch to the task function

### DIFF
--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -18,7 +18,7 @@ The benchmark is the pilot. Product fixes are usually a byproduct of benching a 
 
 These are the same rules the internal methodology runs on. They are publishable on purpose, because a benchmark that only flatters the tool measures nothing.
 
-1. **The agent is the baseline.** Both arms are the same capable agent on the same frontier model. One has Sense, one has grep, read, and its own reasoning. The question is never "is Sense useful in the abstract," it is "where does Sense let the agent reach structure it could not assemble by reading and grepping alone." That reach is hardest to see from the inside, because a strong agent reads and recalls its way to most answers and feels done, which is exactly the false confidence the bench is built to catch.
+1. **The agent is the constant; Sense is a tool it reaches for.** Both arms are the same capable agent on the same frontier model — one working with Sense, one with only grep, read, and its own reasoning (the baseline). The question is never "is Sense useful in the abstract," it is "where does the tool let the agent reach structure it could not assemble by reading and grepping alone." That reach is hardest to see from the inside, because a strong agent reads and recalls its way to most answers and feels done, which is exactly the false confidence the bench is built to catch.
 
 2. **A proxy is never a verdict.** grep-reachability is not "the baseline would have found it." A single run is noise. Metadata is not evidence. Conclusions come from reading the full transcripts of both arms, side by side, per target.
 

--- a/bench/end-goal.md
+++ b/bench/end-goal.md
@@ -17,7 +17,7 @@ The benchmark exists to answer one question, repeatedly and trustworthily: *give
 - **Audience is the next agent.** Scenario prompts say so explicitly ("hand the next agent…"). Rubric criteria score for "could the agent edit from this?" — not "did the human reader feel informed?".
 - **No prose-quality bonuses.** A beautifully-written answer that lacks file:line citations scores worse than a terse list of file:line + reasons. The LLM judge is steered toward that prior.
 - **Citations and call-orders are first-class.** "file:line for every method in the chain, in order" is the bar.
-- **The output of the bench is differential.** Sense vs baseline, with a single fairness number per scenario. Absolute scores matter less than the gap between tools on the same task.
+- **The output of the bench is differential.** The same agent with the tool (sense) vs without it (baseline), with a single fairness number per scenario. Absolute scores matter less than the gap the tool opens on the same task.
 
 ---
 

--- a/internal/extract/python/celery.go
+++ b/internal/extract/python/celery.go
@@ -1,0 +1,69 @@
+package python
+
+import (
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/model"
+)
+
+// celeryDispatchMethods are the Celery async-dispatch entrypoints. A call to
+// one of these on a task object (`task.delay(...)`, `task.apply_async(...)`)
+// ultimately runs that task's function body — an edge that does not exist in
+// the greppable text, because the call names the dispatch method, not the
+// task. Matching on the framework's dispatch API (not on a `*_task` name
+// convention) is the structural signal that the receiver is a task: `.delay`
+// and `.apply_async` are near-unique to Celery. This mirrors the Ruby
+// Sidekiq/ActiveJob enqueue resolution (internal/extract/ruby/enqueue.go).
+var celeryDispatchMethods = map[string]bool{
+	"delay":       true,
+	"apply_async": true,
+}
+
+// tryEmitCeleryDispatch handles a Celery task dispatch
+// (`task.delay(...)`, `mod.task.apply_async(...)`) by emitting a calls edge
+// from the enclosing symbol to the task function (the dispatch call's
+// receiver) at convention confidence (0.9): the edge is inferred from the
+// dispatch convention, never certain, so it is never stamped 1.0. The dispatch
+// API is itself the structural task marker — no task-name convention.
+//
+// fn is the call's `function` node, already known to be an `attribute`. The
+// receiver must be an identifier (`task`) or a dotted attribute (`mod.task`);
+// a dynamic receiver (a call/subscript such as `task.s(x).apply_async()`)
+// cannot be tied to a task statically, so no edge is emitted rather than a
+// guessed one.
+//
+// Safety of the receiver guess is empirical, not structural, exactly as in the
+// Ruby analog: the dispatch API names (delay/apply_async) are near-unique to
+// Celery, so a `name.delay(...)` whose `name` is not a task is vanishingly
+// rare. When it does happen and `name` resolves to an unrelated symbol, the
+// edge points there at 0.9 — a wrong edge; when `name` resolves to nothing the
+// edge simply drops at resolution. We accept that residual risk because the
+// dispatch-API names make it negligible in practice.
+//
+// Returns handled=true when the call was a task dispatch, so the caller skips
+// the (unresolvable `….apply_async`) default edge it would otherwise emit.
+func (w *walker) tryEmitCeleryDispatch(fn *sitter.Node, source string, line int) (bool, error) {
+	if !celeryDispatchMethods[attrLastSegment(fn, w.source)] {
+		return false, nil
+	}
+	target := ""
+	if recv := fn.ChildByFieldName("object"); recv != nil {
+		switch recv.Kind() {
+		case "identifier":
+			target = extract.Text(recv, w.source)
+		case "attribute":
+			target = attrLastSegment(recv, w.source)
+		}
+	}
+	if target == "" {
+		return false, nil
+	}
+	return true, w.emit.Edge(extract.EmittedEdge{
+		SourceQualified: source,
+		TargetQualified: target,
+		Kind:            model.EdgeCalls,
+		Line:            &line,
+		Confidence:      extract.ConfidenceConvention,
+	})
+}

--- a/internal/extract/python/celery_test.go
+++ b/internal/extract/python/celery_test.go
@@ -1,0 +1,76 @@
+package python
+
+import "testing"
+
+// These tests exercise Celery async-dispatch edge resolution: a call to
+// `task.delay(...)` / `task.apply_async(...)` emits a calls edge to the task
+// function (the receiver), never to the dispatch method.
+
+func TestCeleryDelayEmitsTaskEdge(t *testing.T) {
+	r := parse(t, `def enqueue():
+    send_email.delay("a@b.co")
+`)
+	e := findEdge(r, "enqueue", "send_email", "calls")
+	if e == nil {
+		t.Fatal("expected calls edge enqueue -> send_email for .delay dispatch")
+	}
+	if e.Confidence != 0.9 {
+		t.Errorf("celery dispatch confidence = %v, want 0.9 (convention)", e.Confidence)
+	}
+	if findEdge(r, "enqueue", "delay", "calls") != nil {
+		t.Error("must not emit an edge to the dispatch method `delay`")
+	}
+}
+
+func TestCeleryApplyAsyncEmitsTaskEdge(t *testing.T) {
+	r := parse(t, `def enqueue(order_id):
+    process_payment.apply_async(args=[order_id])
+`)
+	if findEdge(r, "enqueue", "process_payment", "calls") == nil {
+		t.Fatal("expected calls edge enqueue -> process_payment for .apply_async dispatch")
+	}
+	if findEdge(r, "enqueue", "apply_async", "calls") != nil {
+		t.Error("must not emit an edge to the dispatch method `apply_async`")
+	}
+}
+
+func TestCeleryDottedReceiverUsesLastSegment(t *testing.T) {
+	// `tasks.cleanup_expired.delay()` — the task is the receiver's last segment.
+	r := parse(t, `def enqueue():
+    tasks.cleanup_expired.delay()
+`)
+	if findEdge(r, "enqueue", "cleanup_expired", "calls") == nil {
+		t.Fatal("expected calls edge enqueue -> cleanup_expired for dotted-receiver dispatch")
+	}
+}
+
+func TestCeleryNonDispatchMethodUnaffected(t *testing.T) {
+	// `.run()` is not a dispatch method: the default attribute-call edge
+	// (surface text, confidence 1.0) is emitted, no task-receiver edge at 0.9.
+	r := parse(t, `def go():
+    worker.run()
+`)
+	e := findEdge(r, "go", "worker.run", "calls")
+	if e == nil {
+		t.Fatal("expected the default attribute-call edge for a non-dispatch method")
+	}
+	if e.Confidence != 1.0 {
+		t.Errorf("default attribute-call confidence = %v, want 1.0", e.Confidence)
+	}
+	if findEdge(r, "go", "worker", "calls") != nil {
+		t.Error("non-dispatch `.run()` must not emit a task-receiver edge")
+	}
+}
+
+func TestCeleryDynamicReceiverSkipped(t *testing.T) {
+	// `task.s(x).apply_async()` — the receiver is a call, not a static task
+	// reference; no convention edge is guessed.
+	r := parse(t, `def enqueue(x):
+    task.s(x).apply_async()
+`)
+	for _, e := range r.edges {
+		if e.SourceQualified == "enqueue" && e.Confidence == 0.9 {
+			t.Errorf("unexpected convention edge for dynamic receiver: -> %v", e.TargetQualified)
+		}
+	}
+}

--- a/internal/extract/python/python.go
+++ b/internal/extract/python/python.go
@@ -366,6 +366,12 @@ func (w *walker) emitCall(call *sitter.Node, source string) error {
 		})
 	}
 
+	if kind == "attribute" {
+		if handled, err := w.tryEmitCeleryDispatch(fn, source, line); handled || err != nil {
+			return err
+		}
+	}
+
 	return w.emit.Edge(extract.EmittedEdge{
 		SourceQualified: source,
 		TargetQualified: target,


### PR DESCRIPTION
## Problem
Celery async dispatch — `task.delay(...)` and `task.apply_async(...)` — emitted no calls edge to the task function. The Python extractor recorded a call to the `.apply_async`/`.delay` method, not to the task, so `blast` and `graph` silently severed the call graph at every async boundary. In a celery-heavy codebase this hides real change-impact: e.g. `post_process_group` in Sentry had zero production callers in the index despite being dispatched from the event stream.

## Summary
Resolve a celery dispatch call to its receiver task function at convention confidence (0.9), mirroring the existing Ruby Sidekiq/ActiveJob enqueue resolution (`internal/extract/ruby/enqueue.go`).

## Changes
- New `internal/extract/python/celery.go`: `tryEmitCeleryDispatch` matches `delay`/`apply_async` on a static receiver (identifier or dotted attribute) and emits a `calls` edge to the task; a dynamic receiver (call/subscript) drops rather than guessing.
- Hook in `emitCall` skips the unresolvable method-name edge when a dispatch is handled.
- Docs: minor bench-framing wording ("the agent with/without the tool").

## Test Plan
- [x] New `celery_test.go`: dispatch by identifier, dotted receiver, non-dispatch method untouched, dynamic receiver skipped, confidence asserted (0.9)
- [x] `celery.go` at 100% coverage; per-file floor (92% line+func) holds
- [x] Full-repo scans (Sentry, Saleor): every resolved dispatch edge lands on a real `@task`-decorated function — zero false edges
- [x] `make ci` green (coverage 95.1%, lint 0, ledger 0)