### PR TITLE
fix(scan): remove the 500K satisfaction budget via rarest-method candidate pruning

### DIFF
--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -223,6 +223,21 @@ func computeHealth(ctx context.Context, db *sql.DB, dir string, resp mcpio.Statu
 		}
 	}
 
+	// The satisfy_unbudgeted stamp records that interface satisfaction ran
+	// without the old 500K budget that silently skipped the whole pass on big
+	// Go repos (dolt-class: zero satisfaction edges). Unlike the stamps
+	// above, the pass recomputes on every scan, so a PLAIN scan heals — the
+	// advisory says scan, not rebuild. Same Go gate: only Go computes
+	// implicit satisfaction.
+	if resp.Index.Symbols > 0 && readMeta(ctx, db, "satisfy_unbudgeted") == "" && hasGoFiles(ctx, db) {
+		if h.verdict == "healthy" {
+			h.verdict = "degraded"
+		}
+		if h.detail == "" {
+			h.detail = "index predates unbudgeted interface satisfaction — run 'sense scan'"
+		}
+	}
+
 	return h
 }
 

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -165,10 +165,11 @@ func TestComputeHealthBareCallBindsStamp(t *testing.T) {
 		t.Errorf("detail = %q, want bare-call message", h.detail)
 	}
 
-	// Stamped: healthy again (composes_go seeded too — it is an independent
-	// full-write stamp with its own advisory branch).
+	// Stamped: healthy again (composes_go and satisfy_unbudgeted seeded too —
+	// independent stamps with their own advisory branches).
 	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('bare_call_binds', '1')`)
 	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('composes_go', '1')`)
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('satisfy_unbudgeted', '1')`)
 	h = computeHealth(ctx, db, t.TempDir(), resp)
 	if h.verdict != "healthy" {
 		t.Errorf("verdict = %q with stamp, want healthy", h.verdict)
@@ -195,6 +196,7 @@ func TestComputeHealthComposesGoStamp(t *testing.T) {
 	// Keep the sibling stamp branches quiet so this test observes its own.
 	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('parent_linkage', '1')`)
 	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('bare_call_binds', '1')`)
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('satisfy_unbudgeted', '1')`)
 
 	resp := mcpio.StatusResponse{
 		Version: &mcpio.StatusVersion{SchemaCurrent: true, EmbeddingModelCurrent: true},
@@ -229,6 +231,51 @@ func TestComputeHealthComposesGoStamp(t *testing.T) {
 	}
 }
 
