### PR TITLE
ci: pin actions by SHA and scope workflow token permissions

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -7,8 +7,7 @@ on:
     types: [completed]
 
 permissions:
-  contents: write
-  actions: write
+  contents: read
 
 concurrency:
   group: auto-release
@@ -18,8 +17,11 @@ jobs:
   tag:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -27,7 +29,7 @@ jobs:
       # plain `run:` steps below. orhun/git-cliff-action only runs git-cliff
       # inside its own sandbox, so bare `git-cliff` calls would not resolve.
       - name: Install git-cliff
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@c93ccc03e00cd0e08e494f5fd058a6c55a6a1907 # v2.82.8
         with:
           tool: git-cliff
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     strategy:
@@ -21,9 +24,9 @@ jobs:
             arch: arm64
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
 
@@ -37,7 +40,7 @@ jobs:
           fi
 
       - name: Cache dependencies (model + ORT)
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: internal/embed/bundle
           key: sense-deps-${{ matrix.os }}-${{ matrix.arch }}-${{ hashFiles('scripts/fetch-deps.sh') }}
@@ -80,7 +83,7 @@ jobs:
 
       - name: Upload coverage
         if: matrix.os == 'linux'
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.txt
@@ -97,7 +100,7 @@ jobs:
   stdout-hygiene:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Complexity ledger is non-increasing
         # The inline //nolint:gocyclo/gocognit ledger is tracked debt the

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,20 +8,24 @@ on:
   schedule:
     - cron: "0 6 * * 1"
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
 
       - name: Cache dependencies (model + ORT)
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: internal/embed/bundle
           key: sense-deps-linux-amd64-${{ hashFiles('scripts/fetch-deps.sh') }}
@@ -30,7 +34,7 @@ jobs:
         run: ./scripts/fetch-deps.sh --local
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: go
 
@@ -38,4 +42,4 @@ jobs:
         run: make build
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3

--- a/.github/workflows/council-review.yml
+++ b/.github/workflows/council-review.yml
@@ -5,18 +5,20 @@ on: workflow_dispatch
 #     types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
-  models: read
-  pull-requests: write
   contents: read
-  checks: write
 
 jobs:
   review:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    permissions:
+      models: read
+      pull-requests: write
+      contents: read
+      checks: write
     steps:
-      - uses: actions/checkout@v7
-      - uses: luuuc/council/action@main
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: luuuc/council/action@24b23e66c1611a4881f3f68b0c6bc013f69b3661 # main 2026-07-05
         with:
           pack: go
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,13 +7,16 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
 
@@ -21,7 +24,7 @@ jobs:
       # model and ORT library, so typechecking fails without them. Same cache
       # key as ci.yml, so this is usually a no-op restore.
       - name: Cache dependencies (model + ORT)
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: internal/embed/bundle
           key: sense-deps-linux-amd64-${{ hashFiles('scripts/fetch-deps.sh') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -15,13 +15,15 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Generate release notes
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
         with:
           args: --latest --strip header
           output: release-notes.md

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -20,7 +20,7 @@ jobs:
     name: Smoke-test released binary (linux/amd64)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Download release archive and checksums
         env:

--- a/bench/global/docker/baseline/Dockerfile
+++ b/bench/global/docker/baseline/Dockerfile
@@ -18,7 +18,7 @@
 # reach bench/scenarios/, bench/lib/, bench/global/docker/entrypoint.sh,
 # bench/PINNED_COMMITS.json.
 
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PATH=/root/.local/bin:/usr/local/bin:/usr/bin:/bin

--- a/bench/global/docker/serena/Dockerfile
+++ b/bench/global/docker/serena/Dockerfile
@@ -16,7 +16,7 @@ ARG BASE_TAG=dev
 # and ruby-lsp runs `bundle install` against the project which then refuses on
 # version mismatch. Carrying Ruby 3.4 alongside Debian's interpreter (in /opt,
 # not /usr/local, to avoid colliding with rust-analyzer / go we install later).
-FROM ruby:3.4-slim-bookworm AS ruby34
+FROM ruby:3.4-slim-bookworm@sha256:6760b6e46941fb77f8229f52d1745a629a20f148c8685226d76758fcb6e33766 AS ruby34
 
 # ── Stage 2: serena runtime ────────────────────────────────────────────────
 FROM bench-baseline:${BASE_TAG}


### PR DESCRIPTION
## Problem

All seven workflows reference actions by mutable tags and two grant `GITHUB_TOKEN` write access workflow-wide, so a hijacked action tag or a compromised step inherits more privilege than it needs. OpenSSF Scorecard flags both: Token-Permissions 0/10, Pinned-Dependencies 0/10.

## Summary

Pin every GitHub Action to a full commit SHA and drop workflow-level tokens to read-only, scoping write grants to the jobs that need them.

## Changes

- **Workflows (all 7):** top-level `permissions: contents: read`; write grants moved to job level — auto-release tag job (`contents`, `actions`), release job (`contents`), council review job (PR/checks), CodeQL analyze job (`security-events`). Runtime behavior is unchanged: each workflow's writes land on its only job that used them.
- **Pinning:** all actions pinned to full commit SHAs with version comments. Dependabot's `github-actions` ecosystem keeps the hashes bumped; `luuuc/council/action` is pinned to its current `main` SHA and needs manual bumps (no releases for Dependabot to track).
- **Bench images:** digest-pin `debian:bookworm-slim` and `ruby:3.4-slim-bookworm`. The `bench-baseline:${BASE_TAG}` FROMs are locally built and the golang image is ARG-driven, so those stay tag-based.

## Test Plan

- [x] `make ci` green locally (build + cover 95.1% + lint + ledger)
- [x] All workflow YAML parses cleanly
- [x] Local Scorecard: Token-Permissions 0 → 10/10 ("tokens follow principle of least privilege")
- [x] Local Scorecard: Pinned-Dependencies 0 → 3/10 (remainder is unpinnable bench-local images)
- [x] No version bump: `git-cliff --bumped-version` unchanged (ci/bench types are skipped)