### PR TITLE
fix(scan): refuse bare-identifier call binds to methods (Go, Rust)

### DIFF
--- a/internal/cli/blast.go
+++ b/internal/cli/blast.go
@@ -195,12 +195,15 @@ func runBlastSymbol(cio IO, opts blastOptions) int {
 	}
 	defer func() { _ = adapter.Close() }()
 
-	matches, err := Lookup(ctx, adapter.DB(), opts.Symbol)
+	// --file constrains resolution inside the tier cascade (the MCP path):
+	// a lower-tier match in the pinned file beats a higher-tier match
+	// elsewhere. --language has no in-cascade variant and filters after.
+	matches, err := LookupInFile(ctx, adapter.DB(), opts.Symbol, opts.File)
 	if err != nil {
 		_, _ = fmt.Fprintln(cio.Stderr, "sense blast:", err)
 		return ExitGeneralError
 	}
-	matches = FilterMatches(matches, opts.File, opts.Language)
+	matches = FilterMatches(matches, "", opts.Language)
 	switch len(matches) {
 	case 0:
 		PrintNotFound(cio.Stderr, opts.Symbol)

--- a/internal/cli/graph.go
+++ b/internal/cli/graph.go
@@ -99,12 +99,15 @@ func RunGraph(args []string, cio IO) int {
 	}
 	defer func() { _ = adapter.Close() }()
 
-	matches, err := Lookup(ctx, adapter.DB(), opts.Symbol)
+	// --file constrains resolution inside the tier cascade (the MCP path):
+	// a lower-tier match in the pinned file beats a higher-tier match
+	// elsewhere. --language has no in-cascade variant and filters after.
+	matches, err := LookupInFile(ctx, adapter.DB(), opts.Symbol, opts.File)
 	if err != nil {
 		_, _ = fmt.Fprintln(cio.Stderr, "sense graph:", err)
 		return ExitGeneralError
 	}
-	matches = FilterMatches(matches, opts.File, opts.Language)
+	matches = FilterMatches(matches, "", opts.Language)
 	switch len(matches) {
 	case 0:
 		PrintNotFound(cio.Stderr, opts.Symbol)

--- a/internal/cli/lookup.go
+++ b/internal/cli/lookup.go
@@ -50,8 +50,20 @@ type Match struct {
 //
 // Each match carries a Resolution field indicating which tier
 // produced it. Later tiers are only consulted when all earlier tiers
-// come up empty. Suffix and containment tiers require query length
-// ≥ 3 (likeMinQueryLen).
+// come up empty — with one exception: a QUALIFIER-FREE query (no
+// `.`/`::`/`#`) that hits tier 1 also consults tier 2, because such a
+// hit is only possible on a symbol whose qualified name IS its bare
+// name (a no-package top-level, e.g. a frontend TS type), and letting
+// it win silently shadowed every same-named qualified symbol — blast
+// answered "0 affected" for a repo's central hub while the real one
+// sat one tier down. When tier 2 adds candidates the union returns as
+// an ambiguous set for disambiguation, stamped uniformly ResExactName
+// (callers read matches[0].Resolution) with the exact-qualified hit
+// first; cross-language candidates are intentionally LISTED, never
+// ranked away — a "helpful" language heuristic here would reintroduce
+// the silent pick from the other side. When tier 2 adds nothing the
+// tier-1 hit resolves exactly as before. Suffix and containment tiers
+// require query length ≥ 3 (likeMinQueryLen).
 //
 // Caller contract:
 //   - len(matches) == 0 → not-found; render "no symbol" message
@@ -100,10 +112,55 @@ func lookupCascade(ctx context.Context, db *sql.DB, query, file string) ([]Match
 		}
 		matches = FilterMatches(matches, file, "")
 		if len(matches) > 0 {
+			if t.res == ResExactQualified && !hasQualifierSeparator(query) {
+				union, err := mergeBareNameTier(ctx, db, query, file, matches)
+				if err != nil {
+					return nil, err
+				}
+				if len(union) > len(matches) {
+					return setResolution(union, ResExactName), nil
+				}
+			}
 			return setResolution(matches, t.res), nil
 		}
 	}
 	return nil, nil
+}
+
+// hasQualifierSeparator reports whether a query names a namespace or
+// receiver (`app.User`, `Admin::User`, `Greeter#hello`). Queries without
+// one are bare names, where an exact-qualified hit can only be a
+// no-package symbol and must not shadow same-named qualified candidates.
+// Synthetic qualified names (`route:users`) test as bare here; the merge
+// is a superset union, so they keep resolving through their tier-1 hit.
+func hasQualifierSeparator(query string) bool {
+	return strings.ContainsAny(query, ".#") || strings.Contains(query, "::")
+}
+
+// mergeBareNameTier unions a bare query's exact-qualified hits with the
+// exact-name tier's candidates (the same file constraint applied), the
+// tier-1 hits first, deduplicated by symbol id. For a separator-free query
+// tier 1 is normally a subset of tier 2 (`qualified == name`); the by-id
+// merge is a guard for stores that break that invariant.
+func mergeBareNameTier(ctx context.Context, db *sql.DB, query, file string, exact []Match) ([]Match, error) {
+	byName, err := lookupByName(ctx, db, query)
+	if err != nil {
+		return nil, err
+	}
+	byName = FilterMatches(byName, file, "")
+	seen := make(map[int64]bool, len(exact))
+	union := make([]Match, 0, len(exact)+len(byName))
+	for _, m := range exact {
+		seen[m.ID] = true
+		union = append(union, m)
+	}
+	for _, m := range byName {
+		if !seen[m.ID] {
+			seen[m.ID] = true
+			union = append(union, m)
+		}
+	}
+	return union, nil
 }
 
 func setResolution(matches []Match, r Resolution) []Match {

--- a/internal/cli/lookup_bare_capture_test.go
+++ b/internal/cli/lookup_bare_capture_test.go
@@ -1,0 +1,172 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// seedCaptureDB is the G-9 collision fixture at the Lookup level: a frontend
+// TypeScript type whose qualified name IS its bare name ("Issue") shadowing
+// same-named backend symbols, plus "Widget" as the unique-name control.
+func seedCaptureDB(t *testing.T) *sql.DB {
+	t.Helper()
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(t.TempDir(), "index.db"))
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	files := []model.File{
+		{Path: "web_src/js/types.ts", Language: "typescript", Hash: "a", IndexedAt: time.Now()},
+		{Path: "models/issues/issue.go", Language: "go", Hash: "b", IndexedAt: time.Now()},
+		{Path: "modules/migration/issue.go", Language: "go", Hash: "c", IndexedAt: time.Now()},
+	}
+	fids := make([]int64, len(files))
+	for i := range files {
+		id, werr := adapter.WriteFile(ctx, &files[i])
+		if werr != nil {
+			t.Fatalf("WriteFile: %v", werr)
+		}
+		fids[i] = id
+	}
+	syms := []model.Symbol{
+		{FileID: fids[0], Name: "Issue", Qualified: "Issue", Kind: "type", LineStart: 38, LineEnd: 55},
+		{FileID: fids[0], Name: "Widget", Qualified: "Widget", Kind: "type", LineStart: 60, LineEnd: 70},
+		{FileID: fids[1], Name: "Issue", Qualified: "issues.Issue", Kind: "class", LineStart: 54, LineEnd: 120},
+		{FileID: fids[2], Name: "Issue", Qualified: "migration.Issue", Kind: "class", LineStart: 10, LineEnd: 40},
+	}
+	for i := range syms {
+		if _, werr := adapter.WriteSymbol(ctx, &syms[i]); werr != nil {
+			t.Fatalf("WriteSymbol: %v", werr)
+		}
+	}
+	return adapter.DB()
+}
+
+// The G-9 defect: a bare query exact-matching a no-package symbol at tier 1
+// silently shadowed every same-named qualified symbol — blast then answered
+// "0 affected, risk low" for a repo's central hub. A bare query with
+// same-named siblings must surface the whole collision for disambiguation.
+func TestLookupBareNameNotCapturedByTopLevelSymbol(t *testing.T) {
+	db := seedCaptureDB(t)
+	matches, err := Lookup(context.Background(), db, "Issue")
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	if len(matches) != 3 {
+		t.Fatalf("want all 3 same-named candidates, got %d: %+v", len(matches), matches)
+	}
+	// The exact-qualified hit ranks first; the set is stamped uniformly
+	// with the tier that made it ambiguous (callers read matches[0].Resolution).
+	if matches[0].Qualified != "Issue" {
+		t.Errorf("matches[0] = %q, want the exact-qualified hit first", matches[0].Qualified)
+	}
+	for _, m := range matches {
+		if m.Resolution != ResExactName {
+			t.Errorf("%s Resolution = %q, want uniform %q", m.Qualified, m.Resolution, ResExactName)
+		}
+	}
+	seen := map[string]bool{}
+	for _, m := range matches {
+		seen[m.Qualified] = true
+	}
+	if !seen["issues.Issue"] || !seen["migration.Issue"] {
+		t.Errorf("union must include the shadowed qualified symbols, got %+v", matches)
+	}
+}
+
+// Unique-name control: when the name tier adds nothing beyond the tier-1
+// hit, the query resolves exactly as before — one match, ResExactQualified.
+func TestLookupBareUniqueNameKeepsExactQualified(t *testing.T) {
+	db := seedCaptureDB(t)
+	matches, err := Lookup(context.Background(), db, "Widget")
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("want 1 match, got %d: %+v", len(matches), matches)
+	}
+	if matches[0].Resolution != ResExactQualified {
+		t.Errorf("Resolution = %q, want %q (tier 2 added nothing)", matches[0].Resolution, ResExactQualified)
+	}
+}
+
+// A query with a qualifier separator is untouched by the bare-query rule.
+func TestLookupSeparatorQueryUntouchedByCaptureFix(t *testing.T) {
+	db := seedCaptureDB(t)
+	matches, err := Lookup(context.Background(), db, "issues.Issue")
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	if len(matches) != 1 || matches[0].Qualified != "issues.Issue" {
+		t.Fatalf("want the single exact-qualified match, got %+v", matches)
+	}
+	if matches[0].Resolution != ResExactQualified {
+		t.Errorf("Resolution = %q, want %q", matches[0].Resolution, ResExactQualified)
+	}
+}
+
+// The file pin still suppresses cross-file additions: pinned to the TS file
+// the bare query resolves to the TS symbol alone, pinned to the Go file it
+// resolves to the Go hub alone — no union across the pin.
+func TestLookupInFileBareQueryHonorsPin(t *testing.T) {
+	db := seedCaptureDB(t)
+	ctx := context.Background()
+
+	matches, err := LookupInFile(ctx, db, "Issue", "types.ts")
+	if err != nil {
+		t.Fatalf("LookupInFile: %v", err)
+	}
+	if len(matches) != 1 || matches[0].Qualified != "Issue" {
+		t.Fatalf("pin types.ts: want the TS Issue alone, got %+v", matches)
+	}
+
+	matches, err = LookupInFile(ctx, db, "Issue", "models/issues/issue.go")
+	if err != nil {
+		t.Fatalf("LookupInFile: %v", err)
+	}
+	if len(matches) != 1 || matches[0].Qualified != "issues.Issue" {
+		t.Fatalf("pin issue.go: want issues.Issue alone, got %+v", matches)
+	}
+}
+
+// Synthetic qualified names (route:orders_path, django-related:addons) carry
+// a single colon, which is NOT a qualifier separator — they must stay bare
+// and keep resolving through their tier-1 exact-qualified hit (the name
+// column holds the same string, so the merge adds nothing). Pins the
+// separator set against a future "helpful" addition of ':'.
+func TestLookupSyntheticColonNameKeepsTierOne(t *testing.T) {
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(t.TempDir(), "index.db"))
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	fid, err := adapter.WriteFile(ctx, &model.File{Path: "config/routes.rb", Language: "ruby", Hash: "a", IndexedAt: time.Now()})
+	if err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err := adapter.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid, Name: "orders_path", Qualified: "route:orders_path", Kind: "method", LineStart: 3, LineEnd: 3,
+	}); err != nil {
+		t.Fatalf("WriteSymbol: %v", err)
+	}
+
+	matches, err := Lookup(ctx, adapter.DB(), "route:orders_path")
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	if len(matches) != 1 || matches[0].Qualified != "route:orders_path" {
+		t.Fatalf("want the synthetic tier-1 match, got %+v", matches)
+	}
+	if matches[0].Resolution != ResExactQualified {
+		t.Errorf("Resolution = %q, want %q", matches[0].Resolution, ResExactQualified)
+	}
+}

