### PR TITLE
fix(scan): expand Go method sets through embedded interfaces

### DIFF
--- a/bench/PINNED_COMMITS.json
+++ b/bench/PINNED_COMMITS.json
@@ -78,5 +78,29 @@
   "wagtail": {
     "commit": "2ac39d351589990d0aec507596e52326e8b4ea72",
     "url": "https://github.com/wagtail/wagtail.git"
+  },
+  "gitea": {
+    "commit": "d2bd1589fedd4baa371d5c8d9a1872d9a2cf3cba",
+    "url": "https://github.com/go-gitea/gitea.git"
+  },
+  "dolt": {
+    "commit": "7e268bfa78545736917550cc1982886c65650550",
+    "url": "https://github.com/dolthub/dolt.git"
+  },
+  "go-mysql-server": {
+    "commit": "363616009b16943e94bebf6e5ba02e80d4f5f2de",
+    "url": "https://github.com/dolthub/go-mysql-server.git"
+  },
+  "containerd": {
+    "commit": "757416ca74e2e4a86c85e0836382a53dfc814b71",
+    "url": "https://github.com/containerd/containerd.git"
+  },
+  "gin": {
+    "commit": "34dac209ffb6ef85cc78c5d217bbb7ad001d68fd",
+    "url": "https://github.com/gin-gonic/gin.git"
+  },
+  "miniflux": {
+    "commit": "070bc9ef3d0a5849792883a3f7f017a5b6f8e0b4",
+    "url": "https://github.com/miniflux/v2.git"
   }
 }

--- a/bench/drivers/new-vertical.sh
+++ b/bench/drivers/new-vertical.sh
@@ -116,6 +116,7 @@ BNR
   # stack-agnostic docs + process prompts: copy with structural retarget + banner
   cptmpl "$RAILS_DOC/scenario-crafting.md" "$DOCDIR/scenario-crafting.md"
   cptmpl "$RAILS_DOC/article-workflow.md" "$DOCDIR/article-workflow.md"
+  cptmpl "$RAILS_DOC/articles-plan.md" "$DOCDIR/articles-plan.md"
   cptmpl "$RAILS_DOC/articles/_skeleton.md" "$DOCDIR/articles/_skeleton.md"
   cptmpl "$RAILS_DOC/articles/00-campaign-scorecard.md" "$DOCDIR/articles/00-campaign-scorecard.md"
   if [ -d "$RAILS_DOC/prompts" ]; then

--- a/bench/verticals/go/matrix-plan.yaml
+++ b/bench/verticals/go/matrix-plan.yaml
@@ -35,7 +35,7 @@ arms:
     big_repo_budget: 2
     pool: ollama-weekly
     adoption_preflight: sense setup (full); opencode MCP registration; verify the NEW model id resolves before cell 1
-    prompt_file: .doc/launch/NN-go-vertical/prompts/07-bench-opencode-devstral.md  # prompt-07 creation owed from Django
+    prompt_file: .doc/launch/NN-go-vertical/prompts/10-bench-opencode-devstral.md  # 10 = the devstral slot (07 is articles-create in every vertical)
   - name: gpt-5.5
     runner: codex-run.sh
     subscription: codex

--- a/bench/verticals/go/matrix-plan.yaml
+++ b/bench/verticals/go/matrix-plan.yaml
@@ -55,8 +55,8 @@ pools:
       provisional. Schedule as one pool, never two arms.
 
 repos:
-  # Filled at Loop 2 admission (Event A). §7.0 composition: 1 framework + 1 big + 2 medium + 2 small
-  # (or the 2-big variant, never both); big scheduled last, rule 2.
-  big: []
-  medium: []
-  small: []
+  # Slate confirmed at Event A (Luc, 2026-07-12), §7.0 variant 2 big + 2 medium + 2 small.
+  # Measurements + backups: .doc/launch/04-go-vertical/repos.md; big scheduled last, rule 2.
+  big: [gitea, dolt]
+  medium: [go-mysql-server, containerd]
+  small: [gin, miniflux]

--- a/bench/verticals/go/repos.txt
+++ b/bench/verticals/go/repos.txt
@@ -1,0 +1,5 @@
+# Go vertical — repo membership (one repo key per line).
+# Self-contained under verticals/go/: scenarios/ + results/.
+# The SET is 6 repos, firm (manifesto §7.0): 1 framework + 1 big + 2 medium + 2 small
+# (or 2 big + 2 medium + 2 small when the framework is too small/memorized).
+# Fill in after the repo-selection gate (bootstrap-runbook §2); one key per line.

--- a/bench/verticals/go/repos.txt
+++ b/bench/verticals/go/repos.txt
@@ -1,5 +1,10 @@
 # Go vertical — repo membership (one repo key per line).
 # Self-contained under verticals/go/: scenarios/ + results/.
-# The SET is 6 repos, firm (manifesto §7.0): 1 framework + 1 big + 2 medium + 2 small
-# (or 2 big + 2 medium + 2 small when the framework is too small/memorized).
-# Fill in after the repo-selection gate (bootstrap-runbook §2); one key per line.
+# Slate confirmed at Event A (Luc, 2026-07-12): 2 big + 2 medium + 2 small (§7.0 variant).
+# Measurements + backups: .doc/launch/04-go-vertical/repos.md
+gitea
+dolt
+go-mysql-server
+containerd
+gin
+miniflux

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -294,6 +294,12 @@ Claude Code, Cursor, and Codex CLI. Opencode is also supported. Any MCP-compatib
 
 Yes. Run `sense setup` again after a Sense upgrade to refresh the integration files.
 
+### Do I need to re-scan after upgrading?
+
+When a release improves the scanner or resolver (the changelog will say so), run one full
+`sense scan` in each indexed repo after upgrading. Incremental updates only re-extract edited
+files, so without a full scan the index mixes old and new resolution semantics.
+
 ---
 
 ## Living with Sense (setup & forget)
@@ -475,7 +481,9 @@ A symbol earns `dead` only when a language voice can prove closed-world for its 
 - Prefer Sense tools over grep, glob, and file-walking for any structural or semantic question. The index is pre-computed, faster, and more complete than re-deriving structure per task.
 - Read `.sense/summary.md` at session start to orient in one read, not a fresh exploration.
 - Use grep instead for: exact text/string search, reading file contents, and editing (Sense is read-only).
-- The index updates itself. You do not need to ask the user to re-scan after edits.
+- The index updates itself. You do not need to ask the user to re-scan after edits. The one
+  exception is right after a Sense upgrade that changed scan/resolve behavior: recommend one
+  full `sense scan` then, so the whole index carries the same resolution semantics.
 - For list outputs (dead code, blast radius, callers), spot-check a sample against the live tree before acting on them, since the index can briefly lag the working copy.
 
 ---

