### PR TITLE
fix(scan): arity-aware interface satisfaction — 30% of big-repo edges were compile-false

### DIFF
--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -238,6 +238,19 @@ func computeHealth(ctx context.Context, db *sql.DB, dir string, resp mcpio.Statu
 		}
 	}
 
+	// The satisfy_arity stamp mirrors satisfy_unbudgeted for the arity-aware
+	// matching fix (name-only satisfaction bound ~30% compile-false edges):
+	// the pass recomputes on every scan, so a PLAIN scan heals and the
+	// advisory says scan, not rebuild. Same Go gate.
+	if resp.Index.Symbols > 0 && readMeta(ctx, db, "satisfy_arity") == "" && hasGoFiles(ctx, db) {
+		if h.verdict == "healthy" {
+			h.verdict = "degraded"
+		}
+		if h.detail == "" {
+			h.detail = "index predates arity-aware satisfaction — run 'sense scan'"
+		}
+	}
+
 	return h
 }
 

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -170,6 +170,7 @@ func TestComputeHealthBareCallBindsStamp(t *testing.T) {
 	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('bare_call_binds', '1')`)
 	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('composes_go', '1')`)
 	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('satisfy_unbudgeted', '1')`)
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('satisfy_arity', '1')`)
 	h = computeHealth(ctx, db, t.TempDir(), resp)
 	if h.verdict != "healthy" {
 		t.Errorf("verdict = %q with stamp, want healthy", h.verdict)
@@ -197,6 +198,7 @@ func TestComputeHealthComposesGoStamp(t *testing.T) {
 	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('parent_linkage', '1')`)
 	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('bare_call_binds', '1')`)
 	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('satisfy_unbudgeted', '1')`)
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('satisfy_arity', '1')`)
 
 	resp := mcpio.StatusResponse{
 		Version: &mcpio.StatusVersion{SchemaCurrent: true, EmbeddingModelCurrent: true},
@@ -262,6 +264,7 @@ func TestComputeHealthSatisfyUnbudgetedStamp(t *testing.T) {
 
 	// Stamped: healthy again.
 	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('satisfy_unbudgeted', '1')`)
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('satisfy_arity', '1')`)
 	h = computeHealth(ctx, db, t.TempDir(), resp)
 	if h.verdict != "healthy" {
 		t.Errorf("verdict = %q with stamp, want healthy", h.verdict)
@@ -306,6 +309,7 @@ func TestComputeHealthParentLinkageStamp(t *testing.T) {
 	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('bare_call_binds', '1')`)
 	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('composes_go', '1')`)
 	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('satisfy_unbudgeted', '1')`)
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('satisfy_arity', '1')`)
 	h = computeHealth(ctx, db, t.TempDir(), resp)
 	if h.verdict != "healthy" {
 		t.Errorf("verdict = %q with stamp, want healthy", h.verdict)
@@ -636,5 +640,49 @@ func TestComputeCLIFreshnessWatchingAndPending(t *testing.T) {
 		t.Error("expected Pending to be reported")
 	} else if *f.Pending != 1 {
 		t.Errorf("pending = %d, want 1 (one unembedded symbol)", *f.Pending)
+	}
+}
+
+func TestComputeHealthSatisfyArityStamp(t *testing.T) {
+	ctx := context.Background()
+	db := healthTestDB(t)
+	_, _ = db.ExecContext(ctx, `CREATE TABLE sense_meta (key TEXT PRIMARY KEY, value TEXT)`)
+	// Go-only gate, same as satisfy_unbudgeted: only Go computes satisfaction.
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_files VALUES (1, 'a.go', 'go', 'abc', 1, '2026-01-01T00:00:00Z')`)
+	// Keep the sibling stamp branches quiet so this test observes its own.
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('parent_linkage', '1')`)
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('bare_call_binds', '1')`)
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('composes_go', '1')`)
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('satisfy_unbudgeted', '1')`)
+
+	resp := mcpio.StatusResponse{
+		Version: &mcpio.StatusVersion{SchemaCurrent: true, EmbeddingModelCurrent: true},
+	}
+	resp.Index.Symbols = 5
+	resp.Index.Embeddings = 5
+
+	// No stamp: the index carries name-only satisfaction edges (~30% measured
+	// compile-false). A PLAIN scan heals — the advisory must not demand a rebuild.
+	h := computeHealth(ctx, db, t.TempDir(), resp)
+	if h.verdict != "degraded" {
+		t.Errorf("verdict = %q without satisfy_arity stamp, want degraded", h.verdict)
+	}
+	if h.detail != "index predates arity-aware satisfaction — run 'sense scan'" {
+		t.Errorf("detail = %q, want arity message advising a plain scan", h.detail)
+	}
+
+	// Stamped: healthy again.
+	_, _ = db.ExecContext(ctx, `INSERT INTO sense_meta VALUES ('satisfy_arity', '1')`)
+	h = computeHealth(ctx, db, t.TempDir(), resp)
+	if h.verdict != "healthy" {
+		t.Errorf("verdict = %q with stamp, want healthy", h.verdict)
+	}
+
+	// A non-Go index computes no satisfaction: no advisory.
+	_, _ = db.ExecContext(ctx, `DELETE FROM sense_meta WHERE key = 'satisfy_arity'`)
+	_, _ = db.ExecContext(ctx, `UPDATE sense_files SET language = 'ruby', path = 'a.rb'`)
+	h = computeHealth(ctx, db, t.TempDir(), resp)
+	if h.verdict != "healthy" {
+		t.Errorf("verdict = %q on ruby-only index without stamp, want healthy", h.verdict)
 	}
 }

--- a/internal/scan/oracle_test.go
+++ b/internal/scan/oracle_test.go
@@ -117,9 +117,9 @@ func oracleDigest(t *testing.T, dbPath string) (digest string, content []string)
 // leave it unchanged, and a refactor that alters derived output fails here
 // loudly. When output changes on purpose, regenerate it (see the capture line
 // in TestScanContentOracleDigest) and update this constant in the same commit.
-// Last regeneration: the satisfy_unbudgeted meta stamp (satisfaction-budget
-// removal) added one meta line; symbols/edges/embeddings unchanged.
-const oracleGolden = "a5fb23c61141369e99b348abf7691778d07eb8de0d16eddf1251b656eb32a7e9"
+// Last regeneration: the satisfy_arity meta stamp (arity-aware satisfaction
+// matching) added one meta line; symbols/edges/embeddings unchanged.
+const oracleGolden = "8c2052f0c221ccc54f70c1e28ce7b7bb910d347d20ec740ba43e53e8653bd72a"
 
 func TestScanContentOracleDigest(t *testing.T) {
 	useFakeEmbedder(t)

--- a/internal/scan/satisfy.go
+++ b/internal/scan/satisfy.go
@@ -3,6 +3,7 @@ package scan
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/luuuc/sense/internal/extract"
 	"github.com/luuuc/sense/internal/index"
@@ -322,3 +323,103 @@ func (h *harness) writeSatisfactionEdge(structID, ifaceID, fileID int64) error {
 	})
 	return err
 }
+
+// parseMethodArity derives the (params, results) slot counts from a method's
+// stored declaration snippet. Both snippet shapes parse through one path:
+// interface members (`Close() error`) and receiver forms
+// (`func (r *T) Close() error {`) — the receiver group is skipped so the
+// param group is always the one after the method name. The zero value
+// (UNKNOWN) is returned for every construct the walker does not model:
+// truncated multi-line declarations, cap-length snippets (a 200-byte cut can
+// BALANCE into a wrong parse), backquoted struct tags, or missing groups.
+// UNKNOWN can only ever keep an edge, never drop one.
+func parseMethodArity(snippet string) arity {
+	s := strings.TrimSpace(snippet)
+	if s == "" || len(snippet) >= snippetMaxBytes || strings.ContainsRune(s, '`') {
+		return arity{}
+	}
+	if strings.HasPrefix(s, "func ") {
+		s = strings.TrimSpace(s[5:])
+		if strings.HasPrefix(s, "(") { // receiver group
+			_, end, _, ok := scanGroup(s, 0)
+			if !ok {
+				return arity{}
+			}
+			s = strings.TrimSpace(s[end:])
+		}
+	}
+	open := strings.IndexByte(s, '(')
+	if open <= 0 { // no param group, or no method name before it
+		return arity{}
+	}
+	commas, end, content, ok := scanGroup(s, open)
+	if !ok {
+		return arity{}
+	}
+	params := 0
+	if content {
+		params = commas + 1
+	}
+	results, ok := countResults(s[end:])
+	if !ok {
+		return arity{}
+	}
+	return arity{params: params, results: results, known: true}
+}
+
+// scanGroup walks one balanced group starting at s[i] == '(' with a combined
+// depth counter across (), [] and {} — commas inside brackets or braces never
+// count as slot separators (generic receivers, Pair[K, V] params, inline
+// structs). Returns the top-level comma count, the index just past the
+// closing paren, whether the group has any content, and ok=false when the
+// group never closes (a truncated multi-line declaration).
+func scanGroup(s string, i int) (commas, end int, content, ok bool) {
+	depth := 0
+	for j := i; j < len(s); j++ {
+		switch s[j] {
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			depth--
+			if depth == 0 {
+				return commas, j + 1, content, true
+			}
+		case ',':
+			if depth == 1 {
+				commas++
+			}
+		default:
+			if depth >= 1 && !isSpaceByte(s[j]) {
+				content = true
+			}
+		}
+	}
+	return 0, 0, false, false
+}
+
+// countResults classifies the text after the param group: nothing (or only
+// the body's opening brace) → 0; a parenthesized group → its slot count; any
+// bare type → 1 (a bare result can never contain a top-level comma — Go
+// requires parentheses for tuples).
+func countResults(rest string) (int, bool) {
+	rest = strings.TrimSpace(rest)
+	if cut := strings.IndexByte(rest, '{'); cut >= 0 && !strings.HasPrefix(rest, "(") && !strings.Contains(rest[:cut], "func(") && !strings.Contains(rest[:cut], "func (") {
+		rest = strings.TrimSpace(rest[:cut])
+	}
+	if rest == "" {
+		return 0, true
+	}
+	if rest[0] == '(' {
+		commas, _, content, ok := scanGroup(rest, 0)
+		if !ok {
+			return 0, false
+		}
+		if !content {
+			return 0, true
+		}
+		return commas + 1, true
+	}
+	return 1, true
+}
+
+func isSpaceByte(b byte) bool { return b == ' ' || b == '\t' }

