### PR TITLE
fix(graph): keep member fold when only synthetic edges name a class

### DIFF
--- a/internal/extract/extractor.go
+++ b/internal/extract/extractor.go
@@ -186,6 +186,7 @@ const (
 //   - search: finalizeResults (internal/search/search.go)
 //   - dead:   the two NOT LIKE lists (internal/dead/dead.go + queries.go)
 //   - conventions: dropSyntheticSymbols uses IsSyntheticQualified (automatic)
+//   - graph fold: hasUsageEdge (internal/sqlite/graph.go) uses IsSyntheticQualified (automatic)
 var syntheticPrefixes = []string{
 	PrefixTurboChannel,
 	PrefixTurboFrame,

--- a/internal/extract/extractor_test.go
+++ b/internal/extract/extractor_test.go
@@ -142,6 +142,7 @@ func TestIsSyntheticQualified(t *testing.T) {
 		PrefixImportmap + "stimulus",
 		PrefixPartial + "users/profile",
 		PrefixRubyCore + "Struct",
+		PrefixDjangoRelated + "variants",
 	}
 	for _, q := range synthetic {
 		if !IsSyntheticQualified(q) {

--- a/internal/sqlite/foldcallees_test.go
+++ b/internal/sqlite/foldcallees_test.go
@@ -188,3 +188,41 @@ func TestReadSymbolGraphMemberCalleesDedupSkipsTemporalKeepsStructural(t *testin
 		t.Error("temporal member edge should not be folded as a callee")
 	}
 }
+
+// The symmetric callee gate: a synthetic outbound target (route:*, i18n:*, …)
+// is plumbing, not a real dependency — it must not suppress the member-callee
+// fold that shows what the class actually reaches through its methods.
+func TestReadSymbolGraphSyntheticCalleeDoesNotSuppressFold(t *testing.T) {
+	a, fileID := newFoldAdapter(t)
+	ctx := context.Background()
+
+	classID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "Portal", Qualified: "Portal", Kind: model.KindClass, LineStart: 1, LineEnd: 40})
+	methodID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "render", Qualified: "Portal#render", Kind: model.KindMethod, ParentID: &classID, LineStart: 3, LineEnd: 6})
+	routeID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "portal_path", Qualified: "route:portal_path", Kind: model.KindConstant, LineStart: 8, LineEnd: 8})
+	depID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "Format", Qualified: "Format", Kind: model.KindFunction, LineStart: 10, LineEnd: 20})
+
+	// The class "calls" a synthetic route helper directly…
+	mustEdge(t, a, &model.Edge{SourceID: &classID, TargetID: routeID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 0.8})
+	// …while its real dependency is reached through a method.
+	mustEdge(t, a, &model.Edge{SourceID: &methodID, TargetID: depID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 1.0})
+
+	gr, err := a.ReadSymbolGraph(ctx, classID, 1, model.DirectionCallees, 0)
+	if err != nil {
+		t.Fatalf("ReadSymbolGraph: %v", err)
+	}
+	var synthetic, folded bool
+	for _, e := range gr.Root.Outbound {
+		if e.Target.ID == routeID {
+			synthetic = true
+		}
+		if e.Target.ID == depID {
+			folded = true
+		}
+	}
+	if !synthetic {
+		t.Error("synthetic route edge should still be listed among callees")
+	}
+	if !folded {
+		t.Error("member-callee fold must fire despite the synthetic outbound edge")
+	}
+}

--- a/internal/sqlite/foldcallers_test.go
+++ b/internal/sqlite/foldcallers_test.go
@@ -196,3 +196,80 @@ func TestReadSymbolGraphMethodRootNotFolded(t *testing.T) {
 		t.Errorf("method root inbound = %d, want 0 (no folding for non-containers)", len(gr.Root.Inbound))
 	}
 }
