### PR TITLE
fix(blast): retention closure — interface-laundered holders in one call

### DIFF
--- a/internal/blast/blast_bench_test.go
+++ b/internal/blast/blast_bench_test.go
@@ -167,3 +167,114 @@ func buildFanInGraph(ctx context.Context, a *sqlite.Adapter, n, branching int) e
 		return nil
 	})
 }
+
+// BenchmarkBlastRetention exercises the retention closure itself — the
+// existing benchmarks are calls-only graphs where the pass early-exits, so
+// they can't see its cost. The synthetic shape mirrors the measured worst
+// hub (teleport-scale): a subject with a wide direct composer fan, carrier
+// chains several levels deep, each carrier satisfying interfaces with their
+// own composer fans.
+func BenchmarkBlastRetention(b *testing.B) {
+	b.ReportAllocs()
+	ctx := context.Background()
+	dbPath := filepath.Join(b.TempDir(), "retention-bench.db")
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		b.Fatalf("sqlite.Open: %v", err)
+	}
+	b.Cleanup(func() { _ = adapter.Close() })
+
+	if err := buildRetentionGraph(ctx, adapter, 200, 5, 40); err != nil {
+		b.Fatalf("build graph: %v", err)
+	}
+
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		b.Fatalf("sql.Open: %v", err)
+	}
+	b.Cleanup(func() { _ = db.Close() })
+
+	const subjectID int64 = 1
+	for b.Loop() {
+		res, err := blast.Compute(ctx, db, []int64{subjectID}, blast.Options{MaxHops: 3})
+		if err != nil {
+			b.Fatalf("Compute: %v", err)
+		}
+		if res.RetainedCount == 0 {
+			b.Fatalf("RetainedCount = 0 — retention graph failed to wire up")
+		}
+	}
+}
+
+// buildRetentionGraph writes a class subject with `fan` direct composers,
+// carrier chains `depth` deep behind each, and `ifaces` satisfied interfaces
+// each composed by two holders — a composes+inherits topology at the scale of
+// the measured worst real closure (245 carriers).
+func buildRetentionGraph(ctx context.Context, a *sqlite.Adapter, fan, depth, ifaces int) error {
+	return a.InTx(ctx, func() error {
+		fileID, err := a.WriteFile(ctx, &model.File{
+			Path: "bench/retention.go", Language: "go", Hash: "bench-ret",
+			Symbols: 1, IndexedAt: time.Now().UTC(),
+		})
+		if err != nil {
+			return fmt.Errorf("write file: %w", err)
+		}
+		writeSym := func(name string, kind model.SymbolKind) (int64, error) {
+			return a.WriteSymbol(ctx, &model.Symbol{
+				FileID: fileID, Name: name, Qualified: "bench." + name,
+				Kind: kind, LineStart: 1, LineEnd: 2,
+			})
+		}
+		writeEdge := func(src, tgt int64, kind model.EdgeKind) error {
+			_, err := a.WriteEdge(ctx, &model.Edge{
+				SourceID: &src, TargetID: tgt, Kind: kind, FileID: fileID, Confidence: 0.9,
+			})
+			return err
+		}
+		subject, err := writeSym("Subject", model.KindClass)
+		if err != nil {
+			return err
+		}
+		var carriers []int64
+		for i := 0; i < fan; i++ {
+			prev := subject
+			for d := 0; d < depth; d++ {
+				c, err := writeSym(fmt.Sprintf("Carrier%d_%d", i, d), model.KindClass)
+				if err != nil {
+					return err
+				}
+				if err := writeEdge(c, prev, model.EdgeComposes); err != nil {
+					return err
+				}
+				carriers = append(carriers, c)
+				prev = c
+			}
+		}
+		for i := 0; i < ifaces; i++ {
+			iface, err := writeSym(fmt.Sprintf("Iface%d", i), model.KindInterface)
+			if err != nil {
+				return err
+			}
+			if _, err := a.WriteSymbol(ctx, &model.Symbol{
+				FileID: fileID, Name: fmt.Sprintf("VisitRare%d", i),
+				Qualified: fmt.Sprintf("bench.Iface%d.VisitRare%d", i, i),
+				Kind:      model.KindMethod, ParentID: &iface, LineStart: 3, LineEnd: 4,
+			}); err != nil {
+				return err
+			}
+			if err := writeEdge(carriers[i%len(carriers)], iface, model.EdgeInherits); err != nil {
+				return err
+			}
+			for h := 0; h < 2; h++ {
+				holder, err := writeSym(fmt.Sprintf("Holder%d_%d", i, h), model.KindClass)
+				if err != nil {
+					return err
+				}
+				if err := writeEdge(holder, iface, model.EdgeComposes); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+}

--- a/internal/blast/engine.go
+++ b/internal/blast/engine.go
@@ -201,6 +201,17 @@ type Result struct {
 	// Keyed by symbol ID. Used by response shapers to cap output.
 	SymbolTiers map[int64]Tier
 
+	// RetainedViaInterfaces lists the interface-laundered may-retain holders
+	// (see RetainedHolder): structs holding the subject only behind an
+	// interface-typed field whose concrete satisfier carries the subject.
+	// Computed one interface indirection deep from the carrier closure; a
+	// weaker claim than the caller lists, so it never feeds TotalAffected.
+	RetainedViaInterfaces []RetainedHolder
+	// RetainedCount is the full computed holder count BEFORE the result cap,
+	// so a capped RetainedViaInterfaces list is self-evident from
+	// RetainedCount > len(RetainedViaInterfaces).
+	RetainedCount int
+
 	Truncated bool
 }
 

--- a/internal/blast/engine.go
+++ b/internal/blast/engine.go
@@ -306,13 +306,27 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 	// under the calls edge and never bucketed here. excludeGrouped keeps the
 	// one-node-one-group invariant against the inherits/includes buckets above.
 	excludeGrouped := symbolIDSet(subclasses, viaIncludes)
-	viaComposition, err := state.loadReverseComposition(ctx, db, symbolIDs, seedSet, excludeGrouped, isSelf, opts.MaxResults)
+	// Fetched once and shared: the composition group and the retention
+	// closure's fixpoint level 1 read the same reverse-composes set.
+	composerIDs, err := inboundComposers(ctx, db, symbolIDs)
+	if err != nil {
+		return Result{}, fmt.Errorf("blast: reverse composition: %w", err)
+	}
+	viaComposition, err := state.loadReverseComposition(ctx, db, composerIDs, seedSet, excludeGrouped, isSelf, opts.MaxResults)
 	if err != nil {
 		return Result{}, fmt.Errorf("blast: reverse composition: %w", err)
 	}
 	// Count any composer the BFS did not visit (pruned by confidence) into the
 	// total so total_affected never under-reports what the response surfaces.
 	totalAffectedCount += countUnvisited(viaComposition, affectedSet)
+
+	retained, retainedCount, retainedTruncated, err := loadRetention(ctx, db, subject, symbolIDs, composerIDs, state.childSet, excludeGrouped, isSelf, opts.MaxResults)
+	if err != nil {
+		return Result{}, fmt.Errorf("blast: retention closure: %w", err)
+	}
+	if retainedTruncated {
+		state.truncated = true
+	}
 
 	return Result{
 		Symbol:                 subject,
@@ -331,6 +345,8 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 		AffectedSubclasses:     subclasses,
 		AffectedViaComposition: viaComposition,
 		AffectedViaIncludes:    viaIncludes,
+		RetainedViaInterfaces:  retained,
+		RetainedCount:          retainedCount,
 		SymbolTiers:            symbolTiers,
 		Truncated:              state.truncated,
 	}, nil

--- a/internal/blast/engine.go
+++ b/internal/blast/engine.go
@@ -298,35 +298,13 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 	symbolTiers := state.buildTiers(directIDs, indirectIDs, symbolsByID, isSelf)
 	subclasses, viaIncludes := state.buildEdgeKindGroups(directIDs, indirectIDs, symbolsByID, isSelf)
 
-	// Composition is derived from the edge table directly rather than from the
-	// capped/visitedKind-bucketed callers: on a high-fan-out hub the reverse
-	// composers (e.g. every Django model holding a ForeignKey to this one) ride
-	// low-confidence composes edges that capResults evicts beneath the 1.0
-	// call/test callers, and a composer that also calls the subject is recorded
-	// under the calls edge and never bucketed here. excludeGrouped keeps the
-	// one-node-one-group invariant against the inherits/includes buckets above.
-	excludeGrouped := symbolIDSet(subclasses, viaIncludes)
-	// Fetched once and shared: the composition group and the retention
-	// closure's fixpoint level 1 read the same reverse-composes set.
-	composerIDs, err := inboundComposers(ctx, db, symbolIDs)
+	viaComposition, retained, retainedCount, err := state.loadEdgeTableGroups(ctx, db, subject, symbolIDs, seedSet, subclasses, viaIncludes, isSelf, opts.MaxResults)
 	if err != nil {
-		return Result{}, fmt.Errorf("blast: reverse composition: %w", err)
-	}
-	viaComposition, err := state.loadReverseComposition(ctx, db, composerIDs, seedSet, excludeGrouped, isSelf, opts.MaxResults)
-	if err != nil {
-		return Result{}, fmt.Errorf("blast: reverse composition: %w", err)
+		return Result{}, err
 	}
 	// Count any composer the BFS did not visit (pruned by confidence) into the
 	// total so total_affected never under-reports what the response surfaces.
 	totalAffectedCount += countUnvisited(viaComposition, affectedSet)
-
-	retained, retainedCount, retainedTruncated, err := loadRetention(ctx, db, subject, symbolIDs, composerIDs, state.childSet, excludeGrouped, isSelf, opts.MaxResults)
-	if err != nil {
-		return Result{}, fmt.Errorf("blast: retention closure: %w", err)
-	}
-	if retainedTruncated {
-		state.truncated = true
-	}
 
 	return Result{
 		Symbol:                 subject,
@@ -350,6 +328,38 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 		SymbolTiers:            symbolTiers,
 		Truncated:              state.truncated,
 	}, nil
+}
+
+// loadEdgeTableGroups computes the two edge-table-derived groups after the
+// BFS: reverse composition and the retention closure.
+//
+// Composition is derived from the edge table directly rather than from the
+// capped/visitedKind-bucketed callers: on a high-fan-out hub the reverse
+// composers (e.g. every Django model holding a ForeignKey to this one) ride
+// low-confidence composes edges that capResults evicts beneath the 1.0
+// call/test callers, and a composer that also calls the subject is recorded
+// under the calls edge and never bucketed here. excludeGrouped keeps the
+// one-node-one-group invariant against the inherits/includes buckets. The
+// composer IDs are fetched once and shared: the composition group and the
+// retention closure's fixpoint level 1 read the same reverse-composes set.
+func (s *bfsState) loadEdgeTableGroups(ctx context.Context, db *sql.DB, subject model.Symbol, symbolIDs []int64, seedSet map[int64]struct{}, subclasses, viaIncludes []model.Symbol, isSelf selfMethodFn, maxResults int) ([]model.Symbol, []RetainedHolder, int, error) {
+	excludeGrouped := symbolIDSet(subclasses, viaIncludes)
+	composerIDs, err := inboundComposers(ctx, db, symbolIDs)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("blast: reverse composition: %w", err)
+	}
+	viaComposition, err := s.loadReverseComposition(ctx, db, composerIDs, seedSet, excludeGrouped, isSelf, maxResults)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("blast: reverse composition: %w", err)
+	}
+	retained, retainedCount, retainedTruncated, err := loadRetention(ctx, db, subject, symbolIDs, composerIDs, s.childSet, excludeGrouped, isSelf, maxResults)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("blast: retention closure: %w", err)
+	}
+	if retainedTruncated {
+		s.truncated = true
+	}
+	return viaComposition, retained, retainedCount, nil
 }
 
 // bfsState carries the mutable traversal state of one blast computation: the

--- a/internal/blast/retention.go
+++ b/internal/blast/retention.go
@@ -1,0 +1,18 @@
+package blast
+
+import "github.com/luuuc/sense/internal/model"
+
+// RetainedHolder is one interface-laundered may-retain row: a struct that
+// holds the subject only behind an interface-typed field whose concrete
+// satisfier is a carrier of the subject. Via is the interface the holder's
+// field is typed as — when a holder reaches the subject through more than
+// one interface, the lowest-ID interface is recorded so output is stable
+// run to run.
+//
+// The claim is MAY-retain: an interface field can legally receive a
+// non-carrier satisfier elsewhere, so these rows are surfaced as a weaker,
+// separately-counted group and never feed TotalAffected.
+type RetainedHolder struct {
+	Symbol model.Symbol
+	Via    model.Symbol
+}

--- a/internal/blast/retention.go
+++ b/internal/blast/retention.go
@@ -127,18 +127,7 @@ func carrierClosure(ctx context.Context, db *sql.DB, seedIDs, directComposerIDs 
 			return nil, false, fmt.Errorf("blast: retention closure cancelled: %w", err)
 		}
 		var next []int64
-		for _, id := range level { // ID-ascending: truncation is order-defined
-			if _, seen := carriers[id]; seen {
-				continue
-			}
-			if admitted >= retentionMaxCarriers {
-				truncated = true
-				break
-			}
-			carriers[id] = struct{}{}
-			admitted++
-			next = append(next, id)
-		}
+		next, admitted, truncated = admitCarrierLevel(carriers, level, admitted)
 		if truncated || len(next) == 0 {
 			break
 		}
@@ -148,16 +137,38 @@ func carrierClosure(ctx context.Context, db *sql.DB, seedIDs, directComposerIDs 
 		}
 		level = mergeSources(nil, pairs)
 	}
