### PR TITLE
fix(cli): bare-name lookup captured by no-package symbols (+ --file parity)

### DIFF
--- a/internal/cli/blast.go
+++ b/internal/cli/blast.go
@@ -195,12 +195,15 @@ func runBlastSymbol(cio IO, opts blastOptions) int {
 	}
 	defer func() { _ = adapter.Close() }()
 
-	matches, err := Lookup(ctx, adapter.DB(), opts.Symbol)
+	// --file constrains resolution inside the tier cascade (the MCP path):
+	// a lower-tier match in the pinned file beats a higher-tier match
+	// elsewhere. --language has no in-cascade variant and filters after.
+	matches, err := LookupInFile(ctx, adapter.DB(), opts.Symbol, opts.File)
 	if err != nil {
 		_, _ = fmt.Fprintln(cio.Stderr, "sense blast:", err)
 		return ExitGeneralError
 	}
-	matches = FilterMatches(matches, opts.File, opts.Language)
+	matches = FilterMatches(matches, "", opts.Language)
 	switch len(matches) {
 	case 0:
 		PrintNotFound(cio.Stderr, opts.Symbol)

--- a/internal/cli/graph.go
+++ b/internal/cli/graph.go
@@ -99,12 +99,15 @@ func RunGraph(args []string, cio IO) int {
 	}
 	defer func() { _ = adapter.Close() }()
 
-	matches, err := Lookup(ctx, adapter.DB(), opts.Symbol)
+	// --file constrains resolution inside the tier cascade (the MCP path):
+	// a lower-tier match in the pinned file beats a higher-tier match
+	// elsewhere. --language has no in-cascade variant and filters after.
+	matches, err := LookupInFile(ctx, adapter.DB(), opts.Symbol, opts.File)
 	if err != nil {
 		_, _ = fmt.Fprintln(cio.Stderr, "sense graph:", err)
 		return ExitGeneralError
 	}
-	matches = FilterMatches(matches, opts.File, opts.Language)
+	matches = FilterMatches(matches, "", opts.Language)
 	switch len(matches) {
 	case 0:
 		PrintNotFound(cio.Stderr, opts.Symbol)

--- a/internal/cli/lookup.go
+++ b/internal/cli/lookup.go
@@ -50,8 +50,20 @@ type Match struct {
 //
 // Each match carries a Resolution field indicating which tier
 // produced it. Later tiers are only consulted when all earlier tiers
-// come up empty. Suffix and containment tiers require query length
-// ≥ 3 (likeMinQueryLen).
+// come up empty — with one exception: a QUALIFIER-FREE query (no
+// `.`/`::`/`#`) that hits tier 1 also consults tier 2, because such a
+// hit is only possible on a symbol whose qualified name IS its bare
+// name (a no-package top-level, e.g. a frontend TS type), and letting
+// it win silently shadowed every same-named qualified symbol — blast
+// answered "0 affected" for a repo's central hub while the real one
+// sat one tier down. When tier 2 adds candidates the union returns as
+// an ambiguous set for disambiguation, stamped uniformly ResExactName
+// (callers read matches[0].Resolution) with the exact-qualified hit
+// first; cross-language candidates are intentionally LISTED, never
+// ranked away — a "helpful" language heuristic here would reintroduce
+// the silent pick from the other side. When tier 2 adds nothing the
+// tier-1 hit resolves exactly as before. Suffix and containment tiers
+// require query length ≥ 3 (likeMinQueryLen).
 //
 // Caller contract:
 //   - len(matches) == 0 → not-found; render "no symbol" message
@@ -100,10 +112,55 @@ func lookupCascade(ctx context.Context, db *sql.DB, query, file string) ([]Match
 		}
 		matches = FilterMatches(matches, file, "")
 		if len(matches) > 0 {
+			if t.res == ResExactQualified && !hasQualifierSeparator(query) {
+				union, err := mergeBareNameTier(ctx, db, query, file, matches)
+				if err != nil {
+					return nil, err
+				}
+				if len(union) > len(matches) {
+					return setResolution(union, ResExactName), nil
+				}
+			}
 			return setResolution(matches, t.res), nil
 		}
 	}
 	return nil, nil
+}
+
+// hasQualifierSeparator reports whether a query names a namespace or
+// receiver (`app.User`, `Admin::User`, `Greeter#hello`). Queries without
+// one are bare names, where an exact-qualified hit can only be a
+// no-package symbol and must not shadow same-named qualified candidates.
+// Synthetic qualified names (`route:users`) test as bare here; the merge
+// is a superset union, so they keep resolving through their tier-1 hit.
+func hasQualifierSeparator(query string) bool {
+	return strings.ContainsAny(query, ".#") || strings.Contains(query, "::")
+}
+
+// mergeBareNameTier unions a bare query's exact-qualified hits with the
+// exact-name tier's candidates (the same file constraint applied), the
+// tier-1 hits first, deduplicated by symbol id. For a separator-free query
+// tier 1 is normally a subset of tier 2 (`qualified == name`); the by-id
+// merge is a guard for stores that break that invariant.
+func mergeBareNameTier(ctx context.Context, db *sql.DB, query, file string, exact []Match) ([]Match, error) {
+	byName, err := lookupByName(ctx, db, query)
+	if err != nil {
+		return nil, err
+	}
+	byName = FilterMatches(byName, file, "")
+	seen := make(map[int64]bool, len(exact))
+	union := make([]Match, 0, len(exact)+len(byName))
+	for _, m := range exact {
+		seen[m.ID] = true
+		union = append(union, m)
+	}
+	for _, m := range byName {
+		if !seen[m.ID] {
+			seen[m.ID] = true
+			union = append(union, m)
+		}
+	}
+	return union, nil
 }
 
 func setResolution(matches []Match, r Resolution) []Match {

--- a/internal/cli/lookup_bare_capture_test.go
+++ b/internal/cli/lookup_bare_capture_test.go
@@ -1,0 +1,172 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// seedCaptureDB is the G-9 collision fixture at the Lookup level: a frontend
+// TypeScript type whose qualified name IS its bare name ("Issue") shadowing
+// same-named backend symbols, plus "Widget" as the unique-name control.
+func seedCaptureDB(t *testing.T) *sql.DB {
+	t.Helper()
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(t.TempDir(), "index.db"))
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	files := []model.File{
+		{Path: "web_src/js/types.ts", Language: "typescript", Hash: "a", IndexedAt: time.Now()},
+		{Path: "models/issues/issue.go", Language: "go", Hash: "b", IndexedAt: time.Now()},
+		{Path: "modules/migration/issue.go", Language: "go", Hash: "c", IndexedAt: time.Now()},
+	}
+	fids := make([]int64, len(files))
+	for i := range files {
+		id, werr := adapter.WriteFile(ctx, &files[i])
+		if werr != nil {
+			t.Fatalf("WriteFile: %v", werr)
+		}
+		fids[i] = id
+	}
+	syms := []model.Symbol{
+		{FileID: fids[0], Name: "Issue", Qualified: "Issue", Kind: "type", LineStart: 38, LineEnd: 55},
+		{FileID: fids[0], Name: "Widget", Qualified: "Widget", Kind: "type", LineStart: 60, LineEnd: 70},
+		{FileID: fids[1], Name: "Issue", Qualified: "issues.Issue", Kind: "class", LineStart: 54, LineEnd: 120},
+		{FileID: fids[2], Name: "Issue", Qualified: "migration.Issue", Kind: "class", LineStart: 10, LineEnd: 40},
+	}
+	for i := range syms {
+		if _, werr := adapter.WriteSymbol(ctx, &syms[i]); werr != nil {
+			t.Fatalf("WriteSymbol: %v", werr)
+		}
+	}
+	return adapter.DB()
+}
+
+// The G-9 defect: a bare query exact-matching a no-package symbol at tier 1
+// silently shadowed every same-named qualified symbol — blast then answered
+// "0 affected, risk low" for a repo's central hub. A bare query with
+// same-named siblings must surface the whole collision for disambiguation.
+func TestLookupBareNameNotCapturedByTopLevelSymbol(t *testing.T) {
+	db := seedCaptureDB(t)
+	matches, err := Lookup(context.Background(), db, "Issue")
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	if len(matches) != 3 {
+		t.Fatalf("want all 3 same-named candidates, got %d: %+v", len(matches), matches)
+	}
+	// The exact-qualified hit ranks first; the set is stamped uniformly
+	// with the tier that made it ambiguous (callers read matches[0].Resolution).
+	if matches[0].Qualified != "Issue" {
+		t.Errorf("matches[0] = %q, want the exact-qualified hit first", matches[0].Qualified)
+	}
+	for _, m := range matches {
+		if m.Resolution != ResExactName {
+			t.Errorf("%s Resolution = %q, want uniform %q", m.Qualified, m.Resolution, ResExactName)
+		}
+	}
+	seen := map[string]bool{}
+	for _, m := range matches {
+		seen[m.Qualified] = true
+	}
+	if !seen["issues.Issue"] || !seen["migration.Issue"] {
+		t.Errorf("union must include the shadowed qualified symbols, got %+v", matches)
+	}
+}
+
+// Unique-name control: when the name tier adds nothing beyond the tier-1
+// hit, the query resolves exactly as before — one match, ResExactQualified.
+func TestLookupBareUniqueNameKeepsExactQualified(t *testing.T) {
+	db := seedCaptureDB(t)
+	matches, err := Lookup(context.Background(), db, "Widget")
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("want 1 match, got %d: %+v", len(matches), matches)
+	}
+	if matches[0].Resolution != ResExactQualified {
+		t.Errorf("Resolution = %q, want %q (tier 2 added nothing)", matches[0].Resolution, ResExactQualified)
+	}
+}
+
+// A query with a qualifier separator is untouched by the bare-query rule.
+func TestLookupSeparatorQueryUntouchedByCaptureFix(t *testing.T) {
+	db := seedCaptureDB(t)
+	matches, err := Lookup(context.Background(), db, "issues.Issue")
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	if len(matches) != 1 || matches[0].Qualified != "issues.Issue" {
+		t.Fatalf("want the single exact-qualified match, got %+v", matches)
+	}
+	if matches[0].Resolution != ResExactQualified {
+		t.Errorf("Resolution = %q, want %q", matches[0].Resolution, ResExactQualified)
+	}
+}
+
+// The file pin still suppresses cross-file additions: pinned to the TS file
+// the bare query resolves to the TS symbol alone, pinned to the Go file it
+// resolves to the Go hub alone — no union across the pin.
+func TestLookupInFileBareQueryHonorsPin(t *testing.T) {
+	db := seedCaptureDB(t)
+	ctx := context.Background()
+
+	matches, err := LookupInFile(ctx, db, "Issue", "types.ts")
+	if err != nil {
+		t.Fatalf("LookupInFile: %v", err)
+	}
+	if len(matches) != 1 || matches[0].Qualified != "Issue" {
+		t.Fatalf("pin types.ts: want the TS Issue alone, got %+v", matches)
+	}
+
+	matches, err = LookupInFile(ctx, db, "Issue", "models/issues/issue.go")
+	if err != nil {
+		t.Fatalf("LookupInFile: %v", err)
+	}
+	if len(matches) != 1 || matches[0].Qualified != "issues.Issue" {
+		t.Fatalf("pin issue.go: want issues.Issue alone, got %+v", matches)
+	}
+}
+
+// Synthetic qualified names (route:orders_path, django-related:addons) carry
+// a single colon, which is NOT a qualifier separator — they must stay bare
+// and keep resolving through their tier-1 exact-qualified hit (the name
+// column holds the same string, so the merge adds nothing). Pins the
+// separator set against a future "helpful" addition of ':'.
+func TestLookupSyntheticColonNameKeepsTierOne(t *testing.T) {
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(t.TempDir(), "index.db"))
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	fid, err := adapter.WriteFile(ctx, &model.File{Path: "config/routes.rb", Language: "ruby", Hash: "a", IndexedAt: time.Now()})
+	if err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if _, err := adapter.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid, Name: "orders_path", Qualified: "route:orders_path", Kind: "method", LineStart: 3, LineEnd: 3,
+	}); err != nil {
+		t.Fatalf("WriteSymbol: %v", err)
+	}
+
+	matches, err := Lookup(ctx, adapter.DB(), "route:orders_path")
+	if err != nil {
+		t.Fatalf("Lookup: %v", err)
+	}
+	if len(matches) != 1 || matches[0].Qualified != "route:orders_path" {
+		t.Fatalf("want the synthetic tier-1 match, got %+v", matches)
+	}
+	if matches[0].Resolution != ResExactQualified {
+		t.Errorf("Resolution = %q, want %q", matches[0].Resolution, ResExactQualified)
+	}
+}

