### PR TITLE
fix(scan): resolve cross-file receiver method parents at finalize

### DIFF
--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -177,7 +177,33 @@ func computeHealth(ctx context.Context, db *sql.DB, dir string, resp mcpio.Statu
 		}
 	}
 
+	// The parent_linkage stamp is written by full-write scans (fresh index
+	// or rebuild). Its absence means the index predates cross-file parent
+	// linkage and a plain rescan will not backfill it — only a rebuild
+	// rewrites every file. Gated on languages that can carry the defect
+	// (receiver/impl-based parent emission: Go, Rust); lexically-scoped
+	// languages never emit cross-file parents, and advising a rebuild
+	// that heals nothing would spend trust for noise.
+	if resp.Index.Symbols > 0 && readMeta(ctx, db, "parent_linkage") == "" && hasCrossFileParentLanguage(ctx, db) {
+		if h.verdict == "healthy" {
+			h.verdict = "degraded"
+		}
+		if h.detail == "" {
+			h.detail = "index predates cross-file parent linkage — run 'sense scan --rebuild'"
+		}
+	}
+
 	return h
+}
+
+// hasCrossFileParentLanguage reports whether the index contains files in a
+// language whose methods can be declared in a different file than their
+// parent type — the shape the parent-linkage advisory is about.
+func hasCrossFileParentLanguage(ctx context.Context, db *sql.DB) bool {
+	var n int
+	err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM sense_files WHERE language IN ('go', 'rust') LIMIT 1`).Scan(&n)
+	return err == nil && n > 0
 }
 
 func queryLangBreakdown(ctx context.Context, db *sql.DB) map[string]mcpio.StatusLanguage {

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -139,6 +139,54 @@ func TestComputeHealthEmbeddingModelMismatch(t *testing.T) {
 	}
 }
 
+func TestComputeHealthParentLinkageStamp(t *testing.T) {
+	ctx := context.Background()
+	db := healthTestDB(t)
+	_, _ = db.ExecContext(ctx, `CREATE TABLE sense_meta (key TEXT PRIMARY KEY, value TEXT)`)
+	// A Go file makes the index eligible for the advisory: only
+	// receiver/impl-based languages can carry cross-file parents.
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_files VALUES (1, 'a.go', 'go', 'abc', 1, '2026-01-01T00:00:00Z')`)
+
+	resp := mcpio.StatusResponse{
+		Version: &mcpio.StatusVersion{SchemaCurrent: true, EmbeddingModelCurrent: true},
+	}
+	resp.Index.Symbols = 5
+	resp.Index.Embeddings = 5 // keep the embeddings-incomplete branch quiet
+
+	// No stamp: the index predates cross-file parent linkage.
+	h := computeHealth(ctx, db, t.TempDir(), resp)
+	if h.verdict != "degraded" {
+		t.Errorf("verdict = %q without parent_linkage stamp, want degraded", h.verdict)
+	}
+	if h.detail != "index predates cross-file parent linkage — run 'sense scan --rebuild'" {
+		t.Errorf("detail = %q, want parent-linkage message", h.detail)
+	}
+
+	// Stamped: healthy again.
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('parent_linkage', '1')`)
+	h = computeHealth(ctx, db, t.TempDir(), resp)
+	if h.verdict != "healthy" {
+		t.Errorf("verdict = %q with stamp, want healthy", h.verdict)
+	}
+
+	// An empty index (no symbols) has nothing to advise about.
+	resp.Index.Symbols = 0
+	_, _ = db.ExecContext(ctx, `DELETE FROM sense_meta`)
+	h = computeHealth(ctx, db, t.TempDir(), resp)
+	if h.verdict != "healthy" {
+		t.Errorf("verdict = %q on empty index without stamp, want healthy", h.verdict)
+	}
+
+	// A pure lexically-scoped index (no Go/Rust files) cannot have the
+	// defect: no advisory, no wasted rebuild.
+	resp.Index.Symbols = 5
+	_, _ = db.ExecContext(ctx, `UPDATE sense_files SET language = 'ruby', path = 'a.rb'`)
+	h = computeHealth(ctx, db, t.TempDir(), resp)
+	if h.verdict != "healthy" {
+		t.Errorf("verdict = %q on ruby-only index without stamp, want healthy (defect impossible)", h.verdict)
+	}
+}
+
 func TestEmbeddingsEnabled(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/scan/incremental.go
+++ b/internal/scan/incremental.go
@@ -105,7 +105,8 @@ func RunIncremental(ctx context.Context, opts IncrementalOptions) (*Result, erro
 }
 
 // removeDeleted deletes the given relative paths from the index in one
-// transaction; FK CASCADE removes their symbols and edges.
+// transaction; FK CASCADE removes their symbols and edges, after
+// DeleteFile detaches cross-file parent links into them.
 func (h *harness) removeDeleted(removed []string) error {
 	err := h.idx.InTx(h.ctx, func() error {
 		for _, rel := range removed {
@@ -126,8 +127,15 @@ func (h *harness) removeDeleted(removed []string) error {
 // recording each phase's timing.
 func (h *harness) deriveIncremental(embeddingsEnabled bool, phases *PhaseTiming) error {
 	t0 := time.Now()
-	if err := h.resolveAndWriteEdges(); err != nil {
-		return fmt.Errorf("resolve edges: %w", err)
+	// The parent-link leg is load-bearing here, not symmetry:
+	// WriteSymbol's upsert clobbers parent_id on every rescan of a
+	// child's file; the resolve phase restores the cross-file links for
+	// the files this run touched. The clobber commits per file and the
+	// repair lands at end of run — a crash in between leaves those
+	// links NULL until the file changes again or a rebuild (benign,
+	// same class as the DeleteFile detach window).
+	if err := h.resolvePhase(); err != nil {
+		return fmt.Errorf("resolve: %w", err)
 	}
 	phases.ResolveEdges = time.Since(t0)
 

--- a/internal/scan/oracle_test.go
+++ b/internal/scan/oracle_test.go
@@ -117,7 +117,9 @@ func oracleDigest(t *testing.T, dbPath string) (digest string, content []string)
 // leave it unchanged, and a refactor that alters derived output fails here
 // loudly. When output changes on purpose, regenerate it (see the capture line
 // in TestScanContentOracleDigest) and update this constant in the same commit.
-const oracleGolden = "e2ae251f1928556d5f19a8a195ace3c7b109d6ebd8b3337c661d1d4332ab8fcb"
+// Last regeneration: the parent_linkage meta stamp (cross-file parent
+// linkage) added one meta line; symbols/edges/embeddings unchanged.
+const oracleGolden = "abc968fbbbdcaac3e3ef4969a72ecb8762561edf0994e4ea8c8658525c726693"
 
 func TestScanContentOracleDigest(t *testing.T) {
 	useFakeEmbedder(t)

--- a/internal/scan/parent_links.go
+++ b/internal/scan/parent_links.go
@@ -1,0 +1,123 @@
+package scan
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// pendingParent is one symbol whose ParentQualified missed the per-file
+// map in writeFileInner: its parent lives in another file (the cross-file
+// receiver-method shape), or later in the same file. resolveParentLinks
+// closes these after every file has been written — the same asymmetry
+// resolveAndWriteEdges already closes for edges.
+type pendingParent struct {
+	SymbolID        int64
+	ParentQualified string
+	FileID          int64
+	Dir             string // filepath.Dir of the symbol's file (relative path)
+}
+
+// pickParent selects the container a pending symbol binds to, from the
+// candidates sharing its ParentQualified. The rule, for every language:
+// same file, else same directory, else nothing. Cross-directory binds are
+// refused — Go qualified names are package-name based, so an identical
+// qualified name in another directory is a different package sharing a
+// name, and Rust impl blocks qualify through the in-file module chain,
+// so their qualified names carry no path component at all: a global
+// fallback would happily bind a `Money` impl in one subtree to a same-
+// named type in another. Lexically-scoped languages (Ruby, Python) can
+// never emit a cross-file parent in the first place (the enclosing scope
+// is in the symbol's own file by construction).
+//
+// Within a tier the winner is the smallest (path, line, id). Path and
+// line are content-derived, so two indexes of the same tree pick the same
+// parent regardless of write history or candidate order; each pending
+// symbol resolves independently against the full candidate set.
+func pickParent(p pendingParent, candidates []sqlite.ContainerRef) (int64, bool) {
+	var best *sqlite.ContainerRef
+	bestTier := 2
+	for i := range candidates {
+		c := &candidates[i]
+		var tier int
+		switch {
+		case c.FileID == p.FileID:
+			tier = 0
+		case filepath.Dir(c.Path) == p.Dir:
+			tier = 1
+		default:
+			continue
+		}
+		if best == nil || tier < bestTier || (tier == bestTier && lessContainerRef(c, best)) {
+			best, bestTier = c, tier
+		}
+	}
+	if best == nil {
+		return 0, false
+	}
+	return best.ID, true
+}
+
+// lessContainerRef orders candidates by (path, line, id) ascending. The
+// id is a last-resort total-order key; ties above it mean the same
+// declaration site.
+func lessContainerRef(a, b *sqlite.ContainerRef) bool {
+	if a.Path != b.Path {
+		return a.Path < b.Path
+	}
+	if a.Line != b.Line {
+		return a.Line < b.Line
+	}
+	return a.ID < b.ID
+}
+
+// resolvePhase drains the two finalize resolutions in their required
+// order — edges, then parent links — so the full and incremental
+// pipelines cannot drift apart. Parent links must land before
+// satisfyInterfaces (full scan only), which re-reads symbols from the DB.
+func (h *harness) resolvePhase() error {
+	if err := h.resolveAndWriteEdges(); err != nil {
+		return err
+	}
+	return h.resolveParentLinks()
+}
+
+// resolveParentLinks drains pendingParents after the walk: load every
+// container-kind symbol once, resolve each pending parent independently,
+// and persist the links in one transaction. Runs in both the full-scan
+// and incremental pipelines — the incremental leg is load-bearing, not
+// symmetry: WriteSymbol's upsert clobbers parent_id on every rescan of a
+// child's file, and only this pass restores the cross-file links.
+func (h *harness) resolveParentLinks() error {
+	if len(h.pendingParents) == 0 {
+		return nil
+	}
+	refs, err := h.idx.ContainerRefs(h.ctx)
+	if err != nil {
+		return fmt.Errorf("load containers for parent resolution: %w", err)
+	}
+	byQualified := make(map[string][]sqlite.ContainerRef, len(refs))
+	for _, r := range refs {
+		byQualified[r.Qualified] = append(byQualified[r.Qualified], r)
+	}
+
+	type link struct{ symbolID, parentID int64 }
+	var links []link
+	for _, p := range h.pendingParents {
+		if id, ok := pickParent(p, byQualified[p.ParentQualified]); ok {
+			links = append(links, link{symbolID: p.SymbolID, parentID: id})
+		}
+	}
+	if len(links) == 0 {
+		return nil
+	}
+	return h.idx.InTx(h.ctx, func() error {
+		for _, l := range links {
+			if err := h.idx.UpdateSymbolParent(h.ctx, l.symbolID, l.parentID); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}

--- a/internal/scan/parent_links_internal_test.go
+++ b/internal/scan/parent_links_internal_test.go
@@ -1,0 +1,134 @@
+package scan
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// TestPickParent pins the resolution rule: same file beats same directory,
+// same directory beats nothing, cross-directory never binds, and within a
+// tier the smallest (path, line, id) wins — independent of candidate order.
+func TestPickParent(t *testing.T) {
+	pending := pendingParent{SymbolID: 99, ParentQualified: "mvcc.Store", FileID: 10, Dir: "server/mvcc"}
+
+	sameFile := sqlite.ContainerRef{ID: 1, Qualified: "mvcc.Store", FileID: 10, Path: "server/mvcc/kvstore.go", Line: 40}
+	sameDirA := sqlite.ContainerRef{ID: 2, Qualified: "mvcc.Store", FileID: 11, Path: "server/mvcc/a_store.go", Line: 12}
+	sameDirB := sqlite.ContainerRef{ID: 3, Qualified: "mvcc.Store", FileID: 12, Path: "server/mvcc/b_store.go", Line: 5}
+	sameDirALater := sqlite.ContainerRef{ID: 4, Qualified: "mvcc.Store", FileID: 13, Path: "server/mvcc/a_store.go", Line: 30}
+	crossDir := sqlite.ContainerRef{ID: 5, Qualified: "mvcc.Store", FileID: 20, Path: "tools/mvcc/store.go", Line: 3}
+
+	cases := []struct {
+		name       string
+		candidates []sqlite.ContainerRef
+		wantID     int64
+		wantOK     bool
+	}{
+		{"no candidates", nil, 0, false},
+		{"cross-directory never binds", []sqlite.ContainerRef{crossDir}, 0, false},
+		{"same file wins over same dir", []sqlite.ContainerRef{sameDirA, sameFile, crossDir}, 1, true},
+		{"same dir wins over cross dir", []sqlite.ContainerRef{crossDir, sameDirB}, 3, true},
+		{"same dir: smallest path wins", []sqlite.ContainerRef{sameDirB, sameDirA}, 2, true},
+		{"same path: smallest line wins", []sqlite.ContainerRef{sameDirALater, sameDirA}, 2, true},
+		{"order independence", []sqlite.ContainerRef{crossDir, sameDirALater, sameDirB, sameDirA}, 2, true},
+		{"order independence reversed", []sqlite.ContainerRef{sameDirA, sameDirB, sameDirALater, crossDir}, 2, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			id, ok := pickParent(pending, tc.candidates)
+			if ok != tc.wantOK || id != tc.wantID {
+				t.Errorf("pickParent = (%d, %v), want (%d, %v)", id, ok, tc.wantID, tc.wantOK)
+			}
+		})
+	}
+}
+
+// TestLessContainerRefTotalOrder pins the final id key: identical
+// (path, line) still yields one deterministic winner.
+func TestLessContainerRefTotalOrder(t *testing.T) {
+	a := &sqlite.ContainerRef{ID: 7, Path: "x/a.go", Line: 3}
+	b := &sqlite.ContainerRef{ID: 9, Path: "x/a.go", Line: 3}
+	if !lessContainerRef(a, b) || lessContainerRef(b, a) {
+		t.Errorf("id tiebreak not a strict total order")
+	}
+}
+
+// errInjectedContainers is the sentinel the fault store below returns.
+var errInjectedContainers = errors.New("injected ContainerRefs failure")
+
+// faultContainerStore embeds the real adapter and fails exactly one named
+// method, ContainerRefs — the seam substitution that drives the parent
+// pass's error branch in deriveIncremental (rollback_internal_test.go sets
+// the pattern).
+type faultContainerStore struct {
+	*sqlite.Adapter
+}
+
+func (f *faultContainerStore) ContainerRefs(_ context.Context) ([]sqlite.ContainerRef, error) {
+	return nil, errInjectedContainers
+}
+
+// TestDeriveIncrementalParentLinkError pins the incremental pipeline's
+// error wrap: a failing container load surfaces as a resolve-parent-links
+// error instead of being swallowed.
+func TestDeriveIncrementalParentLinkError(t *testing.T) {
+	dir := t.TempDir()
+	adapter := openIndex(t, dir)
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	h := &harness{
+		ctx:       context.Background(),
+		idx:       &faultContainerStore{Adapter: adapter},
+		out:       io.Discard,
+		warn:      io.Discard,
+		progress:  newProgress(io.Discard, true),
+		collector: newWarningCollector(),
+		seenPaths: map[string]bool{},
+		pendingParents: []pendingParent{
+			{SymbolID: 1, ParentQualified: "mvcc.Store", FileID: 1, Dir: "server"},
+		},
+	}
+
+	var phases PhaseTiming
+	err := h.deriveIncremental(false, &phases)
+	if err == nil || !errors.Is(err, errInjectedContainers) {
+		t.Fatalf("deriveIncremental error = %v, want wrapped injected ContainerRefs failure", err)
+	}
+}
+
+// errInjectedLangQuery drives the naming pass's error branch after the
+// parent pass succeeds, pinning deriveIncremental's downstream wrap.
+var errInjectedLangQuery = errors.New("injected FileIDsByLanguage failure")
+
+type faultLangStore struct {
+	*sqlite.Adapter
+}
+
+func (f *faultLangStore) FileIDsByLanguage(_ context.Context, _ string) (map[int64]bool, error) {
+	return nil, errInjectedLangQuery
+}
+
+func TestDeriveIncrementalNamingError(t *testing.T) {
+	dir := t.TempDir()
+	adapter := openIndex(t, dir)
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	h := &harness{
+		ctx:       context.Background(),
+		idx:       &faultLangStore{Adapter: adapter},
+		out:       io.Discard,
+		warn:      io.Discard,
+		progress:  newProgress(io.Discard, true),
+		collector: newWarningCollector(),
+		seenPaths: map[string]bool{},
+	}
+
+	var phases PhaseTiming
+	err := h.deriveIncremental(false, &phases)
+	if err == nil || !errors.Is(err, errInjectedLangQuery) {
+		t.Fatalf("deriveIncremental error = %v, want wrapped injected language-query failure", err)
+	}
+}

--- a/internal/scan/parent_links_test.go
+++ b/internal/scan/parent_links_test.go
@@ -1,0 +1,379 @@
+package scan_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/luuuc/sense/internal/ignore"
+	"github.com/luuuc/sense/internal/scan"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// parentOf returns the qualified name of a symbol's parent, or "" when the
+// parent_id is NULL.
+func parentOf(t *testing.T, root, qualified string) string {
+	t.Helper()
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(root, ".sense", "index.db"))
+	if err != nil {
+		t.Fatalf("open index: %v", err)
+	}
+	defer func() { _ = a.Close() }()
+
+	var parent string
+	err = a.DB().QueryRowContext(ctx, `
+		SELECT COALESCE(p.qualified, '')
+		FROM sense_symbols s
+		LEFT JOIN sense_symbols p ON p.id = s.parent_id
+		WHERE s.qualified = ?`, qualified).Scan(&parent)
+	if err != nil {
+		t.Fatalf("query parent of %s: %v", qualified, err)
+	}
+	return parent
+}
+
+func parentFileOf(t *testing.T, root, qualified string) string {
+	t.Helper()
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(root, ".sense", "index.db"))
+	if err != nil {
+		t.Fatalf("open index: %v", err)
+	}
+	defer func() { _ = a.Close() }()
+
+	var path string
+	err = a.DB().QueryRowContext(ctx, `
+		SELECT COALESCE(f.path, '')
+		FROM sense_symbols s
+		LEFT JOIN sense_symbols p ON p.id = s.parent_id
+		LEFT JOIN sense_files f ON f.id = p.file_id
+		WHERE s.qualified = ?`, qualified).Scan(&path)
+	if err != nil {
+		t.Fatalf("query parent file of %s: %v", qualified, err)
+	}
+	return path
+}
+
+func readMetaKey(t *testing.T, root, key string) string {
+	t.Helper()
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(root, ".sense", "index.db"))
+	if err != nil {
+		t.Fatalf("open index: %v", err)
+	}
+	defer func() { _ = a.Close() }()
+	v, _ := a.ReadMeta(ctx, key)
+	return v
+}
+
+func runIncrementalOn(t *testing.T, root string, changed, removed []string) {
+	t.Helper()
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(root, ".sense", "index.db"))
+	if err != nil {
+		t.Fatalf("open adapter: %v", err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	matcher, err := ignore.Build(root, nil)
+	if err != nil {
+		t.Fatalf("build matcher: %v", err)
+	}
+	_, err = scan.RunIncremental(ctx, scan.IncrementalOptions{
+		Root:          root,
+		Idx:           adapter,
+		Matcher:       matcher,
+		MaxFileSizeKB: 512,
+		Output:        io.Discard,
+		Warnings:      &bytes.Buffer{},
+		Changed:       changed,
+		Removed:       removed,
+	})
+	if err != nil {
+		t.Fatalf("RunIncremental: %v", err)
+	}
+}
+
+const storeTypeSrc = `package mvcc
+
+type Store struct {
+	size int
+}
+
+func (s *Store) Size() int {
+	return s.size
+}
+`
+
+const storeTxnSrc = `package mvcc
+
+func (s *Store) Read() int {
+	return 1
+}
+
+func (s *Store) Write(v int) {
+	s.size = v
+}
+`
+
+// TestCrossFileMethodParentResolves is the G-6 repro: a method declared in
+// a sibling file of its receiver type must carry a parent link after a
+// full scan (kvstore.go vs kvstore_txn.go — the core Go idiom).
+func TestCrossFileMethodParentResolves(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "kvstore.go"), storeTypeSrc)
+	writeFile(t, filepath.Join(root, "kvstore_txn.go"), storeTxnSrc)
+
+	if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	for _, m := range []string{"mvcc.Store.Read", "mvcc.Store.Write"} {
+		if got := parentOf(t, root, m); got != "mvcc.Store" {
+			t.Errorf("%s parent = %q, want mvcc.Store", m, got)
+		}
+	}
+	// Same-file binding unchanged.
+	if got := parentOf(t, root, "mvcc.Store.Size"); got != "mvcc.Store" {
+		t.Errorf("mvcc.Store.Size parent = %q, want mvcc.Store", got)
+	}
+}
+
+// TestCrossFileParentSurvivesIncrementalRescan pins the clobber-heal
+// invariant: WriteSymbol's upsert resets parent_id on every rescan of the
+// method's file, and deriveIncremental's parent pass must restore it in
+// the same run.
+func TestCrossFileParentSurvivesIncrementalRescan(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "kvstore.go"), storeTypeSrc)
+	writeFile(t, filepath.Join(root, "kvstore_txn.go"), storeTxnSrc)
+
+	if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Touch only the method file: add a method, rescan incrementally.
+	writeFile(t, filepath.Join(root, "kvstore_txn.go"), storeTxnSrc+`
+func (s *Store) Clear() {
+	s.size = 0
+}
+`)
+	runIncrementalOn(t, root, []string{"kvstore_txn.go"}, nil)
+
+	for _, m := range []string{"mvcc.Store.Read", "mvcc.Store.Write", "mvcc.Store.Clear"} {
+		if got := parentOf(t, root, m); got != "mvcc.Store" {
+			t.Errorf("%s parent = %q after incremental rescan, want mvcc.Store", m, got)
+		}
+	}
+}
+
+// TestParentFileAddedIncrementallyHealsOnlyOnRebuild pins the accepted
+// limitation: when the parent's file arrives later, an untouched child
+// stays orphaned (its ParentQualified lives only in memory during its own
+// file's scan) until a rebuild rewrites every file.
+func TestParentFileAddedIncrementallyHealsOnlyOnRebuild(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "kvstore_txn.go"), storeTxnSrc)
+
+	if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := parentOf(t, root, "mvcc.Store.Read"); got != "" {
+		t.Fatalf("mvcc.Store.Read parent = %q with no type declared, want none", got)
+	}
+
+	// The type arrives in a new file; only that file is scanned.
+	writeFile(t, filepath.Join(root, "kvstore.go"), storeTypeSrc)
+	runIncrementalOn(t, root, []string{"kvstore.go"}, nil)
+	if got := parentOf(t, root, "mvcc.Store.Read"); got != "" {
+		t.Errorf("mvcc.Store.Read parent = %q after parent-only incremental, want still none (pinned limitation)", got)
+	}
+
+	// A rebuild rewrites every file and heals.
+	opts := quietOpts(root)
+	opts.Rebuild = true
+	if _, err := scan.Run(context.Background(), opts); err != nil {
+		t.Fatalf("Run -rebuild: %v", err)
+	}
+	if got := parentOf(t, root, "mvcc.Store.Read"); got != "mvcc.Store" {
+		t.Errorf("mvcc.Store.Read parent = %q after rebuild, want mvcc.Store", got)
+	}
+}
+
+// TestRemoveStaleParentFileDetachesChildren drives the removeStaleFiles
+// path: deleting the type's file must not trip the parent_id foreign key,
+// and surviving children end up detached.
+func TestRemoveStaleParentFileDetachesChildren(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "kvstore.go"), storeTypeSrc)
+	writeFile(t, filepath.Join(root, "kvstore_txn.go"), storeTxnSrc)
+
+	if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := parentOf(t, root, "mvcc.Store.Read"); got != "mvcc.Store" {
+		t.Fatalf("precondition: cross-file link missing (parent = %q)", got)
+	}
+
+	if err := os.Remove(filepath.Join(root, "kvstore.go")); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+		t.Fatalf("rescan after parent file removal: %v", err)
+	}
+	if got := parentOf(t, root, "mvcc.Store.Read"); got != "" {
+		t.Errorf("mvcc.Store.Read parent = %q after parent file removal, want detached", got)
+	}
+}
+
+// TestRemovedFileDetachesChildrenIncremental drives the removeDeleted
+// path with the same shape.
+func TestRemovedFileDetachesChildrenIncremental(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "kvstore.go"), storeTypeSrc)
+	writeFile(t, filepath.Join(root, "kvstore_txn.go"), storeTxnSrc)
+
+	if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if err := os.Remove(filepath.Join(root, "kvstore.go")); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	runIncrementalOn(t, root, nil, []string{"kvstore.go"})
+	if got := parentOf(t, root, "mvcc.Store.Read"); got != "" {
+		t.Errorf("mvcc.Store.Read parent = %q after incremental removal, want detached", got)
+	}
+}
+
+// TestParentChoiceDeterministicAcrossDuplicateDeclarations pins the
+// tiebreak on the build-tag-pair shape: two sibling files declare the same
+// type; the method binds to the lexicographically smallest path in every
+// fresh scan.
+func TestParentChoiceDeterministicAcrossDuplicateDeclarations(t *testing.T) {
+	const twinA = `package git
+
+type Blob struct {
+	idA int
+}
+`
+	const twinB = `package git
+
+type Blob struct {
+	idB int
+}
+`
+	const method = `package git
+
+func (b *Blob) Name() string {
+	return ""
+}
+`
+	for run := 0; run < 2; run++ {
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, "blob_gogit.go"), twinA)
+		writeFile(t, filepath.Join(root, "blob_nogogit.go"), twinB)
+		writeFile(t, filepath.Join(root, "blob.go"), method)
+
+		if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+		if got := parentFileOf(t, root, "git.Blob.Name"); got != "blob_gogit.go" {
+			t.Errorf("run %d: git.Blob.Name parent file = %q, want blob_gogit.go (path-smallest twin)", run, got)
+		}
+	}
+}
+
+// TestSatisfyCountsMethodsAcrossFiles is the mvcc.KV shape: satisfaction
+// must see a method set that spans files, in the same scan that links it.
+func TestSatisfyCountsMethodsAcrossFiles(t *testing.T) {
+	const ifaceSrc = `package mvcc
+
+type KV interface {
+	Read() int
+	Write(v int)
+}
+`
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "kv.go"), ifaceSrc)
+	writeFile(t, filepath.Join(root, "kvstore.go"), storeTypeSrc)
+	writeFile(t, filepath.Join(root, "kvstore_txn.go"), storeTxnSrc)
+
+	if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(root, ".sense", "index.db"))
+	if err != nil {
+		t.Fatalf("open index: %v", err)
+	}
+	defer func() { _ = a.Close() }()
+
+	var n int
+	err = a.DB().QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM sense_edges e
+		JOIN sense_symbols src ON src.id = e.source_id
+		JOIN sense_symbols dst ON dst.id = e.target_id
+		WHERE e.kind = 'inherits' AND src.qualified = 'mvcc.Store' AND dst.qualified = 'mvcc.KV'`).Scan(&n)
+	if err != nil {
+		t.Fatalf("query satisfaction edge: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("mvcc.Store -> mvcc.KV satisfaction edges = %d, want 1 (method set spans kvstore.go + kvstore_txn.go)", n)
+	}
+}
+
+// TestScanStampsParentLinkageMeta pins the staleness signal: a fresh scan
+// stamps parent_linkage, a plain rescan preserves it, and an index
+// stripped of the stamp is only re-stamped by a rebuild.
+func TestScanStampsParentLinkageMeta(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "kvstore.go"), storeTypeSrc)
+
+	if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := readMetaKey(t, root, "parent_linkage"); got != "1" {
+		t.Fatalf("parent_linkage = %q after fresh scan, want 1", got)
+	}
+
+	// A plain rescan (nothing changed) must not clear the stamp.
+	if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+		t.Fatalf("plain rescan: %v", err)
+	}
+	if got := readMetaKey(t, root, "parent_linkage"); got != "1" {
+		t.Errorf("parent_linkage = %q after plain rescan, want preserved 1", got)
+	}
+
+	// Strip the stamp (a pre-fix index); a plain rescan of unchanged
+	// files heals nothing and must NOT stamp; a rebuild must.
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(root, ".sense", "index.db"))
+	if err != nil {
+		t.Fatalf("open index: %v", err)
+	}
+	if err := a.DeleteMeta(ctx, "parent_linkage"); err != nil {
+		t.Fatalf("delete meta: %v", err)
+	}
+	_ = a.Close()
+
+	if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+		t.Fatalf("plain rescan on stripped index: %v", err)
+	}
+	if got := readMetaKey(t, root, "parent_linkage"); got != "" {
+		t.Errorf("parent_linkage = %q after plain rescan of unchanged files, want unstamped", got)
+	}
+
+	opts := quietOpts(root)
+	opts.Rebuild = true
+	if _, err := scan.Run(context.Background(), opts); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	if got := readMetaKey(t, root, "parent_linkage"); got != "1" {
+		t.Errorf("parent_linkage = %q after rebuild, want 1", got)
+	}
+}

