### PR TITLE
fix(extract): type Django private-manager receivers as QuerySet chains

### DIFF
--- a/bench/lib/mcp_probe.py
+++ b/bench/lib/mcp_probe.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Drive `sense mcp` over stdio and print the agent-facing tool results.
+
+The scenario-crafting rule this serves: gold must be verified retrievable in
+the SHOWN budgeted output the AGENT sees — over MCP stdio, at BOTH
+min_confidence 0.3 and 0.7 — because the CLI diverges by design and the
+blast eviction runs both ways (0.7 drops low-confidence riders; 0.3 admits
+more competitors to the caller cap and can evict 0.7-confidence gold).
+Every scenario session was re-writing this probe in its scratchpad; now it
+is one command (craft prompt step 4).
+
+Usage:
+  mcp_probe.py <repo_clone> '<calls_json>'
+
+  <calls_json> is a JSON array of tool calls, e.g.:
+    '[{"name":"sense_blast","arguments":{"symbol":"QuerySet.filter"}},
+      {"name":"sense_blast","arguments":{"symbol":"QuerySet.filter","min_confidence":0.7}},
+      {"name":"sense_graph","arguments":{"symbol":"QuerySet.filter","direction":"callers"}}]'
+
+Each result prints as a `═══ call id=N ═══` header followed by the raw JSON
+text the agent would receive — pipe into python/jq to assert gold presence.
+SENSE_BIN overrides the binary (default: `sense` on PATH).
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+
+def build_messages(calls):
+    msgs = [
+        {"jsonrpc": "2.0", "id": 0, "method": "initialize",
+         "params": {"protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "mcp_probe", "version": "0"}}},
+        {"jsonrpc": "2.0", "method": "notifications/initialized"},
+    ]
+    for i, c in enumerate(calls, start=1):
+        msgs.append({"jsonrpc": "2.0", "id": i, "method": "tools/call",
+                     "params": {"name": c["name"], "arguments": c.get("arguments", {})}})
+    return msgs
+
+
+def probe(repo, calls, sense_bin):
+    inp = "\n".join(json.dumps(m) for m in build_messages(calls)) + "\n"
+    proc = subprocess.run([sense_bin, "mcp"], input=inp, capture_output=True,
+                          text=True, cwd=repo, timeout=120)
+    results = []
+    for line in proc.stdout.splitlines():
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if obj.get("id", 0) >= 1 and "result" in obj:
+            for block in obj["result"].get("content", []):
+                results.append((obj["id"], block.get("text", "")))
+    return results, proc
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(__doc__, file=sys.stderr)
+        sys.exit(1)
+    repo, calls_json = sys.argv[1], sys.argv[2]
+    if not os.path.isdir(os.path.join(repo, ".sense")):
+        print(f"mcp_probe: no .sense index under {repo}", file=sys.stderr)
+        sys.exit(1)
+    calls = json.loads(calls_json)
+    sense_bin = os.environ.get("SENSE_BIN", "sense")
+
+    results, proc = probe(repo, calls, sense_bin)
+    for call_id, text in results:
+        print(f"═══ call id={call_id} ═══")
+        print(text)
+    if proc.returncode != 0:
+        print("STDERR:", proc.stderr[-2000:], file=sys.stderr)
+        sys.exit(proc.returncode)
+    if not results:
+        print("mcp_probe: no tool results returned", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/internal/extract/python/django.go
+++ b/internal/extract/python/django.go
@@ -128,17 +128,55 @@ func isQuerySetExprDepth(n *sitter.Node, src []byte, types map[string]string, de
 	return false
 }
 
-// isModelObjectsAttr matches the chain root: `<PascalModel>.objects`.
+// djangoManagerLeafNames are the attribute names that root a manager chain:
+// the public `objects` plus the private accessors Django's own plumbing uses
+// (`Model._default_manager` / `Model._base_manager`). The exposure bound is
+// the same as the name convention: a wrong guess emits a QuerySet.* target
+// that only resolves in a repo defining a QuerySet class.
+var djangoManagerLeafNames = map[string]bool{
+	"objects":          true,
+	"_default_manager": true,
+	"_base_manager":    true,
+}
+
+// isModelObjectsAttr matches the chain root: a manager leaf (objects /
+// _default_manager / _base_manager) on a model reference — a PascalCase
+// identifier or one of the self-attribute idioms Django's own plumbing uses
+// (`self.model` in managers/descriptors, `self.__class__` in Model methods,
+// `self.through` in related descriptors).
 func isModelObjectsAttr(n *sitter.Node, src []byte) bool {
 	leaf := n.ChildByFieldName("attribute")
 	obj := n.ChildByFieldName("object")
 	if leaf == nil || obj == nil {
 		return false
 	}
-	if extract.Text(leaf, src) != "objects" {
+	if !djangoManagerLeafNames[extract.Text(leaf, src)] {
 		return false
 	}
-	return obj.Kind() == "identifier" && isPascalCase(extract.Text(obj, src))
+	if obj.Kind() == "identifier" && isPascalCase(extract.Text(obj, src)) {
+		return true
+	}
+	return isSelfModelRef(obj, src)
+}
+
+// isSelfModelRef matches exactly `self.model`, `self.__class__`, and
+// `self.through` — the three attribute shapes that hold a model class inside
+// Django framework plumbing. No general attribute walk: anything else
+// (self.request, obj.model) stays unproven.
+func isSelfModelRef(n *sitter.Node, src []byte) bool {
+	if n.Kind() != "attribute" {
+		return false
+	}
+	obj := n.ChildByFieldName("object")
+	leaf := n.ChildByFieldName("attribute")
+	if obj == nil || leaf == nil || obj.Kind() != "identifier" || extract.Text(obj, src) != "self" {
+		return false
+	}
+	switch extract.Text(leaf, src) {
+	case "model", "__class__", "through":
+		return true
+	}
+	return false
 }
 
 // isQuerySetChainCall matches a chain hop: a conventionally QuerySet-returning

--- a/internal/extract/python/typeinfer_test.go
+++ b/internal/extract/python/typeinfer_test.go
@@ -201,6 +201,93 @@ def run(thing):
 	}
 }
 
+func TestPrivateManagerLeafResolvesToQuerySet(t *testing.T) {
+	r := parse(t, `
+def purge():
+    return Product._base_manager.filter(active=False)
+`)
+	if findEdge(r, "purge", "QuerySet.filter", "calls") == nil {
+		t.Fatal("expected QuerySet.filter from a Model._base_manager chain")
+	}
+}
+
+func TestDefaultManagerChainContinuationResolves(t *testing.T) {
+	r := parse(t, `
+def routed(db):
+    return Product._default_manager.using(db).filter(active=True)
+`)
+	if findEdge(r, "routed", "QuerySet.using", "calls") == nil {
+		t.Fatal("expected QuerySet.using for the _default_manager chain root")
+	}
+	if findEdge(r, "routed", "QuerySet.filter", "calls") == nil {
+		t.Fatal("expected QuerySet.filter past the using() hop")
+	}
+}
+
+func TestLowercasePrivateManagerRootDoesNotFire(t *testing.T) {
+	r := parse(t, `
+def run(thing):
+    return thing._default_manager.filter(x=1)
+`)
+	if findEdge(r, "run", "QuerySet.filter", "calls") != nil {
+		t.Fatal("private-manager leaves still require a proven model root")
+	}
+}
+
+func TestSelfModelManagerRootResolves(t *testing.T) {
+	r := parse(t, `
+class RelatedManager:
+    def clear(self, db):
+        self.model._base_manager.using(db).filter(pk__in=ids).delete()
+`)
+	if findEdge(r, "RelatedManager.clear", "QuerySet.filter", "calls") == nil {
+		t.Fatal("expected QuerySet.filter from a self.model._base_manager chain")
+	}
+}
+
+func TestSelfClassDefaultManagerResolves(t *testing.T) {
+	r := parse(t, `
+class Model:
+    def validate_unique(self):
+        return self.__class__._default_manager.filter(**kwargs)
+`)
+	if findEdge(r, "Model.validate_unique", "QuerySet.filter", "calls") == nil {
+		t.Fatal("expected QuerySet.filter from a self.__class__._default_manager chain")
+	}
+}
+
+func TestSelfThroughObjectsRootResolves(t *testing.T) {
+	r := parse(t, `
+class ManyRelatedManager:
+    def exists(self, db):
+        return self.through._default_manager.using(db).exists()
+`)
+	if findEdge(r, "ManyRelatedManager.exists", "QuerySet.exists", "calls") == nil {
+		t.Fatal("expected QuerySet.exists from a self.through._default_manager chain")
+	}
+}
+
+func TestOtherSelfAttributeRootDoesNotFire(t *testing.T) {
+	r := parse(t, `
+class View:
+    def run(self):
+        return self.request._default_manager.filter(x=1)
+`)
+	if findEdge(r, "View.run", "QuerySet.filter", "calls") != nil {
+		t.Fatal("only self.model/self.__class__/self.through prove a model root")
+	}
+}
+
+func TestNonSelfAttributeRootDoesNotFire(t *testing.T) {
+	r := parse(t, `
+def run(obj):
+    return obj.model._base_manager.filter(x=1)
+`)
+	if findEdge(r, "run", "QuerySet.filter", "calls") != nil {
+		t.Fatal("the model-attribute root is proven only on self")
+	}
+}
+
 func TestDottedAnnotationParamUsesLeafType(t *testing.T) {
 	r := parse(t, `
 def compile(query: sql.Query):
@@ -354,6 +441,11 @@ func TestInferenceHelpersTolerateNilNodes(t *testing.T) {
 	// calls pin each helper's own contract.
 	if t2, ok := annotationTypeName(nil, nil); ok || t2 != "" {
 		t.Fatal("nil annotation must yield no type")
+	}
+	// A node without attribute/object fields (any non-attribute kind) must
+	// answer false through the nil-field guard, never panic.
+	if isModelObjectsAttr(mustParseRoot(t, "x = 1\n"), []byte("x = 1\n")) {
+		t.Fatal("a field-less node must not match the manager chain root")
 	}
 	if t2, ok := callResultTypeName(nil, nil, nil); ok || t2 != "" {
 		t.Fatal("nil RHS must yield no type")


### PR DESCRIPTION
## What

The Python convention pass only rooted a Django manager chain at `<PascalModel>.objects`. Django's own internals almost never write that shape — framework plumbing reaches the ORM through private managers and model attributes. Those call sites carried **no QuerySet edge at any confidence**, leaving Sense blind to the framework's own ORM usage in any blast/graph over django-style code.

Two bounded extensions to the chain root (`isModelObjectsAttr`):

- **Leaves:** `_default_manager` and `_base_manager` alongside `objects` (root rule unchanged).
- **Roots:** exactly `self.model`, `self.__class__`, and `self.through` in addition to a PascalCase identifier — no general attribute walk; `self.request` / `obj.model` stay unproven.

The existing double-keyed safety argument carries over unchanged: a wrong guess emits a `QuerySet.*` target that only resolves in a repo defining a `QuerySet` class and is dropped as unresolvable everywhere else.

## Measured (django/django @ e789914, full rescan per iteration)

| | QuerySet.* call edges |
|---|---|
| before | 10,965 |
| + leaf extension | 10,992 (+29 new) |
| + root extension | 11,017 (+26 new) |

- All sampled new edges verified genuine by reading each source line (13 sites): `UserModel._default_manager.get` in auth backends, `self.model.objects.get` in the DB session store, `self.model._default_manager.all()` in generic views, `self.through._default_manager.using(db).filter(...).delete()` in related descriptors, `self.__class__._default_manager.values(...).filter(` in `Model._get_next_or_previous_in_order`.
- Wrong bare-name fallback edges at the affected sites are replaced (e.g. `.update` no longer resolves to `BaseStorage.update`); upgraded edges land at 0.7 instead of the 0.3 fallback tier.
- Total edge growth +0.5% — no convention over-fire.

## Side effects

- healthchecks (Python, small): rescan with this branch vs a main-built binary — **zero** edge diff (sorted full edge set).
- maket (Ruby, non-Python sanity): **zero** edge diff vs pre-fix.
- `make ci` green: coverage 95.1% (per-file gate passes, django.go above the 92% floor), lint 0 issues, complexity ledger 0.

Known residuals (out of scope, documented): repeated same-pair call sites still collapse to one stored line per file (`idx_sense_edges_unique` — the separate schema-level dedup question), and a sliced-queryset hop (`...order_by()[:1].get()`) still falls back to bare-name resolution.