--- a/internal/cli/lookup_file_flag_test.go
+++ b/internal/cli/lookup_file_flag_test.go
@@ -1,0 +1,147 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// seedCaptureProject reproduces the gitea Issue collision (G-9): a frontend
+// TypeScript type whose qualified name IS its bare name, shadowing same-named
+// backend symbols. Returns a project dir with .sense/index.db.
+func seedCaptureProject(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer func() { _ = adapter.Close() }()
+
+	files := []model.File{
+		{Path: "web_src/js/types.ts", Language: "typescript", Hash: "a", IndexedAt: time.Now()},
+		{Path: "models/issues/issue.go", Language: "go", Hash: "b", IndexedAt: time.Now()},
+		{Path: "modules/migration/issue.go", Language: "go", Hash: "c", IndexedAt: time.Now()},
+	}
+	fids := make([]int64, len(files))
+	for i := range files {
+		id, werr := adapter.WriteFile(ctx, &files[i])
+		if werr != nil {
+			t.Fatalf("WriteFile: %v", werr)
+		}
+		fids[i] = id
+	}
+	syms := []model.Symbol{
+		{FileID: fids[0], Name: "Issue", Qualified: "Issue", Kind: "type", LineStart: 38, LineEnd: 55},
+		{FileID: fids[1], Name: "Issue", Qualified: "issues.Issue", Kind: "class", LineStart: 54, LineEnd: 120},
+		{FileID: fids[2], Name: "Issue", Qualified: "migration.Issue", Kind: "class", LineStart: 10, LineEnd: 40},
+	}
+	for i := range syms {
+		if _, werr := adapter.WriteSymbol(ctx, &syms[i]); werr != nil {
+			t.Fatalf("WriteSymbol: %v", werr)
+		}
+	}
+	return dir
+}
+
+// The CLI --file flag must constrain resolution INSIDE the tier cascade (the
+// MCP path), not filter after tier 1 already picked the capture. Today the
+// post-hoc filter empties tier 1's TS match and answers "No symbol matches"
+// for a symbol that is exactly where the flag points.
+func TestRunBlastFileFlagReachesLowerTier(t *testing.T) {
+	dir := seedCaptureProject(t)
+	var stdout, stderr bytes.Buffer
+	code := RunBlast([]string{"Issue", "--file", "models/issues/issue.go", "--json"},
+		IO{Stdout: &stdout, Stderr: &stderr, Dir: dir})
+	if code != ExitSuccess {
+		t.Fatalf("exit = %d, want %d; stderr: %s", code, ExitSuccess, stderr.String())
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("issues.Issue")) {
+		t.Errorf("stdout should name issues.Issue, got: %s", stdout.String())
+	}
+}
+
+func TestRunGraphFileFlagReachesLowerTier(t *testing.T) {
+	dir := seedCaptureProject(t)
+	var stdout, stderr bytes.Buffer
+	code := RunGraph([]string{"Issue", "--file", "models/issues/issue.go", "--json"},
+		IO{Stdout: &stdout, Stderr: &stderr, Dir: dir})
+	if code != ExitSuccess {
+		t.Fatalf("exit = %d, want %d; stderr: %s", code, ExitSuccess, stderr.String())
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("issues.Issue")) {
+		t.Errorf("stdout should name issues.Issue, got: %s", stdout.String())
+	}
+}
+
+// The --language filter has no in-cascade variant and stays post-hoc; pin
+// that it still narrows the (now cascade-resolved) match set.
+func TestRunBlastLanguageFlagStillFilters(t *testing.T) {
+	dir := seedCaptureProject(t)
+	var stdout, stderr bytes.Buffer
+	code := RunBlast([]string{"issues.Issue", "--language", "go", "--json"},
+		IO{Stdout: &stdout, Stderr: &stderr, Dir: dir})
+	if code != ExitSuccess {
+		t.Fatalf("exit = %d, want %d; stderr: %s", code, ExitSuccess, stderr.String())
+	}
+}
+
+// Killer for the M5 survivor: the pinned symbol is only reachable at the
+// SUFFIX tier, so commit 2's bare-name union cannot mask commit 1's
+// in-cascade --file wiring. Query has a separator (no merge path at all).
+func TestRunBlastFileFlagReachesSuffixTier(t *testing.T) {
+	dir := t.TempDir()
+	senseDir := filepath.Join(dir, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(senseDir, "index.db"))
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	files := []model.File{
+		{Path: "models/issues/issue.go", Language: "go", Hash: "a", IndexedAt: time.Now()},
+		{Path: "services/issue.go", Language: "go", Hash: "b", IndexedAt: time.Now()},
+	}
+	fids := make([]int64, len(files))
+	for i := range files {
+		id, werr := adapter.WriteFile(ctx, &files[i])
+		if werr != nil {
+			t.Fatalf("WriteFile: %v", werr)
+		}
+		fids[i] = id
+	}
+	syms := []model.Symbol{
+		{FileID: fids[0], Name: "Issue", Qualified: "issues.Issue", Kind: "class", LineStart: 54, LineEnd: 120},
+		{FileID: fids[1], Name: "Issue", Qualified: "services.issues.Issue", Kind: "class", LineStart: 10, LineEnd: 40},
+	}
+	for i := range syms {
+		if _, werr := adapter.WriteSymbol(ctx, &syms[i]); werr != nil {
+			t.Fatalf("WriteSymbol: %v", werr)
+		}
+	}
+	_ = adapter.Close()
+
+	var stdout, stderr bytes.Buffer
+	code := RunBlast([]string{"issues.Issue", "--file", "services/issue.go", "--json"},
+		IO{Stdout: &stdout, Stderr: &stderr, Dir: dir})
+	if code != ExitSuccess {
+		t.Fatalf("exit = %d, want %d; stderr: %s", code, ExitSuccess, stderr.String())
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte("services.issues.Issue")) {
+		t.Errorf("stdout should name services.issues.Issue, got: %s", stdout.String())
+	}
+}

