### PR TITLE
fix(extract): type Django queryset receivers by convention

### DIFF
--- a/internal/extract/extractor.go
+++ b/internal/extract/extractor.go
@@ -82,11 +82,12 @@ func LanguageTier(lang string) string {
 //     should not require changing the ambiguous clamp.
 //   - Dynamic: the extractor proved the target beyond surface text but
 //     short of a static reference — a literal argument at a
-//     dynamic-dispatch callsite (Ruby send, Python getattr), or a
-//     receiver whose type was inferred from local context (typed
-//     params/locals, constructor assignments, ORM builder chains).
-//     Non-literal dynamic dispatch is skipped entirely, not flagged
-//     low-confidence.
+//     dynamic-dispatch callsite (Ruby send, Python getattr), a receiver
+//     whose type was inferred from local context (typed params/locals,
+//     constructor assignments, ORM builder chains), or a receiver typed
+//     by a double-keyed framework convention (a qs/queryset-named
+//     receiver calling QuerySet API). Non-literal dynamic dispatch is
+//     skipped entirely, not flagged low-confidence.
 const (
 	ConfidenceStatic     = 1.0
 	ConfidenceConvention = 0.9

--- a/internal/extract/python/django.go
+++ b/internal/extract/python/django.go
@@ -48,6 +48,56 @@ var querySetChainMethods = map[string]bool{
 // bounded against pathological generated code).
 const maxQuerySetChainDepth = 10
 
+// querySetReturningMethods are method NAMES that return a QuerySet by Django
+// convention regardless of receiver: the overridable get_queryset hook (and
+// its pre-1.6 spelling) and the ORM-internal _chain. `_clone` is deliberately
+// absent — GIS geometries and sql.Query define their own.
+var querySetReturningMethods = map[string]bool{
+	"get_queryset":  true,
+	"get_query_set": true,
+	"_chain":        true,
+}
+
+// querySetTerminalMethods are the QuerySet methods that do NOT return a
+// QuerySet (instances, scalars, containers). They complete the method key:
+// a call is recognized as QuerySet API when it is either a chain method or
+// one of these.
+var querySetTerminalMethods = map[string]bool{
+	"create": true, "acreate": true,
+	"get": true, "aget": true, "first": true, "afirst": true,
+	"last": true, "alast": true, "earliest": true, "aearliest": true,
+	"latest": true, "alatest": true, "count": true, "acount": true,
+	"exists": true, "aexists": true, "contains": true, "acontains": true,
+	"delete": true, "adelete": true, "update": true, "aupdate": true,
+	"aggregate": true, "aaggregate": true, "explain": true, "aexplain": true,
+	"iterator": true, "aiterator": true, "in_bulk": true, "ain_bulk": true,
+	"get_or_create": true, "aget_or_create": true,
+	"update_or_create": true, "aupdate_or_create": true,
+	"bulk_create": true, "abulk_create": true,
+	"bulk_update": true, "abulk_update": true,
+	"dates": true, "datetimes": true,
+}
+
+// isQuerySetMethodName reports whether a method name belongs to the QuerySet
+// API (chainable or terminal). It is the METHOD key of the double-keyed
+// receiver-name convention: a receiver named qs/queryset types as QuerySet
+// only for calls that are QuerySet API — either key alone proves nothing.
+func isQuerySetMethodName(name string) bool {
+	return querySetChainMethods[name] || querySetTerminalMethods[name]
+}
+
+// isQuerySetNameConvention is the NAME key: locals and parameters literally
+// named qs/queryset are querysets by overwhelming Django convention. Only
+// meaningful combined with isQuerySetMethodName (see typedReceiverTarget).
+//
+// Exposure bound: a wrong guess (a list named qs calling .count()) emits a
+// QuerySet.* target, which resolves ONLY in a repo that defines a QuerySet
+// class — django itself, where the convention holds — and is dropped as
+// unresolvable everywhere else (edges need a resolved target to persist).
+func isQuerySetNameConvention(name string) bool {
+	return name == "qs" || name == "queryset"
+}
+
 // isQuerySetExpr reports whether an expression provably evaluates to a Django
 // QuerySet builder: `<PascalModel>.objects`, a chain of QuerySet-RETURNING
 // method calls rooted there (`Model.objects.filter(…).exclude(…)`), or a
@@ -65,29 +115,52 @@ func isQuerySetExprDepth(n *sitter.Node, src []byte, types map[string]string, de
 	}
 	switch n.Kind() {
 	case "identifier":
-		return types[extract.Text(n, src)] == querySetTypeName
+		name := extract.Text(n, src)
+		// The name convention is safe here: every path FROM this root still
+		// requires whitelisted QuerySet methods (chain hops above, the final
+		// method key in typedReceiverTarget), so both keys always apply.
+		return types[name] == querySetTypeName || isQuerySetNameConvention(name)
 	case "attribute":
-		leaf := n.ChildByFieldName("attribute")
-		obj := n.ChildByFieldName("object")
-		if leaf == nil || obj == nil {
-			return false
-		}
-		if extract.Text(leaf, src) != "objects" {
-			return false
-		}
-		return obj.Kind() == "identifier" && isPascalCase(extract.Text(obj, src))
+		return isModelObjectsAttr(n, src)
 	case "call":
-		fn := n.ChildByFieldName("function")
-		if fn == nil || fn.Kind() != "attribute" {
-			return false
-		}
-		leaf := fn.ChildByFieldName("attribute")
-		if leaf == nil || !querySetChainMethods[extract.Text(leaf, src)] {
-			return false
-		}
-		return isQuerySetExprDepth(fn.ChildByFieldName("object"), src, types, depth+1)
+		return isQuerySetChainCall(n, src, types, depth)
 	}
 	return false
+}
+
+// isModelObjectsAttr matches the chain root: `<PascalModel>.objects`.
+func isModelObjectsAttr(n *sitter.Node, src []byte) bool {
+	leaf := n.ChildByFieldName("attribute")
+	obj := n.ChildByFieldName("object")
+	if leaf == nil || obj == nil {
+		return false
+	}
+	if extract.Text(leaf, src) != "objects" {
+		return false
+	}
+	return obj.Kind() == "identifier" && isPascalCase(extract.Text(obj, src))
+}
+
+// isQuerySetChainCall matches a chain hop: a conventionally QuerySet-returning
+// method regardless of receiver (self.get_queryset(), self._chain()), or a
+// chainable QuerySet method whose receiver is itself a queryset expression.
+func isQuerySetChainCall(n *sitter.Node, src []byte, types map[string]string, depth int) bool {
+	fn := n.ChildByFieldName("function")
+	if fn == nil || fn.Kind() != "attribute" {
+		return false
+	}
+	leaf := fn.ChildByFieldName("attribute")
+	if leaf == nil {
+		return false
+	}
+	name := extract.Text(leaf, src)
+	if querySetReturningMethods[name] {
+		return true
+	}
+	if !querySetChainMethods[name] {
+		return false
+	}
+	return isQuerySetExprDepth(fn.ChildByFieldName("object"), src, types, depth+1)
 }
 
 // emitDjangoModelField checks if an assignment's RHS is a Django relational field

--- a/internal/extract/python/typeinfer.go
+++ b/internal/extract/python/typeinfer.go
@@ -158,6 +158,11 @@ func callResultTypeName(right *sitter.Node, src []byte, types map[string]string)
 		if isReceiverClassName(name) {
 			return name, true
 		}
+		// Conventionally QuerySet-returning hooks type the local regardless
+		// of receiver (objs = self.get_queryset()).
+		if querySetReturningMethods[name] {
+			return querySetTypeName, true
+		}
 		// The call's RESULT is a QuerySet only when the method itself is a
 		// builder (terminal methods like get/first return instances).
 		if querySetChainMethods[name] {
@@ -264,11 +269,22 @@ func typedReceiverTarget(fn *sitter.Node, src []byte, types map[string]string) (
 		return "", false
 	}
 	if obj.Kind() == "identifier" {
-		if t := types[extract.Text(obj, src)]; t != "" {
-			return t + "." + method, true
+		objName := extract.Text(obj, src)
+		if t := types[objName]; t != "" {
+			// A QuerySet-typed receiver only proves QuerySet API calls;
+			// anything else falls back to the bare tier.
+			if t != querySetTypeName || isQuerySetMethodName(method) {
+				return t + "." + method, true
+			}
+			return "", false
+		}
+		// Double-keyed Django convention: receiver NAMED qs/queryset AND a
+		// QuerySet API method — both keys must agree, either alone is noise.
+		if isQuerySetNameConvention(objName) && isQuerySetMethodName(method) {
+			return querySetTypeName + "." + method, true
 		}
 	}
-	if isQuerySetExpr(obj, src, types) {
+	if isQuerySetExpr(obj, src, types) && isQuerySetMethodName(method) {
 		return querySetTypeName + "." + method, true
 	}
 	return "", false

--- a/internal/extract/python/typeinfer_test.go
+++ b/internal/extract/python/typeinfer_test.go
@@ -616,3 +616,108 @@ def run(obj):
 		t.Fatal("attribute-target assignments must not enter the local type map")
 	}
 }
+
+// Django receiver-name convention (double-keyed): a receiver literally named
+// qs/queryset calling a known QuerySet method types as QuerySet — BOTH keys
+// must agree; either alone stays bare.
+
+func TestQuerySetNamedReceiverWithQuerySetMethodResolves(t *testing.T) {
+	r := parse(t, `
+def run(queryset):
+    return queryset.filter(active=True)
+`)
+	e := findEdge(r, "run", "QuerySet.filter", "calls")
+	if e == nil {
+		t.Fatal("expected queryset.filter to resolve via the name+method convention")
+	}
+	if e.Confidence != extract.ConfidenceDynamic {
+		t.Errorf("confidence = %v, want ConfidenceDynamic", e.Confidence)
+	}
+}
+
+func TestQsNamedReceiverTerminalMethodResolves(t *testing.T) {
+	r := parse(t, `
+def run(qs):
+    return qs.get(pk=1)
+`)
+	if findEdge(r, "run", "QuerySet.get", "calls") == nil {
+		t.Fatal("expected qs.get to resolve via the name+method convention")
+	}
+}
+
+func TestQsNamedReceiverNonQuerySetMethodStaysBare(t *testing.T) {
+	r := parse(t, `
+def run(qs):
+    qs.append(x)
+`)
+	if findEdge(r, "run", "QuerySet.append", "calls") != nil {
+		t.Fatal("append is not a QuerySet method; the name key alone must not type")
+	}
+	if findEdge(r, "run", "qs.append", "calls") == nil {
+		t.Fatal("expected the bare edge")
+	}
+}
+
+func TestOtherNamedReceiverWithQuerySetMethodStaysBare(t *testing.T) {
+	r := parse(t, `
+def run(items):
+    items.filter(x)
+`)
+	if findEdge(r, "run", "QuerySet.filter", "calls") != nil {
+		t.Fatal("filter on a non-convention name must not type; the method key alone must not type")
+	}
+}
+
+func TestQsNamedChainContinues(t *testing.T) {
+	r := parse(t, `
+def run(qs):
+    return qs.filter(a=1).annotate(n=Count("id"))
+`)
+	if findEdge(r, "run", "QuerySet.annotate", "calls") == nil {
+		t.Fatal("expected the chain to continue from a convention-named receiver")
+	}
+}
+
+func TestGetQuerysetAssignmentTypesLocal(t *testing.T) {
+	r := parse(t, `
+def run(self):
+    objs = self.get_queryset()
+    return objs.exclude(hidden=True)
+`)
+	if findEdge(r, "run", "QuerySet.exclude", "calls") == nil {
+		t.Fatal("expected a local assigned from get_queryset() to type as QuerySet")
+	}
+}
+
+func TestGetQuerysetDirectChainResolves(t *testing.T) {
+	r := parse(t, `
+def run(self):
+    return self.get_queryset().filter(active=True)
+`)
+	if findEdge(r, "run", "QuerySet.filter", "calls") == nil {
+		t.Fatal("expected a chain rooted at get_queryset() to resolve")
+	}
+}
+
+func TestChainAssignmentTypesLocal(t *testing.T) {
+	r := parse(t, `
+def run(self):
+    clone = self._chain()
+    return clone.order_by("name")
+`)
+	if findEdge(r, "run", "QuerySet.order_by", "calls") == nil {
+		t.Fatal("expected a local assigned from _chain() to type as QuerySet")
+	}
+}
+
+func TestCloneIsNotAQuerySetConvention(t *testing.T) {
+	// GIS geometries and sql.Query both have _clone; it proves nothing.
+	r := parse(t, `
+def run(self):
+    shell = self._clone(rings)
+    shell.filter(x)
+`)
+	if findEdge(r, "run", "QuerySet.filter", "calls") != nil {
+		t.Fatal("_clone must not type the local as QuerySet")
+	}
+}


### PR DESCRIPTION
## Problem
Django codebases pass querysets between functions as unannotated locals (`objs = self.get_queryset()`, a local named `qs`), so the receiver-type inference from #180 cannot prove them and their method calls stay at the bare-name tier. On django/django itself — an essentially unannotated codebase (one return annotation in the whole production tree) — that leaves the ORM's own caller graph thin: ~105 resolvable `QuerySet.*` production callers, dominated by the private `_chain`, with public API like `filter` at 10 and `get` at 7.

## Summary
Type queryset receivers by Django convention, double-keyed so either signal alone proves nothing: locals assigned from conventionally QuerySet-returning hooks (`get_queryset`/`get_query_set`/`_chain`), and receivers literally named `qs`/`queryset` — but only for calls to a whitelisted QuerySet API method.

## Changes
- **extract/python (django.go)** — three convention rules: `querySetReturningMethods` (hooks that return a QuerySet regardless of receiver; `_clone` deliberately excluded — GIS geometries and `sql.Query` define their own), `querySetTerminalMethods` (the non-chainable QuerySet API, completing the method key), and the `qs`/`queryset` name key. Chains root at any of them (`self.get_queryset().filter(...)`).
- **extract/python (typeinfer.go)** — the method key now also gates PROVEN QuerySet locals, so `qs.append()` never fabricates a `QuerySet.append` edge — stricter than the original inference.
- 11 behavior tests, including both single-key negative controls (name without QuerySet method, QuerySet method without the name) and the `_clone` exclusion.

## Architecture Highlights
- **Double-keyed, not heuristic-loose:** a convention edge is emitted only when the receiver signal AND the method signal independently agree.
- **Structurally bounded exposure:** a wrong name-guess emits a `QuerySet.*` target that only resolves in a repo that defines a QuerySet class — django itself, where the convention holds — and is dropped as unresolvable everywhere else.
- `ConfidenceDynamic`'s scale doc now names the convention tier explicitly.

## Rollout Note
⚠️ Scan-layer change: a full `sense scan -rebuild` is required to see the new edges; mixed state degrades gracefully.

## Test Plan
- [x] Behavior suite: hook-assigned locals, direct hook chains, name+method double key, both single-key negatives, `_clone` exclusion
- [x] `make ci` fully green (coverage floor met, lint 0, complexity ledger 0 — `isQuerySetExprDepth` decomposed rather than suppressed)
- [x] django/django measurement: resolvable production `QuerySet.*` callers ~105 → **218** across 48 files (`filter` 10→33, `order_by` 6→14, `get` 7→13); 13/13 random spot-checks genuine, zero false positives
- [x] No-regress bench (Opus 4.8 sense arms, rescanned indexes): saleor dependents **4/4** overall 1.00, sentry **5/5** overall 1.00, zero hallucinated citations