### PR TITLE
test: regenerate smoke floors and pin dedupe triple-collision

### DIFF
--- a/internal/conventions/dedupe_test.go
+++ b/internal/conventions/dedupe_test.go
@@ -192,6 +192,46 @@ func TestDedupeMergeIsDeterministic(t *testing.T) {
 	}
 }
 
+// TestDedupeTripleCollision pins the group shapes beyond a pair: four rows
+// rendering identically, two of them one twin population — the twins merge
+// to the smallest-definingPath survivor, and each of the three surviving
+// populations is qualified against BOTH siblings, escalating past the shared
+// basename to the distinguishing directory.
+func TestDedupeTripleCollision(t *testing.T) {
+	base := Convention{Category: CategoryFramework, Description: "y", Instances: 2}
+	twin1, twin2, third, fourth := base, base, base, base
+	twin1.Examples = []Example{{Name: "A", Path: "p"}, {Name: "B", Path: "q"}}
+	twin1.definingPath = "pkg/v1/base.go"
+	twin2.Examples = twin1.Examples
+	twin2.definingPath = "pkg/v2/base.go"
+	third.Examples = []Example{{Name: "A", Path: "p"}, {Name: "C", Path: "r"}}
+	third.definingPath = "other/base.go"
+	fourth.Examples = []Example{{Name: "D", Path: "s"}, {Name: "E", Path: "t"}}
+	fourth.definingPath = "third/base.go"
+
+	deduped := dedupeRenderedRows([]Convention{twin2, third, twin1, fourth})
+	if len(deduped) != 3 {
+		t.Fatalf("expected twins merged and true differences kept, got %d: %+v", len(deduped), deduped)
+	}
+	want := map[string]bool{
+		"y (defined in v1/base.go)":    false,
+		"y (defined in other/base.go)": false,
+		"y (defined in third/base.go)": false,
+	}
+	for _, c := range deduped {
+		if _, ok := want[c.Description]; !ok {
+			t.Errorf("unexpected qualified description %q", c.Description)
+			continue
+		}
+		want[c.Description] = true
+	}
+	for desc, found := range want {
+		if !found {
+			t.Errorf("missing qualified row %q in %+v", desc, deduped)
+		}
+	}
+}
+
 // TestDedupeQualifyWithoutProvenance pins the fallback: colliding
 // true-difference rows whose detector recorded no defining file are left
 // as-is rather than qualified with a fabricated path.

--- a/testdata/smoke/ground-truth.json
+++ b/testdata/smoke/ground-truth.json
@@ -1,13 +1,14 @@
 {
   "symbols": {
-    "min_total": 48,
+    "min_total": 61,
     "by_language": {
       "go": 19,
-      "javascript": 1,
+      "javascript": 2,
+      "python": 11,
       "ruby": 15,
       "rust": 8,
       "tsx": 2,
-      "typescript": 3
+      "typescript": 4
     }
   },
   "edges": {
@@ -58,7 +59,7 @@
         "kind": "tests"
       }
     ],
-    "min_total": 32
+    "min_total": 34
   },
   "search": [
     {


### PR DESCRIPTION
## Problem

Two test gaps left over from the cycle-30 reviews. The smoke ground-truth floors predate fixture-corpus growth (the real corpus indexes 61 symbols against a 48 floor), so the regression fixture guards less than it could. And the dedupe pass has no test for group shapes beyond a pair: a triple collision with an embedded twin population exercises survivor choice and multi-sibling qualification, which no existing fixture reaches.

## Summary

Regenerate the drifted smoke floors and add one dedupe fixture pinning the triple-collision group shape. Test-only; no production code changes, no version bump (git-cliff stays v1.11.18).

## Changes

- `testdata/smoke/ground-truth.json`: regenerate the floors (61 symbols, python and javascript growth captured). The pinned search expectation is kept as-is: the `-update` generator hardcodes each query as its own top-3 expectation, but `validate_total` actually surfaces its parent `Order`; regenerating blindly would have pinned a failing expectation. That stale generator assumption is worth its own fix. `conventions.min_detected` stays 8.
- `internal/conventions/dedupe_test.go`: four identically rendered rows, two of them one twin population. The twins merge to the smallest-definingPath survivor, and each of the three surviving populations is qualified against both siblings, escalating past the shared basename to the distinguishing directory.

## Test Plan

- [x] `make ci` green (coverage gate PASS at 95.2% total, lint 0, complexity ledger 0)
- [x] `go test ./internal/conventions/ ./internal/smoke/` green
- [x] `git-cliff --bumped-version` unchanged at v1.11.18