--- a/internal/cli/lookup_file_flag_test.go
+++ b/internal/cli/lookup_file_flag_test.go
@@ -1,0 +1,147 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// seedCaptureProject reproduces the gitea Issue collision (G-9): a frontend
+// TypeScript type whose qualified name IS its bare name, shadowing same-named
+// backend symbols. Returns a project dir with .sense/index.db.
+func seedCaptureProject(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	files := []model.File{
+		{Path: "web_src/js/types.ts", Language: "typescript", Hash: "a", IndexedAt: time.Now()},
+		{Path: "models/issues/issue.go", Language: "go", Hash: "b", IndexedAt: time.Now()},
+		{Path: "modules/migration/issue.go", Language: "go", Hash: "c", IndexedAt: time.Now()},
+	}
+	fids := make([]int64, len(files))
+	for i := range files {
+		id, werr := adapter.WriteFile(ctx, &files[i])
+		if werr != nil {
+			t.Fatalf("WriteFile: %v", werr)
+		}
+		fids[i] = id
+	}
+	syms := []model.Symbol{
+		{FileID: fids[0], Name: "Issue", Qualified: "Issue", Kind: "type", LineStart: 38, LineEnd: 55},
+		{FileID: fids[1], Name: "Issue", Qualified: "issues.Issue", Kind: "class", LineStart: 54, LineEnd: 120},
+		{FileID: fids[2], Name: "Issue", Qualified: "migration.Issue", Kind: "class", LineStart: 10, LineEnd: 40},
+	}
+	for i := range syms {
+		if _, werr := adapter.WriteSymbol(ctx, &syms[i]); werr != nil {
+			t.Fatalf("WriteSymbol: %v", werr)
+		}
+	}
+	return dir
+}
+
+// The CLI --file flag must constrain resolution INSIDE the tier cascade (the
+// MCP path), not filter after tier 1 already picked the capture. Today the
+// post-hoc filter empties tier 1's TS match and answers "No symbol matches"
+// for a symbol that is exactly where the flag points.
+func TestRunBlastFileFlagReachesLowerTier(t *testing.T) {
+	dir := seedCaptureProject(t)
+	var stdout, stderr bytes.Buffer
+	code := RunBlast([]string{"Issue", "--file", "models/issues/issue.go", "--json"},
+		IO{Stdout: &stdout, Stderr: &stderr, Dir: dir})
+	if code != ExitSuccess {
+		t.Fatalf("exit = %d, want %d; stderr: %s", code, ExitSuccess, stderr.String())
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("issues.Issue")) {
+		t.Errorf("stdout should name issues.Issue, got: %s", stdout.String())
+	}
+}
+
+func TestRunGraphFileFlagReachesLowerTier(t *testing.T) {
+	dir := seedCaptureProject(t)
+	var stdout, stderr bytes.Buffer
+	code := RunGraph([]string{"Issue", "--file", "models/issues/issue.go", "--json"},
+		IO{Stdout: &stdout, Stderr: &stderr, Dir: dir})
+	if code != ExitSuccess {
+		t.Fatalf("exit = %d, want %d; stderr: %s", code, ExitSuccess, stderr.String())
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("issues.Issue")) {
+		t.Errorf("stdout should name issues.Issue, got: %s", stdout.String())
+	}
+}
+
+// The --language filter has no in-cascade variant and stays post-hoc; pin
+// that it still narrows the (now cascade-resolved) match set.
+func TestRunBlastLanguageFlagStillFilters(t *testing.T) {
+	dir := seedCaptureProject(t)
+	var stdout, stderr bytes.Buffer
+	code := RunBlast([]string{"issues.Issue", "--language", "go", "--json"},
+		IO{Stdout: &stdout, Stderr: &stderr, Dir: dir})
+	if code != ExitSuccess {
+		t.Fatalf("exit = %d, want %d; stderr: %s", code, ExitSuccess, stderr.String())
+	}
+}
+
+// Killer for the M5 survivor: the pinned symbol is only reachable at the
+// SUFFIX tier, so commit 2's bare-name union cannot mask commit 1's
+// in-cascade --file wiring. Query has a separator (no merge path at all).
+func TestRunBlastFileFlagReachesSuffixTier(t *testing.T) {
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	files := []model.File{
+		{Path: "models/issues/issue.go", Language: "go", Hash: "a", IndexedAt: time.Now()},
+		{Path: "services/issue.go", Language: "go", Hash: "b", IndexedAt: time.Now()},
+	}
+	fids := make([]int64, len(files))
+	for i := range files {
+		id, werr := adapter.WriteFile(ctx, &files[i])
+		if werr != nil {
+			t.Fatalf("WriteFile: %v", werr)
+		}
+		fids[i] = id
+	}
+	syms := []model.Symbol{
+		{FileID: fids[0], Name: "Issue", Qualified: "issues.Issue", Kind: "class", LineStart: 54, LineEnd: 120},
+		{FileID: fids[1], Name: "Issue", Qualified: "services.issues.Issue", Kind: "class", LineStart: 10, LineEnd: 40},
+	}
+	for i := range syms {
+		if _, werr := adapter.WriteSymbol(ctx, &syms[i]); werr != nil {
+			t.Fatalf("WriteSymbol: %v", werr)
+		}
+	}
+	_ = adapter.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := RunBlast([]string{"issues.Issue", "--file", "services/issue.go", "--json"},
+		IO{Stdout: &stdout, Stderr: &stderr, Dir: dir})
+	if code != ExitSuccess {
+		t.Fatalf("exit = %d, want %d; stderr: %s", code, ExitSuccess, stderr.String())
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("services.issues.Issue")) {
+		t.Errorf("stdout should name services.issues.Issue, got: %s", stdout.String())
+	}
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -193,6 +193,21 @@ func computeHealth(ctx context.Context, db *sql.DB, dir string, resp mcpio.Statu
 		}
 	}
 
