### PR TITLE
fix: improve call-confidence and orientation accuracy

### DIFF
--- a/internal/extract/python/celery_test.go
+++ b/internal/extract/python/celery_test.go
@@ -1,6 +1,10 @@
 package python
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/luuuc/sense/internal/extract"
+)
 
 // These tests exercise Celery async-dispatch edge resolution: a call to
 // `task.delay(...)` / `task.apply_async(...)` emits a calls edge to the task
@@ -46,7 +50,10 @@ func TestCeleryDottedReceiverUsesLastSegment(t *testing.T) {
 
 func TestCeleryNonDispatchMethodUnaffected(t *testing.T) {
 	// `.run()` is not a dispatch method: the default attribute-call edge
-	// (surface text, confidence 1.0) is emitted, no task-receiver edge at 0.9.
+	// (surface text) is emitted, no task-receiver edge at 0.9. The receiver
+	// `worker` is a lowercase variable of unverified type, so the call is
+	// emitted at ConfidenceUnresolved (not 1.0) — an unknown-receiver instance
+	// call the resolver must not surface as a confident caller.
 	r := parse(t, `def go():
     worker.run()
 `)
@@ -54,8 +61,8 @@ func TestCeleryNonDispatchMethodUnaffected(t *testing.T) {
 	if e == nil {
 		t.Fatal("expected the default attribute-call edge for a non-dispatch method")
 	}
-	if e.Confidence != 1.0 {
-		t.Errorf("default attribute-call confidence = %v, want 1.0", e.Confidence)
+	if e.Confidence != extract.ConfidenceUnresolved {
+		t.Errorf("default attribute-call confidence = %v, want %v (unverified receiver)", e.Confidence, extract.ConfidenceUnresolved)
 	}
 	if findEdge(r, "go", "worker", "calls") != nil {
 		t.Error("non-dispatch `.run()` must not emit a task-receiver edge")

--- a/internal/extract/python/python.go
+++ b/internal/extract/python/python.go
@@ -52,6 +52,8 @@ package python
 import (
 	"slices"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	sitter "github.com/tree-sitter/go-tree-sitter"
 
@@ -366,10 +368,12 @@ func (w *walker) emitCall(call *sitter.Node, source string) error {
 		})
 	}
 
+	conf := 1.0
 	if kind == "attribute" {
 		if handled, err := w.tryEmitCeleryDispatch(fn, source, line); handled || err != nil {
 			return err
 		}
+		conf = attrReceiverConfidence(fn, w.source)
 	}
 
 	return w.emit.Edge(extract.EmittedEdge{
@@ -377,8 +381,31 @@ func (w *walker) emitCall(call *sitter.Node, source string) error {
 		TargetQualified: target,
 		Kind:            model.EdgeCalls,
 		Line:            &line,
-		Confidence:      1.0,
+		Confidence:      conf,
 	})
+}
+
+// attrReceiverConfidence rates a `receiver.method` call by how well the
+// receiver type is known at extraction time. A `self`/`cls` receiver or a
+// Capitalized (class / constant / module-as-class) receiver stays fully
+// confident; a lowercase-variable or chained receiver is an unverified
+// instance call, emitted at ConfidenceUnresolved so the resolver's bare-name
+// fallback does not surface it as a confident caller (a bare `x.id` binding
+// to an arbitrary same-named `id`). Mirrors Ruby's resolveCallTarget, which
+// already distinguishes a constant receiver from an identifier one.
+func attrReceiverConfidence(attr *sitter.Node, src []byte) float64 {
+	obj := attr.ChildByFieldName("object")
+	if obj == nil || obj.Kind() != "identifier" {
+		return extract.ConfidenceUnresolved
+	}
+	t := extract.Text(obj, src)
+	if t == "self" || t == "cls" {
+		return 1.0
+	}
+	if r, _ := utf8.DecodeRuneInString(t); unicode.IsUpper(r) {
+		return 1.0
+	}
+	return extract.ConfidenceUnresolved
 }
 
 // literalGetattrTarget returns the second argument of a `getattr` call

--- a/internal/extract/python/python_test.go
+++ b/internal/extract/python/python_test.go
@@ -1693,3 +1693,37 @@ def run(*ARGS, **KWARGS):
 		t.Error("should not emit references for **kwargs param name")
 	}
 }
+
+// TestAttrReceiverConfidence pins the emit-alignment: an attribute call is
+// rated by how well its receiver type is known. self/cls and a Capitalized
+// (class/constant) receiver stay fully confident; a lowercase-variable or
+// chained receiver is an unverified instance call at ConfidenceUnresolved, so
+// the resolver's bare-name fallback cannot surface it as a confident caller.
+func TestAttrReceiverConfidence(t *testing.T) {
+	r := parse(t, `class C:
+    def m(self):
+        self.helper()
+        Other.build()
+        obj.save()
+        a.b.run()
+`)
+	cases := []struct {
+		target string
+		want   float64
+	}{
+		{"self.helper", 1.0},
+		{"Other.build", 1.0},
+		{"obj.save", extract.ConfidenceUnresolved},
+		{"a.b.run", extract.ConfidenceUnresolved},
+	}
+	for _, c := range cases {
+		e := findEdge(r, "C.m", c.target, "calls")
+		if e == nil {
+			t.Errorf("missing calls edge to %q", c.target)
+			continue
+		}
+		if e.Confidence != c.want {
+			t.Errorf("%s confidence = %v, want %v", c.target, e.Confidence, c.want)
+		}
+	}
+}

--- a/internal/extract/testdata/javascript/calls.golden.json
+++ b/internal/extract/testdata/javascript/calls.golden.json
@@ -65,7 +65,7 @@
       "target": "obj.method",
       "kind": "calls",
       "line": 3,
-      "confidence": 1
+      "confidence": 0.5
     },
     {
       "source": "Dispatcher.mixed",
@@ -79,7 +79,7 @@
       "target": "d.greet",
       "kind": "calls",
       "line": 19,
-      "confidence": 1
+      "confidence": 0.5
     },
     {
       "source": "runner",

--- a/internal/extract/testdata/javascript/classes.golden.json
+++ b/internal/extract/testdata/javascript/classes.golden.json
@@ -129,7 +129,7 @@
       "target": "console.log",
       "kind": "calls",
       "line": 17,
-      "confidence": 1
+      "confidence": 0.5
     },
     {
       "source": "Logger.log",
@@ -143,7 +143,7 @@
       "target": "logger.log",
       "kind": "calls",
       "line": 25,
-      "confidence": 1
+      "confidence": 0.5
     },
     {
       "source": "handleData",
@@ -157,7 +157,7 @@
       "target": "emitter.on",
       "kind": "calls",
       "line": 30,
-      "confidence": 1
+      "confidence": 0.5
     }
   ]
 }