--- a/internal/scan/satisfy.go
+++ b/internal/scan/satisfy.go
@@ -123,10 +123,10 @@ func collectMethodSets(syms []model.Symbol, interfaces map[int64]*ifaceInfo, str
 		}
 		parentID := *s.ParentID
 		if iface, ok := interfaces[parentID]; ok {
-			iface.methods[s.Name] = arity{}
+			iface.methods[s.Name] = parseMethodArity(s.Snippet)
 		}
 		if st, ok := structs[parentID]; ok {
-			st.methods[s.Name] = arity{}
+			st.methods[s.Name] = parseMethodArity(s.Snippet)
 		}
 	}
 }

--- a/internal/scan/satisfy.go
+++ b/internal/scan/satisfy.go
@@ -9,14 +9,29 @@ import (
 	"github.com/luuuc/sense/internal/model"
 )
 
+// arity is the (params, results) slot count parsed from a method's
+// declaration snippet. The zero value means the snippet didn't parse
+// (multi-line declaration, truncation, unmodeled construct); name-only
+// matching applies — UNKNOWN can only ever KEEP an edge, never drop one.
+type arity struct {
+	params, results int
+	known           bool
+}
+
+// compatible reports whether two parsed arities allow satisfaction: either
+// side UNKNOWN falls back to name-only matching; both known require equality.
+func (a arity) compatible(b arity) bool {
+	return !a.known || !b.known || a == b
+}
+
 type ifaceInfo struct {
 	sym     model.Symbol
-	methods map[string]bool
+	methods map[string]arity
 }
 
 type structInfo struct {
 	sym     model.Symbol
-	methods map[string]bool
+	methods map[string]arity
 }
 
 // satisfyInterfaces is a post-extraction pass that computes implicit
@@ -84,12 +99,12 @@ func classifyGoSymbols(syms []model.Symbol, goFiles map[int64]bool) (map[int64]*
 		case model.KindInterface:
 			interfaces[s.ID] = &ifaceInfo{
 				sym:     *s,
-				methods: map[string]bool{},
+				methods: map[string]arity{},
 			}
 		case model.KindClass:
 			structs[s.ID] = &structInfo{
 				sym:     *s,
-				methods: map[string]bool{},
+				methods: map[string]arity{},
 			}
 		default:
 		}
@@ -107,10 +122,10 @@ func collectMethodSets(syms []model.Symbol, interfaces map[int64]*ifaceInfo, str
 		}
 		parentID := *s.ParentID
 		if iface, ok := interfaces[parentID]; ok {
-			iface.methods[s.Name] = true
+			iface.methods[s.Name] = arity{}
 		}
 		if st, ok := structs[parentID]; ok {
-			st.methods[s.Name] = true
+			st.methods[s.Name] = arity{}
 		}
 	}
 }
@@ -159,8 +174,17 @@ func expandInterfaceMethods(id int64, interfaces map[int64]*ifaceInfo, embedding
 			continue
 		}
 		expandInterfaceMethods(embeddedID, interfaces, embeddings, expanded, visiting)
-		for m := range embedded.methods {
-			iface.methods[m] = true
+		for m, ar := range embedded.methods {
+			if have, ok := iface.methods[m]; ok {
+				// Same name from two sources: arity agreement keeps it;
+				// disagreement collapses to UNKNOWN so map order never
+				// decides which declaration wins.
+				if have != ar {
+					iface.methods[m] = arity{}
+				}
+				continue
+			}
+			iface.methods[m] = ar
 		}
 	}
 	delete(visiting, id)
@@ -197,7 +221,7 @@ func indexStructMethods(structs map[int64]*structInfo) map[string][]*structInfo 
 // satisfying struct has every required method, so the smallest bucket contains
 // them all. A required method with no bucket means no struct can satisfy —
 // zero candidates, immediately.