+	// The bare_call_binds stamp mirrors parent_linkage for the bare-call
+	// resolution fix (bare identifier calls binding same-named methods, a
+	// grammar impossibility in Go/Rust): absence means the edges were
+	// resolved by a pre-fix binary and the fabricated binds persist until a
+	// rebuild rewrites every file. Same language gate — lexically-scoped
+	// indexes have nothing to heal.
+	if resp.Index.Symbols > 0 && readMeta(ctx, db, "bare_call_binds") == "" && hasCrossFileParentLanguage(ctx, db) {
+		if h.verdict == "healthy" {
+			h.verdict = "degraded"
+		}
+		if h.detail == "" {
+			h.detail = "index predates the bare-call resolution fix — run 'sense scan --rebuild'"
+		}
+	}
+
 	return h
 }
 

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -139,6 +139,50 @@ func TestComputeHealthEmbeddingModelMismatch(t *testing.T) {
 	}
 }
 
+func TestComputeHealthBareCallBindsStamp(t *testing.T) {
+	ctx := context.Background()
+	db := healthTestDB(t)
+	_, _ = db.ExecContext(ctx, `CREATE TABLE sense_meta (key TEXT PRIMARY KEY, value TEXT)`)
+	// Same language gate as parent_linkage: only Go/Rust grammars forbid
+	// bare-call method binds, so only their indexes carry the defect.
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_files VALUES (1, 'a.go', 'go', 'abc', 1, '2026-01-01T00:00:00Z')`)
+	// Keep the parent-linkage branch quiet so this test observes its own.
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('parent_linkage', '1')`)
+
+	resp := mcpio.StatusResponse{
+		Version: &mcpio.StatusVersion{SchemaCurrent: true, EmbeddingModelCurrent: true},
+	}
+	resp.Index.Symbols = 5
+	resp.Index.Embeddings = 5
+
+	// No stamp: the index predates the bare-call resolution fix and keeps
+	// its fabricated bare→method edges until a rebuild rewrites every file.
+	h := computeHealth(ctx, db, t.TempDir(), resp)
+	if h.verdict != "degraded" {
+		t.Errorf("verdict = %q without bare_call_binds stamp, want degraded", h.verdict)
+	}
+	if h.detail != "index predates the bare-call resolution fix — run 'sense scan --rebuild'" {
+		t.Errorf("detail = %q, want bare-call message", h.detail)
+	}
+
+	// Stamped: healthy again.
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('bare_call_binds', '1')`)
+	h = computeHealth(ctx, db, t.TempDir(), resp)
+	if h.verdict != "healthy" {
+		t.Errorf("verdict = %q with stamp, want healthy", h.verdict)
+	}
+
+	// A pure lexically-scoped index (no Go/Rust files) cannot carry the
+	// defect: no advisory, no wasted rebuild.
+	resp.Index.Symbols = 5
+	_, _ = db.ExecContext(ctx, `DELETE FROM sense_meta WHERE key = 'bare_call_binds'`)
+	_, _ = db.ExecContext(ctx, `UPDATE sense_files SET language = 'ruby', path = 'a.rb'`)
+	h = computeHealth(ctx, db, t.TempDir(), resp)
+	if h.verdict != "healthy" {
+		t.Errorf("verdict = %q on ruby-only index without stamp, want healthy", h.verdict)
+	}
+}
+
 func TestComputeHealthParentLinkageStamp(t *testing.T) {
 	ctx := context.Background()
 	db := healthTestDB(t)
@@ -162,8 +206,10 @@ func TestComputeHealthParentLinkageStamp(t *testing.T) {
 		t.Errorf("detail = %q, want parent-linkage message", h.detail)
 	}
 
-	// Stamped: healthy again.
+	// Stamped: healthy again (bare_call_binds seeded too — it is an
+	// independent full-write stamp with its own advisory branch).
 	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('parent_linkage', '1')`)
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('bare_call_binds', '1')`)
 	h = computeHealth(ctx, db, t.TempDir(), resp)
 	if h.verdict != "healthy" {
 		t.Errorf("verdict = %q with stamp, want healthy", h.verdict)

--- a/internal/extract/golang/golang.go
+++ b/internal/extract/golang/golang.go
@@ -585,6 +585,15 @@ func (w *walker) emitCall(call *sitter.Node, source string, types map[string]loc
 	switch fn.Kind() {
 	case "identifier":
 		target = extract.Text(fn, w.source)
+		// A bare call through a local binding (closure, func param, method
+		// value) cannot statically reach an indexed symbol — the local
+		// shadows package scope, so a same-named match downstream is always
+		// a coincidence (the emitConstRefs precedent, minus goBuiltins:
+		// builtin names stay because a package-block `func min` shadows the
+		// builtin and its bare calls are real edges).
+		if locals[target] {
+			return nil
+		}
 	case "selector_expression":
 		target, confidence = w.resolveSelector(fn, types, locals)
 	default:

--- a/internal/extract/golang/typeinfer.go
+++ b/internal/extract/golang/typeinfer.go
@@ -87,16 +87,19 @@ func (w *walker) collectParamTypes(params *sitter.Node, types map[string]localTy
 		if pd == nil || pd.Kind() != "parameter_declaration" {
 			continue
 		}
+		// A parameter is a local binding whatever its type — record it even
+		// when the type doesn't unwrap to a name (func-typed params are the
+		// closure carriers behind G-10's bare-call false binds). The type
+		// map entry still requires a resolved name.
 		typeName, elemName := resolveTypeAndElem(pd.ChildByFieldName("type"), w.source)
-		if typeName == "" && elemName == "" {
-			continue
-		}
 		for j := uint(0); j < pd.NamedChildCount(); j++ {
 			ch := pd.NamedChild(j)
 			if ch.Kind() == "identifier" {
 				name := extract.Text(ch, w.source)
-				types[name] = localType{typeName, elemName, extract.ConfidenceStatic}
 				locals[name] = true
+				if typeName != "" || elemName != "" {
+					types[name] = localType{typeName, elemName, extract.ConfidenceStatic}
+				}
 			}
 		}
 	}

--- a/internal/extract/golang/walker_edges_test.go
+++ b/internal/extract/golang/walker_edges_test.go
@@ -109,3 +109,47 @@ func Run() {
 		t.Error("missing calls edge svc.Run -> log.Printf")
 	}
 }
+
+func TestBareCallToLocalEmitsNoEdge(t *testing.T) {
+	// A bare call through a local binding (closure, func param, method value)
+	// can never statically reach an indexed symbol — the local shadows
+	// package scope. Emitting it produced G-10-class false binds
+	// (`release()` from `x, release := acquire()` landing on a same-named
+	// method elsewhere).
+	r := parse(t, `package svc
+
+func Run(handle func()) {
+	release := acquire()
+	handle()
+	release()
+}
+`)
+	if e := findEdge(r, "svc.Run", "handle", "calls"); e != nil {
+		t.Error("bare call to a func param must not emit an edge")
+	}
+	if e := findEdge(r, "svc.Run", "release", "calls"); e != nil {
+		t.Error("bare call to a local binding must not emit an edge")
+	}
+	// The initializer call itself is a real package-scope call and stays.
+	if findEdge(r, "svc.Run", "acquire", "calls") == nil {
+		t.Error("missing calls edge svc.Run -> acquire (package-scope bare call)")
+	}
+}
+
+func TestConstReferenceSuppressedByParamShadow(t *testing.T) {
+	// A parameter shadows a same-named package binding for the whole body —
+	// including params whose type doesn't unwrap (func-typed), which the
+	// locals map now registers. No references edge may be emitted for the
+	// shadowed name.
+	r := parse(t, `package svc
+
+var Registry = newRegistry()
+
+func Run(Registry func()) {
+	_ = Registry
+}
+`)
+	if findEdge(r, "svc.Run", "svc.Registry", "references") != nil {
+		t.Error("references edge must be suppressed when a param shadows the package binding")
+	}
+}

--- a/internal/mcpserver/blast.go
+++ b/internal/mcpserver/blast.go
@@ -138,14 +138,12 @@ const disambiguationCap = 10
 // returns a resolveError whose result field carries a pre-built
 // *mcp.CallToolResult with structured JSON for the LLM.
 //
-// A non-empty fileHint is a hard constraint. It serves the same intent
-// as the CLI's --file flag but is deliberately stricter: the CLI
-// filters after the cascade picks a winning tier, while resolution here
-// applies the file filter inside each tier, so a lower-tier match in
-// the pinned file beats a higher-tier match elsewhere. When no tier
-// matches the file, the error names the constraint and lists where the
-// symbol does resolve — it never falls back to a conflicting cross-file
-// winner.
+// A non-empty fileHint is a hard constraint, applied inside each tier
+// of the cascade (the CLI's --file flag rides the same LookupInFile
+// path): a lower-tier match in the pinned file beats a higher-tier
+// match elsewhere. When no tier matches the file, the error names the
+// constraint and lists where the symbol does resolve — it never falls
+// back to a conflicting cross-file winner.
 func (h *handlers) resolveSymbol(ctx context.Context, tool, symbol, fileHint string) (cli.Match, error) {
 	if fileHint != "" {
 		matches, err := cli.LookupInFile(ctx, h.db, symbol, fileHint)

--- a/internal/model/symbol.go
+++ b/internal/model/symbol.go
@@ -53,8 +53,15 @@ type SymbolRef struct {
 	// Path is the symbol's file path (from sense_files). The resolver uses it to
 	// determine test-ness so a production-source calls/references edge cannot
 	// resolve into a test file (production never depends on test code). Empty
-	// when the file path is unknown, in which case that gate is a no-op.
+	// when the path is unknown, in which case that gate is a no-op.
 	Path string
+	// Kind mirrors Symbol.Kind. The resolver's unqualified fallback uses it to
+	// enforce per-language call grammar: in Go and Rust a bare identifier call
+	// can never be a method call (methods are only reachable through receiver
+	// or path expressions), so method-kind candidates are dropped for bare
+	// targets from those languages. Empty when unknown, in which case the
+	// gate is a no-op.
+	Kind SymbolKind
 }
 
 // HydrateSymbolNullables copies the sql.NullXxx carriers scanned from

--- a/internal/resolve/bare_call_test.go
+++ b/internal/resolve/bare_call_test.go
@@ -1,0 +1,188 @@
+package resolve_test
+
+import (
+	"testing"
+
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/resolve"
+)
+
+// bareCallRefs builds a minimal index for the bare-call grammar law: in Go and
+// Rust a bare identifier call can never be a method call, so a bare target
+// must never bind a method-kind symbol (G-10: pebble versionSet.append rode
+// builtin `append(...)` calls to 778 fabricated verified-band edges).
+//
+// File 10 is a Go production file, file 12 a Rust one, file 11 a Ruby one
+// (where bare calls ARE implicit-self method dispatch and must keep binding).
+func bareCallRefs() []model.SymbolRef {
+	return []model.SymbolRef{
+		{ID: 1, Qualified: "pebble.versionSet", FileID: 10, Language: "go", Path: "version_set.go", Kind: model.KindType},
+		{ID: 2, Qualified: "pebble.versionSet.append", FileID: 10, Language: "go", Path: "version_set.go", Kind: model.KindMethod},
+		{ID: 3, Qualified: "Greeter#hello", FileID: 11, Language: "ruby", Path: "greeter.rb", Kind: model.KindMethod},
+		{ID: 4, Qualified: "Buffer::len", FileID: 12, Language: "rust", Path: "buffer.rs", Kind: model.KindMethod},
+	}
+}
+
+// The defect itself: a bare Go call site (`append(x, y)`) emitted at static
+// confidence must NOT bind the same-named method. Today it resolves at 0.8.
+func TestResolveGoBareCallNeverBindsMethod(t *testing.T) {
+	ix := resolve.NewIndex(bareCallRefs())
+	_, ok := ix.Resolve(resolve.Request{
+		Target:         "append",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   10,
+		BaseConfidence: 1.0,
+	})
+	if ok {
+		t.Fatal("bare Go call bound a method symbol — illegal by Go grammar (methods need a receiver expression)")
+	}
+}
+
+// The positive Rust fixture the council required: the gate branch must be
+// observed firing, not assumed from grammar. Same law, same shape.
+func TestResolveRustBareCallNeverBindsMethod(t *testing.T) {
+	ix := resolve.NewIndex(bareCallRefs())
+	_, ok := ix.Resolve(resolve.Request{
+		Target:         "len",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   12,
+		BaseConfidence: 1.0,
+	})
+	if ok {
+		t.Fatal("bare Rust call bound a method symbol — illegal by Rust grammar (methods need a receiver or path)")
+	}
+}
+
+// Mutation guard: Ruby bare calls are implicit-self method dispatch — the
+// language gate must not leak. Kills the "drop the language gate" mutant.
+func TestResolveRubyBareCallStillBindsMethod(t *testing.T) {
+	ix := resolve.NewIndex(bareCallRefs())
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "hello",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   11,
+		BaseConfidence: 1.0,
+	})
+	if !ok {
+		t.Fatal("Ruby bare call must keep binding methods (implicit self is real dispatch)")
+	}
+	if r.SymbolID != 3 {
+		t.Errorf("SymbolID = %d, want 3", r.SymbolID)
+	}
+}
+
+// Mutation guard: a bare Go call to an indexed FUNCTION is the legitimate
+// case the fallback exists for. Kills the "drop all bare Go calls" mutant.
+func TestResolveGoBareCallKeepsFunctionBind(t *testing.T) {
+	rs := append(bareCallRefs(),
+		model.SymbolRef{ID: 5, Qualified: "pebble.makeRoom", FileID: 10, Language: "go", Path: "version_set.go", Kind: model.KindFunction},
+	)
+	ix := resolve.NewIndex(rs)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "makeRoom",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   10,
+		BaseConfidence: 1.0,
+	})
+	if !ok {
+		t.Fatal("bare Go call to an indexed function must resolve")
+	}
+	if r.SymbolID != 5 {
+		t.Errorf("SymbolID = %d, want 5", r.SymbolID)
+	}
+	if r.Confidence != 0.8 {
+		t.Errorf("Confidence = %v, want 0.8 (unqualified-fallback clamp)", r.Confidence)
+	}
+}
+
+// The promotion side effect, pinned on purpose (council: the fix PROMOTES as
+// well as deletes). Today {function, method} under one bare name is an
+// ambiguous set demoted below blast's floor; dropping the illegal method
+// leaves a unique function candidate at the fallback clamp. That is a
+// true-positive gain: the function was the only legal callee.
+func TestResolveGoBareCallMixedSetPromotesFunction(t *testing.T) {
+	rs := append(bareCallRefs(),
+		model.SymbolRef{ID: 5, Qualified: "pebble.run", FileID: 10, Language: "go", Path: "version_set.go", Kind: model.KindFunction},
+		model.SymbolRef{ID: 6, Qualified: "pebble.compaction.run", FileID: 13, Language: "go", Path: "compaction.go", Kind: model.KindMethod},
+	)
+	ix := resolve.NewIndex(rs)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "run",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   10,
+		BaseConfidence: 1.0,
+	})
+	if !ok {
+		t.Fatal("bare Go call must resolve to the function once the method is excluded")
+	}
+	if r.SymbolID != 5 {
+		t.Errorf("SymbolID = %d, want 5 (the function, not the method)", r.SymbolID)
+	}
+	if r.Confidence != 0.8 {
+		t.Errorf("Confidence = %v, want 0.8 (unique after the drop — promoted from the collision demotion)", r.Confidence)
+	}
+	if r.Ambiguous {
+		t.Error("Ambiguous = true, want false (the method was never a legal candidate)")
+	}
+}
+
+// Mutation guard: a DOTTED Go target leaf-falling to a method must stay
+// resolvable — this band carries real reach (gitea context.Base's embedded
+// dispatch edges). Kills the "drop the sep gate" mutant, which would wipe it.
+func TestResolveGoDottedLeafStillBindsMethod(t *testing.T) {
+	ix := resolve.NewIndex(bareCallRefs())
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "vs.append",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   10,
+		BaseConfidence: 1.0,
+	})
+	if !ok {
+		t.Fatal("dotted Go target must keep leaf-falling to the method (receiver-unknown band)")
+	}
+	if r.SymbolID != 2 {
+		t.Errorf("SymbolID = %d, want 2", r.SymbolID)
+	}
+}
+
+// Fail-open: an unknown source language must not drop method candidates —
+// the gate acts only on languages whose grammar proves the bind illegal.
+func TestResolveBareCallUnknownLanguageKeepsMethod(t *testing.T) {
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "Widget.render", FileID: 40, Kind: model.KindMethod},
+		{ID: 2, Qualified: "caller", FileID: 40},
+	}
+	ix := resolve.NewIndex(rs)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "render",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   40,
+		BaseConfidence: 1.0,
+	})
+	if !ok {
+		t.Fatal("unknown-language bare call must keep the method bind (fail-open)")
+	}
+	if r.SymbolID != 1 {
+		t.Errorf("SymbolID = %d, want 1", r.SymbolID)
+	}
+}
+
+// Mutation guard: a bare Go call to a TYPE (a conversion, `versionSet(x)`
+// shape) must stay resolvable — the drop is methods-only, never a
+// keep-functions whitelist. Kills the whitelist mutant that survives the
+// rest of the suite (types and constants are legal bare callees).
+func TestResolveGoBareCallKeepsTypeBind(t *testing.T) {
+	ix := resolve.NewIndex(bareCallRefs())
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "versionSet",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   10,
+		BaseConfidence: 1.0,
+	})
+	if !ok {
+		t.Fatal("bare Go call to an indexed type (conversion) must resolve")
+	}
+	if r.SymbolID != 1 {
+		t.Errorf("SymbolID = %d, want 1", r.SymbolID)
+	}
+}

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -399,6 +399,9 @@ func (ix *Index) resolveByLeaf(target string, req Request) (Result, bool) {
 	matches := ix.byName[name]
 	matches = filterByLanguage(matches, ix.fileLang[req.SourceFileID])
 	matches = filterByTestDirection(matches, ix.fileIsTest[req.SourceFileID], ix.fileIsTest)
+	if sep == "" && !bareCallBindsMethods(ix.fileLang[req.SourceFileID]) {
+		matches = filterOutMethods(matches)
+	}
 	matches, receiverContradicted := filterByReceiver(matches, sep)
 	if len(matches) == 0 {
 		return Result{}, false
@@ -704,6 +707,46 @@ func filterByLanguage(matches []model.SymbolRef, srcLang string) []model.SymbolR
 // ERB is the only such language today; add others here as they gain extractors.
 func isViewLanguage(lang string) bool {
 	return lang == "erb"
+}
+
+// bareCallBindsMethods reports whether a language's grammar allows a bare
+// identifier call to dispatch to a method. In Go and Rust it cannot: methods
+// are only reachable through a receiver or path expression (`x.m()`,
+// `Type::m(recv)`), and the extractors for both emit dotted/pathed targets on
+// every selector path, so a bare target is a genuinely bare call — builtins
+// (`append`, `len`), conversions (`int(…)`), functions, and local closures
+// are its only legal callees, none of which is a method symbol. Ruby's bare
+// calls ARE implicit-self method dispatch, so it (and any unknown language)
+// answers true and the gate fails open.
+func bareCallBindsMethods(lang string) bool {
+	return lang != "go" && lang != "rust"
+}
+
+// filterOutMethods drops method-kind candidates from a bare-target fallback
+// in languages where that bind is grammatically impossible (see
+// bareCallBindsMethods). Like filterByLanguage, a hard exclusion: an
+// all-method set empties and the edge drops to unresolved rather than
+// fabricating a verified-band bind (G-10: Go builtin `append(…)` calls rode
+// this path to 778 false edges on one repo). Candidates with an unknown kind
+// are kept, so the gate fails open.
+func filterOutMethods(matches []model.SymbolRef) []model.SymbolRef {
+	hasMethod := false
+	for _, m := range matches {
+		if m.Kind == model.KindMethod {
+			hasMethod = true
+			break
+		}
+	}
+	if !hasMethod {
+		return matches
+	}
+	kept := make([]model.SymbolRef, 0, len(matches))
+	for _, m := range matches {
+		if m.Kind != model.KindMethod {
+			kept = append(kept, m)
+		}
+	}
+	return kept
 }
 
 // filterByTestDirection drops candidates that live in a test file when the

--- a/internal/scan/bare_call_stamp_test.go
+++ b/internal/scan/bare_call_stamp_test.go
@@ -1,0 +1,61 @@
+package scan_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/luuuc/sense/internal/scan"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// TestScanStampsBareCallBindsMeta pins the staleness signal for the G-10
+// bare-call resolution fix: a fresh scan stamps bare_call_binds, a plain
+// rescan preserves it, and an index stripped of the stamp (one built by a
+// pre-fix binary, still carrying fabricated bare→method edges) is only
+// re-stamped by a full-write scan — a plain rescan of unchanged files
+// re-resolves nothing and must not claim healed.
+func TestScanStampsBareCallBindsMeta(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "kvstore.go"), storeTypeSrc)
+
+	if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := readMetaKey(t, root, "bare_call_binds"); got != "1" {
+		t.Fatalf("bare_call_binds = %q after fresh scan, want 1", got)
+	}
+
+	if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+		t.Fatalf("plain rescan: %v", err)
+	}
+	if got := readMetaKey(t, root, "bare_call_binds"); got != "1" {
+		t.Errorf("bare_call_binds = %q after plain rescan, want preserved 1", got)
+	}
+
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(root, ".sense", "index.db"))
+	if err != nil {
+		t.Fatalf("open index: %v", err)
+	}
+	if err := a.DeleteMeta(ctx, "bare_call_binds"); err != nil {
+		t.Fatalf("delete meta: %v", err)
+	}
+	_ = a.Close()
+
+	if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+		t.Fatalf("plain rescan on stripped index: %v", err)
+	}
+	if got := readMetaKey(t, root, "bare_call_binds"); got != "" {
+		t.Errorf("bare_call_binds = %q after plain rescan of unchanged files, want unstamped", got)
+	}
+
+	opts := quietOpts(root)
+	opts.Rebuild = true
+	if _, err := scan.Run(context.Background(), opts); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	if got := readMetaKey(t, root, "bare_call_binds"); got != "1" {
+		t.Errorf("bare_call_binds = %q after rebuild, want 1", got)
+	}
+}

--- a/internal/scan/oracle_test.go
+++ b/internal/scan/oracle_test.go
@@ -117,9 +117,9 @@ func oracleDigest(t *testing.T, dbPath string) (digest string, content []string)
 // leave it unchanged, and a refactor that alters derived output fails here
 // loudly. When output changes on purpose, regenerate it (see the capture line
 // in TestScanContentOracleDigest) and update this constant in the same commit.
-// Last regeneration: the parent_linkage meta stamp (cross-file parent
-// linkage) added one meta line; symbols/edges/embeddings unchanged.
-const oracleGolden = "abc968fbbbdcaac3e3ef4969a72ecb8762561edf0994e4ea8c8658525c726693"
+// Last regeneration: the bare_call_binds meta stamp (bare-call resolution
+// fix) added one meta line; symbols/edges/embeddings unchanged.
+const oracleGolden = "5e06add5beac2aa2888c81980018e9a25ebda9a18eed4d7168dc3e0e47307dcd"
 
 func TestScanContentOracleDigest(t *testing.T) {
 	useFakeEmbedder(t)

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -420,6 +420,13 @@ func finalizeScan(ctx context.Context, idx *sqlite.Adapter, h *harness, senseDir
 		if err := idx.WriteMeta(ctx, "parent_linkage", "1"); err != nil {
 			_, _ = fmt.Fprintf(h.warn, "warn: write parent_linkage: %v\n", err)
 		}
+		// bare_call_binds records that every edge was resolved by a binary
+		// that refuses bare-call→method binds (G-10). Same full-write gate:
+		// a plain rescan re-resolves only changed files, so a pre-fix
+		// index keeps its fabricated edges until a rebuild.
+		if err := idx.WriteMeta(ctx, "bare_call_binds", "1"); err != nil {
+			_, _ = fmt.Fprintf(h.warn, "warn: write bare_call_binds: %v\n", err)
+		}
 	}
 
 	if err := idx.StampSchemaVersion(ctx); err != nil {

--- a/internal/sqlite/reads.go
+++ b/internal/sqlite/reads.go
@@ -227,7 +227,7 @@ func (a *Adapter) ContainerRefs(ctx context.Context) ([]ContainerRef, error) {
 	return refs, nil
 }
 
-// SymbolRefs returns every symbol's (id, qualified, file_id, receiver,
+// SymbolRefs returns every symbol's (id, qualified, file_id, receiver, kind,
 // language) ordered by ascending id. It exists so resolution passes that build
 // an in-memory qualified-name index can avoid hydrating Snippet / Docstring /
 // Visibility fields that they immediately discard — about a 5× reduction in
@@ -235,9 +235,11 @@ func (a *Adapter) ContainerRefs(ctx context.Context) ([]ContainerRef, error) {
 // build multi-value maps without a follow-up sort: the first id under each key
 // is deterministically the earliest written. The language is left-joined from
 // sense_files so the resolver can gate cross-language bare-name matches; a
-// symbol whose file row is missing returns an empty language.
+// symbol whose file row is missing returns an empty language. Kind is interned
+// to the canonical model constants so half a million refs share backing data
+// instead of each carrying a fresh string.
 func (a *Adapter) SymbolRefs(ctx context.Context) ([]model.SymbolRef, error) {
-	const q = `SELECT s.id, s.qualified, s.file_id, s.receiver, COALESCE(f.language, ''), COALESCE(f.path, '')
+	const q = `SELECT s.id, s.qualified, s.file_id, s.receiver, s.kind, COALESCE(f.language, ''), COALESCE(f.path, '')
 		FROM sense_symbols s
 		LEFT JOIN sense_files f ON f.id = s.file_id
 		ORDER BY s.id ASC`