--- a/internal/extract/testdata/python/celery_tasks.golden.json
+++ b/internal/extract/testdata/python/celery_tasks.golden.json
@@ -94,7 +94,7 @@
       "target": "gateway.charge",
       "kind": "calls",
       "line": 18,
-      "confidence": 1
+      "confidence": 0.5
     },
     {
       "source": "send_email",
@@ -108,7 +108,7 @@
       "target": "mailer.send",
       "kind": "calls",
       "line": 11,
-      "confidence": 1
+      "confidence": 0.5
     }
   ]
 }

--- a/internal/extract/testdata/python/flask_blueprint.golden.json
+++ b/internal/extract/testdata/python/flask_blueprint.golden.json
@@ -65,7 +65,7 @@
       "target": "order.cancel",
       "kind": "calls",
       "line": 33,
-      "confidence": 1
+      "confidence": 0.5
     },
     {
       "source": "OrderService.cancel",
@@ -86,42 +86,42 @@
       "target": "order.save",
       "kind": "calls",
       "line": 28,
-      "confidence": 1
+      "confidence": 0.5
     },
     {
       "source": "list_orders",
       "target": "db.query",
       "kind": "calls",
       "line": 16,
-      "confidence": 1
+      "confidence": 0.5
     },
     {
       "source": "list_orders",
       "target": "db.query(Order).all",
       "kind": "calls",
       "line": 16,
-      "confidence": 1
+      "confidence": 0.5
     },
     {
       "source": "update_order",
       "target": "db.query",
       "kind": "calls",
       "line": 21,
-      "confidence": 1
+      "confidence": 0.5
     },
     {
       "source": "update_order",
       "target": "db.query(Order).get",
       "kind": "calls",
       "line": 21,
-      "confidence": 1
+      "confidence": 0.5
     },
     {
       "source": "update_order",
       "target": "order.save",
       "kind": "calls",
       "line": 22,
-      "confidence": 1
+      "confidence": 0.5
     }
   ]
 }