+
+// A synthetic accessor caller (django-related:*, route:*, …) is declaration-site
+// plumbing, not a real direct caller — it must not suppress the member-caller
+// fold. Regression: saleor's ProductVariant gained ONE django-related:variants
+// edge (0.8) and graph lost all 125 method-derived callers.
+func TestReadSymbolGraphSyntheticCallerDoesNotSuppressFold(t *testing.T) {
+	a, fileID := newFoldAdapter(t)
+	ctx := context.Background()
+
+	classID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "Variant", Qualified: "Variant", Kind: model.KindClass, LineStart: 1, LineEnd: 40})
+	methodID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "sku", Qualified: "Variant#sku", Kind: model.KindMethod, ParentID: &classID, LineStart: 3, LineEnd: 6})
+	accessorID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "variants", Qualified: "django-related:variants", Kind: model.KindConstant, LineStart: 8, LineEnd: 8})
+	realCallerID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "Payload", Qualified: "Payload", Kind: model.KindFunction, LineStart: 10, LineEnd: 20})
+
+	// The synthetic accessor "calls" the class at convention confidence…
+	mustEdge(t, a, &model.Edge{SourceID: &accessorID, TargetID: classID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 0.8})
+	// …while the real consumer reaches it through a method.
+	mustEdge(t, a, &model.Edge{SourceID: &realCallerID, TargetID: methodID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 0.7})
+
+	gr, err := a.ReadSymbolGraph(ctx, classID, 1, model.DirectionCallers, 0)
+	if err != nil {
+		t.Fatalf("ReadSymbolGraph: %v", err)
+	}
+	var synthetic, folded bool
+	for _, e := range gr.Root.Inbound {
+		if e.Target.ID == accessorID {
+			synthetic = true
+		}
+		if e.Target.ID == realCallerID {
+			folded = true
+		}
+	}
+	if !synthetic {
+		t.Error("synthetic accessor edge should still be listed among callers")
+	}
+	if !folded {
+		t.Error("method-caller fold must fire despite the synthetic caller: plumbing is not a real direct caller")
+	}
+}
+
+// A real (non-synthetic) direct caller still suppresses the fold when it
+// arrives alongside a synthetic one — the synthetic edge neither suppresses
+// nor un-suppresses; only genuine usage does.
+func TestReadSymbolGraphRealCallerStillSuppressesFoldBesideSynthetic(t *testing.T) {
+	a, fileID := newFoldAdapter(t)
+	ctx := context.Background()
+
+	classID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "Device", Qualified: "Device", Kind: model.KindClass, LineStart: 1, LineEnd: 40})
+	methodID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "save", Qualified: "Device#save", Kind: model.KindMethod, ParentID: &classID, LineStart: 3, LineEnd: 6})
+	accessorID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "devices", Qualified: "django-related:devices", Kind: model.KindConstant, LineStart: 8, LineEnd: 8})
+	directID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "Filter", Qualified: "Filter", Kind: model.KindFunction, LineStart: 10, LineEnd: 20})
+	methodCallerID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "Task", Qualified: "Task", Kind: model.KindFunction, LineStart: 22, LineEnd: 30})
+
+	mustEdge(t, a, &model.Edge{SourceID: &accessorID, TargetID: classID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 0.8})
+	mustEdge(t, a, &model.Edge{SourceID: &directID, TargetID: classID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 0.9})
+	mustEdge(t, a, &model.Edge{SourceID: &methodCallerID, TargetID: methodID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 1.0})
+
+	gr, err := a.ReadSymbolGraph(ctx, classID, 1, model.DirectionCallers, 0)
+	if err != nil {
+		t.Fatalf("ReadSymbolGraph: %v", err)
+	}
+	var direct, folded bool
+	for _, e := range gr.Root.Inbound {
+		if e.Target.ID == directID {
+			direct = true
+		}
+		if e.Target.ID == methodCallerID {
+			folded = true
+		}
+	}
+	if !direct {
+		t.Error("the genuine direct caller must be listed")
+	}
+	if folded {
+		t.Error("a genuine direct caller must still suppress the method-caller fold")
+	}
+}