@@ -250,15 +252,41 @@ func (a *Adapter) SymbolRefs(ctx context.Context) ([]model.SymbolRef, error) {
 	var refs []model.SymbolRef
 	for rows.Next() {
 		var r model.SymbolRef
-		if err := rows.Scan(&r.ID, &r.Qualified, &r.FileID, &r.Receiver, &r.Language, &r.Path); err != nil {
+		var kind string
+		if err := rows.Scan(&r.ID, &r.Qualified, &r.FileID, &r.Receiver, &kind, &r.Language, &r.Path); err != nil {
 			return nil, fmt.Errorf("sqlite SymbolRefs scan: %w", err)
 		}
+		r.Kind = internSymbolKind(kind)
 		refs = append(refs, r)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("sqlite SymbolRefs iterate: %w", err)
 	}
 	return refs, nil
+}
+
+// internSymbolKind maps a scanned kind string onto the canonical
+// model.SymbolKind constants so every ref shares one backing string per kind.
+// An unrecognised value passes through as-is rather than being erased — the
+// resolver's kind gate fails open on anything it does not know.
+func internSymbolKind(kind string) model.SymbolKind {
+	switch kind {
+	case string(model.KindClass):
+		return model.KindClass
+	case string(model.KindModule):
+		return model.KindModule
+	case string(model.KindMethod):
+		return model.KindMethod
+	case string(model.KindFunction):
+		return model.KindFunction
+	case string(model.KindConstant):
+		return model.KindConstant
+	case string(model.KindInterface):
+		return model.KindInterface
+	case string(model.KindType):
+		return model.KindType
+	}
+	return model.SymbolKind(kind)
 }
 
 // EdgesOfKind returns all edges of a given kind. Used by post-extraction

--- a/internal/sqlite/reads_edges_test.go
+++ b/internal/sqlite/reads_edges_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -324,6 +325,47 @@ func TestSymbolRefsCarriesReceiver(t *testing.T) {
 	}
 	if got["PriceValue#zero?"] != "instance" {
 		t.Errorf("PriceValue#zero? Receiver = %q, want instance", got["PriceValue#zero?"])
+	}
+}
+
+// The wiring test the resolver's bare-call gate depends on: unit tests build
+// SymbolRef literals with Kind set by hand, so only this test fails when the
+// production bulk load stops populating the column and the gate goes dead.
+func TestSymbolRefsCarriesKind(t *testing.T) {
+	a := openTestDB(t)
+	ctx := context.Background()
+
+	fid := seedFile(t, a, "version_set.go", "go", "h1")
+	kinds := map[string]model.SymbolKind{
+		"pebble.versionSet":        model.KindType,
+		"pebble.versionSet.append": model.KindMethod,
+		"pebble.makeRoom":          model.KindFunction,
+		"pebble.Store":             model.KindClass,
+		"pebble.storage":           model.KindModule,
+		"pebble.MaxLevels":         model.KindConstant,
+		"pebble.Reader":            model.KindInterface,
+	}
+	for q, k := range kinds {
+		seedSymbol(t, a, fid, q[strings.LastIndex(q, ".")+1:], q, string(k))
+	}
+	// An unrecognised kind passes through as-is (fail-open), never erased.
+	seedSymbol(t, a, fid, "oddity", "pebble.oddity", "gadget")
+
+	refs, err := a.SymbolRefs(ctx)
+	if err != nil {
+		t.Fatalf("SymbolRefs: %v", err)
+	}
+	got := map[string]model.SymbolKind{}
+	for _, r := range refs {
+		got[r.Qualified] = r.Kind
+	}
+	for q, want := range kinds {
+		if got[q] != want {
+			t.Errorf("%s Kind = %q, want %q", q, got[q], want)
+		}
+	}
+	if got["pebble.oddity"] != model.SymbolKind("gadget") {
+		t.Errorf("oddity Kind = %q, want passthrough %q", got["pebble.oddity"], "gadget")
 	}
 }
 


