### PR TITLE
fix(extract): capture Django to= targets and manager-chain model deps

### DIFF
--- a/internal/extract/python/django.go
+++ b/internal/extract/python/django.go
@@ -130,9 +130,14 @@ func isQuerySetExprDepth(n *sitter.Node, src []byte, types map[string]string, de
 
 // djangoManagerLeafNames are the attribute names that root a manager chain:
 // the public `objects` plus the private accessors Django's own plumbing uses
-// (`Model._default_manager` / `Model._base_manager`). The exposure bound is
-// the same as the name convention: a wrong guess emits a QuerySet.* target
-// that only resolves in a repo defining a QuerySet class.
+// (`Model._default_manager` / `Model._base_manager`). Two edges root here with
+// different exposure bounds: the QuerySet-method edge's wrong guesses emit a
+// QuerySet.* target that only resolves in a repo defining a QuerySet class,
+// while the model edge (managerChainModelRoot) targets the PascalCase root
+// name itself, which resolves against any same-named class — its bound is the
+// gate stack (literal PascalCase receiver + exact manager attr + whitelisted
+// method), and a rare wrong guess (`Config.objects.get(k)` on a class-level
+// dict) still encodes a true textual reference to that class.
 var djangoManagerLeafNames = map[string]bool{
 	"objects":          true,
 	"_default_manager": true,
@@ -179,6 +184,49 @@ func isSelfModelRef(n *sitter.Node, src []byte) bool {
 	return false
 }
 
+// managerChainModelRoot walks a manager-chain receiver expression
+// (`Device.objects`, `Device.objects.filter(…).exclude(…)`) to its root and
+// returns the literal model identifier it is anchored on. The caller emits a
+// dependency edge to the model itself — code querying `Device.objects` depends
+// on Device even though the resolved method target is QuerySet API. Chains
+// rooted on self-attribute idioms (`self.model.objects`) or conventionally
+// named locals (`qs.filter(…)`) carry no literal model name and return false.
+//
+// PRECONDITION: the walk does NOT re-verify hop method names, so it is only
+// valid on a chain typedReceiverTarget has already vetted as QuerySet API —
+// its sole call site. Consequently a chain ending in a CUSTOM manager method
+// (`Device.objects.restrict()`) never reaches this function and emits no model
+// edge: a deliberate false-positive bound, not an oversight. Extending the
+// edge to custom-manager chains is a separate, bench-gated decision.
+func managerChainModelRoot(n *sitter.Node, src []byte) (string, bool) {
+	return managerChainModelRootDepth(n, src, 0)
+}
+
+func managerChainModelRootDepth(n *sitter.Node, src []byte, depth int) (string, bool) {
+	if n == nil || depth > maxQuerySetChainDepth {
+		return "", false
+	}
+	switch n.Kind() {
+	case "attribute":
+		leaf := n.ChildByFieldName("attribute")
+		obj := n.ChildByFieldName("object")
+		if leaf == nil || obj == nil || !djangoManagerLeafNames[extract.Text(leaf, src)] {
+			return "", false
+		}
+		if obj.Kind() == "identifier" && isPascalCase(extract.Text(obj, src)) {
+			return extract.Text(obj, src), true
+		}
+		return "", false
+	case "call":
+		fn := n.ChildByFieldName("function")
+		if fn == nil || fn.Kind() != "attribute" {
+			return "", false
+		}
+		return managerChainModelRootDepth(fn.ChildByFieldName("object"), src, depth+1)
+	}
+	return "", false
+}
+
 // isQuerySetChainCall matches a chain hop: a conventionally QuerySet-returning
 // method regardless of receiver (self.get_queryset(), self._chain()), or a
 // chainable QuerySet method whose receiver is itself a queryset expression.
@@ -204,7 +252,8 @@ func isQuerySetChainCall(n *sitter.Node, src []byte, types map[string]string, de
 // emitDjangoModelField checks if an assignment's RHS is a Django relational field
 // call (e.g. `models.ForeignKey(User)`). If so, it emits a composes edge from the
 // enclosing class to the target model. The call can be bare (`ForeignKey(User)`)
-// or attribute-qualified (`models.ForeignKey(User)`).
+// or attribute-qualified (`models.ForeignKey(User)`), and the target model can be
+// the first positional argument or the `to=` keyword (`ForeignKey(to='dcim.Device')`).
 func (w *walker) emitDjangoModelField(assign *sitter.Node, scope []string) error {
 	if len(scope) == 0 {
 		return nil
@@ -225,6 +274,9 @@ func (w *walker) emitDjangoModelField(assign *sitter.Node, scope []string) error
 		return nil
 	}
 	first := firstPositionalArg(args)
+	if first == nil {
+		first = keywordArgValue(args, "to", w.source)
+	}
 	if first == nil {
 		return nil
 	}

--- a/internal/extract/python/framework.go
+++ b/internal/extract/python/framework.go
@@ -176,6 +176,24 @@ func firstPositionalArg(args *sitter.Node) *sitter.Node {
 	return nil
 }
 
+// keywordArgValue returns the value node of the named keyword argument from an
+// argument_list node, or nil when the keyword is absent.
+func keywordArgValue(args *sitter.Node, name string, source []byte) *sitter.Node {
+	count := args.NamedChildCount()
+	for i := uint(0); i < count; i++ {
+		arg := args.NamedChild(i)
+		if arg == nil || arg.Kind() != "keyword_argument" {
+			continue
+		}
+		key := arg.ChildByFieldName("name")
+		if key == nil || extract.Text(key, source) != name {
+			continue
+		}
+		return arg.ChildByFieldName("value")
+	}
+	return nil
+}
+
 // positionalArgs returns all non-keyword arguments from an argument_list.
 func positionalArgs(args *sitter.Node) []*sitter.Node {
 	var result []*sitter.Node

--- a/internal/extract/python/python.go
+++ b/internal/extract/python/python.go
@@ -377,6 +377,22 @@ func (w *walker) emitCall(call *sitter.Node, source string, localTypes map[strin
 			return err
 		}
 		if typed, ok := typedReceiverTarget(fn, w.source, localTypes); ok {
+			// A chain rooted at a literal `<Model>.objects` also depends on the
+			// model class itself, not only on the QuerySet method it resolves to.
+			// A multi-hop chain re-roots at every call node, emitting this edge
+			// once per hop; the sqlite unique index (source, target, kind, file)
+			// collapses the duplicates at persistence.
+			if root, ok := managerChainModelRoot(fn.ChildByFieldName("object"), w.source); ok {
+				if err := w.emit.Edge(extract.EmittedEdge{
+					SourceQualified: source,
+					TargetQualified: root,
+					Kind:            model.EdgeCalls,
+					Line:            &line,
+					Confidence:      extract.ConfidenceConvention,
+				}); err != nil {
+					return err
+				}
+			}
 			// ConfidenceDynamic here means "receiver type proven from local
 			// context", not dispatch heuristics — the same tier Ruby's typed
 			// locals use, below self/static (1.0), above unverified (0.5).

--- a/internal/extract/python/python_test.go
+++ b/internal/extract/python/python_test.go
@@ -318,6 +318,126 @@ func TestDjangoForeignKeyStringTarget(t *testing.T) {
 	}
 }
 
+func TestDjangoForeignKeyKeywordToString(t *testing.T) {
+	r := parse(t, `class Interface:
+    device = models.ForeignKey(
+        to='dcim.Device',
+        on_delete=models.CASCADE,
+        related_name='interfaces',
+    )
+`)
+	e := findEdge(r, "Interface", "Device", "composes")
+	if e == nil {
+		t.Fatal("missing composes edge Interface -> Device from ForeignKey(to='dcim.Device')")
+	}
+	if e.Confidence != extract.ConfidenceAmbiguous {
+		t.Errorf("ForeignKey to= string confidence = %v, want %v", e.Confidence, extract.ConfidenceAmbiguous)
+	}
+}
+
+func TestDjangoForeignKeyKeywordToIdentifier(t *testing.T) {
+	r := parse(t, `class Profile:
+    user = OneToOneField(to=User, on_delete=CASCADE)
+`)
+	e := findEdge(r, "Profile", "User", "composes")
+	if e == nil {
+		t.Fatal("missing composes edge Profile -> User from OneToOneField(to=User)")
+	}
+	if e.Confidence != extract.ConfidenceConvention {
+		t.Errorf("OneToOneField to= identifier confidence = %v, want %v", e.Confidence, extract.ConfidenceConvention)
+	}
+}
+
+func TestDjangoForeignKeyKeywordsWithoutTo(t *testing.T) {
+	r := parse(t, `class Order:
+    customer = models.ForeignKey(on_delete=models.CASCADE)
+`)
+	for _, e := range r.edges {
+		if string(e.Kind) == "composes" && e.SourceQualified == "Order" {
+			t.Errorf("unexpected composes edge from ForeignKey without a target: Order -> %s", e.TargetQualified)
+		}
+	}
+}
+
+func TestDjangoManagerChainEmitsModelEdge(t *testing.T) {
+	r := parse(t, `class IPAddressFilterSet:
+    def filter_device(self, queryset, name, value):
+        return Device.objects.filter(name__in=value)
+`)
+	e := findEdge(r, "IPAddressFilterSet.filter_device", "Device", "calls")
+	if e == nil {
+		t.Fatal("missing calls edge IPAddressFilterSet.filter_device -> Device from manager chain root")
+	}
+	if e.Confidence != extract.ConfidenceConvention {
+		t.Errorf("manager-chain model edge confidence = %v, want %v", e.Confidence, extract.ConfidenceConvention)
+	}
+	if findEdge(r, "IPAddressFilterSet.filter_device", "QuerySet.filter", "calls") == nil {
+		t.Error("manager-chain model edge must not replace the QuerySet.filter chain edge")
+	}
+}
+
+func TestDjangoManagerTerminalEmitsModelEdge(t *testing.T) {
+	r := parse(t, `def lookup(pk):
+    return Device.objects.get(pk=pk)
+`)
+	if findEdge(r, "lookup", "Device", "calls") == nil {
+		t.Fatal("missing calls edge lookup -> Device from terminal manager call")
+	}
+}
+
+func TestDjangoManagerChainedHopsEmitModelEdge(t *testing.T) {
+	r := parse(t, `def actives():
+    return Device.objects.filter(active=True).exclude(role=None)
+`)
+	// Each hop's call node re-roots the walk, so a 2-hop chain emits the model
+	// edge exactly twice; the sqlite unique index (source, target, kind, file)
+	// collapses the duplicates at persistence. This pins the emission contract
+	// so a change in either direction (dedup at emit, or a third copy) is
+	// deliberate.
+	count := 0
+	for _, e := range r.edges {
+		if string(e.Kind) == "calls" && e.SourceQualified == "actives" && e.TargetQualified == "Device" {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Fatalf("chained manager hops: got %d actives -> Device calls edges, want 2 (one per hop)", count)
+	}
+}
+
+func TestDjangoCustomManagerMethodEmitsNoModelEdge(t *testing.T) {
+	// A chain ending in a CUSTOM manager method never passes the QuerySet
+	// whitelist gate (typedReceiverTarget), so no model edge is emitted — the
+	// deliberate false-positive bound documented on managerChainModelRoot.
+	// Extending the edge to custom-manager chains is a bench-gated decision;
+	// this test makes the boundary intent, not accident.
+	r := parse(t, `def actives():
+    return Device.objects.get_active()
+`)
+	if findEdge(r, "actives", "Device", "calls") != nil {
+		t.Error("custom manager method must not emit a model edge (unvetted chain)")
+	}
+}
+
+func TestDjangoPrivateManagerRootEmitsModelEdge(t *testing.T) {
+	r := parse(t, `def visible():
+    return Device._default_manager.filter(hidden=False)
+`)
+	if findEdge(r, "visible", "Device", "calls") == nil {
+		t.Fatal("missing calls edge visible -> Device from _default_manager chain root")
+	}
+}
+
+func TestDjangoSelfModelManagerEmitsNoModelEdge(t *testing.T) {
+	r := parse(t, `class Manager:
+    def visible(self):
+        return self.model.objects.filter(hidden=False)
+`)
+	if findEdge(r, "Manager.visible", "model", "calls") != nil {
+		t.Error("self.model manager chain must not emit a model edge (model class unknown)")
+	}
+}
+
 func TestFastapiRouteDecorator(t *testing.T) {
 	r := parse(t, `@app.post("/orders")
 def create_order():

--- a/internal/extract/testdata/python/framework_negatives.py
+++ b/internal/extract/testdata/python/framework_negatives.py
@@ -7,9 +7,9 @@ from fastapi import Depends
 Order = apps.get_model("orders", "Order")
 
 
-# ForeignKey with keyword-only target — no positional arg, no edge.
+# ForeignKey with keyword args but no target (no positional, no `to=`) — no edge.
 class Config(models.Model):
-    owner = models.ForeignKey(to=Account, on_delete=models.CASCADE)
+    owner = models.ForeignKey(on_delete=models.CASCADE)
 
 
 # Depends with lambda — unresolvable, no edge.


### PR DESCRIPTION
## What

Two Django relation gaps in the Python extractor, both found on a NetBox-scale index that carried **zero ORM composes edges**:

1. **Keyword `to=` relation targets.** `emitDjangoModelField` only read the first positional argument, so the idiomatic keyword form `ForeignKey(to='dcim.Device')` produced no composes edge. NetBox declares every one of its ~300 relational fields this way. Now falls back to the `to=` keyword value; the existing string/identifier confidence tiers apply unchanged.
2. **Manager-chain model dependency.** A chain rooted at a literal `<Model>.objects` resolved only to the QuerySet method (`QuerySet.filter`), leaving the model itself with no dependency edge — `sense_blast Device` could not see the 129 `Device.objects` call sites across 34 files. A chain vetted by the existing QuerySet-method whitelist now also emits a calls edge to the root model at convention confidence (0.9). Chains ending in custom manager methods deliberately stay out (documented false-positive bound).

## Evidence

| Repo | Check | Result |
|---|---|---|
| netbox (Django, keyword-style) | composes edges | 146 → 383; +3,245 model calls edges across 7 apps |
| healthchecks (Django, positional-style) | edge-kind diff vs main | zero |
| litellm (Python, non-Django) | edge-kind diff vs main | zero, identical resolution counts |
| chatwoot (Rails) | edge-kind diff vs main | zero, identical resolution counts |
| maket (Ruby) | edge-kind diff vs main | zero |
| saleor / sentry benched gold | budgeted-blast probes @ 0.3 and 0.7 | equal or strictly better |

Benched downstream: the NetBox scenario went from unauthorable (Sense could not cite any cross-app dependent) to a +0.75 discriminator cited-recall win on Opus 4.8 ×2.

## Rollback note

Scan-layer change: reverting the code does not remove already-persisted edges from an existing index — a rescan (`sense scan -rebuild`) is required in either direction.