--- a/internal/extract/testdata/python/type_annotations_advanced.golden.json
+++ b/internal/extract/testdata/python/type_annotations_advanced.golden.json
@@ -99,7 +99,7 @@
       "target": "item.ship",
       "kind": "calls",
       "line": 24,
-      "confidence": 1
+      "confidence": 0.5
     }
   ]
 }

--- a/internal/extract/testdata/tsx/react_components.golden.json
+++ b/internal/extract/testdata/tsx/react_components.golden.json
@@ -38,7 +38,7 @@
       "target": "items.map",
       "kind": "calls",
       "line": 24,
-      "confidence": 1
+      "confidence": 0.5
     },
     {
       "source": "TestWidgetAlpha",

--- a/internal/extract/testdata/typescript/calls.golden.json
+++ b/internal/extract/testdata/typescript/calls.golden.json
@@ -56,7 +56,7 @@
       "target": "g.greet",
       "kind": "calls",
       "line": 13,
-      "confidence": 1
+      "confidence": 0.5
     },
     {
       "source": "runner",

--- a/internal/extract/testdata/typescript/conditional_types.golden.json
+++ b/internal/extract/testdata/typescript/conditional_types.golden.json
@@ -123,7 +123,7 @@
       "target": "model.serialize",
       "kind": "calls",
       "line": 28,
-      "confidence": 1
+      "confidence": 0.5
     }
   ]
 }

--- a/internal/extract/testdata/typescript/namespaces.golden.json
+++ b/internal/extract/testdata/typescript/namespaces.golden.json
@@ -80,7 +80,7 @@
       "target": "/^[a-zA-Z]+$/.test",
       "kind": "calls",
       "line": 8,
-      "confidence": 1
+      "confidence": 0.5
     },
     {
       "source": "ZipCodeValidator",
@@ -94,7 +94,7 @@
       "target": "/^\\d{5}$/.test",
       "kind": "calls",
       "line": 14,
-      "confidence": 1
+      "confidence": 0.5
     }
   ]
 }

--- a/internal/extract/tsjs/tsjs.go
+++ b/internal/extract/tsjs/tsjs.go
@@ -50,6 +50,8 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	sitter "github.com/tree-sitter/go-tree-sitter"
 
@@ -713,9 +715,13 @@ func (w *walker) emitCall(call *sitter.Node, source string) error {
 		return nil
 	}
 	var target string
+	conf := 1.0
 	switch fn.Kind() {
-	case "identifier", "member_expression":
+	case "identifier":
 		target = extract.Text(fn, w.source)
+	case "member_expression":
+		target = extract.Text(fn, w.source)
+		conf = memberReceiverConfidence(fn, w.source)
 	default:
 		return nil
 	}
@@ -729,8 +735,33 @@ func (w *walker) emitCall(call *sitter.Node, source string) error {
 		TargetQualified: target,
 		Kind:            model.EdgeCalls,
 		Line:            &line,
-		Confidence:      1.0,
+		Confidence:      conf,
 	})