### PR DESCRIPTION
## What

A bare identifier call can never be a method call in Go or Rust — methods are only reachable through receiver or path expressions — yet the resolver's unqualified fallback bound bare targets to same-named methods at 0.8, straight into the verified band.

Measured damage (the G-10 ledger class): pebble `versionSet.append` carried **778 fabricated call edges across 320 files** — every `append(...)` builtin call in the repo resolved to the method (`batch.go:638`). Same class on every measured Go repo: type conversions (`int(...)` → `reflectionValue.int` on gitea, 112 edges; `string(...)` on go-mysql-server, 144) and local closures/func-values (`release()`, `visit()`, `handle()`).

## How

- `model.SymbolRef` carries `Kind` (interned from the existing symbols column, no schema change); the resolver's leaf fallback drops method-kind candidates for bare targets from languages whose grammar forbids the bind (`bareCallBindsMethods`: go, rust). Dotted targets and all other languages are untouched; unknown kinds and unknown languages fail open.
- The Go extractor skips bare calls through local bindings (a local always shadows package scope). Func-typed params now register as locals — they were skipped when their type didn't unwrap, which also quietly fixes a false-references-edge case. A `goBuiltins` skip was considered and rejected as lossy: package-block declarations shadow predeclared identifiers (go-mysql-server declares `func min` at `internal/similartext/similartext.go:23` — its bare in-package calls are real edges).
- Full-write scans stamp `bare_call_binds`; `sense status` advises a rebuild on unstamped Go/Rust indexes (mirrors `parent_linkage` — plain rescans cannot heal edges resolved by a pre-fix binary).

