### PR TITLE
fix(conventions): dedupe identically rendered convention rows

### DIFF
--- a/internal/conventions/conventions.go
+++ b/internal/conventions/conventions.go
@@ -52,6 +52,11 @@ type Convention struct {
 	// per-language refiners (see refineRubySignificance); zero for conventions a
 	// refiner does not touch, leaving prevalence the sole tiebreak.
 	Significance float64
+	// definingPath is the target symbol's defining file, recorded by the
+	// detectors whose rows can render identically when two distinct symbols
+	// share a qualified name (build-tag twin files). dedupeRenderedRows uses
+	// it to qualify true-difference collisions; it is never output on its own.
+	definingPath string
 }
 
 type Options struct {
@@ -109,6 +114,7 @@ func Detect(ctx context.Context, db *sql.DB, opts Options) ([]Convention, int, e
 	conventions = append(conventions, detectExternalDependencies(ctx, db, opts.Domain, fileFilter)...)
 	conventions = append(conventions, detectKeyTypes(symbols, edges, filePathByID, conventions)...)
 
+	conventions = dedupeRenderedRows(conventions)
 	enrichEdgeCounts(conventions, symbols, edges, filePathByID)
 	refineRubySignificance(conventions)
 

--- a/internal/conventions/dedupe.go
+++ b/internal/conventions/dedupe.go
@@ -1,0 +1,148 @@
+package conventions
+
+import (
+	"sort"
+	"strings"
+)
+
+// dedupeRenderedRows resolves conventions that render identically. Twin
+// symbols (e.g. a Go interface defined once per build tag) are indexed as
+// distinct symbols, so detectors honestly emit one group per symbol — and the
+// rows then render byte-identical. Rows whose (category, description) collide
+// are merged into one when they describe the same population; when the
+// populations genuinely differ, each row is qualified with the shortest path
+// suffix of its target's defining file that tells the rows apart. Resolution
+// is complete only when the defining files differ: colliding rows with no
+// recorded provenance, or defined in the same file, keep their residual
+// duplicate rather than a fabricated qualifier. It compacts the slice in
+// place and mutates Descriptions; callers must not retain the input.
+func dedupeRenderedRows(conventions []Convention) []Convention {
+	type rowKey struct {
+		category    Category
+		description string
+	}
+	groups := map[rowKey][]int{}
+	for i, c := range conventions {
+		k := rowKey{c.Category, c.Description}
+		groups[k] = append(groups[k], i)
+	}
+	drop := map[int]bool{}
+	for _, group := range groups {
+		if len(group) < 2 {
+			continue
+		}
+		survivors := mergeIdenticalPopulations(conventions, group)
+		if len(survivors) < len(group) {
+			kept := make(map[int]bool, len(survivors))
+			for _, i := range survivors {
+				kept[i] = true
+			}
+			for _, i := range group {
+				if !kept[i] {
+					drop[i] = true
+				}
+			}
+		}
+		if len(survivors) > 1 {
+			qualifyByDefiningFile(conventions, survivors)
+		}
+	}
+	if len(drop) == 0 {
+		return conventions
+	}
+	out := conventions[:0]
+	for i := range conventions {
+		if drop[i] {
+			continue
+		}
+		out = append(out, conventions[i])
+	}
+	return out
+}
+
+// mergeIdenticalPopulations answers one question: which group members
+// survive? Members describing the same population — identical instance set
+// (compared as a set of Name+Path, never as a bare count) and identical
+// Instances/Total — collapse to one survivor each. Counts are kept from that
+// one survivor, never summed: the populations are identical by the merge
+// condition, so two rows overstate one fact. The survivor is the member with
+// the smallest definingPath, keeping the merge deterministic across map
+// iteration order. It returns the surviving indices in input order.
+func mergeIdenticalPopulations(conventions []Convention, group []int) []int {
+	type population struct {
+		signature        string
+		instances, total int
+	}
+	survivor := map[population]int{}
+	for _, i := range group {
+		c := conventions[i]
+		p := population{exampleSetSignature(c.Examples), c.Instances, c.Total}
+		if j, ok := survivor[p]; !ok || c.definingPath < conventions[j].definingPath {
+			survivor[p] = i
+		}
+	}
+	out := make([]int, 0, len(survivor))
+	for _, i := range survivor {
+		out = append(out, i)
+	}
+	sort.Ints(out)
+	return out
+}
+
+// exampleSetSignature keys an example list as an order-insensitive set of
+// (Name, Path) members, so population comparison is by set, never by count.
+func exampleSetSignature(examples []Example) string {
+	keys := make([]string, 0, len(examples))
+	seen := map[string]bool{}
+	for _, e := range examples {
+		k := e.Name + "\x00" + e.Path
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, "\x01")
+}
+
+// qualifyByDefiningFile relabels colliding rows that survived the merge —
+// same rendered description over genuinely different populations — by
+// appending the shortest trailing path suffix of each row's defining file
+// that its siblings do not share (the 28-03 label precedent, one level up).
+// A row without a recorded defining file is left as-is, and colliding rows
+// defined in the same file receive the same qualifier: in both cases a
+// residual duplicate is preferable to a fabricated distinction.
+func qualifyByDefiningFile(conventions []Convention, group []int) {
+	for _, i := range group {
+		if conventions[i].definingPath == "" {
+			continue
+		}
+		siblings := make([]string, 0, len(group)-1)
+		for _, j := range group {
+			if j != i && conventions[j].definingPath != "" {
+				siblings = append(siblings, conventions[j].definingPath)
+			}
+		}
+		suffix := distinguishingPathSuffix(conventions[i].definingPath, siblings)
+		conventions[i].Description += " (defined in " + suffix + ")"
+	}
+}
+
+// distinguishingPathSuffix returns the shortest join of trailing path
+// segments of target that no sibling shares, growing one segment at a time;
+// the full target path when nothing shorter distinguishes it. Unlike
+// uniqueDirSuffix it keeps the basename — build-tag twins live in the same
+// directory and differ only there.
+func distinguishingPathSuffix(target string, siblings []string) string {
+	sibSegs := make([][]string, len(siblings))
+	for i, s := range siblings {
+		sibSegs[i] = pathSegments(s)
+	}
+	return shortestUniqueSuffix(pathSegments(target), sibSegs, target)
+}
+
+// pathSegments splits a path into all its segments, basename included.
+func pathSegments(p string) []string {
+	return strings.Split(strings.TrimPrefix(p, "/"), "/")
+}

--- a/internal/conventions/dedupe_test.go
+++ b/internal/conventions/dedupe_test.go
@@ -1,0 +1,199 @@
+package conventions
+
+import (
+	"strings"
+	"testing"
+)
+
+// twinFixture builds the gin build-tag shape: one interface named
+// binding.Binding defined in two files (mutually exclusive builds), with an
+// implementor set per twin placed under the given directory. Implementor ids
+// start at 100 for the first twin's set and 200 for the second's. Same names
+// under the same dir yield identical (Name, Path) sets; same names under
+// different dirs yield identical rendered descriptions over genuinely
+// different sets.
+func twinFixture(firstImpls []string, firstDir string, secondImpls []string, secondDir string) ([]symbolRow, []edgeRow, map[int64]symbolRow, map[int64]string) {
+	twin1 := symbolRow{id: 1, fileID: 10, name: "Binding", qualified: "binding.Binding", kind: "interface"}
+	twin2 := symbolRow{id: 2, fileID: 11, name: "Binding", qualified: "binding.Binding", kind: "interface"}
+	symbols := []symbolRow{twin1, twin2}
+	filePathByID := map[int64]string{
+		10: "binding/binding.go",
+		11: "binding/binding_nomsgpack.go",
+	}
+	var edges []edgeRow
+	addImpls := func(names []string, dir string, base int64, target int64) {
+		for i, n := range names {
+			id := base + int64(i)
+			fid := 1000 + id
+			symbols = append(symbols, symbolRow{id: id, fileID: fid, name: n, kind: "struct"})
+			filePathByID[fid] = dir + strings.ToLower(n) + ".go"
+			edges = append(edges, edgeRow{sourceID: id, targetID: target, kind: "inherits"})
+		}
+	}
+	addImpls(firstImpls, firstDir, 100, twin1.id)
+	addImpls(secondImpls, secondDir, 200, twin2.id)
+	return symbols, edges, indexSymbols(symbols), filePathByID
+}
+
+// TestDedupeMergesTwinRows pins the A1 fix end-to-end at the detector level:
+// two same-qualified-name interfaces with identical implementor sets emit two
+// byte-identical rows per category, and dedupeRenderedRows merges each pair
+// down to one row with the counts of one population, never summed.
+func TestDedupeMergesTwinRows(t *testing.T) {
+	impls := []string{"bsonBinding", "formBinding", "jsonBinding"}
+	symbols, edges, symbolByID, filePathByID := twinFixture(impls, "binding/", nil, "")
+	// Point the second twin's edges at the SAME implementor symbols so both
+	// populations are the identical (Name, Path) set, as in gin where every
+	// binding struct satisfies both build-tag variants.
+	for _, id := range []int64{100, 101, 102} {
+		edges = append(edges, edgeRow{sourceID: id, targetID: 2, kind: "inherits"})
+	}
+
+	var conventions []Convention
+	conventions = append(conventions, detectInheritance(symbols, edges, symbolByID, filePathByID)...)
+	conventions = append(conventions, detectGoInterfaces(symbols, edges, symbolByID, filePathByID)...)
+	if len(conventions) != 4 {
+		t.Fatalf("fixture must reproduce the defect (2 inheritance + 2 framework rows), got %d: %+v", len(conventions), conventions)
+	}
+
+	deduped := dedupeRenderedRows(conventions)
+	if len(deduped) != 2 {
+		t.Fatalf("expected twin rows merged to 1 per category, got %d: %+v", len(deduped), deduped)
+	}
+	seen := map[string]bool{}
+	for _, c := range deduped {
+		key := string(c.Category) + "\x00" + c.Description
+		if seen[key] {
+			t.Errorf("duplicate rendered row survived dedupe: %s", c.Description)
+		}
+		seen[key] = true
+		if c.Instances != 3 {
+			t.Errorf("merged row counts must come from one population, got Instances=%d, want 3", c.Instances)
+		}
+		if strings.Contains(c.Description, "defined in") {
+			t.Errorf("merged row must not be file-qualified: %s", c.Description)
+		}
+	}
+}
+
+// TestDedupeQualifiesTrueDifference pins the qualify branch: two
+// same-qualified-name interfaces with DIFFERENT implementor sets (same names,
+// different files) must stay two rows, each qualified by the shortest
+// distinguishing suffix of its defining file — never silently merged.
+func TestDedupeQualifiesTrueDifference(t *testing.T) {
+	names := []string{"bsonBinding", "formBinding", "jsonBinding"}
+	symbols, edges, symbolByID, filePathByID := twinFixture(names, "binding/", names, "binding/internal/")
+
+	conventions := detectGoInterfaces(symbols, edges, symbolByID, filePathByID)
+	if len(conventions) != 2 {
+		t.Fatalf("fixture must emit one row per twin, got %d", len(conventions))
+	}
+	if conventions[0].Description != conventions[1].Description {
+		t.Fatalf("fixture must reproduce colliding descriptions, got %q vs %q", conventions[0].Description, conventions[1].Description)
+	}
+
+	deduped := dedupeRenderedRows(conventions)
+	if len(deduped) != 2 {
+		t.Fatalf("genuinely different populations must never merge, got %d rows", len(deduped))
+	}
+	if deduped[0].Description == deduped[1].Description {
+		t.Fatalf("colliding rows must be qualified apart, both render %q", deduped[0].Description)
+	}
+	want := map[string]bool{"(defined in binding.go)": false, "(defined in binding_nomsgpack.go)": false}
+	for _, c := range deduped {
+		for suffix := range want {
+			if strings.HasSuffix(c.Description, suffix) {
+				want[suffix] = true
+			}
+		}
+	}
+	for suffix, found := range want {
+		if !found {
+			t.Errorf("expected a row qualified with %q, got %+v", suffix, deduped)
+		}
+	}
+}
+
+// TestDedupeLeavesDistinctRowsAlone pins the no-op path: a response with no
+// rendered collisions comes back unchanged, in order.
+func TestDedupeLeavesDistinctRowsAlone(t *testing.T) {
+	conventions := []Convention{
+		{Category: CategoryInheritance, Description: "a", Instances: 3},
+		{Category: CategoryFramework, Description: "b", Instances: 2},
+		// Same description in a different category is not a rendered collision:
+		// the response groups rows by category.
+		{Category: CategoryFramework, Description: "a", Instances: 2},
+	}
+	deduped := dedupeRenderedRows(conventions)
+	if len(deduped) != 3 {
+		t.Fatalf("expected all 3 rows untouched, got %d", len(deduped))
+	}
+	for i, want := range []string{"a", "b", "a"} {
+		if deduped[i].Description != want {
+			t.Errorf("row %d = %q, want %q (order must be preserved)", i, deduped[i].Description, want)
+		}
+	}
+}
+
+// TestDedupeMergeIsDeterministic pins the survivor choice: whichever detection
+// order the twins arrive in, the merged row is the one with the smallest
+// definingPath, so repeated runs render identically.
+func TestDedupeMergeIsDeterministic(t *testing.T) {
+	rowA := Convention{Category: CategoryFramework, Description: "x", Instances: 2,
+		Examples:     []Example{{Name: "A", Path: "p"}, {Name: "B", Path: "q"}},
+		definingPath: "pkg/a.go"}
+	rowB := rowA
+	rowB.definingPath = "pkg/b.go"
+	// Same set, different order: the merge must compare populations as sets,
+	// so example order can never block it.
+	rowB.Examples = []Example{{Name: "B", Path: "q"}, {Name: "A", Path: "p"}}
+
+	for _, order := range [][]Convention{{rowA, rowB}, {rowB, rowA}} {
+		deduped := dedupeRenderedRows(order)
+		if len(deduped) != 1 {
+			t.Fatalf("identical populations must merge, got %d", len(deduped))
+		}
+		if deduped[0].definingPath != "pkg/a.go" {
+			t.Errorf("survivor must be the smallest definingPath, got %q", deduped[0].definingPath)
+		}
+	}
+}
+
+// TestDedupeQualifyWithoutProvenance pins the fallback: colliding
+// true-difference rows whose detector recorded no defining file are left
+// as-is rather than qualified with a fabricated path.
+func TestDedupeQualifyWithoutProvenance(t *testing.T) {
+	conventions := []Convention{
+		{Category: CategoryNaming, Description: "n", Instances: 3, Examples: []Example{{Name: "A", Path: "p"}}},
+		{Category: CategoryNaming, Description: "n", Instances: 4, Examples: []Example{{Name: "B", Path: "q"}}},
+	}
+	deduped := dedupeRenderedRows(conventions)
+	if len(deduped) != 2 {
+		t.Fatalf("different populations must not merge, got %d", len(deduped))
+	}
+	for _, c := range deduped {
+		if strings.Contains(c.Description, "defined in") {
+			t.Errorf("row without provenance must stay unqualified: %q", c.Description)
+		}
+	}
+}
+
+// TestDistinguishingPathSuffix pins the suffix growth: basename first, then
+// trailing directories, full path when a sibling shares every suffix depth.
+func TestDistinguishingPathSuffix(t *testing.T) {
+	cases := []struct {
+		target   string
+		siblings []string
+		want     string
+	}{
+		{"binding/binding.go", []string{"binding/binding_nomsgpack.go"}, "binding.go"},
+		{"a/render/json.go", []string{"b/render/json.go"}, "a/render/json.go"},
+		{"x/render/json.go", []string{"y/other/json.go"}, "render/json.go"},
+		{"same/path.go", []string{"same/path.go"}, "same/path.go"},
+	}
+	for _, tc := range cases {
+		if got := distinguishingPathSuffix(tc.target, tc.siblings); got != tc.want {
+			t.Errorf("distinguishingPathSuffix(%q, %v) = %q, want %q", tc.target, tc.siblings, got, tc.want)
+		}
+	}
+}

--- a/internal/conventions/detectors_generic.go
+++ b/internal/conventions/detectors_generic.go
@@ -108,13 +108,14 @@ func detectInheritance(symbols []symbolRow, edges []edgeRow, symbolByID map[int6
 		sortExamples(g.examples)
 		label := baseLabel(g.targetName, g.targetQualified, ambiguous)
 		out = append(out, Convention{
-			Category:    CategoryInheritance,
-			Description: fmt.Sprintf("%d %s extend %s as a base class (%s)", g.count, pluralize(g.sourceKind), label, topNames(g.examples)),
-			Instances:   g.count,
-			Total:       total,
-			Strength:    safeStrength(g.count, total),
-			Examples:    g.examples,
-			KeySymbol:   g.targetQualified,
+			Category:     CategoryInheritance,
+			Description:  fmt.Sprintf("%d %s extend %s as a base class (%s)", g.count, pluralize(g.sourceKind), label, topNames(g.examples)),
+			Instances:    g.count,
+			Total:        total,
+			Strength:     safeStrength(g.count, total),
+			Examples:     g.examples,
+			KeySymbol:    g.targetQualified,
+			definingPath: filePathByID[symbolByID[g.targetID].fileID],
 		})
 	}
 	return out
@@ -344,13 +345,14 @@ func detectComposition(symbols []symbolRow, edges []edgeRow, symbolByID map[int6
 		}
 		label := baseLabel(g.targetName, g.targetQualified, ambiguous)
 		out = append(out, Convention{
-			Category:    CategoryComposition,
-			Description: fmt.Sprintf("%d %s mix in %s for shared behavior (%s)", g.count, pluralize(g.sourceKind), label, topNames(g.examples)),
-			Instances:   g.count,
-			Total:       total,
-			Strength:    safeStrength(g.count, total),
-			Examples:    g.examples,
-			KeySymbol:   g.targetQualified,
+			Category:     CategoryComposition,
+			Description:  fmt.Sprintf("%d %s mix in %s for shared behavior (%s)", g.count, pluralize(g.sourceKind), label, topNames(g.examples)),
+			Instances:    g.count,
+			Total:        total,
+			Strength:     safeStrength(g.count, total),
+			Examples:     g.examples,
+			KeySymbol:    g.targetQualified,
+			definingPath: filePathByID[symbolByID[g.targetID].fileID],
 		})
 	}
 	if len(serializerExamples) >= minInstances {

--- a/internal/conventions/detectors_go.go
+++ b/internal/conventions/detectors_go.go
@@ -39,13 +39,14 @@ func detectGoInterfaces(symbols []symbolRow, edges []edgeRow, symbolByID map[int
 		sortExamples(g.implementors)
 		totalStructs := countByKind(symbols, "struct", "class")
 		out = append(out, Convention{
-			Category:    CategoryFramework,
-			Description: fmt.Sprintf("Interface contract: %s is satisfied by %d types (%s) — polymorphic dispatch point", g.iface.name, len(g.implementors), topNames(g.implementors)),
-			Instances:   len(g.implementors),
-			Total:       totalStructs,
-			Strength:    safeStrength(len(g.implementors), totalStructs),
-			Examples:    g.implementors,
-			KeySymbol:   g.iface.name,
+			Category:     CategoryFramework,
+			Description:  fmt.Sprintf("Interface contract: %s is satisfied by %d types (%s) — polymorphic dispatch point", g.iface.name, len(g.implementors), topNames(g.implementors)),
+			Instances:    len(g.implementors),
+			Total:        totalStructs,
+			Strength:     safeStrength(len(g.implementors), totalStructs),
+			Examples:     g.implementors,
+			KeySymbol:    g.iface.name,
+			definingPath: filePathByID[g.iface.fileID],
 		})
 	}
 	return out

--- a/internal/conventions/helpers.go
+++ b/internal/conventions/helpers.go
@@ -78,8 +78,9 @@ func ambiguousTargetNames(nameByID map[int64]string) map[string]bool {
 // name is available. This keeps the common case terse while disambiguating
 // collisions, so "extend Base" lines do not read as duplicates. In the rare case
 // where the qualified names also collide (two "Foo::Base" in different files), it
-// falls back to the bare name rather than render a misleading partial path; that
-// residual duplicate is accepted as not worth a path-suffix escalation here.
+// falls back to the bare name rather than render a misleading partial path; the
+// resulting identical rows are resolved downstream by dedupeRenderedRows, which
+// merges identical populations and file-qualifies genuinely different ones.
 func baseLabel(name, qualified string, ambiguous map[string]bool) string {
 	if ambiguous[name] && qualified != "" && qualified != name {
 		return qualified
@@ -257,12 +258,23 @@ func siblingPaths(picked []Example, group []int, i int) []string {
 // only dir suffix is shared by a deeper sibling, or a sibling differs only in
 // basename — the full target Path is returned as the fallback.
 func uniqueDirSuffix(target string, siblings []string) string {
-	segs := dirSegments(target)
+	sibSegs := make([][]string, len(siblings))
+	for i, s := range siblings {
+		sibSegs[i] = dirSegments(s)
+	}
+	return shortestUniqueSuffix(dirSegments(target), sibSegs, target)
+}
+
+// shortestUniqueSuffix is the shared grow-one-segment loop behind
+// uniqueDirSuffix (directory segments) and distinguishingPathSuffix (full
+// path segments): the shortest join of trailing segs that no sibling shares
+// at the same depth, or fallback when every depth collides — including when
+// segs is empty.
+func shortestUniqueSuffix(segs []string, siblings [][]string, fallback string) string {
 	for k := 1; k <= len(segs); k++ {
 		cand := suffixOf(segs, k)
 		collision := false
-		for _, s := range siblings {
-			other := dirSegments(s)
+		for _, other := range siblings {
 			if len(other) >= k && suffixOf(other, k) == cand {
 				collision = true
 				break
@@ -272,7 +284,7 @@ func uniqueDirSuffix(target string, siblings []string) string {
 			return cand
 		}
 	}
-	return target
+	return fallback
 }
 
 // escalateColliding is the airtight backstop. A dir-suffix label and a full-Path


### PR DESCRIPTION
## Problem

A repo defining the same symbol under mutually exclusive build tags (gin's `binding.Binding` in `binding/binding.go` and `binding/binding_nomsgpack.go`) indexes both — correctly, they are distinct symbols — but the conventions output then shows **verbatim duplicate rows** in the CLI, the JSON, and the agent-facing `summary` string:

```
13 classes extend binding.Binding as a base class (bsonBinding, formBinding, ...)  (21%, 13/61)
13 classes extend binding.Binding as a base class (bsonBinding, formBinding, ...)  (21%, 13/61)
```

`detectInheritance` groups by target symbol id and `detectGoInterfaces` keys by target id — two ids, two groups, two rows — and the existing name-collision guard falls back to the bare name when the qualified names also collide, so the rows render byte-identical. Any repo with build-tag twin files hits this; `#ifdef`-style splits and re-opened definitions are the same shape.

## Summary

Fix the rendering contract, not Go semantics: no build-tag modeling, no detector-logic changes. At the post-detection chokepoint, rows whose (category, description) collide are:

- **merged into one** when their instance sets are identical (compared as sets of name+path, never counts; counts kept from one population, never summed) — the twin-file case;
- **qualified** with the shortest distinguishing path suffix of their defining file when the populations genuinely differ — same-name conventions are never silently merged.

Rows without recorded provenance, or colliding rows defined in the same file, keep their residual duplicate rather than a fabricated qualifier.

## Changes

- `internal/conventions/dedupe.go` — the dedup pass: collision grouping, set-based population merge (deterministic survivor), defining-file qualification.
- `internal/conventions/conventions.go` — wire the pass into `Detect` before enrichment; unexported `definingPath` provenance field on `Convention` (never serialized).
- `internal/conventions/detectors_generic.go`, `detectors_go.go` — the three detectors whose rows can collide (inheritance, composition, Go interface contracts) record the target's defining file.
- `internal/conventions/helpers.go` — shared `shortestUniqueSuffix` loop behind `uniqueDirSuffix` and the new `distinguishingPathSuffix`; `baseLabel` comment now points at the downstream dedup instead of accepting the duplicate.
- `internal/conventions/dedupe_test.go` — fixtures straight from the gin shape: twin merge, true-difference qualification, determinism across input orders, set-not-order comparison, provenance-less fallback.

## Test Plan

- [x] `make ci` green (coverage gate ≥92% incl. new file, lint 0, ledger 0)
- [x] Real gin index: exactly the 4 duplicate rows disappear (2 inheritance + 2 framework), everything else unchanged
- [x] maket (Ruby) conventions output byte-identical before/after
- [x] JSON response and `summary` string contain no repeated rows/sentences on gin