+}
+
+// memberReceiverConfidence rates a `receiver.method()` call by how well the
+// receiver type is known at extraction time. `this` (resolved against the
+// enclosing class) and a Capitalized (class / namespace) receiver stay fully
+// confident; a lowercase-variable or chained receiver is an unverified
+// instance call, emitted at ConfidenceUnresolved so the resolver's bare-name
+// fallback does not surface it as a confident caller (a bare `x.id` binding to
+// an arbitrary same-named `id`). Mirrors the Python and Ruby extractors.
+func memberReceiverConfidence(member *sitter.Node, src []byte) float64 {
+	obj := member.ChildByFieldName("object")
+	if obj == nil {
+		return extract.ConfidenceUnresolved
+	}
+	if obj.Kind() == "this" {
+		return 1.0
+	}
+	if obj.Kind() != "identifier" {
+		return extract.ConfidenceUnresolved
+	}
+	t := extract.Text(obj, src)
+	if r, _ := utf8.DecodeRuneInString(t); unicode.IsUpper(r) {
+		return 1.0
+	}
+	return extract.ConfidenceUnresolved
 }
 
 // handleDefaultExport handles anonymous default exports by synthesizing

--- a/internal/extract/tsjs/tsjs_test.go
+++ b/internal/extract/tsjs/tsjs_test.go
@@ -1653,3 +1653,40 @@ function run() {
 		t.Errorf("expected 1 references edge (skip call target), got %d", edges)
 	}
 }
+
+// TestMemberReceiverConfidence pins the emit-alignment for JS/TS: a member call
+// is rated by how well its receiver type is known. `this` (resolved against the
+// enclosing class) and a Capitalized (class/namespace) receiver stay fully
+// confident; a lowercase-variable or chained receiver is an unverified instance
+// call at ConfidenceUnresolved, so bare-name fallback cannot surface it as a
+// confident caller.
+func TestMemberReceiverConfidence(t *testing.T) {
+	r := parseTS(t, `class C {
+  m() {
+    this.helper();
+    Other.build();
+    obj.save();
+    a.b.run();
+  }
+}
+`, "c.ts")
+	cases := []struct {
+		target string
+		want   float64
+	}{
+		{"helper", 1.0}, // this. is stripped
+		{"Other.build", 1.0},
+		{"obj.save", extract.ConfidenceUnresolved},
+		{"a.b.run", extract.ConfidenceUnresolved},
+	}
+	for _, c := range cases {
+		e := findEdg(r, "C.m", c.target, "calls")
+		if e == nil {
+			t.Errorf("missing calls edge to %q", c.target)
+			continue
+		}
+		if e.Confidence != c.want {
+			t.Errorf("%s confidence = %v, want %v", c.target, e.Confidence, c.want)
+		}
+	}
+}

--- a/internal/ignore/matcher.go
+++ b/internal/ignore/matcher.go
@@ -15,6 +15,11 @@ var defaultPatterns = []string{
 	"node_modules/",
 	"dist/",
 	"build/",
+	// _next/ is the Next.js build output tree (static export under out/_next,
+	// chunks named <hash>.js — not *.min.js). Committing it into a repo (e.g. a
+	// vendored dashboard) otherwise floods the index with minified-bundle
+	// symbols. The .next/ build cache is already skipped as a dot-dir.
+	"_next/",
 	"*.min.js",
 	"*.bundle.js",
 	"*.min.css",

--- a/internal/ignore/matcher_test.go
+++ b/internal/ignore/matcher_test.go
@@ -30,6 +30,30 @@ func TestBasicPatterns(t *testing.T) {
 	}
 }
 
