### PR TITLE
fix(scan): emit composition edges for Go struct fields

### DIFF
--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -208,7 +208,31 @@ func computeHealth(ctx context.Context, db *sql.DB, dir string, resp mcpio.Statu
 		}
 	}
 
+	// The composes_go stamp mirrors the two above for Go composition edges
+	// (named struct fields emitted no composes edges before the fix): absence
+	// means the index was built by a pre-fix binary and Go `composed_by`
+	// stays empty until a rebuild rewrites every file. Gated on Go files
+	// only — every other extracted language already emitted composes, so
+	// there is nothing to heal elsewhere.
+	if resp.Index.Symbols > 0 && readMeta(ctx, db, "composes_go") == "" && hasGoFiles(ctx, db) {
+		if h.verdict == "healthy" {
+			h.verdict = "degraded"
+		}
+		if h.detail == "" {
+			h.detail = "index predates Go composition edges — run 'sense scan --rebuild'"
+		}
+	}
+
 	return h
+}
+
+// hasGoFiles reports whether the index contains Go files — the only language
+// whose composition edges were missing before the composes_go fix.
+func hasGoFiles(ctx context.Context, db *sql.DB) bool {
+	var n int
+	err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM sense_files WHERE language = 'go' LIMIT 1`).Scan(&n)
+	return err == nil && n > 0
 }
 
 // hasCrossFileParentLanguage reports whether the index contains files in a

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -165,8 +165,10 @@ func TestComputeHealthBareCallBindsStamp(t *testing.T) {
 		t.Errorf("detail = %q, want bare-call message", h.detail)
 	}
 
-	// Stamped: healthy again.
+	// Stamped: healthy again (composes_go seeded too — it is an independent
+	// full-write stamp with its own advisory branch).
 	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('bare_call_binds', '1')`)
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('composes_go', '1')`)
 	h = computeHealth(ctx, db, t.TempDir(), resp)
 	if h.verdict != "healthy" {
 		t.Errorf("verdict = %q with stamp, want healthy", h.verdict)
@@ -180,6 +182,50 @@ func TestComputeHealthBareCallBindsStamp(t *testing.T) {
 	h = computeHealth(ctx, db, t.TempDir(), resp)
 	if h.verdict != "healthy" {
 		t.Errorf("verdict = %q on ruby-only index without stamp, want healthy", h.verdict)
+	}
+}
+
+func TestComputeHealthComposesGoStamp(t *testing.T) {
+	ctx := context.Background()
+	db := healthTestDB(t)
+	_, _ = db.ExecContext(ctx, `CREATE TABLE sense_meta (key TEXT PRIMARY KEY, value TEXT)`)
+	// Go-only gate: rust already emitted composes edges, so a rust index has
+	// nothing to heal and must see no advisory.
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_files VALUES (1, 'a.go', 'go', 'abc', 1, '2026-01-01T00:00:00Z')`)
+	// Keep the sibling stamp branches quiet so this test observes its own.
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('parent_linkage', '1')`)
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('bare_call_binds', '1')`)
+
+	resp := mcpio.StatusResponse{
+		Version: &mcpio.StatusVersion{SchemaCurrent: true, EmbeddingModelCurrent: true},
+	}
+	resp.Index.Symbols = 5
+	resp.Index.Embeddings = 5
+
+	// No stamp: the index predates Go composition edges and composed_by
+	// stays empty until a rebuild rewrites every file.
+	h := computeHealth(ctx, db, t.TempDir(), resp)
+	if h.verdict != "degraded" {
+		t.Errorf("verdict = %q without composes_go stamp, want degraded", h.verdict)
+	}
+	if h.detail != "index predates Go composition edges — run 'sense scan --rebuild'" {
+		t.Errorf("detail = %q, want composes message", h.detail)
+	}
+
+	// Stamped: healthy again.
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('composes_go', '1')`)
+	h = computeHealth(ctx, db, t.TempDir(), resp)
+	if h.verdict != "healthy" {
+		t.Errorf("verdict = %q with stamp, want healthy", h.verdict)
+	}
+
+	// A rust-only index already had composes edges: no advisory without the
+	// stamp (the gate is narrower than the go+rust parent-linkage gate).
+	_, _ = db.ExecContext(ctx, `DELETE FROM sense_meta WHERE key = 'composes_go'`)
+	_, _ = db.ExecContext(ctx, `UPDATE sense_files SET language = 'rust', path = 'a.rs'`)
+	h = computeHealth(ctx, db, t.TempDir(), resp)
+	if h.verdict != "healthy" {
+		t.Errorf("verdict = %q on rust-only index without stamp, want healthy", h.verdict)
 	}
 }
 
@@ -206,10 +252,11 @@ func TestComputeHealthParentLinkageStamp(t *testing.T) {
 		t.Errorf("detail = %q, want parent-linkage message", h.detail)
 	}
 
-	// Stamped: healthy again (bare_call_binds seeded too — it is an
-	// independent full-write stamp with its own advisory branch).
+	// Stamped: healthy again (bare_call_binds and composes_go seeded too —
+	// each is an independent full-write stamp with its own advisory branch).
 	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('parent_linkage', '1')`)
 	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('bare_call_binds', '1')`)
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('composes_go', '1')`)
 	h = computeHealth(ctx, db, t.TempDir(), resp)
 	if h.verdict != "healthy" {
 		t.Errorf("verdict = %q with stamp, want healthy", h.verdict)

--- a/internal/extract/golang/compose.go
+++ b/internal/extract/golang/compose.go
@@ -1,0 +1,138 @@
+package golang
+
+// compose.go emits composition edges: a named struct field's declared type is
+// a has-a fact recorded as a composes edge to each user-defined type the
+// field type names. Wrapper types (pointers, slices, arrays, maps, channels,
+// parentheses, generics) unwrap to the types inside them; predeclared types,
+// the declaration's own type parameters, function types, and inline type
+// literals compose no edge. Embedded fields are emitEmbeddings' territory
+// (includes edges) — this file walks the exact complement.
+
+import (
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/model"
+)
+
+// goPredeclaredTypes is the Go spec's predeclared type identifier set — a
+// closed set frozen by the language.
+var goPredeclaredTypes = map[string]bool{
+	"bool": true, "byte": true, "complex64": true, "complex128": true,
+	"error": true, "float32": true, "float64": true,
+	"int": true, "int8": true, "int16": true, "int32": true, "int64": true,
+	"rune": true, "string": true,
+	"uint": true, "uint8": true, "uint16": true, "uint32": true, "uint64": true,
+	"uintptr": true, "any": true, "comparable": true,
+}
+
+// emitFieldCompositions walks a struct_type's field declarations and emits
+// composes edges for named fields. typeParams holds the enclosing
+// declaration's type-parameter names: they are local to the declaration and
+// would false-bind to same-named real types if emitted.
+func (w *walker) emitFieldCompositions(structNode *sitter.Node, structQualified string, typeParams map[string]bool) error {
+	fdl := structNode.NamedChild(0)
+	if fdl == nil || fdl.Kind() != "field_declaration_list" {
+		return nil
+	}
+	for i := uint(0); i < fdl.NamedChildCount(); i++ {
+		fd := fdl.NamedChild(i)
+		if fd == nil || fd.Kind() != "field_declaration" {
+			continue
+		}
+		if fd.ChildByFieldName("name") == nil {
+			continue
+		}
+		line := extract.Line(fd.StartPosition())
+		for _, target := range w.composeTargets(fd.ChildByFieldName("type"), typeParams) {
+			if err := w.emit.Edge(extract.EmittedEdge{
+				SourceQualified: structQualified,
+				TargetQualified: target,
+				Kind:            model.EdgeComposes,
+				Line:            &line,
+				Confidence:      extract.ConfidenceStatic,
+			}); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// composeTargets extracts the user-defined type names a field type expression
+// holds. A generic base recurses through this same switch so a qualified base
+// (pkg.Registry[T]) keeps its package prefix. Function types and inline
+// struct/interface literals hold behavior or their own fields, not a named
+// has-a target — they and every other unlisted shape compose nothing.
+func (w *walker) composeTargets(typeNode *sitter.Node, typeParams map[string]bool) []string {
+	if typeNode == nil {
+		return nil
+	}
+	switch typeNode.Kind() {
+	case "type_identifier":
+		name := extract.Text(typeNode, w.source)
+		if name == "" || goPredeclaredTypes[name] || typeParams[name] {
+			return nil
+		}
+		return []string{w.qualify(name)}
+	case "qualified_type":
+		return []string{extract.Text(typeNode, w.source)}
+	case "pointer_type", "parenthesized_type":
+		return w.composeTargets(typeNode.NamedChild(0), typeParams)
+	case "slice_type", "array_type":
+		return w.composeTargets(typeNode.ChildByFieldName("element"), typeParams)
+	case "map_type":
+		targets := w.composeTargets(typeNode.ChildByFieldName("key"), typeParams)
+		return append(targets, w.composeTargets(typeNode.ChildByFieldName("value"), typeParams)...)
+	case "channel_type":
+		return w.composeTargets(typeNode.ChildByFieldName("value"), typeParams)
+	case "generic_type":
+		targets := w.composeTargets(typeNode.ChildByFieldName("type"), typeParams)
+		return append(targets, w.composeTypeArgTargets(typeNode.ChildByFieldName("type_arguments"), typeParams)...)
+	default:
+		return nil
+	}
+}
+
+// composeTypeArgTargets extracts compose targets from a generic type's
+// argument list. Each argument arrives wrapped in a type_elem node whose
+// children are the type expressions themselves.
+func (w *walker) composeTypeArgTargets(args *sitter.Node, typeParams map[string]bool) []string {
+	if args == nil {
+		return nil
+	}
+	var targets []string
+	for i := uint(0); i < args.NamedChildCount(); i++ {
+		arg := args.NamedChild(i)
+		if arg == nil || arg.Kind() != "type_elem" {
+			continue
+		}
+		for j := uint(0); j < arg.NamedChildCount(); j++ {
+			targets = append(targets, w.composeTargets(arg.NamedChild(j), typeParams)...)
+		}
+	}
+	return targets
+}
+
+// typeParamNames collects a type declaration's type-parameter names from its
+// type_parameter_list (nil for non-generic declarations).
+func typeParamNames(spec *sitter.Node, source []byte) map[string]bool {
+	tpl := spec.ChildByFieldName("type_parameters")
+	if tpl == nil {
+		return nil
+	}
+	params := map[string]bool{}
+	for i := uint(0); i < tpl.NamedChildCount(); i++ {
+		pd := tpl.NamedChild(i)
+		if pd == nil || pd.Kind() != "type_parameter_declaration" {
+			continue
+		}
+		for j := uint(0); j < pd.NamedChildCount(); j++ {
+			ch := pd.NamedChild(j)
+			if ch != nil && ch.Kind() == "identifier" {
+				params[extract.Text(ch, source)] = true
+			}
+		}
+	}
+	return params
+}

--- a/internal/extract/golang/compose_test.go
+++ b/internal/extract/golang/compose_test.go
@@ -1,0 +1,414 @@
+package golang
+
+import (
+	"testing"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+// These tests cover composition-edge emission for named struct fields: a
+// field's declared type is a has-a fact recorded as a composes edge. Embedded
+// fields keep their includes edges (method-set semantics); named fields are
+// the exact complement. Wrapper types (pointer, slice, array, map, channel,
+// parens, generics) unwrap to the user-defined types they name; predeclared
+// types, type parameters, function types, and inline type literals compose
+// no edge.
+
+func composeEdges(r *recorder) []string {
+	var out []string
+	for _, e := range r.edges {
+		if e.Kind == "composes" {
+			out = append(out, e.SourceQualified+"->"+e.TargetQualified)
+		}
+	}
+	return out
+}
+
+func TestComposeSamePackageNamedField(t *testing.T) {
+	r := parse(t, `package shop
+
+type Customer struct{}
+
+type Order struct {
+	c Customer
+}
+`)
+	if findEdge(r, "shop.Order", "shop.Customer", "composes") == nil {
+		t.Error("missing composes edge shop.Order -> shop.Customer for named field")
+	}
+}
+
+func TestComposePredeclaredTypesSkipped(t *testing.T) {
+	r := parse(t, `package shop
+
+type Row struct {
+	a bool
+	b byte
+	c complex64
+	d complex128
+	e error
+	f float32
+	g float64
+	h int
+	i int8
+	j int16
+	k int32
+	l int64
+	m rune
+	n string
+	o uint
+	p uint8
+	q uint16
+	r uint32
+	s uint64
+	u uintptr
+	v any
+}
+`)
+	if got := composeEdges(r); len(got) != 0 {
+		t.Errorf("predeclared-typed fields must compose no edge, got %v", got)
+	}
+}
+
+func TestComposeQualifiedTypeField(t *testing.T) {
+	r := parse(t, `package commithook
+
+import "github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+
+type pushOnWrite struct {
+	srcDB doltdb.DoltDB
+}
+`)
+	if findEdge(r, "commithook.pushOnWrite", "doltdb.DoltDB", "composes") == nil {
+		t.Error("missing composes edge for qualified-type field (raw text target)")
+	}
+}
+
+func TestComposePointerField(t *testing.T) {
+	r := parse(t, `package commithook
+
+import "github.com/dolthub/dolt/go/libraries/doltcore/doltdb"
+
+type Local struct{}
+
+type pushOnWrite struct {
+	destDB *doltdb.DoltDB
+	local  *Local
+}
+`)
+	if findEdge(r, "commithook.pushOnWrite", "doltdb.DoltDB", "composes") == nil {
+		t.Error("missing composes edge through pointer to qualified type")
+	}
+	if findEdge(r, "commithook.pushOnWrite", "commithook.Local", "composes") == nil {
+		t.Error("missing composes edge through pointer to same-package type")
+	}
+}
+
+func TestComposeSliceAndArrayFields(t *testing.T) {
+	r := parse(t, `package shop
+
+type Item struct{}
+type Tag struct{}
+
+type Cart struct {
+	items []Item
+	tags  [4]Tag
+	names []string
+}
+`)
+	if findEdge(r, "shop.Cart", "shop.Item", "composes") == nil {
+		t.Error("missing composes edge through slice element")
+	}
+	if findEdge(r, "shop.Cart", "shop.Tag", "composes") == nil {
+		t.Error("missing composes edge through array element")
+	}
+	if got := composeEdges(r); len(got) != 2 {
+		t.Errorf("expected exactly 2 composes edges ([]string composes none), got %v", got)
+	}
+}
+
+func TestComposeMapKeyAndValue(t *testing.T) {
+	r := parse(t, `package auth
+
+type UserID struct{}
+type Session struct{}
+
+type Store struct {
+	byUser map[UserID]Session
+	names  map[string]int
+}
+`)
+	if findEdge(r, "auth.Store", "auth.UserID", "composes") == nil {
+		t.Error("missing composes edge for map key type")
+	}
+	if findEdge(r, "auth.Store", "auth.Session", "composes") == nil {
+		t.Error("missing composes edge for map value type")
+	}
+	if got := composeEdges(r); len(got) != 2 {
+		t.Errorf("expected exactly 2 composes edges (string/int keys compose none), got %v", got)
+	}
+}
+
+func TestComposeChannelField(t *testing.T) {
+	r := parse(t, `package bus
+
+type Event struct{}
+
+type Fanout struct {
+	events chan Event
+	acks   <-chan bool
+}
+`)
+	if findEdge(r, "bus.Fanout", "bus.Event", "composes") == nil {
+		t.Error("missing composes edge through channel element")
+	}
+	if got := composeEdges(r); len(got) != 1 {
+		t.Errorf("expected exactly 1 composes edge (chan bool composes none), got %v", got)
+	}
+}
+
+func TestComposeNestedWrappers(t *testing.T) {
+	r := parse(t, `package deep
+
+type Foo struct{}
+
+type Holder struct {
+	grid []map[string]*Foo
+	flat (Foo)
+}
+`)
+	if findEdge(r, "deep.Holder", "deep.Foo", "composes") == nil {
+		t.Error("missing composes edge through []map[string]*Foo nesting")
+	}
+	edges := composeEdges(r)
+	if len(edges) != 2 {
+		t.Errorf("expected 2 composes edges (nested + parenthesized), got %v", edges)
+	}
+}
+
+func TestComposeGenericBaseAndArgs(t *testing.T) {
+	// A generic field composes its base type AND its type arguments; a
+	// qualified generic base must keep its package prefix (never re-qualified
+	// into the current package).
+	r := parse(t, `package reg
+
+import "example.com/pool"
+
+type Conn struct{}
+type Registry[T any] struct{}
+
+type Server struct {
+	conns  Registry[*Conn]
+	remote pool.Registry[*Conn]
+}
+`)
+	if findEdge(r, "reg.Server", "reg.Registry", "composes") == nil {
+		t.Error("missing composes edge to generic base type")
+	}
+	if findEdge(r, "reg.Server", "pool.Registry", "composes") == nil {
+		t.Error("missing composes edge to qualified generic base (must not be re-qualified)")
+	}
+	if findEdge(r, "reg.Server", "reg.Conn", "composes") == nil {
+		t.Error("missing composes edge to generic type argument")
+	}
+	for _, e := range r.edges {
+		if e.Kind == "composes" && e.TargetQualified == "reg.pool.Registry" {
+			t.Error("qualified generic base was re-qualified into the current package")
+		}
+	}
+}
+
+func TestComposeTypeParameterNotEmittedWithDecoy(t *testing.T) {
+	// The decoy: a REAL type named T exists in the package. A generic
+	// struct's fields typed by its own type parameter T must not emit a
+	// composes edge to it — bare, wrapped, or as a generic argument.
+	r := parse(t, `package box
+
+type T struct{}
+type Registry[X any] struct{}
+
+type Box[ /* the payload type */ T any] struct {
+	v     T
+	items []T
+	m     map[string]T
+	r     Registry[T]
+}
+`)
+	if e := findEdge(r, "box.Box", "box.T", "composes"); e != nil {
+		t.Error("type-parameter field must not compose to the decoy real type T")
+	}
+	edges := composeEdges(r)
+	if len(edges) != 1 {
+		t.Errorf("expected exactly 1 composes edge (Box -> Registry only), got %v", edges)
+	}
+	if findEdge(r, "box.Box", "box.Registry", "composes") == nil {
+		t.Error("missing composes edge Box -> Registry (generic base survives the param-arg skip)")
+	}
+}
+
+func TestComposeFunctionTypeSkipped(t *testing.T) {
+	r := parse(t, `package hooks
+
+type Payload struct{}
+
+type Handler struct {
+	fn func(Payload) error
+}
+`)
+	if got := composeEdges(r); len(got) != 0 {
+		t.Errorf("function-typed field must compose no edge, got %v", got)
+	}
+}
+
+func TestComposeInlineTypeLiteralsSkipped(t *testing.T) {
+	r := parse(t, `package cfg
+
+type Nested struct{}
+
+type Config struct {
+	meta struct {
+		n Nested
+	}
+	sink interface {
+		Write() error
+	}
+}
+`)
+	if got := composeEdges(r); len(got) != 0 {
+		t.Errorf("inline struct/interface fields must compose no edge, got %v", got)
+	}
+}
+
+func TestComposeEmbeddedNamedComplement(t *testing.T) {
+	// One struct, both field shapes: embedded fields emit includes and never
+	// composes; named fields emit composes and never includes. Embedded
+	// pointer (*Bar) keeps its includes edge — pinned current behavior.
+	r := parse(t, `package mix
+
+type Foo struct{}
+type Bar struct{}
+type Baz struct{}
+
+type Holder struct {
+	Foo
+	*Bar
+	baz Baz
+}
+`)
+	if findEdge(r, "mix.Holder", "mix.Foo", "includes") == nil {
+		t.Error("embedded value field lost its includes edge")
+	}
+	if findEdge(r, "mix.Holder", "mix.Bar", "includes") == nil {
+		t.Error("embedded pointer field lost its includes edge")
+	}
+	if findEdge(r, "mix.Holder", "mix.Foo", "composes") != nil ||
+		findEdge(r, "mix.Holder", "mix.Bar", "composes") != nil {
+		t.Error("embedded fields must not double-emit as composes")
+	}
+	if findEdge(r, "mix.Holder", "mix.Baz", "composes") == nil {
+		t.Error("missing composes edge for the named field")
+	}
+	if findEdge(r, "mix.Holder", "mix.Baz", "includes") != nil {
+		t.Error("named field must not emit an includes edge")
+	}
+}
+
+func TestComposeMultiNameFieldSingleEdge(t *testing.T) {
+	// `a, b *Foo` is ONE field_declaration with two name children: the
+	// has-a fact is the same either way — exactly one edge, never two.
+	r := parse(t, `package dup
+
+type Foo struct{}
+
+type Pair struct {
+	a, b *Foo
+}
+`)
+	edges := composeEdges(r)
+	if len(edges) != 1 {
+		t.Errorf("expected exactly 1 composes edge for multi-name field, got %v", edges)
+	}
+}
+
+func TestComposeAliasDeclarationUnchanged(t *testing.T) {
+	// Aliases never carry a struct body through emitTypeSpec (structNode is
+	// only set for non-alias specs) — no composes edges from alias specs.
+	r := parse(t, `package al
+
+type Base struct {
+	n int
+}
+
+type A = Base
+`)
+	if got := composeEdges(r); len(got) != 0 {
+		t.Errorf("alias declarations must compose no edge, got %v", got)
+	}
+}
+
+func TestComposeAliasedImportKeepsWrittenText(t *testing.T) {
+	// The walker has no import map: a renamed import's qualifier reaches the
+	// edge as written (`user_model.User`), resolving only by leaf downstream.
+	// Pinned so alias normalization (G-7b residue) is a conscious change.
+	r := parse(t, `package issue
+
+import user_model "code.example/models/user"
+
+type Issue struct {
+	Poster user_model.User
+}
+`)
+	if findEdge(r, "issue.Issue", "user_model.User", "composes") == nil {
+		t.Error("aliased qualified field must compose to the written text")
+	}
+}
+
+func TestComposeGuardsOnMalformedNodes(t *testing.T) {
+	src := []byte("package p\n\ntype I interface{}\n")
+	ex := Extractor{}
+	p := sitter.NewParser()
+	defer p.Close()
+	_ = p.SetLanguage(ex.Grammar())
+	tree := p.Parse(src, nil)
+	defer tree.Close()
+
+	r := &recorder{}
+	w := &walker{source: src, emit: r, pkg: "p"}
+	ifaceType := findNodeOfKind(tree.RootNode(), "interface_type")
+	if ifaceType == nil {
+		t.Fatal("no interface_type node in fixture")
+	}
+	// A non-struct node has no field_declaration_list child: the guard
+	// returns cleanly instead of walking garbage.
+	if err := w.emitFieldCompositions(ifaceType, "p.I", nil); err != nil {
+		t.Fatalf("emitFieldCompositions on non-struct node: %v", err)
+	}
+	if len(r.edges) != 0 {
+		t.Errorf("non-struct node must emit no edges, got %d", len(r.edges))
+	}
+	if got := w.composeTargets(nil, nil); got != nil {
+		t.Errorf("composeTargets(nil) = %v, want nil", got)
+	}
+	if got := w.composeTypeArgTargets(nil, nil); got != nil {
+		t.Errorf("composeTypeArgTargets(nil) = %v, want nil", got)
+	}
+	// Named children that are not type_elem (here the root's package_clause
+	// and type_declaration) are skipped, never recursed into.
+	if got := w.composeTypeArgTargets(tree.RootNode(), nil); got != nil {
+		t.Errorf("composeTypeArgTargets on non-argument node = %v, want nil", got)
+	}
+}
+
+func TestComposeEdgeEmitErrorPropagates(t *testing.T) {
+	err := parseWithEmitter(t, `package shop
+
+type Customer struct{}
+
+type Order struct {
+	c Customer
+}
+`, &failAfterN{symbolsLeft: 100, edgesLeft: 0})
+	if err == nil {
+		t.Error("expected error when composes edge emit fails")
+	}
+}

--- a/internal/extract/golang/golang.go
+++ b/internal/extract/golang/golang.go
@@ -314,6 +314,9 @@ func (w *walker) emitTypeSpec(spec *sitter.Node, isAlias bool, doc string) error
 		if err := w.emitEmbeddings(structNode, qualified); err != nil {
 			return err
 		}
+		if err := w.emitFieldCompositions(structNode, qualified, typeParamNames(spec, w.source)); err != nil {
+			return err
+		}
 	}
 	if ifaceNode != nil {
 		if err := w.emitInterfaceMethods(ifaceNode, qualified); err != nil {

--- a/internal/extract/testdata/go/chained_selectors.golden.json
+++ b/internal/extract/testdata/go/chained_selectors.golden.json
@@ -66,6 +66,13 @@
       "confidence": 1
     },
     {
+      "source": "chain.Car",
+      "target": "chain.Engine",
+      "kind": "composes",
+      "line": 8,
+      "confidence": 1
+    },
+    {
       "source": "chain.Drive",
       "target": "c.engine.Start",
       "kind": "calls",

--- a/internal/scan/compose_stamp_test.go
+++ b/internal/scan/compose_stamp_test.go
@@ -1,0 +1,114 @@
+package scan_test
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/luuuc/sense/internal/scan"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// TestScanStampsComposesGoMeta pins the staleness signal for the G-7 Go
+// composition-edge fix: a fresh scan stamps composes_go, a plain rescan
+// preserves it, and an index stripped of the stamp (one built by a pre-fix
+// binary, its Go composed_by still empty) is only re-stamped by a full-write
+// scan — a plain rescan of unchanged files re-extracts nothing and must not
+// claim healed.
+func TestScanStampsComposesGoMeta(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "kvstore.go"), storeTypeSrc)
+
+	if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := readMetaKey(t, root, "composes_go"); got != "1" {
+		t.Fatalf("composes_go = %q after fresh scan, want 1", got)
+	}
+
+	if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+		t.Fatalf("plain rescan: %v", err)
+	}
+	if got := readMetaKey(t, root, "composes_go"); got != "1" {
+		t.Errorf("composes_go = %q after plain rescan, want preserved 1", got)
+	}
+
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(root, ".sense", "index.db"))
+	if err != nil {
+		t.Fatalf("open index: %v", err)
+	}
+	if err := a.DeleteMeta(ctx, "composes_go"); err != nil {
+		t.Fatalf("delete meta: %v", err)
+	}
+	_ = a.Close()
+
+	if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+		t.Fatalf("plain rescan on stripped index: %v", err)
+	}
+	if got := readMetaKey(t, root, "composes_go"); got != "" {
+		t.Errorf("composes_go = %q after plain rescan of unchanged files, want unstamped", got)
+	}
+
+	opts := quietOpts(root)
+	opts.Rebuild = true
+	if _, err := scan.Run(context.Background(), opts); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	if got := readMetaKey(t, root, "composes_go"); got != "1" {
+		t.Errorf("composes_go = %q after rebuild, want 1", got)
+	}
+}
+
+// TestGoComposesEdgePersists proves the G-7 fix end-to-end through
+// resolve/persist: a named struct field typed by an in-repo type lands as a
+// composes edge row, and a field typed by an unindexed external (std-lib
+// time.Time) persists NO edge — unresolved targets drop at resolve rather
+// than anchoring noise.
+func TestGoComposesEdgePersists(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "customer.go"), `package shop
+
+import "time"
+
+type Customer struct{}
+
+type Order struct {
+	c       Customer
+	stamped time.Time
+}
+`)
+
+	if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if n := countComposesEdges(t, root, "shop.Order", "shop.Customer"); n != 1 {
+		t.Errorf("composes edges shop.Order -> shop.Customer = %d, want 1", n)
+	}
+	if n := countComposesEdges(t, root, "shop.Order", ""); n != 1 {
+		t.Errorf("total composes edges from shop.Order = %d, want 1 (time.Time must drop)", n)
+	}
+}
+
+func countComposesEdges(t *testing.T, root, source, target string) int {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file:"+filepath.Join(root, ".sense", "index.db"))
+	if err != nil {
+		t.Fatalf("open index: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	q := `SELECT COUNT(*)
+	      FROM sense_edges e
+	      JOIN sense_symbols ss ON ss.id = e.source_id
+	      JOIN sense_symbols st ON st.id = e.target_id
+	      WHERE e.kind = 'composes' AND ss.qualified = ?
+	        AND (? = '' OR st.qualified = ?)`
+	var n int
+	if err := db.QueryRowContext(context.Background(), q, source, target, target).Scan(&n); err != nil {
+		t.Fatalf("count composes edges: %v", err)
+	}
+	return n
+}

--- a/internal/scan/oracle_test.go
+++ b/internal/scan/oracle_test.go
@@ -117,9 +117,9 @@ func oracleDigest(t *testing.T, dbPath string) (digest string, content []string)
 // leave it unchanged, and a refactor that alters derived output fails here
 // loudly. When output changes on purpose, regenerate it (see the capture line
 // in TestScanContentOracleDigest) and update this constant in the same commit.
-// Last regeneration: the bare_call_binds meta stamp (bare-call resolution
-// fix) added one meta line; symbols/edges/embeddings unchanged.
-const oracleGolden = "5e06add5beac2aa2888c81980018e9a25ebda9a18eed4d7168dc3e0e47307dcd"
+// Last regeneration: the composes_go meta stamp (Go composition-edge fix)
+// added one meta line; symbols/edges/embeddings unchanged.
+const oracleGolden = "a167103865f0532dcbd3e31af0ae098dfd21394f8c2bfbd975fec055c9b1dec8"
 
 func TestScanContentOracleDigest(t *testing.T) {
 	useFakeEmbedder(t)

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -427,6 +427,13 @@ func finalizeScan(ctx context.Context, idx *sqlite.Adapter, h *harness, senseDir
 		if err := idx.WriteMeta(ctx, "bare_call_binds", "1"); err != nil {
 			_, _ = fmt.Fprintf(h.warn, "warn: write bare_call_binds: %v\n", err)
 		}
+		// composes_go records that every Go struct's named fields were
+		// extracted by a binary that emits composition edges (G-7). Same
+		// full-write gate: a plain rescan re-extracts only changed files,
+		// so a pre-fix index keeps its empty composed_by until a rebuild.
+		if err := idx.WriteMeta(ctx, "composes_go", "1"); err != nil {
+			_, _ = fmt.Fprintf(h.warn, "warn: write composes_go: %v\n", err)
+		}
 	}
 
 	if err := idx.StampSchemaVersion(ctx); err != nil {


### PR DESCRIPTION
## Problem

Go was the only extracted language with no `composes` edges. Ruby, Python, Rust, and TS/JS all emit them, and the query side (graph `composed_by`, blast reverse composition) already consumes them — but the Go extractor skipped every named struct field, so `composed_by` was empty on every Go index. Measured on fresh v1.11.23 indexes: dolt 0, pebble 0, photoprism 0, nats 0, gitea 2 (both from its TypeScript frontend). Ruby control: 164 on a mid-size repo.

The missing set is exactly the transitive-carrier closure ("every struct that holds a handle without naming it") — invisible to text search where field access escapes type-derived naming, and until now invisible to Sense too.

## Fix

New `internal/extract/golang/compose.go`, mirroring `extract/rust/compose.go` per the per-language convention: named struct fields (the exact complement of `emitEmbeddings`' embedded-field walk, which keeps its `includes` semantics untouched) emit one `composes` edge per user-defined type the field's type expression names.

- Wrapper recursion: pointer, slice, array, map (key and value), channel, parentheses, generic (base + type arguments; the base recurses through the same resolver so `pkg.Registry[*Conn]` keeps its package).
- Skips: the spec's predeclared types (closed set), the declaration's own type parameters (would false-bind to same-named real types — pinned with a decoy fixture), function types, inline struct/interface literals.
- Cross-package targets keep their written qualifier and ride the exact resolution path existing Go `includes` edges ride; unresolved externals drop at resolve, so std-typed fields (`time.Time`, `context.Context`) persist nothing — pinned end-to-end in `internal/scan/compose_stamp_test.go`.
- `composes_go` meta stamp (full-write scans only) + `sense status` advisory gated on Go files: **healing an existing index requires `sense scan -rebuild`** — a plain scan skips unchanged files. Release-note duty inherited as usual.

## Verification

- 18 unit fixtures (test-first, red before the emitter existed), including: decoy real-`T` type-parameter guard (bare + wrapped + as generic arg, exact-count), embedded value/pointer fields keep `includes` and never double-emit, multi-name field `a, b *Foo` = exactly one edge, aliased-import raw-text behavior pinned, emit-error propagation, malformed-node guards. All four new functions at 100% line coverage.
- Cross-language zero-diff: full edge dumps byte-identical released-vs-branch on a Ruby repo (15,780 edges) and a Python repo (6,702 edges).
- Go additive-only: gitea and pebble pre-existing edge kinds byte-count identical (calls/includes/inherits/references/tests); composes 2→1212 (gitea), 0→2158 (pebble), 0→2042 (dolt). The G-10 anchor band is byte-preserved (pebble `versionSet.append` hi-conf callers: 13 = 13).
- Carrier oracle (dolt): `composed_by` on the three handle types covers every true struct-field carrier file; all 15 rg-oracle misses hand-classified as function parameters or composite literals, plus embedded carriers proven reachable via the `includes` side of the union.
- Side-effect probe runs on the benched verticals: ruby cited-recall 0.4815, inside the frozen band 0.444–0.518 with grounding 71/71; python control at its frozen 1.0 (values in the run log).
- `make ci` green (build + cover + lint + ledger 0), `make smoke` green, scan-content oracle regenerated for the one new meta line (Ruby-only fixture, edges unchanged).

Measured residue is filed in the local ledger: std-shadowing absorption on repos with an internal type shadowing a std package name (31 edges/30 files on one large repo), and aliased-import fields dropping at resolve (undercount, never false-bind) — the alias map is a scoped follow-up.
