### PR TITLE
fix(blast): rank production callers above test files at the cap

### DIFF
--- a/internal/blast/engine.go
+++ b/internal/blast/engine.go
@@ -256,7 +256,14 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 	// pruned by confidence (surfaced below from the edge table) can be reconciled
 	// into total_affected rather than appearing only in the composition list.
 	affectedSet := idSet(directIDs, indirectIDs)
-	directIDs, indirectIDs = state.capResults(directIDs, indirectIDs, opts.MaxResults)
+	// Test-file flags feed the cap's production-first ranking. Fetched here —
+	// only when the cap will actually bite — so capResults stays a pure sort
+	// over maps and the common under-cap blast never pays the lookup.
+	var testFlags map[int64]bool
+	if totalAffectedCount > opts.MaxResults {
+		testFlags = testFileFlags(ctx, db, append(append(make([]int64, 0, totalAffectedCount), directIDs...), indirectIDs...))
+	}
+	directIDs, indirectIDs = state.capResults(directIDs, indirectIDs, testFlags, opts.MaxResults)
 
 	symbolsByID, err := state.hydrate(ctx, db, subject, directIDs, indirectIDs)
 	if err != nil {
@@ -540,29 +547,35 @@ func (s *bfsState) partition(seedSet map[int64]struct{}) (direct, indirect []int
 	return direct, indirect
 }
 
-// capResults trims the caller sets to maxResults total, keeping the
-// highest-confidence callers across both sets.
-func (s *bfsState) capResults(directIDs, indirectIDs []int64, maxResults int) ([]int64, []int64) {
+// capResults trims the caller sets to maxResults total, keeping production
+// callers first and the highest-confidence callers within each group.
+// testFlags marks callers living in test files (see testFileFlags); a nil map
+// treats every caller as production, degrading to the confidence-only order.
+func (s *bfsState) capResults(directIDs, indirectIDs []int64, testFlags map[int64]bool, maxResults int) ([]int64, []int64) {
 	callerCount := len(directIDs) + len(indirectIDs)
 	if callerCount <= maxResults {
 		return directIDs, indirectIDs
 	}
 	type ranked struct {
 		id     int64
+		test   bool
 		conf   float64
 		direct bool
 	}
 	all := make([]ranked, 0, callerCount)
 	for _, id := range directIDs {
-		all = append(all, ranked{id, s.pathConf[id], true})
+		all = append(all, ranked{id: id, test: testFlags[id], conf: s.pathConf[id], direct: true})
 	}
 	for _, id := range indirectIDs {
-		all = append(all, ranked{id, s.pathConf[id], false})
+		all = append(all, ranked{id: id, test: testFlags[id], conf: s.pathConf[id], direct: false})
 	}
-	// Rank by confidence, then prefer direct callers, then break ties on
-	// symbol ID. The two tie-breakers matter on high-fan-out hubs where
-	// almost every path is a 1.0 call edge, so callers cluster at one
-	// confidence and the cap cutoff lands among the ties:
+	// Rank production callers over test-file callers, then by confidence,
+	// then prefer direct callers, then break ties on symbol ID. Each key
+	// matters on high-fan-out hubs where the cap cutoff lands among ties:
+	//   - production-over-test keeps the impact audit's real dependents — a
+	//     test fixture constructing the subject rides a 1.0 call edge and
+	//     would otherwise evict every 0.9 production dependent (netbox
+	//     Device: 49 setUpTestData callers vs the scattered cross-app ones);
 	//   - direct-over-indirect keeps the "what breaks?" signal — a direct
 	//     caller must not be evicted to make room for a weaker indirect one;
 	//   - the ID tie-break makes the kept set deterministic, so repeated
@@ -570,6 +583,9 @@ func (s *bfsState) capResults(directIDs, indirectIDs []int64, maxResults int) ([
 	//     unstable sort keeps an arbitrary subset that varies run to run and
 	//     "audit every dependent" is unreproducible).
 	sort.Slice(all, func(i, j int) bool {
+		if all[i].test != all[j].test {
+			return !all[i].test
+		}
 		if all[i].conf != all[j].conf {
 			return all[i].conf > all[j].conf
 		}

--- a/internal/blast/engine_internal_test.go
+++ b/internal/blast/engine_internal_test.go
@@ -239,6 +239,163 @@ func TestSiblingSymbolIDsNonExistent(t *testing.T) {
 	}
 }
 
+// capResults must keep production callers over test-file callers when the cap
+// bites: a test fixture constructing the subject rides a 1.0 call edge and
+// would otherwise evict every 0.9 production dependent — the callers an
+// impact audit actually needs (netbox Device: 49 setUpTestData callers vs the
+// scattered ipam/virtualization dependents).
+func TestCapResultsPrefersProductionOverTests(t *testing.T) {
+	const prodID, testID = int64(1), int64(2)
+	s := &bfsState{pathConf: map[int64]float64{prodID: 0.9, testID: 1.0}}
+	flags := map[int64]bool{prodID: false, testID: true}
+
+	direct, indirect := s.capResults([]int64{prodID, testID}, nil, flags, 1)
+	if len(indirect) != 0 {
+		t.Fatalf("expected no indirect callers, got %v", indirect)
+	}
+	if len(direct) != 1 || direct[0] != prodID {
+		t.Errorf("cap must keep the production caller over the higher-confidence test caller: got %v, want [%d]", direct, prodID)
+	}
+
+	// Under the cap nothing is trimmed or reordered.
+	direct, _ = s.capResults([]int64{prodID, testID}, nil, flags, 10)
+	if len(direct) != 2 {
+		t.Errorf("no-cap path must return all callers, got %v", direct)
+	}
+}
+
+// Production-over-test is the PRIMARY sort key — above confidence AND above
+// direct-over-indirect. An indirect production caller at 0.3 must evict a
+// direct test caller at 1.0. If a future edit reorders the keys, this test is
+// what notices.
+func TestCapResultsProductionOutranksConfidenceAndDirectness(t *testing.T) {
+	const testDirectID, prodIndirectID = int64(1), int64(2)
+	s := &bfsState{pathConf: map[int64]float64{testDirectID: 1.0, prodIndirectID: 0.3}}
+	flags := map[int64]bool{testDirectID: true, prodIndirectID: false}
+
+	direct, indirect := s.capResults([]int64{testDirectID}, []int64{prodIndirectID}, flags, 1)
+	if len(direct) != 0 {
+		t.Errorf("direct test caller must be evicted, got %v", direct)
+	}
+	if len(indirect) != 1 || indirect[0] != prodIndirectID {
+		t.Errorf("indirect production caller must survive the cap: got %v, want [%d]", indirect, prodIndirectID)
+	}
+}
+
+// A nil flag map is the documented degradation contract (testFileFlags returns
+// nil on query failure): every caller reads as production and the ranking
+// falls back to the previous confidence-only order.
+func TestCapResultsNilFlagsKeepsConfidenceOrder(t *testing.T) {
+	const prodID, testID = int64(1), int64(2)
+	s := &bfsState{pathConf: map[int64]float64{prodID: 0.9, testID: 1.0}}
+
+	direct, _ := s.capResults([]int64{prodID, testID}, nil, nil, 1)
+	if len(direct) != 1 || direct[0] != testID {
+		t.Errorf("nil flags must degrade to confidence-only order (test caller at 1.0 kept): got %v, want [%d]", direct, testID)
+	}
+}
+
+func TestTestFileFlags(t *testing.T) {
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	db := adapter.DB()
+	t.Cleanup(func() { _ = db.Close() })
+
+	var prodID, testID int64
+	err = adapter.InTx(ctx, func() error {
+		fProd, err := adapter.WriteFile(ctx, &model.File{
+			Path: "app/filters.py", Language: "python", Hash: "h1",
+			Symbols: 1, IndexedAt: time.Now().UTC(),
+		})
+		if err != nil {
+			return err
+		}
+		fTest, err := adapter.WriteFile(ctx, &model.File{
+			Path: "app/tests/test_api.py", Language: "python", Hash: "h2",
+			Symbols: 1, IndexedAt: time.Now().UTC(),
+		})
+		if err != nil {
+			return err
+		}
+		prodID, err = adapter.WriteSymbol(ctx, &model.Symbol{
+			FileID: fProd, Name: "filter_device", Qualified: "F.filter_device",
+			Kind: model.KindMethod, LineStart: 1, LineEnd: 5,
+		})
+		if err != nil {
+			return err
+		}
+		testID, err = adapter.WriteSymbol(ctx, &model.Symbol{
+			FileID: fTest, Name: "setUpTestData", Qualified: "T.setUpTestData",
+			Kind: model.KindMethod, LineStart: 1, LineEnd: 5,
+		})
+		return err
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	flags := testFileFlags(ctx, db, []int64{prodID, testID})
+	if flags == nil {
+		t.Fatal("expected a flag map from a healthy index, got nil")
+	}
+	if flags[prodID] {
+		t.Errorf("production symbol flagged as test")
+	}
+	if !flags[testID] {
+		t.Errorf("test-file symbol not flagged")
+	}
+}
+
+// A database without the sense schema exercises the best-effort contract:
+// testFileFlags returns nil rather than failing, and the caller's nil-map
+// reads degrade the ranking to confidence-only (covered above).
+func TestTestFileFlagsNoSchemaReturnsNil(t *testing.T) {
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if flags := testFileFlags(context.Background(), db, []int64{1, 2}); flags != nil {
+		t.Errorf("expected nil flags on a schema-less database, got %v", flags)
+	}
+}
+
+// Mirrors mcpio's TestIsTestPath table: the blast copy must agree with
+// mcpio.IsTestPath (the presentation layer buckets the same paths), and the
+// import cycle rules out asserting parity directly.
+func TestIsTestPathLocalCopy(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"internal/foo/foo_test.go", true},
+		{"src/app.test.ts", true},
+		{"test/helpers.rb", true},
+		{"tests/unit/auth.py", true},
+		{"spec/models/user_spec.rb", true},
+		{"internal/testdata/fixture.json", true},
+		{"src/main/java/com/example/UserTest.java", true},
+		{"src/test/kotlin/TestUser.kt", true},
+		{"src/test/java/UserTests.java", true},
+		{"lib/test_auth.py", true},
+		{"src/main/java/com/example/User.java", false},
+		{"src/main/java/com/example/TestUtils.java", false},
+		{"src/main/java/com/example/Contest.java", false},
+		{"internal/foo/foo.go", false},
+		{"lib/auth.rb", false},
+	}
+	for _, tt := range tests {
+		if got := isTestPath(tt.path); got != tt.want {
+			t.Errorf("isTestPath(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}
+
 // hasTemporal reports temporal coupling from either a direct temporal caller
 // or an indirect (multi-hop) one; the indirect path is the branch the full
 // Compute tests rarely exercise on its own.

--- a/internal/blast/symbols.go
+++ b/internal/blast/symbols.go
@@ -237,6 +237,86 @@ func inboundComposers(ctx context.Context, db *sql.DB, ids []int64) ([]int64, er
 	return out, nil
 }
 
+// testFileFlags reports, for each symbol id, whether the symbol lives in a
+// test file. Used by capResults to keep production callers ahead of test
+// fixtures at the result-cap boundary. Best-effort: on query failure it
+// returns nil, which the caller treats as "no symbol is a test" — the ranking
+// degrades to the previous confidence-only order instead of failing the blast.
+func testFileFlags(ctx context.Context, db *sql.DB, ids []int64) map[int64]bool {
+	out := make(map[int64]bool, len(ids))
+	const chunk = 500
+	for start := 0; start < len(ids); start += chunk {
+		end := start + chunk
+		if end > len(ids) {
+			end = len(ids)
+		}
+		batch := ids[start:end]
+		placeholders := strings.Repeat("?,", len(batch))
+		placeholders = placeholders[:len(placeholders)-1]
+		q := `SELECT s.id, f.path FROM sense_symbols s
+		      JOIN sense_files f ON f.id = s.file_id
+		      WHERE s.id IN (` + placeholders + `)`
+		args := make([]any, len(batch))
+		for i, id := range batch {
+			args[i] = id
+		}
+		rows, err := db.QueryContext(ctx, q, args...)
+		if err != nil {
+			return nil
+		}
+		for rows.Next() {
+			var id int64
+			var path string
+			if err := rows.Scan(&id, &path); err != nil {
+				_ = rows.Close()
+				return nil
+			}
+			out[id] = isTestPath(path)
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil
+		}
+		_ = rows.Close()
+	}
+	return out
+}
+
+// isTestPath reports whether a file path matches common test directory or
+// filename conventions. A verbatim copy of mcpio.IsTestPath, which buckets the
+// SAME paths at presentation time (segmentBlastCallers), so the two MUST agree;
+// the copy exists because mcpio imports blast (a cycle). This is the fourth
+// copy of the heuristic (mcpio, resolve, search each carry one, and they have
+// already drifted) — consolidation into a shared leaf package is tracked as a
+// follow-up, not done here.
+func isTestPath(path string) bool {
+	if strings.Contains(path, "_test.") ||
+		strings.Contains(path, ".test.") ||
+		strings.Contains(path, "/test/") ||
+		strings.Contains(path, "/tests/") ||
+		strings.Contains(path, "/testdata/") ||
+		strings.Contains(path, "/spec/") ||
+		strings.HasPrefix(path, "test/") ||
+		strings.HasPrefix(path, "tests/") ||
+		strings.HasPrefix(path, "spec/") {
+		return true
+	}
+	base := path
+	if i := strings.LastIndex(path, "/"); i >= 0 {
+		base = path[i+1:]
+	}
+	if strings.HasPrefix(base, "test_") {
+		return true
+	}
+	if dot := strings.LastIndex(base, "."); dot > 0 {
+		name := base[:dot]
+		if strings.HasSuffix(name, "Test") || strings.HasSuffix(name, "Tests") {
+			return true
+		}
+	}
+	return false
+}
+
 func filterIDs(ids []int64, keep map[int64]struct{}) []int64 {
 	out := make([]int64, 0, len(ids))
 	for _, id := range ids {


### PR DESCRIPTION
## What

On a high-fan-out subject, `sense_blast`'s 60-result caller cap filled with test fixtures: netbox `Device` has 49 `setUpTestData` callers riding 1.0 call edges, which evicted every 0.9 production dependent — the scattered cross-app callers an impact audit actually needs. (Python test files emit no `tests`-kind edges, so the tier-3 "tests are count-only" design never fires for direct constructor calls from tests.)

`capResults` now ranks **(production, confidence, direct, id)**. Test-file flags are fetched only when the cap actually bites (the under-cap path pays nothing), `capResults` itself stays a pure sort over maps, and a flag-lookup failure degrades best-effort to the previous confidence-only order (nil map ⇒ every caller reads as production).

`isTestPath` is a verbatim local copy of `mcpio.IsTestPath` (mcpio imports blast, so sharing is a cycle); the two must agree because mcpio buckets the same paths at presentation time. Follow-up: the codebase now carries four copies of this heuristic (mcpio, resolve, search, blast) and they have already drifted (`_spec.` infix) — consolidation into a shared leaf package is deliberately out of this fix's scope.

## Evidence (query-layer: takes effect on existing indexes immediately)

| Repo | Check | Result |
|---|---|---|
| netbox Device | shown budgeted blast @ 0.3 and 0.7 | cross-app production dependents (ipam/virtualization) now shown at both settings; previously 0 behavioral callers survived at 0.7 |
| sentry Group (benched WIN anchor) | gold probes @ 0.3 and 0.7 | 5/5 discriminator gold shown, both settings |
| saleor ProductVariant (benched WIN anchor) | gold probes @ 0.3 and 0.7 | strictly better than main (0.7: 1/4 → 2/4; 0.3: 3/4 → 4/4) |
| chatwoot Inbox (Rails benched anchor) | same-index A/B, main vs fix binary | byte-equivalent shown sets, 11/11 gold both binaries |

Tests pin the contract: production-first as the primary key (an indirect 0.3 production caller evicts a direct 1.0 test caller), nil-flag degradation to confidence-only order, the schema-less-DB nil return, and a local `isTestPath` table mirroring mcpio's.

## Rollback note

Query-layer: reverting the binary restores the old ranking immediately, no rescan needed.