### PR TITLE
fix(mcpio): collapse already-seen targets in graph BFS layers

### DIFF
--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -211,14 +211,14 @@ func BuildBlastResponseSeen(ctx context.Context, r blast.Result, files FileLooku
 	// the full magnitude.
 	resp.DirectCallers = enumerateByArea(tier1Direct, directEnumCap)
 	if seenCount > 0 {
-		note := fmt.Sprintf("%d of %d direct callers were already returned by an earlier sense_graph/sense_blast call on this symbol; only new callers are listed.",
+		note := fmt.Sprintf("%d of %d direct callers were already returned by an earlier sense_graph/sense_blast call in this session; only new callers are listed.",
 			seenCount, directTier1)
 		if seenCount == directTier1 {
 			// All direct callers were already shown — there is no "new" subset.
-			note = fmt.Sprintf("all %d direct callers were already returned by an earlier sense_graph/sense_blast call on this symbol; see that response for the list.",
+			note = fmt.Sprintf("all %d direct callers were already returned by an earlier sense_graph/sense_blast call in this session; see that response for the list.",
 				directTier1)
 		}
-		resp.SeenVia = &BlastSeenSummary{Count: seenCount, Note: note}
+		resp.SeenElsewhere = &SeenSummary{Count: seenCount, Note: note}
 	}
 	// Charge the full tier-1 direct count against the shared tier1Cap so
 	// indirect enumeration keeps its prior ceiling even though only the top
@@ -344,8 +344,8 @@ func blastCompleteness(resp *BlastResponse, totalAffected int) *Completeness {
 	// verdict complete (the seen-collapse is a dedup, not a truncation) and
 	// keeps the cap check honest (the full set is still accounted for).
 	seenCollapsed := 0
-	if resp.SeenVia != nil {
-		seenCollapsed = resp.SeenVia.Count
+	if resp.SeenElsewhere != nil {
+		seenCollapsed = resp.SeenElsewhere.Count
 	}
 	// total_affected is the engine's count of the direct+indirect caller union.
 	// The inherit/include/compose groups are a re-classification of those SAME
@@ -473,9 +473,9 @@ func BuildDiffBlastResponseSeen(ctx context.Context, ref string, results []blast
 	}
 
 	if seenCount > 0 {
-		resp.SeenVia = &BlastSeenSummary{
+		resp.SeenElsewhere = &SeenSummary{
 			Count: seenCount,
-			Note: fmt.Sprintf("%d of %d direct callers were already returned by an earlier sense_graph/sense_blast call on this symbol; only new callers are listed.",
+			Note: fmt.Sprintf("%d of %d direct callers were already returned by an earlier sense_graph/sense_blast call in this session; only new callers are listed.",
 				seenCount, directTotal),
 		}
 	}

--- a/internal/mcpio/blast_test.go
+++ b/internal/mcpio/blast_test.go
@@ -1430,8 +1430,8 @@ func TestBuildBlastResponseSeenNilIsByteIdentical(t *testing.T) {
 	plain := BuildBlastResponse(context.Background(), r, files, nil)
 	seenNil := BuildBlastResponseSeen(context.Background(), r, files, nil, nil)
 
-	if seenNil.SeenVia != nil {
-		t.Errorf("nil seen-set must not set seen_elsewhere, got %+v", seenNil.SeenVia)
+	if seenNil.SeenElsewhere != nil {
+		t.Errorf("nil seen-set must not set seen_elsewhere, got %+v", seenNil.SeenElsewhere)
 	}
 	pj, _ := json.Marshal(plain)
 	sj, _ := json.Marshal(seenNil)
@@ -1456,11 +1456,11 @@ func TestBuildBlastResponseSeenCollapsesPerID(t *testing.T) {
 			t.Errorf("seen caller C%d must not be enumerated", id)
 		}
 	}
-	if resp.SeenVia == nil || resp.SeenVia.Count != 3 {
-		t.Fatalf("seen_elsewhere = %+v, want count 3", resp.SeenVia)
+	if resp.SeenElsewhere == nil || resp.SeenElsewhere.Count != 3 {
+		t.Fatalf("seen_elsewhere = %+v, want count 3", resp.SeenElsewhere)
 	}
-	if !strings.Contains(resp.SeenVia.Note, "3 of 5") {
-		t.Errorf("seen_elsewhere note = %q, want it to mention 3 of 5", resp.SeenVia.Note)
+	if !strings.Contains(resp.SeenElsewhere.Note, "3 of 5") {
+		t.Errorf("seen_elsewhere note = %q, want it to mention 3 of 5", resp.SeenElsewhere.Note)
 	}
 }
 
@@ -1538,8 +1538,8 @@ func TestBuildBlastResponseSeenLeavesNonCallerSetsAlone(t *testing.T) {
 	// Mark every id seen — even the indirect/subclass/compose/include ids.
 	resp := BuildBlastResponseSeen(context.Background(), r, noFiles, nil, seenSet(1, 2, 3, 4, 5))
 
-	if len(resp.DirectCallers) != 0 || resp.SeenVia == nil || resp.SeenVia.Count != 1 {
-		t.Errorf("direct caller C1 should collapse: callers=%d seen=%+v", len(resp.DirectCallers), resp.SeenVia)
+	if len(resp.DirectCallers) != 0 || resp.SeenElsewhere == nil || resp.SeenElsewhere.Count != 1 {
+		t.Errorf("direct caller C1 should collapse: callers=%d seen=%+v", len(resp.DirectCallers), resp.SeenElsewhere)
 	}
 	// Only DIRECT callers collapse; the other relations are untouched.
 	if len(resp.IndirectCallers) != 1 {
@@ -1576,8 +1576,8 @@ func TestBuildDiffBlastResponseSeenCollapses(t *testing.T) {
 	if len(resp.DirectCallers) != 1 || resp.DirectCallers[0].Symbol != "New" {
 		t.Errorf("direct_callers = %+v, want only the unseen 'New'", resp.DirectCallers)
 	}
-	if resp.SeenVia == nil || resp.SeenVia.Count != 1 {
-		t.Fatalf("seen_elsewhere = %+v, want count 1", resp.SeenVia)
+	if resp.SeenElsewhere == nil || resp.SeenElsewhere.Count != 1 {
+		t.Fatalf("seen_elsewhere = %+v, want count 1", resp.SeenElsewhere)
 	}
 	if resp.TotalAffected != 2 {
 		t.Errorf("total_affected = %d, want 2 (full dedup union, not the remainder)", resp.TotalAffected)

--- a/internal/mcpio/graph.go
+++ b/internal/mcpio/graph.go
@@ -11,6 +11,47 @@ import (
 
 const testCallerCollapseThreshold = 20
 
+// CollapseSeenLayers collapses deeper-layer call edges whose target the
+// session has already received from an earlier sense_graph/sense_blast
+// call, replacing them with a per-layer seen_elsewhere count + note.
+// Token-saving deduplication, not truncation: every collapsed target was
+// already delivered with its ref, so magnitude and completeness are
+// unaffected. Only the BFS layers collapse — the root's depth-1 edges
+// are the direct answer to the question asked and always render in
+// full. Entries with no symbol id (unresolved view edges) never
+// collapse; a nil SeenFunc disables the pass.
+func CollapseSeenLayers(resp *GraphResponse, seen SeenFunc) {
+	if seen == nil {
+		return
+	}
+	for i := range resp.Layers {
+		l := &resp.Layers[i]
+		collapsed := keepUnseenEdges(&l.Edges.CalledBy, seen) + keepUnseenEdges(&l.Edges.Calls, seen)
+		if collapsed > 0 {
+			l.SeenElsewhere = &BlastSeenSummary{
+				Count: collapsed,
+				Note: fmt.Sprintf("%d depth-%d edges collapsed — their targets were already returned to this session by an earlier call; see those responses for the refs.",
+					collapsed, l.Depth),
+			}
+		}
+	}
+}
+
+// keepUnseenEdges filters a call-edge slice in place to the entries whose
+// target the session has not seen, returning how many were collapsed.
+func keepUnseenEdges(edges *[]CallEdgeRef, seen SeenFunc) int {
+	kept := (*edges)[:0]
+	for _, e := range *edges {
+		if e.ID != 0 && seen.seen(e.ID) {
+			continue
+		}
+		kept = append(kept, e)
+	}
+	collapsed := len(*edges) - len(kept)
+	*edges = kept
+	return collapsed
+}
+
 // ApplyGraphBudget trims a graph response until its estimated token count
 // fits within budget. It sheds the least-relevant content first — deeper
 // BFS layers, then the longest edge list one chunk at a time — keeping

--- a/internal/mcpio/graph.go
+++ b/internal/mcpio/graph.go
@@ -11,35 +11,43 @@ import (
 
 const testCallerCollapseThreshold = 20
 
-// CollapseSeenLayers collapses deeper-layer call edges whose target the
-// session has already received from an earlier sense_graph/sense_blast
-// call, replacing them with a per-layer seen_elsewhere count + note.
-// Token-saving deduplication, not truncation: every collapsed target was
-// already delivered with its ref, so magnitude and completeness are
-// unaffected. Only the BFS layers collapse — the root's depth-1 edges
-// are the direct answer to the question asked and always render in
-// full. Entries with no symbol id (unresolved view edges) never
-// collapse; a nil SeenFunc disables the pass.
-func CollapseSeenLayers(resp *GraphResponse, seen SeenFunc) {
+// CollapseSeenLayerEdges collapses deeper-layer call edges whose target the
+// session already received — from an earlier graph or blast response, or a
+// search result — replacing them with a per-layer seen_elsewhere count +
+// note. Deduplication, not truncation: every collapsed target was already
+// delivered with a citable location, and the magnitude fields are
+// untouched. What is not re-delivered is the edge's membership in this
+// radius (and, for targets first seen only via search, the relationship
+// itself); the note names the recovery — a root's own edges never
+// collapse, so re-querying a specific symbol re-enumerates in full. Only
+// the BFS layers collapse; the root's depth-1 edges are the direct answer
+// to the question asked and always render whole. Entries with no symbol
+// id (unresolved view edges) never collapse; a nil SeenFunc disables the
+// pass.
+//
+// Applied on the MCP path only, matching ApplyGraphBudget: the CLI has no
+// session, so it always emits the full response.
+func CollapseSeenLayerEdges(resp *GraphResponse, seen SeenFunc) {
 	if seen == nil {
 		return
 	}
 	for i := range resp.Layers {
 		l := &resp.Layers[i]
-		collapsed := keepUnseenEdges(&l.Edges.CalledBy, seen) + keepUnseenEdges(&l.Edges.Calls, seen)
+		total := len(l.Edges.CalledBy) + len(l.Edges.Calls)
+		collapsed := collapseSeenEdges(&l.Edges.CalledBy, seen) + collapseSeenEdges(&l.Edges.Calls, seen)
 		if collapsed > 0 {
-			l.SeenElsewhere = &BlastSeenSummary{
+			l.SeenElsewhere = &SeenSummary{
 				Count: collapsed,
-				Note: fmt.Sprintf("%d depth-%d edges collapsed — their targets were already returned to this session by an earlier call; see those responses for the refs.",
-					collapsed, l.Depth),
+				Note: fmt.Sprintf("%d of %d depth-%d targets were already returned to this session by an earlier call; only new targets are listed. A root's own edges never collapse — run sense_graph on a specific symbol to re-enumerate its edges in full.",
+					collapsed, total, l.Depth),
 			}
 		}
 	}
 }
 
-// keepUnseenEdges filters a call-edge slice in place to the entries whose
+// collapseSeenEdges filters a call-edge slice in place to the entries whose
 // target the session has not seen, returning how many were collapsed.
-func keepUnseenEdges(edges *[]CallEdgeRef, seen SeenFunc) int {
+func collapseSeenEdges(edges *[]CallEdgeRef, seen SeenFunc) int {
 	kept := (*edges)[:0]
 	for _, e := range *edges {
 		if e.ID != 0 && seen.seen(e.ID) {

--- a/internal/mcpio/graph_test.go
+++ b/internal/mcpio/graph_test.go
@@ -29,6 +29,60 @@ func bigGraphResponse(callers, layers int) GraphResponse {
 	return r
 }
 
+// TestCollapseSeenLayers pins the layer seen-collapse contract: already-seen
+// layer targets are replaced by a per-layer seen_elsewhere count, the root's
+// depth-1 edges never collapse, id-0 entries never collapse, and a nil
+// SeenFunc disables the pass entirely.
+func TestCollapseSeenLayers(t *testing.T) {
+	build := func() GraphResponse {
+		r := GraphResponse{Symbol: GraphSymbol{Name: "A", Qualified: "pkg.A"}}
+		r.Edges.CalledBy = []CallEdgeRef{{ID: 1, Symbol: "pkg.M"}}
+		r.Layers = []GraphLayer{{
+			Depth: 2,
+			Edges: GraphEdges{
+				CalledBy: []CallEdgeRef{
+					{ID: 10, Symbol: "pkg.Hub"},    // seen — collapses
+					{ID: 11, Symbol: "pkg.Fresh"},  // unseen — stays
+					{ID: 0, Symbol: "views/x.erb"}, // no identity — stays
+				},
+				Calls: []CallEdgeRef{{ID: 12, Symbol: "pkg.Helper"}}, // seen — collapses
+			},
+		}}
+		return r
+	}
+	seen := SeenFunc(func(id int64) bool { return id == 1 || id == 10 || id == 12 })
+
+	r := build()
+	CollapseSeenLayers(&r, seen)
+	if len(r.Edges.CalledBy) != 1 {
+		t.Errorf("root depth-1 edges must never collapse, got %+v", r.Edges.CalledBy)
+	}
+	l := r.Layers[0]
+	if len(l.Edges.CalledBy) != 2 || l.Edges.CalledBy[0].Symbol != "pkg.Fresh" {
+		t.Errorf("layer called_by should keep Fresh + the id-0 entry, got %+v", l.Edges.CalledBy)
+	}
+	if len(l.Edges.Calls) != 0 {
+		t.Errorf("seen layer callee should collapse, got %+v", l.Edges.Calls)
+	}
+	if l.SeenElsewhere == nil || l.SeenElsewhere.Count != 2 {
+		t.Fatalf("expected seen_elsewhere count 2, got %+v", l.SeenElsewhere)
+	}
+
+	// Nothing seen: no summary, nothing removed.
+	r2 := build()
+	CollapseSeenLayers(&r2, func(int64) bool { return false })
+	if r2.Layers[0].SeenElsewhere != nil || len(r2.Layers[0].Edges.CalledBy) != 3 {
+		t.Errorf("no-seen pass must be a no-op, got %+v", r2.Layers[0])
+	}
+
+	// Nil predicate disables the pass.
+	r3 := build()
+	CollapseSeenLayers(&r3, nil)
+	if r3.Layers[0].SeenElsewhere != nil || len(r3.Layers[0].Edges.CalledBy) != 3 {
+		t.Errorf("nil SeenFunc must disable the pass, got %+v", r3.Layers[0])
+	}
+}
+
 func TestApplyGraphBudgetNoopAndDisabled(t *testing.T) {
 	r := bigGraphResponse(3, 0)
 	ApplyGraphBudget(&r, 1_000_000)

--- a/internal/mcpio/graph_test.go
+++ b/internal/mcpio/graph_test.go
@@ -53,7 +53,7 @@ func TestCollapseSeenLayers(t *testing.T) {
 	seen := SeenFunc(func(id int64) bool { return id == 1 || id == 10 || id == 12 })
 
 	r := build()
-	CollapseSeenLayers(&r, seen)
+	CollapseSeenLayerEdges(&r, seen)
 	if len(r.Edges.CalledBy) != 1 {
 		t.Errorf("root depth-1 edges must never collapse, got %+v", r.Edges.CalledBy)
 	}
@@ -70,14 +70,14 @@ func TestCollapseSeenLayers(t *testing.T) {
 
 	// Nothing seen: no summary, nothing removed.
 	r2 := build()
-	CollapseSeenLayers(&r2, func(int64) bool { return false })
+	CollapseSeenLayerEdges(&r2, func(int64) bool { return false })
 	if r2.Layers[0].SeenElsewhere != nil || len(r2.Layers[0].Edges.CalledBy) != 3 {
 		t.Errorf("no-seen pass must be a no-op, got %+v", r2.Layers[0])
 	}
 
 	// Nil predicate disables the pass.
 	r3 := build()
-	CollapseSeenLayers(&r3, nil)
+	CollapseSeenLayerEdges(&r3, nil)
 	if r3.Layers[0].SeenElsewhere != nil || len(r3.Layers[0].Edges.CalledBy) != 3 {
 		t.Errorf("nil SeenFunc must disable the pass, got %+v", r3.Layers[0])
 	}

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -142,10 +142,16 @@ type DispatchInferredRef struct {
 
 // GraphLayer holds edges discovered at one BFS hop beyond the root.
 // Depth is the hop number (2, 3, …). Edges use the same shape as the
-// root's edges so the LLM can process them uniformly.
+// root's edges so the LLM can process them uniformly. SeenElsewhere
+// summarises layer entries collapsed because an earlier call already
+// returned them to this session — a token-saving deduplication, not a
+// truncation: the data is already in the agent's context. The root's
+// depth-1 edges never collapse; they are the direct answer to the
+// question asked.
 type GraphLayer struct {
-	Depth int        `json:"depth"`
-	Edges GraphEdges `json:"edges"`
+	Depth         int               `json:"depth"`
+	Edges         GraphEdges        `json:"edges"`
+	SeenElsewhere *BlastSeenSummary `json:"seen_elsewhere,omitempty"`
 }
 
 // TestCallerSummary segments test callers out of the main called_by

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -143,15 +143,13 @@ type DispatchInferredRef struct {
 // GraphLayer holds edges discovered at one BFS hop beyond the root.
 // Depth is the hop number (2, 3, …). Edges use the same shape as the
 // root's edges so the LLM can process them uniformly. SeenElsewhere
-// summarises layer entries collapsed because an earlier call already
-// returned them to this session — a token-saving deduplication, not a
-// truncation: the data is already in the agent's context. The root's
-// depth-1 edges never collapse; they are the direct answer to the
-// question asked.
+// summarises layer entries collapsed because the session already holds
+// them — never the root's depth-1 edges (see CollapseSeenLayerEdges
+// for the full contract).
 type GraphLayer struct {
-	Depth         int               `json:"depth"`
-	Edges         GraphEdges        `json:"edges"`
-	SeenElsewhere *BlastSeenSummary `json:"seen_elsewhere,omitempty"`
+	Depth         int          `json:"depth"`
+	Edges         GraphEdges   `json:"edges"`
+	SeenElsewhere *SeenSummary `json:"seen_elsewhere,omitempty"`
 }
 
 // TestCallerSummary segments test callers out of the main called_by
@@ -362,23 +360,24 @@ type BlastResponse struct {
 	// question for it but no view edge exists, "" (omitted) otherwise. See
 	// viewedges.go for the full contract.
 	ViewEdges string `json:"view_edges,omitempty"`
-	// SeenVia summarises the direct callers collapsed out of the enumerated
-	// list because an earlier sense_graph/sense_blast call already returned
-	// them to this session. It is a token-saving deduplication, not a
-	// truncation: the data is already in the agent's context, so the magnitude
-	// fields (total_affected, direct_callers_by_area) and the completeness
-	// verdict are unaffected. Present only when at least one caller was
-	// collapsed.
-	SeenVia      *BlastSeenSummary `json:"seen_elsewhere,omitempty"`
-	SenseMetrics BlastMetrics      `json:"-"`
-	Freshness    *Freshness        `json:"freshness,omitempty"`
-	NextSteps    []NextStep        `json:"next_steps"`
+	// SeenElsewhere summarises the direct callers collapsed out of the
+	// enumerated list because the session already received them from an
+	// earlier call. It is a token-saving deduplication, not a truncation:
+	// the data is already in the agent's context, so the magnitude fields
+	// (total_affected, direct_callers_by_area) and the completeness verdict
+	// are unaffected. Present only when at least one caller was collapsed.
+	SeenElsewhere *SeenSummary `json:"seen_elsewhere,omitempty"`
+	SenseMetrics  BlastMetrics `json:"-"`
+	Freshness     *Freshness   `json:"freshness,omitempty"`
+	NextSteps     []NextStep   `json:"next_steps"`
 }
 
-// BlastSeenSummary collapses direct callers already returned earlier this
-// session into a single count + note, instead of re-enumerating them. Count
-// is how many enumerated direct callers were omitted; Note explains why.
-type BlastSeenSummary struct {
+// SeenSummary replaces entries a response would re-enumerate with a single
+// count + note, because an earlier call this session already returned them.
+// Blast uses it for collapsed direct callers; graph uses it for collapsed
+// deeper-layer call edges. Count is how many entries were omitted; Note
+// explains why and how to recover them.
+type SeenSummary struct {
 	Count int    `json:"count"`
 	Note  string `json:"note"`
 }

--- a/internal/mcpserver/graph.go
+++ b/internal/mcpserver/graph.go
@@ -191,18 +191,28 @@ func (h *handlers) shapeGraphResponse(ctx context.Context, resp *mcpio.GraphResp
 	resp.Freshness = computeFreshness(ctx, h.db, h.dir, false, h.watchState, snap)
 	resp.NextSteps = graphHints(*resp, p.direction)
 
+	// Collapse deeper-layer edges the session already received — runs
+	// before the budget so freed room keeps real content instead of being
+	// re-trimmed. Sibling fan-walks (one graph call per subclass of a
+	// shared parent) repeat the same hub callers at depth 2 on every call;
+	// this is where that repetition stops costing tokens.
+	mcpio.CollapseSeenLayers(resp, h.seenPredicate())
+
 	// Keep hub responses within the MCP token budget — sheds deeper layers
 	// and trims the longest edge list, recording the count in OmittedEdges.
 	mcpio.ApplyGraphBudget(resp, h.defaults.GraphTokenBudget)
 
-	// Mark the root AND the FINAL rendered called_by callers seen — AFTER the
-	// budget trim, so a later sense_blast collapses ONLY callers the model
-	// actually received, never ones the budget dropped (collapsing an unshown
-	// caller would silently lose it). The rendered called_by set is exactly
-	// blast's depth-1 direct-caller set; inherit/include/compose and indirect
-	// callers are not marked — blast lists those separately. Test callers,
-	// segmented into their own bucket, are intentionally left un-collapsed.
-	h.markSeen(append(renderedCallerIDs(resp), gr.Root.Symbol.ID))
+	// Mark the root, the FINAL rendered called_by callers, and the rendered
+	// layer call-edge targets seen — AFTER the budget trim, so later calls
+	// collapse ONLY entries the model actually received, never ones the
+	// budget dropped (collapsing an unshown entry would silently lose it).
+	// The rendered called_by set is exactly blast's depth-1 direct-caller
+	// set; layer targets feed the layer collapse above and, like every
+	// shown-with-ref symbol, are fair game for blast's own seen collapse.
+	// Inherit/include/compose targets are not marked — blast lists those
+	// separately. Test callers, segmented into their own bucket, are
+	// intentionally left un-collapsed.
+	h.markSeen(append(renderedGraphIDs(resp), gr.Root.Symbol.ID))
 }
 
 const (
@@ -342,21 +352,29 @@ func appendDispatchCallers(inferred []mcpio.DispatchInferredRef, ids *[]int64, i
 	return inferred
 }
 
-// renderedCallerIDs collects the symbol ids of the callers the graph response
-// ACTUALLY rendered in its
-// called_by bucket, read after segmentation and the budget trim. These are
-// exactly the depth-1 callers the model received and exactly blast's direct-
-// caller set, so a later sense_blast can collapse them with no risk of hiding
-// a caller that was never shown. Test callers (segmented into their own
-// bucket) and indirect/inherit/include/compose targets are deliberately not
-// returned — blast enumerates those separately. IDs of 0 (unresolved-source
-// view edges) are skipped: they carry no symbol blast could match.
-func renderedCallerIDs(resp *mcpio.GraphResponse) []int64 {
+// renderedGraphIDs collects the symbol ids of the call-edge targets the graph
+// response ACTUALLY rendered, read after segmentation and the budget trim:
+// the depth-1 called_by callers (exactly blast's direct-caller set, so a
+// later sense_blast can collapse them with no risk of hiding a caller that
+// was never shown) plus the deeper layers' called_by/calls targets (feeding
+// the layer seen-collapse on later graph calls). Test callers (segmented
+// into their own bucket) and inherit/include/compose targets are
+// deliberately not returned — blast enumerates those separately. IDs of 0
+// (unresolved-source view edges) are skipped: they carry no symbol a later
+// call could match.
+func renderedGraphIDs(resp *mcpio.GraphResponse) []int64 {
 	ids := make([]int64, 0, len(resp.Edges.CalledBy))
-	for _, c := range resp.Edges.CalledBy {
-		if c.ID != 0 {
-			ids = append(ids, c.ID)
+	appendEdgeIDs := func(edges []mcpio.CallEdgeRef) {
+		for _, c := range edges {
+			if c.ID != 0 {
+				ids = append(ids, c.ID)
+			}
 		}
+	}
+	appendEdgeIDs(resp.Edges.CalledBy)
+	for i := range resp.Layers {
+		appendEdgeIDs(resp.Layers[i].Edges.CalledBy)
+		appendEdgeIDs(resp.Layers[i].Edges.Calls)
 	}
 	return ids
 }

--- a/internal/mcpserver/graph.go
+++ b/internal/mcpserver/graph.go
@@ -196,7 +196,7 @@ func (h *handlers) shapeGraphResponse(ctx context.Context, resp *mcpio.GraphResp
 	// re-trimmed. Sibling fan-walks (one graph call per subclass of a
 	// shared parent) repeat the same hub callers at depth 2 on every call;
 	// this is where that repetition stops costing tokens.
-	mcpio.CollapseSeenLayers(resp, h.seenPredicate())
+	mcpio.CollapseSeenLayerEdges(resp, h.seenPredicate())
 
 	// Keep hub responses within the MCP token budget — sheds deeper layers
 	// and trims the longest edge list, recording the count in OmittedEdges.
@@ -207,12 +207,11 @@ func (h *handlers) shapeGraphResponse(ctx context.Context, resp *mcpio.GraphResp
 	// collapse ONLY entries the model actually received, never ones the
 	// budget dropped (collapsing an unshown entry would silently lose it).
 	// The rendered called_by set is exactly blast's depth-1 direct-caller
-	// set; layer targets feed the layer collapse above and, like every
-	// shown-with-ref symbol, are fair game for blast's own seen collapse.
-	// Inherit/include/compose targets are not marked — blast lists those
-	// separately. Test callers, segmented into their own bucket, are
-	// intentionally left un-collapsed.
-	h.markSeen(append(renderedGraphIDs(resp), gr.Root.Symbol.ID))
+	// set; layer targets feed the layer collapse above. Marking layer
+	// targets also means a later blast collapses direct callers the session
+	// first saw as a layer entry — deliberate, they were delivered with
+	// refs. See idsToMarkSeen for what is deliberately NOT marked.
+	h.markSeen(append(idsToMarkSeen(resp), gr.Root.Symbol.ID))
 }
 
 const (
@@ -352,17 +351,20 @@ func appendDispatchCallers(inferred []mcpio.DispatchInferredRef, ids *[]int64, i
 	return inferred
 }
 
-// renderedGraphIDs collects the symbol ids of the call-edge targets the graph
+// idsToMarkSeen collects the symbol ids of the call-edge targets the graph
 // response ACTUALLY rendered, read after segmentation and the budget trim:
 // the depth-1 called_by callers (exactly blast's direct-caller set, so a
 // later sense_blast can collapse them with no risk of hiding a caller that
 // was never shown) plus the deeper layers' called_by/calls targets (feeding
-// the layer seen-collapse on later graph calls). Test callers (segmented
-// into their own bucket) and inherit/include/compose targets are
-// deliberately not returned — blast enumerates those separately. IDs of 0
+// the layer seen-collapse on later graph calls). Root callees are rendered
+// with refs too but deliberately NOT marked: marking them widens what a
+// later blast collapses, and that expansion has no motivating flow yet —
+// it should arrive with its own bench, not as a rider. Test callers
+// (segmented into their own bucket) and inherit/include/compose targets
+// are likewise not returned — blast enumerates those separately. IDs of 0
 // (unresolved-source view edges) are skipped: they carry no symbol a later
 // call could match.
-func renderedGraphIDs(resp *mcpio.GraphResponse) []int64 {
+func idsToMarkSeen(resp *mcpio.GraphResponse) []int64 {
 	ids := make([]int64, 0, len(resp.Edges.CalledBy))
 	appendEdgeIDs := func(edges []mcpio.CallEdgeRef) {
 		for _, c := range edges {

--- a/internal/mcpserver/oracle_test.go
+++ b/internal/mcpserver/oracle_test.go
@@ -195,7 +195,12 @@ func oracleDigest(t *testing.T, calls []labeledCall) (string, []string) {
 // nearest indexed candidates (when the search engine finds any) and a
 // next_steps pointer at sense_search, so graph/not_found gained a next_steps
 // entry — digest moved. The "error" key is unchanged.
-const oracleGolden = "1738ff2d7e6165730e89aa9f19d605524ccd9a3111130b8f5917bd24dc2c0c15"
+// Blast's seen_elsewhere note now says "in this session" instead of "on this
+// symbol": the seen set is session-wide (graph layer targets feed it too),
+// so the old wording was false whenever the collapsed caller was first
+// delivered by a call on a different symbol — digest moved. Counts and keys
+// are unchanged.
+const oracleGolden = "f828538af81dd76968dd9eafc73a539738f51fa9629988d33913adec6b7ee922"
 
 func TestMCPServerResponseOracle(t *testing.T) {
 	got, content := oracleDigest(t, collectOracleCalls(t))

--- a/internal/mcpserver/seen.go
+++ b/internal/mcpserver/seen.go
@@ -24,13 +24,15 @@ func (h *handlers) seenPredicate() mcpio.SeenFunc {
 }
 
 // markSeen records ids as returned to this session so a later collapsing tool
-// dedups against them. The dedup is directional: sense_graph and sense_blast
-// MARK what they return, but only sense_blast COLLAPSES already-seen direct
-// callers (and sense_search blanks already-seen snippets) — graph never
-// collapses. So the practical flows are graph→blast and blast→blast; a blast
-// after a graph is the common one. A nil seenSymbols map (a handler built
-// without session tracking) disables the dedup rather than panicking — the
-// zero value is "track nothing".
+// dedups against them. sense_graph and sense_blast MARK what they render;
+// sense_blast COLLAPSES already-seen direct callers, sense_search blanks
+// already-seen snippets, and sense_graph collapses already-seen targets in
+// its deeper BFS layers (never in the root's depth-1 edges — those are the
+// direct answer to the question asked). The practical flows are graph→blast,
+// blast→blast, and the sibling fan-walk graph→graph, where each call's
+// depth-2 layer repeats the same hub callers. A nil seenSymbols map (a
+// handler built without session tracking) disables the dedup rather than
+// panicking — the zero value is "track nothing".
 func (h *handlers) markSeen(ids []int64) {
 	if len(ids) == 0 {
 		return

--- a/internal/mcpserver/seen.go
+++ b/internal/mcpserver/seen.go
@@ -7,14 +7,19 @@ import "github.com/luuuc/sense/internal/mcpio"
 // blast callers) in seenSymbols. A later tool collapses entries the session
 // already holds instead of re-sending them: sense_search blanks the snippet
 // (search.go), sense_blast collapses already-seen direct callers into a
-// seen_elsewhere summary (blast.go). This file is the one home for the read
-// (seenPredicate) and write (markSeen) sides of that shared state.
+// seen_elsewhere summary (blast.go), and sense_graph collapses already-seen
+// targets in its deeper BFS layers (graph.go). This file is the one home
+// for the read (seenPredicate) and write (markSeen) sides of that shared
+// state. The model assumes shown ≈ retained: ids are marked when a response
+// is built, not when delivery is confirmed (MCP has no ack), so a transport
+// drop after marking degrades to a collapse the agent must recover via a
+// fresh root query — roots never collapse.
 
-// seenPredicate returns a SeenFunc the mcpio blast builders consult to decide
-// which direct callers were already returned this session. The predicate
-// locks per lookup, so it reflects the set as it stands when the builder runs
-// — a blast records its own callers only afterwards (markSeen), so it never
-// collapses against itself.
+// seenPredicate returns a SeenFunc the mcpio builders consult to decide
+// which entries were already returned this session. The predicate locks per
+// lookup, so it reflects the set as it stands when the builder runs — a
+// call records its own rendered entries only afterwards (markSeen), so it
+// never collapses against itself.
 func (h *handlers) seenPredicate() mcpio.SeenFunc {
 	return func(id int64) bool {
 		h.seenMu.Lock()
@@ -28,11 +33,12 @@ func (h *handlers) seenPredicate() mcpio.SeenFunc {
 // sense_blast COLLAPSES already-seen direct callers, sense_search blanks
 // already-seen snippets, and sense_graph collapses already-seen targets in
 // its deeper BFS layers (never in the root's depth-1 edges — those are the
-// direct answer to the question asked). The practical flows are graph→blast,
-// blast→blast, and the sibling fan-walk graph→graph, where each call's
-// depth-2 layer repeats the same hub callers. A nil seenSymbols map (a
-// handler built without session tracking) disables the dedup rather than
-// panicking — the zero value is "track nothing".
+// direct answer to the question asked). The common flows include
+// graph→blast, blast→blast, blast→graph, and the sibling fan-walk
+// graph→graph, where each call's depth-2 layer repeats the same hub
+// callers. A nil seenSymbols map (a handler built without session
+// tracking) disables the dedup rather than panicking — the zero value is
+// "track nothing".
 func (h *handlers) markSeen(ids []int64) {
 	if len(ids) == 0 {
 		return

--- a/internal/mcpserver/seen_test.go
+++ b/internal/mcpserver/seen_test.go
@@ -64,10 +64,10 @@ func TestSeenDedupCollapsesOnlyRenderedCallers(t *testing.T) {
 		if err := json.Unmarshal([]byte(resultText(t, result)), &resp); err != nil {
 			t.Fatalf("unmarshal: %v", err)
 		}
-		if resp.SeenVia == nil {
+		if resp.SeenElsewhere == nil {
 			return 0
 		}
-		return resp.SeenVia.Count
+		return resp.SeenElsewhere.Count
 	}
 
 	trimmed := seenAfterGraph(1)      // budget=1 trims called_by to ~one entry
@@ -142,11 +142,90 @@ func TestGraphFanWalkCollapsesSharedLayer(t *testing.T) {
 	}
 }
 
-// TestRenderedGraphIDs pins what the graph response marks seen: the rendered
+// TestGraphLayerMarkingHonorsBudgetTrim is the layer twin of the caller-leak
+// regression: layer targets must be marked seen AFTER the budget trim, never
+// from the pre-trim response. Call 1 runs with a starvation budget that
+// sheds its depth-2 layer, so the layer's hub target (main.main) was never
+// delivered; call 2 (full budget) shares that hub at depth 2 and must
+// RENDER it, not collapse it — collapsing would tell the agent "already
+// returned to this session", which would be false.
+func TestGraphLayerMarkingHonorsBudgetTrim(t *testing.T) {
+	ts := setupTestServer(t)
+	ctx := context.Background()
+
+	graphLayer := func(symbol string, budget int) (map[string]any, []any) {
+		ts.handlers.defaults.GraphTokenBudget = budget
+		result, err := ts.handlers.handleGraph(ctx, toolReq(map[string]any{
+			"symbol": symbol, "direction": "callers",
+		}))
+		if err != nil {
+			t.Fatalf("handleGraph(%s, budget=%d): %v", symbol, budget, err)
+		}
+		var resp map[string]any
+		if err := json.Unmarshal([]byte(resultText(t, result)), &resp); err != nil {
+			t.Fatalf("unmarshal %s: %v", symbol, err)
+		}
+		layers, _ := resp["layers"].([]any)
+		return resp, layers
+	}
+
+	// Call 1: starve the budget so the depth-2 layer (main.main) is shed.
+	resp1, layers1 := graphLayer("auth.Verify", 1)
+	if len(layers1) != 0 {
+		t.Skipf("budget=1 did not shed the layer (got %v) — fixture grew; retune the starvation budget", resp1["layers"])
+	}
+
+	// Call 2: full budget on the sibling sharing the depth-2 hub. The hub
+	// was never delivered, so it must render, and nothing may collapse.
+	_, layers2 := graphLayer("model.FindUser", 1_000_000)
+	if len(layers2) == 0 {
+		t.Fatal("expected a depth-2 layer on the second call")
+	}
+	l2 := layers2[0].(map[string]any)
+	if se, collapsed := l2["seen_elsewhere"]; collapsed {
+		t.Fatalf("layer collapsed against budget-shed targets the agent never received: %v", se)
+	}
+	callers, _ := l2["edges"].(map[string]any)["called_by"].([]any)
+	if len(callers) == 0 {
+		t.Error("the never-delivered depth-2 hub must render in full on the second call")
+	}
+}
+
+// TestBlastCollapsesCallerFirstSeenAsLayerTarget pins the cross-tool rider:
+// marking layer targets means a later sense_blast collapses a direct caller
+// the session first received only as a graph layer entry. The flow is the
+// fan-walk's natural next step — graph a sibling (layer shows the hub's
+// caller), then blast the hub.
+func TestBlastCollapsesCallerFirstSeenAsLayerTarget(t *testing.T) {
+	ts := setupTestServer(t)
+	ctx := context.Background()
+
+	// graph model.FindUser callers: depth-1 = HandleRequest, depth-2 layer =
+	// main.main (rendered, hence marked).
+	if _, err := ts.handlers.handleGraph(ctx, toolReq(map[string]any{
+		"symbol": "model.FindUser", "direction": "callers",
+	})); err != nil {
+		t.Fatalf("handleGraph: %v", err)
+	}
+
+	// blast HandleRequest: its direct caller main.main was delivered as a
+	// layer entry above, so it collapses into seen_elsewhere.
+	v := runBlast(t, ts.handlers, "handler.HandleRequest")
+	if v.SeenElsewhere == nil || v.SeenElsewhere.Count < 1 {
+		t.Fatalf("expected the layer-delivered caller collapsed into seen_elsewhere, got %+v", v)
+	}
+	for _, c := range v.DirectCallers {
+		if c["symbol"] == "main.main" {
+			t.Errorf("main.main must be collapsed, not re-enumerated: %v", v.DirectCallers)
+		}
+	}
+}
+
+// TestIdsToMarkSeen pins what the graph response marks seen: the rendered
 // depth-1 called_by callers (blast's direct-caller set) plus the rendered
 // layer call-edge targets (feeding the layer seen-collapse) — never the
 // root's callees, and never unresolved view edges (ID 0).
-func TestRenderedGraphIDs(t *testing.T) {
+func TestIdsToMarkSeen(t *testing.T) {
 	resp := &mcpio.GraphResponse{
 		Edges: mcpio.GraphEdges{
 			CalledBy: []mcpio.CallEdgeRef{
@@ -155,8 +234,10 @@ func TestRenderedGraphIDs(t *testing.T) {
 				{ID: 0, Symbol: "app/views/x.erb"}, // unresolved view edge — skip
 				{ID: 3, Symbol: "C#o"},
 			},
-			// Root callees must NOT be collected — they are not blast direct
-			// callers and the root's edges never collapse.
+			// Root callees must NOT be collected — deliberate conservatism,
+			// not principle: marking them would widen what a later blast
+			// collapses, an expansion that needs its own bench (see
+			// idsToMarkSeen's doc), not a rider on this fixture.
 			Calls: []mcpio.CallEdgeRef{{ID: 88, Symbol: "callee"}},
 		},
 		Layers: []mcpio.GraphLayer{{
@@ -168,10 +249,10 @@ func TestRenderedGraphIDs(t *testing.T) {
 		}},
 	}
 
-	got := renderedGraphIDs(resp)
+	got := idsToMarkSeen(resp)
 	want := map[int64]bool{1: true, 2: true, 3: true, 4: true, 5: true}
 	if len(got) != len(want) {
-		t.Fatalf("renderedGraphIDs = %v, want called_by {1,2,3} + layer targets {4,5}", got)
+		t.Fatalf("idsToMarkSeen = %v, want called_by {1,2,3} + layer targets {4,5}", got)
 	}
 	for _, id := range got {
 		if !want[id] {
@@ -186,7 +267,7 @@ type blastView struct {
 	DirectCallers       []map[string]any `json:"direct_callers"`
 	TotalAffected       int              `json:"total_affected"`
 	DirectCallersByArea map[string]int   `json:"direct_callers_by_area"`
-	SeenVia             *struct {
+	SeenElsewhere       *struct {
 		Count int `json:"count"`
 	} `json:"seen_elsewhere"`
 	Completeness *struct {
@@ -221,8 +302,8 @@ func TestBlastSingleCallIsFullThenGraphDedups(t *testing.T) {
 
 	// 1. Fresh session: blast on auth.Verify enumerates its callers in full.
 	first := runBlast(t, h, "auth.Verify")
-	if first.SeenVia != nil {
-		t.Errorf("fresh-session blast must collapse nothing, got seen_elsewhere=%+v", first.SeenVia)
+	if first.SeenElsewhere != nil {
+		t.Errorf("fresh-session blast must collapse nothing, got seen_elsewhere=%+v", first.SeenElsewhere)
 	}
 	if len(first.DirectCallers) == 0 {
 		t.Fatal("fresh blast should enumerate at least one direct caller")
@@ -236,8 +317,8 @@ func TestBlastSingleCallIsFullThenGraphDedups(t *testing.T) {
 	// 2+3. Second blast on the same symbol: the callers recorded by the first
 	// blast are now collapsed, but the radius is preserved.
 	second := runBlast(t, h, "auth.Verify")
-	if second.SeenVia == nil || second.SeenVia.Count != firstCount {
-		t.Errorf("second blast seen_elsewhere = %+v, want count %d (all callers already returned)", second.SeenVia, firstCount)
+	if second.SeenElsewhere == nil || second.SeenElsewhere.Count != firstCount {
+		t.Errorf("second blast seen_elsewhere = %+v, want count %d (all callers already returned)", second.SeenElsewhere, firstCount)
 	}
 	if len(second.DirectCallers) != 0 {
 		t.Errorf("second blast enumerated %d callers, want 0 (all already seen)", len(second.DirectCallers))

--- a/internal/mcpserver/seen_test.go
+++ b/internal/mcpserver/seen_test.go
@@ -83,10 +83,70 @@ func TestSeenDedupCollapsesOnlyRenderedCallers(t *testing.T) {
 	}
 }
 
-// TestRenderedCallerIDs pins that only the callers the graph response actually
-// rendered in called_by are collected (so blast collapses only what the model
-// received), and that unresolved-source view edges (ID 0) are skipped.
-func TestRenderedCallerIDs(t *testing.T) {
+// TestGraphFanWalkCollapsesSharedLayer is the sibling fan-walk regression:
+// two callers-direction graph calls on siblings sharing a depth-2 hub
+// (HandleRequest calls both Verify and FindUser; main.main calls
+// HandleRequest). The first call renders the hub in its layer; the second
+// must collapse it into the layer's seen_elsewhere instead of re-sending
+// it — while its own depth-1 called_by renders in full even though the
+// caller was already seen (the root's edges are the direct answer).
+func TestGraphFanWalkCollapsesSharedLayer(t *testing.T) {
+	ts := setupTestServer(t)
+	ctx := context.Background()
+
+	graph := func(symbol string) map[string]any {
+		result, err := ts.handlers.handleGraph(ctx, toolReq(map[string]any{
+			"symbol": symbol, "direction": "callers",
+		}))
+		if err != nil {
+			t.Fatalf("handleGraph(%s): %v", symbol, err)
+		}
+		var resp map[string]any
+		if err := json.Unmarshal([]byte(resultText(t, result)), &resp); err != nil {
+			t.Fatalf("unmarshal %s: %v", symbol, err)
+		}
+		return resp
+	}
+	layerOf := func(resp map[string]any) map[string]any {
+		layers, _ := resp["layers"].([]any)
+		if len(layers) == 0 {
+			t.Fatalf("expected a depth-2 layer, got %v", resp["layers"])
+		}
+		return layers[0].(map[string]any)
+	}
+
+	// First sibling: the shared hub (main.main) renders in the layer.
+	first := layerOf(graph("auth.Verify"))
+	if _, collapsed := first["seen_elsewhere"]; collapsed {
+		t.Errorf("first call has nothing to collapse, got %v", first["seen_elsewhere"])
+	}
+	firstCallers, _ := first["edges"].(map[string]any)["called_by"].([]any)
+	if len(firstCallers) == 0 {
+		t.Fatal("fixture should render main.main in the first call's layer")
+	}
+
+	// Second sibling: same depth-2 hub — must collapse, not re-send.
+	second := graph("model.FindUser")
+	rootCallers, _ := second["edges"].(map[string]any)["called_by"].([]any)
+	if len(rootCallers) == 0 {
+		t.Error("root depth-1 called_by must render in full even when already seen")
+	}
+	l2 := layerOf(second)
+	se, ok := l2["seen_elsewhere"].(map[string]any)
+	if !ok || se["count"].(float64) < 1 {
+		t.Fatalf("expected the shared depth-2 hub collapsed into seen_elsewhere, got %v", l2)
+	}
+	l2Callers, _ := l2["edges"].(map[string]any)["called_by"].([]any)
+	if len(l2Callers) != 0 {
+		t.Errorf("collapsed layer should not re-enumerate the seen hub, got %v", l2Callers)
+	}
+}
+
+// TestRenderedGraphIDs pins what the graph response marks seen: the rendered
+// depth-1 called_by callers (blast's direct-caller set) plus the rendered
+// layer call-edge targets (feeding the layer seen-collapse) — never the
+// root's callees, and never unresolved view edges (ID 0).
+func TestRenderedGraphIDs(t *testing.T) {
 	resp := &mcpio.GraphResponse{
 		Edges: mcpio.GraphEdges{
 			CalledBy: []mcpio.CallEdgeRef{
@@ -95,20 +155,27 @@ func TestRenderedCallerIDs(t *testing.T) {
 				{ID: 0, Symbol: "app/views/x.erb"}, // unresolved view edge — skip
 				{ID: 3, Symbol: "C#o"},
 			},
-			// Calls (callees) and other buckets must NOT be collected — they are
-			// not blast direct callers.
+			// Root callees must NOT be collected — they are not blast direct
+			// callers and the root's edges never collapse.
 			Calls: []mcpio.CallEdgeRef{{ID: 88, Symbol: "callee"}},
 		},
+		Layers: []mcpio.GraphLayer{{
+			Depth: 2,
+			Edges: mcpio.GraphEdges{
+				CalledBy: []mcpio.CallEdgeRef{{ID: 4, Symbol: "D#p"}, {ID: 0, Symbol: "view"}},
+				Calls:    []mcpio.CallEdgeRef{{ID: 5, Symbol: "E#q"}},
+			},
+		}},
 	}
 
-	got := renderedCallerIDs(resp)
-	want := map[int64]bool{1: true, 2: true, 3: true}
+	got := renderedGraphIDs(resp)
+	want := map[int64]bool{1: true, 2: true, 3: true, 4: true, 5: true}
 	if len(got) != len(want) {
-		t.Fatalf("renderedCallerIDs = %v, want the 3 rendered called_by ids {1,2,3}", got)
+		t.Fatalf("renderedGraphIDs = %v, want called_by {1,2,3} + layer targets {4,5}", got)
 	}
 	for _, id := range got {
 		if !want[id] {
-			t.Errorf("collected id %d — only rendered called_by ids should be marked seen", id)
+			t.Errorf("collected id %d — root callees must not be marked seen", id)
 		}
 	}
 }

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -247,7 +247,7 @@ func TestMCPIntegration(t *testing.T) {
 			Risk          string `json:"risk"`
 			DirectCallers []any  `json:"direct_callers"`
 			TotalAffected int    `json:"total_affected"`
-			SeenVia       *struct {
+			SeenElsewhere *struct {
 				Count int `json:"count"`
 			} `json:"seen_elsewhere"`
 		}
@@ -269,8 +269,8 @@ func TestMCPIntegration(t *testing.T) {
 		// the enumerated direct callers plus the collapsed count cover it.
 		enumerated := len(blastResp.DirectCallers)
 		collapsed := 0
-		if blastResp.SeenVia != nil {
-			collapsed = blastResp.SeenVia.Count
+		if blastResp.SeenElsewhere != nil {
+			collapsed = blastResp.SeenElsewhere.Count
 		}
 		if blastResp.TotalAffected < 5 {
 			t.Errorf("total_affected = %d, want >= 5 (magnitude must survive seen-collapse)", blastResp.TotalAffected)


### PR DESCRIPTION
A sibling fan-walk — one callers-direction `sense_graph` call per subclass of a shared parent — repeats the same hub callers in every response's depth-2 layer. On a real 31-call walk over a 387-subclass fan, 80% of the MCP payload was `called_by` lists, and the depth-2 layer alone carried 226 duplicate ref appearances. Graph responses marked what they returned but never collapsed against the session's seen set; that flow existed only for blast.

## The change

Deeper-BFS-layer call edges whose target the session already received now collapse into a per-layer `seen_elsewhere` count + note, mirroring blast's semantics. Deduplication, not truncation: every collapsed target was already delivered with a citable location, and the note names the recovery path ("a root's own edges never collapse — run sense_graph on a specific symbol to re-enumerate its edges in full"). The root's depth-1 edges never collapse; they are the direct answer to the question asked. The collapse runs before the token budget so freed room keeps real content; marking runs after the budget trim so nothing unshown is ever collapsed — and that invariant is now pinned by a budget-trim differential test verified red against the mutation that marks pre-budget.

**Deliberate cross-tool consequence:** marking rendered layer targets means a later `sense_blast` collapses direct callers the session first saw as a layer entry. They were delivered with refs; the flow is pinned by its own test. Blast's note wording dropped "on this symbol" accordingly (the seen set is session-wide) — oracle golden bumped in-commit.

## Measured ($0, sequential MCP-stdio replay of the real bench sessions)

| Session | Pre | Post | Δ |
|---|---|---|---|
| fan-walk, default depth (31 calls) | ~82.4k tok | ~65.8k tok | **−20%**, 19 collapse blocks |
| fan-walk, explicit depth=1 (46 calls) | ~77.1k tok | ~77.1k tok | byte-identical (no layers, by design) |

No-loss verified: every ref the pre binary delivered was delivered by the post binary, in place or earlier in the session. Single-call sessions are byte-identical (17-symbol probe set at min_confidence 0.3/0.7 plus two high-fan-out WIN-anchor blasts, pre/post diff clean).

## Verification

`make ci` green (coverage floor, lint, complexity ledger), `make smoke` green. Review pass covered essentialism, scope, tests, resilience, systems, API, and idiom seats; all findings applied — including two regression tests the original commit owed (the budget-trim differential and the blast rider) and honest-naming fixes (`SeenSummary`, `CollapseSeenLayerEdges`, `idsToMarkSeen`).

## Merge gate

This is a global query-layer change; the replay is a proxy. A paired Opus 4.8 litellm re-run (the fan-walk vertical, RUNS=2 per arm) is queued as the measuring stick — results will be posted on this PR before merge.