--- a/internal/conventions/detectors_generic.go
+++ b/internal/conventions/detectors_generic.go
@@ -379,7 +379,7 @@ func detectComposition(symbols []symbolRow, edges []edgeRow, symbolByID map[int6
 		label := baseLabel(g.targetName, g.targetQualified, ambiguous)
 		var desc string
 		if isGoDeclared(symbolByID[g.targetID], filePathByID) {
-			desc = goEmbedDescription(g.count, label, topNames(g.examples))
+			desc = goEmbedDescription(g.count, label, topNames(g.examples), g.sourceKind)
 		} else {
 			desc = fmt.Sprintf("%d %s mix in %s for shared behavior (%s)", g.count, pluralize(g.sourceKind), label, topNames(g.examples))
 		}

--- a/internal/conventions/detectors_go.go
+++ b/internal/conventions/detectors_go.go
@@ -22,11 +22,14 @@ func isGoInterfaceSatisfaction(tgt symbolRow, filePathByID map[int64]string) boo
 	return tgt.kind == "interface" && isGoDeclared(tgt, filePathByID)
 }
 
-// goEmbedDescription is the wording for a Go embedding group. Go embedders
-// are structs whatever kind the index stores them under (the extractor files
-// them as class), and embedding promotes the embedded type's members —
-// nothing is mixed in.
-func goEmbedDescription(count int, label, names string) string {
+// goEmbedDescription is the wording for a Go embedding group, split by what
+// does the embedding: struct embedders (the extractor files them as class)
+// promote the embedded type's members; interface embedders union the embedded
+// interface's method set into their contract. Nothing is mixed in either way.
+func goEmbedDescription(count int, label, names, sourceKind string) string {
+	if sourceKind == "interface" {
+		return fmt.Sprintf("%d interfaces embed %s (interface embedding) (%s)", count, label, names)
+	}
 	return fmt.Sprintf("%d structs embed %s (methods promoted) (%s)", count, label, names)
 }
 

--- a/internal/conventions/detectors_go_test.go
+++ b/internal/conventions/detectors_go_test.go
@@ -1,0 +1,61 @@
+package conventions
+
+import "testing"
+
+// TestGoEmbedDescriptionKindAware pins the composition wording split: struct
+// embedders promote methods, interface embedders union contracts — an
+// interface-sourced group must never read "structs embed".
+func TestGoEmbedDescriptionKindAware(t *testing.T) {
+	got := goEmbedDescription(3, "Resource", "A, B, C", "interface")
+	if got != "3 interfaces embed Resource (interface embedding) (A, B, C)" {
+		t.Errorf("interface wording wrong: %q", got)
+	}
+	got = goEmbedDescription(2, "Base", "X, Y", "class")
+	if got != "2 structs embed Base (methods promoted) (X, Y)" {
+		t.Errorf("struct wording wrong: %q", got)
+	}
+}
+
+// TestDetectCompositionSkipsAndThreshold pins detectComposition's guards in
+// one fixture: an edge with an unknown source, an edge with an unknown
+// target, a test-file source, and a group below minInstances all contribute
+// nothing, while a 3-strong interface-sourced Go group gets the kind-aware
+// wording end to end.
+func TestDetectCompositionSkipsAndThreshold(t *testing.T) {
+	symbols := []symbolRow{
+		{id: 1, fileID: 10, name: "Resource", qualified: "resource.Resource", kind: "interface"},
+		{id: 2, fileID: 11, name: "PageA", qualified: "p.PageA", kind: "interface"},
+		{id: 3, fileID: 12, name: "PageB", qualified: "p.PageB", kind: "interface"},
+		{id: 4, fileID: 13, name: "PageC", qualified: "p.PageC", kind: "interface"},
+		{id: 5, fileID: 14, name: "Lonely", qualified: "p.Lonely", kind: "class"},
+		{id: 6, fileID: 15, name: "TestHelper", qualified: "p.TestHelper", kind: "class"},
+	}
+	symbolByID := map[int64]symbolRow{}
+	for _, s := range symbols {
+		symbolByID[s.id] = s
+	}
+	filePathByID := map[int64]string{
+		10: "resource/resource.go", 11: "p/a.go", 12: "p/b.go", 13: "p/c.go",
+		14: "p/lonely.go", 15: "p/helper_test.go",
+	}
+	edges := []edgeRow{
+		{sourceID: 2, targetID: 1, kind: "includes"},
+		{sourceID: 3, targetID: 1, kind: "includes"},
+		{sourceID: 4, targetID: 1, kind: "includes"},
+		{sourceID: 99, targetID: 1, kind: "includes"}, // unknown source: skipped
+		{sourceID: 5, targetID: 98, kind: "includes"}, // unknown target: skipped
+		{sourceID: 6, targetID: 1, kind: "includes"},  // test-file source: skipped
+		{sourceID: 5, targetID: 2, kind: "includes"},  // group of 1 < minInstances
+	}
+	out := detectComposition(symbols, edges, symbolByID, filePathByID)
+	if len(out) != 1 {
+		t.Fatalf("expected exactly one composition convention, got %d: %+v", len(out), out)
+	}
+	want := "3 interfaces embed Resource (interface embedding) (PageA, PageB, PageC)"
+	if out[0].Description != want {
+		t.Errorf("kind-aware wording wrong:\n got %q\nwant %q", out[0].Description, want)
+	}
+	if out[0].Instances != 3 {
+		t.Errorf("instances = %d, want 3 (skips must not count)", out[0].Instances)
+	}
+}

--- a/internal/extract/golang/golang.go
+++ b/internal/extract/golang/golang.go
@@ -274,11 +274,10 @@ func (w *walker) handleTypeDeclaration(n *sitter.Node) error {
 }
 
 func (w *walker) emitTypeSpec(spec *sitter.Node, isAlias bool, doc string) error {
-	nameNode := spec.ChildByFieldName("name")
-	if nameNode == nil {
-		return nil
+	name := ""
+	if nameNode := spec.ChildByFieldName("name"); nameNode != nil {
+		name = extract.Text(nameNode, w.source)
 	}
-	name := extract.Text(nameNode, w.source)
 	if name == "" {
 		return nil
 	}
@@ -320,6 +319,9 @@ func (w *walker) emitTypeSpec(spec *sitter.Node, isAlias bool, doc string) error
 		if err := w.emitInterfaceMethods(ifaceNode, qualified); err != nil {
 			return err
 		}
+		if err := w.emitInterfaceEmbeddings(ifaceNode, qualified); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -356,6 +358,57 @@ func (w *walker) emitInterfaceMethods(ifaceNode *sitter.Node, ifaceQualified str
 	return nil
 }
 
+// emitInterfaceEmbeddings walks an interface_type's type_elem children and
+// emits includes edges for embedded interfaces. A type_elem with more than
+// one term is a Go 1.18 union constraint (`A | B`), and approximation terms
+// (`~T`) are not named types — neither embeds a method set, so both are
+// skipped.
+func (w *walker) emitInterfaceEmbeddings(ifaceNode *sitter.Node, ifaceQualified string) error {
+	for i := uint(0); i < ifaceNode.NamedChildCount(); i++ {
+		te := ifaceNode.NamedChild(i)
+		if te == nil || te.Kind() != "type_elem" {
+			continue
+		}
+		if te.NamedChildCount() != 1 {
+			continue
+		}
+		target := w.embedTargetName(te.NamedChild(0))
+		if target == "" {
+			continue
+		}
+		line := extract.Line(te.StartPosition())
+		if err := w.emit.Edge(extract.EmittedEdge{
+			SourceQualified: ifaceQualified,
+			TargetQualified: target,
+			Kind:            model.EdgeIncludes,
+			Line:            &line,
+			Confidence:      extract.ConfidenceStatic,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// embedTargetName resolves an embedded type node to its qualified target
+// name; non-name terms (unions, approximations, literals) yield "".
+func (w *walker) embedTargetName(typeNode *sitter.Node) string {
+	if typeNode == nil {
+		return ""
+	}
+	switch typeNode.Kind() {
+	case "type_identifier":
+		return w.qualify(extract.Text(typeNode, w.source))
+	case "qualified_type":
+		return extract.Text(typeNode, w.source)
+	case "generic_type":
+		if base := typeNode.ChildByFieldName("type"); base != nil {
+			return w.qualify(extract.Text(base, w.source))
+		}
+	}
+	return ""
+}
+
 // emitEmbeddings walks a struct_type's field declarations and emits
 // includes edges for embedded fields (fields with no explicit name).
 func (w *walker) emitEmbeddings(structNode *sitter.Node, structQualified string) error {
@@ -371,35 +424,17 @@ func (w *walker) emitEmbeddings(structNode *sitter.Node, structQualified string)
 		if fd.ChildByFieldName("name") != nil {
 			continue
 		}
-		typeNode := fd.ChildByFieldName("type")
-		if typeNode == nil {
-			continue
-		}
-		var target string
-		switch typeNode.Kind() {
-		case "type_identifier":
-			target = w.qualify(extract.Text(typeNode, w.source))
-		case "qualified_type":
-			target = extract.Text(typeNode, w.source)
-		case "generic_type":
-			if base := typeNode.ChildByFieldName("type"); base != nil {
-				target = w.qualify(extract.Text(base, w.source))
+		if target := w.embedTargetName(fd.ChildByFieldName("type")); target != "" {
+			line := extract.Line(fd.StartPosition())
+			if err := w.emit.Edge(extract.EmittedEdge{
+				SourceQualified: structQualified,
+				TargetQualified: target,
+				Kind:            model.EdgeIncludes,
+				Line:            &line,
+				Confidence:      extract.ConfidenceStatic,
+			}); err != nil {
+				return err
 			}
-		default:
-			continue
-		}
-		if target == "" {
-			continue
-		}
-		line := extract.Line(fd.StartPosition())
-		if err := w.emit.Edge(extract.EmittedEdge{
-			SourceQualified: structQualified,
-			TargetQualified: target,
-			Kind:            model.EdgeIncludes,
-			Line:            &line,
-			Confidence:      extract.ConfidenceStatic,
-		}); err != nil {
-			return err
 		}
 	}
 	return nil

--- a/internal/extract/golang/golang_test.go
+++ b/internal/extract/golang/golang_test.go
@@ -1354,6 +1354,63 @@ type Order struct {
 	}
 }
 
+func TestInterfaceEmbeddingEdges(t *testing.T) {
+	r := parse(t, `package model
+
+type Reader interface {
+	Read() string
+}
+
+type Closer interface {
+	Close() error
+}
+
+type ReadCloser interface {
+	Reader
+	Closer
+}
+`)
+	if findEdge(r, "model.ReadCloser", "model.Reader", "includes") == nil {
+		t.Error("missing includes edge model.ReadCloser -> model.Reader from interface embedding")
+	}
+	if findEdge(r, "model.ReadCloser", "model.Closer", "includes") == nil {
+		t.Error("missing includes edge model.ReadCloser -> model.Closer from interface embedding")
+	}
+}
+
+func TestInterfaceEmbeddingQualified(t *testing.T) {
+	r := parse(t, `package model
+
+type Page interface {
+	resource.Resource
+	Name() string
+}
+`)
+	if findEdge(r, "model.Page", "resource.Resource", "includes") == nil {
+		t.Error("missing includes edge model.Page -> resource.Resource from qualified interface embedding")
+	}
+}
+
+func TestInterfaceEmbeddingConstraintTermsSkipped(t *testing.T) {
+	r := parse(t, `package model
+
+type Number interface {
+	~int | ~string
+}
+
+type Either interface {
+	Reader | Closer
+}
+`)
+	// Union and approximation terms are Go 1.18 type constraints, not
+	// method-set embedding — they must not produce includes edges.
+	for _, e := range r.edges {
+		if e.Kind == "includes" && (e.SourceQualified == "model.Number" || e.SourceQualified == "model.Either") {
+			t.Errorf("unexpected includes edge from constraint terms: %s -> %s", e.SourceQualified, e.TargetQualified)
+		}
+	}
+}
+
 func TestSelectorCallWithEmptyReturn(t *testing.T) {
 	r := parse(t, `package svc
 
@@ -1941,5 +1998,173 @@ func F() {
 	}
 	if findEdge(r, "svc.F", "svc.Y", "references") == nil {
 		t.Error("missing references edge for grouped var Y")
+	}
+}
+
+func TestInterfaceEmbeddingEdgeError(t *testing.T) {
+	err := parseWithEmitter(t, `package main
+
+type Reader interface {
+	Read() string
+}
+
+type ReadCloser interface {
+	Reader
+}
+`, &failAfterN{symbolsLeft: 100, edgesLeft: 0})
+	if err == nil {
+		t.Error("expected error on interface embedding includes edge emit")
+	}
+}
+
+func TestInterfaceEmbeddingApproximationSkipped(t *testing.T) {
+	r := parse(t, `package model
+
+type Approx interface {
+	~int
+}
+`)
+	// A single approximation term is a constraint, not an embedded interface:
+	// it reaches the target switch and resolves to no name.
+	for _, e := range r.edges {
+		if e.Kind == "includes" && e.SourceQualified == "model.Approx" {
+			t.Errorf("unexpected includes edge from approximation term: -> %s", e.TargetQualified)
+		}
+	}
+}
+
+func TestEmbedTargetNameNil(t *testing.T) {
+	w := &walker{}
+	if got := w.embedTargetName(nil); got != "" {
+		t.Errorf("nil type node must resolve to no target, got %q", got)
+	}
+}
+
+func TestEmptyStructNoEmbeddingEdges(t *testing.T) {
+	r := parse(t, `package model
+
+type Empty struct{}
+`)
+	for _, e := range r.edges {
+		if string(e.Kind) == "includes" && e.SourceQualified == "model.Empty" {
+			t.Errorf("empty struct must emit no includes edges, got -> %s", e.TargetQualified)
+		}
+	}
+}
+
+func TestUnnamedNonTypeFieldNoEmbeddingEdge(t *testing.T) {
+	// Illegal-but-parseable mid-edit code: an unnamed field whose type is not
+	// a name (a map). The target resolves to nothing and no edge is emitted.
+	r := parse(t, `package model
+
+type S struct {
+	map[string]int
+}
+`)
+	for _, e := range r.edges {
+		if string(e.Kind) == "includes" && e.SourceQualified == "model.S" {
+			t.Errorf("non-name unnamed field must emit no includes edge, got -> %s", e.TargetQualified)
+		}
+	}
+}
+
+func TestNamelessTypeSpecSkipped(t *testing.T) {
+	// Mid-edit code: a type declaration without a name parses with error
+	// nodes; the extractor must skip it without emitting or crashing.
+	r := parse(t, `package model
+
+type struct{ A int }
+`)
+	for _, s := range r.symbols {
+		if s.Kind == "class" && s.Name == "" {
+			t.Errorf("nameless type spec must not emit a symbol: %+v", s)
+		}
+	}
+}
+
+func TestEmbeddingSkipsNonFieldChildren(t *testing.T) {
+	// A comment and an ERROR recovery node inside the field list (mid-edit
+	// code) are not field declarations; the walk skips them and still emits
+	// the real embed.
+	r := parse(t, `package model
+
+type S struct {
+	// a comment inside the field list
+	chan int
+	Base
+}
+`)
+	if findEdge(r, "model.S", "model.Base", "includes") == nil {
+		t.Error("missing includes edge past comment/ERROR children")
+	}
+}
+
+// findNodeOfKind walks the tree depth-first for the first node of a kind —
+// the harness for grammar-drift tests that call walker methods directly.
+func findNodeOfKind(n *sitter.Node, kind string) *sitter.Node {
+	if n == nil {
+		return nil
+	}
+	if n.Kind() == kind {
+		return n
+	}
+	for i := uint(0); i < n.NamedChildCount(); i++ {
+		if found := findNodeOfKind(n.NamedChild(i), kind); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// TestEmitTypeSpecNamelessNodeSkipped and TestEmitEmbeddingsNonStructNode are
+// grammar-drift guards: the grammar cannot produce these shapes today, so the
+// tests hand the walker a node of the wrong kind directly — exactly the
+// malformed input the guards exist for.
+func TestEmitTypeSpecNamelessNodeSkipped(t *testing.T) {
+	src := []byte("package p\n\ntype S struct{ Base }\n")
+	ex := Extractor{}
+	p := sitter.NewParser()
+	defer p.Close()
+	_ = p.SetLanguage(ex.Grammar())
+	tree := p.Parse(src, nil)
+	defer tree.Close()
+
+	r := &recorder{}
+	w := &walker{source: src, emit: r, pkg: "p"}
+	structType := findNodeOfKind(tree.RootNode(), "struct_type")
+	if structType == nil {
+		t.Fatal("no struct_type node in fixture")
+	}
+	// struct_type has no "name" field: emitTypeSpec must skip, not emit.
+	if err := w.emitTypeSpec(structType, false, ""); err != nil {
+		t.Fatalf("emitTypeSpec on nameless node: %v", err)
+	}
+	if len(r.symbols) != 0 {
+		t.Errorf("nameless spec must emit nothing, got %d symbols", len(r.symbols))
+	}
+}
+
+func TestEmitEmbeddingsNonStructNode(t *testing.T) {
+	src := []byte("package p\n\ntype I interface{}\n")
+	ex := Extractor{}
+	p := sitter.NewParser()
+	defer p.Close()
+	_ = p.SetLanguage(ex.Grammar())
+	tree := p.Parse(src, nil)
+	defer tree.Close()
+
+	r := &recorder{}
+	w := &walker{source: src, emit: r, pkg: "p"}
+	ifaceType := findNodeOfKind(tree.RootNode(), "interface_type")
+	if ifaceType == nil {
+		t.Fatal("no interface_type node in fixture")
+	}
+	// An empty interface_type has no field_declaration_list child: the guard
+	// returns cleanly instead of walking garbage.
+	if err := w.emitEmbeddings(ifaceType, "p.I"); err != nil {
+		t.Fatalf("emitEmbeddings on non-struct node: %v", err)
+	}
+	if len(r.edges) != 0 {
+		t.Errorf("non-struct node must emit no edges, got %d", len(r.edges))
 	}
 }

--- a/internal/extract/testdata/go/depth.golden.json
+++ b/internal/extract/testdata/go/depth.golden.json
@@ -244,6 +244,13 @@
       "confidence": 0.8
     },
     {
+      "source": "warehouse.FullWorker",
+      "target": "warehouse.ItemPicker",
+      "kind": "includes",
+      "line": 104,
+      "confidence": 1
+    },
+    {
       "source": "warehouse.PickerBot",
       "target": "warehouse.BaseWorker",
       "kind": "includes",

--- a/internal/scan/satisfy.go
+++ b/internal/scan/satisfy.go
@@ -35,7 +35,7 @@ var stdlibInterfaces = []stdlibInterface{
 
 type ifaceInfo struct {
 	sym     model.Symbol
-	methods []string
+	methods map[string]bool
 }
 
 type structInfo struct {
@@ -78,9 +78,14 @@ func (h *harness) satisfyInterfaces() error {
 	}
 
 	collectMethodSets(syms, interfaces, structs)
-	if err := h.promoteEmbeddedMethodSets(structs); err != nil {
+	embeddings, err := h.loadEmbeddings()
+	if err != nil {
 		return err
 	}
+	// Interface sets expand first: struct-side promotion through an embedded
+	// interface field unions the interface's already-expanded set.
+	expandInterfaceMethodSets(interfaces, embeddings)
+	promoteEmbeddedMethodSets(structs, interfaces, embeddings)
 
 	written, err := h.writeSatisfactionEdges(interfaces, structs)
 	if err != nil {
@@ -102,7 +107,10 @@ func classifyGoSymbols(syms []model.Symbol, goFiles map[int64]bool) (map[int64]*
 		}
 		switch s.Kind {
 		case model.KindInterface:
-			interfaces[s.ID] = &ifaceInfo{sym: *s}
+			interfaces[s.ID] = &ifaceInfo{
+				sym:     *s,
+				methods: map[string]bool{},
+			}
 		case model.KindClass:
 			structs[s.ID] = &structInfo{
 				sym:     *s,
@@ -136,7 +144,7 @@ func collectMethodSets(syms []model.Symbol, interfaces map[int64]*ifaceInfo, str
 		}
 		parentID := *s.ParentID
 		if iface, ok := interfaces[parentID]; ok {
-			iface.methods = append(iface.methods, s.Name)
+			iface.methods[s.Name] = true
 		}
 		if st, ok := structs[parentID]; ok {
 			st.methods[s.Name] = true
@@ -144,13 +152,13 @@ func collectMethodSets(syms []model.Symbol, interfaces map[int64]*ifaceInfo, str
 	}
 }
 
-// promoteEmbeddedMethodSets loads resolved embedding (includes) edges and
-// promotes embedded structs' methods onto their embedders, up to depth 3, so an
-// embedded method counts toward interface satisfaction.
-func (h *harness) promoteEmbeddedMethodSets(structs map[int64]*structInfo) error {
+// loadEmbeddings loads the resolved embedding (includes) edges once, as a
+// source→targets adjacency shared by the interface-expansion and the
+// struct-promotion passes.
+func (h *harness) loadEmbeddings() (map[int64][]int64, error) {
 	edges, err := h.idx.EdgesOfKind(h.ctx, model.EdgeIncludes)
 	if err != nil {
-		return fmt.Errorf("satisfy: query embeddings: %w", err)
+		return nil, fmt.Errorf("satisfy: query embeddings: %w", err)
 	}
 	embeddings := map[int64][]int64{}
 	for _, e := range edges {
@@ -159,10 +167,51 @@ func (h *harness) promoteEmbeddedMethodSets(structs map[int64]*structInfo) error
 		}
 		embeddings[*e.SourceID] = append(embeddings[*e.SourceID], e.TargetID)
 	}
-	for id, st := range structs {
-		promoteEmbeddedMethods(st, id, embeddings, structs, 3)
+	return embeddings, nil
+}
+
+// expandInterfaceMethodSets closes every interface's method set over its
+// embedded interfaces. Go makes embedded method sets fully transitive, so the
+// expansion is a memoized full closure — a depth cap here would shrink
+// REQUIRED sets and silently re-create false satisfaction on composites. The
+// visiting guard terminates on cycles, which Go forbids but a mid-edit or
+// misresolved index can still contain. Targets that are not known interfaces
+// (stdlib, unresolved, structs) contribute nothing.
+func expandInterfaceMethodSets(interfaces map[int64]*ifaceInfo, embeddings map[int64][]int64) {
+	expanded := map[int64]bool{}
+	for id := range interfaces {
+		expandInterfaceMethods(id, interfaces, embeddings, expanded, map[int64]bool{})
 	}
-	return nil
+}
+
+func expandInterfaceMethods(id int64, interfaces map[int64]*ifaceInfo, embeddings map[int64][]int64, expanded, visiting map[int64]bool) {
+	if expanded[id] || visiting[id] {
+		return
+	}
+	visiting[id] = true
+	iface := interfaces[id]
+	for _, embeddedID := range embeddings[id] {
+		embedded, ok := interfaces[embeddedID]
+		if !ok {
+			continue
+		}
+		expandInterfaceMethods(embeddedID, interfaces, embeddings, expanded, visiting)
+		for m := range embedded.methods {
+			iface.methods[m] = true
+		}
+	}
+	delete(visiting, id)
+	expanded[id] = true
+}
+
+// promoteEmbeddedMethodSets promotes embedded structs' methods onto their
+// embedders, up to depth 3, so an embedded method counts toward interface
+// satisfaction. An embedded interface field delegates its whole (expanded)
+// method set, so interface targets union in full.
+func promoteEmbeddedMethodSets(structs map[int64]*structInfo, interfaces map[int64]*ifaceInfo, embeddings map[int64][]int64) {
+	for id, st := range structs {
+		promoteEmbeddedMethods(st, id, embeddings, structs, interfaces, 3)
+	}
 }
 
 // writeSatisfactionEdges writes an inherits edge for every struct whose method
@@ -171,6 +220,10 @@ func (h *harness) writeSatisfactionEdges(interfaces map[int64]*ifaceInfo, struct
 	var written int
 	err := h.idx.InTx(h.ctx, func() error {
 		for _, iface := range interfaces {
+			// Post-expansion an empty INDEXED set: interface{}, a
+			// constraint-only interface, or a composite of purely
+			// unresolvable (stdlib) embeds. Everything would satisfy it, so
+			// emitting edges would be noise, not information.
 			if len(iface.methods) == 0 {
 				continue
 			}
@@ -188,24 +241,32 @@ func (h *harness) writeSatisfactionEdges(interfaces map[int64]*ifaceInfo, struct
 	return written, err
 }
 
-func promoteEmbeddedMethods(st *structInfo, id int64, embeddings map[int64][]int64, structs map[int64]*structInfo, depth int) {
+func promoteEmbeddedMethods(st *structInfo, id int64, embeddings map[int64][]int64, structs map[int64]*structInfo, interfaces map[int64]*ifaceInfo, depth int) {
 	if depth <= 0 {
 		return
 	}
 	for _, embeddedID := range embeddings[id] {
+		if iface, ok := interfaces[embeddedID]; ok {
+			// An embedded interface value delegates its whole method set;
+			// the set is already fully expanded, no recursion needed.
+			for m := range iface.methods {
+				st.methods[m] = true
+			}
+			continue
+		}
 		embedded, ok := structs[embeddedID]
 		if !ok {
 			continue
 		}
-		promoteEmbeddedMethods(embedded, embeddedID, embeddings, structs, depth-1)
+		promoteEmbeddedMethods(embedded, embeddedID, embeddings, structs, interfaces, depth-1)
 		for m := range embedded.methods {
 			st.methods[m] = true
 		}
 	}
 }
 
-func methodSetSatisfies(methods map[string]bool, required []string) bool {
-	for _, m := range required {
+func methodSetSatisfies(methods, required map[string]bool) bool {
+	for m := range required {
 		if !methods[m] {
 			return false
 		}

--- a/internal/scan/satisfy_embedding_test.go
+++ b/internal/scan/satisfy_embedding_test.go
@@ -70,3 +70,170 @@ type Derived struct {
 		t.Error("expected Derived → Reader inherits edge via promoted embedded method")
 	}
 }
+
+// TestScan_SatisfyCompositeInterface proves the G-1 false-negative fix: an
+// interface built ONLY from embedded interfaces (the hugo page.Page shape)
+// must still be satisfiable — pre-fix its direct method set was empty and the
+// whole interface was skipped.
+func TestScan_SatisfyCompositeInterface(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, "iface.go"), `package mylib
+
+type Reader interface {
+	Read() string
+}
+
+type Closer interface {
+	Close() error
+}
+
+type ReadCloser interface {
+	Reader
+	Closer
+}
+`)
+	writeFile(t, filepath.Join(root, "impl.go"), `package mylib
+
+type File struct{}
+
+func (f *File) Read() string { return "" }
+func (f *File) Close() error { return nil }
+`)
+
+	if n := queryInherits(t, root, "File", "ReadCloser"); n == 0 {
+		t.Error("expected File → ReadCloser inherits edge via composite-interface expansion")
+	}
+}
+
+// TestScan_NoSatisfyOnPartialCover proves the G-1 false-positive fix (the
+// containerd ExecProcess shape): an interface with a big embedded set and one
+// direct method must NOT be satisfied by a type that has only the direct
+// method — pre-fix the required set collapsed to the direct method alone.
+func TestScan_NoSatisfyOnPartialCover(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, "iface.go"), `package mylib
+
+type Process interface {
+	Start() error
+	Stop() error
+}
+
+type ExecProcess interface {
+	Process
+	Delete() error
+}
+`)
+	writeFile(t, filepath.Join(root, "impl.go"), `package mylib
+
+type Store struct{}
+
+func (s *Store) Delete() error { return nil }
+`)
+
+	if n := queryInherits(t, root, "Store", "ExecProcess"); n != 0 {
+		t.Error("Store must NOT satisfy ExecProcess with only the direct method covered")
+	}
+}
+
+// TestScan_SatisfyViaEmbeddedInterfaceValue proves the struct-side fix (the
+// hugo pageState shape): a struct that embeds an interface VALUE delegates
+// the interface's whole method set and satisfies it — pre-fix promotion only
+// walked embedded structs.
+func TestScan_SatisfyViaEmbeddedInterfaceValue(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, "iface.go"), `package mylib
+
+type Pager interface {
+	Title() string
+	Kind() string
+}
+`)
+	writeFile(t, filepath.Join(root, "impl.go"), `package mylib
+
+type wrapper struct {
+	Pager
+}
+`)
+
+	if n := queryInherits(t, root, "wrapper", "Pager"); n == 0 {
+		t.Error("expected wrapper → Pager inherits edge via embedded interface value")
+	}
+}
+
+// TestScan_SatisfyPins pins three behaviors the fix must NOT change: a NAMED
+// interface field does not promote (Go semantics), an empty interface earns
+// no edges (everything satisfies it — noise), and a composite of only
+// unresolvable stdlib interfaces stays at zero edges (the recorded residual).
+func TestScan_SatisfyPins(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, "iface.go"), `package mylib
+
+import (
+	"fmt"
+	"io"
+)
+
+type Pager interface {
+	Title() string
+}
+
+type Any interface{}
+
+type StdOnly interface {
+	fmt.Stringer
+	io.Closer
+}
+`)
+	writeFile(t, filepath.Join(root, "impl.go"), `package mylib
+
+type named struct {
+	p Pager
+}
+
+type stringerCloser struct{}
+
+func (s *stringerCloser) String() string { return "" }
+func (s *stringerCloser) Close() error   { return nil }
+`)
+
+	if n := queryInherits(t, root, "named", "Pager"); n != 0 {
+		t.Error("a NAMED interface field must not satisfy the interface")
+	}
+	if n := queryInherits(t, root, "named", "Any"); n != 0 {
+		t.Error("interface{} must earn no satisfaction edges")
+	}
+	if n := queryInherits(t, root, "stringerCloser", "StdOnly"); n != 0 {
+		t.Error("stdlib-only composite stays at zero edges (recorded residual)")
+	}
+}
+
+// queryInherits scans root and counts inherits edges source→target by name.
+func queryInherits(t *testing.T, root, source, target string) int {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := scan.Run(ctx, quietOpts(root)); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	db, err := sql.Open("sqlite", filepath.Join(root, ".sense", "index.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+	var count int
+	err = db.QueryRow(`
+		SELECT COUNT(*)
+		FROM sense_edges e
+		JOIN sense_symbols s ON s.id = e.source_id
+		JOIN sense_symbols t ON t.id = e.target_id
+		WHERE e.kind = 'inherits'
+		  AND s.name = ?
+		  AND t.name = ?`, source, target).Scan(&count)
+	if err != nil {
+		t.Fatalf("query inherits edge: %v", err)
+	}
+	return count
+}

--- a/internal/scan/satisfy_internal_test.go
+++ b/internal/scan/satisfy_internal_test.go
@@ -68,13 +68,12 @@ func TestSatisfyInterfacesQueryError(t *testing.T) {
 	}
 }
 
-// TestPromoteEmbeddedMethodSetsEdgeQueryError covers promoteEmbeddedMethodSets'
-// edge-load failure (satisfy.go:152-154): querying the includes edges fails on a
-// closed index and the wrapped error returns before any promotion.
-func TestPromoteEmbeddedMethodSetsEdgeQueryError(t *testing.T) {
+// TestLoadEmbeddingsEdgeQueryError covers the shared embeddings load failure:
+// querying the includes edges fails on a closed index and the wrapped error
+// returns before any expansion or promotion consumes the map.
+func TestLoadEmbeddingsEdgeQueryError(t *testing.T) {
 	h := &harness{ctx: context.Background(), idx: newClosedAdapter(t), out: io.Discard, warn: io.Discard}
-	structs := map[int64]*structInfo{1: {methods: map[string]bool{}}}
-	if err := h.promoteEmbeddedMethodSets(structs); err == nil {
+	if _, err := h.loadEmbeddings(); err == nil {
 		t.Fatal("expected error loading includes edges on a closed index")
 	}
 }
@@ -113,13 +112,13 @@ func TestSatisfyInterfacesSymbolQueryError(t *testing.T) {
 func TestMethodSetSatisfies(t *testing.T) {
 	methods := map[string]bool{"Read": true, "Write": true, "Close": true}
 
-	if !methodSetSatisfies(methods, []string{"Read", "Write"}) {
+	if !methodSetSatisfies(methods, map[string]bool{"Read": true, "Write": true}) {
 		t.Error("should satisfy subset")
 	}
-	if !methodSetSatisfies(methods, []string{"Read", "Write", "Close"}) {
+	if !methodSetSatisfies(methods, map[string]bool{"Read": true, "Write": true, "Close": true}) {
 		t.Error("should satisfy exact set")
 	}
-	if methodSetSatisfies(methods, []string{"Read", "Flush"}) {
+	if methodSetSatisfies(methods, map[string]bool{"Read": true, "Flush": true}) {
 		t.Error("should not satisfy with missing method")
 	}
 	if !methodSetSatisfies(methods, nil) {
@@ -139,7 +138,7 @@ func TestPromoteEmbeddedMethods(t *testing.T) {
 		1: {2},
 	}
 
-	promoteEmbeddedMethods(outer, 1, embeddings, structs, 3)
+	promoteEmbeddedMethods(outer, 1, embeddings, structs, nil, 3)
 
 	if !outer.methods["Read"] {
 		t.Error("expected Read promoted from embedded struct")
@@ -160,11 +159,195 @@ func TestPromoteEmbeddedMethodsDepthLimit(t *testing.T) {
 	structs := map[int64]*structInfo{1: a, 2: b, 3: c}
 	embeddings := map[int64][]int64{1: {2}, 2: {3}}
 
-	promoteEmbeddedMethods(a, 1, embeddings, structs, 1)
+	promoteEmbeddedMethods(a, 1, embeddings, structs, nil, 1)
 
 	// Depth=1 means we only go one hop. b's methods get promoted,
 	// but c's methods should not (they need depth=2).
 	if a.methods["Deep"] {
 		t.Error("expected depth limit to prevent promoting from 2 hops away")
+	}
+}
+
+// TestExpandInterfaceMethodSets proves the interface-side closure: a chain of
+// embedded interfaces unions transitively (no depth cap — a truncated
+// expansion would shrink required sets and re-create false satisfaction),
+// diamonds dedupe, and unknown targets contribute nothing.
+func TestExpandInterfaceMethodSets(t *testing.T) {
+	interfaces := map[int64]*ifaceInfo{
+		1: {methods: map[string]bool{"A": true}},
+		2: {methods: map[string]bool{"B": true}},
+		3: {methods: map[string]bool{}},
+		4: {methods: map[string]bool{"D": true}},
+	}
+	// 3 embeds 2 embeds 1 (chain, deeper than one hop); 4 embeds 1 and 2
+	// (diamond: A arrives via both paths); 2 also embeds an unknown target.
+	embeddings := map[int64][]int64{
+		2: {1, 99},
+		3: {2},
+		4: {1, 2},
+	}
+	expandInterfaceMethodSets(interfaces, embeddings)
+
+	for _, m := range []string{"A", "B"} {
+		if !interfaces[3].methods[m] {
+			t.Errorf("chain: interface 3 missing %s after expansion", m)
+		}
+	}
+	if len(interfaces[4].methods) != 3 { // A, B, D — diamond dedupes
+		t.Errorf("diamond: expected 3 methods on interface 4, got %v", interfaces[4].methods)
+	}
+	if !interfaces[2].methods["A"] || len(interfaces[2].methods) != 2 {
+		t.Errorf("unknown target must contribute nothing: %v", interfaces[2].methods)
+	}
+}
+
+// TestExpandInterfaceMethodSetsCycle proves termination on an embedding cycle
+// (illegal Go, but the index can contain mid-edit or misresolved code).
+func TestExpandInterfaceMethodSetsCycle(t *testing.T) {
+	interfaces := map[int64]*ifaceInfo{
+		1: {methods: map[string]bool{"A": true}},
+		2: {methods: map[string]bool{"B": true}},
+	}
+	embeddings := map[int64][]int64{1: {2}, 2: {1}}
+	expandInterfaceMethodSets(interfaces, embeddings) // must terminate
+	if !interfaces[1].methods["B"] {
+		t.Error("cycle: interface 1 should still union interface 2's methods")
+	}
+}
+
+// TestPromoteThroughEmbeddedInterface proves the struct-side path for an
+// embedded interface VALUE (the pageState shape): the interface's expanded
+// method set delegates wholesale onto the struct.
+func TestPromoteThroughEmbeddedInterface(t *testing.T) {
+	iface := &ifaceInfo{methods: map[string]bool{"A": true, "B": true}}
+	st := &structInfo{methods: map[string]bool{"Own": true}}
+	structs := map[int64]*structInfo{1: st}
+	interfaces := map[int64]*ifaceInfo{7: iface}
+	embeddings := map[int64][]int64{1: {7}}
+
+	promoteEmbeddedMethodSets(structs, interfaces, embeddings)
+
+	for _, m := range []string{"A", "B", "Own"} {
+		if !st.methods[m] {
+			t.Errorf("struct missing %s after embedded-interface promotion", m)
+		}
+	}
+}
+
+// satisfyFakeStore drives satisfyInterfaces past classification with an
+// in-memory symbol set, then lets each test override one downstream call.
+type satisfyFakeStore struct {
+	*sqlite.Adapter
+	syms      []model.Symbol
+	edges     []model.Edge
+	edgesErr  error
+	writeErr  error
+	structCnt int64
+}
+
+func (f *satisfyFakeStore) FileIDsByLanguage(context.Context, string) (map[int64]bool, error) {
+	return map[int64]bool{1: true}, nil
+}
+
+func (f *satisfyFakeStore) Query(context.Context, index.Filter) ([]model.Symbol, error) {
+	if f.syms != nil {
+		return f.syms, nil
+	}
+	iface := int64(1)
+	syms := []model.Symbol{
+		{ID: 1, Name: "I", Kind: model.KindInterface, FileID: 1},
+		{ID: 2, Name: "M", Kind: model.KindMethod, FileID: 1, ParentID: &iface},
+		{ID: 3, Name: "S", Kind: model.KindClass, FileID: 1},
+	}
+	for i := int64(0); i < f.structCnt; i++ {
+		syms = append(syms, model.Symbol{ID: 100 + i, Kind: model.KindClass, FileID: 1})
+	}
+	return syms, nil
+}
+
+func (f *satisfyFakeStore) EdgesOfKind(context.Context, model.EdgeKind) ([]model.Edge, error) {
+	return f.edges, f.edgesErr
+}
+
+func (f *satisfyFakeStore) InTx(_ context.Context, fn func() error) error { return fn() }
+
+func (f *satisfyFakeStore) WriteEdge(context.Context, *model.Edge) (int64, error) {
+	return 0, f.writeErr
+}
+
+// TestSatisfyInterfacesBudgetSkip covers the budget short-circuit through the
+// full pass: enough structs to blow 500K means no edges are attempted. The
+// trip arithmetic leans on the dormant stdlibInterfaces table: (1 declared +
+// len(stdlibInterfaces)=12) × 50,001 structs ≈ 650K > 500K. If that table
+// ever shrinks below 9 entries this fails on the warn assertion — adjust
+// structCnt, not the gate.
+func TestSatisfyInterfacesBudgetSkip(t *testing.T) {
+	var warn bytes.Buffer
+	h := &harness{ctx: context.Background(),
+		idx: &satisfyFakeStore{Adapter: newOpenAdapter(t), structCnt: 50_000, writeErr: errors.New("must not write")},
+		out: io.Discard, warn: &warn}
+	if err := h.satisfyInterfaces(); err != nil {
+		t.Fatalf("budget skip must not error: %v", err)
+	}
+	if warn.Len() == 0 {
+		t.Error("expected the budget skip warning")
+	}
+}
+
+// TestSatisfyInterfacesEmbeddingsLoadError covers the shared embeddings load
+// failing inside the full pass.
+func TestSatisfyInterfacesEmbeddingsLoadError(t *testing.T) {
+	h := &harness{ctx: context.Background(),
+		idx: &satisfyFakeStore{Adapter: newOpenAdapter(t), edgesErr: errors.New("injected edges failure")},
+		out: io.Discard, warn: io.Discard}
+	if err := h.satisfyInterfaces(); err == nil {
+		t.Fatal("expected the embeddings load error to surface")
+	}
+}
+
+// TestSatisfyInterfacesWriteError covers a satisfaction-edge write failing
+// inside the transaction: S has method M so it satisfies I, and the injected
+// WriteEdge failure must surface wrapped.
+func TestSatisfyInterfacesWriteError(t *testing.T) {
+	structID := int64(3)
+	f := &satisfyFakeStore{Adapter: newOpenAdapter(t), writeErr: errors.New("injected write failure")}
+	f.syms = []model.Symbol{
+		{ID: 1, Name: "I", Kind: model.KindInterface, FileID: 1},
+		{ID: 2, Name: "M", Kind: model.KindMethod, FileID: 1, ParentID: func() *int64 { i := int64(1); return &i }()},
+		{ID: 3, Name: "S", Kind: model.KindClass, FileID: 1},
+		{ID: 4, Name: "M", Kind: model.KindMethod, FileID: 1, ParentID: &structID},
+	}
+	h := &harness{ctx: context.Background(), idx: f, out: io.Discard, warn: io.Discard}
+	if err := h.satisfyInterfaces(); err == nil {
+		t.Fatal("expected the write failure to surface")
+	}
+}
+
+// TestLoadEmbeddingsSkipsNilSource pins the adjacency build: an includes edge
+// without a resolved source contributes nothing.
+func TestLoadEmbeddingsSkipsNilSource(t *testing.T) {
+	src := int64(1)
+	f := &satisfyFakeStore{Adapter: newOpenAdapter(t), edges: []model.Edge{
+		{SourceID: nil, TargetID: 9},
+		{SourceID: &src, TargetID: 2},
+	}}
+	h := &harness{ctx: context.Background(), idx: f, out: io.Discard, warn: io.Discard}
+	embeddings, err := h.loadEmbeddings()
+	if err != nil {
+		t.Fatalf("loadEmbeddings: %v", err)
+	}
+	if len(embeddings) != 1 || len(embeddings[1]) != 1 || embeddings[1][0] != 2 {
+		t.Errorf("expected only the resolved edge in the adjacency, got %v", embeddings)
+	}
+}
+
+// TestPromoteEmbeddedMethodsUnknownTarget pins the skip for a target that is
+// neither a known interface nor a known struct (stdlib, unresolved).
+func TestPromoteEmbeddedMethodsUnknownTarget(t *testing.T) {
+	st := &structInfo{methods: map[string]bool{"Own": true}}
+	structs := map[int64]*structInfo{1: st}
+	promoteEmbeddedMethods(st, 1, map[int64][]int64{1: {99}}, structs, nil, 3)
+	if len(st.methods) != 1 {
+		t.Errorf("unknown embed target must contribute nothing, got %v", st.methods)
 	}
 }


### PR DESCRIPTION
## What

Go interface satisfaction (`satisfy.go`) computed method-set cover over **directly declared methods only**, ignoring interface embedding on both sides. That made the agent-facing `inherited_by` wrong in both directions on idiomatic Go:

- **False positives:** an interface with a tiny direct set over-matched — `containerd`'s `ExecProcess` (embedded `Process` + direct `Delete`) had a required set of `[Delete]`, so metadata stores and image services "implemented" it; all 43 of grpc-go's `base.PickerBuilder` implementor edges were false.
- **False negatives:** composite interfaces built purely from embedded interfaces (hugo's `page.Page`, etcd's `mvcc.KV`) had an empty direct set and were skipped outright — zero satisfaction edges.

## How

One mechanism, three surfaces:

- **extract/golang:** emit `includes` edges for interface→interface embedding (`type_elem` children). Go 1.18 union (`A | B`) and approximation (`~T`) constraint terms are skipped — they are type constraints, not method-set embedding. The struct-side/interface-side target switch is factored into a shared `embedTargetName`.
- **scan/satisfy:** interface method sets close over embedded interfaces before matching — a memoized full transitive closure with a cycle guard (a depth cap would shrink *required* sets and silently recreate the false-positive class; hugo's `Page` chain is 5–6 hops deep). Struct-side promotion additionally unions the expanded set of an embedded interface *value* (Go delegation semantics). The `includes` edges load once, shared by both passes.
- **conventions:** composition wording is source-kind aware — interface-sourced embed groups read "N interfaces embed X (interface embedding)", never "N structs embed".

## Verification

- Test-first: extractor reds (two-embed, qualified, constraint-negative), unit reds (union, diamond dedupe, cycle termination, absent-target), e2e shapes (all-embedded composite gains its edge; `ExecProcess`-shape partial cover earns NO edge; embedded-interface-value satisfies), and pins (named interface field never promotes; `interface{}` earns no edges; stdlib-only composites stay at zero — the recorded residual).
- On real repos: go-mysql-server `sql.Expression` 318→323 implementors with every delta hand-verified real; containerd `ExecProcess` 59→2, both real; hugo `page.Page` 0→9 and `resource.Resource` 0→13, spot-checked; gin's `Render` contract count unchanged.
- Double-rescan determinism: 2,194 satisfaction edges byte-identical. Ruby/python edge sets byte-stable (the pass is Go-gated). Scan wall time unchanged.

## Notes

- Known residuals, deliberate: name-collision over-match on flat single-common-method interfaces (signature-aware matching is a separate change); interfaces embedding only stdlib interfaces still expand to nothing.
- **Upgrade note: run one full `sense scan` after upgrading** — satisfaction edges rebuild only on rescan. Documented in the FAQ ("Do I need to re-scan after upgrading?").