--- a/internal/mcpserver/blast.go
+++ b/internal/mcpserver/blast.go
@@ -138,14 +138,12 @@ const disambiguationCap = 10
 // returns a resolveError whose result field carries a pre-built
 // *mcp.CallToolResult with structured JSON for the LLM.
 //
-// A non-empty fileHint is a hard constraint. It serves the same intent
-// as the CLI's --file flag but is deliberately stricter: the CLI
-// filters after the cascade picks a winning tier, while resolution here
-// applies the file filter inside each tier, so a lower-tier match in
-// the pinned file beats a higher-tier match elsewhere. When no tier
-// matches the file, the error names the constraint and lists where the
-// symbol does resolve — it never falls back to a conflicting cross-file
-// winner.
+// A non-empty fileHint is a hard constraint, applied inside each tier
+// of the cascade (the CLI's --file flag rides the same LookupInFile
+// path): a lower-tier match in the pinned file beats a higher-tier
+// match elsewhere. When no tier matches the file, the error names the
+// constraint and lists where the symbol does resolve — it never falls
+// back to a conflicting cross-file winner.
 func (h *handlers) resolveSymbol(ctx context.Context, tool, symbol, fileHint string) (cli.Match, error) {
 	if fileHint != "" {
 		matches, err := cli.LookupInFile(ctx, h.db, symbol, fileHint)


### PR DESCRIPTION
Stacked on #202 (retarget to main after it merges; both commits also apply clean to main independently — the layers are disjoint).

## What

Two G-9 defects in symbol lookup, one per commit:

1. **CLI `--file` divergence.** The CLI filtered `--file` after the tier cascade picked a winner, so `sense blast Issue --file models/issues/issue.go` answered "No symbol matches" for a symbol sitting exactly where the flag pointed, while MCP resolved it. Both surfaces now ride `LookupInFile` (file constraint inside every tier); `--language` stays post-cascade (no in-cascade variant, no known defect).
2. **Silent bare-name capture.** A bare query exact-matching a symbol whose qualified name IS its bare name (a no-package top-level, e.g. a frontend TS type) won tier 1 silently and shadowed every same-named qualified symbol. On gitea, `sense_blast Issue` bound the TS `Issue` type and answered **total_affected=0, risk low** while `issues.Issue` (295 affected) sat one tier down. A bare query with a tier-1 hit now also consults the exact-name tier; when that adds candidates the union returns for disambiguation (uniform `exact_name` stamp, exact-qualified hit first, by-id dedupe, cross-language candidates deliberately listed). Unique names and separator queries are byte-identical to before; synthetic qualified names (`route:orders_path`) keep their tier-1 resolution by the superset-union property, pinned by test.

## Behavior change, measured before merge

A $0 audit of 186 banked winning sense-arm transcripts found 14 bare-name queries that flip from silent-resolve to the collision surfacing. Scored against the MCP dominant-match rule: 6 auto-resolve unchanged; 8 become one extra disambiguation round-trip. The flagship affected winner was re-run as the merge gate:

- **chatwoot** (frozen: cited_recall 1.0, 17/17/17, 17,770 billed): stacked binary run = **1.0 (17/17/17), 17,697 billed** (73 under frozen), adoption 0.91 vs 0.70, grounding 1.0, 0 hallucinations. The disambiguation hop is visible (6 sense calls) and fully absorbed.
- llm.rb: 0.4815 cited_recall, dead center of the 0.444–0.518 frozen band; healthchecks: 1.0 (= frozen); grounding 1.0 on all runs.

## Verification

- Red-first per sub-fix at each parent; mutation scoreboard run at HEAD: union-guard, uniform-stamp, dedupe, and file-pin mutants each killed by a named test; the commit-1-revert survivor found in review is killed by the suffix-tier `--file` test (red under the revert, green at HEAD).
- MCP battery on gitea: bare `Issue` → ambiguity payload with `issues.Issue` visible (rank 3 of 14 shown), qualified query unchanged, widest repo collision (17 candidates) payload ~1 KB.
- `make ci` green (95.3% total, per-file floor, lint 0, ledger 0).

## Operational note

If reverting, revert the top commit first (or both together): the capture fix's disambiguation hint prescribes a `--file` retry that only works with the parity commit underneath it.