Dropping the illegal method from a `{function, method}` collision also **promotes** the surviving function bind out of the collision demotion (0.3 → 0.8). That is a true-positive gain, pinned by test and audited on pebble: 69 promotions, every target a function or type.

## Verification

- Red-first test set incl. mutation guards (Ruby implicit-self control, dotted-leaf reach guard, type-conversion keep, wiring test for the Kind column, positive Rust fixture, promotion pin with ordering assertions).
- Battery on branch-binary rescans (scratch clones, pinned bench indexes untouched): pebble `versionSet.append` 778 → **13**, all thirteen literal `vs.append(...)` receiver calls at 1.0; ruby control **zero-diff across 15,262 maket edges**; gitea verified bands byte-preserved (gitcmd.Command 52 files, context.Base 18, Base.FormString 205 edges/6 hi); repo-wide pebble prod diff: 1789 fabricated edge-keys dropped, 32 added, 69 promoted (all function/type).
- Side-effect runs vs frozen cells: llm.rb cited_recall 0.4815 (band 0.444–0.518), healthchecks 1.0 (= frozen), grounding 1.0 on both.
- `make ci` green (95.3% total, per-file floor met, lint 0, ledger 0); scan content oracle regenerated for the one new meta line.

## Notes

- Full-rescan class: existing Go/Rust indexes keep fabricated edges until `sense scan -rebuild`; the release note must say so (the status advisory covers the CLI surface).
- Known residue, ledgered not fixed here: bare→cross-package-function binds (pre-1.21 `min`/`max` shadows in both directions) and the package-scope law (a bare Go call can only legally reach same-package/dot-import/predeclared names).
