### PR TITLE
ci(release): sign artifacts with Sigstore and attest provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # Keyless cosign signing and build provenance attestations both
+      # authenticate through the job's OIDC identity.
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -31,6 +35,19 @@ jobs:
       - name: Clean git-cliff artifacts
         run: rm -rf git-cliff/
 
+      # quill stamps the darwin binaries with a stable code-signing
+      # identifier (scripts/sign-darwin.sh, wired as a GoReleaser post-build
+      # hook). Installed to RUNNER_TEMP so the repo stays git-clean for
+      # `goreleaser release --clean`, then mounted into the container.
+      - name: Install quill (darwin binary signing)
+        run: |
+          set -euo pipefail
+          curl -fsSL -o "${RUNNER_TEMP}/quill.tar.gz" \
+            https://github.com/anchore/quill/releases/download/v0.7.1/quill_0.7.1_linux_amd64.tar.gz
+          echo "e58c6f86378a22507c1123e24412afd4ee2d3bb32ebd94d6059827dc0c1b3fbf  ${RUNNER_TEMP}/quill.tar.gz" | sha256sum -c -
+          mkdir -p "${RUNNER_TEMP}/quill"
+          tar -xzf "${RUNNER_TEMP}/quill.tar.gz" -C "${RUNNER_TEMP}/quill" quill
+
       # Tree-sitter bindings require CGO, and we ship darwin + linux for both
       # amd64 and arm64. goreleaser-cross bundles osxcross and the gcc
       # cross-toolchains the .goreleaser.yml overrides reference (o64-clang,
@@ -41,11 +58,33 @@ jobs:
           docker run --rm \
             -e GITHUB_TOKEN \
             -v "$PWD":/src \
+            -v "${RUNNER_TEMP}/quill/quill":/usr/local/bin/quill:ro \
             -w /src \
             ghcr.io/goreleaser/goreleaser-cross:v1.25.5 \
             release --clean --release-notes release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      # Keyless (Sigstore) signature over the checksums file: the ephemeral
+      # certificate is bound to this workflow's OIDC identity and logged in
+      # Rekor, so verifying checksums.txt.sig transitively verifies every
+      # artifact listed in it. smoke.yml verifies this on each release.
+      # dist/ is root-owned until the MCPB chown below, so the signature
+      # files are written to the workspace instead.
+      - name: Sign checksums file (Sigstore keyless)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          CHECKSUMS="sense_${GITHUB_REF_NAME#v}_checksums.txt"
+          cosign sign-blob --yes \
+            --output-signature "${CHECKSUMS}.sig" \
+            --output-certificate "${CHECKSUMS}.pem" \
+            "dist/${CHECKSUMS}"
+          gh release upload "$GITHUB_REF_NAME" "${CHECKSUMS}.sig" "${CHECKSUMS}.pem" --clobber
 
       - name: Build MCPB bundles
         run: |
