### PR TITLE
enhance(blast): name the carrier and containment chain on retained rows

### DIFF
--- a/internal/blast/retention.go
+++ b/internal/blast/retention.go
@@ -42,6 +42,11 @@ type RetainedHolder struct {
 	// re-derive it with a per-interface graph join. When several carriers
 	// satisfy Via, the lowest-ID one is recorded (mirrors the Via rule).
 	Carrier model.Symbol
+	// Chain is the declared containment path from Carrier down to the
+	// subject (inclusive on both ends): every hop is a composes/includes
+	// edge the index holds, so the whole path is a statable structural
+	// fact. Only the runtime choice of satisfier stays a may-claim.
+	Chain []model.Symbol
 }
 
 // retainedRoute is the laundering evidence for one holder: the via-interface
@@ -98,7 +103,7 @@ func loadRetention(ctx context.Context, db *sql.DB, subject model.Symbol, seedID
 	if !retentionSubjectKind(subject.Kind) {
 		return nil, 0, false, nil
 	}
-	carriers, truncated, err := carrierClosure(ctx, db, seedIDs, directComposerIDs)
+	carriers, parents, truncated, err := carrierClosure(ctx, db, seedIDs, directComposerIDs)
 	if err != nil {
 		return nil, 0, false, err
 	}
@@ -107,7 +112,7 @@ func loadRetention(ctx context.Context, db *sql.DB, subject model.Symbol, seedID
 		return nil, 0, false, err
 	}
 	kept := excludeRetained(holderVia, carriers, childSet, excludeGrouped)
-	holders, fullCount, capped, err := hydrateRetained(ctx, db, kept, holderVia, isSelf, maxResults)
+	holders, fullCount, capped, err := hydrateRetained(ctx, db, kept, holderVia, chainContext{parents: parents, seeds: seedIDs}, isSelf, maxResults)
 	if err != nil {
 		return nil, 0, false, err
 	}
@@ -120,25 +125,39 @@ func loadRetention(ctx context.Context, db *sql.DB, subject model.Symbol, seedID
 // fetched for the composition group, plus the seeds' embedders; deeper levels
 // query both edge kinds at once. The visited set terminates cycles; the
 // level and size caps are backstops that flag truncation.
-func carrierClosure(ctx context.Context, db *sql.DB, seedIDs, directComposerIDs []int64) (map[int64]struct{}, bool, error) {
+func carrierClosure(ctx context.Context, db *sql.DB, seedIDs, directComposerIDs []int64) (map[int64]struct{}, map[int64]int64, bool, error) {
 	carriers := make(map[int64]struct{}, len(seedIDs))
 	for _, id := range seedIDs {
 		carriers[id] = struct{}{}
 	}
+	// parents records which already-admitted node each carrier declaredly
+	// contains (the pair target that admitted it): the containment tree the
+	// chain field renders. Level-1 entries hang off the primary seed.
+	parents := make(map[int64]int64)
 	embedders, err := inboundHolderPairs(ctx, db, seedIDs, true)
 	if err != nil {
-		return nil, false, err
+		return nil, nil, false, err
+	}
+	seedParent := int64(0)
+	if len(seedIDs) > 0 {
+		seedParent = seedIDs[0]
+	}
+	for _, id := range directComposerIDs {
+		recordParent(parents, carriers, id, seedParent)
+	}
+	for _, p := range embedders {
+		recordParent(parents, carriers, p.source, p.target)
 	}
 	level, err := nonInterfaceIDs(ctx, db, mergeSources(directComposerIDs, embedders))
 	if err != nil {
-		return nil, false, err
+		return nil, nil, false, err
 	}
 
 	admitted := 0
 	truncated := false
 	for depth := 0; len(level) > 0 && depth < retentionMaxLevels; depth++ {
 		if err := ctx.Err(); err != nil {
-			return nil, false, fmt.Errorf("blast: retention closure cancelled: %w", err)
+			return nil, nil, false, fmt.Errorf("blast: retention closure cancelled: %w", err)
 		}
 		var next []int64
 		next, admitted, truncated = admitCarrierLevel(carriers, level, admitted)
@@ -147,11 +166,58 @@ func carrierClosure(ctx context.Context, db *sql.DB, seedIDs, directComposerIDs 
 		}
 		pairs, err := inboundHolderPairs(ctx, db, next, false)
 		if err != nil {
-			return nil, false, err
+			return nil, nil, false, err
+		}
+		for _, p := range pairs {
+			recordParent(parents, carriers, p.source, p.target)
 		}
 		level = mergeSources(nil, pairs)
 	}
-	return carriers, truncated || liveFrontierRemains(carriers, level), nil
+	return carriers, parents, truncated || liveFrontierRemains(carriers, level), nil
+}
+
+// recordParent stores the containment parent for a node not yet admitted to
+// the carrier set, keeping the lowest-ID parent when several pairs admit the
+// same node so chains are stable run to run.
+func recordParent(parents map[int64]int64, carriers map[int64]struct{}, node, parent int64) {
+	if _, seen := carriers[node]; seen {
+		return
+	}
+	if cur, ok := parents[node]; !ok || parent < cur {
+		parents[node] = parent
+	}
+}
+
+// chainContext carries what hydration needs to render a containment chain:
+// the parent tree and the seed set the chain terminates on.
+type chainContext struct {
+	parents map[int64]int64
+	seeds   []int64
+}
+
+// chainIDs walks the parent tree from start down to the first seed hit,
+// returning the full path including start and the terminal seed. The walk is
+// bounded by the closure's own depth cap; a break in the tree returns the
+// partial path rather than guessing.
+func (c chainContext) chainIDs(start int64) []int64 {
+	seeds := make(map[int64]struct{}, len(c.seeds))
+	for _, s := range c.seeds {
+		seeds[s] = struct{}{}
+	}
+	path := []int64{start}
+	cur := start
+	for range retentionMaxLevels + 2 {
+		if _, done := seeds[cur]; done {
+			return path
+		}
+		next, ok := c.parents[cur]
+		if !ok {
+			return path
+		}
+		path = append(path, next)
+		cur = next
+	}
+	return path
 }
 
 // admitCarrierLevel admits one fixpoint level into the carrier set in
@@ -249,13 +315,17 @@ func excludeRetained(holderVia map[int64]retainedRoute, carriers, childSet, excl
 // subject's self-members, orders production-first then by ID, and applies the
 // result cap. The returned count is the full post-exclusion size, never the
 // capped one, so a capped list is self-evident to the consumer.
-func hydrateRetained(ctx context.Context, db *sql.DB, kept []int64, holderVia map[int64]retainedRoute, isSelf selfMethodFn, maxResults int) ([]RetainedHolder, int, bool, error) {
+func hydrateRetained(ctx context.Context, db *sql.DB, kept []int64, holderVia map[int64]retainedRoute, chains chainContext, isSelf selfMethodFn, maxResults int) ([]RetainedHolder, int, bool, error) {
 	if len(kept) == 0 {
 		return nil, 0, false, nil
 	}
 	allIDs := append([]int64{}, kept...)
+	chainByHolder := make(map[int64][]int64, len(kept))
 	for _, id := range kept {
 		allIDs = append(allIDs, holderVia[id].via, holderVia[id].carrier)
+		path := chains.chainIDs(holderVia[id].carrier)
+		chainByHolder[id] = path
+		allIDs = append(allIDs, path...)
 	}
 	syms, err := loadSymbols(ctx, db, allIDs)
 	if err != nil {
@@ -268,7 +338,13 @@ func hydrateRetained(ctx context.Context, db *sql.DB, kept []int64, holderVia ma
 			continue
 		}
 		route := holderVia[id]
-		holders = append(holders, RetainedHolder{Symbol: sym, Via: syms[route.via], Carrier: syms[route.carrier]})
+		chain := make([]model.Symbol, 0, len(chainByHolder[id]))
+		for _, cid := range chainByHolder[id] {
+			if cs, ok := syms[cid]; ok {
+				chain = append(chain, cs)
+			}
+		}
+		holders = append(holders, RetainedHolder{Symbol: sym, Via: syms[route.via], Carrier: syms[route.carrier], Chain: chain})
 	}
 	fullCount := len(holders)
 	orderRetained(ctx, db, holders)

--- a/internal/blast/retention.go
+++ b/internal/blast/retention.go
@@ -37,6 +37,19 @@ import (
 type RetainedHolder struct {
 	Symbol model.Symbol
 	Via    model.Symbol
+	// Carrier is one concrete satisfier of Via that carries the subject:
+	// the laundering round's own proof, surfaced so the consumer does not
+	// re-derive it with a per-interface graph join. When several carriers
+	// satisfy Via, the lowest-ID one is recorded (mirrors the Via rule).
+	Carrier model.Symbol
+}
+
+// retainedRoute is the laundering evidence for one holder: the via-interface
+// its field is typed as, and the concrete carrier proving the interface can
+// hold the subject.
+type retainedRoute struct {
+	via     int64
+	carrier int64
 }
 
 const (
@@ -178,9 +191,9 @@ func liveFrontierRemains(carriers map[int64]struct{}, level []int64) bool {
 // those interfaces' reverse composers/embedders. Returns holder → lowest-ID
 // via-interface so a holder reachable through several interfaces appears
 // once, deterministically.
-func launderOneRound(ctx context.Context, db *sql.DB, carriers map[int64]struct{}) (map[int64]int64, error) {
+func launderOneRound(ctx context.Context, db *sql.DB, carriers map[int64]struct{}) (map[int64]retainedRoute, error) {
 	base := sortedIDSet(carriers)
-	ifaces, err := forwardInterfaceTargets(ctx, db, base)
+	ifaces, ifaceCarrier, err := forwardInterfaceTargets(ctx, db, base)
 	if err != nil {
 		return nil, err
 	}
@@ -201,10 +214,10 @@ func launderOneRound(ctx context.Context, db *sql.DB, carriers map[int64]struct{
 	if err != nil {
 		return nil, err
 	}
-	holderVia := make(map[int64]int64, len(pairs))
+	holderVia := make(map[int64]retainedRoute, len(pairs))
 	for _, p := range pairs {
-		if via, ok := holderVia[p.source]; !ok || p.target < via {
-			holderVia[p.source] = p.target
+		if route, ok := holderVia[p.source]; !ok || p.target < route.via {
+			holderVia[p.source] = retainedRoute{via: p.target, carrier: ifaceCarrier[p.target]}
 		}
 	}
 	return holderVia, nil
@@ -214,7 +227,7 @@ func launderOneRound(ctx context.Context, db *sql.DB, carriers map[int64]struct{
 // (which includes the seeds — a carrier belongs to the composition group),
 // the subject's own members, and symbols already placed in another edge-kind
 // group (the one-node-one-group invariant).
-func excludeRetained(holderVia map[int64]int64, carriers, childSet, excludeGrouped map[int64]struct{}) []int64 {
+func excludeRetained(holderVia map[int64]retainedRoute, carriers, childSet, excludeGrouped map[int64]struct{}) []int64 {
 	kept := make([]int64, 0, len(holderVia))
 	for id := range holderVia {
 		if _, isCarrier := carriers[id]; isCarrier {
@@ -236,13 +249,13 @@ func excludeRetained(holderVia map[int64]int64, carriers, childSet, excludeGroup
 // subject's self-members, orders production-first then by ID, and applies the
 // result cap. The returned count is the full post-exclusion size, never the
 // capped one, so a capped list is self-evident to the consumer.
-func hydrateRetained(ctx context.Context, db *sql.DB, kept []int64, holderVia map[int64]int64, isSelf selfMethodFn, maxResults int) ([]RetainedHolder, int, bool, error) {
+func hydrateRetained(ctx context.Context, db *sql.DB, kept []int64, holderVia map[int64]retainedRoute, isSelf selfMethodFn, maxResults int) ([]RetainedHolder, int, bool, error) {
 	if len(kept) == 0 {
 		return nil, 0, false, nil
 	}
 	allIDs := append([]int64{}, kept...)
 	for _, id := range kept {
-		allIDs = append(allIDs, holderVia[id])
+		allIDs = append(allIDs, holderVia[id].via, holderVia[id].carrier)
 	}
 	syms, err := loadSymbols(ctx, db, allIDs)
 	if err != nil {
@@ -254,7 +267,8 @@ func hydrateRetained(ctx context.Context, db *sql.DB, kept []int64, holderVia ma
 		if !ok || isSelf(sym) {
 			continue
 		}
-		holders = append(holders, RetainedHolder{Symbol: sym, Via: syms[holderVia[id]]})
+		route := holderVia[id]
+		holders = append(holders, RetainedHolder{Symbol: sym, Via: syms[route.via], Carrier: syms[route.carrier]})
 	}
 	fullCount := len(holders)
 	orderRetained(ctx, db, holders)
@@ -487,7 +501,10 @@ func inboundHolderPairs(ctx context.Context, db *sql.DB, ids []int64, includesOn
 // TARGET's symbol kind, never on edge confidence: Go satisfaction edges ride
 // convention confidence but Rust/TS declared implements are full-confidence,
 // and both launder.
-func forwardInterfaceTargets(ctx context.Context, db *sql.DB, ids []int64) ([]int64, error) {
+// forwardInterfaceTargets returns the interface-kind inherit targets of ids,
+// plus each interface's lowest-ID satisfying carrier, the laundering proof
+// that rides into RetainedHolder.Carrier.
+func forwardInterfaceTargets(ctx context.Context, db *sql.DB, ids []int64) ([]int64, map[int64]int64, error) {
 	query := func(placeholders string) string {
 		return `SELECT DISTINCT e.source_id, e.target_id FROM sense_edges e
 		        JOIN sense_symbols s ON s.id = e.target_id
@@ -497,13 +514,17 @@ func forwardInterfaceTargets(ctx context.Context, db *sql.DB, ids []int64) ([]in
 	}
 	pairs, err := queryHolderPairs(ctx, db, ids, query)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	set := make(map[int64]struct{}, len(pairs))
+	carrier := make(map[int64]int64, len(pairs))
 	for _, p := range pairs {
 		set[p.target] = struct{}{}
+		if lowest, ok := carrier[p.target]; !ok || p.source < lowest {
+			carrier[p.target] = p.source
+		}
 	}
-	return sortedIDSet(set), nil
+	return sortedIDSet(set), carrier, nil
 }
 
 // nonInterfaceIDs filters ids down to symbols whose kind is not interface.

--- a/internal/blast/retention.go
+++ b/internal/blast/retention.go
@@ -42,10 +42,11 @@ type RetainedHolder struct {
 	// re-derive it with a per-interface graph join. When several carriers
 	// satisfy Via, the lowest-ID one is recorded (mirrors the Via rule).
 	Carrier model.Symbol
-	// Chain is the declared containment path from Carrier down to the
+	// Chain is a declared containment path from Carrier down to the
 	// subject (inclusive on both ends): every hop is a composes/includes
 	// edge the index holds, so the whole path is a statable structural
-	// fact. Only the runtime choice of satisfier stays a may-claim.
+	// fact. The tree records one deterministic path among possibly
+	// several. Only the runtime choice of satisfier stays a may-claim.
 	Chain []model.Symbol
 }
 
@@ -112,7 +113,7 @@ func loadRetention(ctx context.Context, db *sql.DB, subject model.Symbol, seedID
 		return nil, 0, false, err
 	}
 	kept := excludeRetained(holderVia, carriers, childSet, excludeGrouped)
-	holders, fullCount, capped, err := hydrateRetained(ctx, db, kept, holderVia, chainContext{parents: parents, seeds: seedIDs}, isSelf, maxResults)
+	holders, fullCount, capped, err := hydrateRetained(ctx, db, kept, holderVia, newChainTree(parents, seedIDs), isSelf, maxResults)
 	if err != nil {
 		return nil, 0, false, err
 	}
@@ -132,7 +133,9 @@ func carrierClosure(ctx context.Context, db *sql.DB, seedIDs, directComposerIDs 
 	}
 	// parents records which already-admitted node each carrier declaredly
 	// contains (the pair target that admitted it): the containment tree the
-	// chain field renders. Level-1 entries hang off the primary seed.
+	// chain field renders. Level-1 composers hang off the primary seed;
+	// with a multi-seed subject the edge may land on a sibling seed, but
+	// siblings share one qualified name, so the rendered hop is unchanged.
 	parents := make(map[int64]int64)
 	embedders, err := inboundHolderPairs(ctx, db, seedIDs, true)
 	if err != nil {
@@ -177,8 +180,10 @@ func carrierClosure(ctx context.Context, db *sql.DB, seedIDs, directComposerIDs 
 }
 
 // recordParent stores the containment parent for a node not yet admitted to
-// the carrier set, keeping the lowest-ID parent when several pairs admit the
-// same node so chains are stable run to run.
+// the carrier set. The choice is earliest-level first (the admitted guard
+// refuses re-parenting, so chains are shortest-path), then lowest-ID within
+// a level, making chains stable run to run with no ordering assumption on
+// the pair queries.
 func recordParent(parents map[int64]int64, carriers map[int64]struct{}, node, parent int64) {
 	if _, seen := carriers[node]; seen {
 		return
@@ -188,26 +193,31 @@ func recordParent(parents map[int64]int64, carriers map[int64]struct{}, node, pa
 	}
 }
 
-// chainContext carries what hydration needs to render a containment chain:
+// chainTree carries what hydration needs to render a containment chain:
 // the parent tree and the seed set the chain terminates on.
-type chainContext struct {
+type chainTree struct {
 	parents map[int64]int64
-	seeds   []int64
+	seeds   map[int64]struct{}
+}
+
+// newChainTree builds the walkable tree once so per-row walks pay no setup.
+func newChainTree(parents map[int64]int64, seedIDs []int64) chainTree {
+	seeds := make(map[int64]struct{}, len(seedIDs))
+	for _, s := range seedIDs {
+		seeds[s] = struct{}{}
+	}
+	return chainTree{parents: parents, seeds: seeds}
 }
 
 // chainIDs walks the parent tree from start down to the first seed hit,
 // returning the full path including start and the terminal seed. The walk is
 // bounded by the closure's own depth cap; a break in the tree returns the
 // partial path rather than guessing.
-func (c chainContext) chainIDs(start int64) []int64 {
-	seeds := make(map[int64]struct{}, len(c.seeds))
-	for _, s := range c.seeds {
-		seeds[s] = struct{}{}
-	}
+func (c chainTree) chainIDs(start int64) []int64 {
 	path := []int64{start}
 	cur := start
 	for range retentionMaxLevels + 2 {
-		if _, done := seeds[cur]; done {
+		if _, done := c.seeds[cur]; done {
 			return path
 		}
 		next, ok := c.parents[cur]
@@ -315,7 +325,7 @@ func excludeRetained(holderVia map[int64]retainedRoute, carriers, childSet, excl
 // subject's self-members, orders production-first then by ID, and applies the
 // result cap. The returned count is the full post-exclusion size, never the
 // capped one, so a capped list is self-evident to the consumer.
-func hydrateRetained(ctx context.Context, db *sql.DB, kept []int64, holderVia map[int64]retainedRoute, chains chainContext, isSelf selfMethodFn, maxResults int) ([]RetainedHolder, int, bool, error) {
+func hydrateRetained(ctx context.Context, db *sql.DB, kept []int64, holderVia map[int64]retainedRoute, chains chainTree, isSelf selfMethodFn, maxResults int) ([]RetainedHolder, int, bool, error) {
 	if len(kept) == 0 {
 		return nil, 0, false, nil
 	}
@@ -338,13 +348,7 @@ func hydrateRetained(ctx context.Context, db *sql.DB, kept []int64, holderVia ma
 			continue
 		}
 		route := holderVia[id]
-		chain := make([]model.Symbol, 0, len(chainByHolder[id]))
-		for _, cid := range chainByHolder[id] {
-			if cs, ok := syms[cid]; ok {
-				chain = append(chain, cs)
-			}
-		}
-		holders = append(holders, RetainedHolder{Symbol: sym, Via: syms[route.via], Carrier: syms[route.carrier], Chain: chain})
+		holders = append(holders, RetainedHolder{Symbol: sym, Via: syms[route.via], Carrier: syms[route.carrier], Chain: assembleChain(syms, chainByHolder[id])})
 	}
 	fullCount := len(holders)
 	orderRetained(ctx, db, holders)
@@ -354,6 +358,23 @@ func hydrateRetained(ctx context.Context, db *sql.DB, kept []int64, holderVia ma
 		capped = true
 	}
 	return holders, fullCount, capped, nil
+}
+
+// assembleChain hydrates a chain's IDs whole or not at all: splicing over a
+// hop whose symbol failed to hydrate (index churn between the edge walk and
+// hydration) would fabricate a containment edge the index does not hold, so
+// a single missing hop drops the entire chain (mirrors the zero-value
+// carrier policy).
+func assembleChain(syms map[int64]model.Symbol, ids []int64) []model.Symbol {
+	chain := make([]model.Symbol, 0, len(ids))
+	for _, id := range ids {
+		cs, ok := syms[id]
+		if !ok {
+			return nil
+		}
+		chain = append(chain, cs)
+	}
+	return chain
 }
 
 // orderRetained sorts holders production-first, then by symbol ID. A test
@@ -573,13 +594,11 @@ func inboundHolderPairs(ctx context.Context, db *sql.DB, ids []int64, includesOn
 }
 
 // forwardInterfaceTargets returns the distinct interface-kind symbols any of
-// ids satisfies or implements (forward inherits edges). The filter is on the
-// TARGET's symbol kind, never on edge confidence: Go satisfaction edges ride
-// convention confidence but Rust/TS declared implements are full-confidence,
-// and both launder.
-// forwardInterfaceTargets returns the interface-kind inherit targets of ids,
-// plus each interface's lowest-ID satisfying carrier, the laundering proof
-// that rides into RetainedHolder.Carrier.
+// ids satisfies or implements (forward inherits edges), plus each interface's
+// lowest-ID satisfying carrier, the laundering proof that rides into
+// RetainedHolder.Carrier. The filter is on the TARGET's symbol kind, never on
+// edge confidence: Go satisfaction edges ride convention confidence but
+// Rust/TS declared implements are full-confidence, and both launder.
 func forwardInterfaceTargets(ctx context.Context, db *sql.DB, ids []int64) ([]int64, map[int64]int64, error) {
 	query := func(placeholders string) string {
 		return `SELECT DISTINCT e.source_id, e.target_id FROM sense_edges e

--- a/internal/blast/retention_internal_test.go
+++ b/internal/blast/retention_internal_test.go
@@ -1,0 +1,33 @@
+package blast
+
+// Chain assembly policy: a chain renders whole or not at all. These are
+// internal tests because the churn window they guard (a symbol row vanishing
+// between the edge walk and hydration) cannot be constructed through the
+// public Compute path: the closure would simply never admit the carrier.
+
+import (
+	"testing"
+
+	"github.com/luuuc/sense/internal/model"
+)
+
+func TestAssembleChainDropsWholeOnMissingHop(t *testing.T) {
+	syms := map[int64]model.Symbol{
+		1: {ID: 1, Name: "A"},
+		3: {ID: 3, Name: "C"},
+	}
+	if got := assembleChain(syms, []int64{1, 2, 3}); got != nil {
+		t.Fatalf("missing hop 2 must drop the whole chain, got %v (a spliced A > C fabricates an edge)", got)
+	}
+}
+
+func TestAssembleChainWholeWhenAllHydrate(t *testing.T) {
+	syms := map[int64]model.Symbol{
+		1: {ID: 1, Name: "A"},
+		2: {ID: 2, Name: "B"},
+	}
+	got := assembleChain(syms, []int64{1, 2})
+	if len(got) != 2 || got[0].ID != 1 || got[1].ID != 2 {
+		t.Fatalf("full chain must hydrate in order, got %v", got)
+	}
+}

--- a/internal/blast/retention_test.go
+++ b/internal/blast/retention_test.go
@@ -526,3 +526,44 @@ func TestRetentionAllInterfacesScreened(t *testing.T) {
 		t.Errorf("all-junk candidates must leave the group empty, got %+v", res.RetainedViaInterfaces)
 	}
 }
+
+// TestRetainedHolderNamesConcreteCarrier: each retained row must name a
+// concrete carrier that satisfies its via-interface: the fact the laundering
+// round proves and the consumer otherwise re-derives one graph join per
+// interface (measured: 30 follow-up lookups on the dolt hub, cell 5).
+func TestRetainedHolderNamesConcreteCarrier(t *testing.T) {
+	fix, subject, carrier, _, holder := launderedFixture(t)
+
+	res := computeRetention(t, fix, subject)
+
+	found := false
+	for _, rh := range res.RetainedViaInterfaces {
+		if rh.Symbol.ID == holder {
+			found = true
+			if rh.Carrier.ID != carrier {
+				t.Errorf("Carrier = %d, want concrete carrier %d", rh.Carrier.ID, carrier)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("holder missing from RetainedViaInterfaces: %+v", res.RetainedViaInterfaces)
+	}
+}
+
+// TestRetainedCarrierDeterministicOnMultiSatisfier: when several carriers
+// satisfy the via-interface, the lowest-ID carrier is recorded (mirrors the
+// lowest-via rule) so output is stable run to run.
+func TestRetainedCarrierDeterministicOnMultiSatisfier(t *testing.T) {
+	fix, subject, carrier, iface, holder := launderedFixture(t)
+	carrier2 := fix.addSymbol(t, "CarrierD")
+	fix.addEdge(t, carrier2, subject, model.EdgeComposes, 0.9)
+	fix.addEdge(t, carrier2, iface, model.EdgeInherits, confConvention)
+
+	res := computeRetention(t, fix, subject)
+
+	for _, rh := range res.RetainedViaInterfaces {
+		if rh.Symbol.ID == holder && rh.Carrier.ID != carrier {
+			t.Errorf("Carrier = %d, want lowest-ID satisfier %d (not %d)", rh.Carrier.ID, carrier, carrier2)
+		}
+	}
+}

--- a/internal/blast/retention_test.go
+++ b/internal/blast/retention_test.go
@@ -630,3 +630,82 @@ func TestRetainedChainDepthOne(t *testing.T) {
 	}
 	t.Fatalf("holder missing")
 }
+
+// TestRetainedChainDiamondPicksLowestParent: when two level-1 parents both
+// compose the same inner carrier (a containment diamond), the rendered chain
+// goes through the lowest-ID parent. Kills the recordParent tie-break mutant
+// (lowest flipped to highest): pair order from SELECT DISTINCT carries no
+// guarantee, so the rule is the only thing standing between a diamond and
+// run-to-run chain flapping.
+func TestRetainedChainDiamondPicksLowestParent(t *testing.T) {
+	fix := newFixtureDB(t)
+	subject := fix.addSymbol(t, "SubjectA")
+	p1 := fix.addSymbol(t, "ParentLow")
+	p2 := fix.addSymbol(t, "ParentHigh")
+	inner := fix.addSymbol(t, "InnerCarrier")
+	iface := fix.addSymbolWith(t, "DiamondIface", model.KindInterface, nil)
+	fix.addSymbolWith(t, "VisitDiamondThing", model.KindMethod, &iface)
+	holder := fix.addSymbol(t, "DiamondHolder")
+	fix.addEdge(t, p1, subject, model.EdgeComposes, 0.9)
+	fix.addEdge(t, p2, subject, model.EdgeComposes, 0.9)
+	fix.addEdge(t, inner, p1, model.EdgeComposes, 0.9)
+	fix.addEdge(t, inner, p2, model.EdgeComposes, 0.9)
+	fix.addEdge(t, inner, iface, model.EdgeInherits, confConvention)
+	fix.addEdge(t, holder, iface, model.EdgeComposes, 0.9)
+
+	res := computeRetention(t, fix, subject)
+
+	assertChain(t, res, holder, []int64{inner, p1, subject})
+}
+
+// TestRetainedChainNonSeedCycle: a composes cycle among non-seed carriers
+// must not corrupt the parent tree. Kills the already-admitted-guard mutant
+// in recordParent: without the guard, the cycle's back edge re-parents an
+// admitted node onto its own descendant and the chain walk emits a garbage
+// bound-length path instead of the true one. The cycle partner is created
+// with a LOWER ID than the true parent so the lowest-ID rule cannot mask
+// the guard's absence.
+func TestRetainedChainNonSeedCycle(t *testing.T) {
+	fix := newFixtureDB(t)
+	subject := fix.addSymbol(t, "SubjectA")
+	cyc := fix.addSymbol(t, "CyclePartner") // lower ID than trueParent
+	trueParent := fix.addSymbol(t, "TrueParent")
+	deep := fix.addSymbol(t, "DeepCarrier")
+	iface := fix.addSymbolWith(t, "CycleChainIface", model.KindInterface, nil)
+	fix.addSymbolWith(t, "VisitCycleChainThing", model.KindMethod, &iface)
+	holder := fix.addSymbol(t, "CycleChainHolder")
+	fix.addEdge(t, trueParent, subject, model.EdgeComposes, 0.9)
+	fix.addEdge(t, deep, trueParent, model.EdgeComposes, 0.9)
+	fix.addEdge(t, cyc, deep, model.EdgeComposes, 0.9)
+	fix.addEdge(t, deep, cyc, model.EdgeComposes, 0.9)
+	fix.addEdge(t, cyc, iface, model.EdgeInherits, confConvention)
+	fix.addEdge(t, holder, iface, model.EdgeComposes, 0.9)
+
+	res := computeRetention(t, fix, subject)
+
+	assertChain(t, res, holder, []int64{cyc, deep, trueParent, subject})
+}
+
+// assertChain fails unless the holder's rendered chain is exactly want.
+func assertChain(t *testing.T, res blast.Result, holder int64, want []int64) {
+	t.Helper()
+	for _, rh := range res.RetainedViaInterfaces {
+		if rh.Symbol.ID != holder {
+			continue
+		}
+		got := make([]int64, 0, len(rh.Chain))
+		for _, s := range rh.Chain {
+			got = append(got, s.ID)
+		}
+		if len(got) != len(want) {
+			t.Fatalf("chain = %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("chain[%d] = %d, want %d (full: %v vs %v)", i, got[i], want[i], got, want)
+			}
+		}
+		return
+	}
+	t.Fatalf("holder %d missing from retained rows", holder)
+}

--- a/internal/blast/retention_test.go
+++ b/internal/blast/retention_test.go
@@ -567,3 +567,66 @@ func TestRetainedCarrierDeterministicOnMultiSatisfier(t *testing.T) {
 		}
 	}
 }
+
+// TestRetainedRowCarriesDeclaredChain: each retained row names the declared
+// containment chain from its carrier down to the subject, so the row is a
+// statable structural fact rather than an unverifiable hint (measured:
+// agents re-verify hedged rows by hand and lose the wall to it).
+func TestRetainedRowCarriesDeclaredChain(t *testing.T) {
+	fix := newFixtureDB(t)
+	subject := fix.addSymbol(t, "SubjectA")
+	c1 := fix.addSymbol(t, "DirectCarrier")
+	c2 := fix.addSymbol(t, "DeepCarrier")
+	iface := fix.addSymbolWith(t, "DeepIface", model.KindInterface, nil)
+	fix.addSymbolWith(t, "VisitDeepThing", model.KindMethod, &iface)
+	holder := fix.addSymbol(t, "DeepHolder")
+	fix.addEdge(t, c1, subject, model.EdgeComposes, 0.9)
+	fix.addEdge(t, c2, c1, model.EdgeComposes, 0.9)
+	fix.addEdge(t, c2, iface, model.EdgeInherits, confConvention)
+	fix.addEdge(t, holder, iface, model.EdgeComposes, 0.9)
+
+	res := computeRetention(t, fix, subject)
+
+	for _, rh := range res.RetainedViaInterfaces {
+		if rh.Symbol.ID != holder {
+			continue
+		}
+		got := make([]int64, 0, len(rh.Chain))
+		for _, s := range rh.Chain {
+			got = append(got, s.ID)
+		}
+		want := []int64{c2, c1, subject}
+		if len(got) != len(want) {
+			t.Fatalf("chain IDs = %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("chain[%d] = %d, want %d (carrier down to subject)", i, got[i], want[i])
+			}
+		}
+		return
+	}
+	t.Fatalf("holder missing from retained rows")
+}
+
+// TestRetainedChainDepthOne: a carrier composing the subject directly chains
+// [carrier, subject].
+func TestRetainedChainDepthOne(t *testing.T) {
+	fix, subject, carrier, _, holder := launderedFixture(t)
+
+	res := computeRetention(t, fix, subject)
+
+	for _, rh := range res.RetainedViaInterfaces {
+		if rh.Symbol.ID == holder {
+			if len(rh.Chain) != 2 || rh.Chain[0].ID != carrier || rh.Chain[1].ID != subject {
+				ids := []int64{}
+				for _, s := range rh.Chain {
+					ids = append(ids, s.ID)
+				}
+				t.Fatalf("chain = %v, want [%d %d]", ids, carrier, subject)
+			}
+			return
+		}
+	}
+	t.Fatalf("holder missing")
+}

--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -91,15 +91,18 @@ func shedRetainedField(resp *BlastResponse, budget int, field func(*BlastRetaine
 			if f := field(&resp.RetainedViaInterfaces[i]); *f != "" {
 				*f = ""
 				stripped = true
+				// Set at the first strip so the flag's own bytes are
+				// priced by every estimate from here on; a post-loop set
+				// would break the fit this pass just found and push the
+				// NEXT pass into stripping out of order.
+				resp.Truncated = true
+				resp.RetainedTrimmed = true
 			}
 			i--
 			if i < 0 {
 				break
 			}
 		}
-	}
-	if stripped {
-		resp.Truncated = true
 	}
 	return stripped
 }
@@ -170,19 +173,11 @@ func ApplyBlastBudget(resp *BlastResponse, budget int) {
 	// dropping rows). Strips batch by trimStep: the estimator re-marshals
 	// the whole response per probe, and one-field-per-marshal cost 8.2ms on
 	// a 100-row hub (measured) for precision no consumer can observe.
-	shedEnrichment := shedRetainedField(resp, budget, func(r *BlastRetained) *string { return &r.Chain })
-	shedEnrichment = shedRetainedField(resp, budget, func(r *BlastRetained) *string { return &r.Carrier }) || shedEnrichment
-	if shedEnrichment {
-		// Disclose the trim so an absent field is distinguishable from a
-		// never-computed one. Best-effort: if the sentence itself would
-		// push a fitting response back over budget, silence beats shedding
-		// a holder row to fund the disclosure.
-		fit := estimateBlastWireTokens(resp) <= budget
-		resp.RetainedNote += " Some rows had carrier/chain trimmed for budget: an absent field is trimmed, not unknown."
-		if fit && estimateBlastWireTokens(resp) > budget {
-			resp.RetainedNote = strings.TrimSuffix(resp.RetainedNote, " Some rows had carrier/chain trimmed for budget: an absent field is trimmed, not unknown.")
-		}
-	}
+	// Stripping sets retained_trimmed, which is priced through every
+	// subsequent estimate like any other content, so no later stage can be
+	// surprised by it and no revert dance is needed.
+	shedRetainedField(resp, budget, func(r *BlastRetained) *string { return &r.Chain })
+	shedRetainedField(resp, budget, func(r *BlastRetained) *string { return &r.Carrier })
 	// 7. Retained holders carry a weaker claim than any direct caller, so
 	// they shed next. RetainedCount is never reduced — a trimmed group is
 	// self-evident from count > len(entries).

--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -80,6 +80,30 @@ func spanIndirectByFile(hops []blast.CallerHop, directCallers []model.Symbol) []
 	return append(ordered, deferred...)
 }
 
+// shedRetainedField strips one enrichment field from retained rows,
+// tail-first in trimStep batches, until the response fits the budget or
+// every row's field is empty. Reports whether anything was stripped.
+func shedRetainedField(resp *BlastResponse, budget int, field func(*BlastRetained) *string) bool {
+	stripped := false
+	i := len(resp.RetainedViaInterfaces) - 1
+	for i >= 0 && estimateBlastWireTokens(resp) > budget {
+		for range trimStep(i + 1) {
+			if f := field(&resp.RetainedViaInterfaces[i]); *f != "" {
+				*f = ""
+				stripped = true
+			}
+			i--
+			if i < 0 {
+				break
+			}
+		}
+	}
+	if stripped {
+		resp.Truncated = true
+	}
+	return stripped
+}
+
 // ApplyBlastBudget trims a blast response in least-relevant-first order
 // until its estimated token count fits within budget. Summary counts
 // (total_affected, tests_affected_count, references.count) are never
@@ -124,7 +148,7 @@ func ApplyBlastBudget(resp *BlastResponse, budget int) {
 		resp.IndirectCallers = resp.IndirectCallers[:n-trimStep(n)]
 		resp.Truncated = true
 	}
-	// 3b. Tier-2 reference examples are pure duplication under pressure —
+	// 4. Tier-2 reference examples are pure duplication under pressure;
 	// every example is an entry the subclass/composition/includes lists
 	// already enumerate in full — so they shed before any content-bearing
 	// group. references.count keeps the magnitude.
@@ -132,31 +156,34 @@ func ApplyBlastBudget(resp *BlastResponse, budget int) {
 		resp.References.Examples = resp.References.Examples[:0]
 		resp.Truncated = true
 	}
-	// 3c. The affected-test sample is illustrative; tests_affected_count
+	// 5. The affected-test sample is illustrative; tests_affected_count
 	// carries the true total, so the sample empties before answer content.
 	if estimateBlastWireTokens(resp) > budget && len(resp.AffectedTests) > 0 {
 		resp.AffectedTests = resp.AffectedTests[:0]
 		resp.Truncated = true
 	}
-	// 3c'. Chains and carrier names are enrichment on retained rows, not the
+	// 6. Chains and carrier names are enrichment on retained rows, not the
 	// rows' claim: strip them tail-first (chains, the heavier field, first)
 	// before any whole row sheds, so a squeeze costs proof detail before it
 	// costs a holder (count- and gold-preserving; measured live: the 0.7
 	// band sat near budget and the carrier bytes alone tipped it into
-	// dropping rows).
-	for i := len(resp.RetainedViaInterfaces) - 1; i >= 0 && estimateBlastWireTokens(resp) > budget; i-- {
-		if resp.RetainedViaInterfaces[i].Chain != "" {
-			resp.RetainedViaInterfaces[i].Chain = ""
-			resp.Truncated = true
+	// dropping rows). Strips batch by trimStep: the estimator re-marshals
+	// the whole response per probe, and one-field-per-marshal cost 8.2ms on
+	// a 100-row hub (measured) for precision no consumer can observe.
+	shedEnrichment := shedRetainedField(resp, budget, func(r *BlastRetained) *string { return &r.Chain })
+	shedEnrichment = shedRetainedField(resp, budget, func(r *BlastRetained) *string { return &r.Carrier }) || shedEnrichment
+	if shedEnrichment {
+		// Disclose the trim so an absent field is distinguishable from a
+		// never-computed one. Best-effort: if the sentence itself would
+		// push a fitting response back over budget, silence beats shedding
+		// a holder row to fund the disclosure.
+		fit := estimateBlastWireTokens(resp) <= budget
+		resp.RetainedNote += " Some rows had carrier/chain trimmed for budget: an absent field is trimmed, not unknown."
+		if fit && estimateBlastWireTokens(resp) > budget {
+			resp.RetainedNote = strings.TrimSuffix(resp.RetainedNote, " Some rows had carrier/chain trimmed for budget: an absent field is trimmed, not unknown.")
 		}
 	}
-	for i := len(resp.RetainedViaInterfaces) - 1; i >= 0 && estimateBlastWireTokens(resp) > budget; i-- {
-		if resp.RetainedViaInterfaces[i].Carrier != "" {
-			resp.RetainedViaInterfaces[i].Carrier = ""
-			resp.Truncated = true
-		}
-	}
-	// 3d. Retained holders carry a weaker claim than any direct caller, so
+	// 7. Retained holders carry a weaker claim than any direct caller, so
 	// they shed next. RetainedCount is never reduced — a trimmed group is
 	// self-evident from count > len(entries).
 	for estimateBlastWireTokens(resp) > budget && len(resp.RetainedViaInterfaces) > 0 {
@@ -164,7 +191,7 @@ func ApplyBlastBudget(resp *BlastResponse, budget int) {
 		resp.RetainedViaInterfaces = resp.RetainedViaInterfaces[:n-trimStep(n)]
 		resp.Truncated = true
 	}
-	// 4. Direct callers last; keep at least one. total_affected still
+	// 8. Direct callers last; keep at least one. total_affected still
 	// reports how many exist beyond what is shown.
 	for estimateBlastWireTokens(resp) > budget && len(resp.DirectCallers) > 1 {
 		n := len(resp.DirectCallers)
@@ -416,11 +443,10 @@ func BuildBlastResponseSeen(ctx context.Context, r blast.Result, files FileLooku
 	}
 	if len(resp.RetainedViaInterfaces) > 0 {
 		resp.RetainedCount = r.RetainedCount
-		resp.RetainedNote = "each row may retain " + r.Symbol.Name + ", one interface indirection deep, and every part but one " +
-			"is an INDEXED STRUCTURAL FACT: the holder declares a field typed `via`; `carrier` is a concrete satisfier of " +
-			"`via`; `chain` is the declared containment path from carrier to " + r.Symbol.Name + ". The one unverified part " +
-			"is which satisfier lands at runtime - cite rows with their chain; verify installation sites only where proof " +
-			"is demanded. Not counted in total_affected; blast a listed holder to go deeper."
+		resp.RetainedNote = "each row may retain " + r.Symbol.Name + ", one interface indirection deep. As indexed: the " +
+			"holder declares a field typed as `via`; `carrier` is a concrete satisfier of `via`; `chain` is a declared " +
+			"containment path from carrier to " + r.Symbol.Name + ". Which satisfier lands at runtime is unverified. " +
+			"Not counted in total_affected; blast a listed holder to go deeper."
 	}
 
 	examples := tier2All

--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -82,15 +82,13 @@ func spanIndirectByFile(hops []blast.CallerHop, directCallers []model.Symbol) []
 
 // shedRetainedField strips one enrichment field from retained rows,
 // tail-first in trimStep batches, until the response fits the budget or
-// every row's field is empty. Reports whether anything was stripped.
-func shedRetainedField(resp *BlastResponse, budget int, field func(*BlastRetained) *string) bool {
-	stripped := false
+// every row's field is empty.
+func shedRetainedField(resp *BlastResponse, budget int, field func(*BlastRetained) *string) {
 	i := len(resp.RetainedViaInterfaces) - 1
 	for i >= 0 && estimateBlastWireTokens(resp) > budget {
 		for range trimStep(i + 1) {
 			if f := field(&resp.RetainedViaInterfaces[i]); *f != "" {
 				*f = ""
-				stripped = true
 				// Set at the first strip so the flag's own bytes are
 				// priced by every estimate from here on; a post-loop set
 				// would break the fit this pass just found and push the
@@ -104,7 +102,6 @@ func shedRetainedField(resp *BlastResponse, budget int, field func(*BlastRetaine
 			}
 		}
 	}
-	return stripped
 }
 
 // ApplyBlastBudget trims a blast response in least-relevant-first order

--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"path"
 	"sort"
+	"strings"
 
 	"github.com/luuuc/sense/internal/blast"
 	"github.com/luuuc/sense/internal/model"
@@ -137,11 +138,18 @@ func ApplyBlastBudget(resp *BlastResponse, budget int) {
 		resp.AffectedTests = resp.AffectedTests[:0]
 		resp.Truncated = true
 	}
-	// 3c'. Carrier names are enrichment on retained rows, not the rows'
-	// claim: strip them tail-first before any whole row sheds, so a squeeze
-	// costs proof detail before it costs a holder (count- and
-	// gold-preserving; measured live: the 0.7 band sat near budget and the
-	// carrier bytes alone tipped it into dropping rows).
+	// 3c'. Chains and carrier names are enrichment on retained rows, not the
+	// rows' claim: strip them tail-first (chains, the heavier field, first)
+	// before any whole row sheds, so a squeeze costs proof detail before it
+	// costs a holder (count- and gold-preserving; measured live: the 0.7
+	// band sat near budget and the carrier bytes alone tipped it into
+	// dropping rows).
+	for i := len(resp.RetainedViaInterfaces) - 1; i >= 0 && estimateBlastWireTokens(resp) > budget; i-- {
+		if resp.RetainedViaInterfaces[i].Chain != "" {
+			resp.RetainedViaInterfaces[i].Chain = ""
+			resp.Truncated = true
+		}
+	}
 	for i := len(resp.RetainedViaInterfaces) - 1; i >= 0 && estimateBlastWireTokens(resp) > budget; i-- {
 		if resp.RetainedViaInterfaces[i].Carrier != "" {
 			resp.RetainedViaInterfaces[i].Carrier = ""
@@ -397,12 +405,22 @@ func BuildBlastResponseSeen(ctx context.Context, r blast.Result, files FileLooku
 		if rh.Carrier.ID != 0 {
 			entry.Carrier = qualifiedOrName(rh.Carrier)
 		}
+		if len(rh.Chain) > 0 {
+			names := make([]string, 0, len(rh.Chain))
+			for _, s := range rh.Chain {
+				names = append(names, qualifiedOrName(s))
+			}
+			entry.Chain = strings.Join(names, " > ")
+		}
 		resp.RetainedViaInterfaces = append(resp.RetainedViaInterfaces, entry)
 	}
 	if len(resp.RetainedViaInterfaces) > 0 {
 		resp.RetainedCount = r.RetainedCount
-		resp.RetainedNote = "each entry may retain " + r.Symbol.Name + ": its `via` interface field can hold a carrier of " +
-			r.Symbol.Name + " (one satisfier is named in `carrier`), one interface indirection deep. Not counted in total_affected; blast a listed holder to go deeper."
+		resp.RetainedNote = "each row may retain " + r.Symbol.Name + ", one interface indirection deep, and every part but one " +
+			"is an INDEXED STRUCTURAL FACT: the holder declares a field typed `via`; `carrier` is a concrete satisfier of " +
+			"`via`; `chain` is the declared containment path from carrier to " + r.Symbol.Name + ". The one unverified part " +
+			"is which satisfier lands at runtime - cite rows with their chain; verify installation sites only where proof " +
+			"is demanded. Not counted in total_affected; blast a listed holder to go deeper."
 	}
 
 	examples := tier2All

--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -378,16 +378,20 @@ func BuildBlastResponseSeen(ctx context.Context, r blast.Result, files FileLooku
 		if path, ok := files(rh.Symbol.FileID); ok {
 			file = path
 		}
-		resp.RetainedViaInterfaces = append(resp.RetainedViaInterfaces, BlastRetained{
+		entry := BlastRetained{
 			Symbol: qualifiedOrName(rh.Symbol),
 			Ref:    FormatRef(file, rh.Symbol.LineStart),
 			Via:    rh.Via.Name,
-		})
+		}
+		if rh.Carrier.ID != 0 {
+			entry.Carrier = qualifiedOrName(rh.Carrier)
+		}
+		resp.RetainedViaInterfaces = append(resp.RetainedViaInterfaces, entry)
 	}
 	if len(resp.RetainedViaInterfaces) > 0 {
 		resp.RetainedCount = r.RetainedCount
 		resp.RetainedNote = "each entry may retain " + r.Symbol.Name + ": its `via` interface field can hold a carrier of " +
-			r.Symbol.Name + ", one interface indirection deep. Not counted in total_affected; blast a listed holder to go deeper."
+			r.Symbol.Name + " (one satisfier is named in `carrier`), one interface indirection deep. Not counted in total_affected; blast a listed holder to go deeper."
 	}
 
 	examples := tier2All

--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -137,6 +137,17 @@ func ApplyBlastBudget(resp *BlastResponse, budget int) {
 		resp.AffectedTests = resp.AffectedTests[:0]
 		resp.Truncated = true
 	}
+	// 3c'. Carrier names are enrichment on retained rows, not the rows'
+	// claim: strip them tail-first before any whole row sheds, so a squeeze
+	// costs proof detail before it costs a holder (count- and
+	// gold-preserving; measured live: the 0.7 band sat near budget and the
+	// carrier bytes alone tipped it into dropping rows).
+	for i := len(resp.RetainedViaInterfaces) - 1; i >= 0 && estimateBlastWireTokens(resp) > budget; i-- {
+		if resp.RetainedViaInterfaces[i].Carrier != "" {
+			resp.RetainedViaInterfaces[i].Carrier = ""
+			resp.Truncated = true
+		}
+	}
 	// 3d. Retained holders carry a weaker claim than any direct caller, so
 	// they shed next. RetainedCount is never reduced — a trimmed group is
 	// self-evident from count > len(entries).

--- a/internal/mcpio/retained_test.go
+++ b/internal/mcpio/retained_test.go
@@ -304,3 +304,57 @@ func TestRetainedEntryRendersChainAndShedOrder(t *testing.T) {
 		t.Errorf("carrier stripped while chains remained (order inverted)")
 	}
 }
+
+// TestRetainedNoteAnnouncesEnrichmentShed: when the budget strips carriers or
+// chains, the note says so: a shed field must be distinguishable from a
+// never-computed one (the package contract: "Sense looked, found nothing" vs
+// "this emitter forgot a field", and here, "the budget trimmed it").
+func TestRetainedNoteAnnouncesEnrichmentShed(t *testing.T) {
+	ctx := context.Background()
+	r := retainedResult(true)
+	for i := range r.RetainedViaInterfaces {
+		r.RetainedViaInterfaces[i].Carrier = model.Symbol{ID: 100 + int64(i), Name: "Carrier", Qualified: "pkg.CarrierType", FileID: 1}
+		r.RetainedViaInterfaces[i].Chain = []model.Symbol{
+			{ID: 100 + int64(i), Name: "Carrier", Qualified: "pkg.CarrierType", FileID: 1},
+			{ID: 1, Name: "Widget", Qualified: "Widget", FileID: 1},
+		}
+	}
+	full := BuildBlastResponse(ctx, r, retainedFiles, nil)
+	if strings.Contains(full.RetainedNote, "trimmed") {
+		t.Fatalf("unsqueezed note must not claim trimming: %q", full.RetainedNote)
+	}
+	fullTokens := estimateBlastWireTokens(&full)
+
+	// A squeeze with post-strip slack discloses the trim.
+	squeezed := BuildBlastResponse(ctx, r, retainedFiles, nil)
+	ApplyBlastBudget(&squeezed, fullTokens-1)
+	stripped := squeezed.RetainedViaInterfaces[len(squeezed.RetainedViaInterfaces)-1].Chain == ""
+	if !stripped {
+		t.Fatalf("squeeze did not strip enrichment")
+	}
+	// Disclosure is best-effort: it must appear when it fits, and must
+	// never cost a holder row. At this margin either outcome of the fit
+	// check is legal, so pin both halves of the contract explicitly.
+	if strings.Contains(squeezed.RetainedNote, "trimmed") {
+		if len(squeezed.RetainedViaInterfaces) != len(full.RetainedViaInterfaces) {
+			t.Errorf("a row was shed to fund the disclosure sentence")
+		}
+	} else {
+		t.Logf("disclosure reverted at the tight margin (legal); note: %q", squeezed.RetainedNote)
+	}
+
+	// And with slack, the disclosure lands: budget just below full but with
+	// room for the sentence after strips.
+	slack := BuildBlastResponse(ctx, r, retainedFiles, nil)
+	strippedAll := BuildBlastResponse(ctx, r, retainedFiles, nil)
+	for i := range strippedAll.RetainedViaInterfaces {
+		strippedAll.RetainedViaInterfaces[i].Chain = ""
+		strippedAll.RetainedViaInterfaces[i].Carrier = ""
+	}
+	floor := estimateBlastWireTokens(&strippedAll)
+	ApplyBlastBudget(&slack, floor+40)
+	if slack.RetainedViaInterfaces[len(slack.RetainedViaInterfaces)-1].Chain == "" &&
+		!strings.Contains(slack.RetainedNote, "trimmed") {
+		t.Errorf("shed fired with slack for the sentence but the note is silent: %q", slack.RetainedNote)
+	}
+}

--- a/internal/mcpio/retained_test.go
+++ b/internal/mcpio/retained_test.go
@@ -270,3 +270,37 @@ func TestRetainedCarrierShedsBeforeRows(t *testing.T) {
 		t.Errorf("head carrier stripped before tail (order inverted)")
 	}
 }
+
+// TestRetainedEntryRendersChainAndShedOrder: the chain renders as a
+// ">"-joined containment path (a statable structural fact), and under
+// pressure enrichments strip in evidence-weight order: chains tail-first,
+// then carriers, then whole rows.
+func TestRetainedEntryRendersChainAndShedOrder(t *testing.T) {
+	ctx := context.Background()
+	r := retainedResult(true)
+	for i := range r.RetainedViaInterfaces {
+		r.RetainedViaInterfaces[i].Carrier = model.Symbol{ID: 100 + int64(i), Name: "Carrier", Qualified: "pkg.CarrierType", FileID: 1}
+		r.RetainedViaInterfaces[i].Chain = []model.Symbol{
+			{ID: 100 + int64(i), Name: "Carrier", Qualified: "pkg.CarrierType", FileID: 1},
+			{ID: 1, Name: "Widget", Qualified: "Widget", FileID: 1},
+		}
+	}
+	full := BuildBlastResponse(ctx, r, retainedFiles, nil)
+	if got := full.RetainedViaInterfaces[0].Chain; got != "pkg.CarrierType > Widget" {
+		t.Fatalf("chain = %q, want %q", got, "pkg.CarrierType > Widget")
+	}
+	fullTokens := estimateBlastWireTokens(&full)
+
+	squeezed := BuildBlastResponse(ctx, r, retainedFiles, nil)
+	ApplyBlastBudget(&squeezed, fullTokens-1)
+	if len(squeezed.RetainedViaInterfaces) != len(full.RetainedViaInterfaces) {
+		t.Fatalf("rows shed before enrichments")
+	}
+	last := len(squeezed.RetainedViaInterfaces) - 1
+	if squeezed.RetainedViaInterfaces[last].Chain != "" {
+		t.Errorf("tail chain survived a squeeze that required shedding")
+	}
+	if squeezed.RetainedViaInterfaces[last].Carrier == "" {
+		t.Errorf("carrier stripped while chains remained (order inverted)")
+	}
+}

--- a/internal/mcpio/retained_test.go
+++ b/internal/mcpio/retained_test.go
@@ -239,3 +239,34 @@ func TestRetainedEntryCarriesConcreteCarrier(t *testing.T) {
 		t.Errorf("carrier for zero-value = %q, want empty", got)
 	}
 }
+
+// TestRetainedCarrierShedsBeforeRows: under budget pressure the carrier
+// names strip tail-first (count- and row-preserving) BEFORE any whole
+// retained row sheds; a row is strictly worth more than its enrichment.
+// Kills both mutants: skipping the carrier shed (rows drop while carriers
+// survive) and inverting its order (head-first stripping).
+func TestRetainedCarrierShedsBeforeRows(t *testing.T) {
+	ctx := context.Background()
+	r := retainedResult(true)
+	for i := range r.RetainedViaInterfaces {
+		r.RetainedViaInterfaces[i].Carrier = model.Symbol{
+			ID: 100 + int64(i), Name: "Carrier", Qualified: "pkg.SomeVeryLongCarrierTypeName", FileID: 1,
+		}
+	}
+	full := BuildBlastResponse(ctx, r, retainedFiles, nil)
+	fullTokens := estimateBlastWireTokens(&full)
+
+	// A budget just below the full size must strip a tail carrier, not a row.
+	squeezed := BuildBlastResponse(ctx, r, retainedFiles, nil)
+	ApplyBlastBudget(&squeezed, fullTokens-1)
+	if len(squeezed.RetainedViaInterfaces) != len(full.RetainedViaInterfaces) {
+		t.Fatalf("rows shed before carriers: %d rows, want %d", len(squeezed.RetainedViaInterfaces), len(full.RetainedViaInterfaces))
+	}
+	last := len(squeezed.RetainedViaInterfaces) - 1
+	if squeezed.RetainedViaInterfaces[last].Carrier != "" {
+		t.Errorf("tail carrier survived a squeeze that required shedding")
+	}
+	if squeezed.RetainedViaInterfaces[0].Carrier == "" {
+		t.Errorf("head carrier stripped before tail (order inverted)")
+	}
+}

--- a/internal/mcpio/retained_test.go
+++ b/internal/mcpio/retained_test.go
@@ -300,61 +300,113 @@ func TestRetainedEntryRendersChainAndShedOrder(t *testing.T) {
 	if squeezed.RetainedViaInterfaces[last].Chain != "" {
 		t.Errorf("tail chain survived a squeeze that required shedding")
 	}
-	if squeezed.RetainedViaInterfaces[last].Carrier == "" {
-		t.Errorf("carrier stripped while chains remained (order inverted)")
+	anyChain := false
+	for _, e := range squeezed.RetainedViaInterfaces {
+		anyChain = anyChain || e.Chain != ""
+	}
+	for _, e := range squeezed.RetainedViaInterfaces {
+		if e.Carrier == "" && anyChain {
+			t.Errorf("a carrier stripped while chains remained (order inverted)")
+		}
 	}
 }
 
-// TestRetainedNoteAnnouncesEnrichmentShed: when the budget strips carriers or
-// chains, the note says so: a shed field must be distinguishable from a
-// never-computed one (the package contract: "Sense looked, found nothing" vs
-// "this emitter forgot a field", and here, "the budget trimmed it").
-func TestRetainedNoteAnnouncesEnrichmentShed(t *testing.T) {
+// TestRetainedTrimmedFlagDisclosesEnrichmentShed: when the budget strips
+// carriers or chains, retained_trimmed must be true: a shed field must be
+// distinguishable from a never-computed one. The flag is set during the
+// strip and priced through every later estimate, so the disclosure holds
+// unconditionally in every band and can never surprise a later shed stage.
+func TestRetainedTrimmedFlagDisclosesEnrichmentShed(t *testing.T) {
 	ctx := context.Background()
-	r := retainedResult(true)
-	for i := range r.RetainedViaInterfaces {
-		r.RetainedViaInterfaces[i].Carrier = model.Symbol{ID: 100 + int64(i), Name: "Carrier", Qualified: "pkg.CarrierType", FileID: 1}
-		r.RetainedViaInterfaces[i].Chain = []model.Symbol{
-			{ID: 100 + int64(i), Name: "Carrier", Qualified: "pkg.CarrierType", FileID: 1},
-			{ID: 1, Name: "Widget", Qualified: "Widget", FileID: 1},
-		}
-	}
+	r := heavyRetainedResult(12)
 	full := BuildBlastResponse(ctx, r, retainedFiles, nil)
-	if strings.Contains(full.RetainedNote, "trimmed") {
-		t.Fatalf("unsqueezed note must not claim trimming: %q", full.RetainedNote)
+	if full.RetainedTrimmed {
+		t.Fatalf("unsqueezed response must not claim trimming")
 	}
 	fullTokens := estimateBlastWireTokens(&full)
-
-	// A squeeze with post-strip slack discloses the trim.
-	squeezed := BuildBlastResponse(ctx, r, retainedFiles, nil)
-	ApplyBlastBudget(&squeezed, fullTokens-1)
-	stripped := squeezed.RetainedViaInterfaces[len(squeezed.RetainedViaInterfaces)-1].Chain == ""
-	if !stripped {
-		t.Fatalf("squeeze did not strip enrichment")
-	}
-	// Disclosure is best-effort: it must appear when it fits, and must
-	// never cost a holder row. At this margin either outcome of the fit
-	// check is legal, so pin both halves of the contract explicitly.
-	if strings.Contains(squeezed.RetainedNote, "trimmed") {
-		if len(squeezed.RetainedViaInterfaces) != len(full.RetainedViaInterfaces) {
-			t.Errorf("a row was shed to fund the disclosure sentence")
-		}
-	} else {
-		t.Logf("disclosure reverted at the tight margin (legal); note: %q", squeezed.RetainedNote)
+	floor := strippedFloor(ctx, r)
+	slackBudget := floor + 60
+	if slackBudget >= fullTokens {
+		t.Fatalf("fixture too light: floor=%d full=%d leaves no slack window", floor, fullTokens)
 	}
 
-	// And with slack, the disclosure lands: budget just below full but with
-	// room for the sentence after strips.
+	// Enrichment band: strips fire, rows survive, flag set, budget held.
 	slack := BuildBlastResponse(ctx, r, retainedFiles, nil)
-	strippedAll := BuildBlastResponse(ctx, r, retainedFiles, nil)
-	for i := range strippedAll.RetainedViaInterfaces {
-		strippedAll.RetainedViaInterfaces[i].Chain = ""
-		strippedAll.RetainedViaInterfaces[i].Carrier = ""
+	ApplyBlastBudget(&slack, slackBudget)
+	if len(slack.RetainedViaInterfaces) != len(full.RetainedViaInterfaces) {
+		t.Fatalf("rows shed in the enrichment band: %d vs %d", len(slack.RetainedViaInterfaces), len(full.RetainedViaInterfaces))
 	}
-	floor := estimateBlastWireTokens(&strippedAll)
-	ApplyBlastBudget(&slack, floor+40)
-	if slack.RetainedViaInterfaces[len(slack.RetainedViaInterfaces)-1].Chain == "" &&
-		!strings.Contains(slack.RetainedNote, "trimmed") {
-		t.Errorf("shed fired with slack for the sentence but the note is silent: %q", slack.RetainedNote)
+	if slack.RetainedViaInterfaces[len(slack.RetainedViaInterfaces)-1].Chain != "" {
+		t.Fatalf("budget below full must strip enrichment")
 	}
+	if !slack.RetainedTrimmed {
+		t.Errorf("enrichment stripped but retained_trimmed is false")
+	}
+	if estimateBlastWireTokens(&slack) > slackBudget {
+		t.Errorf("response exceeds its budget in the enrichment band")
+	}
+
+	// Sub-floor: flag still true, budget held, and rows shed identically
+	// to a control whose flag and strips are pre-applied, so the disclosure
+	// never changes a shedding decision beyond its own priced bytes.
+	for _, budget := range []int{floor - 1, floor - 40, floor - 120} {
+		got := BuildBlastResponse(ctx, r, retainedFiles, nil)
+		ApplyBlastBudget(&got, budget)
+		control := BuildBlastResponse(ctx, r, retainedFiles, nil)
+		for i := range control.RetainedViaInterfaces {
+			control.RetainedViaInterfaces[i].Chain = ""
+			control.RetainedViaInterfaces[i].Carrier = ""
+		}
+		control.Truncated = true
+		control.RetainedTrimmed = true
+		ApplyBlastBudget(&control, budget)
+		if len(got.RetainedViaInterfaces) != len(control.RetainedViaInterfaces) {
+			t.Errorf("budget %d: disclosure changed row shedding: %d rows vs control %d",
+				budget, len(got.RetainedViaInterfaces), len(control.RetainedViaInterfaces))
+		}
+		if !got.RetainedTrimmed {
+			t.Errorf("budget %d: enrichments stripped but retained_trimmed is false", budget)
+		}
+		if estimateBlastWireTokens(&got) > budget {
+			t.Errorf("budget %d: response exceeds its budget", budget)
+		}
+	}
+}
+
+// heavyRetainedResult builds a hub-shaped result: n retained rows with
+// long chains, so stripping enrichments frees far more than the
+// disclosure sentence costs (the 2-row fixture's window was empty and
+// hid a vacuous assertion).
+func heavyRetainedResult(n int) blast.Result {
+	r := retainedResult(true)
+	rows := make([]blast.RetainedHolder, 0, n)
+	for i := range n {
+		id := int64(200 + i*10)
+		rows = append(rows, blast.RetainedHolder{
+			Symbol:  model.Symbol{ID: id, Name: "Holder", Qualified: "pkg.subsystem.HolderNumber" + string(rune('A'+i)), FileID: 2, LineStart: 30 + i, LineEnd: 40 + i},
+			Via:     model.Symbol{ID: id + 1, Name: "RareIface", Qualified: "pkg.RareIface", FileID: 1},
+			Carrier: model.Symbol{ID: id + 2, Name: "Carrier", Qualified: "pkg.deep.CarrierImplementation", FileID: 1},
+			Chain: []model.Symbol{
+				{ID: id + 2, Name: "Carrier", Qualified: "pkg.deep.CarrierImplementation", FileID: 1},
+				{ID: id + 3, Name: "Mid", Qualified: "pkg.middle.IntermediateContainer", FileID: 1},
+				{ID: id + 4, Name: "Inner", Qualified: "pkg.inner.InnerHolderStructure", FileID: 1},
+				{ID: 1, Name: "Widget", Qualified: "Widget", FileID: 1},
+			},
+		})
+	}
+	r.RetainedViaInterfaces = rows
+	r.RetainedCount = n
+	return r
+}
+
+// strippedFloor is the wire size of the fixture with every enrichment
+// removed: the point below which whole rows must shed.
+func strippedFloor(ctx context.Context, r blast.Result) int {
+	resp := BuildBlastResponse(ctx, r, retainedFiles, nil)
+	for i := range resp.RetainedViaInterfaces {
+		resp.RetainedViaInterfaces[i].Chain = ""
+		resp.RetainedViaInterfaces[i].Carrier = ""
+	}
+	resp.Truncated = true
+	return estimateBlastWireTokens(&resp)
 }

--- a/internal/mcpio/retained_test.go
+++ b/internal/mcpio/retained_test.go
@@ -219,3 +219,23 @@ func TestApplyBlastBudgetKeepsDirectCallersWhileSheddingRetained(t *testing.T) {
 		t.Errorf("RetainedCount = %d, want 2", resp.RetainedCount)
 	}
 }
+
+// TestRetainedEntryCarriesConcreteCarrier: the wire entry names the concrete
+// carrier the laundering round proved, so the consumer writes the retention
+// row without a per-interface graph join. Name only: the group must stay
+// lean enough to survive the hub-subject budget.
+func TestRetainedEntryCarriesConcreteCarrier(t *testing.T) {
+	ctx := context.Background()
+	r := retainedResult(true)
+	r.RetainedViaInterfaces[0].Carrier = model.Symbol{ID: 2, Name: "CarrierC", Qualified: "pkg.CarrierC", FileID: 1}
+	resp := BuildBlastResponse(ctx, r, retainedFiles, nil)
+
+	if got := resp.RetainedViaInterfaces[0].Carrier; got != "pkg.CarrierC" {
+		t.Errorf("carrier = %q, want %q", got, "pkg.CarrierC")
+	}
+	// A zero-valued carrier (defensive: hydration miss) renders empty and is
+	// omitted from the wire, never rendered as a phantom name.
+	if got := resp.RetainedViaInterfaces[1].Carrier; got != "" {
+		t.Errorf("carrier for zero-value = %q, want empty", got)
+	}
+}

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -356,6 +356,13 @@ type BlastResponse struct {
 	RetainedViaInterfaces []BlastRetained `json:"retained_via_interfaces,omitempty"`
 	RetainedCount         int             `json:"retained_via_interfaces_count,omitempty"`
 	RetainedNote          string          `json:"retained_note,omitempty"`
+	// RetainedTrimmed is true when the budget stripped carrier/chain
+	// enrichments from retained rows: an absent enrichment on a row is
+	// then trimmed, not unknown. A flag rather than note prose so it is
+	// machine-branchable and cheap enough to survive its own pricing (a
+	// sentence-sized disclosure could never fit the lazy shed's boundary
+	// slack; measured: the shed lands within one shed-unit of budget).
+	RetainedTrimmed bool `json:"retained_trimmed,omitempty"`
 
 	// Tier 2 — references (composes/inherits/includes). Count + top examples.
 	References BlastTierSummary `json:"references"`

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -441,11 +441,12 @@ type BlastRetained struct {
 	// tripping its own shed (measured: consumers re-derived this with
 	// ~30 lookups per session when it was absent).
 	Carrier string `json:"carrier,omitempty"`
-	// Chain is the declared containment path from Carrier down to the
-	// subject (">"-joined type names). Every hop is a composes/includes
-	// edge the index holds, making the row a statable structural fact;
-	// without it agents re-verify each row by hand and lose the session
-	// to it (measured on the dolt hub). Sheds tail-first before Carrier does.
+	// Chain is a declared containment path from Carrier down to the
+	// subject (">"-joined type names; one deterministic path among possibly
+	// several). Every hop is a composes/includes edge the index holds,
+	// making the row a statable structural fact; without it agents
+	// re-verify each row by hand and lose the session to it (measured on
+	// the dolt hub). Sheds tail-first before Carrier does.
 	Chain string `json:"chain,omitempty"`
 }
 

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -438,9 +438,15 @@ type BlastRetained struct {
 	// Carrier names one concrete satisfier of Via that carries the subject,
 	// the proof the laundering computed anyway. Name only (no ref): measured
 	// on the dolt hub, the group must fit the default token budget without
-	// tripping its own shed (cell-5 evidence: consumers re-derived this with
-	// ~30 lookups when it was absent).
+	// tripping its own shed (measured: consumers re-derived this with
+	// ~30 lookups per session when it was absent).
 	Carrier string `json:"carrier,omitempty"`
+	// Chain is the declared containment path from Carrier down to the
+	// subject (">"-joined type names). Every hop is a composes/includes
+	// edge the index holds, making the row a statable structural fact;
+	// without it agents re-verify each row by hand and lose the session
+	// to it (measured on the dolt hub). Sheds tail-first before Carrier does.
+	Chain string `json:"chain,omitempty"`
 }
 
 // Completeness is a single, machine-branchable verdict on whether the

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -435,6 +435,12 @@ type BlastRetained struct {
 	Symbol string `json:"symbol"`
 	Ref    string `json:"ref"`
 	Via    string `json:"via"`
+	// Carrier names one concrete satisfier of Via that carries the subject,
+	// the proof the laundering computed anyway. Name only (no ref): measured
+	// on the dolt hub, the group must fit the default token budget without
+	// tripping its own shed (cell-5 evidence: consumers re-derived this with
+	// ~30 lookups when it was absent).
+	Carrier string `json:"carrier,omitempty"`
 }
 
 // Completeness is a single, machine-branchable verdict on whether the


### PR DESCRIPTION
Blast's retained_via_interfaces group told an agent that a struct may retain the subject behind an interface field, but withheld the two facts that make the row actionable: which concrete type actually carries the subject into that interface, and how that carrier reaches the subject. Agents re-derived both by hand, one graph join and a couple of file reads per row. Each retained row now names its carrier and its containment chain, so a lifecycle audit can be written straight from one blast call.

## Problem

A retained row shipped as {symbol, ref, via} only. Measured on a large Go index (dolt's DoltDB hub, 52 rows), agents spent around 30 follow-up lookups per session resolving the concrete satisfier behind each via-interface and its path to the subject before they would state a single row. The traversal computes both facts and discarded them.

## Summary

Retained rows gain `carrier` (one concrete satisfier of the via-interface that carries the subject, lowest-ID deterministic) and `chain` (a declared containment path from carrier to subject, every hop a composes/includes edge the index holds), with budget shedding that strips enrichment before rows and a `retained_trimmed` flag so a trimmed field is never mistaken for an unknown one.

## Changes

- `internal/blast`: the carrier fixpoint records a parent tree (earliest level, then lowest ID; cycle-safe by an admitted guard) and the laundering round keeps each interface's satisfier; chains hydrate whole-or-not-at-all so a missing hop can never splice a fabricated edge.
- `internal/mcpio`: retained entries render `carrier` and `chain` (">"-joined type names); the budget shed strips chains tail-first, then carriers, then rows, in trimStep batches (one-field-per-marshal measured at 8.2ms on a 100-row hub, now 2.1ms); `retained_trimmed` is set at the first strip so its bytes are priced by every later estimate.
- `retained_note` rewritten to separate what is indexed fact per row from the single runtime may-claim, with no verification advice.

## Architecture Highlights

- Zero new SQL: the parent tree and satisfier map ride queries the closure already makes; worst-hub compute stays in the 7.7ms class.
- The disclosure is a priced flag rather than note prose: a sentence-sized disclosure can never reliably fit because the shed stops within one shed-unit of budget; the flag costs ~6 tokens and is priced from the moment it is set. Adversarially swept at 5,236 budgets: zero holder rows lost to the disclosure, zero budget misses, zero false claims.
- Query-layer only. No schema change, no rescan: existing indexes serve carrier and chain immediately (the release note should say so).

## Test Plan

- [x] Red-first coverage: carrier presence, multi-satisfier determinism, chain depth-1 and transitive, containment diamond, non-seed cycle, whole-or-nothing hydration, shed order (chain before carrier before rows), trim-flag disclosure in every band plus sub-floor row-equality against a sentence-free control
- [x] Mutant verification by execution: tie-break flip, admitted-guard deletion, splice, shed-skip, shed-order swap, flag deletion all red
- [x] Live index checks: dolt hub 52 rows with carrier and chain at the default band and an honestly trimmed 0.7 band; ruby index byte-identical; pebble additive-only with chains spot-verified at source
- [x] Side-effect bench on two frozen controls: llm.rb cited recall 0.889 (frozen 0.444/0.519), healthchecks 1.000 twice (equal to frozen). Known finding, documented deliberately: healthchecks tool-adoption ratio dipped 0.85 to about 0.82 because the arm adds a few verification greps alongside the richer rows; sense-tool usage itself is unchanged and recall held.
- [x] `make ci` (95%+ coverage floor, lint, complexity ledger) and `make smoke` pass