-	if len(level) > 0 && !truncated {
-		// The depth cap cut a live frontier.
-		for _, id := range level {
-			if _, seen := carriers[id]; !seen {
-				truncated = true
-				break
-			}
+	return carriers, truncated || liveFrontierRemains(carriers, level), nil
+}
+
+// admitCarrierLevel admits one fixpoint level into the carrier set in
+// ID-ascending order, so a size-cap truncation is order-defined rather than
+// map-defined. Returns the newly admitted IDs, the running admission count,
+// and whether the cap tripped.
+func admitCarrierLevel(carriers map[int64]struct{}, level []int64, admitted int) ([]int64, int, bool) {
+	var next []int64
+	for _, id := range level {
+		if _, seen := carriers[id]; seen {
+			continue
+		}
+		if admitted >= retentionMaxCarriers {
+			return next, admitted, true
+		}
+		carriers[id] = struct{}{}
+		admitted++
+		next = append(next, id)
+	}
+	return next, admitted, false
+}
+
+// liveFrontierRemains reports whether the level the depth cap cut still held
+// unvisited carriers — the closure is then incomplete and must say so.
+func liveFrontierRemains(carriers map[int64]struct{}, level []int64) bool {
+	for _, id := range level {
+		if _, seen := carriers[id]; !seen {
+			return true
 		}
 	}
-	return carriers, truncated, nil
+	return false
 }
 
 // launderOneRound performs the single laundering round: the interfaces any

--- a/internal/blast/retention.go
+++ b/internal/blast/retention.go
@@ -48,6 +48,19 @@ const (
 	// over the top-500 hubs of teleport/dolt/gitea/pebble: 245 structs
 	// (dolt hash.Hash); ~8x headroom.
 	retentionMaxCarriers = 2000
+	// retentionCommonNameThreshold drives the F-31-09b INTERIM junk screen:
+	// a via-interface with exactly one distinct direct member whose name
+	// occurs as a method name more than this many times index-wide is junk —
+	// its satisfaction edges are fabricated by name+arity matching on a
+	// common member (Next/Close/Get/String), not by a real contract.
+	// Measured margins: every genuine single-member via-interface across six
+	// Go bench indexes sits at ≤25 (dolt VisitGCRoots 14, HasMany 15; pebble
+	// Stat 25); every fabricating interface at ≥49 (Get 49, Next 135,
+	// Close 248, CheckAndSetDefaults 551). Junk iff STRICTLY above. On a
+	// small index common names fall under the threshold and junk can show —
+	// the safe side for an advisory may-retain group. Delete this screen
+	// when satisfaction matching goes param-type-aware (F-31-09b's real fix).
+	retentionCommonNameThreshold = 25
 )
 
 // retentionSubjectKind reports whether a subject can be retained through a
@@ -162,6 +175,16 @@ func launderOneRound(ctx context.Context, db *sql.DB, carriers map[int64]struct{
 	if len(ifaces) == 0 {
 		return nil, nil
 	}
+	// Screen BEFORE expanding composers — load-bearing ordering: a junk
+	// interface like Closer can carry hundreds of composers that must never
+	// be fetched, so the screen is the perf guard as well as the truth guard.
+	ifaces, err = screenJunkInterfaces(ctx, db, ifaces)
+	if err != nil {
+		return nil, err
+	}
+	if len(ifaces) == 0 {
+		return nil, nil
+	}
 	pairs, err := inboundHolderPairs(ctx, db, ifaces, false)
 	if err != nil {
 		return nil, err
@@ -249,6 +272,150 @@ func orderRetained(ctx context.Context, db *sql.DB, holders []RetainedHolder) {
 		}
 		return holders[i].Symbol.ID < holders[j].Symbol.ID
 	})
+}
+
+// screenJunkInterfaces drops the F-31-09b junk stratum from the candidate
+// via-interfaces: exactly one distinct direct member whose name is common
+// index-wide (see retentionCommonNameThreshold). Multi-member and zero-member
+// (embedded-only) interfaces always pass — their method-SET match is the
+// signal. The frequency lookup is scoped to the candidate member names, never
+// a whole-index scan, and only runs when a single-member candidate exists.
+func screenJunkInterfaces(ctx context.Context, db *sql.DB, ifaces []int64) ([]int64, error) {
+	soleMember, err := soleMemberNames(ctx, db, ifaces)
+	if err != nil {
+		return nil, err
+	}
+	if len(soleMember) == 0 {
+		return ifaces, nil
+	}
+	names := make([]string, 0, len(soleMember))
+	seen := map[string]struct{}{}
+	for _, name := range soleMember {
+		if _, dup := seen[name]; !dup {
+			seen[name] = struct{}{}
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	freq, err := methodNameCounts(ctx, db, names)
+	if err != nil {
+		return nil, err
+	}
+	kept := make([]int64, 0, len(ifaces))
+	for _, id := range ifaces {
+		if name, single := soleMember[id]; single && freq[name] > retentionCommonNameThreshold {
+			continue
+		}
+		kept = append(kept, id)
+	}
+	return kept, nil
+}
+
+// soleMemberNames returns, for each interface that declares exactly one
+// distinct direct method name, that name.
+func soleMemberNames(ctx context.Context, db *sql.DB, ifaces []int64) (map[int64]string, error) {
+	members := map[int64]map[string]struct{}{}
+	query := func(placeholders string) string {
+		return `SELECT parent_id, name FROM sense_symbols
+		        WHERE parent_id IN (` + placeholders + `) AND kind = 'method'`
+	}
+	err := queryIDStringRows(ctx, db, ifaces, query, func(id int64, name string) {
+		if members[id] == nil {
+			members[id] = map[string]struct{}{}
+		}
+		members[id][name] = struct{}{}
+	})
+	if err != nil {
+		return nil, err
+	}
+	sole := make(map[int64]string, len(members))
+	for id, names := range members {
+		if len(names) == 1 {
+			for name := range names {
+				sole[id] = name
+			}
+		}
+	}
+	return sole, nil
+}
+
+// methodNameCounts returns the index-wide method-symbol count per name,
+// scoped to the given names.
+func methodNameCounts(ctx context.Context, db *sql.DB, names []string) (map[string]int, error) {
+	out := make(map[string]int, len(names))
+	const chunk = 500
+	for start := 0; start < len(names); start += chunk {
+		end := start + chunk
+		if end > len(names) {
+			end = len(names)
+		}
+		batch := names[start:end]
+		placeholders := strings.Repeat("?,", len(batch))
+		placeholders = placeholders[:len(placeholders)-1]
+		args := make([]any, len(batch))
+		for i, n := range batch {
+			args[i] = n
+		}
+		q := `SELECT name, COUNT(*) FROM sense_symbols
+		      WHERE kind = 'method' AND name IN (` + placeholders + `) GROUP BY name`
+		rows, err := db.QueryContext(ctx, q, args...)
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			var name string
+			var n int
+			if err := rows.Scan(&name, &n); err != nil {
+				_ = rows.Close()
+				return nil, err
+			}
+			out[name] = n
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		_ = rows.Close()
+	}
+	return out, nil
+}
+
+// queryIDStringRows runs an (int64, string) two-column query with one IN
+// clause over ids, chunked, feeding each row to visit.
+func queryIDStringRows(ctx context.Context, db *sql.DB, ids []int64, build func(placeholders string) string, visit func(int64, string)) error {
+	const chunk = 500
+	for start := 0; start < len(ids); start += chunk {
+		end := start + chunk
+		if end > len(ids) {
+			end = len(ids)
+		}
+		batch := ids[start:end]
+		placeholders := strings.Repeat("?,", len(batch))
+		placeholders = placeholders[:len(placeholders)-1]
+		args := make([]any, len(batch))
+		for i, id := range batch {
+			args[i] = id
+		}
+		rows, err := db.QueryContext(ctx, build(placeholders), args...)
+		if err != nil {
+			return err
+		}
+		for rows.Next() {
+			var id int64
+			var s string
+			if err := rows.Scan(&id, &s); err != nil {
+				_ = rows.Close()
+				return err
+			}
+			visit(id, s)
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		_ = rows.Close()
+	}
+	return nil
 }
 
 // holderPair is one (holder, held) row from the reverse composition/embedding

--- a/internal/blast/retention.go
+++ b/internal/blast/retention.go
@@ -11,6 +11,7 @@
 // compose across interface indirections, and the measured mutual fixpoint on
 // dolt grew 47→357 holders with junk-shaped extras (pitch design table). An
 // agent that needs the deeper tail blasts a returned holder.
+
 package blast
 
 import (

--- a/internal/blast/retention.go
+++ b/internal/blast/retention.go
@@ -1,6 +1,27 @@
+// Retention closure (pitch 31-12, ledger G-11): surfaces the interface-
+// laundered may-retain holders — structs that hold the subject only behind an
+// interface-typed field whose concrete satisfier is a carrier of the subject.
+//
+// The BFS cannot reach them: it walks reverse edges only, and the laundering
+// path needs one FORWARD satisfaction hop (carrier →inherits→ interface)
+// before the reverse composition hop (interface ←composes/includes← holder).
+// This pass walks exactly that: a reverse composes/includes fixpoint from the
+// subject (the typed-field carrier closure), then ONE laundering round over
+// it. One round is the auditable claim — the may-retain qualifier does not
+// compose across interface indirections, and the measured mutual fixpoint on
+// dolt grew 47→357 holders with junk-shaped extras (pitch design table). An
+// agent that needs the deeper tail blasts a returned holder.
 package blast
 
-import "github.com/luuuc/sense/internal/model"
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/luuuc/sense/internal/model"
+)
 
 // RetainedHolder is one interface-laundered may-retain row: a struct that
 // holds the subject only behind an interface-typed field whose concrete
@@ -15,4 +36,354 @@ import "github.com/luuuc/sense/internal/model"
 type RetainedHolder struct {
 	Symbol model.Symbol
 	Via    model.Symbol
+}
+
+const (
+	// retentionMaxLevels bounds the carrier fixpoint depth. Measured worst
+	// case across the four biggest Go bench indexes: 7 levels (pebble
+	// base.DiskFileNum); dolt DoltDB converges in 5. Termination comes from
+	// the visited set — this cap is a pathological-index backstop.
+	retentionMaxLevels = 20
+	// retentionMaxCarriers bounds the carrier set. Measured worst closure
+	// over the top-500 hubs of teleport/dolt/gitea/pebble: 245 structs
+	// (dolt hash.Hash); ~8x headroom.
+	retentionMaxCarriers = 2000
+)
+
+// retentionSubjectKind reports whether a subject can be retained through a
+// typed field at all. Functions and methods cannot — gating here means a
+// function blast (most blasts) pays zero retention queries.
+func retentionSubjectKind(kind model.SymbolKind) bool {
+	switch kind {
+	case model.KindClass, model.KindType, model.KindInterface:
+		return true
+	default:
+		return false
+	}
+}
+
+// loadRetention computes the retention group for the subject: the carrier
+// fixpoint (internal), one laundering round over it, then exclusion,
+// hydration, ordering, and the result cap. Returns the holders, the full
+// post-exclusion count (never reduced by the cap), and whether any cap
+// truncated the computation.
+func loadRetention(ctx context.Context, db *sql.DB, subject model.Symbol, seedIDs, directComposerIDs []int64, childSet, excludeGrouped map[int64]struct{}, isSelf selfMethodFn, maxResults int) ([]RetainedHolder, int, bool, error) {
+	if !retentionSubjectKind(subject.Kind) {
+		return nil, 0, false, nil
+	}
+	carriers, truncated, err := carrierClosure(ctx, db, seedIDs, directComposerIDs)
+	if err != nil {
+		return nil, 0, false, err
+	}
+	holderVia, err := launderOneRound(ctx, db, carriers)
+	if err != nil {
+		return nil, 0, false, err
+	}
+	kept := excludeRetained(holderVia, carriers, childSet, excludeGrouped)
+	holders, fullCount, capped, err := hydrateRetained(ctx, db, kept, holderVia, isSelf, maxResults)
+	if err != nil {
+		return nil, 0, false, err
+	}
+	return holders, fullCount, truncated || capped, nil
+}
+
+// carrierClosure walks the reverse composes/includes fixpoint from the seeds:
+// every non-interface type that reaches the subject through a chain of typed
+// fields or embeds. Level 1 reuses the direct-composer IDs Compute already
+// fetched for the composition group, plus the seeds' embedders; deeper levels
+// query both edge kinds at once. The visited set terminates cycles; the
+// level and size caps are backstops that flag truncation.
+func carrierClosure(ctx context.Context, db *sql.DB, seedIDs, directComposerIDs []int64) (map[int64]struct{}, bool, error) {
+	carriers := make(map[int64]struct{}, len(seedIDs))
+	for _, id := range seedIDs {
+		carriers[id] = struct{}{}
+	}
+	embedders, err := inboundHolderPairs(ctx, db, seedIDs, true)
+	if err != nil {
+		return nil, false, err
+	}
+	level, err := nonInterfaceIDs(ctx, db, mergeSources(directComposerIDs, embedders))
+	if err != nil {
+		return nil, false, err
+	}
+
+	admitted := 0
+	truncated := false
+	for depth := 0; len(level) > 0 && depth < retentionMaxLevels; depth++ {
+		if err := ctx.Err(); err != nil {
+			return nil, false, fmt.Errorf("blast: retention closure cancelled: %w", err)
+		}
+		var next []int64
+		for _, id := range level { // ID-ascending: truncation is order-defined
+			if _, seen := carriers[id]; seen {
+				continue
+			}
+			if admitted >= retentionMaxCarriers {
+				truncated = true
+				break
+			}
+			carriers[id] = struct{}{}
+			admitted++
+			next = append(next, id)
+		}
+		if truncated || len(next) == 0 {
+			break
+		}
+		pairs, err := inboundHolderPairs(ctx, db, next, false)
+		if err != nil {
+			return nil, false, err
+		}
+		level = mergeSources(nil, pairs)
+	}
+	if len(level) > 0 && !truncated {
+		// The depth cap cut a live frontier.
+		for _, id := range level {
+			if _, seen := carriers[id]; !seen {
+				truncated = true
+				break
+			}
+		}
+	}
+	return carriers, truncated, nil
+}
+
+// launderOneRound performs the single laundering round: the interfaces any
+// carrier satisfies (forward inherits, interface-kind targets only — the
+// kind gate is what keeps languages without interface symbols out), then
+// those interfaces' reverse composers/embedders. Returns holder → lowest-ID
+// via-interface so a holder reachable through several interfaces appears
+// once, deterministically.
+func launderOneRound(ctx context.Context, db *sql.DB, carriers map[int64]struct{}) (map[int64]int64, error) {
+	base := sortedIDSet(carriers)
+	ifaces, err := forwardInterfaceTargets(ctx, db, base)
+	if err != nil {
+		return nil, err
+	}
+	if len(ifaces) == 0 {
+		return nil, nil
+	}
+	pairs, err := inboundHolderPairs(ctx, db, ifaces, false)
+	if err != nil {
+		return nil, err
+	}
+	holderVia := make(map[int64]int64, len(pairs))
+	for _, p := range pairs {
+		if via, ok := holderVia[p.source]; !ok || p.target < via {
+			holderVia[p.source] = p.target
+		}
+	}
+	return holderVia, nil
+}
+
+// excludeRetained drops holders that already have a stronger home: carriers
+// (which includes the seeds — a carrier belongs to the composition group),
+// the subject's own members, and symbols already placed in another edge-kind
+// group (the one-node-one-group invariant).
+func excludeRetained(holderVia map[int64]int64, carriers, childSet, excludeGrouped map[int64]struct{}) []int64 {
+	kept := make([]int64, 0, len(holderVia))
+	for id := range holderVia {
+		if _, isCarrier := carriers[id]; isCarrier {
+			continue
+		}
+		if _, isChild := childSet[id]; isChild {
+			continue
+		}
+		if _, grouped := excludeGrouped[id]; grouped {
+			continue
+		}
+		kept = append(kept, id)
+	}
+	sort.Slice(kept, func(i, j int) bool { return kept[i] < kept[j] })
+	return kept
+}
+
+// hydrateRetained loads the holder and via-interface symbols, filters the
+// subject's self-members, orders production-first then by ID, and applies the
+// result cap. The returned count is the full post-exclusion size, never the
+// capped one, so a capped list is self-evident to the consumer.
+func hydrateRetained(ctx context.Context, db *sql.DB, kept []int64, holderVia map[int64]int64, isSelf selfMethodFn, maxResults int) ([]RetainedHolder, int, bool, error) {
+	if len(kept) == 0 {
+		return nil, 0, false, nil
+	}
+	allIDs := append([]int64{}, kept...)
+	for _, id := range kept {
+		allIDs = append(allIDs, holderVia[id])
+	}
+	syms, err := loadSymbols(ctx, db, allIDs)
+	if err != nil {
+		return nil, 0, false, fmt.Errorf("blast: hydrate retained: %w", err)
+	}
+	holders := make([]RetainedHolder, 0, len(kept))
+	for _, id := range kept {
+		sym, ok := syms[id]
+		if !ok || isSelf(sym) {
+			continue
+		}
+		holders = append(holders, RetainedHolder{Symbol: sym, Via: syms[holderVia[id]]})
+	}
+	fullCount := len(holders)
+	orderRetained(ctx, db, holders)
+	capped := false
+	if len(holders) > maxResults {
+		holders = holders[:maxResults]
+		capped = true
+	}
+	return holders, fullCount, capped, nil
+}
+
+// orderRetained sorts holders production-first, then by symbol ID. A test
+// fixture holding the subject rides the same may-retain claim as a production
+// holder but matters less to a lifecycle audit, so it must not crowd the cap.
+// testFileFlags is best-effort: a nil map degrades to pure ID order, still
+// deterministic.
+func orderRetained(ctx context.Context, db *sql.DB, holders []RetainedHolder) {
+	ids := make([]int64, len(holders))
+	for i, h := range holders {
+		ids[i] = h.Symbol.ID
+	}
+	testFlags := testFileFlags(ctx, db, ids)
+	sort.SliceStable(holders, func(i, j int) bool {
+		ti, tj := testFlags[holders[i].Symbol.ID], testFlags[holders[j].Symbol.ID]
+		if ti != tj {
+			return !ti
+		}
+		return holders[i].Symbol.ID < holders[j].Symbol.ID
+	})
+}
+
+// holderPair is one (holder, held) row from the reverse composition/embedding
+// queries: source holds target through a named field or an embed.
+type holderPair struct {
+	source int64
+	target int64
+}
+
+// mergeSources unions a plain ID list with the source column of pairs,
+// deduplicated and ID-ascending for deterministic traversal order.
+func mergeSources(ids []int64, pairs []holderPair) []int64 {
+	set := make(map[int64]struct{}, len(ids)+len(pairs))
+	for _, id := range ids {
+		set[id] = struct{}{}
+	}
+	for _, p := range pairs {
+		set[p.source] = struct{}{}
+	}
+	return sortedIDSet(set)
+}
+
+// sortedIDSet flattens a membership set into an ascending ID slice.
+func sortedIDSet(set map[int64]struct{}) []int64 {
+	out := make([]int64, 0, len(set))
+	for id := range set {
+		out = append(out, id)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// inboundHolderPairs returns the (source, target) rows of reverse holding
+// edges onto ids: includes edges always, composes edges too unless
+// includesOnly (level 1 reuses the composition group's already-fetched
+// composers, so only embedders are missing there). Interface-kind sources are
+// excluded — an interface embedding an interface declares a contract, it
+// holds nothing.
+func inboundHolderPairs(ctx context.Context, db *sql.DB, ids []int64, includesOnly bool) ([]holderPair, error) {
+	kinds := `'composes','includes'`
+	if includesOnly {
+		kinds = `'includes'`
+	}
+	query := func(placeholders string) string {
+		return `SELECT DISTINCT e.source_id, e.target_id FROM sense_edges e
+		        JOIN sense_symbols s ON s.id = e.source_id
+		        WHERE e.target_id IN (` + placeholders + `)
+		          AND e.kind IN (` + kinds + `)
+		          AND e.source_id IS NOT NULL
+		          AND s.kind != 'interface'`
+	}
+	return queryHolderPairs(ctx, db, ids, query)
+}
+
+// forwardInterfaceTargets returns the distinct interface-kind symbols any of
+// ids satisfies or implements (forward inherits edges). The filter is on the
+// TARGET's symbol kind, never on edge confidence: Go satisfaction edges ride
+// convention confidence but Rust/TS declared implements are full-confidence,
+// and both launder.
+func forwardInterfaceTargets(ctx context.Context, db *sql.DB, ids []int64) ([]int64, error) {
+	query := func(placeholders string) string {
+		return `SELECT DISTINCT e.source_id, e.target_id FROM sense_edges e
+		        JOIN sense_symbols s ON s.id = e.target_id
+		        WHERE e.source_id IN (` + placeholders + `)
+		          AND e.kind = 'inherits'
+		          AND s.kind = 'interface'`
+	}
+	pairs, err := queryHolderPairs(ctx, db, ids, query)
+	if err != nil {
+		return nil, err
+	}
+	set := make(map[int64]struct{}, len(pairs))
+	for _, p := range pairs {
+		set[p.target] = struct{}{}
+	}
+	return sortedIDSet(set), nil
+}
+
+// nonInterfaceIDs filters ids down to symbols whose kind is not interface.
+// Level 1 of the closure reuses the composition group's composer IDs, which
+// carry no kind information; deeper levels filter in SQL.
+func nonInterfaceIDs(ctx context.Context, db *sql.DB, ids []int64) ([]int64, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	query := func(placeholders string) string {
+		return `SELECT id, id FROM sense_symbols
+		        WHERE id IN (` + placeholders + `) AND kind != 'interface'`
+	}
+	pairs, err := queryHolderPairs(ctx, db, ids, query)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]int64, 0, len(pairs))
+	for _, p := range pairs {
+		out = append(out, p.source)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out, nil
+}
+
+// queryHolderPairs runs a two-int64-column query with one IN clause over ids,
+// chunked under SQLITE_MAX_VARIABLE_NUMBER like every other blast query.
+func queryHolderPairs(ctx context.Context, db *sql.DB, ids []int64, build func(placeholders string) string) ([]holderPair, error) {
+	const chunk = 500
+	var out []holderPair
+	for start := 0; start < len(ids); start += chunk {
+		end := start + chunk
+		if end > len(ids) {
+			end = len(ids)
+		}
+		batch := ids[start:end]
+		placeholders := strings.Repeat("?,", len(batch))
+		placeholders = placeholders[:len(placeholders)-1]
+		args := make([]any, len(batch))
+		for i, id := range batch {
+			args[i] = id
+		}
+		rows, err := db.QueryContext(ctx, build(placeholders), args...)
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			var p holderPair
+			if err := rows.Scan(&p.source, &p.target); err != nil {
+				_ = rows.Close()
+				return nil, err
+			}
+			out = append(out, p)
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		_ = rows.Close()
+	}
+	return out, nil
 }

--- a/internal/blast/retention_faults_test.go
+++ b/internal/blast/retention_faults_test.go
@@ -1,0 +1,203 @@
+package blast
+
+// Fault-injection coverage for the retention closure's error returns: every
+// SQL helper propagates query failures, row-scan failures, and iteration
+// failures up through loadRetention. A healthy database never reaches these
+// branches; the fault driver (symbols_faults_test.go) forces them.
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// openRetentionFaultDB seeds the minimal laundering shape (subject, carrier,
+// rare interface + member, holder) on the fault driver so every retention
+// query executes.
+func openRetentionFaultDB(t *testing.T) (*sql.DB, model.Symbol, []int64) {
+	t.Helper()
+	ctx := context.Background()
+	dbPath := t.TempDir() + "/retention.db"
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	var subject model.Symbol
+	var composerIDs []int64
+	err = adapter.InTx(ctx, func() error {
+		f, err := adapter.WriteFile(ctx, &model.File{
+			Path: "widget.go", Language: "go", Hash: "h1", Symbols: 5, IndexedAt: time.Now().UTC(),
+		})
+		if err != nil {
+			return err
+		}
+		write := func(name string, kind model.SymbolKind, parent *int64) int64 {
+			id, werr := adapter.WriteSymbol(ctx, &model.Symbol{
+				FileID: f, Name: name, Qualified: name, Kind: kind,
+				ParentID: parent, LineStart: 1, LineEnd: 2,
+			})
+			if werr != nil {
+				err = werr
+			}
+			return id
+		}
+		subjectID := write("Widget", model.KindClass, nil)
+		carrier := write("Carrier", model.KindClass, nil)
+		iface := write("RareIface", model.KindInterface, nil)
+		write("VisitRareThing", model.KindMethod, &iface)
+		holder := write("Holder", model.KindClass, nil)
+		if err != nil {
+			return err
+		}
+		edge := func(src, tgt int64, kind model.EdgeKind) {
+			if _, werr := adapter.WriteEdge(ctx, &model.Edge{
+				SourceID: &src, TargetID: tgt, Kind: kind, FileID: f, Confidence: 0.9,
+			}); werr != nil {
+				err = werr
+			}
+		}
+		edge(carrier, subjectID, model.EdgeComposes)
+		edge(carrier, iface, model.EdgeInherits)
+		edge(holder, iface, model.EdgeComposes)
+		if err != nil {
+			return err
+		}
+		subject = model.Symbol{ID: subjectID, Name: "Widget", Qualified: "Widget", Kind: model.KindClass, FileID: f}
+		composerIDs = []int64{carrier}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	blastFaultOnce.Do(func() {
+		probe, perr := sql.Open("sqlite", ":memory:")
+		if perr != nil {
+			panic(perr)
+		}
+		base := probe.Driver()
+		_ = probe.Close()
+		sql.Register("sqlite-blastfault", &blastFaultDriver{base: base})
+	})
+	db, err := sql.Open("sqlite-blastfault", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("open fault db: %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+	return db, subject, composerIDs
+}
+
+func runRetention(t *testing.T, db *sql.DB, subject model.Symbol, composerIDs []int64) error {
+	t.Helper()
+	noSelf := func(model.Symbol) bool { return false }
+	_, _, _, err := loadRetention(context.Background(), db, subject, []int64{subject.ID},
+		composerIDs, map[int64]struct{}{}, map[int64]struct{}{}, noSelf, 100)
+	return err
+}
+
+// TestRetentionPropagatesQueryFaults arms an outright query failure on each
+// distinct retention query and expects loadRetention to surface it.
+func TestRetentionPropagatesQueryFaults(t *testing.T) {
+	cases := map[string]string{
+		"level1_embedders":   `e.kind IN ('includes')`,
+		"level1_kind_filter": `AND kind != 'interface'`,
+		"deeper_levels":      `e.kind IN ('composes','includes')`,
+		"forward_interfaces": `e.kind = 'inherits'`,
+		"sole_members":       `AND kind = 'method'`,
+		"name_frequency":     `GROUP BY name`,
+		"hydration":          `docstring, complexity, snippet`,
+	}
+	for name, sub := range cases {
+		t.Run(name, func(t *testing.T) {
+			db, subject, composerIDs := openRetentionFaultDB(t)
+			armBlastQueryFault(sub)
+			t.Cleanup(disarmBlastFaults)
+			if err := runRetention(t, db, subject, composerIDs); err == nil {
+				t.Fatalf("expected propagated query error for %s", name)
+			}
+		})
+	}
+}
+
+// TestRetentionPropagatesRowFaults drives the row-scan and rows.Err branches
+// of the chunked query helpers.
+func TestRetentionPropagatesRowFaults(t *testing.T) {
+	cases := map[string]struct {
+		sub  string
+		kind blastRowsFaultMode
+	}{
+		"pair_scan":      {`e.kind IN ('composes','includes')`, blastRowsBadValue},
+		"pair_iteration": {`e.kind IN ('composes','includes')`, blastRowsNext},
+		"member_scan":    {`AND kind = 'method'`, blastRowsScan},
+		"member_iter":    {`AND kind = 'method'`, blastRowsNext},
+		"freq_scan":      {`GROUP BY name`, blastRowsScan},
+		"freq_iter":      {`GROUP BY name`, blastRowsNext},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			db, subject, composerIDs := openRetentionFaultDB(t)
+			armBlastRowsFault(c.sub, c.kind)
+			t.Cleanup(disarmBlastFaults)
+			if err := runRetention(t, db, subject, composerIDs); err == nil {
+				t.Fatalf("expected propagated rows error for %s", name)
+			}
+		})
+	}
+}
+
+// TestRetentionCancelledContext: a context cancelled between the level-1
+// fetch and the fixpoint loop surfaces as the loop's cancellation error.
+func TestRetentionCancelledContext(t *testing.T) {
+	db, subject, composerIDs := openRetentionFaultDB(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	noSelf := func(model.Symbol) bool { return false }
+	_, _, _, err := loadRetention(ctx, db, subject, []int64{subject.ID},
+		composerIDs, map[int64]struct{}{}, map[int64]struct{}{}, noSelf, 100)
+	if err == nil {
+		t.Fatal("expected cancellation error")
+	}
+}
+
+// TestEdgeTableGroupsPropagateFaults drives the three error wraps in
+// loadEdgeTableGroups: the shared composer fetch, the composition group's
+// hydration, and the retention closure.
+func TestEdgeTableGroupsPropagateFaults(t *testing.T) {
+	cases := map[string]string{
+		"composer_fetch":      `kind = 'composes'`,
+		"composition_hydrate": `docstring, complexity, snippet`,
+		"retention":           `e.kind IN ('includes')`,
+	}
+	for name, sub := range cases {
+		t.Run(name, func(t *testing.T) {
+			db, subject, _ := openRetentionFaultDB(t)
+			armBlastQueryFault(sub)
+			t.Cleanup(disarmBlastFaults)
+			s := &bfsState{childSet: map[int64]struct{}{}}
+			noSelf := func(model.Symbol) bool { return false }
+			_, _, _, err := s.loadEdgeTableGroups(context.Background(), db, subject,
+				[]int64{subject.ID}, map[int64]struct{}{subject.ID: {}}, nil, nil, noSelf, 100)
+			if err == nil {
+				t.Fatalf("expected propagated error for %s", name)
+			}
+		})
+	}
+}
+
+// TestComputePropagatesEdgeTableGroupFault covers Compute's error return for
+// the edge-table-group stage end to end.
+func TestComputePropagatesEdgeTableGroupFault(t *testing.T) {
+	db, subject, _ := openRetentionFaultDB(t)
+	armBlastQueryFault(`kind = 'composes'`)
+	t.Cleanup(disarmBlastFaults)
+	if _, err := Compute(context.Background(), db, []int64{subject.ID}, Options{MaxHops: 1}); err == nil {
+		t.Fatal("Compute: expected propagated edge-table-group error, got nil")
+	}
+}

--- a/internal/blast/retention_test.go
+++ b/internal/blast/retention_test.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/luuuc/sense/internal/blast"
 	"github.com/luuuc/sense/internal/model"
@@ -378,5 +379,111 @@ func TestRetentionJunkScreen(t *testing.T) {
 		if got[id] != want {
 			t.Errorf("holder %d: present=%v, want %v", id, got[id], want)
 		}
+	}
+}
+
+// TestRetentionResultCapSetsTruncated: more holders than MaxResults trims the
+// list, flags Truncated, and leaves RetainedCount at the full size.
+func TestRetentionResultCapSetsTruncated(t *testing.T) {
+	fix, subject, carrier, _, _ := launderedFixture(t)
+	iface2, _ := launderedVia(t, fix, carrier, "VisitCapThing")
+	extra := fix.addSymbol(t, "CapHolderB")
+	fix.addEdge(t, extra, iface2, model.EdgeComposes, 0.9)
+
+	res, err := blast.Compute(context.Background(), fix.db, []int64{subject},
+		blast.Options{MaxHops: 3, MinConfidence: 0.1, MaxResults: 2})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+
+	if len(res.RetainedViaInterfaces) != 2 {
+		t.Errorf("holders enumerated = %d, want 2 (capped)", len(res.RetainedViaInterfaces))
+	}
+	if res.RetainedCount != 3 {
+		t.Errorf("RetainedCount = %d, want 3 (full size survives the cap)", res.RetainedCount)
+	}
+	if !res.Truncated {
+		t.Errorf("Truncated must be set when the retained cap bites")
+	}
+}
+
+// TestRetentionLevelCapSetsTruncated: a composition chain deeper than the
+// fixpoint level cap flags Truncated instead of walking forever.
+func TestRetentionLevelCapSetsTruncated(t *testing.T) {
+	fix := newFixtureDB(t)
+	subject := fix.addSymbol(t, "ChainSubject")
+	prev := subject
+	for i := 0; i < 25; i++ { // depth > retentionMaxLevels (20)
+		next := fix.addSymbol(t, fmt.Sprintf("ChainCarrier%02d", i))
+		fix.addEdge(t, next, prev, model.EdgeComposes, 0.9)
+		prev = next
+	}
+
+	res := computeRetention(t, fix, subject)
+
+	if !res.Truncated {
+		t.Errorf("Truncated must be set when the level cap cuts a live frontier")
+	}
+}
+
+// TestRetentionDeterministicOrder: production holders come first in ID order;
+// a test-path holder sorts last even with the lowest ID.
+func TestRetentionDeterministicOrder(t *testing.T) {
+	fix, subject, _, iface, holder := launderedFixture(t)
+
+	testFileID, err := fix.adapter.WriteFile(context.Background(), &model.File{
+		Path: "spec/fixture_spec.rb", Language: "ruby", Hash: "spec",
+		Symbols: 1, IndexedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	testHolder, err := fix.adapter.WriteSymbol(context.Background(), &model.Symbol{
+		FileID: testFileID, Name: "SpecHolder", Qualified: "SpecHolder",
+		Kind: model.KindClass, LineStart: 1, LineEnd: 5,
+	})
+	if err != nil {
+		t.Fatalf("WriteSymbol: %v", err)
+	}
+	fix.addEdge(t, testHolder, iface, model.EdgeComposes, 0.9)
+	prodHolder := fix.addSymbol(t, "SecondProdHolder")
+	fix.addEdge(t, prodHolder, iface, model.EdgeComposes, 0.9)
+
+	res := computeRetention(t, fix, subject)
+
+	want := []int64{holder, prodHolder, testHolder}
+	if len(res.RetainedViaInterfaces) != len(want) {
+		t.Fatalf("holders = %d, want %d", len(res.RetainedViaInterfaces), len(want))
+	}
+	for i, id := range want {
+		if res.RetainedViaInterfaces[i].Symbol.ID != id {
+			t.Errorf("holder[%d] = %d, want %d (production-first, then ID)",
+				i, res.RetainedViaInterfaces[i].Symbol.ID, id)
+		}
+	}
+}
+
+// TestRetentionDualInterfaceAttribution: a holder reaching the subject through
+// two via-interfaces appears once, attributed to the lowest interface ID.
+func TestRetentionDualInterfaceAttribution(t *testing.T) {
+	fix, subject, carrier, iface, holder := launderedFixture(t)
+	iface2 := fix.addSymbolWith(t, "SecondRareIface", model.KindInterface, nil)
+	fix.addSymbolWith(t, "VisitOtherRareThing", model.KindMethod, &iface2)
+	fix.addEdge(t, carrier, iface2, model.EdgeInherits, confConvention)
+	fix.addEdge(t, holder, iface2, model.EdgeComposes, 0.9)
+
+	res := computeRetention(t, fix, subject)
+
+	seen := 0
+	for _, rh := range res.RetainedViaInterfaces {
+		if rh.Symbol.ID == holder {
+			seen++
+			if rh.Via.ID != iface {
+				t.Errorf("Via = %d, want lowest interface ID %d", rh.Via.ID, iface)
+			}
+		}
+	}
+	if seen != 1 {
+		t.Errorf("holder appears %d times, want exactly once", seen)
 	}
 }

--- a/internal/blast/retention_test.go
+++ b/internal/blast/retention_test.go
@@ -76,3 +76,228 @@ func TestLaunderedHolderInvisibleToCallerGroups(t *testing.T) {
 		}
 	}
 }
+
+// retainedIDs collects holder IDs from the retained group.
+func retainedIDs(res blast.Result) map[int64]bool {
+	out := map[int64]bool{}
+	for _, rh := range res.RetainedViaInterfaces {
+		out[rh.Symbol.ID] = true
+	}
+	return out
+}
+
+func computeRetention(t *testing.T, fix *fixtureDB, subject int64) blast.Result {
+	t.Helper()
+	res, err := blast.Compute(context.Background(), fix.db, []int64{subject},
+		blast.Options{MaxHops: 3, MinConfidence: 0.1})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	return res
+}
+
+// TestRetentionSurfacesLaunderedHolder is the primary G-11 repro: the
+// laundered holder surfaces in RetainedViaInterfaces with its via-interface,
+// while TotalAffected stays what it was without the group (may-retain never
+// inflates the headline).
+func TestRetentionSurfacesLaunderedHolder(t *testing.T) {
+	fix, subject, _, iface, holder := launderedFixture(t)
+
+	res := computeRetention(t, fix, subject)
+
+	if !retainedIDs(res)[holder] {
+		t.Fatalf("holder must appear in RetainedViaInterfaces, got %+v", res.RetainedViaInterfaces)
+	}
+	if res.RetainedCount != 1 {
+		t.Errorf("RetainedCount = %d, want 1", res.RetainedCount)
+	}
+	for _, rh := range res.RetainedViaInterfaces {
+		if rh.Symbol.ID == holder && rh.Via.ID != iface {
+			t.Errorf("holder Via = %d, want interface %d", rh.Via.ID, iface)
+		}
+	}
+	// Carrier C is the only affected symbol; the holder must not count.
+	if res.TotalAffected != 1 {
+		t.Errorf("TotalAffected = %d, want 1 (retained holders never counted)", res.TotalAffected)
+	}
+}
+
+// TestRetentionOneRoundBound kills the fixpoint mutant: a holder reachable
+// only through a SECOND interface indirection (holder satisfies another
+// interface some other struct composes) must NOT surface.
+func TestRetentionOneRoundBound(t *testing.T) {
+	fix, subject, _, _, holder := launderedFixture(t)
+	iface2 := fix.addSymbolWith(t, "SecondIface", model.KindInterface, nil)
+	fix.addSymbolWith(t, "ResolveSecondThing", model.KindMethod, &iface2)
+	holder2 := fix.addSymbol(t, "TwoHopHolder")
+	fix.addEdge(t, holder, iface2, model.EdgeInherits, confConvention)
+	fix.addEdge(t, holder2, iface2, model.EdgeComposes, 0.9)
+
+	res := computeRetention(t, fix, subject)
+
+	got := retainedIDs(res)
+	if !got[holder] {
+		t.Errorf("one-hop holder must stay present")
+	}
+	if got[holder2] {
+		t.Errorf("two-interface-hop holder must NOT surface (one laundering round)")
+	}
+}
+
+// TestRetentionKindRestriction: a class-kind inherits target never launders —
+// only interface-kind targets open the reverse-composition hop.
+func TestRetentionKindRestriction(t *testing.T) {
+	fix := newFixtureDB(t)
+	subject := fix.addSymbol(t, "SubjectA")
+	carrier := fix.addSymbol(t, "CarrierC")
+	base := fix.addSymbol(t, "BaseClass") // kind class, not interface
+	k := fix.addSymbol(t, "BaseComposer")
+	fix.addEdge(t, carrier, subject, model.EdgeComposes, 0.9)
+	fix.addEdge(t, carrier, base, model.EdgeInherits, 1.0)
+	fix.addEdge(t, k, base, model.EdgeComposes, 0.9)
+
+	res := computeRetention(t, fix, subject)
+
+	if len(res.RetainedViaInterfaces) != 0 || res.RetainedCount != 0 {
+		t.Errorf("class-kind inherits target must not launder, got %+v", res.RetainedViaInterfaces)
+	}
+}
+
+// TestRetentionTerminatesOnCompositionCycle: mutually-composing structs must
+// not hang the carrier fixpoint, and the laundered holder still surfaces.
+func TestRetentionTerminatesOnCompositionCycle(t *testing.T) {
+	fix, subject, carrier, _, holder := launderedFixture(t)
+	fix.addEdge(t, subject, carrier, model.EdgeComposes, 0.9) // cycle: A composes C, C composes A
+
+	res := computeRetention(t, fix, subject)
+
+	got := retainedIDs(res)
+	if !got[holder] {
+		t.Errorf("holder must surface despite composition cycle")
+	}
+	if got[subject] {
+		t.Errorf("subject must never be its own holder")
+	}
+}
+
+// TestRetentionTransitiveCarrierLaunders: the laundering base is the FULL
+// typed-field carrier closure, not just direct composers — a level-2 carrier's
+// satisfied interface still reaches its holders (the DoltSession shape; the
+// measured direct-only variant lost 7/18 gold files).
+func TestRetentionTransitiveCarrierLaunders(t *testing.T) {
+	fix := newFixtureDB(t)
+	subject := fix.addSymbol(t, "SubjectA")
+	c1 := fix.addSymbol(t, "DirectCarrier")
+	c2 := fix.addSymbol(t, "DeepCarrier")
+	iface := fix.addSymbolWith(t, "DeepIface", model.KindInterface, nil)
+	fix.addSymbolWith(t, "VisitDeepThing", model.KindMethod, &iface)
+	holder := fix.addSymbol(t, "DeepHolder")
+	fix.addEdge(t, c1, subject, model.EdgeComposes, 0.9)
+	fix.addEdge(t, c2, c1, model.EdgeComposes, 0.9)
+	fix.addEdge(t, c2, iface, model.EdgeInherits, confConvention)
+	fix.addEdge(t, holder, iface, model.EdgeComposes, 0.9)
+
+	res := computeRetention(t, fix, subject)
+
+	if !retainedIDs(res)[holder] {
+		t.Errorf("holder via a level-2 carrier must surface, got %+v", res.RetainedViaInterfaces)
+	}
+}
+
+// TestRetentionEmbeddedShapes: an embedded interface field (includes edge)
+// retains just as a named field does — for the holder AND for the carrier
+// chain — while an interface embedding the via-interface (interface source)
+// is never a holder.
+func TestRetentionEmbeddedShapes(t *testing.T) {
+	fix, subject, _, iface, _ := launderedFixture(t)
+	embedHolder := fix.addSymbol(t, "EmbedHolder")
+	fix.addEdge(t, embedHolder, iface, model.EdgeIncludes, 0.9)
+	superIface := fix.addSymbolWith(t, "SuperIface", model.KindInterface, nil)
+	fix.addEdge(t, superIface, iface, model.EdgeIncludes, 0.9) // interface embeds interface
+
+	// embed-carrier: EmbedCarrier embeds the subject (struct-embeds-struct),
+	// satisfies its own rare interface, whose holder must surface.
+	embedCarrier := fix.addSymbol(t, "EmbedCarrier")
+	iface2 := fix.addSymbolWith(t, "EmbedCarrierIface", model.KindInterface, nil)
+	fix.addSymbolWith(t, "VisitEmbedThing", model.KindMethod, &iface2)
+	holder2 := fix.addSymbol(t, "EmbedCarrierHolder")
+	fix.addEdge(t, embedCarrier, subject, model.EdgeIncludes, 0.9)
+	fix.addEdge(t, embedCarrier, iface2, model.EdgeInherits, confConvention)
+	fix.addEdge(t, holder2, iface2, model.EdgeComposes, 0.9)
+
+	res := computeRetention(t, fix, subject)
+
+	got := retainedIDs(res)
+	if !got[embedHolder] {
+		t.Errorf("embedded-interface-field holder must surface")
+	}
+	if !got[holder2] {
+		t.Errorf("holder via an embed-carrier must surface")
+	}
+	if got[superIface] {
+		t.Errorf("an interface embedding the via-interface is not a holder")
+	}
+}
+
+// TestRetentionExclusionOverlaps pins the one-node-one-group boundaries:
+// the subject never holds itself, a holder that is also a carrier stays in
+// affected_via_composition, a holder that is also a subclass stays in
+// affected_subclasses, and a member of the subject never appears.
+func TestRetentionExclusionOverlaps(t *testing.T) {
+	fix, subject, _, iface, holder := launderedFixture(t)
+	// (a) subject composes its own satisfied interface.
+	fix.addEdge(t, subject, iface, model.EdgeInherits, confConvention)
+	fix.addEdge(t, subject, iface, model.EdgeComposes, 0.9)
+	// (b) holder that is also a direct carrier.
+	carrierHolder := fix.addSymbol(t, "CarrierHolder")
+	fix.addEdge(t, carrierHolder, subject, model.EdgeComposes, 0.9)
+	fix.addEdge(t, carrierHolder, iface, model.EdgeComposes, 0.9)
+	// (c) holder that is also a subclass of the subject.
+	subclassHolder := fix.addSymbol(t, "SubclassHolder")
+	fix.addEdge(t, subclassHolder, subject, model.EdgeInherits, 1.0)
+	fix.addEdge(t, subclassHolder, iface, model.EdgeComposes, 0.9)
+	// (d) a member of the subject with a stray composes edge to the interface.
+	member := fix.addSymbolWith(t, "subjectMethod", model.KindMethod, &subject)
+	fix.addEdge(t, member, iface, model.EdgeComposes, 0.9)
+
+	res := computeRetention(t, fix, subject)
+
+	got := retainedIDs(res)
+	if !got[holder] {
+		t.Fatalf("plain holder must stay present")
+	}
+	for id, label := range map[int64]string{
+		subject:        "subject (self)",
+		carrierHolder:  "carrier-holder (belongs to composition group)",
+		subclassHolder: "subclass-holder (belongs to subclasses group)",
+		member:         "subject member (childSet)",
+	} {
+		if got[id] {
+			t.Errorf("%s must not appear in RetainedViaInterfaces", label)
+		}
+	}
+	// The excluded overlaps stay in their own groups.
+	if !symbolIDs(res.AffectedViaComposition)[carrierHolder] {
+		t.Errorf("carrier-holder must stay in AffectedViaComposition")
+	}
+	if !symbolIDs(res.AffectedSubclasses)[subclassHolder] {
+		t.Errorf("subclass-holder must stay in AffectedSubclasses")
+	}
+}
+
+// TestRetentionSkipsNonTypeSubjects: only class/type/interface subjects can be
+// retained through fields; a function subject pays nothing and gets nothing.
+func TestRetentionSkipsNonTypeSubjects(t *testing.T) {
+	fix := newFixtureDB(t)
+	fn := fix.addSymbolWith(t, "DoWork", model.KindFunction, nil)
+	iface := fix.addSymbolWith(t, "WorkIface", model.KindInterface, nil)
+	holder := fix.addSymbol(t, "WorkHolder")
+	fix.addEdge(t, fn, iface, model.EdgeInherits, confConvention)
+	fix.addEdge(t, holder, iface, model.EdgeComposes, 0.9)
+
+	res := computeRetention(t, fix, fn)
+
+	if len(res.RetainedViaInterfaces) != 0 || res.RetainedCount != 0 {
+		t.Errorf("function subject must produce no retained group, got %+v", res.RetainedViaInterfaces)
+	}
+}

--- a/internal/blast/retention_test.go
+++ b/internal/blast/retention_test.go
@@ -11,6 +11,7 @@ package blast_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/luuuc/sense/internal/blast"
@@ -299,5 +300,83 @@ func TestRetentionSkipsNonTypeSubjects(t *testing.T) {
 
 	if len(res.RetainedViaInterfaces) != 0 || res.RetainedCount != 0 {
 		t.Errorf("function subject must produce no retained group, got %+v", res.RetainedViaInterfaces)
+	}
+}
+
+// addCommonMethods seeds n method symbols sharing the bare name but with
+// distinct qualified names (T1.Next, T2.Next, …) — the real-repo shape the
+// junk screen's frequency count reads. Distinct qualifieds matter: the
+// adapter upserts same-file same-qualified symbols into one row.
+func addCommonMethods(t *testing.T, fix *fixtureDB, name string, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		line := fix.nextLine
+		fix.nextLine += 10
+		if _, err := fix.adapter.WriteSymbol(context.Background(), &model.Symbol{
+			FileID: fix.fileID, Name: name,
+			Qualified: fmt.Sprintf("FreqType%d.%s", i, name),
+			Kind:      model.KindMethod, LineStart: line, LineEnd: line + 5,
+		}); err != nil {
+			t.Fatalf("WriteSymbol %s#%d: %v", name, i, err)
+		}
+	}
+}
+
+// launderedVia wires carrier→iface (satisfaction) and holder→iface
+// (composition) so iface becomes a laundering route for the fixture.
+func launderedVia(t *testing.T, fix *fixtureDB, carrier int64, memberNames ...string) (iface, holder int64) {
+	t.Helper()
+	iface = fix.addSymbolWith(t, "Iface"+memberNames[0], model.KindInterface, nil)
+	for _, m := range memberNames {
+		fix.addSymbolWith(t, m, model.KindMethod, &iface)
+	}
+	holder = fix.addSymbol(t, "HolderVia"+memberNames[0])
+	fix.addEdge(t, carrier, iface, model.EdgeInherits, confConvention)
+	fix.addEdge(t, holder, iface, model.EdgeComposes, 0.9)
+	return iface, holder
+}
+
+// TestRetentionJunkScreen pins the F-31-09b interim screen: a single-member
+// via-interface whose member name is common (index-wide method-name frequency
+// strictly above the threshold) is junk — its holders never surface. The
+// boundary is exact: frequency 25 keeps, 26 screens. Zero-member (embedded-
+// only) interfaces and multi-member interfaces with a common member always
+// pass — the method-SET match is their signal.
+func TestRetentionJunkScreen(t *testing.T) {
+	fix, subject, carrier, _, holder := launderedFixture(t)
+
+	// Junk twin: sole member "Next", 60 same-named methods index-wide.
+	_, junkHolder := launderedVia(t, fix, carrier, "Next")
+	addCommonMethods(t, fix, "Next", 59) // + the member itself = 60 > threshold
+
+	// Boundary pair: exactly 25 total stays, 26 total is screened.
+	_, keptBoundary := launderedVia(t, fix, carrier, "AtBoundary")
+	addCommonMethods(t, fix, "AtBoundary", 24) // 24 + member = 25, kept
+	_, screenedBoundary := launderedVia(t, fix, carrier, "PastBoundary")
+	addCommonMethods(t, fix, "PastBoundary", 25) // 25 + member = 26, screened
+
+	// Zero-direct-member interface (embedded-only shape) is never screened.
+	emptyIface := fix.addSymbolWith(t, "EmbeddedOnlyIface", model.KindInterface, nil)
+	emptyHolder := fix.addSymbol(t, "HolderViaEmpty")
+	fix.addEdge(t, carrier, emptyIface, model.EdgeInherits, confConvention)
+	fix.addEdge(t, emptyHolder, emptyIface, model.EdgeComposes, 0.9)
+
+	// Multi-member interface with one common name (the CommitItr shape) passes.
+	_, multiHolder := launderedVia(t, fix, carrier, "Next", "ResetToRareState")
+
+	res := computeRetention(t, fix, subject)
+
+	got := retainedIDs(res)
+	for id, want := range map[int64]bool{
+		holder:           true,
+		junkHolder:       false,
+		keptBoundary:     true,
+		screenedBoundary: false,
+		emptyHolder:      true,
+		multiHolder:      true,
+	} {
+		if got[id] != want {
+			t.Errorf("holder %d: present=%v, want %v", id, got[id], want)
+		}
 	}
 }

--- a/internal/blast/retention_test.go
+++ b/internal/blast/retention_test.go
@@ -1,0 +1,78 @@
+package blast_test
+
+// Retention-closure fixtures (pitch 31-12 / ledger G-11): a struct that holds
+// the subject only behind an interface-typed field (an "interface-laundered
+// holder") is reachable from the subject by one forward satisfaction hop plus
+// one reverse composition hop. The BFS walks reverse edges only, so such
+// holders are structurally invisible to every existing blast group — the
+// characterization test below pins that fact, and stays true after the fix:
+// laundered holders surface ONLY in RetainedViaInterfaces, never in the
+// caller lists or the edge-kind groups.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luuuc/sense/internal/blast"
+	"github.com/luuuc/sense/internal/model"
+)
+
+const confConvention = 0.9 // extract.ConfidenceConvention (satisfaction edges)
+
+// launderedFixture builds the minimal laundering shape:
+//
+//	subject A ←composes— carrier C —inherits→ interface I ←composes— holder H
+//
+// C carries A through a named field; C satisfies I; H holds an I-typed field.
+// I's single member is rare, so the junk screen keeps it.
+func launderedFixture(t *testing.T) (fix *fixtureDB, subject, carrier, iface, holder int64) {
+	t.Helper()
+	fix = newFixtureDB(t)
+	subject = fix.addSymbol(t, "SubjectA")
+	carrier = fix.addSymbol(t, "CarrierC")
+	iface = fix.addSymbolWith(t, "RareIface", model.KindInterface, nil)
+	fix.addSymbolWith(t, "VisitRareThing", model.KindMethod, &iface)
+	holder = fix.addSymbol(t, "HolderH")
+
+	fix.addEdge(t, carrier, subject, model.EdgeComposes, 0.9)
+	fix.addEdge(t, carrier, iface, model.EdgeInherits, confConvention)
+	fix.addEdge(t, holder, iface, model.EdgeComposes, 0.9)
+	return fix, subject, carrier, iface, holder
+}
+
+// symbolIDs collects the IDs of a symbol slice.
+func symbolIDs(syms []model.Symbol) map[int64]bool {
+	out := map[int64]bool{}
+	for _, s := range syms {
+		out[s.ID] = true
+	}
+	return out
+}
+
+// TestLaunderedHolderInvisibleToCallerGroups pins the G-11 defect shape: the
+// interface-laundered holder appears in NO caller list and NO edge-kind group,
+// at any hop count. This characterization holds before AND after the fix —
+// laundered holders belong to RetainedViaInterfaces exclusively.
+func TestLaunderedHolderInvisibleToCallerGroups(t *testing.T) {
+	fix, subject, _, _, holder := launderedFixture(t)
+
+	res, err := blast.Compute(context.Background(), fix.db, []int64{subject},
+		blast.Options{MaxHops: 5, MinConfidence: 0.1})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+
+	if symbolIDs(res.DirectCallers)[holder] {
+		t.Errorf("holder %d must not appear in DirectCallers", holder)
+	}
+	for _, hop := range res.IndirectCallers {
+		if hop.Symbol.ID == holder {
+			t.Errorf("holder %d must not appear in IndirectCallers", holder)
+		}
+	}
+	for _, group := range [][]model.Symbol{res.AffectedSubclasses, res.AffectedViaComposition, res.AffectedViaIncludes} {
+		if symbolIDs(group)[holder] {
+			t.Errorf("holder %d must not appear in edge-kind groups", holder)
+		}
+	}
+}

--- a/internal/blast/retention_test.go
+++ b/internal/blast/retention_test.go
@@ -306,7 +306,7 @@ func TestRetentionSkipsNonTypeSubjects(t *testing.T) {
 
 // addCommonMethods seeds n method symbols sharing the bare name but with
 // distinct qualified names (T1.Next, T2.Next, …) — the real-repo shape the
-// junk screen's frequency count reads. Distinct qualifieds matter: the
+// junk screen's frequency count reads. Distinct qualified names matter: the
 // adapter upserts same-file same-qualified symbols into one row.
 func addCommonMethods(t *testing.T, fix *fixtureDB, name string, n int) {
 	t.Helper()
@@ -485,5 +485,44 @@ func TestRetentionDualInterfaceAttribution(t *testing.T) {
 	}
 	if seen != 1 {
 		t.Errorf("holder appears %d times, want exactly once", seen)
+	}
+}
+
+// TestRetentionCarrierSetCapTrips: a direct-composer fan wider than the
+// carrier-set cap truncates the closure (order-defined: the ID-ascending
+// prefix is admitted) and flags Truncated.
+func TestRetentionCarrierSetCapTrips(t *testing.T) {
+	if testing.Short() {
+		t.Skip("wide-fan fixture")
+	}
+	fix := newFixtureDB(t)
+	subject := fix.addSymbol(t, "WideSubject")
+	for i := 0; i < 2100; i++ { // > retentionMaxCarriers (2000)
+		c := fix.addSymbol(t, fmt.Sprintf("WideCarrier%04d", i))
+		fix.addEdge(t, c, subject, model.EdgeComposes, 0.9)
+	}
+
+	res := computeRetention(t, fix, subject)
+
+	if !res.Truncated {
+		t.Errorf("Truncated must be set when the carrier-set cap trips")
+	}
+}
+
+// TestRetentionAllInterfacesScreened: when every candidate via-interface is
+// junk, the group is empty — the screen's empty result short-circuits before
+// any composer expansion.
+func TestRetentionAllInterfacesScreened(t *testing.T) {
+	fix := newFixtureDB(t)
+	subject := fix.addSymbol(t, "SubjectA")
+	carrier := fix.addSymbol(t, "CarrierC")
+	fix.addEdge(t, carrier, subject, model.EdgeComposes, 0.9)
+	_, _ = launderedVia(t, fix, carrier, "Close")
+	addCommonMethods(t, fix, "Close", 40)
+
+	res := computeRetention(t, fix, subject)
+
+	if len(res.RetainedViaInterfaces) != 0 || res.RetainedCount != 0 {
+		t.Errorf("all-junk candidates must leave the group empty, got %+v", res.RetainedViaInterfaces)
 	}
 }

--- a/internal/blast/symbols.go
+++ b/internal/blast/symbols.go
@@ -148,14 +148,12 @@ func SiblingSymbolIDs(ctx context.Context, db *sql.DB, symbolID int64) ([]int64,
 // composer that also calls the subject is recorded under the calls edge, never
 // bucketed as a composer. Because it selects `composes` edges only, the test
 // call-sites that dominate the caller list (calls/tests edges) are excluded by
-// construction. Seeds, the subject's own members (childSet / isSelf), and ids
-// already placed in another edge-kind group (excludeGrouped) are skipped; output
-// is ordered by id and capped to maxResults.
-func (s *bfsState) loadReverseComposition(ctx context.Context, db *sql.DB, seedIDs []int64, seedSet, excludeGrouped map[int64]struct{}, isSelf selfMethodFn, maxResults int) ([]model.Symbol, error) {
-	composerIDs, err := inboundComposers(ctx, db, seedIDs)
-	if err != nil {
-		return nil, err
-	}
+// construction. composerIDs is the inboundComposers result for the seeds —
+// fetched once by Compute and shared with the retention closure's fixpoint.
+// Seeds, the subject's own members (childSet / isSelf), and ids already placed
+// in another edge-kind group (excludeGrouped) are skipped; output is ordered by
+// id and capped to maxResults.
+func (s *bfsState) loadReverseComposition(ctx context.Context, db *sql.DB, composerIDs []int64, seedSet, excludeGrouped map[int64]struct{}, isSelf selfMethodFn, maxResults int) ([]model.Symbol, error) {
 	kept := make([]int64, 0, len(composerIDs))
 	for _, id := range composerIDs {
 		if _, isSeed := seedSet[id]; isSeed {

--- a/internal/blast/symbols_faults_test.go
+++ b/internal/blast/symbols_faults_test.go
@@ -269,10 +269,12 @@ func TestInboundComposersRowsIterationError(t *testing.T) {
 }
 
 // TestLoadReverseCompositionPropagatesQueryError covers the error return after
-// inboundComposers fails inside the method.
+// the symbol hydration fails inside the method (composerIDs now arrive
+// pre-fetched from Compute, so the composes-query fault lives with
+// inboundComposers' own tests above).
 func TestLoadReverseCompositionPropagatesQueryError(t *testing.T) {
 	db := openBlastFaultDB(t)
-	armBlastQueryFault("kind = 'composes'")
+	armBlastQueryFault("FROM sense_symbols")
 	t.Cleanup(disarmBlastFaults)
 	s := &bfsState{childSet: map[int64]struct{}{}}
 	noSelf := func(model.Symbol) bool { return false }

--- a/internal/cli/blast.go
+++ b/internal/cli/blast.go
@@ -284,6 +284,9 @@ func CollectBlastFileIDs(r blast.Result) []int64 {
 			note(sym.FileID)
 		}
 	}
+	for _, rh := range r.RetainedViaInterfaces {
+		note(rh.Symbol.FileID)
+	}
 	return ids
 }
 

--- a/internal/cli/blast_test.go
+++ b/internal/cli/blast_test.go
@@ -128,12 +128,16 @@ func TestCollectBlastFileIDsIncludesEdgeKindGroups(t *testing.T) {
 		AffectedViaComposition: []model.Symbol{{ID: 9, FileID: 99}},
 		AffectedSubclasses:     []model.Symbol{{ID: 8, FileID: 88}},
 		AffectedViaIncludes:    []model.Symbol{{ID: 7, FileID: 77}},
+		// a retained holder's file is likewise reachable only via its group
+		RetainedViaInterfaces: []blast.RetainedHolder{
+			{Symbol: model.Symbol{ID: 6, FileID: 66}, Via: model.Symbol{ID: 5, FileID: 1}},
+		},
 	}
 	got := map[int64]bool{}
 	for _, id := range CollectBlastFileIDs(r) {
 		got[id] = true
 	}
-	for _, want := range []int64{1, 2, 99, 88, 77} {
+	for _, want := range []int64{1, 2, 99, 88, 77, 66} {
 		if !got[want] {
 			t.Errorf("CollectBlastFileIDs missing file id %d (edge-kind group file not collected)", want)
 		}

--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -118,6 +118,14 @@ func ApplyBlastBudget(resp *BlastResponse, budget int) {
 		resp.IndirectCallers = resp.IndirectCallers[:n-trimStep(n)]
 		resp.Truncated = true
 	}
+	// 3b. Retained holders carry a weaker claim than any direct caller, so
+	// they shed next. RetainedCount is never reduced — a trimmed group is
+	// self-evident from count > len(entries).
+	for estimateJSONTokens(resp) > budget && len(resp.RetainedViaInterfaces) > 0 {
+		n := len(resp.RetainedViaInterfaces)
+		resp.RetainedViaInterfaces = resp.RetainedViaInterfaces[:n-trimStep(n)]
+		resp.Truncated = true
+	}
 	// 4. Direct callers last; keep at least one. total_affected still
 	// reports how many exist beyond what is shown.
 	for estimateJSONTokens(resp) > budget && len(resp.DirectCallers) > 1 {
@@ -326,6 +334,30 @@ func BuildBlastResponseSeen(ctx context.Context, r blast.Result, files FileLooku
 		entry := BlastCaller{Symbol: qualifiedOrName(s), File: file, Relation: "includes " + r.Symbol.Name, LineStart: s.LineStart, LineEnd: s.LineEnd, Ref: FormatRef(file, s.LineStart)}
 		resp.AffectedViaIncludes = append(resp.AffectedViaIncludes, entry)
 		tier2All = append(tier2All, entry)
+	}
+
+	// Retained holders are a MAY-claim, weaker than every affected_* group:
+	// they stay out of tier2All (references.count), the production/test
+	// segmentation, affected_files, and the completeness arithmetic — their
+	// own count field is the only place they are tallied.
+	for _, rh := range r.RetainedViaInterfaces {
+		var file string
+		if path, ok := files(rh.Symbol.FileID); ok {
+			file = path
+		}
+		resp.RetainedViaInterfaces = append(resp.RetainedViaInterfaces, BlastCaller{
+			Symbol:    qualifiedOrName(rh.Symbol),
+			File:      file,
+			Relation:  "may retain " + r.Symbol.Name + " via " + rh.Via.Name,
+			LineStart: rh.Symbol.LineStart,
+			LineEnd:   rh.Symbol.LineEnd,
+			Ref:       FormatRef(file, rh.Symbol.LineStart),
+		})
+	}
+	if len(resp.RetainedViaInterfaces) > 0 {
+		resp.RetainedCount = r.RetainedCount
+		resp.RetainedNote = "may-retain holders: structs whose interface-typed field a carrier of " + r.Symbol.Name +
+			" satisfies, one interface indirection deep. Not counted in total_affected; blast a listed holder to go deeper."
 	}
 
 	examples := tier2All

--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -3,6 +3,7 @@ package mcpio
 import (
 	"context"
 	"fmt"
+	"math"
 	"path"
 	"sort"
 
@@ -87,20 +88,24 @@ func spanIndirectByFile(hops []blast.CallerHop, directCallers []model.Symbol) []
 //
 // Applied on the MCP path only — the token budget is an LLM-context
 // concern. The CLI emits the full (untrimmed) response for piping to
-// jq and friends, so the two surfaces can diverge by design.
+// jq and friends, so the two surfaces can diverge by design. Because
+// this path is MCP-only, the estimate prices the COMPACT marshal the
+// transport actually sends (estimateBlastWireTokens): pretty-pricing
+// was charging ~25% phantom indentation against the budget, which on
+// a hub subject trimmed away real content the wire had room for.
 func ApplyBlastBudget(resp *BlastResponse, budget int) {
 	if budget <= 0 {
 		return
 	}
 	// 1. Affected-test sample: tests_affected_count carries the real total.
-	if estimateJSONTokens(resp) > budget && len(resp.AffectedTests) > blastTestExamplesCap {
+	if estimateBlastWireTokens(resp) > budget && len(resp.AffectedTests) > blastTestExamplesCap {
 		resp.AffectedTests = resp.AffectedTests[:blastTestExamplesCap]
 		resp.Truncated = true
 	}
 	// 2. Call-site snippets are supporting detail; a caller's identity is
 	// the decision-relevant signal for "what breaks?". Shed snippets before
 	// dropping any caller, so more callers survive within the same budget.
-	if estimateJSONTokens(resp) > budget {
+	if estimateBlastWireTokens(resp) > budget {
 		stripped := false
 		for i := range resp.DirectCallers {
 			if resp.DirectCallers[i].CallSite != nil {
@@ -113,22 +118,36 @@ func ApplyBlastBudget(resp *BlastResponse, budget int) {
 		}
 	}
 	// 3. Indirect callers are a weaker signal than direct callers.
-	for estimateJSONTokens(resp) > budget && len(resp.IndirectCallers) > 0 {
+	for estimateBlastWireTokens(resp) > budget && len(resp.IndirectCallers) > 0 {
 		n := len(resp.IndirectCallers)
 		resp.IndirectCallers = resp.IndirectCallers[:n-trimStep(n)]
 		resp.Truncated = true
 	}
-	// 3b. Retained holders carry a weaker claim than any direct caller, so
+	// 3b. Tier-2 reference examples are pure duplication under pressure —
+	// every example is an entry the subclass/composition/includes lists
+	// already enumerate in full — so they shed before any content-bearing
+	// group. references.count keeps the magnitude.
+	if estimateBlastWireTokens(resp) > budget && len(resp.References.Examples) > 0 {
+		resp.References.Examples = resp.References.Examples[:0]
+		resp.Truncated = true
+	}
+	// 3c. The affected-test sample is illustrative; tests_affected_count
+	// carries the true total, so the sample empties before answer content.
+	if estimateBlastWireTokens(resp) > budget && len(resp.AffectedTests) > 0 {
+		resp.AffectedTests = resp.AffectedTests[:0]
+		resp.Truncated = true
+	}
+	// 3d. Retained holders carry a weaker claim than any direct caller, so
 	// they shed next. RetainedCount is never reduced — a trimmed group is
 	// self-evident from count > len(entries).
-	for estimateJSONTokens(resp) > budget && len(resp.RetainedViaInterfaces) > 0 {
+	for estimateBlastWireTokens(resp) > budget && len(resp.RetainedViaInterfaces) > 0 {
 		n := len(resp.RetainedViaInterfaces)
 		resp.RetainedViaInterfaces = resp.RetainedViaInterfaces[:n-trimStep(n)]
 		resp.Truncated = true
 	}
 	// 4. Direct callers last; keep at least one. total_affected still
 	// reports how many exist beyond what is shown.
-	for estimateJSONTokens(resp) > budget && len(resp.DirectCallers) > 1 {
+	for estimateBlastWireTokens(resp) > budget && len(resp.DirectCallers) > 1 {
 		n := len(resp.DirectCallers)
 		resp.DirectCallers = resp.DirectCallers[:n-trimStep(n-1)]
 		resp.Truncated = true
@@ -138,6 +157,20 @@ func ApplyBlastBudget(resp *BlastResponse, budget int) {
 	if resp.Completeness != nil {
 		resp.Completeness = blastCompleteness(resp, resp.TotalAffected)
 	}
+}
+
+// estimateBlastWireTokens prices a blast response as the MCP transport
+// sends it: the compact marshal (MarshalBlastCompact), at the shared
+// 4-chars-per-token heuristic. The generic estimateJSONTokens prices the
+// pretty marshal — correct for surfaces that ship pretty JSON, but the
+// blast budget is applied on the MCP path only, and charging indentation
+// that never reaches the wire trims real content for nothing.
+func estimateBlastWireTokens(resp *BlastResponse) int {
+	out, err := marshalCompact(*resp)
+	if err != nil {
+		return math.MaxInt
+	}
+	return len(out) / 4
 }
 
 // trimStep returns how many trailing items to drop this iteration —
@@ -345,19 +378,16 @@ func BuildBlastResponseSeen(ctx context.Context, r blast.Result, files FileLooku
 		if path, ok := files(rh.Symbol.FileID); ok {
 			file = path
 		}
-		resp.RetainedViaInterfaces = append(resp.RetainedViaInterfaces, BlastCaller{
-			Symbol:    qualifiedOrName(rh.Symbol),
-			File:      file,
-			Relation:  "may retain " + r.Symbol.Name + " via " + rh.Via.Name,
-			LineStart: rh.Symbol.LineStart,
-			LineEnd:   rh.Symbol.LineEnd,
-			Ref:       FormatRef(file, rh.Symbol.LineStart),
+		resp.RetainedViaInterfaces = append(resp.RetainedViaInterfaces, BlastRetained{
+			Symbol: qualifiedOrName(rh.Symbol),
+			Ref:    FormatRef(file, rh.Symbol.LineStart),
+			Via:    rh.Via.Name,
 		})
 	}
 	if len(resp.RetainedViaInterfaces) > 0 {
 		resp.RetainedCount = r.RetainedCount
-		resp.RetainedNote = "may-retain holders: structs whose interface-typed field a carrier of " + r.Symbol.Name +
-			" satisfies, one interface indirection deep. Not counted in total_affected; blast a listed holder to go deeper."
+		resp.RetainedNote = "each entry may retain " + r.Symbol.Name + ": its `via` interface field can hold a " +
+			r.Symbol.Name + " carrier, one interface indirection deep. Not counted in total_affected; blast a listed holder to go deeper."
 	}
 
 	examples := tier2All

--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -386,8 +386,8 @@ func BuildBlastResponseSeen(ctx context.Context, r blast.Result, files FileLooku
 	}
 	if len(resp.RetainedViaInterfaces) > 0 {
 		resp.RetainedCount = r.RetainedCount
-		resp.RetainedNote = "each entry may retain " + r.Symbol.Name + ": its `via` interface field can hold a " +
-			r.Symbol.Name + " carrier, one interface indirection deep. Not counted in total_affected; blast a listed holder to go deeper."
+		resp.RetainedNote = "each entry may retain " + r.Symbol.Name + ": its `via` interface field can hold a carrier of " +
+			r.Symbol.Name + ", one interface indirection deep. Not counted in total_affected; blast a listed holder to go deeper."
 	}
 
 	examples := tier2All

--- a/internal/mcpio/blast_test.go
+++ b/internal/mcpio/blast_test.go
@@ -1785,3 +1785,26 @@ func TestBuildDiffBlastResponseSeenCollapses(t *testing.T) {
 		t.Errorf("risk factor = %q, want it to report 2 direct callers (full magnitude)", resp.RiskFactors[0])
 	}
 }
+
+// TestApplyBlastBudgetPricesTheWireNotThePrettyPrint pins the estimator to
+// the compact marshal the MCP transport sends: a budget that the wire fits
+// but the pretty print exceeds must trim NOTHING. Under pretty pricing this
+// response sheds real content to pay for indentation nobody receives.
+func TestApplyBlastBudgetPricesTheWireNotThePrettyPrint(t *testing.T) {
+	r := bigBlastResponse(60, 20, 12)
+	wire := estimateBlastWireTokens(&r)
+	pretty := estimateJSONTokens(&r)
+	if wire >= pretty {
+		t.Fatalf("fixture must diverge: wire=%d pretty=%d", wire, pretty)
+	}
+	budget := (wire + pretty) / 2
+
+	before := len(r.DirectCallers) + len(r.IndirectCallers) + len(r.AffectedTests)
+	ApplyBlastBudget(&r, budget)
+	after := len(r.DirectCallers) + len(r.IndirectCallers) + len(r.AffectedTests)
+
+	if after != before || r.Truncated {
+		t.Errorf("in-wire-budget response must be untouched: before=%d after=%d truncated=%v (wire=%d pretty=%d budget=%d)",
+			before, after, r.Truncated, wire, pretty, budget)
+	}
+}

--- a/internal/mcpio/blast_test.go
+++ b/internal/mcpio/blast_test.go
@@ -1214,8 +1214,10 @@ func TestApplyBlastBudgetTrimsToFitPreservingCounts(t *testing.T) {
 	const budget = 1500
 	ApplyBlastBudget(&r, budget)
 
-	if got := estimateJSONTokens(&r); got > budget {
-		t.Errorf("after trim, tokens=%d still exceed budget=%d", got, budget)
+	// The budget is priced against the wire (compact) marshal — what the MCP
+	// transport actually sends — not the pretty marshal the CLI prints.
+	if got := estimateBlastWireTokens(&r); got > budget {
+		t.Errorf("after trim, wire tokens=%d still exceed budget=%d", got, budget)
 	}
 	if !r.Truncated {
 		t.Error("expected Truncated=true after trimming")
@@ -1241,7 +1243,7 @@ func TestApplyBlastBudgetTrimShedsTestCallersFirst(t *testing.T) {
 	for i := 20; i < 40; i++ {
 		r.DirectCallers[i].File = "app/tests/caller" + itoa(i) + "_test.rb"
 	}
-	const budget = 900 // forces step 4 into the direct-caller list
+	const budget = 500 // forces step 4 into the direct-caller list (wire-priced)
 	ApplyBlastBudget(&r, budget)
 
 	if !r.Truncated {

--- a/internal/mcpio/retained_test.go
+++ b/internal/mcpio/retained_test.go
@@ -36,3 +36,112 @@ func TestBlastResponseOmitsEmptyRetainedGroup(t *testing.T) {
 		}
 	}
 }
+
+// retainedResult builds a Result with one direct caller and two retained
+// holders — the comparison base for the pins below.
+func retainedResult(withRetained bool) blast.Result {
+	r := blast.Result{
+		Symbol:        model.Symbol{ID: 1, Name: "Widget", Qualified: "Widget", FileID: 1},
+		Risk:          blast.RiskLow,
+		RiskReasons:   []string{"1 direct caller"},
+		AffectedTests: []string{},
+		DirectCallers: []model.Symbol{
+			{ID: 2, Name: "CarrierC", Qualified: "CarrierC", FileID: 1, LineStart: 10},
+		},
+		TotalAffected: 1,
+	}
+	if withRetained {
+		r.RetainedViaInterfaces = []blast.RetainedHolder{
+			{Symbol: model.Symbol{ID: 5, Name: "HolderH", Qualified: "HolderH", FileID: 2, LineStart: 30, LineEnd: 40},
+				Via: model.Symbol{ID: 3, Name: "RareIface", Qualified: "RareIface", FileID: 1}},
+			{Symbol: model.Symbol{ID: 6, Name: "HolderK", Qualified: "HolderK", FileID: 2, LineStart: 50, LineEnd: 60},
+				Via: model.Symbol{ID: 4, Name: "OtherIface", Qualified: "OtherIface", FileID: 1}},
+		}
+		r.RetainedCount = 2
+	}
+	return r
+}
+
+func retainedFiles(id int64) (string, bool) {
+	switch id {
+	case 1:
+		return "app/widget.go", true
+	case 2:
+		return "app/holder.go", true
+	}
+	return "", false
+}
+
+// TestBuildBlastResponseRendersRetainedGroup: the group renders with the
+// may-retain relation naming the via-interface, the full count, the depth-1
+// note — and it stays OUT of every existing accounting surface
+// (references.count, production/test segmentation, affected_files,
+// total_affected, completeness).
+func TestBuildBlastResponseRendersRetainedGroup(t *testing.T) {
+	ctx := context.Background()
+	base := BuildBlastResponse(ctx, retainedResult(false), retainedFiles, nil)
+	resp := BuildBlastResponse(ctx, retainedResult(true), retainedFiles, nil)
+
+	if len(resp.RetainedViaInterfaces) != 2 {
+		t.Fatalf("retained entries = %d, want 2", len(resp.RetainedViaInterfaces))
+	}
+	first := resp.RetainedViaInterfaces[0]
+	if first.Relation != "may retain Widget via RareIface" {
+		t.Errorf("relation = %q, want may-retain wording with the via-interface", first.Relation)
+	}
+	if first.File != "app/holder.go" || first.Ref == "" {
+		t.Errorf("entry must carry file and ref, got file=%q ref=%q", first.File, first.Ref)
+	}
+	if resp.RetainedCount != 2 {
+		t.Errorf("RetainedCount = %d, want 2", resp.RetainedCount)
+	}
+	if !strings.Contains(resp.RetainedNote, "one interface indirection") {
+		t.Errorf("group note must state the depth-1 bound, got %q", resp.RetainedNote)
+	}
+
+	// Exclusion pins: every existing accounting surface is byte-equal.
+	if resp.References.Count != base.References.Count {
+		t.Errorf("references.count changed: %d vs %d", resp.References.Count, base.References.Count)
+	}
+	if resp.ProductionAffected != base.ProductionAffected || resp.TestAffected != base.TestAffected {
+		t.Errorf("segmentation changed: prod %d vs %d, test %d vs %d",
+			resp.ProductionAffected, base.ProductionAffected, resp.TestAffected, base.TestAffected)
+	}
+	if resp.AffectedFiles != base.AffectedFiles {
+		t.Errorf("affected_files changed: %d vs %d", resp.AffectedFiles, base.AffectedFiles)
+	}
+	if resp.TotalAffected != base.TotalAffected {
+		t.Errorf("total_affected changed: %d vs %d", resp.TotalAffected, base.TotalAffected)
+	}
+	if resp.Completeness == nil || base.Completeness == nil ||
+		resp.Completeness.Verdict != base.Completeness.Verdict {
+		t.Errorf("completeness verdict must not react to the retained group")
+	}
+	if resp.SenseMetrics != base.SenseMetrics {
+		t.Errorf("sense metrics changed: %+v vs %+v", resp.SenseMetrics, base.SenseMetrics)
+	}
+}
+
+// TestApplyBlastBudgetTrimsRetainedBeforeDirect: under budget pressure the
+// retained entries shed before any direct caller, the count survives
+// untrimmed, and the response flags truncation.
+func TestApplyBlastBudgetTrimsRetainedBeforeDirect(t *testing.T) {
+	resp := BuildBlastResponse(context.Background(), retainedResult(true), retainedFiles, nil)
+	resp.IndirectCallers = nil // isolate the retained trim step
+
+	tiny := 1 // force every trim step to fire
+	ApplyBlastBudget(&resp, tiny)
+
+	if len(resp.RetainedViaInterfaces) != 0 {
+		t.Errorf("retained entries must shed under budget, got %d", len(resp.RetainedViaInterfaces))
+	}
+	if resp.RetainedCount != 2 {
+		t.Errorf("RetainedCount = %d, want 2 (never reduced by trimming)", resp.RetainedCount)
+	}
+	if len(resp.DirectCallers) != 1 {
+		t.Errorf("the last direct caller must survive, got %d", len(resp.DirectCallers))
+	}
+	if !resp.Truncated {
+		t.Errorf("Truncated must be set")
+	}
+}

--- a/internal/mcpio/retained_test.go
+++ b/internal/mcpio/retained_test.go
@@ -8,6 +8,7 @@ package mcpio
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -181,5 +182,40 @@ func TestApplyBlastBudgetShedsDuplicativeContentFirst(t *testing.T) {
 	}
 	if !resp.Truncated {
 		t.Errorf("Truncated must be set")
+	}
+}
+
+// TestApplyBlastBudgetKeepsDirectCallersWhileSheddingRetained pins the shed
+// ORDER between steps 3d and 4: with a budget that shedding retained alone
+// satisfies, every direct caller survives — a weaker may-claim must never
+// outlive a stronger one.
+func TestApplyBlastBudgetKeepsDirectCallersWhileSheddingRetained(t *testing.T) {
+	r := retainedResult(true)
+	for i := int64(0); i < 4; i++ {
+		r.DirectCallers = append(r.DirectCallers, model.Symbol{
+			ID: 10 + i, Name: fmt.Sprintf("Caller%d", i), Qualified: fmt.Sprintf("Caller%d", i),
+			FileID: 1, LineStart: int(100 + i)})
+	}
+	r.TotalAffected = len(r.DirectCallers)
+	resp := BuildBlastResponse(context.Background(), r, retainedFiles, nil)
+	resp.AffectedTests = nil
+	resp.References.Examples = nil
+
+	noRetained := resp
+	noRetained.RetainedViaInterfaces = nil
+	// +8 covers the `"truncated":true` the shed itself adds; still far under
+	// one retained entry's cost, so only the retained shed can satisfy it.
+	budget := estimateBlastWireTokens(&noRetained) + 8
+
+	ApplyBlastBudget(&resp, budget)
+
+	if len(resp.DirectCallers) != 5 {
+		t.Errorf("direct callers = %d, want all 5 (retained must shed before any direct caller)", len(resp.DirectCallers))
+	}
+	if len(resp.RetainedViaInterfaces) >= 2 {
+		t.Errorf("retained entries = %d, want trimmed below 2", len(resp.RetainedViaInterfaces))
+	}
+	if resp.RetainedCount != 2 {
+		t.Errorf("RetainedCount = %d, want 2", resp.RetainedCount)
 	}
 }

--- a/internal/mcpio/retained_test.go
+++ b/internal/mcpio/retained_test.go
@@ -86,17 +86,23 @@ func TestBuildBlastResponseRendersRetainedGroup(t *testing.T) {
 		t.Fatalf("retained entries = %d, want 2", len(resp.RetainedViaInterfaces))
 	}
 	first := resp.RetainedViaInterfaces[0]
-	if first.Relation != "may retain Widget via RareIface" {
-		t.Errorf("relation = %q, want may-retain wording with the via-interface", first.Relation)
+	if first.Via != "RareIface" {
+		t.Errorf("via = %q, want the via-interface name", first.Via)
 	}
-	if first.File != "app/holder.go" || first.Ref == "" {
-		t.Errorf("entry must carry file and ref, got file=%q ref=%q", first.File, first.Ref)
+	if first.Ref != "app/holder.go:30" {
+		t.Errorf("entry must carry the file:line ref, got %q", first.Ref)
+	}
+	if first.Symbol != "HolderH" {
+		t.Errorf("symbol = %q, want HolderH", first.Symbol)
 	}
 	if resp.RetainedCount != 2 {
 		t.Errorf("RetainedCount = %d, want 2", resp.RetainedCount)
 	}
 	if !strings.Contains(resp.RetainedNote, "one interface indirection") {
 		t.Errorf("group note must state the depth-1 bound, got %q", resp.RetainedNote)
+	}
+	if !strings.Contains(resp.RetainedNote, "may retain Widget") {
+		t.Errorf("group note must carry the may-retain semantics once, got %q", resp.RetainedNote)
 	}
 
 	// Exclusion pins: every existing accounting surface is byte-equal.
@@ -140,6 +146,38 @@ func TestApplyBlastBudgetTrimsRetainedBeforeDirect(t *testing.T) {
 	}
 	if len(resp.DirectCallers) != 1 {
 		t.Errorf("the last direct caller must survive, got %d", len(resp.DirectCallers))
+	}
+	if !resp.Truncated {
+		t.Errorf("Truncated must be set")
+	}
+}
+
+// TestApplyBlastBudgetShedsDuplicativeContentFirst: under pressure the tier-2
+// reference examples (duplicates of fully-enumerated group lists) and the
+// affected-test sample empty BEFORE any retained entry sheds, and their
+// counts survive.
+func TestApplyBlastBudgetShedsDuplicativeContentFirst(t *testing.T) {
+	resp := BuildBlastResponse(context.Background(), retainedResult(true), retainedFiles, nil)
+	resp.AffectedTests = []string{"a_test.go", "b_test.go"}
+	resp.TestsAffectedCount = 2
+	resp.References = BlastTierSummary{Count: 7, Examples: []BlastCaller{{Symbol: "Dup", File: "app/widget.go"}}}
+
+	// A budget wide enough that shedding examples+tests suffices: current
+	// size minus just those two lists.
+	over := estimateBlastWireTokens(&resp) - 1
+	ApplyBlastBudget(&resp, over)
+
+	if len(resp.References.Examples) != 0 {
+		t.Errorf("reference examples must shed first, got %d", len(resp.References.Examples))
+	}
+	if resp.References.Count != 7 {
+		t.Errorf("references.count must survive, got %d", resp.References.Count)
+	}
+	if resp.TestsAffectedCount != 2 {
+		t.Errorf("tests_affected_count must survive, got %d", resp.TestsAffectedCount)
+	}
+	if len(resp.RetainedViaInterfaces) != 2 {
+		t.Errorf("retained entries must not shed while duplicative content remains, got %d", len(resp.RetainedViaInterfaces))
 	}
 	if !resp.Truncated {
 		t.Errorf("Truncated must be set")

--- a/internal/mcpio/retained_test.go
+++ b/internal/mcpio/retained_test.go
@@ -1,0 +1,38 @@
+package mcpio
+
+// Wire-shape pins for the retained_via_interfaces group (pitch 31-12): the
+// group is omitted entirely when empty — byte-identity for languages without
+// interface symbols depends on ALL THREE keys (list, count, note) vanishing
+// from the marshaled response, not serializing as empty values.
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/internal/blast"
+	"github.com/luuuc/sense/internal/model"
+)
+
+// TestBlastResponseOmitsEmptyRetainedGroup pins the empty case: a Result with
+// no retained holders marshals with no retained_* keys at all.
+func TestBlastResponseOmitsEmptyRetainedGroup(t *testing.T) {
+	r := blast.Result{
+		Symbol:        model.Symbol{ID: 1, Name: "Widget", Qualified: "Widget"},
+		Risk:          blast.RiskLow,
+		RiskReasons:   []string{"0 direct callers"},
+		AffectedTests: []string{},
+	}
+	resp := BuildBlastResponse(context.Background(), r, func(int64) (string, bool) { return "", false }, nil)
+
+	raw, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, key := range []string{"retained_via_interfaces", "retained_via_interfaces_count", "retained_note"} {
+		if strings.Contains(string(raw), key) {
+			t.Errorf("empty retained group must omit %q, got: %s", key, raw)
+		}
+	}
+}

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -350,9 +350,12 @@ type BlastResponse struct {
 	// produce it). RetainedCount is the full computed size and is never
 	// reduced by budget trimming, so a trimmed list is self-evident from
 	// retained_via_interfaces_count > len(retained_via_interfaces).
-	RetainedViaInterfaces []BlastCaller `json:"retained_via_interfaces,omitempty"`
-	RetainedCount         int           `json:"retained_via_interfaces_count,omitempty"`
-	RetainedNote          string        `json:"retained_note,omitempty"`
+	// RetainedNote carries the group's shared semantics once — per-entry
+	// weight is what decides whether the group survives the token budget on
+	// a hub subject, so entries stay minimal (see BlastRetained).
+	RetainedViaInterfaces []BlastRetained `json:"retained_via_interfaces,omitempty"`
+	RetainedCount         int             `json:"retained_via_interfaces_count,omitempty"`
+	RetainedNote          string          `json:"retained_note,omitempty"`
 
 	// Tier 2 — references (composes/inherits/includes). Count + top examples.
 	References BlastTierSummary `json:"references"`
@@ -419,6 +422,19 @@ type BlastCaller struct {
 	Ref         string    `json:"ref,omitempty"`
 	ViaTemporal bool      `json:"via_temporal,omitempty"`
 	CallSite    *CallSite `json:"call_site,omitempty"`
+}
+
+// BlastRetained is the shape of a retained_via_interfaces entry: the holder,
+// its citable file:line ref, and the interface its field is typed as (the
+// laundering route, so the agent can verify the hop without a second call).
+// Deliberately leaner than BlastCaller — the ref already encodes file and
+// line, and the may-retain relation lives once in retained_note; on a hub
+// subject the whole group must fit the token budget alongside the caller
+// lists or it is the first thing trimmed away.
+type BlastRetained struct {
+	Symbol string `json:"symbol"`
+	Ref    string `json:"ref"`
+	Via    string `json:"via"`
 }
 
 // Completeness is a single, machine-branchable verdict on whether the

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -37,6 +37,7 @@ const ServerInstructions = "When Sense is available and indexed, prefer Sense to
 	"WHEN TO USE SENSE TOOLS:\n" +
 	"- Symbol relationships, callers, dependencies → sense_graph\n" +
 	"- Who holds/embeds X, which structs carry it → sense_graph (composed_by)\n" +
+	"- What retains X transitively, incl. behind interface fields (lifecycle audit) → sense_blast (retained_via_interfaces)\n" +
 	"- \"What would break if I changed X?\", impact analysis → sense_blast\n" +
 	"- Conceptual/semantic code search (not exact string match) → sense_search\n" +
 	"- Project patterns and conventions → sense_conventions\n" +

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -36,6 +36,7 @@ const ServerInstructions = "When Sense is available and indexed, prefer Sense to
 	"Sense provides pre-indexed results that are faster and more complete.\n\n" +
 	"WHEN TO USE SENSE TOOLS:\n" +
 	"- Symbol relationships, callers, dependencies → sense_graph\n" +
+	"- Who holds/embeds X, which structs carry it → sense_graph (composed_by)\n" +
 	"- \"What would break if I changed X?\", impact analysis → sense_blast\n" +
 	"- Conceptual/semantic code search (not exact string match) → sense_search\n" +
 	"- Project patterns and conventions → sense_conventions\n" +
@@ -338,6 +339,19 @@ type BlastResponse struct {
 	AffectedSubclasses     []BlastCaller `json:"affected_subclasses"`
 	AffectedViaComposition []BlastCaller `json:"affected_via_composition"`
 	AffectedViaIncludes    []BlastCaller `json:"affected_via_includes"`
+
+	// RetainedViaInterfaces lists may-retain holders: structs holding the
+	// subject only behind an interface-typed field whose concrete satisfier
+	// is a carrier of the subject, one interface indirection deep. A weaker
+	// claim than the affected_* groups — it never feeds total_affected,
+	// references.count, or the production/test segmentation, and it is
+	// omitted entirely when empty (languages without interface symbols never
+	// produce it). RetainedCount is the full computed size and is never
+	// reduced by budget trimming, so a trimmed list is self-evident from
+	// retained_via_interfaces_count > len(retained_via_interfaces).
+	RetainedViaInterfaces []BlastCaller `json:"retained_via_interfaces,omitempty"`
+	RetainedCount         int           `json:"retained_via_interfaces_count,omitempty"`
+	RetainedNote          string        `json:"retained_note,omitempty"`
 
 	// Tier 2 — references (composes/inherits/includes). Count + top examples.
 	References BlastTierSummary `json:"references"`

--- a/internal/setup/marker.go
+++ b/internal/setup/marker.go
@@ -37,6 +37,8 @@ Sense gives you structural understanding of the codebase (symbols, relationships
 | Question | Tool |
 |---|---|
 | Who calls X? What does X call? | sense_graph |
+| Who holds/embeds X? Which structs carry it (directly or via a field)? | sense_graph (composed_by) |
+| What retains X transitively, incl. behind interface-typed fields (lifecycle audit)? | sense_blast (retained_via_interfaces) |
 | Find code related to a concept | sense_search |
 | What breaks if I change X? | sense_blast |
 | What patterns does this project follow? | sense_conventions |

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -859,6 +859,12 @@ func TestGuidanceMarkdownContent(t *testing.T) {
 	if !strings.Contains(guidanceMarkdown, "grepping a name") {
 		t.Error("guidanceMarkdown must include the name-vs-string grep routing rule")
 	}
+	if !strings.Contains(guidanceMarkdown, "holds/embeds") || !strings.Contains(guidanceMarkdown, "composed_by") {
+		t.Error("guidanceMarkdown must route who-holds/embeds questions to sense_graph composed_by")
+	}
+	if !strings.Contains(guidanceMarkdown, "retains X transitively") || !strings.Contains(guidanceMarkdown, "retained_via_interfaces") {
+		t.Error("guidanceMarkdown must route retention/lifecycle-audit questions to sense_blast")
+	}
 	if strings.Contains(guidanceMarkdown, "FIRST action in every conversation") {
 		t.Error("guidanceMarkdown must not include cold-start protocol (now handled by SessionStart hook)")
 	}
@@ -874,6 +880,12 @@ func TestGuidanceMarkdownContent(t *testing.T) {
 	}
 	if strings.Contains(mcpio.ServerInstructions, "sense.orient") {
 		t.Error("ServerInstructions must not reference the removed orient tool")
+	}
+	if !strings.Contains(mcpio.ServerInstructions, "holds/embeds") {
+		t.Error("ServerInstructions must route who-holds/embeds questions to sense_graph")
+	}
+	if !strings.Contains(mcpio.ServerInstructions, "retained_via_interfaces") {
+		t.Error("ServerInstructions must route retention questions to sense_blast")
 	}
 	if lines := strings.Count(guidanceMarkdown, "\n"); lines > 20 {
 		t.Errorf("guidanceMarkdown should be ≤20 lines, got %d", lines)


### PR DESCRIPTION
## What

`sense_blast` now returns **`retained_via_interfaces`**: the interface-laundered may-retain holders — structs that hold the subject only behind an interface-typed field whose concrete satisfier is a carrier of the subject. The engine walks the typed-field carrier closure (reverse composes/includes fixpoint, visited-set terminated, capped) and runs **one** laundering round over it: forward satisfaction edges to interface-kind targets, junk-screened, then those interfaces' reverse composers/embedders. Entries are `{symbol, ref, via}`; the may-retain semantics, the one-indirection depth bound, and the escalation path live once in `retained_note`. The group never feeds `total_affected`, `references.count`, the production/test segmentation, or the completeness verdict, and is omitted entirely for languages without interface symbols.

Query-layer only — no scan/resolve/extract change, no schema change: takes effect on existing indexes immediately.

## Why

A retention/lifecycle audit asks "everything that retains X, including through interface-typed fields." The BFS walks reverse edges only; the laundering path needs one forward satisfaction hop, so these holders were structurally unreachable at any hop count — `blast(doltdb.DoltDB)` surfaced 2 of 18 hand-audited laundered dependents. An agent had to hand-join 13 via-interfaces (measured: it did 3, then fell back to 23 grep calls). The data was indexed; the access shape lost. This PR returns the assembled closure in one call.

## Design (measured, not argued)

- **One laundering round, not a fixpoint**: on the dolt index, one round = 47 holders / 18/18 hand-audited gold / 0 junk (exactly reproducing the independent hand-derived join); the mutual fixpoint = 357 with junk-shaped extras. The may-retain claim does not compose across interface indirections; a two-hop mutant is pinned dead by test.
- **Carrier fixpoint is load-bearing**: laundering from direct composers alone loses 7/18 gold (the transitive-carrier shape).
- **Junk screen** (interim until satisfaction matching goes param-type-aware): a via-interface with exactly one distinct direct member whose name occurs >25 times index-wide fabricates its satisfaction edges by name+arity matching (`Next`/`Close`/`Get` class). Margins measured on six repos: genuine ≤25, junk ≥49. A fan/ratio alternative was measured against the same battery and lost — no separating threshold exists.
- **Wire-priced budget** (blast-scoped): the trim estimator now prices the compact marshal the MCP transport actually sends; pretty-pricing charged ~25% phantom indentation and trimmed real content (a hub blast was shedding 90+ real caller lines for indentation nobody receives). Two count-preserving shed steps (tier-2 reference examples, affected-test sample — duplicative/illustrative content) run before any retained entry drops. Monotonic: no trim fires earlier than before.

## Acceptance (un-fakeable checks, all run over MCP stdio)

- dolt `blast(doltdb.DoltDB)`: 52/52 holders shown, **18/18 hand-audited gold files in one call**, 0 junk rows, in budget — at both min_confidence bands.
- ruby + python controls byte-identical (freshness masked); the one budget-saturated ruby hub differs strictly additively (the estimator fix un-hiding previously-trimmed callers, zero retained keys).
- dolt invariants: `total_affected` 225=225, `affected_via_composition` 49=49, risk unchanged.
- Go controls additive-only (pebble identical; gitea gains the group).
- Perf: retention path 7.7ms on a 1,000-carrier synthetic worst hub; calls-only subjects early-exit (function blasts pay zero queries).
- Cross-vertical side-effect RUN (llm.rb + healthchecks single sense-arm cells vs frozen bands): GREEN. llm.rb cited-recall 0.926 (prior-window 7c: 0.593; campaign variance envelope 0.44–0.93), adoption 0.70 = frozen, grounding 186/186; healthchecks cited-recall 1.0 = frozen, adoption 0.85 ≥ 0.836, grounding 88/88, tokens down. No regression signal on either vertical.

## Guidance

The setup guidance table and MCP server instructions gain two sibling rows shipped with the capability: "who holds/embeds X → sense_graph (composed_by)" and "what retains X transitively (lifecycle audit) → sense_blast (retained_via_interfaces)".

## Tests

Red-first characterization → structure → behavior commits; fixtures for the one-round bound, threshold boundary (25/26), zero-member and multi-member interfaces, kind restriction, four exclusion overlaps, composition cycles, all three cap trips, determinism + lowest-via attribution, omit-when-empty wire shape, accounting isolation pins, trim-order and wire-estimator behavioral pins; fault-injection coverage for every query/scan/iteration error path; four targeted mutants run and killed. Coverage 95.4% total, complexity ledger 0.
