### PR TITLE
fix(conventions): one category owns Go satisfaction, in Go words

### DIFF
--- a/internal/conventions/dedupe_test.go
+++ b/internal/conventions/dedupe_test.go
@@ -35,10 +35,11 @@ func twinFixture(firstImpls []string, firstDir string, secondImpls []string, sec
 	return symbols, edges, indexSymbols(symbols), filePathByID
 }
 
-// TestDedupeMergesTwinRows pins the A1 fix end-to-end at the detector level:
-// two same-qualified-name interfaces with identical implementor sets emit two
-// byte-identical rows per category, and dedupeRenderedRows merges each pair
-// down to one row with the counts of one population, never summed.
+// TestDedupeMergesTwinRows pins the twin-file merge end-to-end at the
+// detector level: two same-qualified-name interfaces with identical
+// implementor sets emit two byte-identical framework rows (inheritance
+// routes Go satisfaction away entirely), and dedupeRenderedRows merges the
+// pair down to one row with the counts of one population, never summed.
 func TestDedupeMergesTwinRows(t *testing.T) {
 	impls := []string{"bsonBinding", "formBinding", "jsonBinding"}
 	symbols, edges, symbolByID, filePathByID := twinFixture(impls, "binding/", nil, "")
@@ -52,27 +53,56 @@ func TestDedupeMergesTwinRows(t *testing.T) {
 	var conventions []Convention
 	conventions = append(conventions, detectInheritance(symbols, edges, symbolByID, filePathByID)...)
 	conventions = append(conventions, detectGoInterfaces(symbols, edges, symbolByID, filePathByID)...)
-	if len(conventions) != 4 {
-		t.Fatalf("fixture must reproduce the defect (2 inheritance + 2 framework rows), got %d: %+v", len(conventions), conventions)
+	if len(conventions) != 2 {
+		t.Fatalf("fixture must reproduce the defect (2 identical framework rows, 0 inheritance), got %d: %+v", len(conventions), conventions)
 	}
 
 	deduped := dedupeRenderedRows(conventions)
-	if len(deduped) != 2 {
-		t.Fatalf("expected twin rows merged to 1 per category, got %d: %+v", len(deduped), deduped)
+	if len(deduped) != 1 {
+		t.Fatalf("expected twin framework rows merged to 1, got %d: %+v", len(deduped), deduped)
 	}
-	seen := map[string]bool{}
-	for _, c := range deduped {
-		key := string(c.Category) + "\x00" + c.Description
-		if seen[key] {
-			t.Errorf("duplicate rendered row survived dedupe: %s", c.Description)
-		}
-		seen[key] = true
-		if c.Instances != 3 {
-			t.Errorf("merged row counts must come from one population, got Instances=%d, want 3", c.Instances)
-		}
-		if strings.Contains(c.Description, "defined in") {
-			t.Errorf("merged row must not be file-qualified: %s", c.Description)
-		}
+	c := deduped[0]
+	if c.Instances != 3 {
+		t.Errorf("merged row counts must come from one population, got Instances=%d, want 3", c.Instances)
+	}
+	if strings.Contains(c.Description, "defined in") {
+		t.Errorf("merged row must not be file-qualified: %s", c.Description)
+	}
+}
+
+// TestDedupeMergesRubyTwinRows pins the inheritance-category merge with the
+// re-opened-class shape: one Ruby class defined in two files (the same
+// qualified name twice), the same three subclasses — two byte-identical
+// inheritance rows merge to one.
+func TestDedupeMergesRubyTwinRows(t *testing.T) {
+	twin1 := symbolRow{id: 1, fileID: 10, name: "Base", qualified: "Billing::Base", kind: "class"}
+	twin2 := symbolRow{id: 2, fileID: 11, name: "Base", qualified: "Billing::Base", kind: "class"}
+	symbols := []symbolRow{twin1, twin2,
+		{id: 3, fileID: 12, name: "Invoice", kind: "class"},
+		{id: 4, fileID: 13, name: "Receipt", kind: "class"},
+		{id: 5, fileID: 14, name: "Refund", kind: "class"},
+	}
+	filePathByID := map[int64]string{
+		10: "app/models/billing/base.rb", 11: "lib/billing/base.rb",
+		12: "app/models/invoice.rb", 13: "app/models/receipt.rb", 14: "app/models/refund.rb",
+	}
+	var edges []edgeRow
+	for _, src := range []int64{3, 4, 5} {
+		edges = append(edges,
+			edgeRow{sourceID: src, targetID: 1, kind: "inherits"},
+			edgeRow{sourceID: src, targetID: 2, kind: "inherits"})
+	}
+
+	conventions := detectInheritance(symbols, edges, indexSymbols(symbols), filePathByID)
+	if len(conventions) != 2 || conventions[0].Description != conventions[1].Description {
+		t.Fatalf("fixture must reproduce two identical inheritance rows, got: %+v", conventions)
+	}
+	deduped := dedupeRenderedRows(conventions)
+	if len(deduped) != 1 {
+		t.Fatalf("expected twin inheritance rows merged to 1, got %d: %+v", len(deduped), deduped)
+	}
+	if deduped[0].Instances != 3 {
+		t.Errorf("merged row counts must come from one population, got %d", deduped[0].Instances)
 	}
 }
 

--- a/internal/conventions/detectors_generic.go
+++ b/internal/conventions/detectors_generic.go
@@ -70,6 +70,13 @@ func detectInheritance(symbols []symbolRow, edges []edgeRow, symbolByID map[int6
 		if !ok {
 			continue
 		}
+		// Go interface satisfaction is owned by the framework
+		// interface-contract row; reporting it here as inheritance would state
+		// the same fact twice, in the wrong vocabulary (Go has no classes and
+		// nothing extends).
+		if isGoInterfaceSatisfaction(tgt, filePathByID) {
+			continue
+		}
 		key := groupKey{targetID: e.targetID, sourceKind: src.kind}
 		if g, exists := groups[key]; exists {
 			g.count++
@@ -370,9 +377,15 @@ func detectComposition(symbols []symbolRow, edges []edgeRow, symbolByID map[int6
 			continue
 		}
 		label := baseLabel(g.targetName, g.targetQualified, ambiguous)
+		var desc string
+		if isGoDeclared(symbolByID[g.targetID], filePathByID) {
+			desc = goEmbedDescription(g.count, label, topNames(g.examples))
+		} else {
+			desc = fmt.Sprintf("%d %s mix in %s for shared behavior (%s)", g.count, pluralize(g.sourceKind), label, topNames(g.examples))
+		}
 		out = append(out, Convention{
 			Category:     CategoryComposition,
-			Description:  fmt.Sprintf("%d %s mix in %s for shared behavior (%s)", g.count, pluralize(g.sourceKind), label, topNames(g.examples)),
+			Description:  desc,
 			Instances:    g.count,
 			Total:        total,
 			Strength:     safeStrength(g.count, total),

--- a/internal/conventions/detectors_go.go
+++ b/internal/conventions/detectors_go.go
@@ -6,6 +6,30 @@ import (
 	"strings"
 )
 
+// isGoDeclared reports whether the symbol is declared in a Go file — the
+// structural language gate the routing and wording decisions share.
+func isGoDeclared(s symbolRow, filePathByID map[int64]string) bool {
+	return strings.HasSuffix(filePathByID[s.fileID], ".go")
+}
+
+// isGoInterfaceSatisfaction reports whether an inherits-edge target marks Go
+// interface satisfaction: the only inherits edges over Go code are the ones
+// the scanner writes into interface targets, so an interface-kind target
+// declared in a Go file IS satisfaction, and the framework interface-contract
+// row is its one owner. The discriminator is structural (target kind +
+// language), never the confidence stamp, which every language shares.
+func isGoInterfaceSatisfaction(tgt symbolRow, filePathByID map[int64]string) bool {
+	return tgt.kind == "interface" && isGoDeclared(tgt, filePathByID)
+}
+
+// goEmbedDescription is the wording for a Go embedding group. Go embedders
+// are structs whatever kind the index stores them under (the extractor files
+// them as class), and embedding promotes the embedded type's members —
+// nothing is mixed in.
+func goEmbedDescription(count int, label, names string) string {
+	return fmt.Sprintf("%d structs embed %s (methods promoted) (%s)", count, label, names)
+}
+
 func detectGoInterfaces(symbols []symbolRow, edges []edgeRow, symbolByID map[int64]symbolRow, filePathByID map[int64]string) []Convention {
 	type ifaceGroup struct {
 		iface        symbolRow
@@ -24,6 +48,9 @@ func detectGoInterfaces(symbols []symbolRow, edges []edgeRow, symbolByID map[int
 		if !ok || (src.kind != "struct" && src.kind != "class") {
 			continue
 		}
+		if isTestFile(filePathByID, src.fileID) {
+			continue
+		}
 		g, exists := ifaces[e.targetID]
 		if !exists {
 			g = &ifaceGroup{iface: tgt}
@@ -31,19 +58,24 @@ func detectGoInterfaces(symbols []symbolRow, edges []edgeRow, symbolByID map[int
 		}
 		g.implementors = append(g.implementors, Example{Name: src.name, Path: filePathByID[src.fileID]})
 	}
+	// Same test-source exclusion and denominator discipline as
+	// detectInheritance (domainKindCounts), so the two detectors can never
+	// drift on the population they describe: "N types" counts non-test
+	// struct/class types.
+	kindCounts := domainKindCounts(symbols, filePathByID)
+	totalTypes := kindCounts["struct"] + kindCounts["class"]
 	var out []Convention
 	for _, g := range ifaces {
 		if len(g.implementors) < minInterfaceInstances {
 			continue
 		}
 		sortExamples(g.implementors)
-		totalStructs := countByKind(symbols, "struct", "class")
 		out = append(out, Convention{
 			Category:     CategoryFramework,
-			Description:  fmt.Sprintf("Interface contract: %s is satisfied by %d types (%s) — polymorphic dispatch point", g.iface.name, len(g.implementors), topNames(g.implementors)),
+			Description:  fmt.Sprintf("Interface contract: %d types implement %s (%s) — polymorphic dispatch point", len(g.implementors), g.iface.name, topNames(g.implementors)),
 			Instances:    len(g.implementors),
-			Total:        totalStructs,
-			Strength:     safeStrength(len(g.implementors), totalStructs),
+			Total:        totalTypes,
+			Strength:     safeStrength(len(g.implementors), totalTypes),
 			Examples:     g.implementors,
 			KeySymbol:    g.iface.name,
 			definingPath: filePathByID[g.iface.fileID],

--- a/internal/conventions/go_interfaces_test.go
+++ b/internal/conventions/go_interfaces_test.go
@@ -81,7 +81,7 @@ func TestDetectGoInterfaces(t *testing.T) {
 	if c.Strength != wantStrength {
 		t.Errorf("strength = %v, want %v", c.Strength, wantStrength)
 	}
-	if !strings.Contains(c.Description, "Interface contract: Reader is satisfied by 3 types") {
+	if !strings.Contains(c.Description, "Interface contract: 3 types implement Reader") {
 		t.Errorf("description = %q, missing interface-contract phrasing", c.Description)
 	}
 	if !strings.Contains(c.Description, "polymorphic dispatch point") {

--- a/internal/conventions/satisfaction_routing_test.go
+++ b/internal/conventions/satisfaction_routing_test.go
@@ -1,0 +1,166 @@
+package conventions
+
+import (
+	"strings"
+	"testing"
+)
+
+// satisfactionFixture builds a Go interface with three production
+// implementors and one implementor declared in a test file — the shape that
+// produced gin's 18-vs-19 count drift between categories.
+func satisfactionFixture() ([]symbolRow, []edgeRow, map[int64]symbolRow, map[int64]string) {
+	// Go structs are indexed as kind "class" (the extractor's classification);
+	// fixtures mirror the real index, not the Go keyword.
+	symbols := []symbolRow{
+		{id: 1, fileID: 10, name: "Render", qualified: "render.Render", kind: "interface"},
+		{id: 2, fileID: 11, name: "JSON", kind: "class"},
+		{id: 3, fileID: 12, name: "XML", kind: "class"},
+		{id: 4, fileID: 13, name: "YAML", kind: "class"},
+		{id: 5, fileID: 14, name: "fakeRender", kind: "class"},
+	}
+	filePathByID := map[int64]string{
+		10: "render/render.go",
+		11: "render/json.go",
+		12: "render/xml.go",
+		13: "render/yaml.go",
+		14: "render/render_test.go",
+	}
+	edges := []edgeRow{
+		{sourceID: 2, targetID: 1, kind: "inherits"},
+		{sourceID: 3, targetID: 1, kind: "inherits"},
+		{sourceID: 4, targetID: 1, kind: "inherits"},
+		{sourceID: 5, targetID: 1, kind: "inherits"},
+	}
+	return symbols, edges, indexSymbols(symbols), filePathByID
+}
+
+// TestSatisfactionRoutedToFrameworkOnly pins the one-fact-one-category rule:
+// inherits edges into a Go interface are satisfaction, owned by the framework
+// interface-contract row; the inheritance category emits NOTHING for them,
+// and the framework row applies the same test-source exclusion as
+// detectInheritance, so cross-category count drift is structurally
+// impossible.
+func TestSatisfactionRoutedToFrameworkOnly(t *testing.T) {
+	symbols, edges, symbolByID, filePathByID := satisfactionFixture()
+
+	if got := detectInheritance(symbols, edges, symbolByID, filePathByID); len(got) != 0 {
+		t.Fatalf("inheritance must not report Go interface satisfaction, got: %+v", got)
+	}
+
+	convs := detectGoInterfaces(symbols, edges, symbolByID, filePathByID)
+	if len(convs) != 1 {
+		t.Fatalf("expected one framework interface-contract row, got %d: %+v", len(convs), convs)
+	}
+	c := convs[0]
+	if c.Instances != 3 {
+		t.Errorf("instances = %d, want 3 (test-file implementor excluded)", c.Instances)
+	}
+	// Denominator matches the sentence: "N types" counts non-test
+	// struct/class types (JSON, XML, YAML — fakeRender lives in a test file).
+	if c.Total != 3 {
+		t.Errorf("total = %d, want 3 (non-test struct/class types)", c.Total)
+	}
+	if !strings.Contains(c.Description, "3 types implement Render") {
+		t.Errorf("description must use the implement wording, got %q", c.Description)
+	}
+	for _, banned := range []string{"extend", "base class", "satisfied by"} {
+		if strings.Contains(c.Description, banned) {
+			t.Errorf("description must not say %q over Go code: %q", banned, c.Description)
+		}
+	}
+	for _, ex := range c.Examples {
+		if ex.Name == "fakeRender" {
+			t.Errorf("test-file implementor leaked into the contract row: %+v", c.Examples)
+		}
+	}
+}
+
+// TestInheritanceKeepsNonGoTargets pins the routing discriminator to the
+// language, not the target kind alone: an interface-kind target declared
+// outside a Go file stays in the inheritance category. Asserted with
+// fixtures, not reasoning, per the pitch. This is a guard test (it never
+// went red). Known asymmetry it documents rather than fixes: non-Go
+// interface-kind targets (Rust traits, TS implements) still appear in BOTH
+// inheritance and the framework contract row — one-category ownership for
+// them is a separate behavioral change that needs its own bench.
+func TestInheritanceKeepsNonGoTargets(t *testing.T) {
+	cases := []struct {
+		lang    string
+		kind    string
+		files   map[int64]string
+		mention string
+	}{
+		{"ruby", "class", map[int64]string{
+			10: "app/models/base.rb", 11: "app/models/a.rb", 12: "app/models/b.rb", 13: "app/models/c.rb",
+		}, "Base"},
+		{"python", "class", map[int64]string{
+			10: "core/models.py", 11: "core/a.py", 12: "core/b.py", 13: "core/c.py",
+		}, "Base"},
+		{"typescript", "interface", map[int64]string{
+			10: "src/base.ts", 11: "src/a.ts", 12: "src/b.ts", 13: "src/c.ts",
+		}, "Base"},
+	}
+	for _, tc := range cases {
+		symbols := []symbolRow{
+			{id: 1, fileID: 10, name: "Base", qualified: "Base", kind: tc.kind},
+			{id: 2, fileID: 11, name: "A", kind: "class"},
+			{id: 3, fileID: 12, name: "B", kind: "class"},
+			{id: 4, fileID: 13, name: "C", kind: "class"},
+		}
+		edges := []edgeRow{
+			{sourceID: 2, targetID: 1, kind: "inherits"},
+			{sourceID: 3, targetID: 1, kind: "inherits"},
+			{sourceID: 4, targetID: 1, kind: "inherits"},
+		}
+		convs := detectInheritance(symbols, edges, indexSymbols(symbols), tc.files)
+		if len(convs) != 1 || !strings.Contains(convs[0].Description, tc.mention) {
+			t.Errorf("%s: inheritance must keep non-Go %s targets, got: %+v", tc.lang, tc.kind, convs)
+		}
+	}
+}
+
+// TestGoEmbeddingWording pins the composition vocabulary over Go code: struct
+// embedding promotes methods, nothing is mixed in — while Ruby include
+// targets keep the generic mixin wording.
+func TestGoEmbeddingWording(t *testing.T) {
+	build := func(targetPath string, srcPaths [3]string) ([]symbolRow, []edgeRow, map[int64]symbolRow, map[int64]string) {
+		// Kind "class" mirrors how the extractor indexes Go structs; the
+		// wording must still say structs, which is what they are in Go.
+		symbols := []symbolRow{
+			{id: 1, fileID: 10, name: "Base", qualified: "pkg.Base", kind: "class"},
+			{id: 2, fileID: 11, name: "A", kind: "class"},
+			{id: 3, fileID: 12, name: "B", kind: "class"},
+			{id: 4, fileID: 13, name: "C", kind: "class"},
+		}
+		files := map[int64]string{10: targetPath, 11: srcPaths[0], 12: srcPaths[1], 13: srcPaths[2]}
+		edges := []edgeRow{
+			{sourceID: 2, targetID: 1, kind: "includes"},
+			{sourceID: 3, targetID: 1, kind: "includes"},
+			{sourceID: 4, targetID: 1, kind: "includes"},
+		}
+		return symbols, edges, indexSymbols(symbols), files
+	}
+
+	symbols, edges, symbolByID, files := build("pkg/base.go", [3]string{"pkg/a.go", "pkg/b.go", "pkg/c.go"})
+	convs := detectComposition(symbols, edges, symbolByID, files)
+	if len(convs) != 1 {
+		t.Fatalf("expected one Go composition row, got %d: %+v", len(convs), convs)
+	}
+	if !strings.Contains(convs[0].Description, "3 structs embed Base (methods promoted)") {
+		t.Errorf("Go embedding must use embed wording, got %q", convs[0].Description)
+	}
+	if strings.Contains(convs[0].Description, "mix in") {
+		t.Errorf("mixin wording over Go code: %q", convs[0].Description)
+	}
+
+	symbols, edges, symbolByID, files = build("app/models/concerns/base.rb", [3]string{"app/a.rb", "app/b.rb", "app/c.rb"})
+	// Ruby modules are the usual include target; kind stays as declared in
+	// the fixture, only the language changes the wording.
+	convs = detectComposition(symbols, edges, symbolByID, files)
+	if len(convs) != 1 {
+		t.Fatalf("expected one Ruby composition row, got %d: %+v", len(convs), convs)
+	}
+	if !strings.Contains(convs[0].Description, "mix in Base for shared behavior") {
+		t.Errorf("non-Go composition must keep mixin wording, got %q", convs[0].Description)
+	}
+}

--- a/testdata/smoke/ground-truth.json
+++ b/testdata/smoke/ground-truth.json
@@ -77,7 +77,7 @@
     }
   ],
   "conventions": {
-    "min_detected": 9
+    "min_detected": 8
   },
   "performance": {
     "scan_max_seconds": 10,


### PR DESCRIPTION
## Problem

The same underlying fact — gin's types satisfying the `Render` interface — appeared twice, in two categories, with two different counts and the wrong vocabulary:

```
inheritance: 18 classes extend Render as a base class (...)              (30%, 18/61)
framework:   Interface contract: Render is satisfied by 19 types (...)   (15%, 19/124)
```

Go has no classes, nothing extends, and `Render` is not a base class. Both rows consume the same satisfaction edges; the 18-vs-19 drift exists because `detectInheritance` excludes test-file sources while `detectGoInterfaces` applied no test filter. An agent reads a contradiction about the repo's most important structural fact.

## Summary

- **One category owns satisfaction.** An `inherits` edge into an interface-kind target declared in a Go file IS satisfaction (the scanner writes no other Go inherits edges — verified), so `detectInheritance` skips those groups and the framework interface-contract row is the single owner. The discriminator is structural (target kind + language), never the confidence stamp, which every language's extractors share as a scale.
- **One test-filter, shared.** `detectGoInterfaces` adopts the same test-source exclusion and `domainKindCounts` denominator discipline as `detectInheritance` (the invariant `countByKind` call is also hoisted out of the emit loop). Cross-category count drift is now structurally impossible: only one row exists, counted over the population its sentence names.
- **Kind-true wording.** Satisfaction reads `N types implement X`; Go embedding reads `N structs embed X (methods promoted)`; the generic `mix in` wording is preserved for other languages. Never "extends", "base class", or "inherits" over Go code.

Known asymmetry, deliberately out of scope: non-Go interface-kind targets (Rust traits, TS `implements`) still double-report; one-category ownership for them is a separate behavioral change that needs its own bench.

## Changes

- `internal/conventions/detectors_go.go` — `isGoDeclared` + `isGoInterfaceSatisfaction` predicates and the Go wording; test filter + hoisted denominator in `detectGoInterfaces`; reworded contract template.
- `internal/conventions/detectors_generic.go` — inheritance skips Go satisfaction groups; composition picks Go embedding wording via the shared predicate.
- `internal/conventions/satisfaction_routing_test.go` — the 18-vs-19 shape (3 production + 1 test implementor): inheritance emits nothing, framework emits one row with test-excluded counts and denominator; Ruby/Python/TS targets stay in inheritance; Go embed vs Ruby mixin wording.
- `internal/conventions/go_interfaces_test.go`, `dedupe_test.go` — updated to the new wording/routing; a Ruby twin fixture keeps the inheritance-merge coverage alive.
- `testdata/smoke/ground-truth.json` — `min_detected` 9→8 (one previously double-reported row), surgical edit rather than a full regen that would absorb unrelated fixture drift.

## Test Plan

- [x] `make ci` green (coverage ≥92%, lint 0, ledger 0)
- [x] gin: inheritance category empties into framework rows at drift-free counts (18/61); `--domain binding` recomputes in-scope (81%, 13/16)
- [x] gin's `Core` contract honestly drops below the prevalence floor once its test-file implementor (`binding/json_test.go`) is excluded
- [x] axum (Rust): trait contracts get the same test-exclusion honesty (Rust is unbenched; recorded)
- [x] maket and healthchecks byte-identical