--- a/internal/sqlite/graph.go
+++ b/internal/sqlite/graph.go
@@ -209,10 +209,14 @@ func isUsageEdge(k model.EdgeKind) bool {
 // usage edge — a real call/reference signal, as opposed to a structural
 // edge or a low-confidence resolution guess. Used by both fold paths:
 // against Inbound it means "has a real caller", against Outbound it means
-// "has a real callee".
+// "has a real callee". A synthetic counterpart (django-related:*, route:*,
+// i18n:*, …) is declaration-site plumbing, not real usage, so it neither
+// counts as a caller nor as a callee here — one such edge must not starve
+// the fold of every method-derived caller.
 func hasUsageEdge(edges []model.EdgeRef) bool {
 	for _, e := range edges {
-		if isUsageEdge(e.Edge.Kind) && e.Edge.Confidence >= extract.ConfidenceUnresolved {
+		if isUsageEdge(e.Edge.Kind) && e.Edge.Confidence >= extract.ConfidenceUnresolved &&
+			!extract.IsSyntheticQualified(e.Target.Qualified) {
 			return true
 		}
 	}


### PR DESCRIPTION
## Problem

`sense graph` on a container class enriches the answer with its members' callers only when the class has no "real" caller of its own (`foldMemberCallers`/`foldMemberCallees`). The gate counted **synthetic accessor edges** as real callers: one `django-related:*` edge (a `related_name` declaration site, confidence 0.8) was the first ≥0.5 usage edge saleor's `models.ProductVariant` ever had, and the fold silently stopped firing — graph dropped from 125 method-derived callers to 1, and the resolve oracle fell from 4/4 to 1/4 on that anchor. Any repo whose model names are shadowed (so manager-chain edges bind elsewhere) loses its entire method-fold reachability the moment a single synthetic edge lands.

## Summary

`hasUsageEdge` now skips counterparts whose qualified name is synthetic (`extract.IsSyntheticQualified` — the established single source of truth), so declaration-site plumbing can neither suppress the caller fold nor the callee fold. Synthetic edges remain **listed** in the output; they just no longer gate.

## Changes

- `internal/sqlite/graph.go` — one added conjunct in `hasUsageEdge`, doc comment updated to state the contract ("plumbing is not real usage").
- `internal/extract/extractor.go` — graph fold registered in the synthetic-prefix chokepoint checklist (automatic for future prefixes).
- Tests (red-first on main): synthetic caller does not suppress the fold + the synthetic edge stays listed; symmetric callee direction; a genuine direct caller beside a synthetic one **still** suppresses (the boundary that keeps precise answers precise). `PrefixDjangoRelated` added to `TestIsSyntheticQualified`.

## Verification

- saleor resolve oracle: 25% → **100%** resolved coverage (4/4 gold), graph callers 1 → 126.
- ruby-rails resolve oracle: **byte-identical** across all 13 contracts, fix vs main.
- Canonicalized `blast`+`graph` JSON identical on chatwoot `Inbox`, gitlabhq `MergeRequest`, discourse `Topic`, rails `ActiveRecord::Relation`.
- Flip-set measurement over the bench indexes (classes whose only ≥0.5 calls/references counterpart is synthetic, both directions, patterns taken from the literal 8 `syntheticPrefixes`): **0 Rails classes flip**; Django flips are exactly the intended set (saleor 36, netbox 4, pretix 4, sentry/healthchecks 0; callers-direction only).
- Query-layer read path only — no schema change, no rescan needed; existing indexes pick the fix up immediately.

## Residual notes (out of scope, documented deliberately)

- An unresolved inbound edge COALESCEs its source `Qualified` to `""`, which is non-synthetic, so a dangling ≥0.5 usage edge still suppresses the fold (pre-existing behavior, unchanged).
- The fold-admission loops still **admit** synthetic entries into folded results — visible-but-not-gating is the intended asymmetry, not an omission.
- Manager-chain edges misbinding to same-named GraphQL type classes (why saleor had no real caller in the first place) is a separate defect with its own fix shape; not addressed here.

## Test Plan

- [x] `go test ./internal/sqlite/ ./internal/extract/` — new tests fail on main, pass here
- [x] `make ci` green (build + per-file ≥92% coverage gate + lint + ledger; total 95.1%)
- [x] Cross-vertical no-regress evidence above
- [x] saleor single-cell re-bench (Opus 4.8 ×2) on this binary — **WIN +0.50 dependents** (2/4→4/4 both runs), overall 0.85→1.00
