### PR TITLE
fix(extract): resolve provable Python receiver types to typed targets

### DIFF
--- a/internal/extract/extractor.go
+++ b/internal/extract/extractor.go
@@ -80,9 +80,12 @@ func LanguageTier(lang string) string {
 //     checkout_service.rb). Same numeric value as Ambiguous today
 //     but semantically distinct — a change to the tests confidence
 //     should not require changing the ambiguous clamp.
-//   - Dynamic: the extractor resolved a literal argument passed to a
-//     dynamic-dispatch callsite (Ruby send, Python getattr). Non-
-//     literal dynamic dispatch is skipped entirely, not flagged
+//   - Dynamic: the extractor proved the target beyond surface text but
+//     short of a static reference — a literal argument at a
+//     dynamic-dispatch callsite (Ruby send, Python getattr), or a
+//     receiver whose type was inferred from local context (typed
+//     params/locals, constructor assignments, ORM builder chains).
+//     Non-literal dynamic dispatch is skipped entirely, not flagged
 //     low-confidence.
 const (
 	ConfidenceStatic     = 1.0

--- a/internal/extract/python/django.go
+++ b/internal/extract/python/django.go
@@ -23,6 +23,73 @@ var djangoRelationFields = map[string]bool{
 	"ManyToManyField": true,
 }
 
+// querySetTypeName is the receiver type assigned to Django manager/builder
+// chains. Manager methods are generated from QuerySet (Manager.from_queryset),
+// so `Model.objects.filter` resolves to the real definition, QuerySet.filter.
+const querySetTypeName = "QuerySet"
+
+// querySetChainMethods are the QuerySet methods that RETURN a QuerySet, so a
+// chain may continue past them. Terminal methods (get, first, create, count,
+// aggregate, …) return instances or scalars — a chain hop after one of those
+// proves nothing, so they are deliberately absent (closed-world: emit only
+// what is provable).
+var querySetChainMethods = map[string]bool{
+	"filter": true, "exclude": true, "all": true, "none": true,
+	"order_by": true, "reverse": true, "distinct": true,
+	"annotate": true, "alias": true, "values": true, "values_list": true,
+	"select_related": true, "prefetch_related": true,
+	"only": true, "defer": true, "using": true,
+	"union": true, "intersection": true, "difference": true,
+	"select_for_update": true, "complex_filter": true,
+}
+
+// maxQuerySetChainDepth bounds the chain recursion (the Ruby receiver walk
+// caps at 3 hops; ORM chains legitimately run longer, so allow more but stay
+// bounded against pathological generated code).
+const maxQuerySetChainDepth = 10
+
+// isQuerySetExpr reports whether an expression provably evaluates to a Django
+// QuerySet builder: `<PascalModel>.objects`, a chain of QuerySet-RETURNING
+// method calls rooted there (`Model.objects.filter(…).exclude(…)`), or a
+// local variable already typed QuerySet in the function's type map. The
+// PascalCase-model requirement keeps the rule off arbitrary `.objects`
+// attributes; the chain-method whitelist keeps it off terminal calls
+// (`Model.objects.get(pk=1)` returns an instance, not a QuerySet).
+func isQuerySetExpr(n *sitter.Node, src []byte, types map[string]string) bool {
+	return isQuerySetExprDepth(n, src, types, 0)
+}
+
+func isQuerySetExprDepth(n *sitter.Node, src []byte, types map[string]string, depth int) bool {
+	if n == nil || depth > maxQuerySetChainDepth {
+		return false
+	}
+	switch n.Kind() {
+	case "identifier":
+		return types[extract.Text(n, src)] == querySetTypeName
+	case "attribute":
+		leaf := n.ChildByFieldName("attribute")
+		obj := n.ChildByFieldName("object")
+		if leaf == nil || obj == nil {
+			return false
+		}
+		if extract.Text(leaf, src) != "objects" {
+			return false
+		}
+		return obj.Kind() == "identifier" && isPascalCase(extract.Text(obj, src))
+	case "call":
+		fn := n.ChildByFieldName("function")
+		if fn == nil || fn.Kind() != "attribute" {
+			return false
+		}
+		leaf := fn.ChildByFieldName("attribute")
+		if leaf == nil || !querySetChainMethods[extract.Text(leaf, src)] {
+			return false
+		}
+		return isQuerySetExprDepth(fn.ChildByFieldName("object"), src, types, depth+1)
+	}
+	return false
+}
+
 // emitDjangoModelField checks if an assignment's RHS is a Django relational field
 // call (e.g. `models.ForeignKey(User)`). If so, it emits a composes edge from the
 // enclosing class to the target model. The call can be bare (`ForeignKey(User)`)

--- a/internal/extract/python/django_edges_test.go
+++ b/internal/extract/python/django_edges_test.go
@@ -107,3 +107,16 @@ func TestURLPatternEdgeError(t *testing.T) {
 		t.Error("expected error from failing emitter on URL pattern edge")
 	}
 }
+
+func TestModuleLevelRelationFieldAssignmentIsSkipped(t *testing.T) {
+	// A relational field assigned at module scope has no owning class, so the
+	// composes rule must not fire.
+	r := parse(t, `
+owner = ForeignKey(User)
+`)
+	for _, e := range r.edges {
+		if string(e.Kind) == "composes" && e.TargetQualified == "User" {
+			t.Fatal("module-level ForeignKey must not emit a composes edge")
+		}
+	}
+}

--- a/internal/extract/python/python.go
+++ b/internal/extract/python/python.go
@@ -324,8 +324,9 @@ func (w *walker) emitFunctionAndWalkBody(n *sitter.Node, scope []string, decorat
 	}
 
 	body := n.ChildByFieldName("body")
+	localTypes := inferLocalTypes(n, w.source)
 	if err := extract.WalkNamedDescendants(body, "call", func(c *sitter.Node) error {
-		return w.emitCall(c, qualified)
+		return w.emitCall(c, qualified, localTypes)
 	}); err != nil {
 		return err
 	}
@@ -338,8 +339,10 @@ func (w *walker) emitFunctionAndWalkBody(n *sitter.Node, scope []string, decorat
 // emit surface text with confidence 1.0. `getattr(obj, "name")` with a
 // literal string second argument emits target = the string with
 // confidence 0.7; any other callable form (subscript, lambda call,
-// `f()()`) is skipped.
-func (w *walker) emitCall(call *sitter.Node, source string) error {
+// `f()()`) is skipped. An attribute call whose receiver type is provable
+// (localTypes / the django objects chain) resolves to `<Type>.<method>`
+// at ConfidenceDynamic instead of the bare-name tier.
+func (w *walker) emitCall(call *sitter.Node, source string, localTypes map[string]string) error {
 	fn := call.ChildByFieldName("function")
 	if fn == nil {
 		return nil
@@ -372,6 +375,18 @@ func (w *walker) emitCall(call *sitter.Node, source string) error {
 	if kind == "attribute" {
 		if handled, err := w.tryEmitCeleryDispatch(fn, source, line); handled || err != nil {
 			return err
+		}
+		if typed, ok := typedReceiverTarget(fn, w.source, localTypes); ok {
+			// ConfidenceDynamic here means "receiver type proven from local
+			// context", not dispatch heuristics — the same tier Ruby's typed
+			// locals use, below self/static (1.0), above unverified (0.5).
+			return w.emit.Edge(extract.EmittedEdge{
+				SourceQualified: source,
+				TargetQualified: typed,
+				Kind:            model.EdgeCalls,
+				Line:            &line,
+				Confidence:      extract.ConfidenceDynamic,
+			})
 		}
 		conf = attrReceiverConfidence(fn, w.source)
 	}

--- a/internal/extract/python/typeinfer.go
+++ b/internal/extract/python/typeinfer.go
@@ -1,0 +1,275 @@
+package python
+
+import (
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+)
+
+// Receiver-type inference for method calls. A call on a receiver whose type is
+// provable inside the function scope resolves to `<Type>.<method>` at
+// ConfidenceDynamic instead of falling to the bare-name ConfidenceUnresolved
+// tier. This is deliberately NOT a type inferencer — it covers exactly the
+// provable local patterns (mirroring Ruby's localTypes in
+// extract/ruby/typeinfer.go): annotated parameters, annotated locals,
+// constructor-assigned locals, and (via django.go) the `Model.objects`
+// builder chain.
+
+// inferLocalTypes builds the function-scope receiver→class map. The map is
+// POSITION-BLIND: it is precomputed over the whole body before calls are
+// walked, so a call textually before a reassignment also sees the final type
+// (there is no flow analysis; a wrong edge is bounded at ConfidenceDynamic to
+// a class the variable provably held somewhere in the function). Assignments
+// inside nested defs are NOT collected, and any name a nested def's
+// parameters shadow is dropped from the map — calls inside closures are
+// attributed to the enclosing function (see handleFunction), so a shadowed
+// name is no longer provable there.
+func inferLocalTypes(funcNode *sitter.Node, src []byte) map[string]string {
+	types := map[string]string{}
+	collectParamTypes(funcNode, src, types)
+	walkOuterAssignments(funcNode.ChildByFieldName("body"), src, types)
+	return types
+}
+
+// walkOuterAssignments visits assignments in document order (last wins),
+// stopping at nested function boundaries: a nested def's assignments belong
+// to its own scope, and its parameter names shadow the outer scope, so those
+// names are deleted from the map instead.
+func walkOuterAssignments(n *sitter.Node, src []byte, types map[string]string) {
+	if n == nil {
+		return
+	}
+	count := n.NamedChildCount()
+	for i := uint(0); i < count; i++ {
+		child := n.NamedChild(i)
+		if child == nil {
+			continue
+		}
+		if child.Kind() == "function_definition" {
+			deleteShadowedParams(child, src, types)
+			continue
+		}
+		if child.Kind() == "assignment" {
+			collectAssignmentType(child, src, types)
+		}
+		walkOuterAssignments(child, src, types)
+	}
+}
+
+// deleteShadowedParams removes a nested def's parameter names from the outer
+// type map (conservative: the outer type may still hold before the nested
+// def, but position-blind maps cannot express that).
+func deleteShadowedParams(funcNode *sitter.Node, src []byte, types map[string]string) {
+	for name := range collectParams(funcNode, src) {
+		delete(types, name)
+	}
+}
+
+// collectParamTypes records `def f(q: Query)` / `def f(q: Query = None)`
+// parameter annotations. `self`/`cls` are skipped: the resolver's
+// self-rewrite path already resolves them to the enclosing class at full
+// confidence, which an annotation must not downgrade.
+func collectParamTypes(funcNode *sitter.Node, src []byte, types map[string]string) {
+	params := funcNode.ChildByFieldName("parameters")
+	if params == nil {
+		return
+	}
+	count := params.NamedChildCount()
+	for i := uint(0); i < count; i++ {
+		p := params.NamedChild(i)
+		if p == nil {
+			continue
+		}
+		// typed_parameter has no "name" field in the grammar — its name is
+		// the first named child; typed_default_parameter does carry one.
+		var name *sitter.Node
+		switch p.Kind() {
+		case "typed_parameter":
+			if first := p.NamedChild(0); first != nil && first.Kind() == "identifier" {
+				name = first
+			}
+		case "typed_default_parameter":
+			name = p.ChildByFieldName("name")
+		default:
+			continue
+		}
+		typ := p.ChildByFieldName("type")
+		if name == nil || typ == nil {
+			continue
+		}
+		paramName := extract.Text(name, src)
+		if paramName == "self" || paramName == "cls" {
+			continue
+		}
+		if t, ok := annotationTypeName(typ, src); ok {
+			types[paramName] = t
+		}
+	}
+}
+
+// collectAssignmentType records `x: Query = …` annotated assignments and
+// `x = Query(…)` / `x = sql.Query(…)` constructor assignments, plus the
+// django `x = Model.objects.…(…)` chain (typed QuerySet). A reassignment
+// whose RHS proves nothing DELETES the entry — the variable is no longer
+// provably the old type.
+func collectAssignmentType(a *sitter.Node, src []byte, types map[string]string) {
+	left := a.ChildByFieldName("left")
+	if left == nil || left.Kind() != "identifier" {
+		return
+	}
+	name := extract.Text(left, src)
+	if typ := a.ChildByFieldName("type"); typ != nil {
+		if t, ok := annotationTypeName(typ, src); ok {
+			types[name] = t
+		} else {
+			delete(types, name)
+		}
+		return
+	}
+	if t, ok := callResultTypeName(a.ChildByFieldName("right"), src, types); ok {
+		types[name] = t
+	} else {
+		delete(types, name)
+	}
+}
+
+// callResultTypeName resolves an assignment's RHS call to the class of its
+// result: a direct constructor call (`Query(…)`, `sql.Query(…)`) or a django
+// objects chain (`Model.objects.filter(…)` → QuerySet).
+func callResultTypeName(right *sitter.Node, src []byte, types map[string]string) (string, bool) {
+	if right == nil || right.Kind() != "call" {
+		return "", false
+	}
+	fn := right.ChildByFieldName("function")
+	if fn == nil {
+		return "", false
+	}
+	switch fn.Kind() {
+	case "identifier":
+		if name := extract.Text(fn, src); isReceiverClassName(name) {
+			return name, true
+		}
+	case "attribute":
+		leaf := fn.ChildByFieldName("attribute")
+		if leaf == nil {
+			return "", false
+		}
+		name := extract.Text(leaf, src)
+		if isReceiverClassName(name) {
+			return name, true
+		}
+		// The call's RESULT is a QuerySet only when the method itself is a
+		// builder (terminal methods like get/first return instances).
+		if querySetChainMethods[name] {
+			if obj := fn.ChildByFieldName("object"); isQuerySetExpr(obj, src, types) {
+				return querySetTypeName, true
+			}
+		}
+	}
+	return "", false
+}
+
+// isReceiverClassName gates every name admitted as a receiver type: PascalCase
+// and neither a primitive nor a bare generic wrapper (`x = typing.List(…)`
+// must not type x as List).
+func isReceiverClassName(name string) bool {
+	return isPascalCase(name) && !pythonPrimitives[name] && !pythonGenericWrappers[name]
+}
+
+// annotationTypeName resolves an annotation node to a single class name: a
+// bare PascalCase identifier, `Optional[X]` unwrapped to X, or the PascalCase
+// leaf of a dotted annotation (`sql.Query`).
+//
+// This deliberately diverges from annotations.go's composes walk in two ways:
+// a receiver has exactly ONE type, so only the first proving name is taken
+// (composes emits an edge per referenced class), and a dotted annotation
+// yields its leaf (targets bind by unqualified class name, while composes
+// keeps the full dotted text).
+func annotationTypeName(typeNode *sitter.Node, src []byte) (string, bool) {
+	if typeNode == nil {
+		return "", false
+	}
+	switch typeNode.Kind() {
+	case "type":
+		if typeNode.NamedChildCount() > 0 {
+			return annotationTypeName(typeNode.NamedChild(0), src)
+		}
+	case "identifier":
+		if name := extract.Text(typeNode, src); isReceiverClassName(name) {
+			return name, true
+		}
+	case "generic_type":
+		return genericAnnotationTypeName(typeNode, src)
+	case "attribute":
+		if leaf := typeNode.ChildByFieldName("attribute"); leaf != nil {
+			if name := extract.Text(leaf, src); isReceiverClassName(name) {
+				return name, true
+			}
+		}
+	}
+	return "", false
+}
+
+// genericAnnotationTypeName types a generic annotation for RECEIVER use.
+// Only `Optional[X]` proves the receiver is X; every other wrapper lies about
+// the receiver (`items: list[Item]` makes items a list, NOT an Item, and
+// `Union[A, B]` proves neither) so they yield nothing — unlike annotations.go,
+// where unwrapping the full wrapper set is correct for composes edges. A
+// non-wrapper PascalCase outer name (`Registry[Task]`) IS the receiver type.
+func genericAnnotationTypeName(typeNode *sitter.Node, src []byte) (string, bool) {
+	outer := typeNode.ChildByFieldName("type")
+	if outer == nil && typeNode.NamedChildCount() > 0 {
+		outer = typeNode.NamedChild(0)
+	}
+	if outer == nil {
+		return "", false
+	}
+	outerName := extract.Text(outer, src)
+	if !pythonGenericWrappers[outerName] {
+		if isReceiverClassName(outerName) {
+			return outerName, true
+		}
+		return "", false
+	}
+	if outerName != "Optional" {
+		return "", false
+	}
+	count := typeNode.NamedChildCount()
+	for i := uint(0); i < count; i++ {
+		child := typeNode.NamedChild(i)
+		if child == nil || child.Kind() != "type_parameter" {
+			continue
+		}
+		inner := child.NamedChildCount()
+		for j := uint(0); j < inner; j++ {
+			if t, ok := annotationTypeName(child.NamedChild(j), src); ok {
+				return t, true
+			}
+		}
+	}
+	return "", false
+}
+
+// typedReceiverTarget resolves an attribute call to `<Type>.<method>` when
+// the receiver's type is provable: an identifier in the local type map, or a
+// django objects chain (django.go's isQuerySetExpr).
+func typedReceiverTarget(fn *sitter.Node, src []byte, types map[string]string) (string, bool) {
+	leaf := fn.ChildByFieldName("attribute")
+	obj := fn.ChildByFieldName("object")
+	if leaf == nil || obj == nil {
+		return "", false
+	}
+	method := extract.Text(leaf, src)
+	if method == "" {
+		return "", false
+	}
+	if obj.Kind() == "identifier" {
+		if t := types[extract.Text(obj, src)]; t != "" {
+			return t + "." + method, true
+		}
+	}
+	if isQuerySetExpr(obj, src, types) {
+		return querySetTypeName + "." + method, true
+	}
+	return "", false
+}

--- a/internal/extract/python/typeinfer_test.go
+++ b/internal/extract/python/typeinfer_test.go
@@ -1,0 +1,618 @@
+package python
+
+import (
+	"testing"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+)
+
+// Receiver-type inference: a method call on a receiver whose type is provable
+// inside the function scope resolves to `<Type>.<method>` at ConfidenceDynamic,
+// instead of falling to the bare-name 0.5 tier. Patterns covered (and ONLY
+// these — this is not a type inferencer): annotated parameters, annotated
+// locals, constructor-assigned locals, and the Django `Model.objects` builder
+// chain (which lives in django.go but is asserted here alongside its general
+// cousins).
+
+func TestTypedParamReceiverResolvesToTypeMethod(t *testing.T) {
+	r := parse(t, `
+def handle(query: Query):
+    query.add_q(cond)
+`)
+	e := findEdge(r, "handle", "Query.add_q", "calls")
+	if e == nil {
+		t.Fatal("expected handle -> Query.add_q calls edge from annotated param")
+	}
+	if e.Confidence != extract.ConfidenceDynamic {
+		t.Errorf("confidence = %v, want ConfidenceDynamic", e.Confidence)
+	}
+}
+
+func TestTypedDefaultParamReceiverResolves(t *testing.T) {
+	r := parse(t, `
+def handle(query: Query = None):
+    query.get_compiler(using)
+`)
+	if findEdge(r, "handle", "Query.get_compiler", "calls") == nil {
+		t.Fatal("expected handle -> Query.get_compiler from typed default param")
+	}
+}
+
+func TestAnnotatedLocalReceiverResolves(t *testing.T) {
+	r := parse(t, `
+def build():
+    q: Query = clone()
+    q.chain()
+`)
+	if findEdge(r, "build", "Query.chain", "calls") == nil {
+		t.Fatal("expected build -> Query.chain from annotated local")
+	}
+}
+
+func TestConstructorLocalReceiverResolves(t *testing.T) {
+	r := parse(t, `
+def check(model):
+    query = Query(model=model)
+    query.add_q(condition)
+`)
+	e := findEdge(r, "check", "Query.add_q", "calls")
+	if e == nil {
+		t.Fatal("expected check -> Query.add_q from constructor-assigned local")
+	}
+	if e.Confidence != extract.ConfidenceDynamic {
+		t.Errorf("confidence = %v, want ConfidenceDynamic", e.Confidence)
+	}
+}
+
+func TestDottedConstructorLocalUsesLeafType(t *testing.T) {
+	r := parse(t, `
+def check(model):
+    query = sql.Query(model)
+    query.get_compiler(connection)
+`)
+	if findEdge(r, "check", "Query.get_compiler", "calls") == nil {
+		t.Fatal("expected check -> Query.get_compiler from sql.Query(...) constructor")
+	}
+}
+
+func TestOptionalWrappedParamAnnotationResolves(t *testing.T) {
+	r := parse(t, `
+def handle(query: Optional[Query]):
+    query.resolve()
+`)
+	if findEdge(r, "handle", "Query.resolve", "calls") == nil {
+		t.Fatal("expected handle -> Query.resolve from Optional[Query] param")
+	}
+}
+
+func TestUnknownReceiverStaysBareAtUnresolved(t *testing.T) {
+	r := parse(t, `
+def handle(query):
+    query.add_q(cond)
+`)
+	e := findEdge(r, "handle", "query.add_q", "calls")
+	if e == nil {
+		t.Fatal("expected bare query.add_q edge for unannotated param")
+	}
+	if e.Confidence != extract.ConfidenceUnresolved {
+		t.Errorf("confidence = %v, want ConfidenceUnresolved", e.Confidence)
+	}
+}
+
+func TestPrimitiveAnnotationDoesNotInfer(t *testing.T) {
+	r := parse(t, `
+def handle(count: int):
+    count.bit_length()
+`)
+	if findEdge(r, "handle", "int.bit_length", "calls") != nil {
+		t.Fatal("primitive annotations must not produce typed-receiver targets")
+	}
+	if findEdge(r, "handle", "count.bit_length", "calls") == nil {
+		t.Fatal("expected the bare edge to remain for a primitive-typed receiver")
+	}
+}
+
+func TestSelfReceiverUnaffectedByInference(t *testing.T) {
+	r := parse(t, `
+class Compiler:
+    def run(self):
+        self.setup()
+`)
+	e := findEdge(r, "Compiler.run", "self.setup", "calls")
+	if e == nil {
+		t.Fatal("expected self.setup edge to remain the resolver's self-rewrite path")
+	}
+	if e.Confidence != 1.0 {
+		t.Errorf("self receiver confidence = %v, want 1.0", e.Confidence)
+	}
+}
+
+func TestLastAssignmentWinsInTypeMap(t *testing.T) {
+	r := parse(t, `
+def handle():
+    q = Query(model)
+    q = Raw(sql)
+    q.execute()
+`)
+	if findEdge(r, "handle", "Raw.execute", "calls") == nil {
+		t.Fatal("expected the last constructor assignment to type the receiver")
+	}
+}
+
+// Django `.objects` builder chains (rule lives in django.go).
+
+func TestObjectsChainFirstHopResolvesToQuerySet(t *testing.T) {
+	r := parse(t, `
+def actives():
+    return Product.objects.filter(active=True)
+`)
+	e := findEdge(r, "actives", "QuerySet.filter", "calls")
+	if e == nil {
+		t.Fatal("expected actives -> QuerySet.filter from Model.objects chain")
+	}
+	if e.Confidence != extract.ConfidenceDynamic {
+		t.Errorf("confidence = %v, want ConfidenceDynamic", e.Confidence)
+	}
+}
+
+func TestObjectsChainContinuationResolvesEachHop(t *testing.T) {
+	r := parse(t, `
+def stats():
+    return Product.objects.filter(active=True).annotate(n=Count("id"))
+`)
+	if findEdge(r, "stats", "QuerySet.filter", "calls") == nil {
+		t.Fatal("expected QuerySet.filter for the chain's first hop")
+	}
+	if findEdge(r, "stats", "QuerySet.annotate", "calls") == nil {
+		t.Fatal("expected QuerySet.annotate for the chain's second hop")
+	}
+}
+
+func TestObjectsChainAssignedLocalContinues(t *testing.T) {
+	r := parse(t, `
+def paged():
+    qs = Product.objects.filter(active=True)
+    return qs.order_by("name")
+`)
+	if findEdge(r, "paged", "QuerySet.order_by", "calls") == nil {
+		t.Fatal("expected QuerySet.order_by on a local assigned from an objects chain")
+	}
+}
+
+func TestNonObjectsChainIsNotRewritten(t *testing.T) {
+	r := parse(t, `
+def run(conn):
+    conn.cursor().execute(sql)
+`)
+	if findEdge(r, "run", "QuerySet.execute", "calls") != nil {
+		t.Fatal("non-objects chains must not resolve to QuerySet")
+	}
+}
+
+func TestLowercaseObjectsRootDoesNotFire(t *testing.T) {
+	r := parse(t, `
+def run(thing):
+    return thing.objects.filter(x=1)
+`)
+	if findEdge(r, "run", "QuerySet.filter", "calls") != nil {
+		t.Fatal("objects rule requires a PascalCase model root")
+	}
+}
+
+func TestDottedAnnotationParamUsesLeafType(t *testing.T) {
+	r := parse(t, `
+def compile(query: sql.Query):
+    query.get_compiler(using)
+`)
+	if findEdge(r, "compile", "Query.get_compiler", "calls") == nil {
+		t.Fatal("expected dotted annotation sql.Query to type the receiver as Query")
+	}
+}
+
+func TestNonWrapperGenericAnnotationUsesOuterType(t *testing.T) {
+	r := parse(t, `
+def drain(q: Registry[Task]):
+    q.pop()
+`)
+	if findEdge(r, "drain", "Registry.pop", "calls") == nil {
+		t.Fatal("expected a non-wrapper PascalCase generic to type the receiver as its outer name")
+	}
+}
+
+func TestLowercaseAnnotationDoesNotInfer(t *testing.T) {
+	r := parse(t, `
+def run(conn: connection):
+    conn.execute(sql)
+`)
+	if findEdge(r, "run", "connection.execute", "calls") != nil {
+		t.Fatal("lowercase annotations must not produce typed targets")
+	}
+	if findEdge(r, "run", "conn.execute", "calls") == nil {
+		t.Fatal("expected the bare edge to remain")
+	}
+}
+
+func TestDottedLowercaseAnnotationLeafDoesNotInfer(t *testing.T) {
+	r := parse(t, `
+def run(conn: db.connection):
+    conn.execute(sql)
+`)
+	if findEdge(r, "run", "conn.execute", "calls") == nil {
+		t.Fatal("expected the bare edge for a lowercase dotted-annotation leaf")
+	}
+}
+
+func TestTypedSplatParamIsSkipped(t *testing.T) {
+	r := parse(t, `
+def run(*args: int):
+    args.count(x)
+`)
+	if findEdge(r, "run", "args.count", "calls") == nil {
+		t.Fatal("expected the bare edge for a typed splat param")
+	}
+}
+
+func TestBareWrapperAnnotationDoesNotInfer(t *testing.T) {
+	r := parse(t, `
+def run(x: Optional):
+    x.get()
+`)
+	if findEdge(r, "run", "Optional.get", "calls") != nil {
+		t.Fatal("a bare generic-wrapper annotation must not become a receiver type")
+	}
+}
+
+func TestDottedModelObjectsRootDoesNotFire(t *testing.T) {
+	r := parse(t, `
+def run():
+    return app.Product.objects.filter(x=1)
+`)
+	if findEdge(r, "run", "QuerySet.filter", "calls") != nil {
+		t.Fatal("objects rule requires a bare PascalCase root, not a dotted one")
+	}
+}
+
+func TestCallRootedChainWithoutAttributeDoesNotFire(t *testing.T) {
+	r := parse(t, `
+def run():
+    return factory()().finish()
+`)
+	if findEdge(r, "run", "QuerySet.finish", "calls") != nil {
+		t.Fatal("a call chain without an objects root must not resolve to QuerySet")
+	}
+}
+
+func TestAnnotatedLocalWithUnprovableValueStillTypes(t *testing.T) {
+	// The annotation proves the type even when the RHS does not.
+	r := parse(t, `
+def run():
+    q: Query = fetch()
+    q.reset()
+`)
+	if findEdge(r, "run", "Query.reset", "calls") == nil {
+		t.Fatal("expected annotated local to type the receiver")
+	}
+}
+
+func TestAliasingDoesNotPropagateType(t *testing.T) {
+	r := parse(t, `
+def run():
+    q = Query(model)
+    r = q
+    r.reset()
+`)
+	if findEdge(r, "run", "Query.reset", "calls") != nil {
+		t.Fatal("identifier aliasing is not provable; r must stay bare")
+	}
+}
+
+func TestLowercaseDottedConstructorDoesNotInfer(t *testing.T) {
+	r := parse(t, `
+def run():
+    client = http.factory(url)
+    client.request(x)
+`)
+	if findEdge(r, "run", "client.request", "calls") == nil {
+		t.Fatal("expected the bare edge for a lowercase dotted-constructor local")
+	}
+}
+
+func TestLowercaseGenericOuterDoesNotInfer(t *testing.T) {
+	r := parse(t, `
+def run(x: registry[Task]):
+    x.pop()
+`)
+	if findEdge(r, "run", "x.pop", "calls") == nil {
+		t.Fatal("expected the bare edge for a lowercase generic annotation")
+	}
+}
+
+func TestWrapperWithPrimitiveInnerDoesNotInfer(t *testing.T) {
+	r := parse(t, `
+def run(x: Optional[int]):
+    x.bit_length()
+`)
+	if findEdge(r, "run", "x.bit_length", "calls") == nil {
+		t.Fatal("expected the bare edge when the wrapper's inner type is a primitive")
+	}
+}
+
+func TestIsQuerySetExprNilNodeIsFalse(t *testing.T) {
+	// Recursion hands isQuerySetExpr the receiver of a chained call, which an
+	// ERROR-node parse can leave nil; it must answer false, never crash.
+	if isQuerySetExpr(nil, nil, nil) {
+		t.Fatal("nil node must not be a queryset expression")
+	}
+}
+
+func TestInferenceHelpersTolerateNilNodes(t *testing.T) {
+	// ERROR-node trees (watch mode on half-typed source) can leave any field
+	// nil; every helper must degrade to "no type", never panic. These are the
+	// same guards the malformed-source suite exercises end to end; direct
+	// calls pin each helper's own contract.
+	if t2, ok := annotationTypeName(nil, nil); ok || t2 != "" {
+		t.Fatal("nil annotation must yield no type")
+	}
+	if t2, ok := callResultTypeName(nil, nil, nil); ok || t2 != "" {
+		t.Fatal("nil RHS must yield no type")
+	}
+	walkOuterAssignments(nil, nil, map[string]string{}) // must not panic
+	types := map[string]string{}
+	r := parse(t, "x = 1\n") // any tree; grab a non-function node
+	_ = r
+	collectParamTypes(mustParseRoot(t, "x = 1\n"), nil, types)
+	if len(types) != 0 {
+		t.Fatal("a node without parameters must collect nothing")
+	}
+}
+
+// mustParseRoot parses source and returns the tree's root node for direct
+// helper calls. The tree is intentionally not closed until test exit.
+func mustParseRoot(t *testing.T, src string) *sitter.Node {
+	t.Helper()
+	ex := Extractor{}
+	p := sitter.NewParser()
+	t.Cleanup(p.Close)
+	if err := p.SetLanguage(ex.Grammar()); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	tree := p.Parse([]byte(src), nil)
+	if tree == nil {
+		t.Fatal("Parse returned nil tree")
+	}
+	t.Cleanup(tree.Close)
+	return tree.RootNode()
+}
+
+func TestMalformedSourceDoesNotPanic(t *testing.T) {
+	// Broken mid-edit source (watch mode sees these constantly): ERROR nodes
+	// can leave any field nil, so inference must degrade, never crash.
+	for _, src := range []string{
+		"def broken(q: Query:\n    q.m(\n",
+		"def f(*, ):\n    x = (\n    x.m()\n",
+		"def g(a:\n",
+		"qs = Product.objects.\n",
+		"def h(q: ) :\n    q.m()\n",
+		"def i(x: Query\n",
+	} {
+		_ = parse(t, src)
+	}
+}
+
+func TestContainerAnnotationDoesNotTypeReceiver(t *testing.T) {
+	// items is a list, NOT an Item — only Optional proves the receiver.
+	r := parse(t, `
+def run(items: list[Item]):
+    items.append(x)
+`)
+	if findEdge(r, "run", "Item.append", "calls") != nil {
+		t.Fatal("list[Item] must not type the receiver as Item")
+	}
+	if findEdge(r, "run", "items.append", "calls") == nil {
+		t.Fatal("expected the bare edge for a container-annotated receiver")
+	}
+}
+
+func TestUnionAnnotationDoesNotTypeReceiver(t *testing.T) {
+	r := parse(t, `
+def run(q: Union[Query, Raw]):
+    q.execute()
+`)
+	if findEdge(r, "run", "Query.execute", "calls") != nil {
+		t.Fatal("Union proves neither arm; must not type the receiver")
+	}
+}
+
+func TestDottedWrapperAnnotationDoesNotTypeReceiver(t *testing.T) {
+	// The dotted-leaf path applies the same primitive/wrapper gate as the
+	// identifier path.
+	r := parse(t, `
+def run(x: typing.List):
+    x.append(v)
+`)
+	if findEdge(r, "run", "List.append", "calls") != nil {
+		t.Fatal("typing.List must not type the receiver as List")
+	}
+}
+
+func TestDottedWrapperConstructorDoesNotTypeReceiver(t *testing.T) {
+	r := parse(t, `
+def run():
+    x = typing.List(v)
+    x.append(v)
+`)
+	if findEdge(r, "run", "List.append", "calls") != nil {
+		t.Fatal("typing.List(...) must not type the assigned local as List")
+	}
+}
+
+func TestNestedDefParamShadowsOuterType(t *testing.T) {
+	// Calls inside a nested def are attributed to the enclosing function, so
+	// a name the nested def's params shadow is no longer provable there.
+	r := parse(t, `
+def outer(q: Query):
+    def inner(q):
+        q.run()
+`)
+	if findEdge(r, "outer", "Query.run", "calls") != nil {
+		t.Fatal("a nested def's shadowing param must drop the outer type")
+	}
+}
+
+func TestNestedDefAssignmentDoesNotTypeOuter(t *testing.T) {
+	r := parse(t, `
+def outer(q):
+    def inner():
+        q = Raw(sql)
+    q.run()
+`)
+	if findEdge(r, "outer", "Raw.run", "calls") != nil {
+		t.Fatal("an assignment inside a nested def must not type the outer variable")
+	}
+}
+
+func TestAnnotatedSelfKeepsSelfPath(t *testing.T) {
+	// The resolver's self-rewrite resolves self at 1.0; an annotation must
+	// not downgrade it to the 0.7 inference path.
+	r := parse(t, `
+class Compiler:
+    def run(self: Compiler):
+        self.setup()
+`)
+	e := findEdge(r, "Compiler.run", "self.setup", "calls")
+	if e == nil {
+		t.Fatal("annotated self must stay on the resolver's self-rewrite path")
+	}
+	if e.Confidence != 1.0 {
+		t.Errorf("annotated self confidence = %v, want 1.0", e.Confidence)
+	}
+}
+
+func TestTerminalChainMethodDoesNotContinueQuerySet(t *testing.T) {
+	// Model.objects.get(...) returns an instance, not a QuerySet; a hop past
+	// it proves nothing.
+	r := parse(t, `
+def run():
+    User.objects.get(pk=1).save()
+`)
+	if findEdge(r, "run", "QuerySet.save", "calls") != nil {
+		t.Fatal("a chain hop past a terminal method must not resolve to QuerySet")
+	}
+	if findEdge(r, "run", "QuerySet.get", "calls") == nil {
+		t.Fatal("the first hop (objects.get) is still a QuerySet method")
+	}
+}
+
+func TestTerminalChainAssignmentDoesNotTypeQuerySet(t *testing.T) {
+	r := parse(t, `
+def run():
+    u = User.objects.get(pk=1)
+    u.save()
+`)
+	if findEdge(r, "run", "QuerySet.save", "calls") != nil {
+		t.Fatal("a local assigned from a terminal chain call is not a QuerySet")
+	}
+}
+
+func TestUnprovableReassignmentDropsType(t *testing.T) {
+	r := parse(t, `
+def run():
+    q = Query(model)
+    q = fetch()
+    q.run()
+`)
+	if findEdge(r, "run", "Query.run", "calls") != nil {
+		t.Fatal("a reassignment to an unprovable RHS must drop the stale type")
+	}
+	if findEdge(r, "run", "q.run", "calls") == nil {
+		t.Fatal("expected the bare edge after the unprovable reassignment")
+	}
+}
+
+func TestChainedAssignmentTypesInnerTargetOnly(t *testing.T) {
+	// Pins the accidental-but-acceptable asymmetry: the inner assignment's
+	// target is typed, the outer stays bare (its RHS is an assignment node).
+	r := parse(t, `
+def run():
+    x = y = Query(model)
+    y.run()
+    x.run()
+`)
+	if findEdge(r, "run", "Query.run", "calls") == nil {
+		t.Fatal("expected the inner chained-assignment target to be typed")
+	}
+	if findEdge(r, "run", "x.run", "calls") == nil {
+		t.Fatal("expected the outer chained-assignment target to stay bare")
+	}
+}
+
+func TestAsyncDefTypedParamResolves(t *testing.T) {
+	r := parse(t, `
+async def handle(query: Query):
+    query.chain()
+`)
+	if findEdge(r, "handle", "Query.chain", "calls") == nil {
+		t.Fatal("async def must type annotated params like a plain def")
+	}
+}
+
+func TestTupleUnpackingStaysBare(t *testing.T) {
+	r := parse(t, `
+def run():
+    a, b = Query(m), Raw(sql)
+    a.run()
+`)
+	if findEdge(r, "run", "Query.run", "calls") != nil {
+		t.Fatal("tuple-unpacking targets are not collected; a must stay bare")
+	}
+}
+
+func TestUnprovableAnnotationReassignmentDropsType(t *testing.T) {
+	r := parse(t, `
+def run():
+    q = Query(model)
+    q: unknown_alias = fetch()
+    q.run()
+`)
+	if findEdge(r, "run", "Query.run", "calls") != nil {
+		t.Fatal("an annotated reassignment that proves nothing must drop the stale type")
+	}
+}
+
+func TestChainMethodOnUnprovenReceiverStaysBare(t *testing.T) {
+	// .filter is a QuerySet builder name, but the receiver is not provably a
+	// QuerySet, so the assignment proves nothing.
+	r := parse(t, `
+def run(thing):
+    x = thing.filter(y)
+    x.count()
+`)
+	if findEdge(r, "run", "QuerySet.count", "calls") != nil {
+		t.Fatal("a builder-named call on an unproven receiver must not type the local")
+	}
+}
+
+func TestWalrusStaysBare(t *testing.T) {
+	// named_expression is not an assignment node; stays bare by design.
+	r := parse(t, `
+def run():
+    if (q := Query(m)):
+        q.run()
+`)
+	if findEdge(r, "run", "Query.run", "calls") != nil {
+		t.Fatal("walrus bindings are not collected; q must stay bare")
+	}
+}
+
+func TestNonIdentifierAssignmentTargetIsSkipped(t *testing.T) {
+	r := parse(t, `
+def run(obj):
+    obj.attr = Query(model)
+    obj.attr.add_q(x)
+`)
+	if findEdge(r, "run", "Query.add_q", "calls") != nil {
+		t.Fatal("attribute-target assignments must not enter the local type map")
+	}
+}

--- a/internal/extract/testdata/python/celery_tasks.golden.json
+++ b/internal/extract/testdata/python/celery_tasks.golden.json
@@ -91,10 +91,10 @@
     },
     {
       "source": "process_payment",
-      "target": "gateway.charge",
+      "target": "PaymentGateway.charge",
       "kind": "calls",
       "line": 18,
-      "confidence": 0.5
+      "confidence": 0.7
     },
     {
       "source": "send_email",
@@ -105,10 +105,10 @@
     },
     {
       "source": "send_email",
-      "target": "mailer.send",
+      "target": "Mailer.send",
       "kind": "calls",
       "line": 11,
-      "confidence": 0.5
+      "confidence": 0.7
     }
   ]
 }

--- a/internal/extract/testdata/python/flask_blueprint.golden.json
+++ b/internal/extract/testdata/python/flask_blueprint.golden.json
@@ -83,10 +83,10 @@
     },
     {
       "source": "OrderService.create",
-      "target": "order.save",
+      "target": "Order.save",
       "kind": "calls",
       "line": 28,
-      "confidence": 0.5
+      "confidence": 0.7
     },
     {
       "source": "list_orders",

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -125,7 +125,7 @@ func blastTool() mcp.Tool {
 			mcp.Description("How many dependency hops to follow (default 3). Higher values find more distant impacts."),
 		),
 		mcp.WithNumber("min_confidence",
-			mcp.Description("Minimum edge confidence 0.0–1.0 (default 0.7). Lower values include weaker relationships."),
+			mcp.Description("Minimum edge confidence 0.0–1.0 (default 0.3, which already includes weak edges). Raising it above 0.5 silently drops unverified-receiver call edges — most production dependents. Prefer leaving it unset."),
 		),
 		mcp.WithBoolean("include_tests",
 			mcp.Description("Include affected test files in the results (default true)"),

--- a/internal/mcpserver/tools_test.go
+++ b/internal/mcpserver/tools_test.go
@@ -1,0 +1,33 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/internal/profile"
+)
+
+// TestBlastSchemaAdvertisesRealDefault pins the min_confidence description to
+// the constant the handler actually uses (profile.Defaults). The description
+// once said "default 0.7" (copied from the CLI, which diverges by design)
+// while the MCP default was 0.3 — agents that passed the documented value
+// lost every sub-0.7 edge. A description is a contract; keep it tied to the
+// value.
+func TestBlastSchemaAdvertisesRealDefault(t *testing.T) {
+	tool := blastTool()
+	raw, err := json.Marshal(tool.InputSchema)
+	if err != nil {
+		t.Fatalf("marshal schema: %v", err)
+	}
+	schema := string(raw)
+	def := profile.DefaultParams()
+	want := fmt.Sprintf("default %.1f", def.BlastMinConfidence)
+	if !strings.Contains(schema, want) {
+		t.Errorf("blast min_confidence description must state %q (the real MCP default); schema: %s", want, schema)
+	}
+	if strings.Contains(schema, "default 0.7") {
+		t.Error("blast schema must not advertise the CLI's 0.7 default")
+	}
+}


### PR DESCRIPTION
## Problem
A Python method call on an unannotated receiver falls back to bare-name matching, so the callers of core ORM methods drown below the display floor: on the django/django index `QuerySet.filter` resolved 2 callers while 1703 sat hidden at the collision tier — method-level tracing was worse than grep exactly where impact analysis matters most. Separately, `sense_blast`'s schema advertised `min_confidence` "(default 0.7)" — the CLI's default, not the MCP server's 0.3 — so agents that passed the documented value silently dropped every unverified-receiver production dependent (observed twice in real sessions: a 202→30 blast collapse).

## Summary
Resolve method calls whose receiver type is provable from local context to `<Type>.<method>` at ConfidenceDynamic (0.7), and correct the blast schema to advertise the real default with a warning about the 0.5 tier.

## Changes
- **extract/python — receiver-type inference** (`typeinfer.go`, new): annotated parameters and locals, `Optional[X]` unwrapping, constructor-assigned locals (including dotted `sql.Query(...)`), per-function, position-blind, last-wins.
- **extract/python — Django builder chains** (`django.go`): `Model.objects.<m>(...)` resolves each QuerySet-returning hop to `QuerySet.<m>`, continuing through assigned locals; a curated whitelist stops chains at terminal methods (`get`, `first`, `create`, …) whose results are instances, not QuerySets.
- **Closed-world guards** — every admission path is gated so only provable receivers type: containers never type their receiver (`list[Item]` is a list, not an Item; `Union` proves neither arm), nested defs neither leak assignments outward nor inherit shadowed outer types, annotated `self`/`cls` stays on the resolver's full-confidence self path, an unprovable reassignment drops the stale type, dotted leaves apply the same primitive/wrapper gate as identifiers, and chain recursion is depth-capped.
- **mcpserver** (`tools.go`): `min_confidence` description states the real default (0.3) and warns that raising it above 0.5 drops unverified-receiver call edges; a schema test pins the description to `profile.DefaultParams()` so it cannot drift again.
- Golden fixtures updated (`gateway.charge`@0.5 → `PaymentGateway.charge`@0.7 and siblings); ~45 behavior tests including a malformed-source no-panic suite for watch mode.

## Architecture Highlights
- This is deliberately NOT a type inferencer: a small closed set of provable patterns, mirroring Ruby's `localTypes` precedent, emitting only when proven and staying silent otherwise.
- `ConfidenceDynamic` (0.7) now explicitly covers "receiver type proven from local context" alongside literal dynamic dispatch — same tier Ruby's typed locals use; the confidence-scale doc is updated.
- `annotationTypeName` intentionally diverges from `annotations.go`'s composes walk (one type per receiver, dotted leaf instead of full dotted text); both divergences are documented in place. If a third consumer of annotation→class-name resolution appears, unify the walkers then — not before.

## Rollout Note
⚠️ Scan-layer change: existing indexes keep the old bare-name edges until a full `sense scan -rebuild`. Mixed state degrades gracefully (both tiers pre-exist), but release notes should say a rescan is required to see the benefit.

## Test Plan
- [x] Receiver-inference behavior suite (typed params/locals, constructors, chains, and every negative control: containers, Union, aliasing, tuple unpacking, walrus, nested defs, annotated self, terminal chain methods)
- [x] Malformed-source no-panic suite (watch mode on half-typed files) + nil-tolerance contract tests
- [x] Golden fixtures regenerated; diffs are exactly the intended 0.5→0.7 typed upgrades
- [x] Schema drift test ties the blast description to the real MCP default
- [x] `make ci` fully green (coverage gate ≥92% every file, lint 0, complexity ledger 0)
- [x] Cross-vertical no-regress bench on Opus 4.8: saleor 4/4 dependents, sentry 5/5 (both 1.00 overall), solidus held, discourse 16/16 on the confirmation run; django QuerySet.filter 2→1548 resolved callers, spot-checked correct