@@ -70,3 +109,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload "$GITHUB_REF_NAME" mcpb-dist/*.mcpb --clobber
+
+      # SLSA build provenance for every shipped artifact, verifiable with
+      # `gh attestation verify <file> --owner luuuc`.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            dist/sense_*.tar.gz
+            dist/sense_*_checksums.txt
+            mcpb-dist/*.mcpb

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -52,6 +52,41 @@ jobs:
           tar -xzf "${ARCHIVE}"
           chmod +x ./sense
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      # Regression gate for release signing: verifies the keyless signature
+      # release.yml attached to the checksums file, pinned to this repo's
+      # release workflow identity. Catches cosign CLI breaks, identity
+      # drift, and signing regressions on every release.
+      - name: Verify checksums signature (Sigstore keyless)
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          CHECKSUMS="sense_${VERSION}_checksums.txt"
+          BASE="https://github.com/${REPO}/releases/download/${TAG}"
+
+          # The "published" event fires when GoReleaser creates the release;
+          # release.yml uploads the signature a few minutes later. Poll.
+          for i in $(seq 1 30); do
+            if curl -fsSL -o "${CHECKSUMS}.sig" "${BASE}/${CHECKSUMS}.sig" &&
+               curl -fsSL -o "${CHECKSUMS}.pem" "${BASE}/${CHECKSUMS}.pem"; then
+              break
+            fi
+            echo "signature assets not published yet (attempt ${i}/30)"
+            sleep 10
+          done
+          test -s "${CHECKSUMS}.sig" && test -s "${CHECKSUMS}.pem"
+
+          cosign verify-blob \
+            --certificate-identity-regexp "^https://github.com/${REPO}/\.github/workflows/release\.yml@refs/tags/v.+$" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            --certificate "${CHECKSUMS}.pem" \
+            --signature "${CHECKSUMS}.sig" \
+            "${CHECKSUMS}"
+
       - name: sense version reports the tagged version
         run: |
           set -euo pipefail

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,6 +42,9 @@ builds:
         env:
           - CC=aarch64-linux-gnu-gcc
           - CXX=aarch64-linux-gnu-g++
+    hooks:
+      post:
+        - cmd: ./scripts/sign-darwin.sh "{{ .Path }}" "{{ .Os }}"
 
 archives:
   - id: sense

--- a/README.md
+++ b/README.md
@@ -80,6 +80,21 @@ curl -fsSL https://luuuc.github.io/sense/install.sh | sh
 
 Or download the binary for your OS from the [latest release](https://github.com/luuuc/sense/releases/latest), unzip, and move `sense` somewhere on your `PATH`.
 
+### Verify a release (optional)
+
+Every release's checksums file is signed with [Sigstore](https://www.sigstore.dev/) (keyless, bound to this repository's release workflow). With [cosign](https://docs.sigstore.dev/cosign/system_config/installation/) installed:
+
+```bash
+cosign verify-blob \
+  --certificate-identity-regexp '^https://github.com/luuuc/sense/\.github/workflows/release\.yml@refs/tags/v.+$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate sense_<version>_checksums.txt.pem \
+  --signature sense_<version>_checksums.txt.sig \
+  sense_<version>_checksums.txt
+```
+
+Artifacts also carry [build provenance attestations](https://docs.github.com/en/actions/concepts/security/artifact-attestations): `gh attestation verify sense_<version>_<os>_<arch>.tar.gz --owner luuuc`.
+
 ### With Go (1.25+)
 
 ```bash

--- a/scripts/sign-darwin.sh
+++ b/scripts/sign-darwin.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# GoReleaser post-build hook: stamp darwin binaries with a stable
+# code-signing identifier. The cross-linker's ad-hoc signature identifies
+# the binary as "a.out"; quill re-signs it (still ad-hoc, no certificate)
+# so `codesign -dv` reports com.github.luuuc.sense. This is also the slot
+# where a Developer ID certificate drops in later (swap --ad-hoc for
+# --p12 via QUILL_SIGN_P12) without touching the pipeline shape.
+#
+# quill is mounted into the goreleaser-cross container by release.yml.
+set -eu
+
+BINARY="$1"
+GOOS="$2"
+
+[ "$GOOS" = "darwin" ] || exit 0
+
+quill sign --ad-hoc --identity com.github.luuuc.sense -q "$BINARY"


### PR DESCRIPTION
## Problem

Releases ship with checksums but no cryptographic signature or provenance: nothing proves an artifact was built by this repository's release workflow rather than tampered with after upload. Scorecard rates Signed-Releases 0/10, and the darwin binaries carry the cross-linker's anonymous `a.out` ad-hoc identifier, which makes them look unintentional in `codesign -dv` and gives identity-checking tools (e.g. Little Snitch) nothing stable to key on.

## Summary

Keyless-sign the checksums file with Sigstore, attach SLSA build provenance attestations to every artifact, and stamp darwin binaries with a stable code-signing identifier, all without holding any signing secret.

## Changes

- **release.yml**: cosign keyless-signs the checksums file immediately after GoReleaser publishes and uploads `.sig`/`.pem` as release assets; `actions/attest-build-provenance` covers dist archives, checksums, and MCPB bundles; job gains `id-token: write` + `attestations: write`. New actions SHA-pinned.
- **GoReleaser post-build hook** (`scripts/sign-darwin.sh` + `.goreleaser.yml`): quill re-signs darwin binaries ad-hoc with identifier `com.github.luuuc.sense`. quill v0.7.1 is installed to `RUNNER_TEMP` with sha256 verification (repo stays git-clean for `release --clean`) and mounted into the goreleaser-cross container.
- **smoke.yml**: verifies the checksums signature against the pinned release-workflow identity on every published release (with a short poll for the asset race), so signing regressions red CI.
- **README**: "Verify a release" section with the `cosign verify-blob` and `gh attestation verify` commands.

## Architecture Highlights

- Keyless signing means no key custody: the ephemeral certificate is bound to this workflow's OIDC identity and logged in Rekor. The only sync obligation is the workflow path embedded in the documented verify command.
- The quill hook is the drop-in slot for a future Developer ID certificate (swap `--ad-hoc` for a p12 via secrets, zero pipeline redesign).

## Test Plan

- [x] quill ad-hoc signing exercised on a real built binary: identifier `a.out` → `com.github.luuuc.sense`, `codesign --verify` passes, binary executes on Apple Silicon
- [x] hook no-op verified for linux builds
- [x] `goreleaser check` validates the config with the new hook
- [x] `make ci` green (build + cover + lint + ledger); workflow YAML parses
- [x] no version bump: `git-cliff --bumped-version` unchanged (ci/docs types skipped)
- [ ] first tagged release after merge exercises the full pipeline; smoke.yml gates the signature end-to-end

Scorecard Signed-Releases moves 0 → 8 as the last five releases roll over.