--- a/internal/scan/rollback_internal_test.go
+++ b/internal/scan/rollback_internal_test.go
@@ -142,6 +142,128 @@ func TestFlushBatchPartialFailureRollsBackAndRetries(t *testing.T) {
 	assertQualified(t, fresh, map[string]bool{"A": true, "B": true})
 }
 
+// goMethodFile builds a fileResult whose method's receiver type lives in
+// another file, so writeFileInner buffers a pendingParent for it — the
+// shape the rollback snapshots must clean up.
+func goMethodFile(rel string) *fileResult {
+	return &fileResult{
+		Rel:      rel,
+		Language: "go",
+		Source:   []byte("package mvcc\n\nfunc (s *Store) Read() int { return 1 }\n"),
+		Hash:     "hash-" + rel,
+		Symbols: []extract.EmittedSymbol{
+			{Name: "Read", Qualified: "mvcc.Store.Read", Kind: "method", ParentQualified: "mvcc.Store", LineStart: 3, LineEnd: 3},
+		},
+	}
+}
+
+// TestFlushBatchRollbackDropsPendingParents kills the mutant Beck named:
+// deleting the pendingParents truncate in flushBatch must fail this test.
+// File A buffers a pendingParent, file B's WriteFile fault rolls the
+// transaction back (freeing A's rowids), and the retry re-writes A with
+// NEW ids. A stale entry surviving the rollback would carry a freed rowid
+// that resolveParentLinks could stamp onto the wrong symbol.
+func TestFlushBatchRollbackDropsPendingParents(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	writeSource(t, dir, "read.go", "package mvcc\n\nfunc (s *Store) Read() int { return 1 }\n")
+	writeSource(t, dir, "b.rb", "class B\nend\n")
+
+	adapter := openIndex(t, dir)
+	t.Cleanup(func() { _ = adapter.Close() })
+	store := &faultWriteStore{Adapter: adapter, failPath: "b.rb"}
+	h := &harness{
+		ctx:       ctx,
+		idx:       store,
+		out:       io.Discard,
+		warn:      io.Discard,
+		collector: newWarningCollector(),
+		progress:  &progress{},
+		seenPaths: map[string]bool{},
+	}
+
+	if err := h.flushBatch([]*fileResult{goMethodFile("read.go"), classFile("b.rb", "B")}); err != nil {
+		t.Fatalf("flushBatch: %v", err)
+	}
+	if !store.fired {
+		t.Fatal("fault was never triggered")
+	}
+
+	if got := len(h.pendingParents); got != 1 {
+		t.Fatalf("pendingParents = %d entries after rollback+retry, want exactly 1 (stale rolled-back entry must be truncated)", got)
+	}
+	var liveID int64
+	err := adapter.DB().QueryRowContext(ctx,
+		"SELECT id FROM sense_symbols WHERE qualified = 'mvcc.Store.Read'").Scan(&liveID)
+	if err != nil {
+		t.Fatalf("read surviving symbol: %v", err)
+	}
+	if h.pendingParents[0].SymbolID != liveID {
+		t.Errorf("pendingParents[0].SymbolID = %d, want the live rowid %d (a stale id would mislink on rowid reuse)",
+			h.pendingParents[0].SymbolID, liveID)
+	}
+}
+
+// faultSymbolStore fails WriteSymbol once for a named qualified — the
+// failure point AFTER a pendingParent append, driving writeFileResult's
+// rollback snapshot (the incremental per-file path).
+type faultSymbolStore struct {
+	*sqlite.Adapter
+	failQualified string
+	fired         bool
+}
+
+func (f *faultSymbolStore) WriteSymbol(ctx context.Context, s *model.Symbol) (int64, error) {
+	if !f.fired && s.Qualified == f.failQualified {
+		f.fired = true
+		return 0, errInjectedWrite
+	}
+	return f.Adapter.WriteSymbol(ctx, s)
+}
+
+// TestWriteFileResultRollbackDropsPendingParents pins the incremental
+// twin of the flushBatch snapshot: the method's pendingParent is appended
+// before a later symbol's write fails, and the rollback must drop it.
+func TestWriteFileResultRollbackDropsPendingParents(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	adapter := openIndex(t, dir)
+	t.Cleanup(func() { _ = adapter.Close() })
+	store := &faultSymbolStore{Adapter: adapter, failQualified: "mvcc.Store.Write"}
+	h := &harness{
+		ctx:       ctx,
+		idx:       store,
+		out:       io.Discard,
+		warn:      io.Discard,
+		collector: newWarningCollector(),
+		progress:  &progress{},
+		seenPaths: map[string]bool{},
+	}
+
+	fr := goMethodFile("txn.go")
+	fr.Symbols = append(fr.Symbols, extract.EmittedSymbol{
+		Name: "Write", Qualified: "mvcc.Store.Write", Kind: "method",
+		ParentQualified: "mvcc.Store", LineStart: 5, LineEnd: 5,
+	})
+
+	if err := h.writeFileResult(fr); err == nil {
+		t.Fatal("writeFileResult should surface the injected symbol failure")
+	}
+	if !store.fired {
+		t.Fatal("fault was never triggered")
+	}
+	if got := len(h.pendingParents); got != 0 {
+		t.Errorf("pendingParents = %d entries after rolled-back writeFileResult, want 0", got)
+	}
+	if got := len(h.pendingEdges); got != 0 {
+		t.Errorf("pendingEdges = %d entries after rolled-back writeFileResult, want 0", got)
+	}
+	if got := len(h.indexedFiles); got != 0 {
+		t.Errorf("indexedFiles = %d entries after rolled-back writeFileResult, want 0", got)
+	}
+}
+
 // TestFlushBatchWholeBatchFailsDropsAllCleanly covers flushBatch's
 // retry-exhausted branch: when the only file in a batch fails, the retry list
 // is empty, so flushBatch returns cleanly with nothing indexed and a warning

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -104,6 +104,12 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	defer func() { _ = idx.Close() }()
 	defer h.closeParsers()
 