+func TestComputeHealthSatisfyUnbudgetedStamp(t *testing.T) {
+	ctx := context.Background()
+	db := healthTestDB(t)
+	_, _ = db.ExecContext(ctx, `CREATE TABLE sense_meta (key TEXT PRIMARY KEY, value TEXT)`)
+	// Go-only gate: implicit interface satisfaction is computed for Go alone,
+	// so only a Go index can be satisfaction-blind.
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_files VALUES (1, 'a.go', 'go', 'abc', 1, '2026-01-01T00:00:00Z')`)
+	// Keep the sibling stamp branches quiet so this test observes its own.
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('parent_linkage', '1')`)
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('bare_call_binds', '1')`)
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('composes_go', '1')`)
+
+	resp := mcpio.StatusResponse{
+		Version: &mcpio.StatusVersion{SchemaCurrent: true, EmbeddingModelCurrent: true},
+	}
+	resp.Index.Symbols = 5
+	resp.Index.Embeddings = 5
+
+	// No stamp: the index may predate the unbudgeted pass (a big repo's
+	// satisfaction edges were silently skipped). A PLAIN scan heals — the
+	// advisory must not demand a rebuild.
+	h := computeHealth(ctx, db, t.TempDir(), resp)
+	if h.verdict != "degraded" {
+		t.Errorf("verdict = %q without satisfy_unbudgeted stamp, want degraded", h.verdict)
+	}
+	if h.detail != "index predates unbudgeted interface satisfaction — run 'sense scan'" {
+		t.Errorf("detail = %q, want satisfy message advising a plain scan", h.detail)
+	}
+
+	// Stamped: healthy again.
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('satisfy_unbudgeted', '1')`)
+	h = computeHealth(ctx, db, t.TempDir(), resp)
+	if h.verdict != "healthy" {
+		t.Errorf("verdict = %q with stamp, want healthy", h.verdict)
+	}
+
+	// A non-Go index computes no implicit satisfaction: no advisory.
+	_, _ = db.ExecContext(ctx, `DELETE FROM sense_meta WHERE key = 'satisfy_unbudgeted'`)
+	_, _ = db.ExecContext(ctx, `UPDATE sense_files SET language = 'ruby', path = 'a.rb'`)
+	h = computeHealth(ctx, db, t.TempDir(), resp)
+	if h.verdict != "healthy" {
+		t.Errorf("verdict = %q on ruby-only index without stamp, want healthy", h.verdict)
+	}
+}
+
 func TestComputeHealthParentLinkageStamp(t *testing.T) {
 	ctx := context.Background()
 	db := healthTestDB(t)
@@ -252,11 +299,13 @@ func TestComputeHealthParentLinkageStamp(t *testing.T) {
 		t.Errorf("detail = %q, want parent-linkage message", h.detail)
 	}
 
-	// Stamped: healthy again (bare_call_binds and composes_go seeded too —
-	// each is an independent full-write stamp with its own advisory branch).
+	// Stamped: healthy again (bare_call_binds, composes_go and
+	// satisfy_unbudgeted seeded too — each is an independent stamp with its
+	// own advisory branch).
 	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('parent_linkage', '1')`)
 	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('bare_call_binds', '1')`)
 	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('composes_go', '1')`)
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('satisfy_unbudgeted', '1')`)
 	h = computeHealth(ctx, db, t.TempDir(), resp)
 	if h.verdict != "healthy" {
 		t.Errorf("verdict = %q with stamp, want healthy", h.verdict)

--- a/internal/scan/oracle_test.go
+++ b/internal/scan/oracle_test.go
@@ -117,8 +117,8 @@ func oracleDigest(t *testing.T, dbPath string) (digest string, content []string)
 // leave it unchanged, and a refactor that alters derived output fails here
 // loudly. When output changes on purpose, regenerate it (see the capture line
 // in TestScanContentOracleDigest) and update this constant in the same commit.
-// Last regeneration: the composes_go meta stamp (Go composition-edge fix)
-// added one meta line; symbols/edges/embeddings unchanged.
+// Last regeneration: the satisfy_unbudgeted meta stamp (satisfaction-budget
+// removal) added one meta line; symbols/edges/embeddings unchanged.
 const oracleGolden = "a5fb23c61141369e99b348abf7691778d07eb8de0d16eddf1251b656eb32a7e9"
 
 func TestScanContentOracleDigest(t *testing.T) {

--- a/internal/scan/oracle_test.go
+++ b/internal/scan/oracle_test.go
@@ -119,7 +119,7 @@ func oracleDigest(t *testing.T, dbPath string) (digest string, content []string)
 // in TestScanContentOracleDigest) and update this constant in the same commit.
 // Last regeneration: the composes_go meta stamp (Go composition-edge fix)
 // added one meta line; symbols/edges/embeddings unchanged.
-const oracleGolden = "a167103865f0532dcbd3e31af0ae098dfd21394f8c2bfbd975fec055c9b1dec8"
+const oracleGolden = "a5fb23c61141369e99b348abf7691778d07eb8de0d16eddf1251b656eb32a7e9"
 
 func TestScanContentOracleDigest(t *testing.T) {
 	useFakeEmbedder(t)

--- a/internal/scan/satisfy.go
+++ b/internal/scan/satisfy.go
@@ -2,6 +2,7 @@ package scan
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/luuuc/sense/internal/extract"
 	"github.com/luuuc/sense/internal/index"
@@ -87,7 +88,9 @@ func (h *harness) satisfyInterfaces() error {
 	expandInterfaceMethodSets(interfaces, embeddings)
 	promoteEmbeddedMethodSets(structs, interfaces, embeddings)
 
-	written, err := h.writeSatisfactionEdges(interfaces, structs)
+	// Buckets index the FINAL method sets — built any earlier, promoted
+	// methods are missing and embedded satisfiers silently drop.
+	written, err := h.writeSatisfactionEdges(interfaces, indexStructMethods(structs))
 	if err != nil {
 		return fmt.Errorf("satisfy: write edges: %w", err)
 	}
@@ -214,12 +217,54 @@ func promoteEmbeddedMethodSets(structs map[int64]*structInfo, interfaces map[int
 	}
 }
 
+// indexStructMethods buckets the structs by method name so satisfaction can
+// prune candidates instead of scanning every interface×struct pair. Each
+// bucket is sorted by symbol ID: edge-write order stays deterministic.
+func indexStructMethods(structs map[int64]*structInfo) map[string][]*structInfo {
+	buckets := map[string][]*structInfo{}
+	for _, st := range structs {
+		for m := range st.methods {
+			buckets[m] = append(buckets[m], st)
+		}
+	}
+	for _, b := range buckets {
+		sort.Slice(b, func(i, j int) bool { return b[i].sym.ID < b[j].sym.ID })
+	}
+	return buckets
+}
+
+// candidateStructs bounds the satisfiers of a required method set: a
+// satisfying struct has every required method, so the smallest bucket contains
+// them all. A required method with no bucket means no struct can satisfy —
+// zero candidates, immediately.
+func candidateStructs(required map[string]bool, buckets map[string][]*structInfo) []*structInfo {
+	var smallest []*structInfo
+	first := true
+	for m := range required {
+		b, ok := buckets[m]
+		if !ok {
+			return nil
+		}
+		if first || len(b) < len(smallest) {
+			smallest, first = b, false
+		}
+	}
+	return smallest
+}
+
 // writeSatisfactionEdges writes an inherits edge for every struct whose method
-// set satisfies an interface's, in one transaction.
-func (h *harness) writeSatisfactionEdges(interfaces map[int64]*ifaceInfo, structs map[int64]*structInfo) (int, error) {
+// set satisfies an interface's, in one transaction. Interfaces are visited in
+// symbol-ID order and buckets are pre-sorted, so write order is deterministic.
+func (h *harness) writeSatisfactionEdges(interfaces map[int64]*ifaceInfo, buckets map[string][]*structInfo) (int, error) {
+	ordered := make([]*ifaceInfo, 0, len(interfaces))
+	for _, iface := range interfaces {
+		ordered = append(ordered, iface)
+	}
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].sym.ID < ordered[j].sym.ID })
+
 	var written int
 	err := h.idx.InTx(h.ctx, func() error {
-		for _, iface := range interfaces {
+		for _, iface := range ordered {
 			// Post-expansion an empty INDEXED set: interface{}, a
 			// constraint-only interface, or a composite of purely
 			// unresolvable (stdlib) embeds. Everything would satisfy it, so
@@ -227,7 +272,7 @@ func (h *harness) writeSatisfactionEdges(interfaces map[int64]*ifaceInfo, struct
 			if len(iface.methods) == 0 {
 				continue
 			}
-			for _, st := range structs {
+			for _, st := range candidateStructs(iface.methods, buckets) {
 				if methodSetSatisfies(st.methods, iface.methods) {
 					if werr := h.writeSatisfactionEdge(st.sym.ID, iface.sym.ID, st.sym.FileID); werr != nil {
 						return werr

--- a/internal/scan/satisfy.go
+++ b/internal/scan/satisfy.go
@@ -9,31 +9,6 @@ import (
 	"github.com/luuuc/sense/internal/model"
 )
 
-// stdlibInterface represents a well-known standard library interface
-// whose method set is hardcoded so structs can satisfy it without
-// indexing the standard library.
-type stdlibInterface struct {
-	qualified string
-	methods   []string
-}
-
-// Unused today: stdlib symbols aren't in the index so there's no target_id to reference.
-// Will produce edges once external symbol stubs are supported.
-var stdlibInterfaces = []stdlibInterface{
-	{"io.Reader", []string{"Read"}},
-	{"io.Writer", []string{"Write"}},
-	{"io.Closer", []string{"Close"}},
-	{"io.ReadWriter", []string{"Read", "Write"}},
-	{"io.ReadCloser", []string{"Read", "Close"}},
-	{"io.WriteCloser", []string{"Write", "Close"}},
-	{"fmt.Stringer", []string{"String"}},
-	{"error", []string{"Error"}},
-	{"sort.Interface", []string{"Len", "Less", "Swap"}},
-	{"encoding.BinaryMarshaler", []string{"MarshalBinary"}},
-	{"json.Marshaler", []string{"MarshalJSON"}},
-	{"json.Unmarshaler", []string{"UnmarshalJSON"}},
-}
-
 type ifaceInfo struct {
 	sym     model.Symbol
 	methods map[string]bool
@@ -72,9 +47,6 @@ func (h *harness) satisfyInterfaces() error {
 
 	interfaces, structs := classifyGoSymbols(syms, goFiles)
 	if len(interfaces) == 0 || len(structs) == 0 {
-		return nil
-	}
-	if h.satisfyExceedsBudget(interfaces, structs) {
 		return nil
 	}
 
@@ -123,18 +95,6 @@ func classifyGoSymbols(syms []model.Symbol, goFiles map[int64]bool) (map[int64]*
 		}
 	}
 	return interfaces, structs
-}
-
-// satisfyExceedsBudget reports whether the interface×struct product exceeds the
-// 500K performance gate, warning and skipping the pass when it does.
-func (h *harness) satisfyExceedsBudget(interfaces map[int64]*ifaceInfo, structs map[int64]*structInfo) bool {
-	ifaceCount := int64(len(interfaces)) + int64(len(stdlibInterfaces))
-	product := ifaceCount * int64(len(structs))
-	if product > 500_000 {
-		_, _ = fmt.Fprintf(h.warn, "satisfy: skipping (interfaces×structs = %d > 500K)\n", product)
-		return true
-	}
-	return false
 }
 
 // collectMethodSets fills each interface's method list and each struct's method

--- a/internal/scan/satisfy_internal_test.go
+++ b/internal/scan/satisfy_internal_test.go
@@ -12,52 +12,6 @@ import (
 	"github.com/luuuc/sense/internal/sqlite"
 )
 
-// TestSatisfyExceedsBudget proves the performance gate: when the
-// interface×struct product exceeds 500K the pass warns and reports the budget
-// as exceeded, so satisfyInterfaces skips the O(n²) satisfaction scan rather
-// than stalling a large repo.
-func TestSatisfyExceedsBudget(t *testing.T) {
-	var warn bytes.Buffer
-	h := &harness{warn: &warn}
-
-	// One interface, but enough structs that ifaceCount×structs blows the gate
-	// (the stdlib interfaces are added to ifaceCount, so even one declared
-	// interface needs a large struct set; 600K structs clears 500K outright).
-	interfaces := map[int64]*ifaceInfo{1: {}}
-	structs := make(map[int64]*structInfo, 1)
-	structs[1] = &structInfo{}
-
-	// Cheaper than allocating 600K maps: the product is len×len, so make the
-	// struct count large by faking the length via many keys is expensive; use
-	// a count that, multiplied by (1 declared + len(stdlibInterfaces)), exceeds
-	// the gate. len(stdlibInterfaces) is ~12, so 50_000 structs → >600K.
-	for i := int64(2); i <= 50_000; i++ {
-		structs[i] = &structInfo{}
-	}
-
-	if !h.satisfyExceedsBudget(interfaces, structs) {
-		t.Fatal("expected the budget gate to trip for a large struct set")
-	}
-	if warn.Len() == 0 {
-		t.Error("expected a skip warning when the budget is exceeded")
-	}
-}
-
-// TestSatisfyExceedsBudgetWithinLimit confirms a small product does not trip
-// the gate, so the satisfaction scan runs.
-func TestSatisfyExceedsBudgetWithinLimit(t *testing.T) {
-	var warn bytes.Buffer
-	h := &harness{warn: &warn}
-	interfaces := map[int64]*ifaceInfo{1: {}}
-	structs := map[int64]*structInfo{1: {}, 2: {}}
-	if h.satisfyExceedsBudget(interfaces, structs) {
-		t.Fatal("small interface×struct product should be within budget")
-	}
-	if warn.Len() != 0 {
-		t.Errorf("no warning expected within budget, got %q", warn.String())
-	}
-}
-
 // TestSatisfyInterfacesQueryError covers satisfyInterfaces' first failure
 // guard: querying the Go files fails on a closed index and the wrapped error
 // surfaces instead of an empty-but-successful pass.
@@ -275,22 +229,32 @@ func (f *satisfyFakeStore) WriteEdge(context.Context, *model.Edge) (int64, error
 	return 0, f.writeErr
 }
 
-// TestSatisfyInterfacesBudgetSkip covers the budget short-circuit through the
-// full pass: enough structs to blow 500K means no edges are attempted. The
-// trip arithmetic leans on the dormant stdlibInterfaces table: (1 declared +
-// len(stdlibInterfaces)=12) × 50,001 structs ≈ 650K > 500K. If that table
-// ever shrinks below 9 entries this fails on the warn assertion — adjust
-// structCnt, not the gate.
-func TestSatisfyInterfacesBudgetSkip(t *testing.T) {
+// TestSatisfyInterfacesOverBudgetWrites is the G-2 behavior gate: a repo whose
+// interface×struct product would have blown the old 500K budget still gets its
+// satisfaction edges, silently (no skip warning). S has method M so it
+// satisfies I; the 50K method-less filler structs satisfy nothing.
+func TestSatisfyInterfacesOverBudgetWrites(t *testing.T) {
 	var warn bytes.Buffer
-	h := &harness{ctx: context.Background(),
-		idx: &satisfyFakeStore{Adapter: newOpenAdapter(t), structCnt: 50_000, writeErr: errors.New("must not write")},
-		out: io.Discard, warn: &warn}
-	if err := h.satisfyInterfaces(); err != nil {
-		t.Fatalf("budget skip must not error: %v", err)
+	structID := int64(3)
+	f := &recordingSatisfyStore{satisfyFakeStore: satisfyFakeStore{Adapter: newOpenAdapter(t), structCnt: 600_000}}
+	f.syms = []model.Symbol{
+		{ID: 1, Name: "I", Kind: model.KindInterface, FileID: 1},
+		{ID: 2, Name: "M", Kind: model.KindMethod, FileID: 1, ParentID: func() *int64 { i := int64(1); return &i }()},
+		{ID: 3, Name: "S", Kind: model.KindClass, FileID: 1},
+		{ID: 4, Name: "M", Kind: model.KindMethod, FileID: 1, ParentID: &structID},
 	}
-	if warn.Len() == 0 {
-		t.Error("expected the budget skip warning")
+	for i := int64(0); i < 600_000; i++ {
+		f.syms = append(f.syms, model.Symbol{ID: 100 + i, Kind: model.KindClass, FileID: 1})
+	}
+	h := &harness{ctx: context.Background(), idx: f, out: io.Discard, warn: &warn}
+	if err := h.satisfyInterfaces(); err != nil {
+		t.Fatalf("over-budget pass must not error: %v", err)
+	}
+	if len(f.written) != 1 {
+		t.Fatalf("want exactly 1 satisfaction edge over budget, got %d", len(f.written))
+	}
+	if warn.Len() != 0 {
+		t.Errorf("no skip warning may remain, got %q", warn.String())
 	}
 }
 

--- a/internal/scan/satisfy_internal_test.go
+++ b/internal/scan/satisfy_internal_test.go
@@ -402,9 +402,12 @@ func satisfyPairs(t *testing.T, syms []model.Symbol, includes []model.Edge) map[
 // pruning: the emitted edge set must equal a naive all-pairs oracle computed
 // with the untouched methodSetSatisfies predicate. The fixture family is
 // chosen to kill the mutants the pruning could hide:
-//   - iface 10 (Read+Close): struct 3 HAS the rarest method but lacks Close —
-//     candidate that must FAIL the re-check (kills skip-re-check);
-//   - iface 11 (Rare): served from a 1-struct bucket;
+//   - iface 10 (Read+Close): its smallest bucket is Close {1,4,5,6} (Read has
+//     five members thanks to struct 7), and struct 6 sits IN that bucket while
+//     lacking Read — a candidate that must FAIL the re-check (kills
+//     skip-re-check; verified by running the mutant, per council pass 2);
+//   - iface 11 (Rare): served from a 2-struct bucket; struct 3 satisfies it
+//     while never being a candidate for iface 10 (not in the Close bucket);
 //   - iface 12 (Ghost): required method exists on NO struct — zero edges;
 //   - struct 4 satisfies iface 10 ONLY through methods promoted from its
 //     embedded struct 5 (kills index-built-before-promotion).
@@ -430,6 +433,10 @@ func TestSatisfyDifferentialOracle(t *testing.T) {
 		{ID: 5, Name: "Embedded", Kind: model.KindClass, FileID: 1},
 		{ID: 35, Name: "Read", Kind: model.KindMethod, FileID: 1, ParentID: pid(5)},
 		{ID: 36, Name: "Close", Kind: model.KindMethod, FileID: 1, ParentID: pid(5)},
+		{ID: 6, Name: "CloseOnly", Kind: model.KindClass, FileID: 1},
+		{ID: 37, Name: "Close", Kind: model.KindMethod, FileID: 1, ParentID: pid(6)},
+		{ID: 7, Name: "ReadOnly", Kind: model.KindClass, FileID: 1},
+		{ID: 38, Name: "Read", Kind: model.KindMethod, FileID: 1, ParentID: pid(7)},
 	}
 	// Struct 4 embeds struct 5 (its only route to Read+Close).
 	includes := []model.Edge{{SourceID: pid(4), TargetID: 5, Kind: model.EdgeIncludes}}
@@ -439,9 +446,12 @@ func TestSatisfyDifferentialOracle(t *testing.T) {
 	// Naive oracle over the same classified sets, untouched predicate.
 	want := map[[2]int64]bool{
 		{1, 10}: true, {1, 11}: true, // Full satisfies IReadCloser and IRare
-		{3, 11}: true, // HasRareLacksClose: candidate for 10, must fail; satisfies 11
+		{3, 11}: true, // HasRareLacksClose satisfies IRare; never a candidate for 10
 		{4, 10}: true, // Embedder: only via promotion from Embedded
 		{5, 10}: true, // Embedded satisfies IReadCloser directly
+		// CloseOnly (6) and ReadOnly (7) satisfy NOTHING: 6 is the in-bucket
+		// candidate the re-check must reject, 7 only pads the Read bucket so
+		// Close stays strictly smallest.
 	}
 	if len(got) != len(want) {
 		t.Fatalf("edge set mismatch: got %v want %v", got, want)

--- a/internal/scan/satisfy_internal_test.go
+++ b/internal/scan/satisfy_internal_test.go
@@ -192,11 +192,10 @@ func TestPromoteThroughEmbeddedInterface(t *testing.T) {
 // in-memory symbol set, then lets each test override one downstream call.
 type satisfyFakeStore struct {
 	*sqlite.Adapter
-	syms      []model.Symbol
-	edges     []model.Edge
-	edgesErr  error
-	writeErr  error
-	structCnt int64
+	syms     []model.Symbol
+	edges    []model.Edge
+	edgesErr error
+	writeErr error
 }
 
 func (f *satisfyFakeStore) FileIDsByLanguage(context.Context, string) (map[int64]bool, error) {
@@ -208,15 +207,11 @@ func (f *satisfyFakeStore) Query(context.Context, index.Filter) ([]model.Symbol,
 		return f.syms, nil
 	}
 	iface := int64(1)
-	syms := []model.Symbol{
+	return []model.Symbol{
 		{ID: 1, Name: "I", Kind: model.KindInterface, FileID: 1},
 		{ID: 2, Name: "M", Kind: model.KindMethod, FileID: 1, ParentID: &iface},
 		{ID: 3, Name: "S", Kind: model.KindClass, FileID: 1},
-	}
-	for i := int64(0); i < f.structCnt; i++ {
-		syms = append(syms, model.Symbol{ID: 100 + i, Kind: model.KindClass, FileID: 1})
-	}
-	return syms, nil
+	}, nil
 }
 
 func (f *satisfyFakeStore) EdgesOfKind(context.Context, model.EdgeKind) ([]model.Edge, error) {
@@ -232,11 +227,11 @@ func (f *satisfyFakeStore) WriteEdge(context.Context, *model.Edge) (int64, error
 // TestSatisfyInterfacesOverBudgetWrites is the G-2 behavior gate: a repo whose
 // interface×struct product would have blown the old 500K budget still gets its
 // satisfaction edges, silently (no skip warning). S has method M so it
-// satisfies I; the 50K method-less filler structs satisfy nothing.
+// satisfies I; the 600K method-less filler structs satisfy nothing.
 func TestSatisfyInterfacesOverBudgetWrites(t *testing.T) {
 	var warn bytes.Buffer
 	structID := int64(3)
-	f := &recordingSatisfyStore{satisfyFakeStore: satisfyFakeStore{Adapter: newOpenAdapter(t), structCnt: 600_000}}
+	f := &recordingSatisfyStore{satisfyFakeStore: satisfyFakeStore{Adapter: newOpenAdapter(t)}}
 	f.syms = []model.Symbol{
 		{ID: 1, Name: "I", Kind: model.KindInterface, FileID: 1},
 		{ID: 2, Name: "M", Kind: model.KindMethod, FileID: 1, ParentID: func() *int64 { i := int64(1); return &i }()},

--- a/internal/scan/satisfy_internal_test.go
+++ b/internal/scan/satisfy_internal_test.go
@@ -351,3 +351,170 @@ func TestPromoteEmbeddedMethodsUnknownTarget(t *testing.T) {
 		t.Errorf("unknown embed target must contribute nothing, got %v", st.methods)
 	}
 }
+
+// mkStruct builds a structInfo with the given symbol id and method names.
+func mkStruct(id int64, methods ...string) *structInfo {
+	st := &structInfo{sym: model.Symbol{ID: id, FileID: 1}, methods: map[string]bool{}}
+	for _, m := range methods {
+		st.methods[m] = true
+	}
+	return st
+}
+
+// TestIndexStructMethods pins the bucket build: every struct appears in the
+// bucket of each of its methods, exactly once, and buckets are sorted by
+// symbol ID so downstream edge writes are deterministic.
+func TestIndexStructMethods(t *testing.T) {
+	structs := map[int64]*structInfo{
+		2: mkStruct(2, "Read", "Close"),
+		1: mkStruct(1, "Read"),
+		3: mkStruct(3, "Write"),
+	}
+	buckets := indexStructMethods(structs)
+	if got := len(buckets["Read"]); got != 2 {
+		t.Fatalf("Read bucket: want 2 structs, got %d", got)
+	}
+	if buckets["Read"][0].sym.ID != 1 || buckets["Read"][1].sym.ID != 2 {
+		t.Errorf("Read bucket must be sorted by symbol ID, got %d,%d",
+			buckets["Read"][0].sym.ID, buckets["Read"][1].sym.ID)
+	}
+	if len(buckets["Close"]) != 1 || len(buckets["Write"]) != 1 {
+		t.Errorf("Close/Write buckets wrong: %d/%d", len(buckets["Close"]), len(buckets["Write"]))
+	}
+	if _, ok := buckets["Flush"]; ok {
+		t.Error("no struct has Flush; bucket must be absent")
+	}
+}
+
+// TestCandidateStructs pins the pruning rule: candidates are EXACTLY the
+// smallest bucket among the required methods (kills the largest-bucket
+// mutant), and a required method with no bucket short-circuits to zero
+// candidates — falling through to any other bucket would emit false 0.9
+// satisfaction edges for interfaces nothing implements.
+func TestCandidateStructs(t *testing.T) {
+	structs := map[int64]*structInfo{
+		1: mkStruct(1, "Read", "Close"),
+		2: mkStruct(2, "Read"),
+		3: mkStruct(3, "Read", "Close", "Rare"),
+	}
+	buckets := indexStructMethods(structs)
+
+	// Rare's bucket (1 struct) is strictly smaller than Read's (3) and Close's (2).
+	got := candidateStructs(map[string]bool{"Read": true, "Close": true, "Rare": true}, buckets)
+	if len(got) != 1 || got[0].sym.ID != 3 {
+		t.Fatalf("candidates must be exactly the smallest (Rare) bucket, got %d structs", len(got))
+	}
+
+	// A required method with NO bucket anywhere → zero candidates, immediately.
+	if got := candidateStructs(map[string]bool{"Read": true, "Missing": true}, buckets); got != nil {
+		t.Fatalf("missing bucket must short-circuit to zero candidates, got %d", len(got))
+	}
+}
+
+// recordingSatisfyStore extends satisfyFakeStore to capture written edges so
+// full-pass tests can compare the emitted set against an oracle.
+type recordingSatisfyStore struct {
+	satisfyFakeStore
+	written []model.Edge
+}
+
+func (r *recordingSatisfyStore) WriteEdge(_ context.Context, e *model.Edge) (int64, error) {
+	r.written = append(r.written, *e)
+	return int64(len(r.written)), nil
+}
+
+// satisfyPairs runs the full satisfyInterfaces pass over the given symbols and
+// includes edges, returning the emitted (struct,interface) pairs.
+func satisfyPairs(t *testing.T, syms []model.Symbol, includes []model.Edge) map[[2]int64]bool {
+	t.Helper()
+	f := &recordingSatisfyStore{satisfyFakeStore: satisfyFakeStore{Adapter: newOpenAdapter(t), syms: syms, edges: includes}}
+	h := &harness{ctx: context.Background(), idx: f, out: io.Discard, warn: io.Discard}
+	if err := h.satisfyInterfaces(); err != nil {
+		t.Fatalf("satisfyInterfaces: %v", err)
+	}
+	pairs := map[[2]int64]bool{}
+	for _, e := range f.written {
+		pairs[[2]int64{*e.SourceID, e.TargetID}] = true
+	}
+	return pairs
+}
+
+// TestSatisfyDifferentialOracle is the correctness anchor for the candidate
+// pruning: the emitted edge set must equal a naive all-pairs oracle computed
+// with the untouched methodSetSatisfies predicate. The fixture family is
+// chosen to kill the mutants the pruning could hide:
+//   - iface 10 (Read+Close): struct 3 HAS the rarest method but lacks Close —
+//     candidate that must FAIL the re-check (kills skip-re-check);
+//   - iface 11 (Rare): served from a 1-struct bucket;
+//   - iface 12 (Ghost): required method exists on NO struct — zero edges;
+//   - struct 4 satisfies iface 10 ONLY through methods promoted from its
+//     embedded struct 5 (kills index-built-before-promotion).
+func TestSatisfyDifferentialOracle(t *testing.T) {
+	pid := func(i int64) *int64 { return &i }
+	syms := []model.Symbol{
+		{ID: 10, Name: "IReadCloser", Kind: model.KindInterface, FileID: 1},
+		{ID: 20, Name: "Read", Kind: model.KindMethod, FileID: 1, ParentID: pid(10)},
+		{ID: 21, Name: "Close", Kind: model.KindMethod, FileID: 1, ParentID: pid(10)},
+		{ID: 11, Name: "IRare", Kind: model.KindInterface, FileID: 1},
+		{ID: 22, Name: "Rare", Kind: model.KindMethod, FileID: 1, ParentID: pid(11)},
+		{ID: 12, Name: "IGhost", Kind: model.KindInterface, FileID: 1},
+		{ID: 23, Name: "Ghost", Kind: model.KindMethod, FileID: 1, ParentID: pid(12)},
+
+		{ID: 1, Name: "Full", Kind: model.KindClass, FileID: 1},
+		{ID: 30, Name: "Read", Kind: model.KindMethod, FileID: 1, ParentID: pid(1)},
+		{ID: 31, Name: "Close", Kind: model.KindMethod, FileID: 1, ParentID: pid(1)},
+		{ID: 32, Name: "Rare", Kind: model.KindMethod, FileID: 1, ParentID: pid(1)},
+		{ID: 3, Name: "HasRareLacksClose", Kind: model.KindClass, FileID: 1},
+		{ID: 33, Name: "Read", Kind: model.KindMethod, FileID: 1, ParentID: pid(3)},
+		{ID: 34, Name: "Rare", Kind: model.KindMethod, FileID: 1, ParentID: pid(3)},
+		{ID: 4, Name: "Embedder", Kind: model.KindClass, FileID: 1},
+		{ID: 5, Name: "Embedded", Kind: model.KindClass, FileID: 1},
+		{ID: 35, Name: "Read", Kind: model.KindMethod, FileID: 1, ParentID: pid(5)},
+		{ID: 36, Name: "Close", Kind: model.KindMethod, FileID: 1, ParentID: pid(5)},
+	}
+	// Struct 4 embeds struct 5 (its only route to Read+Close).
+	includes := []model.Edge{{SourceID: pid(4), TargetID: 5, Kind: model.EdgeIncludes}}
+
+	got := satisfyPairs(t, syms, includes)
+
+	// Naive oracle over the same classified sets, untouched predicate.
+	want := map[[2]int64]bool{
+		{1, 10}: true, {1, 11}: true, // Full satisfies IReadCloser and IRare
+		{3, 11}: true, // HasRareLacksClose: candidate for 10, must fail; satisfies 11
+		{4, 10}: true, // Embedder: only via promotion from Embedded
+		{5, 10}: true, // Embedded satisfies IReadCloser directly
+	}
+	if len(got) != len(want) {
+		t.Fatalf("edge set mismatch: got %v want %v", got, want)
+	}
+	for p := range want {
+		if !got[p] {
+			t.Errorf("missing edge %v", p)
+		}
+	}
+}
+
+// TestSatisfyUbiquitousMethodInterfaces pins the degenerate CPU shape: many
+// one-method interfaces sharing a ubiquitous method. Every candidate is a true
+// satisfier, so the "cost" is exactly the correct output, not wasted checks.
+func TestSatisfyUbiquitousMethodInterfaces(t *testing.T) {
+	pid := func(i int64) *int64 { return &i }
+	var syms []model.Symbol
+	const nIfaces, nStructs = 5, 4
+	for i := int64(0); i < nIfaces; i++ {
+		id := 10 + i
+		syms = append(syms,
+			model.Symbol{ID: id, Name: "I", Kind: model.KindInterface, FileID: 1},
+			model.Symbol{ID: 100 + i, Name: "Reset", Kind: model.KindMethod, FileID: 1, ParentID: pid(id)})
+	}
+	for s := int64(0); s < nStructs; s++ {
+		id := 50 + s
+		syms = append(syms,
+			model.Symbol{ID: id, Name: "S", Kind: model.KindClass, FileID: 1},
+			model.Symbol{ID: 200 + s, Name: "Reset", Kind: model.KindMethod, FileID: 1, ParentID: pid(id)})
+	}
+	got := satisfyPairs(t, syms, nil)
+	if len(got) != nIfaces*nStructs {
+		t.Fatalf("ubiquitous shape: want %d edges (all true), got %d", nIfaces*nStructs, len(got))
+	}
+}

--- a/internal/scan/satisfy_stamp_test.go
+++ b/internal/scan/satisfy_stamp_test.go
@@ -1,0 +1,45 @@
+package scan_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/luuuc/sense/internal/scan"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// TestScanStampsSatisfyUnbudgetedMeta pins the healing signal for the G-2
+// satisfaction-budget fix: a fresh scan stamps satisfy_unbudgeted, and —
+// unlike the rebuild-gated stamps (composes_go et al.) — a PLAIN rescan
+// re-stamps a stripped index, because the satisfy pass recomputes over the
+// full symbol table on every scan. The status advisory can therefore honestly
+// say "run 'sense scan'" instead of demanding a rebuild.
+func TestScanStampsSatisfyUnbudgetedMeta(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "kvstore.go"), storeTypeSrc)
+
+	if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := readMetaKey(t, root, "satisfy_unbudgeted"); got != "1" {
+		t.Fatalf("satisfy_unbudgeted = %q after fresh scan, want 1", got)
+	}
+
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(root, ".sense", "index.db"))
+	if err != nil {
+		t.Fatalf("open index: %v", err)
+	}
+	if err := a.DeleteMeta(ctx, "satisfy_unbudgeted"); err != nil {
+		t.Fatalf("delete meta: %v", err)
+	}
+	_ = a.Close()
+
+	if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+		t.Fatalf("plain rescan: %v", err)
+	}
+	if got := readMetaKey(t, root, "satisfy_unbudgeted"); got != "1" {
+		t.Errorf("satisfy_unbudgeted = %q after plain rescan, want re-stamped 1 (the pass runs every scan)", got)
+	}
+}

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -416,6 +416,15 @@ func finalizeScan(ctx context.Context, idx *sqlite.Adapter, h *harness, senseDir
 		_, _ = fmt.Fprintf(h.warn, "warn: write last_scan_at: %v\n", err)
 	}
 
+	// satisfy_unbudgeted records that interface satisfaction ran without the
+	// old 500K interfaces×structs budget that silently skipped the whole pass
+	// on big Go repos (G-2). Unlike the rebuild-gated stamps below, the
+	// satisfy pass recomputes over the full symbol table on EVERY scan, so a
+	// plain scan heals a blind index — the stamp writes unconditionally.
+	if err := idx.WriteMeta(ctx, "satisfy_unbudgeted", "1"); err != nil {
+		_, _ = fmt.Fprintf(h.warn, "warn: write satisfy_unbudgeted: %v\n", err)
+	}
+
 	if h.fullyLinked {
 		if err := idx.WriteMeta(ctx, "parent_linkage", "1"); err != nil {
 			_, _ = fmt.Fprintf(h.warn, "warn: write parent_linkage: %v\n", err)


### PR DESCRIPTION
## Problem (measured)

`satisfyExceedsBudget` skipped the ENTIRE Go implicit-satisfaction pass when interfaces×structs > 500K — silently (a scan-time stderr line; nothing recorded in the index). Every big Go repo is satisfaction-blind: dolt (552K pairs) has **0** satisfaction edges on disk, vitess (1.0M), temporal (1.6M) and teleport (9.7M) likewise; `sqlparser.SQLNode` shows `inherited_by: 0`. dolt misses everything for being 10% over an arbitrary line.

## Fix

Candidates are pruned by a rarest-method bucket index built AFTER embedding expansion/promotion: a satisfying struct has every required method, so the smallest bucket bounds the candidates; the untouched `methodSetSatisfies` predicate remains the truth. A required method with no bucket short-circuits to zero candidates. With cost now output-sensitive there is nothing left for a budget to protect — the gate is deleted (not raised), along with the dormant `stdlibInterfaces` table it counted (its only reference). A `satisfy_unbudgeted` meta stamp + `sense status` advisory distinguish pre-fix indexes; the pass recomputes on every scan, so the advisory says **run `sense scan`** — a plain scan heals, no rebuild needed.

## Evidence

- **Equivalence:** gin (80) / pebble (927) / gitea (671) satisfaction edge sets byte-identical pre/post (sorted-set diff) — the pruning is a pure candidate filter.
- **Healing:** dolt 0 → 2,726 edges from a 2.3s plain scan (satisfy phase 176ms); teleport 0 → 31,311; vitess 0 → 4,025; SQLNode `inherited_by` 0 → 8.
- **Measured worst case:** teleport full scan **57.8s doing the complete pass** (satisfy = 1.07s, 1%) vs 59.5s on the old binary with the skip firing. Checks are output-sensitive: 14,787 subset checks for 13,551 edges (naive: 9.68M).
- **Idempotence:** second plain scan holds dolt at 2,726 exactly. Non-Go control (ruby): edge counts byte-identical.
- **Correctness anchor:** a differential-oracle test compares the emitted set against a naive all-pairs oracle over a mutant-targeted fixture family (in-bucket candidate that must fail the re-check, promotion-only satisfier, ghost method, empty bucket); the skip-re-check mutant kill is verified by execution.
- **Side-effect runs:** healthchecks cited-recall 1.0 (= frozen); llm.rb 0.926 vs frozen band 0.44-0.52 — above-band long-session outlier (billed 2× the comparison run; the fix is Go-gated and the ruby control is byte-identical).

## Known limitation (disclosed, pre-existing)

Satisfaction matching is name-only (no signatures) — pre-existing, and byte-identical on the repos where the pass already ran. Healing scales its exposure: on dolt, single-method interfaces are 68% of healed edges and a stratified n=12 hand-verify classified **5/12 as compile-false** name collisions (`Close()` vs `Close(ctx)` class); multi-method interfaces sampled 4/4 genuine. Filed as a follow-up (signature/arity-aware matching); the edges carry convention confidence 0.9, and the alternative on big repos was zero edges and no signal anything was skipped.