+// TestDefaultPatternsIgnoreNextBuildOutput pins that a committed Next.js build
+// tree (the litellm dashboard: out/_next/static/chunks/<hash>.js — a dir named
+// _next, chunks NOT named *.min.js) is excluded by the built-in defaults, while
+// a real source file under an unrelated path is not.
+func TestDefaultPatternsIgnoreNextBuildOutput(t *testing.T) {
+	m := New(DefaultPatterns()...)
+	tests := []struct {
+		path  string
+		isDir bool
+		want  bool
+	}{
+		{"litellm/proxy/_experimental/out/_next", true, true},
+		{"litellm/proxy/_experimental/out/_next/static/chunks/496b84010c33cf69.js", false, true},
+		{"node_modules/react/index.js", false, true},
+		{"litellm/proxy/main.py", false, false},
+		{"ui/src/components/Foo.tsx", false, false},
+	}
+	for _, tt := range tests {
+		if got := m.Match(tt.path, tt.isDir); got != tt.want {
+			t.Errorf("Match(%q, dir=%v) = %v, want %v", tt.path, tt.isDir, got, tt.want)
+		}
+	}
+}
+
 func TestNegation(t *testing.T) {
 	m := New("*.log", "!important.log")
 	if m.Match("debug.log", false) != true {
@@ -214,7 +238,7 @@ func TestDefaultPatterns(t *testing.T) {
 		t.Error("DefaultPatterns must return a defensive copy")
 	}
 	want := map[string]bool{
-		"vendor/": true, "node_modules/": true, "dist/": true, "build/": true,
+		"vendor/": true, "node_modules/": true, "dist/": true, "build/": true, "_next/": true,
 		"*.min.js": true, "*.bundle.js": true, "*.min.css": true,
 	}
 	for _, p := range again {

--- a/internal/summary/render_test.go
+++ b/internal/summary/render_test.go
@@ -3,6 +3,7 @@ package summary
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -129,6 +130,74 @@ func seedTestDB(t *testing.T) (*sql.DB, func()) {
 		t.Fatalf("sql.Open: %v", err)
 	}
 	return db, func() { _ = db.Close() }
+}
+
+// TestRenderHubSymbolsConfidenceFilter proves the hub list counts only edges at
+// or above blast's traversal floor (extract.ConfidenceUnresolved). A bare-name
+// collision target (0.3) with many incoming edges must NOT out-rank a genuinely
+// resolved target with fewer high-confidence edges — the litellm `get`-8019-callers
+// nonsense-hub bug.
+func TestRenderHubSymbolsConfidenceFilter(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "index.db")
+
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+
+	now := time.Now()
+	fid, err := adapter.WriteFile(ctx, &model.File{
+		Path: "app/models/thing.rb", Language: "ruby", Hash: "h", Symbols: 6, IndexedAt: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mkSym := func(name string) int64 {
+		id, e := adapter.WriteSymbol(ctx, &model.Symbol{
+			FileID: fid, Name: name, Qualified: name, Kind: model.KindMethod, LineStart: 1, LineEnd: 2,
+		})
+		if e != nil {
+			t.Fatal(e)
+		}
+		return id
+	}
+	// `noise` = bare-name collision target; `Real` = resolved central symbol.
+	noiseID := mkSym("noise")
+	realID := mkSym("Real")
+
+	callerN := 0
+	writeEdges := func(target int64, n int, conf float64) {
+		for i := 0; i < n; i++ {
+			callerN++
+			caller := mkSym(fmt.Sprintf("caller_%d", callerN))
+			if _, e := adapter.WriteEdge(ctx, &model.Edge{
+				SourceID: model.Int64Ptr(caller), TargetID: target,
+				Kind: model.EdgeCalls, FileID: fid, Confidence: conf,
+			}); e != nil {
+				t.Fatal(e)
+			}
+		}
+	}
+	writeEdges(noiseID, 20, 0.3) // below the 0.5 floor — must be excluded
+	writeEdges(realID, 3, 1.0)   // resolved — must appear
+
+	_ = adapter.Close()
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	got := renderHubSymbols(ctx, db)
+	if !strings.Contains(got, "`Real` (3 callers)") {
+		t.Errorf("expected resolved hub `Real` (3 callers), got: %q", got)
+	}
+	if strings.Contains(got, "noise") {
+		t.Errorf("bare-name collision target (0.3) must be excluded from hubs, got: %q", got)
+	}
 }
 
 func TestRenderFingerprint(t *testing.T) {

--- a/internal/summary/summary.go
+++ b/internal/summary/summary.go
@@ -16,6 +16,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/luuuc/sense/internal/extract"
 	"github.com/luuuc/sense/internal/sqlite"
 	"github.com/luuuc/sense/internal/version"
 )
@@ -654,6 +655,9 @@ func renderQuickOrientation(ctx context.Context, db *sql.DB) (string, error) {
 }
 
 func renderEntryPoints(ctx context.Context, db *sql.DB) string {
+	// NB: unlike renderHubSymbols, this does not confidence-filter its edges yet;
+	// its dominant noise source is build-artifact symbols (minified JS bundles),
+	// addressed at the scanner layer, not here.
 	rows, err := db.QueryContext(ctx, `
 		WITH outgoing AS (
 			SELECT source_id, COUNT(*) AS cnt
@@ -693,14 +697,20 @@ func renderEntryPoints(ctx context.Context, db *sql.DB) string {
 }
 
 func renderHubSymbols(ctx context.Context, db *sql.DB) string {
+	// Count only edges at or above blast's traversal floor. Bare-name
+	// collision guesses (ConfidenceNameCollision, 0.3) are deliberately below
+	// it so impact analysis ignores them; counting them here manufactured
+	// nonsense hubs (a generic `get`/`patch`/`items` collecting thousands of
+	// unresolved-receiver `.get()` calls), contradicting what blast/graph show.
 	rows, err := db.QueryContext(ctx, `
 		SELECT s.qualified, COUNT(e.id) as callers
 		FROM sense_symbols s
 		JOIN sense_edges e ON e.target_id = s.id
 		WHERE e.kind IN ('calls', 'references')
+		  AND e.confidence >= ?
 		GROUP BY s.id
 		ORDER BY callers DESC
-		LIMIT 5`)
+		LIMIT 5`, extract.ConfidenceUnresolved)
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
## Problem
Three inaccuracies in the index misled an AI reading Sense's output:
1. Summary "hub symbols" counted low-confidence bare-name collision edges that
   the resolver keeps below blast's floor, manufacturing nonsense hubs (a generic
   `get` reported with 8019 callers).
2. Committed Next.js build output (`_next/`) was indexed as source, flooding the
   index with thousands of minified-bundle symbols and polluting orientation
   (they even surfaced as "entry points").
3. The Python and JS/TS extractors emitted every attribute/member call at full
   confidence even when the receiver type was unknown, so an unverified `x.save()`
   was surfaced as a confident caller and could bind to an arbitrary same-named
   symbol.

## Summary
Three targeted accuracy fixes to the summary, scanner, and extractors so Sense's
orientation and edge confidence reflect what it actually resolved.

## Changes
- **summary**: hub-symbol ranking now counts only edges at or above blast's
  confidence floor (`ConfidenceUnresolved`), so bare-name collision guesses no
  longer manufacture nonsense hubs. Language-neutral.
- **scan**: add `_next/` to the default ignore patterns. Next.js build output is a
  directory named `_next` whose chunks are `<hash>.js` (not `*.min.js`), so it
  escaped the existing filters. Removes the minified-bundle symbols with no
  collateral on real source (the Next.js source repo itself has no `_next/`).
- **extract (python, tsjs)**: rate an attribute/member call by receiver knownness.
  `self`/`cls`/`this` and Capitalized (class/constant) receivers stay fully
  confident; a lowercase-variable or chained (unverified) receiver emits at the
  unresolved-confidence tier, mirroring the Ruby extractor's existing
  constant-vs-identifier distinction. 9 golden fixtures regenerated
  (confidence-only diffs).

## Architecture Highlights
- The extract change re-rates emission only; it is the first, foundational step of
  a broader effort to make call-edge confidence reflect receiver certainty, and
  deliberately does not yet demote or drop generic-name guesses (a follow-up that
  requires benchmark calibration).
- The two receiver helpers are kept duplicated in the `python` and `tsjs` packages
  by design, since the receiver node shapes differ (`self` identifier vs `this`
  node), rather than hoisted into a shared helper.

## Test Plan
- [x] Behavior-named unit tests per fix: hub confidence filter, `_next` match +
      negative cases (real source not matched), receiver-confidence table
      (self/Constant to full; lowercase/chain to unresolved).
- [x] 9 golden fixtures regenerated; confidence-only diffs verified as correct
      demotions (`order.save`, `db.query`, `obj.method`, `d.greet`).
- [x] Benched on the frontier model (Opus 4.8, x2) across four repositories: no
      cited-recall regression. Three held or improved; the fourth's dip in the
      dependent-recall metric is run-to-run variance, structurally confirmed not
      caused by this change (its gold dependents connect via reference edges this
      change does not touch).
- [x] `make ci` green (per-file coverage >=92%, lint, complexity ledger 0).
- [x] sense binary builds cleanly.