+	// Fresh index or rebuild: every file is written this run, so the
+	// index carries complete cross-file parent linkage and finalizeScan
+	// may stamp it. A plain scan skips unchanged-hash files and heals
+	// nothing on a pre-linkage index, so it must not stamp.
+	h.fullyLinked = firstRun || opts.Rebuild || idx.Rebuilt
+
 	h.progress.start()
 	defer h.progress.stop()
 
@@ -126,7 +132,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 
 	h.progress.setPhase("Resolving edges...", 0)
 	t0 = time.Now()
-	if err := h.resolveAndWriteEdges(); err != nil {
+	if err := h.resolvePhase(); err != nil {
 		return nil, err
 	}
 	phases.ResolveEdges = time.Since(t0)
@@ -410,6 +416,12 @@ func finalizeScan(ctx context.Context, idx *sqlite.Adapter, h *harness, senseDir
 		_, _ = fmt.Fprintf(h.warn, "warn: write last_scan_at: %v\n", err)
 	}
 
+	if h.fullyLinked {
+		if err := idx.WriteMeta(ctx, "parent_linkage", "1"); err != nil {
+			_, _ = fmt.Fprintf(h.warn, "warn: write parent_linkage: %v\n", err)
+		}
+	}
+
 	if err := idx.StampSchemaVersion(ctx); err != nil {
 		return err
 	}
@@ -521,6 +533,18 @@ type harness struct {
 	// Empty at start, filled by writeFile, drained by
 	// resolveAndWriteEdges.
 	pendingEdges []pendingEdge
+
+	// pendingParents holds symbols whose ParentQualified missed the
+	// per-file map in writeFileInner (cross-file receiver methods).
+	// Appended only from writeFileInner — the parse phase is parallel —
+	// and drained by resolveParentLinks after the walk.
+	pendingParents []pendingParent
+
+	// fullyLinked records that this scan wrote every file (fresh index
+	// or rebuild), so finalizeScan may stamp the parent_linkage meta
+	// key. A plain scan skips unchanged-hash files and must not stamp:
+	// it heals nothing on an index built before cross-file linkage.
+	fullyLinked bool
 
 	// indexedFiles lists every file successfully processed during
 	// the walk, in visit order. The test-association post-pass
@@ -891,6 +915,7 @@ func (h *harness) flushBatch(batch []*fileResult) error {
 	snapEdges := len(h.pendingEdges)
 	snapIndexed := len(h.indexedFiles)
 	snapChanged := len(h.changedFileIDs)
+	snapParents := len(h.pendingParents)
 
 	var totalSyms int
 	failedIdx := -1
@@ -910,6 +935,7 @@ func (h *harness) flushBatch(batch []*fileResult) error {
 		h.pendingEdges = h.pendingEdges[:snapEdges]
 		h.indexedFiles = h.indexedFiles[:snapIndexed]
 		h.changedFileIDs = h.changedFileIDs[:snapChanged]
+		h.pendingParents = h.pendingParents[:snapParents]
 
 		h.addWarning(warnWriteFailed, "%s (%v)", batch[failedIdx].Rel, err)
 		retry := make([]*fileResult, 0, len(batch)-1)
@@ -1000,6 +1026,15 @@ func (h *harness) processFile(path, rel string) {
 // Used by processFile (RunIncremental) where per-file transactions
 // are appropriate for small change sets.
 func (h *harness) writeFileResult(fr *fileResult) error {
+	// Snapshot the in-memory buffers writeFileInner appends to, mirroring
+	// flushBatch: an entry surviving a rolled-back transaction would carry
+	// symbol ids the rollback freed, and SQLite reuses top rowids — a later
+	// finalize pass would then link or edge the WRONG symbol.
+	snapEdges := len(h.pendingEdges)
+	snapParents := len(h.pendingParents)
+	snapIndexed := len(h.indexedFiles)
+	snapChanged := len(h.changedFileIDs)
+
 	var symsWritten int
 	err := h.idx.InTx(h.ctx, func() error {
 		n, err := h.writeFileInner(fr)
@@ -1010,6 +1045,10 @@ func (h *harness) writeFileResult(fr *fileResult) error {
 		return nil
 	})
 	if err != nil {
+		h.pendingEdges = h.pendingEdges[:snapEdges]
+		h.pendingParents = h.pendingParents[:snapParents]
+		h.indexedFiles = h.indexedFiles[:snapIndexed]
+		h.changedFileIDs = h.changedFileIDs[:snapChanged]
 		return err
 	}
 	h.symbols += symsWritten
@@ -1067,6 +1106,14 @@ func (h *harness) writeFileInner(fr *fileResult) (int, error) {
 		}
 		idByQualified[s.Qualified] = id
 		parentByQualified[s.Qualified] = s.ParentQualified
+		if s.ParentQualified != "" && parentID == nil {
+			h.pendingParents = append(h.pendingParents, pendingParent{
+				SymbolID:        id,
+				ParentQualified: s.ParentQualified,
+				FileID:          fileID,
+				Dir:             filepath.Dir(fr.Rel),
+			})
+		}
 		symsWritten++
 	}
 
@@ -1091,8 +1138,9 @@ func (h *harness) writeFileInner(fr *fileResult) (int, error) {
 
 // removeStaleFiles deletes index entries for files that were not seen
 // during this walk (deleted from disk, or now excluded by ignore rules).
-// FK CASCADE on sense_symbols cleans up symbols; edges referencing those
-// symbols are also cascaded.
+// FK CASCADE on sense_symbols cleans up symbols and their edges;
+// DeleteFile first detaches cross-file parent links into the doomed
+// symbols (parent_id has no ON DELETE action).
 func (h *harness) removeStaleFiles() error {
 	tracked, err := h.idx.FilePaths(h.ctx)
 	if err != nil {

--- a/internal/scan/seam.go
+++ b/internal/scan/seam.go
@@ -32,11 +32,13 @@ type indexStore interface {
 	WriteFile(ctx context.Context, f *model.File) (int64, error)
 	WriteSymbol(ctx context.Context, s *model.Symbol) (int64, error)
 	WriteEdge(ctx context.Context, e *model.Edge) (int64, error)
+	UpdateSymbolParent(ctx context.Context, symbolID, parentID int64) error
 	DeleteFile(ctx context.Context, path string) error
 
 	// Reads used across the resolve, temporal, satisfy and embed passes.
 	Query(ctx context.Context, f index.Filter) ([]model.Symbol, error)
 	SymbolRefs(ctx context.Context) ([]model.SymbolRef, error)
+	ContainerRefs(ctx context.Context) ([]sqlite.ContainerRef, error)
 	FileMeta(ctx context.Context, path string) (int64, string, error)
 	FileHashMap(ctx context.Context) (map[string]sqlite.CachedFile, error)
 	FilePaths(ctx context.Context) ([]string, error)

--- a/internal/sqlite/parent_detach_test.go
+++ b/internal/sqlite/parent_detach_test.go
@@ -1,0 +1,147 @@
+package sqlite_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// writeParentChildFixture builds two files with a container symbol in
+// parentPath and a method in childPath whose ParentID points at the
+// container — the cross-file link shape introduced by the parent-linkage
+// finalize pass.
+func writeParentChildFixture(t *testing.T, a *sqlite.Adapter, parentPath, childPath string) (parentID, childID int64) {
+	t.Helper()
+	ctx := context.Background()
+
+	parentFile, err := a.WriteFile(ctx, &model.File{Path: parentPath, Language: "go", IndexedAt: time.Now()})
+	if err != nil {
+		t.Fatalf("WriteFile parent: %v", err)
+	}
+	childFile := parentFile
+	if childPath != parentPath {
+		childFile, err = a.WriteFile(ctx, &model.File{Path: childPath, Language: "go", IndexedAt: time.Now()})
+		if err != nil {
+			t.Fatalf("WriteFile child: %v", err)
+		}
+	}
+
+	parentID, err = a.WriteSymbol(ctx, &model.Symbol{
+		FileID: parentFile, Name: "Store", Qualified: "mvcc.Store",
+		Kind: model.KindClass, LineStart: 1, LineEnd: 3,
+	})
+	if err != nil {
+		t.Fatalf("WriteSymbol parent: %v", err)
+	}
+	childID, err = a.WriteSymbol(ctx, &model.Symbol{
+		FileID: childFile, Name: "Read", Qualified: "mvcc.Store.Read",
+		Kind: model.KindMethod, ParentID: &parentID, LineStart: 1, LineEnd: 2,
+	})
+	if err != nil {
+		t.Fatalf("WriteSymbol child: %v", err)
+	}
+	return parentID, childID
+}
+
+// TestDeleteFileDetachesCrossFileChildren pins the FK hazard closed by the
+// detach: parent_id carries no ON DELETE action, so deleting the parent's
+// file while a child in ANOTHER file still references the parent must not
+// trip the foreign key — and the child must end up detached (NULL), not
+// dangling.
+func TestDeleteFileDetachesCrossFileChildren(t *testing.T) {
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(t.TempDir(), "index.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = a.Close() })
+
+	_, childID := writeParentChildFixture(t, a, "kvstore.go", "kvstore_txn.go")
+
+	if err := a.DeleteFile(ctx, "kvstore.go"); err != nil {
+		t.Fatalf("DeleteFile with cross-file child: %v", err)
+	}
+
+	var parent any
+	err = a.DB().QueryRowContext(ctx,
+		"SELECT parent_id FROM sense_symbols WHERE id = ?", childID).Scan(&parent)
+	if err != nil {
+		t.Fatalf("read child after delete: %v", err)
+	}
+	if parent != nil {
+		t.Errorf("child parent_id = %v after parent file delete, want NULL", parent)
+	}
+}
+
+// TestDeleteFileSameFileParentStillCascades pins the pre-existing shape:
+// parent and child in the same file both leave with the file, and the
+// detach does not disturb links in files that survive.
+func TestDeleteFileSameFileParentStillCascades(t *testing.T) {
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(t.TempDir(), "index.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = a.Close() })
+
+	_, _ = writeParentChildFixture(t, a, "same.go", "same.go")
+	survivorParent, survivorChild := writeParentChildFixtureNamed(t, a, "other.go", "other.go", "sql.Engine", "sql.Engine.Query")
+
+	if err := a.DeleteFile(ctx, "same.go"); err != nil {
+		t.Fatalf("DeleteFile same-file parent+child: %v", err)
+	}
+
+	var n int
+	if err := a.DB().QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM sense_symbols WHERE qualified LIKE 'mvcc.%'").Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("deleted file left %d symbols behind", n)
+	}
+
+	var got int64
+	if err := a.DB().QueryRowContext(ctx,
+		"SELECT parent_id FROM sense_symbols WHERE id = ?", survivorChild).Scan(&got); err != nil {
+		t.Fatalf("surviving child lost its parent link: %v", err)
+	}
+	if got != survivorParent {
+		t.Errorf("surviving child parent_id = %d, want %d", got, survivorParent)
+	}
+}
+
+func writeParentChildFixtureNamed(t *testing.T, a *sqlite.Adapter, parentPath, childPath, parentQual, childQual string) (parentID, childID int64) {
+	t.Helper()
+	ctx := context.Background()
+
+	parentFile, err := a.WriteFile(ctx, &model.File{Path: parentPath, Language: "go", IndexedAt: time.Now()})
+	if err != nil {
+		t.Fatalf("WriteFile parent: %v", err)
+	}
+	childFile := parentFile
+	if childPath != parentPath {
+		childFile, err = a.WriteFile(ctx, &model.File{Path: childPath, Language: "go", IndexedAt: time.Now()})
+		if err != nil {
+			t.Fatalf("WriteFile child: %v", err)
+		}
+	}
+	parentID, err = a.WriteSymbol(ctx, &model.Symbol{
+		FileID: parentFile, Name: "X", Qualified: parentQual,
+		Kind: model.KindClass, LineStart: 1, LineEnd: 3,
+	})
+	if err != nil {
+		t.Fatalf("WriteSymbol parent: %v", err)
+	}
+	childID, err = a.WriteSymbol(ctx, &model.Symbol{
+		FileID: childFile, Name: "Y", Qualified: childQual,
+		Kind: model.KindMethod, ParentID: &parentID, LineStart: 1, LineEnd: 2,
+	})
+	if err != nil {
+		t.Fatalf("WriteSymbol child: %v", err)
+	}
+	return parentID, childID
+}

--- a/internal/sqlite/reads.go
+++ b/internal/sqlite/reads.go
@@ -183,6 +183,50 @@ func (a *Adapter) Query(ctx context.Context, f index.Filter) ([]model.Symbol, er
 	return out, nil
 }
 
+// ContainerRef is one container-kind symbol (class, module, interface,
+// type) as loaded for parent-link resolution. Path is the symbol's file
+// path (empty when the file row is missing); Line is its line_start. Both
+// feed the content-derived tiebreak in the scan layer's pickParent.
+type ContainerRef struct {
+	ID        int64
+	Qualified string
+	FileID    int64
+	Path      string
+	Line      int
+}
+
+// ContainerRefs returns every container-kind symbol with its file path,
+// for the parent-link finalize pass. The kind set is fixed — the one
+// caller resolves method/nested-symbol parents, which extractors only
+// ever point at these four kinds. The full-key ORDER BY keeps the result
+// deterministic; callers must still not depend on relative order across
+// scans (ids are history-dependent).
+func (a *Adapter) ContainerRefs(ctx context.Context) ([]ContainerRef, error) {
+	const q = `SELECT s.id, s.qualified, s.file_id, COALESCE(f.path, ''), s.line_start
+		FROM sense_symbols s
+		LEFT JOIN sense_files f ON f.id = s.file_id
+		WHERE s.kind IN ('class', 'module', 'interface', 'type')
+		ORDER BY s.qualified ASC, COALESCE(f.path, '') ASC, s.line_start ASC, s.id ASC`
+	rows, err := a.db.QueryContext(ctx, q)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite ContainerRefs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var refs []ContainerRef
+	for rows.Next() {
+		var r ContainerRef
+		if err := rows.Scan(&r.ID, &r.Qualified, &r.FileID, &r.Path, &r.Line); err != nil {
+			return nil, fmt.Errorf("sqlite ContainerRefs scan: %w", err)
+		}
+		refs = append(refs, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("sqlite ContainerRefs iterate: %w", err)
+	}
+	return refs, nil
+}
+
 // SymbolRefs returns every symbol's (id, qualified, file_id, receiver,
 // language) ordered by ascending id. It exists so resolution passes that build
 // an in-memory qualified-name index can avoid hydrating Snippet / Docstring /

--- a/internal/sqlite/scan_errors_test.go
+++ b/internal/sqlite/scan_errors_test.go
@@ -123,6 +123,46 @@ func TestLoadEdgesScanError(t *testing.T) {
 
 // --- query errors: a closed handle surfaces the QueryContext error path. ---
 
+// A closed handle fails ContainerRefs at QueryContext; a corrupt line_start
+// on a container row fails its row scan. Together they pin the parent-link
+// pass's read against both sqlite failure shapes.
+func TestContainerRefsQueryErrorOnClosedDB(t *testing.T) {
+	ctx := context.Background()
+	a := closedSeededAdapter(t, nil)
+	if _, err := a.ContainerRefs(ctx); err == nil {
+		t.Error("expected error from ContainerRefs on closed DB")
+	}
+}
+
+func TestContainerRefsScanError(t *testing.T) {
+	a := openTestDB(t)
+	ctx := context.Background()
+
+	fid := seedFile(t, a, "kv.go", "go", "h1")
+	classID := seedSymbol(t, a, fid, "Store", "mvcc.Store", "class")
+	corruptColumn(t, a, "sense_symbols", "line_start", classID)
+
+	if _, err := a.ContainerRefs(ctx); err == nil {
+		t.Error("expected scan error from ContainerRefs, got nil")
+	}
+}
+
+func TestParentWritesErrorOnClosedDB(t *testing.T) {
+	ctx := context.Background()
+	a := closedSeededAdapter(t, nil)
+
+	t.Run("UpdateSymbolParent", func(t *testing.T) {
+		if err := a.UpdateSymbolParent(ctx, 1, 2); err == nil {
+			t.Error("expected error from UpdateSymbolParent on closed DB")
+		}
+	})
+	t.Run("DeleteFileDetach", func(t *testing.T) {
+		if err := a.DeleteFile(ctx, "a.go"); err == nil {
+			t.Error("expected error from DeleteFile detach on closed DB")
+		}
+	})
+}
+
 func TestKeySymbolsQueryErrorsOnClosedDB(t *testing.T) {
 	ctx := context.Background()
 	a := closedSeededAdapter(t, nil)

--- a/internal/sqlite/writes.go
+++ b/internal/sqlite/writes.go
@@ -10,7 +10,25 @@ import (
 )
 
 // DeleteFile removes a file and (via FK CASCADE) its symbols from the index.
+// Children in OTHER files that hold a parent_id into the doomed symbols are
+// detached first: parent_id carries no ON DELETE action, so the cascade
+// would otherwise trip the foreign key. Detached children re-link when
+// their own file is next scanned, or on a full rebuild. When a schema bump
+// happens for any other reason, parent_id gains ON DELETE SET NULL and this
+// detach retires. The two statements are not wrapped in a transaction here
+// (InTx is raw BEGIN/COMMIT on the shared connection and callers may
+// already hold one); a crash between them leaves detached children with a
+// live parent — benign, it heals like any orphan.
 func (a *Adapter) DeleteFile(ctx context.Context, path string) error {
+	const detach = `
+		UPDATE sense_symbols SET parent_id = NULL
+		WHERE parent_id IN (
+			SELECT s.id FROM sense_symbols s
+			JOIN sense_files f ON f.id = s.file_id
+			WHERE f.path = ?)`
+	if _, err := a.db.ExecContext(ctx, detach, path); err != nil {
+		return fmt.Errorf("sqlite DeleteFile detach: %w", err)
+	}
 	_, err := a.db.ExecContext(ctx, "DELETE FROM sense_files WHERE path = ?", path)
 	if err != nil {
 		return fmt.Errorf("sqlite DeleteFile: %w", err)
@@ -186,6 +204,17 @@ func ExecEdgeStmt(ctx context.Context, stmt *sql.Stmt, e *model.Edge) (int64, er
 		return 0, fmt.Errorf("sqlite WriteEdge (prepared): %w", err)
 	}
 	return id, nil
+}
+
+// UpdateSymbolParent sets a symbol's parent_id. Used by the scan layer's
+// parent-link finalize pass; call inside a transaction when batching.
+func (a *Adapter) UpdateSymbolParent(ctx context.Context, symbolID, parentID int64) error {
+	_, err := a.db.ExecContext(ctx,
+		"UPDATE sense_symbols SET parent_id = ? WHERE id = ?", parentID, symbolID)
+	if err != nil {
+		return fmt.Errorf("sqlite UpdateSymbolParent: %w", err)
+	}
+	return nil
 }
 
 // WriteMeta upserts a key-value pair into sense_meta.


### PR DESCRIPTION
## The defect (G-6)

Methods declared in a different file than their receiver type carried `parent_id = NULL`: `writeFileInner` resolved `ParentQualified` only through its per-file map, and parents were the one linkage without a global finalize pass (edges have `resolveAndWriteEdges`). Every measured index had **zero** cross-file method→parent links — etcd alone had 105 orphans (`mvcc.store.Read` in `kvstore_txn.go` vs `kvstore.go`, a core Go idiom). Consequences: satisfaction blind on multi-file types (`mvcc.KV` = 0 implementors), depressed `graph called_by`, and a third of measured Go hub candidates unmeasurable.

## The fix

Mirrors the edge pattern: `writeFileInner` buffers unresolved parents; a `resolvePhase` leg drains them after the walk in **both** the full and incremental pipelines (the incremental leg is load-bearing — the symbol upsert clobbers `parent_id` on every rescan of a child's file).

- **Binding rule** (pure `pickParent`, table-tested): exact qualified match → same file → same directory → nothing. Cross-directory binds are refused: Go qualified names are package-name based, and Rust impl qualified names carry no path component — a cross-directory match is a different type sharing a name. Lexically-scoped languages (Ruby, Python) never emit cross-file parents, verified against extractor sources.
- **Determinism by construction**: ties break on (path, line) — content-derived; the id key is provably confined to identical declaration sites by the `(file_id, qualified)` + path uniqueness constraints. 20 alternating rescans: zero diffs.
- **FK safety**: `parent_id` has no ON DELETE action, so `DeleteFile` now detaches cross-file children first (covers all delete paths at the choke point). Rollbacks in both write paths truncate the pending buffers — a stale entry would mislink on SQLite rowid reuse (mutation-tested: deleting either truncate fails its test).
- **Staleness signal**: full-write scans stamp `parent_linkage` in `sense_meta`; `sense status` reports degraded with a rebuild hint when the stamp is absent — gated on languages that can carry the defect (go, rust), so a pure-Ruby index is never told to rebuild for nothing. A plain rescan skips unchanged files and cannot backfill; healing an existing index requires `sense scan -rebuild`.

## Acceptance (rebuilt indexes, this branch's binary)

| Index | Orphans | Cross-file links | Cross-dir binds | Notes |
|---|---|---|---|---|
| etcd | 105 → 5 | 0 → 100 | 0 | the 5 = parents in unindexed generated `.pb.go` (honest misses); `mvcc.KV` 0 → 3 implementors |
| gitea | 306 → 0 | 0 → 306 | 0 | build-tag twins: own-file methods bind same-file; shared-file methods glue deterministically to the path-smallest twin |
| maket (ruby) | 38 → 38 | 0 | — | unchanged, as designed |
| healthchecks (python) | 0 → 0 | 0 | — | unchanged |
| rust (synthetic) | — | impl healed | — | cross-file `impl` now links |

Cross-vertical side-effect runs (sense arm, fresh indexes, scratch results): llm.rb cited-recall **0.4815** (frozen band 0.444–0.518), healthchecks **1.0** (= frozen), grounding 1.0 both, zero hallucinated citations.

Gates: `make ci` green, coverage 95.2%+ total (touched files ≥94%; scan.go 92.6% under the diff-only rule for large pre-existing files), complexity ledger 0, qlty clean, smoke green.

## Notes for release

Scan-layer change → indexes heal on their next `sense scan -rebuild` (release note; `sense status` self-signals). Version bumps to v1.11.22.