-func candidateStructs(required map[string]bool, buckets map[string][]*structInfo) []*structInfo {
+func candidateStructs(required map[string]arity, buckets map[string][]*structInfo) []*structInfo {
 	var smallest []*structInfo
 	first := true
 	for m := range required {
@@ -254,8 +278,11 @@ func promoteEmbeddedMethods(st *structInfo, id int64, embeddings map[int64][]int
 		if iface, ok := interfaces[embeddedID]; ok {
 			// An embedded interface value delegates its whole method set;
 			// the set is already fully expanded, no recursion needed.
-			for m := range iface.methods {
-				st.methods[m] = true
+			// Insert-if-absent: the embedder's own declaration shadows.
+			for m, ar := range iface.methods {
+				if _, ok := st.methods[m]; !ok {
+					st.methods[m] = ar
+				}
 			}
 			continue
 		}
@@ -264,15 +291,21 @@ func promoteEmbeddedMethods(st *structInfo, id int64, embeddings map[int64][]int
 			continue
 		}
 		promoteEmbeddedMethods(embedded, embeddedID, embeddings, structs, interfaces, depth-1)
-		for m := range embedded.methods {
-			st.methods[m] = true
+		for m, ar := range embedded.methods {
+			if _, ok := st.methods[m]; !ok {
+				st.methods[m] = ar
+			}
 		}
 	}
 }
 
-func methodSetSatisfies(methods, required map[string]bool) bool {
-	for m := range required {
-		if !methods[m] {
+func methodSetSatisfies(methods, required map[string]arity) bool {
+	for m, want := range required {
+		have, ok := methods[m]
+		if !ok {
+			return false
+		}
+		if !have.compatible(want) {
 			return false
 		}
 	}

--- a/internal/scan/satisfy.go
+++ b/internal/scan/satisfy.go
@@ -249,6 +249,13 @@ func (h *harness) writeSatisfactionEdges(interfaces map[int64]*ifaceInfo, bucket
 
 	var written int
 	err := h.idx.InTx(h.ctx, func() error {
+		// The pass owns its edge set and rewrites it wholesale: clear every
+		// previously-written satisfaction edge (this pass's exact output
+		// signature) so a TIGHTENING of the matcher reaches existing indexes
+		// — upsert semantics alone would keep stale junk forever.
+		if err := h.clearSatisfactionEdges(); err != nil {
+			return err
+		}
 		for _, iface := range ordered {
 			// Post-expansion an empty INDEXED set: interface{}, a
 			// constraint-only interface, or a composite of purely
@@ -311,6 +318,23 @@ func methodSetSatisfies(methods, required map[string]arity) bool {
 		}
 	}
 	return true
+}
+
+// clearSatisfactionEdges deletes the satisfaction pass's owned edge set:
+// inherits edges at convention confidence targeting Go-file interfaces —
+// exactly what writeSatisfactionEdge emits and nothing else.
+func (h *harness) clearSatisfactionEdges() error {
+	_, err := h.idx.DB().ExecContext(h.ctx, `
+		DELETE FROM sense_edges WHERE kind = 'inherits' AND confidence = ?
+		AND target_id IN (
+			SELECT s.id FROM sense_symbols s
+			JOIN sense_files f ON f.id = s.file_id
+			WHERE s.kind = 'interface' AND f.language = 'go')`,
+		extract.ConfidenceConvention)
+	if err != nil {
+		return fmt.Errorf("satisfy: clear stale edges: %w", err)
+	}
+	return nil
 }
 
 func (h *harness) writeSatisfactionEdge(structID, ifaceID, fileID int64) error {

--- a/internal/scan/satisfy.go
+++ b/internal/scan/satisfy.go
@@ -197,8 +197,38 @@ func expandInterfaceMethods(id int64, interfaces map[int64]*ifaceInfo, embedding
 // satisfaction. An embedded interface field delegates its whole (expanded)
 // method set, so interface targets union in full.
 func promoteEmbeddedMethodSets(structs map[int64]*structInfo, interfaces map[int64]*ifaceInfo, embeddings map[int64][]int64) {
+	// Snapshot each struct's OWN method names before any promotion mutates
+	// the maps: own declarations shadow embedded ones (Go), while two
+	// EMBEDDED sources disagreeing on an absent name collapse to UNKNOWN —
+	// embed order must never pick a winner and drop a compile-true edge.
+	own := make(map[int64]map[string]bool, len(structs))
 	for id, st := range structs {
-		promoteEmbeddedMethods(st, id, embeddings, structs, interfaces, 3)
+		names := make(map[string]bool, len(st.methods))
+		for m := range st.methods {
+			names[m] = true
+		}
+		own[id] = names
+	}
+	for id, st := range structs {
+		promoteEmbeddedMethods(st, id, own, embeddings, structs, interfaces, 3)
+	}
+}
+
+// mergePromoted folds one embedded source's method set into the embedder:
+// names the embedder declares itself are never touched; a name two embedded
+// sources disagree on collapses to UNKNOWN (conservative: keeps the edge).
+func mergePromoted(st *structInfo, ownNames map[string]bool, promoted map[string]arity) {
+	for m, ar := range promoted {
+		if ownNames[m] {
+			continue
+		}
+		if have, ok := st.methods[m]; ok {
+			if have != ar {
+				st.methods[m] = arity{}
+			}
+			continue
+		}
+		st.methods[m] = ar
 	}
 }
 
@@ -278,7 +308,7 @@ func (h *harness) writeSatisfactionEdges(interfaces map[int64]*ifaceInfo, bucket
 	return written, err
 }
 
-func promoteEmbeddedMethods(st *structInfo, id int64, embeddings map[int64][]int64, structs map[int64]*structInfo, interfaces map[int64]*ifaceInfo, depth int) {
+func promoteEmbeddedMethods(st *structInfo, id int64, own map[int64]map[string]bool, embeddings map[int64][]int64, structs map[int64]*structInfo, interfaces map[int64]*ifaceInfo, depth int) {
 	if depth <= 0 {
 		return
 	}
@@ -286,24 +316,15 @@ func promoteEmbeddedMethods(st *structInfo, id int64, embeddings map[int64][]int
 		if iface, ok := interfaces[embeddedID]; ok {
 			// An embedded interface value delegates its whole method set;
 			// the set is already fully expanded, no recursion needed.
-			// Insert-if-absent: the embedder's own declaration shadows.
-			for m, ar := range iface.methods {
-				if _, ok := st.methods[m]; !ok {
-					st.methods[m] = ar
-				}
-			}
+			mergePromoted(st, own[id], iface.methods)
 			continue
 		}
 		embedded, ok := structs[embeddedID]
 		if !ok {
 			continue
 		}
-		promoteEmbeddedMethods(embedded, embeddedID, embeddings, structs, interfaces, depth-1)
-		for m, ar := range embedded.methods {
-			if _, ok := st.methods[m]; !ok {
-				st.methods[m] = ar
-			}
-		}
+		promoteEmbeddedMethods(embedded, embeddedID, own, embeddings, structs, interfaces, depth-1)
+		mergePromoted(st, own[id], embedded.methods)
 	}
 }
 
@@ -362,14 +383,19 @@ func parseMethodArity(snippet string) arity {
 	if s == "" || len(snippet) >= snippetMaxBytes || strings.ContainsRune(s, '`') {
 		return arity{}
 	}
-	if strings.HasPrefix(s, "func ") {
-		s = strings.TrimSpace(s[5:])
-		if strings.HasPrefix(s, "(") { // receiver group
-			_, end, _, ok := scanGroup(s, 0)
+	if strings.HasPrefix(s, "func") {
+		// Go does not require a space before the receiver group: `func(r *T)`
+		// is legal source. A method named exactly `func` is impossible, so
+		// `func` followed by any spacing then `(` is always the receiver.
+		rest := strings.TrimLeft(s[4:], " \t")
+		if strings.HasPrefix(rest, "(") {
+			_, end, _, ok := scanGroup(rest, 0)
 			if !ok {
 				return arity{}
 			}
-			s = strings.TrimSpace(s[end:])
+			s = strings.TrimSpace(rest[end:])
+		} else if len(s) > 4 && (s[4] == ' ' || s[4] == '\t') {
+			s = rest // plain function declaration
 		}
 	}
 	open := strings.IndexByte(s, '(')
@@ -427,7 +453,7 @@ func scanGroup(s string, i int) (commas, end int, content, ok bool) {
 // requires parentheses for tuples).
 func countResults(rest string) (int, bool) {
 	rest = strings.TrimSpace(rest)
-	if cut := strings.IndexByte(rest, '{'); cut >= 0 && !strings.HasPrefix(rest, "(") && !strings.Contains(rest[:cut], "func(") && !strings.Contains(rest[:cut], "func (") {
+	if cut := strings.IndexByte(rest, '{'); cut >= 0 && !strings.HasPrefix(rest, "(") {
 		rest = strings.TrimSpace(rest[:cut])
 	}
 	if rest == "" {

--- a/internal/scan/satisfy_internal_test.go
+++ b/internal/scan/satisfy_internal_test.go
@@ -156,6 +156,28 @@ func TestExpandInterfaceMethodSets(t *testing.T) {
 	}
 }
 
+// TestExpandInterfaceMethodSetsArityConflict pins the diamond-disagreement
+// rule: the same member name arriving from two embedded interfaces with
+// DIFFERENT arities collapses to UNKNOWN — map order never decides, and the
+// conservative direction (keep the edge) holds.
+func TestExpandInterfaceMethodSetsArityConflict(t *testing.T) {
+	k := func(p, r int) arity { return arity{params: p, results: r, known: true} }
+	interfaces := map[int64]*ifaceInfo{
+		1: {methods: map[string]arity{"Close": k(0, 1)}},
+		2: {methods: map[string]arity{"Close": k(1, 1)}},
+		3: {methods: map[string]arity{}},
+	}
+	embeddings := map[int64][]int64{3: {1, 2}}
+	expandInterfaceMethodSets(interfaces, embeddings)
+	got, ok := interfaces[3].methods["Close"]
+	if !ok {
+		t.Fatal("Close must be present after expansion")
+	}
+	if got.known {
+		t.Errorf("conflicting arities must collapse to UNKNOWN, got %+v", got)
+	}
+}
+
 // TestExpandInterfaceMethodSetsCycle proves termination on an embedding cycle
 // (illegal Go, but the index can contain mid-edit or misresolved code).
 func TestExpandInterfaceMethodSetsCycle(t *testing.T) {

--- a/internal/scan/satisfy_internal_test.go
+++ b/internal/scan/satisfy_internal_test.go
@@ -64,15 +64,15 @@ func TestSatisfyInterfacesSymbolQueryError(t *testing.T) {
 }
 
 func TestMethodSetSatisfies(t *testing.T) {
-	methods := map[string]bool{"Read": true, "Write": true, "Close": true}
+	methods := map[string]arity{"Read": {}, "Write": {}, "Close": {}}
 
-	if !methodSetSatisfies(methods, map[string]bool{"Read": true, "Write": true}) {
+	if !methodSetSatisfies(methods, map[string]arity{"Read": {}, "Write": {}}) {
 		t.Error("should satisfy subset")
 	}
-	if !methodSetSatisfies(methods, map[string]bool{"Read": true, "Write": true, "Close": true}) {
+	if !methodSetSatisfies(methods, map[string]arity{"Read": {}, "Write": {}, "Close": {}}) {
 		t.Error("should satisfy exact set")
 	}
-	if methodSetSatisfies(methods, map[string]bool{"Read": true, "Flush": true}) {
+	if methodSetSatisfies(methods, map[string]arity{"Read": {}, "Flush": {}}) {
 		t.Error("should not satisfy with missing method")
 	}
 	if !methodSetSatisfies(methods, nil) {
@@ -81,8 +81,8 @@ func TestMethodSetSatisfies(t *testing.T) {
 }
 
 func TestPromoteEmbeddedMethods(t *testing.T) {
-	outer := &structInfo{methods: map[string]bool{"Own": true}}
-	inner := &structInfo{methods: map[string]bool{"Read": true, "Write": true}}
+	outer := &structInfo{methods: map[string]arity{"Own": {}}}
+	inner := &structInfo{methods: map[string]arity{"Read": {}, "Write": {}}}
 
 	structs := map[int64]*structInfo{
 		1: outer,
@@ -94,21 +94,21 @@ func TestPromoteEmbeddedMethods(t *testing.T) {
 
 	promoteEmbeddedMethods(outer, 1, embeddings, structs, nil, 3)
 
-	if !outer.methods["Read"] {
+	if !hasMethod(outer.methods, "Read") {
 		t.Error("expected Read promoted from embedded struct")
 	}
-	if !outer.methods["Write"] {
+	if !hasMethod(outer.methods, "Write") {
 		t.Error("expected Write promoted from embedded struct")
 	}
-	if !outer.methods["Own"] {
+	if !hasMethod(outer.methods, "Own") {
 		t.Error("expected Own to remain")
 	}
 }
 
 func TestPromoteEmbeddedMethodsDepthLimit(t *testing.T) {
-	a := &structInfo{methods: map[string]bool{}}
-	b := &structInfo{methods: map[string]bool{}}
-	c := &structInfo{methods: map[string]bool{"Deep": true}}
+	a := &structInfo{methods: map[string]arity{}}
+	b := &structInfo{methods: map[string]arity{}}
+	c := &structInfo{methods: map[string]arity{"Deep": {}}}
 
 	structs := map[int64]*structInfo{1: a, 2: b, 3: c}
 	embeddings := map[int64][]int64{1: {2}, 2: {3}}
@@ -117,7 +117,7 @@ func TestPromoteEmbeddedMethodsDepthLimit(t *testing.T) {
 
 	// Depth=1 means we only go one hop. b's methods get promoted,
 	// but c's methods should not (they need depth=2).
-	if a.methods["Deep"] {
+	if hasMethod(a.methods, "Deep") {
 		t.Error("expected depth limit to prevent promoting from 2 hops away")
 	}
 }
@@ -128,10 +128,10 @@ func TestPromoteEmbeddedMethodsDepthLimit(t *testing.T) {
 // diamonds dedupe, and unknown targets contribute nothing.
 func TestExpandInterfaceMethodSets(t *testing.T) {
 	interfaces := map[int64]*ifaceInfo{
-		1: {methods: map[string]bool{"A": true}},
-		2: {methods: map[string]bool{"B": true}},
-		3: {methods: map[string]bool{}},
-		4: {methods: map[string]bool{"D": true}},
+		1: {methods: map[string]arity{"A": {}}},
+		2: {methods: map[string]arity{"B": {}}},
+		3: {methods: map[string]arity{}},
+		4: {methods: map[string]arity{"D": {}}},
 	}
 	// 3 embeds 2 embeds 1 (chain, deeper than one hop); 4 embeds 1 and 2
 	// (diamond: A arrives via both paths); 2 also embeds an unknown target.
@@ -143,14 +143,14 @@ func TestExpandInterfaceMethodSets(t *testing.T) {
 	expandInterfaceMethodSets(interfaces, embeddings)
 
 	for _, m := range []string{"A", "B"} {
-		if !interfaces[3].methods[m] {
+		if !hasMethod(interfaces[3].methods, m) {
 			t.Errorf("chain: interface 3 missing %s after expansion", m)
 		}
 	}
 	if len(interfaces[4].methods) != 3 { // A, B, D — diamond dedupes
 		t.Errorf("diamond: expected 3 methods on interface 4, got %v", interfaces[4].methods)
 	}
-	if !interfaces[2].methods["A"] || len(interfaces[2].methods) != 2 {
+	if !hasMethod(interfaces[2].methods, "A") || len(interfaces[2].methods) != 2 {
 		t.Errorf("unknown target must contribute nothing: %v", interfaces[2].methods)
 	}
 }
@@ -159,12 +159,12 @@ func TestExpandInterfaceMethodSets(t *testing.T) {
 // (illegal Go, but the index can contain mid-edit or misresolved code).
 func TestExpandInterfaceMethodSetsCycle(t *testing.T) {
 	interfaces := map[int64]*ifaceInfo{
-		1: {methods: map[string]bool{"A": true}},
-		2: {methods: map[string]bool{"B": true}},
+		1: {methods: map[string]arity{"A": {}}},
+		2: {methods: map[string]arity{"B": {}}},
 	}
 	embeddings := map[int64][]int64{1: {2}, 2: {1}}
 	expandInterfaceMethodSets(interfaces, embeddings) // must terminate
-	if !interfaces[1].methods["B"] {
+	if !hasMethod(interfaces[1].methods, "B") {
 		t.Error("cycle: interface 1 should still union interface 2's methods")
 	}
 }
@@ -173,8 +173,8 @@ func TestExpandInterfaceMethodSetsCycle(t *testing.T) {
 // embedded interface VALUE (the pageState shape): the interface's expanded
 // method set delegates wholesale onto the struct.
 func TestPromoteThroughEmbeddedInterface(t *testing.T) {
-	iface := &ifaceInfo{methods: map[string]bool{"A": true, "B": true}}
-	st := &structInfo{methods: map[string]bool{"Own": true}}
+	iface := &ifaceInfo{methods: map[string]arity{"A": {}, "B": {}}}
+	st := &structInfo{methods: map[string]arity{"Own": {}}}
 	structs := map[int64]*structInfo{1: st}
 	interfaces := map[int64]*ifaceInfo{7: iface}
 	embeddings := map[int64][]int64{1: {7}}
@@ -182,7 +182,7 @@ func TestPromoteThroughEmbeddedInterface(t *testing.T) {
 	promoteEmbeddedMethodSets(structs, interfaces, embeddings)
 
 	for _, m := range []string{"A", "B", "Own"} {
-		if !st.methods[m] {
+		if !hasMethod(st.methods, m) {
 			t.Errorf("struct missing %s after embedded-interface promotion", m)
 		}
 	}
@@ -303,7 +303,7 @@ func TestLoadEmbeddingsSkipsNilSource(t *testing.T) {
 // TestPromoteEmbeddedMethodsUnknownTarget pins the skip for a target that is
 // neither a known interface nor a known struct (stdlib, unresolved).
 func TestPromoteEmbeddedMethodsUnknownTarget(t *testing.T) {
-	st := &structInfo{methods: map[string]bool{"Own": true}}
+	st := &structInfo{methods: map[string]arity{"Own": {}}}
 	structs := map[int64]*structInfo{1: st}
 	promoteEmbeddedMethods(st, 1, map[int64][]int64{1: {99}}, structs, nil, 3)
 	if len(st.methods) != 1 {
@@ -313,11 +313,18 @@ func TestPromoteEmbeddedMethodsUnknownTarget(t *testing.T) {
 
 // mkStruct builds a structInfo with the given symbol id and method names.
 func mkStruct(id int64, methods ...string) *structInfo {
-	st := &structInfo{sym: model.Symbol{ID: id, FileID: 1}, methods: map[string]bool{}}
+	st := &structInfo{sym: model.Symbol{ID: id, FileID: 1}, methods: map[string]arity{}}
 	for _, m := range methods {
-		st.methods[m] = true
+		st.methods[m] = arity{}
 	}
 	return st
+}
+
+// hasMethod reports name membership in an arity method set (test helper for
+// the pre-arity boolean assertions).
+func hasMethod(methods map[string]arity, name string) bool {
+	_, ok := methods[name]
+	return ok
 }
 
 // TestIndexStructMethods pins the bucket build: every struct appears in the
@@ -359,13 +366,13 @@ func TestCandidateStructs(t *testing.T) {
 	buckets := indexStructMethods(structs)
 
 	// Rare's bucket (1 struct) is strictly smaller than Read's (3) and Close's (2).
-	got := candidateStructs(map[string]bool{"Read": true, "Close": true, "Rare": true}, buckets)
+	got := candidateStructs(map[string]arity{"Read": {}, "Close": {}, "Rare": {}}, buckets)
 	if len(got) != 1 || got[0].sym.ID != 3 {
 		t.Fatalf("candidates must be exactly the smallest (Rare) bucket, got %d structs", len(got))
 	}
 
 	// A required method with NO bucket anywhere → zero candidates, immediately.
-	if got := candidateStructs(map[string]bool{"Read": true, "Missing": true}, buckets); got != nil {
+	if got := candidateStructs(map[string]arity{"Read": {}, "Missing": {}}, buckets); got != nil {
 		t.Fatalf("missing bucket must short-circuit to zero candidates, got %d", len(got))
 	}
 }

--- a/internal/scan/satisfy_internal_test.go
+++ b/internal/scan/satisfy_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/luuuc/sense/internal/index"
@@ -492,5 +493,89 @@ func TestSatisfyUbiquitousMethodInterfaces(t *testing.T) {
 	got := satisfyPairs(t, syms, nil)
 	if len(got) != nIfaces*nStructs {
 		t.Fatalf("ubiquitous shape: want %d edges (all true), got %d", nIfaces*nStructs, len(got))
+	}
+}
+
+// TestParseMethodArity is the parser's input contract (council pass 1, Beck's
+// matrix): every construct the walker models parses to exact slot counts;
+// every construct it does not model returns UNKNOWN — never a miscount. The
+// two-shape equivalence rows are load-bearing: interface members and
+// receiver-form declarations of the same signature MUST parse equal.
+func TestParseMethodArity(t *testing.T) {
+	known := func(p, r int) arity { return arity{params: p, results: r, known: true} }
+	unknown := arity{}
+	cases := []struct {
+		name, snippet string
+		want          arity
+	}{
+		{"iface empty both", "Close()", known(0, 0)},
+		{"recv empty both", "func (r *T) Close() {", known(0, 0)},
+		{"iface bare return", "Close() error", known(0, 1)},
+		{"recv bare return", "func (r *T) Close() error {", known(0, 1)},
+		{"iface tuple return", "Next() (*CommitMeta, error)", known(0, 2)},
+		{"parenthesized single return", "Sum() (int)", known(0, 1)},
+		{"grouped params", "Set(key, value []byte, o *WriteOptions)", known(3, 0)},
+		{"func-typed param", "Iterate(ctx context.Context, cb func(k, v []byte) error)", known(2, 0)},
+		{"func-typed return", "Handler() func(a, b int) bool", known(0, 1)},
+		{"variadic", "Printf(format string, args ...interface{})", known(2, 0)},
+		{"generic tuple return", "Next(ctx context.Context) (K, V, error)", known(1, 3)},
+		{"generic receiver", "func (m *Map[K, V]) Get(k K) (V, bool) {", known(1, 2)},
+		{"bracket-comma param", "Do(p Pair[K, V])", known(1, 0)},
+		{"brace-comma param", "Apply(s struct{ a, b int })", known(1, 0)},
+		{"map return", "Snapshot() map[string]int", known(0, 1)},
+		{"one-line body literal commas", "func (t T) Pair() point { return point{1, 2} }", known(0, 1)},
+		{"the flagship junk pair A", "Close(ctx context.Context) error", known(1, 1)},
+		{"truncated multi-line", "NewIterator(ctx context.Context,", unknown},
+		{"empty snippet", "", unknown},
+		{"backquote struct tag", "Parse(v struct{ A int `json:\"a,b\"` })", unknown},
+		{"no param group", "type Closer interface {", unknown},
+	}
+	for _, c := range cases {
+		if got := parseMethodArity(c.snippet); got != c.want {
+			t.Errorf("%s: parseMethodArity(%q) = %+v, want %+v", c.name, c.snippet, got, c.want)
+		}
+	}
+
+	// The 200-byte cap: a single-line declaration at or over snippetMaxBytes
+	// may be truncated into a BALANCED wrong parse — cap-length input is
+	// always UNKNOWN.
+	long := "LongOne(" + strings.Repeat("a int, ", 40) + "b int)"
+	if len(long) < snippetMaxBytes {
+		t.Fatalf("fixture must reach the cap")
+	}
+	if got := parseMethodArity(long[:snippetMaxBytes]); got != unknown {
+		t.Errorf("cap-length snippet must be UNKNOWN, got %+v", got)
+	}
+
+	// Two-shape equivalence (the load-bearing rows, asserted pairwise).
+	pairs := [][2]string{
+		{"Close() error", "func (r *reader) Close() error {"},
+		{"Get(k K) (V, bool)", "func (m *Map[K, V]) Get(k K) (V, bool) {"},
+		{"Set(key, value []byte, o *WriteOptions) error", "func (b *Batch) Set(key, value []byte, o *WriteOptions) error {"},
+	}
+	for _, p := range pairs {
+		a, b := parseMethodArity(p[0]), parseMethodArity(p[1])
+		if !a.known || !b.known || a != b {
+			t.Errorf("shape equivalence: %q=%+v vs %q=%+v", p[0], a, p[1], b)
+		}
+	}
+}
+
+// TestArityCompatible pins the asymmetry: UNKNOWN on either side keeps the
+// name-only fallback; both known require equality on BOTH params and results.
+func TestArityCompatible(t *testing.T) {
+	k := func(p, r int) arity { return arity{params: p, results: r, known: true} }
+	u := arity{}
+	if !u.compatible(k(1, 1)) || !k(1, 1).compatible(u) || !u.compatible(u) {
+		t.Error("UNKNOWN must always be compatible (keep the edge)")
+	}
+	if !k(2, 1).compatible(k(2, 1)) {
+		t.Error("equal arities must be compatible")
+	}
+	if k(2, 1).compatible(k(1, 1)) {
+		t.Error("params-differ must be incompatible")
+	}
+	if k(2, 1).compatible(k(2, 2)) {
+		t.Error("results-differ must be incompatible (returns are compared, not just params)")
 	}
 }

--- a/internal/scan/satisfy_internal_test.go
+++ b/internal/scan/satisfy_internal_test.go
@@ -539,12 +539,20 @@ func TestParseMethodArity(t *testing.T) {
 	// The 200-byte cap: a single-line declaration at or over snippetMaxBytes
 	// may be truncated into a BALANCED wrong parse — cap-length input is
 	// always UNKNOWN.
-	long := "LongOne(" + strings.Repeat("a int, ", 40) + "b int)"
-	if len(long) < snippetMaxBytes {
-		t.Fatalf("fixture must reach the cap")
+	// BALANCED at the cap: the cut lands exactly after the params' closing
+	// paren, so without the length guard this parses cleanly as (1,0) while
+	// the real declaration carried results — the false-clean-parse hole.
+	balanced := "F(" + strings.Repeat("a", snippetMaxBytes-3) + ")"
+	if len(balanced) != snippetMaxBytes {
+		t.Fatalf("fixture must sit exactly at the cap, got %d", len(balanced))
 	}
+	if got := parseMethodArity(balanced); got != unknown {
+		t.Errorf("cap-length snippet must be UNKNOWN even when balanced, got %+v", got)
+	}
+	// And an unbalanced truncation for the ordinary multi-line path.
+	long := "LongOne(" + strings.Repeat("a int, ", 40) + "b int)"
 	if got := parseMethodArity(long[:snippetMaxBytes]); got != unknown {
-		t.Errorf("cap-length snippet must be UNKNOWN, got %+v", got)
+		t.Errorf("cap-length truncation must be UNKNOWN, got %+v", got)
 	}
 
 	// Two-shape equivalence (the load-bearing rows, asserted pairwise).
@@ -577,5 +585,101 @@ func TestArityCompatible(t *testing.T) {
 	}
 	if k(2, 1).compatible(k(2, 2)) {
 		t.Error("results-differ must be incompatible (returns are compared, not just params)")
+	}
+}
+
+// TestSatisfyArityThroughFullPass extends the differential oracle with real
+// snippets: arity now decides where names collide. Iface 40 requires
+// Write(p []byte) (int, error); struct 8 declares it exactly (edge), struct 9
+// declares Write() (a name-only match that MUST drop — the F-31-09a junk
+// class), struct 10's declaration is a truncated multi-line snippet (UNKNOWN
+// → name-only keep, the conservative fallback). The not-UNKNOWN pin: struct
+// 8's parse must be a concrete arity, so this test FAILS the day snippet
+// shape drifts and the junk quietly returns.
+func TestSatisfyArityThroughFullPass(t *testing.T) {
+	pid := func(i int64) *int64 { return &i }
+	syms := []model.Symbol{
+		{ID: 40, Name: "IWriter", Kind: model.KindInterface, FileID: 1},
+		{ID: 41, Name: "Write", Kind: model.KindMethod, FileID: 1, ParentID: pid(40),
+			Snippet: "Write(p []byte) (int, error)"},
+		{ID: 8, Name: "GoodWriter", Kind: model.KindClass, FileID: 1},
+		{ID: 42, Name: "Write", Kind: model.KindMethod, FileID: 1, ParentID: pid(8),
+			Snippet: "func (w *GoodWriter) Write(p []byte) (int, error) {"},
+		{ID: 9, Name: "JunkWriter", Kind: model.KindClass, FileID: 1},
+		{ID: 43, Name: "Write", Kind: model.KindMethod, FileID: 1, ParentID: pid(9),
+			Snippet: "func (w *JunkWriter) Write() {"},
+		{ID: 10, Name: "TruncWriter", Kind: model.KindClass, FileID: 1},
+		{ID: 44, Name: "Write", Kind: model.KindMethod, FileID: 1, ParentID: pid(10),
+			Snippet: "func (w *TruncWriter) Write(p []byte,"},
+	}
+	got := satisfyPairs(t, syms, nil)
+	want := map[[2]int64]bool{
+		{8, 40}:  true, // exact arity match
+		{10, 40}: true, // UNKNOWN keeps (truncated declaration)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("edge set mismatch: got %v want %v", got, want)
+	}
+	for p := range want {
+		if !got[p] {
+			t.Errorf("missing edge %v", p)
+		}
+	}
+	if got[[2]int64{9, 40}] {
+		t.Error("name-only junk (Write() vs Write(p []byte) (int, error)) must drop")
+	}
+
+	// the not-UNKNOWN contract pin: the interface member's snippet must parse
+	// to a concrete arity — if snippet shape ever drifts, this reds.
+	if a := parseMethodArity("Write(p []byte) (int, error)"); !a.known || a.params != 1 || a.results != 2 {
+		t.Errorf("snippet contract drifted: %+v", a)
+	}
+}
+
+// TestSatisfyArityPromotion pins the insert-if-absent threading: a struct
+// satisfying only via a promoted embedded method drops on promoted-arity
+// MISMATCH and survives on match; an embedder's own declaration shadows an
+// embedded one with different arity (Go semantics), order-proof.
+func TestSatisfyArityPromotion(t *testing.T) {
+	pid := func(i int64) *int64 { return &i }
+	syms := []model.Symbol{
+		{ID: 50, Name: "ICloser", Kind: model.KindInterface, FileID: 1},
+		{ID: 51, Name: "Close", Kind: model.KindMethod, FileID: 1, ParentID: pid(50),
+			Snippet: "Close() error"},
+		// Embedder satisfies only via embedded struct whose Close matches.
+		{ID: 11, Name: "GoodEmbedder", Kind: model.KindClass, FileID: 1},
+		{ID: 12, Name: "GoodInner", Kind: model.KindClass, FileID: 1},
+		{ID: 52, Name: "Close", Kind: model.KindMethod, FileID: 1, ParentID: pid(12),
+			Snippet: "func (i *GoodInner) Close() error {"},
+		// Embedder whose embedded Close has WRONG arity — must not satisfy.
+		{ID: 13, Name: "JunkEmbedder", Kind: model.KindClass, FileID: 1},
+		{ID: 14, Name: "JunkInner", Kind: model.KindClass, FileID: 1},
+		{ID: 53, Name: "Close", Kind: model.KindMethod, FileID: 1, ParentID: pid(14),
+			Snippet: "func (i *JunkInner) Close(ctx context.Context) error {"},
+		// Shadowing: own correct Close + embedded wrong-arity Close — own wins.
+		{ID: 15, Name: "Shadower", Kind: model.KindClass, FileID: 1},
+		{ID: 54, Name: "Close", Kind: model.KindMethod, FileID: 1, ParentID: pid(15),
+			Snippet: "func (s *Shadower) Close() error {"},
+	}
+	includes := []model.Edge{
+		{SourceID: pid(11), TargetID: 12, Kind: model.EdgeIncludes},
+		{SourceID: pid(13), TargetID: 14, Kind: model.EdgeIncludes},
+		{SourceID: pid(15), TargetID: 14, Kind: model.EdgeIncludes}, // wrong-arity embed shadowed by own
+	}
+	got := satisfyPairs(t, syms, includes)
+	for _, expect := range []struct {
+		src  int64
+		want bool
+		why  string
+	}{
+		{11, true, "promoted matching arity must satisfy"},
+		{12, true, "inner itself satisfies"},
+		{13, false, "promoted MISMATCHED arity must not satisfy"},
+		{14, false, "junk inner must not satisfy"},
+		{15, true, "own declaration shadows the wrong-arity embed"},
+	} {
+		if got[[2]int64{expect.src, 50}] != expect.want {
+			t.Errorf("struct %d → ICloser = %v, want %v (%s)", expect.src, !expect.want, expect.want, expect.why)
+		}
 	}
 }

--- a/internal/scan/satisfy_internal_test.go
+++ b/internal/scan/satisfy_internal_test.go
@@ -93,7 +93,7 @@ func TestPromoteEmbeddedMethods(t *testing.T) {
 		1: {2},
 	}
 
-	promoteEmbeddedMethods(outer, 1, embeddings, structs, nil, 3)
+	promoteEmbeddedMethods(outer, 1, map[int64]map[string]bool{}, embeddings, structs, nil, 3)
 
 	if !hasMethod(outer.methods, "Read") {
 		t.Error("expected Read promoted from embedded struct")
@@ -114,7 +114,7 @@ func TestPromoteEmbeddedMethodsDepthLimit(t *testing.T) {
 	structs := map[int64]*structInfo{1: a, 2: b, 3: c}
 	embeddings := map[int64][]int64{1: {2}, 2: {3}}
 
-	promoteEmbeddedMethods(a, 1, embeddings, structs, nil, 1)
+	promoteEmbeddedMethods(a, 1, map[int64]map[string]bool{}, embeddings, structs, nil, 1)
 
 	// Depth=1 means we only go one hop. b's methods get promoted,
 	// but c's methods should not (they need depth=2).
@@ -328,7 +328,7 @@ func TestLoadEmbeddingsSkipsNilSource(t *testing.T) {
 func TestPromoteEmbeddedMethodsUnknownTarget(t *testing.T) {
 	st := &structInfo{methods: map[string]arity{"Own": {}}}
 	structs := map[int64]*structInfo{1: st}
-	promoteEmbeddedMethods(st, 1, map[int64][]int64{1: {99}}, structs, nil, 3)
+	promoteEmbeddedMethods(st, 1, map[int64]map[string]bool{}, map[int64][]int64{1: {99}}, structs, nil, 3)
 	if len(st.methods) != 1 {
 		t.Errorf("unknown embed target must contribute nothing, got %v", st.methods)
 	}
@@ -556,6 +556,8 @@ func TestParseMethodArity(t *testing.T) {
 		{"returns group truncated", "Foo() (int,", unknown},
 		{"empty parens returns", "Foo() ()", known(0, 0)},
 		{"func keyword bare (no receiver)", "func Standalone(a int) error {", known(1, 1)},
+		{"receiver without space", "func(r *T) Close() error {", known(0, 1)},
+		{"receiver after tab", "func\t(r *T) Close() error {", known(0, 1)},
 	}
 	for _, c := range cases {
 		if got := parseMethodArity(c.snippet); got != c.want {
@@ -708,5 +710,65 @@ func TestSatisfyArityPromotion(t *testing.T) {
 		if got[[2]int64{expect.src, 50}] != expect.want {
 			t.Errorf("struct %d → ICloser = %v, want %v (%s)", expect.src, !expect.want, expect.want, expect.why)
 		}
+	}
+}
+
+// TestPromoteSiblingEmbedConflict is Rams's witness (council pass 2): struct S
+// embeds A (which embeds B carrying m()) and C (carrying m(int)). Go's depth
+// rule resolves S.m to C's m(int) — S genuinely satisfies I{ m(int) }. Sibling
+// disagreement must collapse to UNKNOWN (keep the edge), never let embed order
+// pick a winner and drop a compile-true satisfier.
+func TestPromoteSiblingEmbedConflict(t *testing.T) {
+	pid := func(i int64) *int64 { return &i }
+	syms := []model.Symbol{
+		{ID: 60, Name: "IM", Kind: model.KindInterface, FileID: 1},
+		{ID: 61, Name: "M", Kind: model.KindMethod, FileID: 1, ParentID: pid(60),
+			Snippet: "M(x int)"},
+		{ID: 20, Name: "S", Kind: model.KindClass, FileID: 1},
+		{ID: 21, Name: "A", Kind: model.KindClass, FileID: 1},
+		{ID: 22, Name: "B", Kind: model.KindClass, FileID: 1},
+		{ID: 62, Name: "M", Kind: model.KindMethod, FileID: 1, ParentID: pid(22),
+			Snippet: "func (b *B) M() {"},
+		{ID: 23, Name: "C", Kind: model.KindClass, FileID: 1},
+		{ID: 63, Name: "M", Kind: model.KindMethod, FileID: 1, ParentID: pid(23),
+			Snippet: "func (c *C) M(x int) {"},
+	}
+	includes := []model.Edge{
+		{SourceID: pid(20), TargetID: 21, Kind: model.EdgeIncludes}, // S embeds A (first)
+		{SourceID: pid(21), TargetID: 22, Kind: model.EdgeIncludes}, // A embeds B
+		{SourceID: pid(20), TargetID: 23, Kind: model.EdgeIncludes}, // S embeds C (second)
+	}
+	got := satisfyPairs(t, syms, includes)
+	if !got[[2]int64{20, 60}] {
+		t.Error("sibling-embed arity conflict must collapse to UNKNOWN and keep S -> IM")
+	}
+}
+
+// TestSatisfyComposedInterfaceArity requires arity to survive interface
+// EXPANSION: IRW acquires Write(p []byte) (int, error) only through an
+// embedded interface. The junk struct's Write() must drop and the true
+// implementor must survive — if expansion loses arity, the junk class
+// silently returns on every composed interface (the common Go shape).
+func TestSatisfyComposedInterfaceArity(t *testing.T) {
+	pid := func(i int64) *int64 { return &i }
+	syms := []model.Symbol{
+		{ID: 70, Name: "IWrite", Kind: model.KindInterface, FileID: 1},
+		{ID: 71, Name: "Write", Kind: model.KindMethod, FileID: 1, ParentID: pid(70),
+			Snippet: "Write(p []byte) (int, error)"},
+		{ID: 72, Name: "IRW", Kind: model.KindInterface, FileID: 1}, // embeds IWrite only
+		{ID: 24, Name: "TrueWriter", Kind: model.KindClass, FileID: 1},
+		{ID: 73, Name: "Write", Kind: model.KindMethod, FileID: 1, ParentID: pid(24),
+			Snippet: "func (w *TrueWriter) Write(p []byte) (int, error) {"},
+		{ID: 25, Name: "JunkW", Kind: model.KindClass, FileID: 1},
+		{ID: 74, Name: "Write", Kind: model.KindMethod, FileID: 1, ParentID: pid(25),
+			Snippet: "func (w *JunkW) Write() {"},
+	}
+	includes := []model.Edge{{SourceID: pid(72), TargetID: 70, Kind: model.EdgeIncludes}}
+	got := satisfyPairs(t, syms, includes)
+	if !got[[2]int64{24, 72}] {
+		t.Error("true implementor must satisfy the composed interface (arity survives expansion)")
+	}
+	if got[[2]int64{25, 72}] {
+		t.Error("junk Write() must not satisfy the composed interface — expansion lost arity")
 	}
 }

--- a/internal/scan/satisfy_internal_test.go
+++ b/internal/scan/satisfy_internal_test.go
@@ -772,3 +772,27 @@ func TestSatisfyComposedInterfaceArity(t *testing.T) {
 		t.Error("junk Write() must not satisfy the composed interface — expansion lost arity")
 	}
 }
+
+// TestClearSatisfactionEdgesError surfaces the delete failing (closed index):
+// the transaction must abort rather than write alongside a failed clear.
+func TestClearSatisfactionEdgesError(t *testing.T) {
+	h := &harness{ctx: context.Background(), idx: newClosedAdapter(t), out: io.Discard, warn: io.Discard}
+	if err := h.clearSatisfactionEdges(); err == nil {
+		t.Fatal("expected the clear to surface a closed-index error")
+	}
+}
+
+// BenchmarkParseMethodArity pins the parser's cost claim: a short forward
+// byte-walk, no allocation on the hot path.
+func BenchmarkParseMethodArity(b *testing.B) {
+	snippets := []string{
+		"Close(ctx context.Context) error",
+		"func (b *Batch) Set(key, value []byte, o *WriteOptions) error {",
+		"func (m *Map[K, V]) Get(k K) (V, bool) {",
+		"Iterate(ctx context.Context, cb func(k, v []byte) error)",
+	}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		parseMethodArity(snippets[i%len(snippets)])
+	}
+}

--- a/internal/scan/satisfy_internal_test.go
+++ b/internal/scan/satisfy_internal_test.go
@@ -529,6 +529,11 @@ func TestParseMethodArity(t *testing.T) {
 		{"empty snippet", "", unknown},
 		{"backquote struct tag", "Parse(v struct{ A int `json:\"a,b\"` })", unknown},
 		{"no param group", "type Closer interface {", unknown},
+		{"leading paren no name", "(x int) error", unknown},
+		{"receiver group unbalanced", "func (r *T[K,", unknown},
+		{"returns group truncated", "Foo() (int,", unknown},
+		{"empty parens returns", "Foo() ()", known(0, 0)},
+		{"func keyword bare (no receiver)", "func Standalone(a int) error {", known(1, 1)},
 	}
 	for _, c := range cases {
 		if got := parseMethodArity(c.snippet); got != c.want {

--- a/internal/scan/satisfy_stamp_test.go
+++ b/internal/scan/satisfy_stamp_test.go
@@ -43,3 +43,35 @@ func TestScanStampsSatisfyUnbudgetedMeta(t *testing.T) {
 		t.Errorf("satisfy_unbudgeted = %q after plain rescan, want re-stamped 1 (the pass runs every scan)", got)
 	}
 }
+
+// TestScanStampsSatisfyArityMeta mirrors the unbudgeted stamp for the
+// arity-matching fix: fresh scan stamps, and a PLAIN rescan re-stamps a
+// stripped index because the satisfy pass recomputes every scan.
+func TestScanStampsSatisfyArityMeta(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "kvstore.go"), storeTypeSrc)
+
+	if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := readMetaKey(t, root, "satisfy_arity"); got != "1" {
+		t.Fatalf("satisfy_arity = %q after fresh scan, want 1", got)
+	}
+
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(root, ".sense", "index.db"))
+	if err != nil {
+		t.Fatalf("open index: %v", err)
+	}
+	if err := a.DeleteMeta(ctx, "satisfy_arity"); err != nil {
+		t.Fatalf("delete meta: %v", err)
+	}
+	_ = a.Close()
+
+	if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+		t.Fatalf("plain rescan: %v", err)
+	}
+	if got := readMetaKey(t, root, "satisfy_arity"); got != "1" {
+		t.Errorf("satisfy_arity = %q after plain rescan, want re-stamped 1", got)
+	}
+}

--- a/internal/scan/satisfy_stamp_test.go
+++ b/internal/scan/satisfy_stamp_test.go
@@ -75,3 +75,77 @@ func TestScanStampsSatisfyArityMeta(t *testing.T) {
 		t.Errorf("satisfy_arity = %q after plain rescan, want re-stamped 1", got)
 	}
 }
+
+// TestSatisfyClearsStaleEdges pins the shrink path: a satisfaction edge that
+// no longer holds (here: injected junk) must DISAPPEAR on a plain rescan —
+// the pass owns its edge set and rewrites it wholesale. Without the clear,
+// upsert semantics keep stale junk forever and a tightening of the matcher
+// never reaches existing indexes.
+func TestSatisfyClearsStaleEdges(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "kvstore.go"), `package kv
+
+import "context"
+
+type Closer interface {
+	Close(ctx context.Context) error
+}
+
+type GoodStore struct{}
+
+func (g *GoodStore) Close(ctx context.Context) error { return nil }
+
+type JunkStore struct{}
+
+func (j *JunkStore) Close() error { return nil }
+`)
+
+	if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	ctx := context.Background()
+	a, err := sqlite.Open(ctx, filepath.Join(root, ".sense", "index.db"))
+	if err != nil {
+		t.Fatalf("open index: %v", err)
+	}
+	// Inject the junk pair a pre-arity binary would have written: JunkStore's
+	// Close() does NOT satisfy Closer's Close(ctx) error, so the arity-aware
+	// pass never emits it — a persisted stale row is exactly the upgrade case.
+	if _, err := a.DB().ExecContext(ctx, `
+		INSERT INTO sense_edges (source_id, target_id, kind, file_id, line, confidence)
+		SELECT s.id, i.id, 'inherits', s.file_id, 1, 0.9
+		FROM sense_symbols s, sense_symbols i
+		WHERE s.name='JunkStore' AND i.name='Closer'`); err != nil {
+		t.Fatalf("inject stale edge: %v", err)
+	}
+	var before int
+	_ = a.DB().QueryRowContext(ctx, `SELECT COUNT(*) FROM sense_edges e JOIN sense_symbols i ON e.target_id=i.id
+		WHERE e.kind='inherits' AND i.kind='interface' AND e.confidence=0.9`).Scan(&before)
+	if before != 2 {
+		t.Fatalf("fixture expects the true edge + the injected junk, got %d", before)
+	}
+	_ = a.Close()
+
+	if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+		t.Fatalf("plain rescan: %v", err)
+	}
+	a2, err := sqlite.Open(ctx, filepath.Join(root, ".sense", "index.db"))
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer func() { _ = a2.Close() }()
+	var after int
+	_ = a2.DB().QueryRowContext(ctx, `SELECT COUNT(*) FROM sense_edges e JOIN sense_symbols i ON e.target_id=i.id
+		WHERE e.kind='inherits' AND i.kind='interface' AND e.confidence=0.9`).Scan(&after)
+	if after != 1 {
+		t.Errorf("want exactly the true GoodStore edge after rescan, got %d (before=%d)", after, before)
+	}
+	var junk int
+	_ = a2.DB().QueryRowContext(ctx, `SELECT COUNT(*) FROM sense_edges e
+		JOIN sense_symbols s ON e.source_id=s.id JOIN sense_symbols i ON e.target_id=i.id
+		WHERE s.name='JunkStore' AND i.name='Closer' AND e.kind='inherits'`).Scan(&junk)
+	if junk != 0 {
+		t.Errorf("the arity-junk edge survived: Close() must not satisfy Close(ctx) error")
+	}
+}

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -424,6 +424,12 @@ func finalizeScan(ctx context.Context, idx *sqlite.Adapter, h *harness, senseDir
 	if err := idx.WriteMeta(ctx, "satisfy_unbudgeted", "1"); err != nil {
 		_, _ = fmt.Fprintf(h.warn, "warn: write satisfy_unbudgeted: %v\n", err)
 	}
+	// satisfy_arity records that satisfaction edges were matched on name AND
+	// signature slot counts (F-31-09a): pre-fix indexes carry ~30% measured
+	// compile-false edges. Same unconditional placement — a plain scan heals.
+	if err := idx.WriteMeta(ctx, "satisfy_arity", "1"); err != nil {
+		_, _ = fmt.Fprintf(h.warn, "warn: write satisfy_arity: %v\n", err)
+	}
 
 	if h.fullyLinked {
 		if err := idx.WriteMeta(ctx, "parent_linkage", "1"); err != nil {


### PR DESCRIPTION
## Problem (measured)

Interface satisfaction matched by method NAME only. On dolt's healed index a stratified hand-verify classified 5/12 sampled single-method-stratum edges as compile-false (`Close()` bound to `Close(ctx) error` interfaces); simulating the arity filter over the real index put the junk at **30% of all satisfaction edges** (821/2,726), all at confidence 0.9 where both blast floors admit them.

## Fix

`collectMethodSets` parses each method's stored declaration snippet into `(params, results)` slot counts — one text-shape-detected path for interface members and receiver forms (spaced or not), combined `()[]{}` depth so generic and inline-struct commas never miscount, and a hard rule: **any construct the walker does not model returns UNKNOWN**, which can only keep an edge (truncated multi-line declarations, cap-length snippets whose cut balances, backquoted struct tags). `methodSetSatisfies` then requires name presence AND arity compatibility. Promotion and interface expansion thread arity with the embedder's own declarations shadowing and sibling-source disagreements collapsing to UNKNOWN — embed order never decides an edge.

Two review-found holes are fixed and pinned: sibling embeds disagreeing on arity could drop a compile-true satisfier (witness fixture on Go's depth rule), and `func(r *T)` without the optional space parsed its receiver as the param group.

**The battery caught an upgrade-path bug unit fakes cannot see:** edge upserts never removed previously-written rows, so the tightened matcher never reached existing indexes (dolt held its junk through a heal scan). The pass now clears its exact output signature — `inherits` at convention confidence targeting Go-file interfaces, verified unique to this pass across every edge writer — inside the write transaction and rewrites wholesale.

## Evidence

- dolt: 2,726 → **1,871** (855 dropped, 31%); `table.Closer` 235 → **115**; idempotent across plain scans; re-verified on the final binary.
- **Acceptance oracle 14/14 exact**: every hand-verified junk pair dropped; every hand-verified genuine pair survived (including the generics row); the same-arity type-mismatch pair survived as designed — the recorded boundary.
- **Dropped-edge mirror n=12**: 12/12 sampled drops show real slot mismatches on inspection.
- teleport: 31,311 → **22,509** (28%); wall clock 72.8s/76.4s (two runs) vs 57.8s pre-fix — the delta is the one-time-per-scan clear+rewrite of ~31K rows (the DELETE itself is index-driven per EXPLAIN QUERY PLAN); parser cost is 88ns/declaration, 0 allocs (~3ms for teleport's 33.6K methods).
- maket (ruby) edge counts byte-identical — the pass and its clear are unreachable off Go.
- Mutant battery killed against HEAD, including expansion-drops-arity (composed-interface fixture), the receiver-prefix bug, sibling-conflict first-wins, and clear-removal.
- Side-effect runs green: healthchecks cited-recall 1.0 (= frozen); llm.rb 0.593 vs frozen 0.44-0.52 band, normal token range.
- `satisfy_arity` stamp + `sense status` advisory: a plain `sense scan` heals — no rebuild.

## Known limitation (disclosed)

Arity equality is necessary, not sufficient: survivors are name+arity matched at 0.9 and may still be compile-false on parameter/return TYPES (measured residue: one pair in the dolt sample). Type-aware matching is a recorded future increment, built only if measured to matter.

## Release-note requirement

Go satisfaction edge counts SHRINK ~30% on the first post-upgrade scan. The release note must state: expected, the removed edges were compile-false (31% dolt / 28% teleport, 12/12 sampled drops verified), a plain `sense scan` heals, no rebuild.