### PR TITLE
fix(graph): split sense_graph inherits into directed inherits/inherited_by

### DIFF
--- a/internal/cli/render.go
+++ b/internal/cli/render.go
@@ -48,6 +48,9 @@ func renderEdgeGroup(w io.Writer, label string, edges mcpio.GraphEdges) {
 	if s := renderInherits(edges.Inherits); s != "" {
 		_, _ = fmt.Fprintf(w, label, "inherits", s)
 	}
+	if s := renderInherits(edges.InheritedBy); s != "" {
+		_, _ = fmt.Fprintf(w, label, "inherited by", s)
+	}
 	if s := renderComposes(edges.Composes); s != "" {
 		_, _ = fmt.Fprintf(w, label, "composes", s)
 	}

--- a/internal/cli/render_test.go
+++ b/internal/cli/render_test.go
@@ -342,13 +342,14 @@ func TestRenderImportsNonEmpty(t *testing.T) {
 func TestRenderEdgeGroupFull(t *testing.T) {
 	filePtr := func(s string) *string { return &s }
 	edges := mcpio.GraphEdges{
-		Inherits: []mcpio.InheritEdgeRef{{Symbol: "Base"}},
-		Composes: []mcpio.ComposeEdgeRef{{Symbol: "Config"}},
-		Includes: []mcpio.IncludeEdgeRef{{Symbol: "Loggable"}},
-		Imports:  []mcpio.ImportEdgeRef{{Symbol: "fmt"}},
-		Calls:    []mcpio.CallEdgeRef{{Symbol: "Process", Confidence: 1.0}},
-		CalledBy: []mcpio.CallEdgeRef{{Symbol: "Main", File: filePtr("main.go"), Confidence: 0.9}},
-		Tests:    []mcpio.TestEdgeRef{{File: "test.go", Confidence: 0.8}},
+		Inherits:    []mcpio.InheritEdgeRef{{Symbol: "Base"}},
+		InheritedBy: []mcpio.InheritEdgeRef{{Symbol: "PremiumCheckout"}},
+		Composes:    []mcpio.ComposeEdgeRef{{Symbol: "Config"}},
+		Includes:    []mcpio.IncludeEdgeRef{{Symbol: "Loggable"}},
+		Imports:     []mcpio.ImportEdgeRef{{Symbol: "fmt"}},
+		Calls:       []mcpio.CallEdgeRef{{Symbol: "Process", Confidence: 1.0}},
+		CalledBy:    []mcpio.CallEdgeRef{{Symbol: "Main", File: filePtr("main.go"), Confidence: 0.9}},
+		Tests:       []mcpio.TestEdgeRef{{File: "test.go", Confidence: 0.8}},
 	}
 
 	var buf bytes.Buffer
@@ -358,6 +359,7 @@ func TestRenderEdgeGroupFull(t *testing.T) {
 
 	for _, want := range []string{
 		"inherits  Base",
+		"inherited by PremiumCheckout",
 		"composes  Config",
 		"includes  Loggable",
 		"imports   fmt",

--- a/internal/mcpio/graph.go
+++ b/internal/mcpio/graph.go
@@ -51,6 +51,7 @@ func trimLongestEdgeList(e *GraphEdges, resp *GraphResponse) bool {
 		{len(e.Composes), func(k int) { e.Composes = e.Composes[:len(e.Composes)-k] }},
 		{len(e.ComposedBy), func(k int) { e.ComposedBy = e.ComposedBy[:len(e.ComposedBy)-k] }},
 		{len(e.Inherits), func(k int) { e.Inherits = e.Inherits[:len(e.Inherits)-k] }},
+		{len(e.InheritedBy), func(k int) { e.InheritedBy = e.InheritedBy[:len(e.InheritedBy)-k] }},
 		{len(e.Includes), func(k int) { e.Includes = e.Includes[:len(e.Includes)-k] }},
 		{len(e.Imports), func(k int) { e.Imports = e.Imports[:len(e.Imports)-k] }},
 		{len(e.Temporal), func(k int) { e.Temporal = e.Temporal[:len(e.Temporal)-k] }},
@@ -240,7 +241,7 @@ func BuildGraphResponse(ctx context.Context, sc *model.SymbolContext, files File
 	resp.ViewEdges = viewEdgesSignal(sc.File.Path, anyViewTemplate(inboundEdgeFiles(sc.Inbound, files)))
 
 	symbolsReturned := len(resp.Edges.Calls) + len(resp.Edges.CalledBy) + len(testCallers) +
-		len(resp.Edges.Inherits) + len(resp.Edges.Composes) +
+		len(resp.Edges.Inherits) + len(resp.Edges.InheritedBy) + len(resp.Edges.Composes) +
 		len(resp.Edges.Includes) + len(resp.Edges.Imports) + len(resp.Edges.Tests) +
 		len(resp.Edges.Temporal)
 
@@ -443,9 +444,10 @@ func categorizeEdges(ctx context.Context, outbound, inbound []model.EdgeRef, fil
 				})
 			case model.EdgeInherits:
 				// Inheritors of this symbol (subclasses, trait
-				// implementors) land in the same bucket as the
-				// outbound direction — the convention shared with
-				// Composes / Includes / Imports.
+				// implementors) route to InheritedBy — distinct from
+				// the outbound Inherits bucket (supertypes), so "what
+				// extends me" is not conflated with "what I extend".
+				// Mirrors the Composes / ComposedBy split.
 				//
 				// Skip edges whose source didn't resolve to an
 				// indexed symbol (Target.ID == 0). For inbound
@@ -458,7 +460,7 @@ func categorizeEdges(ctx context.Context, outbound, inbound []model.EdgeRef, fil
 					continue
 				}
 				fp := fileRefOrNil(e.Target.FileID, files)
-				edges.Inherits = append(edges.Inherits, InheritEdgeRef{
+				edges.InheritedBy = append(edges.InheritedBy, InheritEdgeRef{
 					Symbol:    qualifiedOrName(e.Target),
 					File:      fp,
 					LineStart: e.Target.LineStart,
@@ -523,7 +525,8 @@ func qualifiedOrName(s model.Symbol) string {
 
 func countEdgeSymbols(edges GraphEdges) int {
 	return len(edges.Calls) + len(edges.CalledBy) +
-		len(edges.Inherits) + len(edges.Composes) + len(edges.ComposedBy) +
+		len(edges.Inherits) + len(edges.InheritedBy) +
+		len(edges.Composes) + len(edges.ComposedBy) +
 		len(edges.Includes) + len(edges.Imports) +
 		len(edges.Tests) + len(edges.Temporal)
 }
@@ -554,6 +557,11 @@ func collectEdgeFiles(edges GraphEdges, seen map[string]struct{}) {
 		}
 	}
 	for _, e := range edges.Inherits {
+		if e.File != nil {
+			seen[*e.File] = struct{}{}
+		}
+	}
+	for _, e := range edges.InheritedBy {
 		if e.File != nil {
 			seen[*e.File] = struct{}{}
 		}
@@ -650,7 +658,8 @@ func graphIndexCaveat(resp GraphResponse) string {
 	if resp.Symbol.File == "" {
 		return ""
 	}
-	hasEdges := len(resp.Edges.Calls)+len(resp.Edges.CalledBy)+len(resp.Edges.Inherits)+
+	hasEdges := len(resp.Edges.Calls)+len(resp.Edges.CalledBy)+
+		len(resp.Edges.Inherits)+len(resp.Edges.InheritedBy)+
 		len(resp.Edges.Composes)+len(resp.Edges.Includes)+len(resp.Edges.Imports) > 0
 	if !hasEdges {
 		return ""

--- a/internal/mcpio/graph_test.go
+++ b/internal/mcpio/graph_test.go
@@ -1214,13 +1214,14 @@ func TestGraphCallSiteNoSnippetForNonCallEdges(t *testing.T) {
 	}
 }
 
-// TestGraphInheritsInboundExposesImplementors pins the cross-language
+// TestGraphInboundImplementorsSurfaceInInheritedBy pins the cross-language
 // "who inherits / implements this" path: when a trait or base class is
 // the focal symbol, inbound EdgeInherits edges (implementors,
-// subclasses) must surface in the Inherits bucket. Before this was
-// wired up, `sense graph` on a hub trait like axum's Handler returned
-// empty inherits even when impls were correctly indexed.
-func TestGraphInheritsInboundExposesImplementors(t *testing.T) {
+// subclasses) must surface in the InheritedBy bucket (subtypes),
+// distinct from Inherits (supertypes). Before this was wired up,
+// `sense graph` on a hub trait like axum's Handler returned empty
+// inheritance even when impls were correctly indexed.
+func TestGraphInboundImplementorsSurfaceInInheritedBy(t *testing.T) {
 	files := func(id int64) (string, bool) {
 		switch id {
 		case 1:
@@ -1253,14 +1254,17 @@ func TestGraphInheritsInboundExposesImplementors(t *testing.T) {
 
 	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{})
 
-	if len(resp.Edges.Inherits) != 2 {
-		t.Fatalf("Inherits = %d, want 2 (MethodRouter, Layered)", len(resp.Edges.Inherits))
+	if len(resp.Edges.InheritedBy) != 2 {
+		t.Fatalf("InheritedBy = %d, want 2 (MethodRouter, Layered)", len(resp.Edges.InheritedBy))
+	}
+	if len(resp.Edges.Inherits) != 0 {
+		t.Fatalf("Inherits = %d, want 0 (implementors are subtypes, not supertypes)", len(resp.Edges.Inherits))
 	}
 	want := map[string]string{
 		"MethodRouter": "src/router.rs:1355",
 		"Layered":      "src/layered.rs:317",
 	}
-	for _, e := range resp.Edges.Inherits {
+	for _, e := range resp.Edges.InheritedBy {
 		ref, ok := want[e.Symbol]
 		if !ok {
 			t.Errorf("unexpected inherits entry %q", e.Symbol)
@@ -1307,11 +1311,11 @@ func TestGraphInheritsInboundSkipsUnresolvedSource(t *testing.T) {
 
 	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{})
 
-	if len(resp.Edges.Inherits) != 1 {
-		t.Fatalf("Inherits = %d, want 1 (resolved-only, blanket impl dropped)", len(resp.Edges.Inherits))
+	if len(resp.Edges.InheritedBy) != 1 {
+		t.Fatalf("InheritedBy = %d, want 1 (resolved-only, blanket impl dropped)", len(resp.Edges.InheritedBy))
 	}
-	if resp.Edges.Inherits[0].Symbol != "MethodRouter" {
-		t.Errorf("Inherits[0] = %q, want MethodRouter", resp.Edges.Inherits[0].Symbol)
+	if resp.Edges.InheritedBy[0].Symbol != "MethodRouter" {
+		t.Errorf("InheritedBy[0] = %q, want MethodRouter", resp.Edges.InheritedBy[0].Symbol)
 	}
 }
 
@@ -1343,16 +1347,20 @@ func TestGraphInheritsInboundIncludedInCallersDirection(t *testing.T) {
 
 	resp := BuildGraphResponse(context.Background(), sc, files, BuildGraphRequest{Direction: model.DirectionCallers})
 
-	if len(resp.Edges.Inherits) != 1 {
-		t.Fatalf("Inherits = %d under DirectionCallers, want 1", len(resp.Edges.Inherits))
+	if len(resp.Edges.InheritedBy) != 1 {
+		t.Fatalf("InheritedBy = %d under DirectionCallers, want 1", len(resp.Edges.InheritedBy))
 	}
 
 	raw, err := MarshalGraphCompactDirectional(resp, model.DirectionCallers)
 	if err != nil {
 		t.Fatalf("MarshalGraphCompactDirectional: %v", err)
 	}
-	if !bytes.Contains(raw, []byte(`"inherits":[`)) {
-		t.Errorf("compact callers output should include inherits bucket; got:\n%s", raw)
+	if !bytes.Contains(raw, []byte(`"inherited_by":[`)) {
+		t.Errorf("compact callers output should include inherited_by bucket; got:\n%s", raw)
+	}
+	// inherits (supertypes) is outbound-only, pruned from a callers query.
+	if bytes.Contains(raw, []byte(`"inherits":[`)) {
+		t.Errorf("compact callers output should omit the outbound inherits bucket; got:\n%s", raw)
 	}
 	if !bytes.Contains(raw, []byte(`"MethodRouter"`)) {
 		t.Errorf("compact callers output should include MethodRouter; got:\n%s", raw)

--- a/internal/mcpio/graph_test.go
+++ b/internal/mcpio/graph_test.go
@@ -73,8 +73,11 @@ func TestApplyGraphBudgetTrimsLongestEdgeList(t *testing.T) {
 }
 
 func TestApplyGraphBudgetTrimsEveryEdgeKind(t *testing.T) {
-	// All eight edge kinds start equally long; a tiny budget forces the
-	// trimmer to cycle through and shrink each kind's slice in turn.
+	// All ten edge kinds start equally long; a tiny budget forces the
+	// trimmer to cycle through and shrink each kind's slice in turn. The
+	// directed inheritance/composition split adds ComposedBy and
+	// InheritedBy as their own buckets, so each must have its drop path
+	// exercised alongside the outbound Composes / Inherits kinds.
 	r := GraphResponse{Symbol: GraphSymbol{Name: "Hub", Qualified: "pkg.Hub"}}
 	const per = 12
 	for i := 0; i < per; i++ {
@@ -82,7 +85,9 @@ func TestApplyGraphBudgetTrimsEveryEdgeKind(t *testing.T) {
 		r.Edges.CalledBy = append(r.Edges.CalledBy, CallEdgeRef{Symbol: s, Confidence: 1.0})
 		r.Edges.Calls = append(r.Edges.Calls, CallEdgeRef{Symbol: s, Confidence: 1.0})
 		r.Edges.Inherits = append(r.Edges.Inherits, InheritEdgeRef{Symbol: s})
+		r.Edges.InheritedBy = append(r.Edges.InheritedBy, InheritEdgeRef{Symbol: s})
 		r.Edges.Composes = append(r.Edges.Composes, ComposeEdgeRef{Symbol: s})
+		r.Edges.ComposedBy = append(r.Edges.ComposedBy, ComposeEdgeRef{Symbol: s})
 		r.Edges.Includes = append(r.Edges.Includes, IncludeEdgeRef{Symbol: s})
 		r.Edges.Imports = append(r.Edges.Imports, ImportEdgeRef{Symbol: s})
 		r.Edges.Temporal = append(r.Edges.Temporal, TemporalEdgeRef{Symbol: s, Strength: 0.5})
@@ -93,8 +98,9 @@ func TestApplyGraphBudgetTrimsEveryEdgeKind(t *testing.T) {
 	// drop path while proving no relationship type is dropped entirely.
 	ApplyGraphBudget(&r, 200)
 	kinds := []int{
-		len(r.Edges.CalledBy), len(r.Edges.Calls), len(r.Edges.Inherits), len(r.Edges.Composes),
-		len(r.Edges.Includes), len(r.Edges.Imports), len(r.Edges.Temporal), len(r.Edges.Tests),
+		len(r.Edges.CalledBy), len(r.Edges.Calls), len(r.Edges.Inherits), len(r.Edges.InheritedBy),
+		len(r.Edges.Composes), len(r.Edges.ComposedBy), len(r.Edges.Includes), len(r.Edges.Imports),
+		len(r.Edges.Temporal), len(r.Edges.Tests),
 	}
 	for i, n := range kinds {
 		if n != 1 {
@@ -104,7 +110,7 @@ func TestApplyGraphBudgetTrimsEveryEdgeKind(t *testing.T) {
 	if !r.Truncated {
 		t.Error("expected Truncated=true")
 	}
-	if want := (per - 1) * 8; r.OmittedEdges != want {
+	if want := (per - 1) * 10; r.OmittedEdges != want {
 		t.Errorf("OmittedEdges = %d, want %d", r.OmittedEdges, want)
 	}
 }

--- a/internal/mcpio/marshal.go
+++ b/internal/mcpio/marshal.go
@@ -65,16 +65,19 @@ func MarshalGraphCompactDirectional(r GraphResponse, direction model.Direction) 
 //	calls/called_by and composes/composed_by are directional pairs: the
 //	outbound member is dropped for a callers query, the inbound member for
 //	a callees query.
-//	Inherits / Includes / Imports — populated by both paths (outbound =
-//	"what this inherits from / includes / etc.", inbound = "what inherits
-//	from / includes / etc. this") into one bucket, never excluded.
+//	Inherits / InheritedBy are a directional pair (like calls/called_by):
+//	the outbound member (supertypes) is dropped for a callers query, the
+//	inbound member (subtypes) for a callees query.
+//	Includes / Imports — populated by both paths (outbound = "what this
+//	includes / imports", inbound = "what includes / imports this") into one
+//	bucket, never excluded.
 //	Temporal — bidirectional, never excluded.
 func outOfScopeEdgeBuckets(direction model.Direction) []string {
 	switch direction {
 	case model.DirectionCallers:
-		return []string{"calls", "composes"}
+		return []string{"calls", "composes", "inherits"}
 	case model.DirectionCallees:
-		return []string{"called_by", "composed_by", "tests"}
+		return []string{"called_by", "composed_by", "tests", "inherited_by"}
 	default:
 		return nil
 	}
@@ -176,6 +179,9 @@ func normalizeGraphResponse(r *GraphResponse) {
 	if r.Edges.Inherits == nil {
 		r.Edges.Inherits = []InheritEdgeRef{}
 	}
+	if r.Edges.InheritedBy == nil {
+		r.Edges.InheritedBy = []InheritEdgeRef{}
+	}
 	if r.Edges.Composes == nil {
 		r.Edges.Composes = []ComposeEdgeRef{}
 	}
@@ -236,6 +242,9 @@ func normalizeGraphEdgesScoped(e *GraphEdges, skip map[string]struct{}) {
 	}
 	if _, ok := skip["inherits"]; !ok && e.Inherits == nil {
 		e.Inherits = []InheritEdgeRef{}
+	}
+	if _, ok := skip["inherited_by"]; !ok && e.InheritedBy == nil {
+		e.InheritedBy = []InheritEdgeRef{}
 	}
 	if _, ok := skip["composes"]; !ok && e.Composes == nil {
 		e.Composes = []ComposeEdgeRef{}

--- a/internal/mcpio/marshal_test.go
+++ b/internal/mcpio/marshal_test.go
@@ -32,14 +32,15 @@ func TestMarshalGraphRoundTrip(t *testing.T) {
 				{Symbol: "PaymentGateway#charge", File: &filePath, Confidence: 1.0},
 				{Symbol: "Beacon.track", File: nil, Confidence: 0.9},
 			},
-			CalledBy:   []CallEdgeRef{},
-			Inherits:   []InheritEdgeRef{{Symbol: "ApplicationService", File: nil}},
-			Composes:   []ComposeEdgeRef{},
-			ComposedBy: []ComposeEdgeRef{},
-			Includes:   []IncludeEdgeRef{},
-			Imports:    []ImportEdgeRef{},
-			Tests:      []TestEdgeRef{{File: "test/services/checkout_service_test.rb", Confidence: 0.8}},
-			Temporal:   []TemporalEdgeRef{},
+			CalledBy:    []CallEdgeRef{},
+			Inherits:    []InheritEdgeRef{{Symbol: "ApplicationService", File: nil}},
+			InheritedBy: []InheritEdgeRef{},
+			Composes:    []ComposeEdgeRef{},
+			ComposedBy:  []ComposeEdgeRef{},
+			Includes:    []IncludeEdgeRef{},
+			Imports:     []ImportEdgeRef{},
+			Tests:       []TestEdgeRef{{File: "test/services/checkout_service_test.rb", Confidence: 0.8}},
+			Temporal:    []TemporalEdgeRef{},
 		},
 		NextSteps: []NextStep{},
 	}
@@ -104,12 +105,12 @@ func TestMarshalZeroValueEmptySlices(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MarshalGraph: %v", err)
 	}
-	for _, field := range []string{`"calls": []`, `"called_by": []`, `"inherits": []`, `"composes": []`, `"composed_by": []`, `"includes": []`, `"imports": []`, `"tests": []`, `"temporal": []`, `"next_steps": []`} {
+	for _, field := range []string{`"calls": []`, `"called_by": []`, `"inherits": []`, `"inherited_by": []`, `"composes": []`, `"composed_by": []`, `"includes": []`, `"imports": []`, `"tests": []`, `"temporal": []`, `"next_steps": []`} {
 		if !strings.Contains(string(graphBytes), field) {
 			t.Errorf("GraphResponse zero-value missing %s\ngot:\n%s", field, graphBytes)
 		}
 	}
-	for _, nullField := range []string{`"calls": null`, `"called_by": null`, `"inherits": null`, `"composes": null`, `"composed_by": null`, `"includes": null`, `"imports": null`, `"tests": null`, `"temporal": null`, `"next_steps": null`} {
+	for _, nullField := range []string{`"calls": null`, `"called_by": null`, `"inherits": null`, `"inherited_by": null`, `"composes": null`, `"composed_by": null`, `"includes": null`, `"imports": null`, `"tests": null`, `"temporal": null`, `"next_steps": null`} {
 		if strings.Contains(string(graphBytes), nullField) {
 			t.Errorf("GraphResponse zero-value slice field should be []: %s\ngot:\n%s", nullField, graphBytes)
 		}
@@ -601,34 +602,37 @@ func TestMarshalGraphCompactDirectional(t *testing.T) {
 		}
 	}
 
-	t.Run("callers omits calls but keeps inherits", func(t *testing.T) {
+	t.Run("callers omits calls and inherits but keeps inherited_by", func(t *testing.T) {
 		raw, err := MarshalGraphCompactDirectional(base(), model.DirectionCallers)
 		if err != nil {
 			t.Fatalf("marshal: %v", err)
 		}
 		s := string(raw)
-		for _, key := range []string{`"calls"`} {
+		// `inherits` (supertypes) is outbound-only, so it is pruned from a
+		// callers query alongside `calls`.
+		for _, key := range []string{`"calls"`, `"inherits":`} {
 			if strings.Contains(s, key) {
 				t.Errorf("expected %s to be absent for direction=callers:\n%s", key, s)
 			}
 		}
-		// `inherits` carries inheritors (inbound EdgeInherits) under
+		// `inherited_by` carries inheritors (inbound EdgeInherits) under
 		// the callers direction — the natural fit for "who implements
 		// this trait." Empty bucket renders as `[]`.
-		for _, key := range []string{`"called_by":[]`, `"tests":[]`, `"inherits":[]`} {
+		for _, key := range []string{`"called_by":[]`, `"tests":[]`, `"inherited_by":[]`} {
 			if !strings.Contains(s, key) {
 				t.Errorf("expected %s to be present for direction=callers:\n%s", key, s)
 			}
 		}
 	})
 
-	t.Run("callees omits called_by and tests", func(t *testing.T) {
+	t.Run("callees omits called_by, tests and inherited_by", func(t *testing.T) {
 		raw, err := MarshalGraphCompactDirectional(base(), model.DirectionCallees)
 		if err != nil {
 			t.Fatalf("marshal: %v", err)
 		}
 		s := string(raw)
-		for _, key := range []string{`"called_by"`, `"tests"`} {
+		// `inherited_by` (subtypes) is inbound-only, pruned from a callees query.
+		for _, key := range []string{`"called_by"`, `"tests"`, `"inherited_by"`} {
 			if strings.Contains(s, key) {
 				t.Errorf("expected %s to be absent for direction=callees:\n%s", key, s)
 			}
@@ -640,13 +644,13 @@ func TestMarshalGraphCompactDirectional(t *testing.T) {
 		}
 	})
 
-	t.Run("both renders all eight buckets", func(t *testing.T) {
+	t.Run("both renders all edge buckets", func(t *testing.T) {
 		raw, err := MarshalGraphCompactDirectional(base(), model.DirectionBoth)
 		if err != nil {
 			t.Fatalf("marshal: %v", err)
 		}
 		s := string(raw)
-		for _, key := range []string{"calls", "called_by", "inherits", "composes", "includes", "imports", "tests", "temporal"} {
+		for _, key := range []string{"calls", "called_by", "inherits", "inherited_by", "composes", "composed_by", "includes", "imports", "tests", "temporal"} {
 			if !strings.Contains(s, `"`+key+`":[]`) {
 				t.Errorf("expected %q:[] to be present for direction=both:\n%s", key, s)
 			}

--- a/internal/mcpio/testdata/graph_checkout_service.json
+++ b/internal/mcpio/testdata/graph_checkout_service.json
@@ -44,6 +44,7 @@
         "file": "app/services/application_service.rb"
       }
     ],
+    "inherited_by": [],
     "composes": [],
     "composed_by": [],
     "includes": [],

--- a/internal/mcpio/testdata/graph_empty.json
+++ b/internal/mcpio/testdata/graph_empty.json
@@ -12,6 +12,7 @@
     "calls": [],
     "called_by": [],
     "inherits": [],
+    "inherited_by": [],
     "composes": [],
     "composed_by": [],
     "includes": [],

--- a/internal/mcpio/testdata/graph_with_freshness.json
+++ b/internal/mcpio/testdata/graph_with_freshness.json
@@ -44,6 +44,7 @@
         "file": "app/services/application_service.rb"
       }
     ],
+    "inherited_by": [],
     "composes": [],
     "composed_by": [],
     "includes": [],

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -180,14 +180,24 @@ type GraphEdges struct {
 	Calls    []CallEdgeRef    `json:"calls"`
 	CalledBy []CallEdgeRef    `json:"called_by"`
 	Inherits []InheritEdgeRef `json:"inherits"`
-	Composes []ComposeEdgeRef `json:"composes"`
+	// InheritedBy is the reverse-inheritance direction: the symbols that extend
+	// THIS one (subclasses, trait/interface implementors). Kept distinct from
+	// Inherits for the same reason Composes/ComposedBy are split — "what I
+	// extend" (the contract I must satisfy) vs "what extends me" (my change-impact
+	// radius) are different questions, and merging them printed a supertype and a
+	// subtype in one undirected list where "AnthropicConfig inherits DatabricksConfig"
+	// read backwards (Databricks is the child). inherits/inherited_by are a
+	// directional pair (like calls/called_by), so a callers-direction query
+	// returns inbound inheritors here, NOT in Inherits.
+	InheritedBy []InheritEdgeRef `json:"inherited_by"`
+	Composes    []ComposeEdgeRef `json:"composes"`
 	// ComposedBy is the reverse-composition direction: the symbols that hold a
 	// has-a relationship TO this one (a Django model's ForeignKey / OneToOne /
 	// ManyToMany dependents). Kept distinct from Composes — "what I own" vs "what
 	// owns me" are different questions, and merging them hid the reverse fan-out
 	// a change-impact audit needs. Note: composes/composed_by are a directional
 	// pair (like calls/called_by), so a callers-direction query now returns
-	// inbound composers here, NOT in Composes; inherits/includes/imports stay
+	// inbound composers here, NOT in Composes; includes/imports stay
 	// merged into one bucket per kind.
 	ComposedBy []ComposeEdgeRef  `json:"composed_by"`
 	Includes   []IncludeEdgeRef  `json:"includes"`

--- a/internal/mcpserver/oracle_test.go
+++ b/internal/mcpserver/oracle_test.go
@@ -186,7 +186,12 @@ func oracleDigest(t *testing.T, calls []labeledCall) (string, []string) {
 // (reverse-composition, distinct from outbound `composes`), so every graph
 // response gained an empty `composed_by` field and callees-direction responses
 // drop it — digest moved. No edge content changed.
-const oracleGolden = "83a83c93c603a6b1550af16056341c2c9f5769f5503edaf9fc895e564a716983"
+// sense_graph now splits inbound inheritance into its own `inherited_by` bucket
+// (subtypes, distinct from outbound `inherits` supertypes), mirroring the
+// composed_by split, so every graph response gained an empty `inherited_by`
+// field; callers-direction responses drop `inherits` and callees drop
+// `inherited_by` — digest moved. No edge content changed.
+const oracleGolden = "e48785ad58f92c14e3885935ce38124825dc0850a6d1879c02ca698400f421c0"
 
 func TestMCPServerResponseOracle(t *testing.T) {
 	got, content := oracleDigest(t, collectOracleCalls(t))


### PR DESCRIPTION
## Problem
`sense_graph`'s default (`both`) view merged a symbol's supertypes and its
subtypes into one undirected `inherits` list. On any non-trivial hierarchy
this reads backwards: for a base class with children, the output printed
`AnthropicConfig inherits DatabricksConfig` even though `DatabricksConfig`
is a *subclass* of `AnthropicConfig`. An agent consuming the graph builds an
inverted mental model of the type hierarchy — the opposite of what the tool
is for. The underlying edges were already stored directionally; only the
presentation flattened them.

## Summary
Split the `inherits` edge bucket into a directional pair — `inherits`
(supertypes / what this extends) and `inherited_by` (subtypes / what extends
this) — mirroring the existing `composes`/`composed_by` split.

## Changes
- `mcpio/types.go`: new `inherited_by` field on `GraphEdges` (JSON key
  `inherited_by`), documented as the reverse-inheritance direction.
- `mcpio/graph.go`: inbound `EdgeInherits` now routes to `inherited_by`;
  the field is threaded through budget trimming, symbol/file counting, and
  `graphIndexCaveat` (so pure base classes keep their dynamic-dispatch caveat).
- `mcpio/marshal.go`: normalized to `[]` (never `null`); on the compact MCP
  transport a callers query drops the outbound `inherits`, a callees query
  drops the inbound `inherited_by`.
- `cli/render.go`: the reverse bucket renders as `inherited by`.
- Tests re-pinned to assert both sides of the split; regenerated the 3 graph
  goldens and the mcpserver response-oracle digest.

## Test Plan
- [x] `graph <BaseClass>` shows parents under `inherits`, children under `inherited_by`
- [x] `graph <Class> --direction callees` populates only `inherits`; `--direction callers` populates only `inherited_by` (out-of-scope bucket dropped on the MCP transport)
- [x] Empty buckets serialize as `[]`, not `null`
- [x] `make ci` passes (build + cover + lint + ledger)
- [x] `make smoke` passes
- [x] sense binary builds cleanly
