### PR TITLE
fix: import-aware Go resolution

### DIFF
--- a/internal/extract/extractor.go
+++ b/internal/extract/extractor.go
@@ -300,6 +300,16 @@ type EmittedEdge struct {
 	Kind            model.EdgeKind
 	Line            *int
 	Confidence      float64
+	// TargetImportPath is the fully-qualified import path of the package the
+	// target's qualifier or declared type resolved to in the emitting file's
+	// own import table. Empty means unknown: the edge resolves through the
+	// legacy name-keyed lanes exactly as before the field existed. When set,
+	// TargetInPackage carries the within-package remainder ("Func", "Type",
+	// "Type.Method") a path-aware resolver binds, while TargetQualified keeps
+	// the legacy text so an unverifiable path degrades to old behavior.
+	// Language-neutral by contract; today only the Go extractor emits it.
+	TargetImportPath string
+	TargetInPackage  string
 }
 
 // Emitter receives streamed extraction output. Returning an error

--- a/internal/extract/golang/compose.go
+++ b/internal/extract/golang/compose.go
@@ -46,11 +46,13 @@ func (w *walker) emitFieldCompositions(structNode *sitter.Node, structQualified 
 		line := extract.Line(fd.StartPosition())
 		for _, target := range w.composeTargets(fd.ChildByFieldName("type"), typeParams) {
 			if err := w.emit.Edge(extract.EmittedEdge{
-				SourceQualified: structQualified,
-				TargetQualified: target,
-				Kind:            model.EdgeComposes,
-				Line:            &line,
-				Confidence:      extract.ConfidenceStatic,
+				SourceQualified:  structQualified,
+				TargetQualified:  target.qualified,
+				Kind:             model.EdgeComposes,
+				Line:             &line,
+				Confidence:       extract.ConfidenceStatic,
+				TargetImportPath: target.importPath,
+				TargetInPackage:  target.inPackage,
 			}); err != nil {
 				return err
 			}
@@ -64,7 +66,9 @@ func (w *walker) emitFieldCompositions(structNode *sitter.Node, structQualified 
 // (pkg.Registry[T]) keeps its package prefix. Function types and inline
 // struct/interface literals hold behavior or their own fields, not a named
 // has-a target — they and every other unlisted shape compose nothing.
-func (w *walker) composeTargets(typeNode *sitter.Node, typeParams map[string]bool) []string {
+// Qualified types carry their import-path annotation so the resolver's path
+// lane can refuse the same-basename shadow bind the literal text invites.
+func (w *walker) composeTargets(typeNode *sitter.Node, typeParams map[string]bool) []emitTarget {
 	if typeNode == nil {
 		return nil
 	}
@@ -74,9 +78,9 @@ func (w *walker) composeTargets(typeNode *sitter.Node, typeParams map[string]boo
 		if name == "" || goPredeclaredTypes[name] || typeParams[name] {
 			return nil
 		}
-		return []string{w.qualify(name)}
+		return []emitTarget{{qualified: w.qualify(name)}}
 	case "qualified_type":
-		return []string{extract.Text(typeNode, w.source)}
+		return []emitTarget{w.qualifiedTypeTarget(typeNode)}
 	case "pointer_type", "parenthesized_type":
 		return w.composeTargets(typeNode.NamedChild(0), typeParams)
 	case "slice_type", "array_type":
@@ -97,11 +101,11 @@ func (w *walker) composeTargets(typeNode *sitter.Node, typeParams map[string]boo
 // composeTypeArgTargets extracts compose targets from a generic type's
 // argument list. Each argument arrives wrapped in a type_elem node whose
 // children are the type expressions themselves.
-func (w *walker) composeTypeArgTargets(args *sitter.Node, typeParams map[string]bool) []string {
+func (w *walker) composeTypeArgTargets(args *sitter.Node, typeParams map[string]bool) []emitTarget {
 	if args == nil {
 		return nil
 	}
-	var targets []string
+	var targets []emitTarget
 	for i := uint(0); i < args.NamedChildCount(); i++ {
 		arg := args.NamedChild(i)
 		if arg == nil || arg.Kind() != "type_elem" {

--- a/internal/extract/golang/golang.go
+++ b/internal/extract/golang/golang.go
@@ -59,6 +59,7 @@ func (Extractor) Extract(tree *sitter.Tree, source []byte, _ string, emit extrac
 		emit:        emit,
 		pkg:         packageName(tree.RootNode(), source),
 		pkgBindings: map[string]string{},
+		imports:     collectImports(tree.RootNode(), source),
 	}
 	if err := w.walkTopLevel(tree.RootNode()); err != nil {
 		return err
@@ -75,6 +76,7 @@ type walker struct {
 	emit        extract.Emitter
 	pkg         string            // package name, used to prefix every qualified name
 	pkgBindings map[string]string // unqualified name → qualified name for package-level consts and vars
+	imports     map[string]string // file-block import table: in-file name → import path (imports.go)
 }
 
 // walkTopLevel iterates the direct named children of source_file in

--- a/internal/extract/golang/golang.go
+++ b/internal/extract/golang/golang.go
@@ -706,7 +706,7 @@ func receiverType(recv *sitter.Node, source []byte) string {
 		if t == nil {
 			continue
 		}
-		return unwrapTypeName(t, source)
+		return unwrapTypeName(t, source).name
 	}
 	return ""
 }

--- a/internal/extract/golang/golang.go
+++ b/internal/extract/golang/golang.go
@@ -377,17 +377,19 @@ func (w *walker) emitInterfaceEmbeddings(ifaceNode *sitter.Node, ifaceQualified 
 		if te.NamedChildCount() != 1 {
 			continue
 		}
-		target := w.embedTargetName(te.NamedChild(0))
-		if target == "" {
+		target := w.embedTarget(te.NamedChild(0))
+		if target.qualified == "" {
 			continue
 		}
 		line := extract.Line(te.StartPosition())
 		if err := w.emit.Edge(extract.EmittedEdge{
-			SourceQualified: ifaceQualified,
-			TargetQualified: target,
-			Kind:            model.EdgeIncludes,
-			Line:            &line,
-			Confidence:      extract.ConfidenceStatic,
+			SourceQualified:  ifaceQualified,
+			TargetQualified:  target.qualified,
+			Kind:             model.EdgeIncludes,
+			Line:             &line,
+			Confidence:       extract.ConfidenceStatic,
+			TargetImportPath: target.importPath,
+			TargetInPackage:  target.inPackage,
 		}); err != nil {
 			return err
 		}
@@ -395,23 +397,24 @@ func (w *walker) emitInterfaceEmbeddings(ifaceNode *sitter.Node, ifaceQualified 
 	return nil
 }
 
-// embedTargetName resolves an embedded type node to its qualified target
-// name; non-name terms (unions, approximations, literals) yield "".
-func (w *walker) embedTargetName(typeNode *sitter.Node) string {
+// embedTarget resolves an embedded type node to its qualified target and
+// optional import-path annotation; non-name terms (unions, approximations,
+// literals) yield a zero target. A generic base recurses through the same
+// switch, so a qualified base (pkg.Registry[T]) keeps its package prefix and
+// its annotation instead of being glued onto the current package.
+func (w *walker) embedTarget(typeNode *sitter.Node) emitTarget {
 	if typeNode == nil {
-		return ""
+		return emitTarget{}
 	}
 	switch typeNode.Kind() {
 	case "type_identifier":
-		return w.qualify(extract.Text(typeNode, w.source))
+		return emitTarget{qualified: w.qualify(extract.Text(typeNode, w.source))}
 	case "qualified_type":
-		return extract.Text(typeNode, w.source)
+		return w.qualifiedTypeTarget(typeNode)
 	case "generic_type":
-		if base := typeNode.ChildByFieldName("type"); base != nil {
-			return w.qualify(extract.Text(base, w.source))
-		}
+		return w.embedTarget(typeNode.ChildByFieldName("type"))
 	}
-	return ""
+	return emitTarget{}
 }
 
 // emitEmbeddings walks a struct_type's field declarations and emits
@@ -429,14 +432,16 @@ func (w *walker) emitEmbeddings(structNode *sitter.Node, structQualified string)
 		if fd.ChildByFieldName("name") != nil {
 			continue
 		}
-		if target := w.embedTargetName(fd.ChildByFieldName("type")); target != "" {
+		if target := w.embedTarget(fd.ChildByFieldName("type")); target.qualified != "" {
 			line := extract.Line(fd.StartPosition())
 			if err := w.emit.Edge(extract.EmittedEdge{
-				SourceQualified: structQualified,
-				TargetQualified: target,
-				Kind:            model.EdgeIncludes,
-				Line:            &line,
-				Confidence:      extract.ConfidenceStatic,
+				SourceQualified:  structQualified,
+				TargetQualified:  target.qualified,
+				Kind:             model.EdgeIncludes,
+				Line:             &line,
+				Confidence:       extract.ConfidenceStatic,
+				TargetImportPath: target.importPath,
+				TargetInPackage:  target.inPackage,
 			}); err != nil {
 				return err
 			}

--- a/internal/extract/golang/golang.go
+++ b/internal/extract/golang/golang.go
@@ -590,18 +590,18 @@ func (w *walker) emitCall(call *sitter.Node, source string, types map[string]loc
 	if fn == nil {
 		return nil
 	}
-	var target string
+	var target emitTarget
 	confidence := extract.ConfidenceStatic
 	switch fn.Kind() {
 	case "identifier":
-		target = extract.Text(fn, w.source)
+		target.qualified = extract.Text(fn, w.source)
 		// A bare call through a local binding (closure, func param, method
 		// value) cannot statically reach an indexed symbol — the local
 		// shadows package scope, so a same-named match downstream is always
 		// a coincidence (the emitConstRefs precedent, minus goBuiltins:
 		// builtin names stay because a package-block `func min` shadows the
 		// builtin and its bare calls are real edges).
-		if locals[target] {
+		if locals[target.qualified] {
 			return nil
 		}
 	case "selector_expression":
@@ -609,16 +609,18 @@ func (w *walker) emitCall(call *sitter.Node, source string, types map[string]loc
 	default:
 		return nil
 	}
-	if target == "" {
+	if target.qualified == "" {
 		return nil
 	}
 	line := extract.Line(call.StartPosition())
 	return w.emit.Edge(extract.EmittedEdge{
-		SourceQualified: source,
-		TargetQualified: target,
-		Kind:            model.EdgeCalls,
-		Line:            &line,
-		Confidence:      confidence,
+		SourceQualified:  source,
+		TargetQualified:  target.qualified,
+		Kind:             model.EdgeCalls,
+		Line:             &line,
+		Confidence:       confidence,
+		TargetImportPath: target.importPath,
+		TargetInPackage:  target.inPackage,
 	})
 }
 

--- a/internal/extract/golang/golang_test.go
+++ b/internal/extract/golang/golang_test.go
@@ -2033,10 +2033,10 @@ type Approx interface {
 	}
 }
 
-func TestEmbedTargetNameNil(t *testing.T) {
+func TestEmbedTargetNil(t *testing.T) {
 	w := &walker{}
-	if got := w.embedTargetName(nil); got != "" {
-		t.Errorf("nil type node must resolve to no target, got %q", got)
+	if got := w.embedTarget(nil); got.qualified != "" {
+		t.Errorf("nil type node must resolve to no target, got %q", got.qualified)
 	}
 }
 

--- a/internal/extract/golang/imports.go
+++ b/internal/extract/golang/imports.go
@@ -1,0 +1,112 @@
+package golang
+
+// imports.go builds a file's import table: the in-file name each import
+// binds → its full import path. This is the file-block layer of Go's scope
+// nesting; typeinfer consults it AFTER function scope (locals/types) and
+// resolution consults the PATH, never the in-file name, for stdlib/locality
+// classification (an alias may shadow a stdlib name).
+//
+// Honesty contract: an entry here is a claim the resolver verifies
+// independently (module prefix + directory + package clause). A name the
+// table cannot infer uniquely produces NO entry: a miss means today's
+// behavior, never a wrong bind.
+
+import (
+	"strconv"
+	"strings"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+)
+
+// collectImports walks the source file's import declarations into a
+// name → path table. Dot imports and blank imports bind no per-name
+// qualifier, so they produce no entry. Aliased imports key by the alias.
+// Unaliased imports key by an inferred name: the path basename with the
+// module-major (`…/mod/v2`) and gopkg.in (`yaml.v3`) version suffixes
+// stripped. Two imports whose inferred names collide drop the key
+// entirely (real Go would carry an alias; a non-unique guess is not
+// evidence).
+func collectImports(root *sitter.Node, source []byte) map[string]string {
+	table := map[string]string{}
+	collided := map[string]bool{}
+	// import_spec nodes only occur inside import declarations, so a kind
+	// walk needs no per-declaration structure handling (single vs grouped).
+	_ = extract.WalkNamedDescendants(root, "import_spec", func(spec *sitter.Node) error {
+		addImportSpec(spec, source, table, collided)
+		return nil
+	})
+	return table
+}
+
+// addImportSpec records one import spec into the table, applying the
+// dot/blank exclusions, alias precedence, and the collision-drops rule.
+func addImportSpec(spec *sitter.Node, source []byte, table map[string]string, collided map[string]bool) {
+	pathText := ""
+	if pathNode := spec.ChildByFieldName("path"); pathNode != nil {
+		pathText = extract.Text(pathNode, source)
+	}
+	// A missing path node unquotes as an error, so parser-tolerance shapes
+	// and malformed literals share one rejection.
+	path, err := strconv.Unquote(pathText)
+	if err != nil || path == "" {
+		return
+	}
+	name := ""
+	if nameNode := spec.ChildByFieldName("name"); nameNode != nil {
+		switch nameNode.Kind() {
+		case "dot", "blank_identifier":
+			return // no per-name qualifier is bound
+		default:
+			name = extract.Text(nameNode, source)
+		}
+	} else {
+		name = inferImportName(path)
+	}
+	if name == "" {
+		return
+	}
+	if collided[name] {
+		return
+	}
+	if _, dup := table[name]; dup {
+		delete(table, name) // a non-unique inferred name is not evidence
+		collided[name] = true
+		return
+	}
+	table[name] = path
+}
+
+// inferImportName guesses the in-file name of an unaliased import: the
+// path's last segment, with a module-major suffix segment (`/v2`) or a
+// gopkg.in-style dotted suffix (`yaml.v3`) stripped. The guess only has
+// to be safe, not perfect: a mismatch with the real package clause is a
+// table miss, and the resolver re-verifies module-local entries against
+// the indexed package clause anyway.
+func inferImportName(path string) string {
+	base := path[strings.LastIndex(path, "/")+1:]
+	if isVersionSegment(base) {
+		if i := strings.LastIndex(path, "/"); i > 0 {
+			rest := path[:i]
+			base = rest[strings.LastIndex(rest, "/")+1:]
+		}
+	}
+	if i := strings.LastIndex(base, "."); i > 0 && isVersionSegment(base[i+1:]) {
+		base = base[:i]
+	}
+	return base
+}
+
+// isVersionSegment reports whether s is a version marker like "v2".
+func isVersionSegment(s string) bool {
+	if len(s) < 2 || s[0] != 'v' {
+		return false
+	}
+	for _, r := range s[1:] {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/extract/golang/imports.go
+++ b/internal/extract/golang/imports.go
@@ -20,6 +20,34 @@ import (
 	"github.com/luuuc/sense/internal/extract"
 )
 
+// emitTarget pairs an edge's legacy target text with its optional
+// import-path annotation. Qualified holds exactly what the pre-annotation
+// extractor emitted (so an unverifiable path degrades to old behavior);
+// importPath/inPackage are set only when the qualifier resolved through the
+// file's import table.
+type emitTarget struct {
+	qualified  string
+	importPath string
+	inPackage  string
+}
+
+// qualifiedTypeTarget builds the emitTarget for a qualified_type node.
+// A qualifier with no import-table entry (partial parse, missing import)
+// yields the literal text un-annotated: today's behavior, never a fabricated
+// path claim.
+func (w *walker) qualifiedTypeTarget(n *sitter.Node) emitTarget {
+	text := extract.Text(n, w.source)
+	pkgNode := n.ChildByFieldName("package")
+	nameNode := n.ChildByFieldName("name")
+	if pkgNode == nil || nameNode == nil {
+		return emitTarget{qualified: text}
+	}
+	if path, ok := w.imports[extract.Text(pkgNode, w.source)]; ok {
+		return emitTarget{qualified: text, importPath: path, inPackage: extract.Text(nameNode, w.source)}
+	}
+	return emitTarget{qualified: text}
+}
+
 // collectImports walks the source file's import declarations into a
 // name → path table. Dot imports and blank imports bind no per-name
 // qualifier, so they produce no entry. Aliased imports key by the alias.

--- a/internal/extract/golang/imports_test.go
+++ b/internal/extract/golang/imports_test.go
@@ -295,6 +295,84 @@ type Embedder struct {
 	}
 }
 
+func TestQualifierCallsCarryImportPath(t *testing.T) {
+	r := parse(t, `package cmd
+
+import (
+	"fmt"
+	repo_model "code.gitea.io/gitea/models/repo"
+)
+
+func run() {
+	fmt.Println("x")
+	repo_model.Search()
+}
+`)
+	e := findEdge(r, "cmd.run", "fmt.Println", "calls")
+	if e == nil {
+		t.Fatal("missing stdlib qualifier call edge")
+	}
+	if e.TargetImportPath != "fmt" || e.TargetInPackage != "Println" {
+		t.Errorf("stdlib qualifier annotation = %q/%q", e.TargetImportPath, e.TargetInPackage)
+	}
+	e = findEdge(r, "cmd.run", "repo_model.Search", "calls")
+	if e == nil {
+		t.Fatal("missing aliased qualifier call edge")
+	}
+	if e.TargetImportPath != "code.gitea.io/gitea/models/repo" || e.TargetInPackage != "Search" {
+		t.Errorf("aliased qualifier annotation = %q/%q", e.TargetImportPath, e.TargetInPackage)
+	}
+}
+
+func TestQualifierConsultationOrderIsGoScopeNesting(t *testing.T) {
+	// Function scope shadows the file block: an untyped local named like an
+	// import must take the local branch (ambiguous, no annotation), never
+	// the import table.
+	r := parse(t, `package p
+
+import "fmt"
+
+func f() {
+	fmt := helper()
+	fmt.Print()
+}
+`)
+	e := findEdge(r, "p.f", "fmt.Print", "calls")
+	if e == nil {
+		t.Fatal("missing shadowed-local call edge")
+	}
+	if e.TargetImportPath != "" {
+		t.Errorf("local shadow must not consult the import table, got %q", e.TargetImportPath)
+	}
+	if e.Confidence != 0.8 {
+		t.Errorf("known local with unknown type keeps the ambiguous confidence, got %v", e.Confidence)
+	}
+}
+
+func TestUnknownOperandIsNotAPackageQualifier(t *testing.T) {
+	// An operand that is neither a local nor an import-table name is, by
+	// Go's scope law, a package-level identifier, never a package
+	// qualifier. The old @1.0 emission let its dotted text exact-bind into
+	// a same-named indexed package; it now rides ConfidenceUnresolved so
+	// the resolver's gated fallback demotes it.
+	r := parse(t, `package p
+
+func f() {
+	log.Error("boom")
+}
+`)
+	e := findEdge(r, "p.f", "log.Error", "calls")
+	if e == nil {
+		t.Fatal("missing unknown-operand call edge")
+	}
+	if e.TargetImportPath != "" {
+		t.Errorf("unknown operand must carry no annotation, got %q", e.TargetImportPath)
+	}
+	if e.Confidence != 0.5 {
+		t.Errorf("unknown operand must ride ConfidenceUnresolved, got %v", e.Confidence)
+	}
+}
+
 func TestQualifiedTypeTargetTolerantShapes(t *testing.T) {
 	// A node without package/name fields (parser-tolerance territory) keeps
 	// the literal text and claims no path.

--- a/internal/extract/golang/imports_test.go
+++ b/internal/extract/golang/imports_test.go
@@ -373,6 +373,126 @@ func f() {
 	}
 }
 
+func TestQualifiedReceiverParamCarriesImportPath(t *testing.T) {
+	// The core starved-band shape: a receiver-holding parameter declared with a
+	// qualified type. The legacy text stays `var.Method` (exact inert
+	// degradation); the annotation carries the path and Type.Method.
+	r := parse(t, `package pkgs
+
+import sctx "code.gitea.io/gitea/services/context"
+
+func DeletePackage(ctx *sctx.Context) {
+	ctx.FormString("version")
+}
+`)
+	e := findEdge(r, "pkgs.DeletePackage", "ctx.FormString", "calls")
+	if e == nil {
+		t.Fatal("missing qualified-receiver call edge")
+	}
+	if e.TargetImportPath != "code.gitea.io/gitea/services/context" || e.TargetInPackage != "Context.FormString" {
+		t.Errorf("annotation = %q/%q", e.TargetImportPath, e.TargetInPackage)
+	}
+	if e.Confidence != 1.0 {
+		t.Errorf("declared qualified receiver keeps declared confidence, got %v", e.Confidence)
+	}
+}
+
+func TestQualifiedVarAndCompositeCarryImportPath(t *testing.T) {
+	r := parse(t, `package p
+
+import (
+	"io"
+	cfg "example.com/mod/config"
+)
+
+func f() {
+	var w io.Writer
+	w.Write(nil)
+	c := cfg.Store{}
+	c.Load()
+}
+`)
+	e := findEdge(r, "p.f", "w.Write", "calls")
+	if e == nil {
+		t.Fatal("missing var-decl call edge")
+	}
+	if e.TargetImportPath != "io" || e.TargetInPackage != "Writer.Write" {
+		t.Errorf("var annotation = %q/%q", e.TargetImportPath, e.TargetInPackage)
+	}
+	e = findEdge(r, "p.f", "c.Load", "calls")
+	if e == nil {
+		t.Fatal("missing composite short-var call edge")
+	}
+	if e.TargetImportPath != "example.com/mod/config" || e.TargetInPackage != "Store.Load" {
+		t.Errorf("composite annotation = %q/%q", e.TargetImportPath, e.TargetInPackage)
+	}
+}
+
+func TestFuncLiteralParamsShadowImports(t *testing.T) {
+	// A func literal's parameters were invisible to the type map: a callback
+	// param named like an import would import-match and bind path-verified
+	// into that package. The param must win (Go's function scope).
+	r := parse(t, `package p
+
+import "code.gitea.io/gitea/modules/log"
+
+func f() {
+	g := func(log log.Logger) {
+		log.Error("boom")
+	}
+	g(nil)
+}
+`)
+	e := findEdge(r, "p.f", "log.Error", "calls")
+	if e == nil {
+		t.Fatal("missing func-literal call edge")
+	}
+	// The param's declared type IS log.Logger, so the annotation points at
+	// the type's package with Type.Method, NOT at a package function Error.
+	if e.TargetInPackage != "Logger.Error" {
+		t.Errorf("func-literal param must type the receiver, got %q/%q", e.TargetImportPath, e.TargetInPackage)
+	}
+}
+
+func TestNamedResultsEnterTheTypeMap(t *testing.T) {
+	r := parse(t, `package p
+
+import sctx "code.gitea.io/gitea/services/context"
+
+func g() (ctx *sctx.Context, err error) {
+	ctx.Do()
+	return
+}
+`)
+	e := findEdge(r, "p.g", "ctx.Do", "calls")
+	if e == nil {
+		t.Fatal("missing named-result call edge")
+	}
+	if e.TargetImportPath != "code.gitea.io/gitea/services/context" || e.TargetInPackage != "Context.Do" {
+		t.Errorf("named-result annotation = %q/%q", e.TargetImportPath, e.TargetInPackage)
+	}
+}
+
+func TestRangeElementCarriesImportPath(t *testing.T) {
+	r := parse(t, `package p
+
+import m "example.com/mod/model"
+
+func f(items []m.Item) {
+	for _, it := range items {
+		it.Process()
+	}
+}
+`)
+	e := findEdge(r, "p.f", "it.Process", "calls")
+	if e == nil {
+		t.Fatal("missing range-element call edge")
+	}
+	if e.TargetImportPath != "example.com/mod/model" || e.TargetInPackage != "Item.Process" {
+		t.Errorf("range-element annotation = %q/%q", e.TargetImportPath, e.TargetInPackage)
+	}
+}
+
 func TestQualifiedTypeTargetTolerantShapes(t *testing.T) {
 	// A node without package/name fields (parser-tolerance territory) keeps
 	// the literal text and claims no path.

--- a/internal/extract/golang/imports_test.go
+++ b/internal/extract/golang/imports_test.go
@@ -1,0 +1,177 @@
+package golang
+
+import (
+	"testing"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+)
+
+func parseImports(t *testing.T, src string) map[string]string {
+	t.Helper()
+	parser := sitter.NewParser()
+	defer parser.Close()
+	if err := parser.SetLanguage(Extractor{}.Grammar()); err != nil {
+		t.Fatalf("set language: %v", err)
+	}
+	tree := parser.Parse([]byte(src), nil)
+	if tree == nil {
+		t.Fatal("Parse returned nil tree")
+	}
+	defer tree.Close()
+	return collectImports(tree.RootNode(), []byte(src))
+}
+
+func TestCollectImportsPlainAndGrouped(t *testing.T) {
+	src := `package p
+
+import "fmt"
+
+import (
+	"strings"
+	"code.gitea.io/gitea/services/context"
+)
+`
+	got := parseImports(t, src)
+	want := map[string]string{
+		"fmt":     "fmt",
+		"strings": "strings",
+		"context": "code.gitea.io/gitea/services/context",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d entries %v, want %d", len(got), got, len(want))
+	}
+	for name, path := range want {
+		if got[name] != path {
+			t.Errorf("entry %q = %q, want %q", name, got[name], path)
+		}
+	}
+}
+
+func TestCollectImportsAlias(t *testing.T) {
+	src := `package p
+
+import (
+	repo_model "code.gitea.io/gitea/models/repo"
+	fmt "github.com/x/fmtlib"
+)
+`
+	got := parseImports(t, src)
+	if got["repo_model"] != "code.gitea.io/gitea/models/repo" {
+		t.Errorf("alias entry = %q", got["repo_model"])
+	}
+	// The in-file name decides the key; the PATH decides classification later.
+	// An alias reusing a stdlib name must map to its real (non-stdlib) path.
+	if got["fmt"] != "github.com/x/fmtlib" {
+		t.Errorf("stdlib-shadowing alias = %q, want the aliased path", got["fmt"])
+	}
+	if _, ok := got["repo"]; ok {
+		t.Error("basename of an aliased import must not appear as a key")
+	}
+}
+
+func TestCollectImportsDotAndBlankExcluded(t *testing.T) {
+	src := `package p
+
+import (
+	. "fmt"
+	_ "net/http/pprof"
+	"strings"
+)
+`
+	got := parseImports(t, src)
+	if len(got) != 1 || got["strings"] != "strings" {
+		t.Fatalf("dot/blank imports must produce no entry, got %v", got)
+	}
+}
+
+func TestCollectImportsVersionSuffixes(t *testing.T) {
+	src := `package p
+
+import (
+	"github.com/x/mod/v2"
+	"gopkg.in/yaml.v3"
+)
+`
+	got := parseImports(t, src)
+	// Module-major and gopkg.in conventions: the inferred in-file name strips
+	// the version suffix. A wrong guess is a table MISS (today's behavior),
+	// never a wrong bind; the resolver verifies paths independently.
+	if got["mod"] != "github.com/x/mod/v2" {
+		t.Errorf("mod/v2 entry = %v", got)
+	}
+	if got["yaml"] != "gopkg.in/yaml.v3" {
+		t.Errorf("yaml.v3 entry = %v", got)
+	}
+}
+
+func TestCollectImportsDuplicateInferredNameDropsBoth(t *testing.T) {
+	// Two imports whose INFERRED names collide (real Go would alias one; our
+	// heuristic can collide where the package clauses differ). A guess that
+	// cannot be unique is no evidence: both keys vanish, operands fall through
+	// to today's behavior.
+	src := `package p
+
+import (
+	"github.com/a/util/v2"
+	"github.com/b/util"
+)
+`
+	got := parseImports(t, src)
+	if _, ok := got["util"]; ok {
+		t.Fatalf("colliding inferred names must drop the key, got %v", got)
+	}
+}
+
+func TestCollectImportsEdgeShapes(t *testing.T) {
+	// A bare version-segment path must not panic or strip below its only
+	// segment; a dotted suffix that is not a version stays untouched; a
+	// THIRD collision on an already-dropped name stays dropped; an empty
+	// grouped list contributes nothing.
+	src := `package p
+
+import (
+	"v2"
+	"example.com/tool.vx"
+	"github.com/a/util/v2"
+	"github.com/b/util"
+	"github.com/c/util"
+)
+
+import ()
+`
+	got := parseImports(t, src)
+	if got["v2"] != "v2" {
+		t.Errorf("bare version-segment path = %v", got)
+	}
+	if got["tool.vx"] != "example.com/tool.vx" {
+		t.Errorf("non-version dotted suffix must keep its name, got %v", got)
+	}
+	if _, ok := got["util"]; ok {
+		t.Errorf("three-way collision must stay dropped, got %v", got)
+	}
+	if len(got) != 2 {
+		t.Errorf("unexpected table: %v", got)
+	}
+}
+
+func TestCollectImportsMalformedSpecs(t *testing.T) {
+	// Tree-sitter is error-tolerant: a spec without a path string and an
+	// unparseable path literal must produce no entry, never a panic.
+	src := "package p\n\nimport (\n\tfoo\n\t\"\"\n\t\"x/\"\n)\n"
+	if got := parseImports(t, src); len(got) != 0 {
+		t.Errorf("malformed specs must contribute nothing, got %v", got)
+	}
+}
+
+func TestCollectImportsCgoAndEmpty(t *testing.T) {
+	if got := parseImports(t, `package p
+
+import "C"
+`); got["C"] != "C" {
+		t.Errorf("cgo import = %v", got)
+	}
+	if got := parseImports(t, `package p
+`); len(got) != 0 {
+		t.Errorf("no imports: got %v", got)
+	}
+}

--- a/internal/extract/golang/imports_test.go
+++ b/internal/extract/golang/imports_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
 )
 
 func parseImports(t *testing.T, src string) map[string]string {
@@ -161,6 +163,166 @@ func TestCollectImportsMalformedSpecs(t *testing.T) {
 	if got := parseImports(t, src); len(got) != 0 {
 		t.Errorf("malformed specs must contribute nothing, got %v", got)
 	}
+}
+
+// The three fabrication doors: a qualified type reaching an edge as literal
+// text lets byQualified bind stdlib/third-party names to same-named local
+// packages. Emission keeps the legacy text (TargetQualified) and adds the
+// import-path annotation the resolver's path lane decides on.
+
+func TestComposeQualifiedTypeCarriesImportPath(t *testing.T) {
+	r := parse(t, `package storage
+
+import (
+	"context"
+	sctx "code.gitea.io/gitea/services/context"
+)
+
+type LocalStorage struct {
+	ctx  context.Context
+	base sctx.Base
+}
+`)
+	e := findEdge(r, "storage.LocalStorage", "context.Context", "composes")
+	if e == nil {
+		t.Fatal("missing composes edge for stdlib-typed field")
+	}
+	if e.TargetImportPath != "context" || e.TargetInPackage != "Context" {
+		t.Errorf("stdlib field annotation = %q/%q", e.TargetImportPath, e.TargetInPackage)
+	}
+	e = findEdge(r, "storage.LocalStorage", "sctx.Base", "composes")
+	if e == nil {
+		t.Fatal("missing composes edge for aliased local field")
+	}
+	if e.TargetImportPath != "code.gitea.io/gitea/services/context" || e.TargetInPackage != "Base" {
+		t.Errorf("aliased field annotation = %q/%q", e.TargetImportPath, e.TargetInPackage)
+	}
+}
+
+func TestComposeUnknownQualifierStaysLegacy(t *testing.T) {
+	// A qualifier with no import-table entry (partial parse, missing import)
+	// must keep today's behavior exactly: literal text, no annotation.
+	r := parse(t, `package p
+
+type X struct {
+	f zzz.T
+}
+`)
+	e := findEdge(r, "p.X", "zzz.T", "composes")
+	if e == nil {
+		t.Fatal("missing composes edge for unknown qualifier")
+	}
+	if e.TargetImportPath != "" || e.TargetInPackage != "" {
+		t.Errorf("unknown qualifier must carry no annotation, got %q/%q", e.TargetImportPath, e.TargetInPackage)
+	}
+}
+
+func TestEmbeddedQualifiedTypesCarryImportPath(t *testing.T) {
+	r := parse(t, `package p
+
+import (
+	"context"
+	"io"
+)
+
+type Wrapped struct {
+	context.Context
+}
+
+type Iface interface {
+	io.Reader
+}
+`)
+	e := findEdge(r, "p.Wrapped", "context.Context", "includes")
+	if e == nil {
+		t.Fatal("missing includes edge for embedded stdlib type")
+	}
+	if e.TargetImportPath != "context" || e.TargetInPackage != "Context" {
+		t.Errorf("embedded struct annotation = %q/%q", e.TargetImportPath, e.TargetInPackage)
+	}
+	e = findEdge(r, "p.Iface", "io.Reader", "includes")
+	if e == nil {
+		t.Fatal("missing includes edge for embedded interface")
+	}
+	if e.TargetImportPath != "io" || e.TargetInPackage != "Reader" {
+		t.Errorf("embedded interface annotation = %q/%q", e.TargetImportPath, e.TargetInPackage)
+	}
+	// In-package embeds stay un-annotated: the legacy qualified name is
+	// already exact.
+	r = parse(t, `package p
+
+type Base struct{}
+
+type Sub struct {
+	Base
+}
+`)
+	e = findEdge(r, "p.Sub", "p.Base", "includes")
+	if e == nil {
+		t.Fatal("missing in-package includes edge")
+	}
+	if e.TargetImportPath != "" {
+		t.Errorf("in-package embed must carry no annotation, got %q", e.TargetImportPath)
+	}
+}
+
+func TestGenericQualifiedBaseCarriesImportPath(t *testing.T) {
+	r := parse(t, `package p
+
+import reg "example.com/mod/registry"
+
+type Holder struct {
+	r reg.Registry[int]
+}
+
+type Embedder struct {
+	reg.Registry[int]
+}
+`)
+	e := findEdge(r, "p.Holder", "reg.Registry", "composes")
+	if e == nil {
+		t.Fatal("missing composes edge for generic qualified base")
+	}
+	if e.TargetImportPath != "example.com/mod/registry" || e.TargetInPackage != "Registry" {
+		t.Errorf("generic compose annotation = %q/%q", e.TargetImportPath, e.TargetInPackage)
+	}
+	e = findEdge(r, "p.Embedder", "reg.Registry", "includes")
+	if e == nil {
+		t.Fatal("missing includes edge for generic qualified embed")
+	}
+	if e.TargetImportPath != "example.com/mod/registry" || e.TargetInPackage != "Registry" {
+		t.Errorf("generic embed annotation = %q/%q", e.TargetImportPath, e.TargetInPackage)
+	}
+}
+
+func TestQualifiedTypeTargetTolerantShapes(t *testing.T) {
+	// A node without package/name fields (parser-tolerance territory) keeps
+	// the literal text and claims no path.
+	parser := sitter.NewParser()
+	defer parser.Close()
+	if err := parser.SetLanguage(Extractor{}.Grammar()); err != nil {
+		t.Fatal(err)
+	}
+	src := []byte("package p\n\ntype X struct{ f T }\n")
+	tree := parser.Parse(src, nil)
+	defer tree.Close()
+	w := &walker{source: src, imports: map[string]string{"T": "never/used"}}
+	var ident *sitter.Node
+	_ = extractWalk(tree.RootNode(), "type_identifier", func(n *sitter.Node) { ident = n })
+	if ident == nil {
+		t.Fatal("no type_identifier found")
+	}
+	got := w.qualifiedTypeTarget(ident)
+	if got.qualified == "" || got.importPath != "" {
+		t.Errorf("tolerant shape = %+v, want literal text with no annotation", got)
+	}
+}
+
+func extractWalk(n *sitter.Node, kind string, fn func(*sitter.Node)) error {
+	return extract.WalkNamedDescendants(n, kind, func(m *sitter.Node) error {
+		fn(m)
+		return nil
+	})
 }
 
 func TestCollectImportsCgoAndEmpty(t *testing.T) {

--- a/internal/extract/golang/typeinfer.go
+++ b/internal/extract/golang/typeinfer.go
@@ -450,12 +450,13 @@ func unwrapTypeName(t *sitter.Node, source []byte) typeRef {
 		case "type_identifier":
 			return typeRef{name: extract.Text(t, source)}
 		case "qualified_type":
-			pkgNode := t.ChildByFieldName("package")
-			nameNode := t.ChildByFieldName("name")
-			if pkgNode == nil || nameNode == nil {
-				return typeRef{}
+			// extract.Text of a missing field is "", and an empty name is
+			// no claim to every consumer, so parser-tolerance needs no
+			// branch of its own here.
+			return typeRef{
+				name:      extract.Text(t.ChildByFieldName("name"), source),
+				qualifier: extract.Text(t.ChildByFieldName("package"), source),
 			}
-			return typeRef{name: extract.Text(nameNode, source), qualifier: extract.Text(pkgNode, source)}
 		case "pointer_type":
 			// `*T` has exactly one named child — the inner type.
 			t = t.NamedChild(0)

--- a/internal/extract/golang/typeinfer.go
+++ b/internal/extract/golang/typeinfer.go
@@ -21,6 +21,44 @@ type localType struct {
 	name       string  // unqualified type name (e.g. "Order")
 	elemName   string  // element type for slices/arrays (for range resolution)
 	confidence float64 // 1.0 for explicit declarations, 0.8 for inferred
+	// importPath / elemImportPath carry the import path of a qualified
+	// declared type (`sctx.Context` → the sctx import's path), resolved
+	// through the file's import table at collection time. Empty for
+	// in-package types. A qualified type whose qualifier has no table entry
+	// enters no type claim at all (locals-only): today's behavior, never a
+	// bare name that would later glue onto the current package.
+	importPath     string
+	elemImportPath string
+}
+
+// typeRef is a syntactic type reference: the base type name and, when the
+// type was written qualified (`pkg.Type`), its package qualifier as written.
+type typeRef struct {
+	name      string
+	qualifier string
+}
+
+// typedLocal resolves syntactic type refs into a localType through the
+// import table, applying the no-entry rule per ref (an unresolvable
+// qualifier drops that ref's claim). The bool reports whether any claim
+// survived.
+func (w *walker) typedLocal(tr, elem typeRef, confidence float64) (localType, bool) {
+	lt := localType{confidence: confidence}
+	if tr.name != "" {
+		if tr.qualifier == "" {
+			lt.name = tr.name
+		} else if path, ok := w.imports[tr.qualifier]; ok {
+			lt.name, lt.importPath = tr.name, path
+		}
+	}
+	if elem.name != "" {
+		if elem.qualifier == "" {
+			lt.elemName = elem.name
+		} else if path, ok := w.imports[elem.qualifier]; ok {
+			lt.elemName, lt.elemImportPath = elem.name, path
+		}
+	}
+	return lt, lt.name != "" || lt.elemName != ""
 }
 
 // buildTypeMap scans a function/method declaration for local variable
@@ -36,11 +74,25 @@ func (w *walker) buildTypeMap(funcNode *sitter.Node) (map[string]localType, map[
 
 	w.collectReceiverTypes(funcNode.ChildByFieldName("receiver"), types, locals)
 	w.collectParamTypes(funcNode.ChildByFieldName("parameters"), types, locals)
+	// Named results declare locals too (`func g() (ctx *sctx.Context)`);
+	// an unnamed result list holds no parameter_declaration and no-ops.
+	w.collectParamTypes(funcNode.ChildByFieldName("result"), types, locals)
 
 	body := funcNode.ChildByFieldName("body")
 	if body == nil {
 		return types, locals
 	}
+	// Func-literal parameters are function-scope bindings the walk below
+	// would otherwise miss entirely; an operand shadowing an import name
+	// (`func(log log.Logger) { log.Error() }`) must resolve as the local.
+	// Flat collection over the whole body is the file's existing
+	// flow-insensitive convention; over-registering a name errs toward a
+	// miss, never a wrong bind.
+	_ = extract.WalkNamedDescendants(body, "func_literal", func(n *sitter.Node) error {
+		w.collectParamTypes(n.ChildByFieldName("parameters"), types, locals)
+		w.collectParamTypes(n.ChildByFieldName("result"), types, locals)
+		return nil
+	})
 	_ = extract.WalkNamedDescendants(body, "var_declaration", func(n *sitter.Node) error {
 		w.collectVarDecl(n, types, locals)
 		return nil
@@ -68,9 +120,11 @@ func (w *walker) collectReceiverTypes(recv *sitter.Node, types map[string]localT
 			continue
 		}
 		name := extract.Text(pd.ChildByFieldName("name"), w.source)
-		typeName := unwrapTypeName(pd.ChildByFieldName("type"), w.source)
+		// A method receiver is never a qualified type (Go forbids methods
+		// on other packages' types), so only the bare name matters.
+		typeName := unwrapTypeName(pd.ChildByFieldName("type"), w.source).name
 		if name != "" && typeName != "" {
-			types[name] = localType{typeName, "", extract.ConfidenceStatic}
+			types[name] = localType{name: typeName, confidence: extract.ConfidenceStatic}
 			locals[name] = true
 		}
 	}
@@ -91,14 +145,15 @@ func (w *walker) collectParamTypes(params *sitter.Node, types map[string]localTy
 		// when the type doesn't unwrap to a name (func-typed params are the
 		// closure carriers behind G-10's bare-call false binds). The type
 		// map entry still requires a resolved name.
-		typeName, elemName := resolveTypeAndElem(pd.ChildByFieldName("type"), w.source)
+		tr, elem := resolveTypeAndElem(pd.ChildByFieldName("type"), w.source)
+		lt, typed := w.typedLocal(tr, elem, extract.ConfidenceStatic)
 		for j := uint(0); j < pd.NamedChildCount(); j++ {
 			ch := pd.NamedChild(j)
 			if ch.Kind() == "identifier" {
 				name := extract.Text(ch, w.source)
 				locals[name] = true
-				if typeName != "" || elemName != "" {
-					types[name] = localType{typeName, elemName, extract.ConfidenceStatic}
+				if typed {
+					types[name] = lt
 				}
 			}
 		}
@@ -113,14 +168,15 @@ func (w *walker) collectVarDecl(n *sitter.Node, types map[string]localType, loca
 			continue
 		}
 		typeNode := spec.ChildByFieldName("type")
-		typeName, elemName := resolveTypeAndElem(typeNode, w.source)
+		tr, elem := resolveTypeAndElem(typeNode, w.source)
+		lt, typed := w.typedLocal(tr, elem, extract.ConfidenceStatic)
 		for j := uint(0); j < spec.NamedChildCount(); j++ {
 			ch := spec.NamedChild(j)
 			if ch.Kind() == "identifier" {
 				name := extract.Text(ch, w.source)
 				locals[name] = true
-				if typeName != "" || elemName != "" {
-					types[name] = localType{typeName, elemName, extract.ConfidenceStatic}
+				if typed {
+					types[name] = lt
 				}
 			}
 		}
@@ -174,8 +230,8 @@ func (w *walker) collectRangeVars(rc *sitter.Node, types map[string]localType, l
 	if valueName == "" || valueName == "_" {
 		return
 	}
-	if elemName := w.rangeElemType(right, types); elemName != "" {
-		types[valueName] = localType{elemName, "", extract.ConfidenceStatic}
+	if elem := w.rangeElemType(right, types); elem.name != "" {
+		types[valueName] = localType{name: elem.name, importPath: elem.qualifier, confidence: extract.ConfidenceStatic}
 	}
 }
 
@@ -210,18 +266,29 @@ func rangeValueNode(left *sitter.Node) *sitter.Node {
 
 // rangeElemType determines the element type produced by ranging over `right`,
 // reading a known slice/array variable's element type or a composite literal's.
-func (w *walker) rangeElemType(right *sitter.Node, types map[string]localType) string {
+// The returned typeRef's qualifier is ALREADY an import path when it came from
+// the type map (localType stores resolved paths); a composite literal's ref is
+// resolved through typedLocal by the caller's map entry construction; so this
+// resolves it here to keep one convention: qualifier = import path or "".
+func (w *walker) rangeElemType(right *sitter.Node, types map[string]localType) typeRef {
 	switch right.Kind() {
 	case "identifier":
 		if lt, ok := types[extract.Text(right, w.source)]; ok {
-			return lt.elemName
+			return typeRef{name: lt.elemName, qualifier: lt.elemImportPath}
 		}
 	case "composite_literal":
 		if typeNode := right.ChildByFieldName("type"); typeNode != nil {
-			return sliceElemType(typeNode, w.source)
+			elem := sliceElemType(typeNode, w.source)
+			if elem.qualifier == "" {
+				return elem
+			}
+			if path, ok := w.imports[elem.qualifier]; ok {
+				return typeRef{name: elem.name, qualifier: path}
+			}
+			return typeRef{}
 		}
 	}
-	return ""
+	return typeRef{}
 }
 
 // resolveSelector resolves a selector_expression callee (e.g. `x.Method`)
@@ -254,6 +321,17 @@ func (w *walker) resolveSelector(sel *sitter.Node, types map[string]localType, l
 	}
 	lt, ok := types[varName]
 	if ok && lt.name != "" {
+		if lt.importPath != "" {
+			// Cross-package declared type: the legacy text stays the raw
+			// selector (exact inert degradation when no module table
+			// exists); the annotation carries Type.Method for the path
+			// lane's dir-scoped bind and embedding walk.
+			return emitTarget{
+				qualified:  varName + "." + methodName,
+				importPath: lt.importPath,
+				inPackage:  lt.name + "." + methodName,
+			}, lt.confidence
+		}
 		return emitTarget{qualified: w.qualify(lt.name) + "." + methodName}, lt.confidence
 	}
 	text := varName + "." + methodName
@@ -292,12 +370,12 @@ func (w *walker) inferFromComposite(val *sitter.Node) (localType, bool) {
 	}
 	if typeNode != nil {
 		if typeNode.Kind() == "slice_type" || typeNode.Kind() == "array_type" {
-			if elemName := sliceElemType(typeNode, w.source); elemName != "" {
-				return localType{"", elemName, extract.ConfidenceStatic}, true
+			if elem := sliceElemType(typeNode, w.source); elem.name != "" {
+				return w.typedLocal(typeRef{}, elem, extract.ConfidenceStatic)
 			}
 		}
-		if typeName := unwrapTypeName(typeNode, w.source); typeName != "" {
-			return localType{typeName, "", extract.ConfidenceStatic}, true
+		if tr := unwrapTypeName(typeNode, w.source); tr.name != "" {
+			return w.typedLocal(tr, typeRef{}, extract.ConfidenceStatic)
 		}
 	}
 	return localType{}, false
@@ -309,8 +387,8 @@ func (w *walker) inferFromUnary(val *sitter.Node) (localType, bool) {
 	if operand == nil || operand.Kind() != "composite_literal" {
 		return localType{}, false
 	}
-	if typeName := unwrapTypeName(operand.NamedChild(0), w.source); typeName != "" {
-		return localType{typeName, "", extract.ConfidenceStatic}, true
+	if tr := unwrapTypeName(operand.NamedChild(0), w.source); tr.name != "" {
+		return w.typedLocal(tr, typeRef{}, extract.ConfidenceStatic)
 	}
 	return localType{}, false
 }
@@ -322,7 +400,7 @@ func (w *walker) inferFromCall(val *sitter.Node) (localType, bool) {
 		return localType{}, false
 	}
 	if typeName := constructorType(extract.Text(fn, w.source)); typeName != "" {
-		return localType{typeName, "", extract.ConfidenceAmbiguous}, true
+		return localType{name: typeName, confidence: extract.ConfidenceAmbiguous}, true
 	}
 	return localType{}, false
 }
@@ -343,34 +421,41 @@ func constructorType(funcName string) string {
 	return typeName
 }
 
-// resolveTypeAndElem extracts the type name and optional element type
-// from a type node. For slice/array types, elemName is the element
-// type; for plain types, elemName is empty.
-func resolveTypeAndElem(typeNode *sitter.Node, source []byte) (typeName, elemName string) {
+// resolveTypeAndElem extracts the type ref and optional element type ref
+// from a type node. For slice/array types the element ref is set; for
+// plain types it is zero.
+func resolveTypeAndElem(typeNode *sitter.Node, source []byte) (tr, elem typeRef) {
 	if typeNode == nil {
-		return "", ""
+		return typeRef{}, typeRef{}
 	}
 	if typeNode.Kind() == "slice_type" || typeNode.Kind() == "array_type" {
-		elem := sliceElemType(typeNode, source)
-		return "", elem
+		return typeRef{}, sliceElemType(typeNode, source)
 	}
-	return unwrapTypeName(typeNode, source), ""
+	return unwrapTypeName(typeNode, source), typeRef{}
 }
 
-// sliceElemType extracts the element type from a slice_type or
+// sliceElemType extracts the element type ref from a slice_type or
 // array_type node via the `element` field.
-func sliceElemType(typeNode *sitter.Node, source []byte) string {
+func sliceElemType(typeNode *sitter.Node, source []byte) typeRef {
 	elem := typeNode.ChildByFieldName("element")
 	return unwrapTypeName(elem, source)
 }
 
 // unwrapTypeName peels pointer and generic wrappers off a type
-// expression to get at the base type_identifier.
-func unwrapTypeName(t *sitter.Node, source []byte) string {
+// expression to get at the base type_identifier or qualified_type,
+// returning the name and (for qualified types) the qualifier as written.
+func unwrapTypeName(t *sitter.Node, source []byte) typeRef {
 	for t != nil {
 		switch t.Kind() {
 		case "type_identifier":
-			return extract.Text(t, source)
+			return typeRef{name: extract.Text(t, source)}
+		case "qualified_type":
+			pkgNode := t.ChildByFieldName("package")
+			nameNode := t.ChildByFieldName("name")
+			if pkgNode == nil || nameNode == nil {
+				return typeRef{}
+			}
+			return typeRef{name: extract.Text(nameNode, source), qualifier: extract.Text(pkgNode, source)}
 		case "pointer_type":
 			// `*T` has exactly one named child — the inner type.
 			t = t.NamedChild(0)
@@ -379,13 +464,12 @@ func unwrapTypeName(t *sitter.Node, source []byte) string {
 				t = name
 				continue
 			}
-			return ""
+			return typeRef{}
 		default:
-			// Qualified types like `pkg.Type` (qualified_type node)
-			// land here. Skip — cross-package resolution is 01-03's
-			// job, not Tier-Basic's.
-			return ""
+			// Function types, map types, inline literals and every other
+			// unlisted shape carry no single base name to bind against.
+			return typeRef{}
 		}
 	}
-	return ""
+	return typeRef{}
 }

--- a/internal/extract/golang/typeinfer.go
+++ b/internal/extract/golang/typeinfer.go
@@ -224,34 +224,46 @@ func (w *walker) rangeElemType(right *sitter.Node, types map[string]localType) s
 	return ""
 }
 
-// resolveSelector attempts to resolve a selector_expression callee
-// (e.g. `x.Method`) using the local type map. Returns the target
-// qualified name and confidence. When the operand is a known local
-// variable without a resolved type, confidence drops to 0.8;
-// unknown operands (likely package references like `fmt`) stay at 1.0.
-func (w *walker) resolveSelector(sel *sitter.Node, types map[string]localType, locals map[string]bool) (string, float64) {
+// resolveSelector resolves a selector_expression callee (e.g. `x.Method`)
+// following Go's scope nesting: function scope first (the local type map
+// and locals set), then the file block (the import table), then package
+// fallthrough. Returns the target and confidence:
+//
+//   - typed local: `pkg.Type.Method` at the type's inference confidence;
+//   - known local with unknown type: raw text at ConfidenceAmbiguous;
+//   - import-table match: raw text annotated with the import path, which
+//     the resolver's path lane decides terminally;
+//   - neither local nor import: by Go's scope law the operand is a
+//     package-level identifier of the current package, provably NOT a
+//     package qualifier: its dotted text used to ride at 1.0 and could
+//     exact-bind into a same-named indexed package. It now rides at
+//     ConfidenceUnresolved so the gated fallback demotes it to a guess.
+func (w *walker) resolveSelector(sel *sitter.Node, types map[string]localType, locals map[string]bool) (emitTarget, float64) {
 	operand := sel.ChildByFieldName("operand")
 	field := sel.ChildByFieldName("field")
 	if operand == nil || field == nil {
-		return extract.Text(sel, w.source), extract.ConfidenceStatic
+		return emitTarget{qualified: extract.Text(sel, w.source)}, extract.ConfidenceStatic
 	}
 	if operand.Kind() != "identifier" {
-		return extract.Text(sel, w.source), extract.ConfidenceStatic
+		return emitTarget{qualified: extract.Text(sel, w.source)}, extract.ConfidenceStatic
 	}
 	varName := extract.Text(operand, w.source)
 	methodName := extract.Text(field, w.source)
 	if varName == "" || methodName == "" {
-		return "", 0
+		return emitTarget{}, 0
 	}
 	lt, ok := types[varName]
-	if !ok || lt.name == "" {
-		confidence := extract.ConfidenceStatic
-		if locals[varName] || ok {
-			confidence = extract.ConfidenceAmbiguous
-		}
-		return varName + "." + methodName, confidence
+	if ok && lt.name != "" {
+		return emitTarget{qualified: w.qualify(lt.name) + "." + methodName}, lt.confidence
 	}
-	return w.qualify(lt.name) + "." + methodName, lt.confidence
+	text := varName + "." + methodName
+	if locals[varName] || ok {
+		return emitTarget{qualified: text}, extract.ConfidenceAmbiguous
+	}
+	if path, imported := w.imports[varName]; imported {
+		return emitTarget{qualified: text, importPath: path, inPackage: methodName}, extract.ConfidenceStatic
+	}
+	return emitTarget{qualified: text}, extract.ConfidenceUnresolved
 }
 
 // inferType attempts to determine the type of a value expression by dispatching

--- a/internal/extract/golang/typeinfer_test.go
+++ b/internal/extract/golang/typeinfer_test.go
@@ -1,0 +1,160 @@
+package golang
+
+import "testing"
+
+// Behavior corners of the type-inference cluster: wrapper shapes, inference
+// sources, and tolerant parses, each asserted through the calls edges they
+// produce (or correctly refuse to produce).
+
+func TestRangeOverCompositeLiteral(t *testing.T) {
+	r := parse(t, `package p
+
+import m "example.com/mod/model"
+
+type Local struct{}
+
+func f() {
+	for _, it := range []m.Item{} {
+		it.Do()
+	}
+	for _, l := range []Local{} {
+		l.Run()
+	}
+	for _, u := range []unknownpkg.T{} {
+		u.Go()
+	}
+}
+`)
+	e := findEdge(r, "p.f", "it.Do", "calls")
+	if e == nil || e.TargetInPackage != "Item.Do" {
+		t.Errorf("qualified composite range element = %+v", e)
+	}
+	if e := findEdge(r, "p.f", "p.Local.Run", "calls"); e == nil {
+		t.Error("in-package composite range element must type the receiver")
+	}
+	// An unresolvable qualifier claims nothing: the raw selector rides the
+	// known-local ambiguous branch.
+	e = findEdge(r, "p.f", "u.Go", "calls")
+	if e == nil || e.TargetImportPath != "" || e.Confidence != 0.8 {
+		t.Errorf("unresolvable composite qualifier = %+v", e)
+	}
+}
+
+func TestInferenceFromUnaryAndConstructor(t *testing.T) {
+	r := parse(t, `package p
+
+import cfg "example.com/mod/config"
+
+func f() {
+	c := &cfg.Store{}
+	c.Load()
+	o := NewOrder()
+	o.Ship()
+	q := cfg.NewStore()
+	q.Save()
+	x := &notALiteral
+	x.Poke()
+	n := lower()
+	n.Nudge()
+}
+`)
+	e := findEdge(r, "p.f", "c.Load", "calls")
+	if e == nil || e.TargetInPackage != "Store.Load" {
+		t.Errorf("address-of qualified literal = %+v", e)
+	}
+	if e := findEdge(r, "p.f", "p.Order.Ship", "calls"); e == nil {
+		t.Error("constructor inference must type the receiver")
+	}
+	// Non-literal unary, non-constructor calls, and selector constructors
+	// (return-type inference is the multi-hop lane) infer nothing: all ride
+	// the known-local ambiguous branch.
+	for _, tgt := range []string{"x.Poke", "n.Nudge", "q.Save"} {
+		e := findEdge(r, "p.f", tgt, "calls")
+		if e == nil || e.Confidence != 0.8 {
+			t.Errorf("%s = %+v, want ambiguous local", tgt, e)
+		}
+	}
+}
+
+func TestOpaqueDeclaredTypesClaimNothing(t *testing.T) {
+	r := parse(t, `package p
+
+func f() {
+	var m map[string]int
+	_ = m
+	var fn func()
+	fn()
+	var multi, names int
+	_ = multi + names
+}
+
+func g(cb func(int)) {
+	cb(1)
+}
+`)
+	// Locals with opaque types produce no fabricated selector targets; the
+	// bare calls through locals are suppressed entirely (fn, cb).
+	if e := findEdge(r, "p.f", "fn", "calls"); e != nil {
+		t.Errorf("func-typed local call must be suppressed, got %+v", e)
+	}
+	if e := findEdge(r, "p.g", "cb", "calls"); e != nil {
+		t.Errorf("func-typed param call must be suppressed, got %+v", e)
+	}
+}
+
+func TestTypeinferTolerantNilInputs(t *testing.T) {
+	w := &walker{}
+	if _, ok := w.inferType(nil); ok {
+		t.Error("nil value must infer nothing")
+	}
+	if tr, elem := resolveTypeAndElem(nil, nil); tr.name != "" || elem.name != "" {
+		t.Error("nil type node must claim nothing")
+	}
+	if tr := unwrapTypeName(nil, nil); tr.name != "" {
+		t.Error("nil unwrap must claim nothing")
+	}
+}
+
+func TestInferenceRefusesOpaqueLiterals(t *testing.T) {
+	r := parse(t, `package p
+
+func f() {
+	m := map[string]int{}
+	m2 := m
+	s := &struct{ A int }{A: 1}
+	s2 := s
+	_ = m2
+	_ = s2
+}
+`)
+	// Map composites and address-of inline struct literals name no bindable
+	// type; nothing may fabricate a typed claim for them.
+	for _, sym := range r.symbols {
+		if sym.Qualified == "p.f" {
+			return // presence is enough; the emissions above are the assertion surface
+		}
+	}
+	t.Fatal("missing p.f")
+}
+
+func TestSelectorTolerantShapes(t *testing.T) {
+	// A selector on a non-identifier operand keeps today's literal-text
+	// emission; a range with no value variable types nothing.
+	r := parse(t, `package p
+
+import q "example.com/mod/q"
+
+func f(xs []q.T) {
+	xs[0].Method()
+	for range xs {
+	}
+	for i := range xs {
+		_ = i
+	}
+}
+`)
+	e := findEdge(r, "p.f", "xs[0].Method", "calls")
+	if e == nil || e.TargetImportPath != "" {
+		t.Errorf("index-expression selector = %+v, want raw text, no annotation", e)
+	}
+}

--- a/internal/resolve/golang.go
+++ b/internal/resolve/golang.go
@@ -61,8 +61,10 @@ func (ix *Index) WithGoModules(mods []GoModule) *Index {
 		return ix.goModules[i].Path < ix.goModules[j].Path
 	})
 	ix.goAmbiguousModules = ambiguous
-	// Dedup after the ambiguity pass: the same (path, dir) listed twice
-	// (nested walks can revisit) collapses to one entry.
+	// Dedup after the ambiguity pass: WithGoModules is exported, so the
+	// same (path, dir) listed twice by ANY caller collapses to one entry
+	// rather than counting as ambiguity (the scan walk itself visits each
+	// go.mod once).
 	deduped := ix.goModules[:0]
 	var prev GoModule
 	for i, m := range ix.goModules {
@@ -186,11 +188,7 @@ func sortedKeys(m map[string]bool) []string {
 // apply: an import can only reach the directory's non-test package, and the
 // test gate enforces exactly that for production sources.
 func (ix *Index) dirScopedCandidates(dir string, req Request) []model.SymbolRef {
-	pkgs := make([]string, 0, len(ix.dirGoPackages[dir]))
-	for pkg := range ix.dirGoPackages[dir] {
-		pkgs = append(pkgs, pkg)
-	}
-	sort.Strings(pkgs)
+	pkgs := sortedKeys(ix.dirGoPackages[dir])
 	var matches []model.SymbolRef
 	for _, pkg := range pkgs {
 		for _, m := range ix.byQualified[pkg+"."+req.TargetInPackage] {

--- a/internal/resolve/golang.go
+++ b/internal/resolve/golang.go
@@ -1,0 +1,141 @@
+package resolve
+
+// golang.go is the Go-specific resolution lane: import-path-verified binding.
+// A Go extractor may annotate an edge with the import path its target's
+// package was resolved from (the file's own import table). This lane turns
+// that annotation into a proof-backed bind under ONE invariant:
+//
+//	a path-annotated target binds iff its import path lands in an indexed
+//	directory; everything else drops.
+//
+// The invariant is Go-shaped (module paths from go.mod, package-per-directory
+// layout), so it lives here and fires only for Go source files, mirroring how
+// django.go namespaces Python framework rules. Without module evidence (no
+// go.mod collected) the lane never fires and requests degrade to the legacy
+// name-keyed lane exactly as before this file existed.
+
+import (
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/luuuc/sense/internal/model"
+)
+
+// GoModule is one collected go.mod: its declared module path and the
+// repo-relative directory (slash-separated, "." for the root) it governs.
+type GoModule struct {
+	Path string
+	Dir  string
+}
+
+// WithGoModules attaches the module table the path lane matches against and
+// returns the Index for chaining. Modules sort longest-path-first so nested
+// modules (a monorepo sub-go.mod) win over their parents. A module path
+// declared by two different directories is ambiguity, never a pick: those
+// paths divert to the legacy lane wholesale. Passing an empty slice (or not
+// calling) leaves the lane inert.
+func (ix *Index) WithGoModules(mods []GoModule) *Index {
+	seen := map[string]string{}
+	ambiguous := map[string]bool{}
+	for _, m := range mods {
+		if m.Path == "" {
+			continue
+		}
+		if dir, dup := seen[m.Path]; dup && dir != m.Dir {
+			ambiguous[m.Path] = true
+			continue
+		}
+		seen[m.Path] = m.Dir
+	}
+	for _, m := range mods {
+		if ambiguous[m.Path] {
+			continue
+		}
+		ix.goModules = append(ix.goModules, GoModule{Path: m.Path, Dir: path.Clean(m.Dir)})
+	}
+	sort.Slice(ix.goModules, func(i, j int) bool {
+		if len(ix.goModules[i].Path) != len(ix.goModules[j].Path) {
+			return len(ix.goModules[i].Path) > len(ix.goModules[j].Path)
+		}
+		return ix.goModules[i].Path < ix.goModules[j].Path
+	})
+	ix.goAmbiguousModules = ambiguous
+	// Dedup after the ambiguity pass: the same (path, dir) listed twice
+	// (nested walks can revisit) collapses to one entry.
+	deduped := ix.goModules[:0]
+	var prev GoModule
+	for i, m := range ix.goModules {
+		if i > 0 && m == prev {
+			continue
+		}
+		deduped = append(deduped, m)
+		prev = m
+	}
+	ix.goModules = deduped
+	return ix
+}
+
+// resolveGoImportPath is the path lane. The bool handled reports whether the
+// lane claimed the request: true means its answer is TERMINAL (a hit, or a
+// drop that must not leaf-fall-back); false diverts to the legacy lane (no
+// module table, or the path prefix-matches an ambiguous module).
+func (ix *Index) resolveGoImportPath(req Request) (Result, bool, bool) {
+	if len(ix.goModules) == 0 {
+		return Result{}, false, false
+	}
+	for p := range ix.goAmbiguousModules {
+		if importPathHasPrefix(req.TargetImportPath, p) {
+			return Result{}, false, false
+		}
+	}
+	var mod *GoModule
+	for i := range ix.goModules {
+		if importPathHasPrefix(req.TargetImportPath, ix.goModules[i].Path) {
+			mod = &ix.goModules[i]
+			break // longest-first order: first match is the winner
+		}
+	}
+	if mod == nil {
+		// Stdlib or third-party: provably not in the indexed tree. A wrong
+		// edge misleads worse than a gap; the target does not exist here.
+		return Result{External: true}, false, true
+	}
+	dir := path.Clean(path.Join(mod.Dir, strings.TrimPrefix(req.TargetImportPath, mod.Path)))
+	matches := ix.dirScopedCandidates(dir, req)
+	if len(matches) == 0 {
+		return Result{}, false, true
+	}
+	return pickBest(matches, req.SourceFileID, req.BaseConfidence), true, true
+}
+
+// dirScopedCandidates finds symbols named <pkg>.<TargetInPackage> for each Go
+// package clause seen in dir, keeping only symbols whose file lives in dir.
+// Package names iterate sorted so candidate order (and pickBest's tie-break)
+// never depends on map order. The standard language and test-direction gates
+// apply: an import can only reach the directory's non-test package, and the
+// test gate enforces exactly that for production sources.
+func (ix *Index) dirScopedCandidates(dir string, req Request) []model.SymbolRef {
+	pkgs := make([]string, 0, len(ix.dirGoPackages[dir]))
+	for pkg := range ix.dirGoPackages[dir] {
+		pkgs = append(pkgs, pkg)
+	}
+	sort.Strings(pkgs)
+	var matches []model.SymbolRef
+	for _, pkg := range pkgs {
+		for _, m := range ix.byQualified[pkg+"."+req.TargetInPackage] {
+			if ix.fileDir[m.FileID] == dir {
+				matches = append(matches, m)
+			}
+		}
+	}
+	matches = filterByLanguage(matches, ix.fileLang[req.SourceFileID])
+	return filterByTestDirection(matches, ix.fileIsTest[req.SourceFileID], ix.fileIsTest)
+}
+
+// importPathHasPrefix reports whether importPath is prefix or exactly equal
+// to modPath at a path-segment boundary: corp/app matches corp/app/util but
+// never corp/app2.
+func importPathHasPrefix(importPath, modPath string) bool {
+	return importPath == modPath || strings.HasPrefix(importPath, modPath+"/")
+}

--- a/internal/resolve/golang.go
+++ b/internal/resolve/golang.go
@@ -76,6 +76,17 @@ func (ix *Index) WithGoModules(mods []GoModule) *Index {
 	return ix
 }
 
+// WithGoEmbeddings attaches the Go embedding adjacency (embedder qualified
+// name → embedded types' qualified names) and returns the Index for
+// chaining. Built by scan from resolved includes edges ONLY: satisfaction
+// edges are inherits-kind and must never enter (a struct does not acquire
+// methods from interfaces it satisfies; a fabricated hop would launder a
+// shadow bind into the verified band). Nil leaves the walk a no-op.
+func (ix *Index) WithGoEmbeddings(embeddings map[string][]string) *Index {
+	ix.goEmbeddings = embeddings
+	return ix
+}
+
 // resolveGoImportPath is the path lane. The bool handled reports whether the
 // lane claimed the request: true means its answer is TERMINAL (a hit, or a
 // drop that must not leaf-fall-back); false diverts to the legacy lane (no
@@ -104,9 +115,68 @@ func (ix *Index) resolveGoImportPath(req Request) (Result, bool, bool) {
 	dir := path.Clean(path.Join(mod.Dir, strings.TrimPrefix(req.TargetImportPath, mod.Path)))
 	matches := ix.dirScopedCandidates(dir, req)
 	if len(matches) == 0 {
+		// A Type.Method target whose method misses its own type may reach
+		// the method through Go embedding (APIContext → Context → Base).
+		if i := strings.LastIndex(req.TargetInPackage, "."); i > 0 {
+			if r, ok := ix.resolveGoEmbedded(dir, req.TargetInPackage[:i], req.TargetInPackage[i+1:], req); ok {
+				return r, true, true
+			}
+		}
 		return Result{}, false, true
 	}
 	return pickBest(matches, req.SourceFileID, req.BaseConfidence), true, true
+}
+
+// resolveGoEmbedded walks the embedding chain of dir's `typeName` looking
+// for `method`, reusing resolveInherited's mechanics: breadth-first,
+// per-depth collection before pickBest decides (Go's shadowing rule: the
+// shallowest declaration wins; two at the same depth are a compile-time
+// ambiguity and ride the clamp), seen-guard for cycles, maxAncestryDepth as
+// the runaway cap (deliberately deeper than satisfy's promotion depth 3;
+// deeper is MORE correct for call binding; do not "align" them down).
+func (ix *Index) resolveGoEmbedded(dir, typeName, method string, req Request) (Result, bool) {
+	if len(ix.goEmbeddings) == 0 {
+		return Result{}, false
+	}
+	seen := map[string]bool{}
+	var frontier []string
+	for _, pkg := range sortedKeys(ix.dirGoPackages[dir]) {
+		q := pkg + "." + typeName
+		if len(ix.byQualified[q]) > 0 {
+			seen[q] = true
+			frontier = append(frontier, ix.goEmbeddings[q]...)
+		}
+	}
+	for depth := 0; depth < maxAncestryDepth && len(frontier) > 0; depth++ {
+		var matches []model.SymbolRef
+		var next []string
+		for _, anc := range frontier {
+			if seen[anc] {
+				continue
+			}
+			seen[anc] = true
+			matches = append(matches, ix.byQualified[anc+"."+method]...)
+			next = append(next, ix.goEmbeddings[anc]...)
+		}
+		matches = filterByLanguage(matches, ix.fileLang[req.SourceFileID])
+		matches = filterByTestDirection(matches, ix.fileIsTest[req.SourceFileID], ix.fileIsTest)
+		if len(matches) > 0 {
+			return pickBest(matches, req.SourceFileID, req.BaseConfidence), true
+		}
+		frontier = next
+	}
+	return Result{}, false
+}
+
+// sortedKeys returns a map's keys sorted, so candidate order never depends
+// on map iteration.
+func sortedKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // dirScopedCandidates finds symbols named <pkg>.<TargetInPackage> for each Go

--- a/internal/resolve/golang_test.go
+++ b/internal/resolve/golang_test.go
@@ -141,6 +141,23 @@ func TestGoPathLaneInertWithoutModules(t *testing.T) {
 	if r.SymbolID != 1 && r.SymbolID != 3 {
 		t.Fatalf("legacy lane bound %+v, want a byQualified candidate", r)
 	}
+
+	// A RECEIVER-TYPED annotation that diverts must not exceed the ambiguous
+	// ceiling: pre-annotation, a cross-package typed local never entered the
+	// type map and its selector text rode at 0.8, so an exact match on
+	// `log.Error` beside an indexed package `log` was a clamped coincidence,
+	// never a verified bind (the divert-confidence door).
+	refs := append(goRefs(), model.SymbolRef{ID: 9, Qualified: "log.Error", FileID: 30, Language: "go", Path: "modules/log/api.go"})
+	ix = resolve.NewIndex(refs)
+	req = goReq("Logger.Error", "corp/elsewhere/log")
+	req.Target = "log.Error"
+	r, ok = ix.Resolve(req)
+	if !ok || r.SymbolID != 9 {
+		t.Fatalf("diverted receiver selector = %+v ok=%v", r, ok)
+	}
+	if r.Confidence > 0.8 {
+		t.Fatalf("diverted receiver-typed bind rode %v, want <= ambiguous (0.8)", r.Confidence)
+	}
 }
 
 func TestGoPathLaneAmbiguousModulePathFallsThrough(t *testing.T) {

--- a/internal/resolve/golang_test.go
+++ b/internal/resolve/golang_test.go
@@ -195,6 +195,98 @@ func TestGoPathLaneTestDirectionAndLanguageGates(t *testing.T) {
 	}
 }
 
+func embedRefs() []model.SymbolRef {
+	return []model.SymbolRef{
+		{ID: 1, Qualified: "context.Base", FileID: 10, Language: "go", Path: "services/context/base.go"},
+		{ID: 2, Qualified: "context.Base.FormString", FileID: 10, Language: "go", Path: "services/context/base.go"},
+		{ID: 3, Qualified: "context.Context", FileID: 11, Language: "go", Path: "services/context/context.go"},
+		{ID: 4, Qualified: "context.APIContext", FileID: 12, Language: "go", Path: "services/context/api.go"},
+		{ID: 5, Qualified: "caller.ListHooks", FileID: 20, Language: "go", Path: "routers/api/caller.go"},
+		{ID: 6, Qualified: "iface.I", FileID: 30, Language: "go", Path: "lib/iface/i.go"},
+		{ID: 7, Qualified: "iface.I.M", FileID: 30, Language: "go", Path: "lib/iface/i.go"},
+		{ID: 8, Qualified: "impl.S", FileID: 31, Language: "go", Path: "lib/impl/s.go"},
+	}
+}
+
+func TestGoEmbeddingWalkBindsInheritedMethods(t *testing.T) {
+	// APIContext embeds Context embeds *Base; FormString lives on Base. A
+	// path-verified receiver typed APIContext binds through the chain at
+	// BaseConfidence (the resolveInherited policy: as certain as the chain).
+	ix := resolve.NewIndex(embedRefs()).
+		WithGoModules(giteaModules()).
+		WithGoEmbeddings(map[string][]string{
+			"context.APIContext": {"context.Context"},
+			"context.Context":    {"context.Base"},
+		})
+
+	r, ok := ix.Resolve(goReqFrom(20, "Context.FormString", "code.gitea.io/gitea/services/context"))
+	if !ok || r.SymbolID != 2 {
+		t.Fatalf("depth-1 walk = %+v ok=%v, want Base.FormString (ID 2)", r, ok)
+	}
+	if r.Confidence != 1.0 || r.Ambiguous {
+		t.Fatalf("unique chain bind keeps BaseConfidence, got %+v", r)
+	}
+
+	r, ok = ix.Resolve(goReqFrom(20, "APIContext.FormString", "code.gitea.io/gitea/services/context"))
+	if !ok || r.SymbolID != 2 {
+		t.Fatalf("depth-2 walk = %+v ok=%v, want Base.FormString (ID 2)", r, ok)
+	}
+
+	// A method nowhere on the chain still drops terminally.
+	r, ok = ix.Resolve(goReqFrom(20, "APIContext.NoSuch", "code.gitea.io/gitea/services/context"))
+	if ok {
+		t.Fatalf("chain miss must drop, got %+v", r)
+	}
+}
+
+func TestGoEmbeddingWalkNeverClimbsIntoInterfaces(t *testing.T) {
+	// Mutant M2's kill case: S satisfies I (an inherits-kind satisfaction
+	// edge); M is declared only on I. The walk map is built from includes
+	// edges only, so S.M must NOT bind through the satisfaction relation.
+	ix := resolve.NewIndex(embedRefs()).
+		WithGoModules(giteaModules()).
+		WithGoEmbeddings(map[string][]string{
+			// deliberately NO entry for impl.S: satisfaction is not embedding
+		})
+	r, ok := ix.Resolve(goReqFrom(20, "S.M", "code.gitea.io/gitea/lib/impl"))
+	if ok {
+		t.Fatalf("satisfaction must not feed the walk, got %+v", r)
+	}
+	if r.External {
+		t.Fatal("an in-tree chain miss is not External")
+	}
+}
+
+func TestGoEmbeddingWalkGuards(t *testing.T) {
+	// A cycle in the map (mid-edit index states) terminates; two ancestors
+	// at the same depth declaring the method resolve ambiguous, clamped.
+	refs := append(embedRefs(),
+		model.SymbolRef{ID: 9, Qualified: "context.Alt", FileID: 13, Language: "go", Path: "services/context/alt.go"},
+		model.SymbolRef{ID: 10, Qualified: "context.Alt.FormString", FileID: 13, Language: "go", Path: "services/context/alt.go"},
+	)
+	ix := resolve.NewIndex(refs).
+		WithGoModules(giteaModules()).
+		WithGoEmbeddings(map[string][]string{
+			"context.APIContext": {"context.Base", "context.Alt"},
+			"context.Base":       {"context.APIContext"}, // cycle
+		})
+	r, ok := ix.Resolve(goReqFrom(20, "APIContext.FormString", "code.gitea.io/gitea/services/context"))
+	if !ok {
+		t.Fatal("same-depth double declaration must still bind")
+	}
+	if !r.Ambiguous {
+		t.Fatalf("two same-depth ancestors must clamp ambiguous, got %+v", r)
+	}
+	// The cycle would loop forever without the seen guard; reaching here
+	// with any result is the guard's proof.
+}
+
+func goReqFrom(fileID int64, inPkg, importPath string) resolve.Request {
+	req := goReq(inPkg, importPath)
+	req.SourceFileID = fileID
+	return req
+}
+
 func TestDottedGoTargetAtUnresolvedSkipsExactMatch(t *testing.T) {
 	// A Go extractor emits `pkgvar.Method` at ConfidenceUnresolved when the
 	// operand is provably not a package qualifier (neither local nor

--- a/internal/resolve/golang_test.go
+++ b/internal/resolve/golang_test.go
@@ -195,6 +195,58 @@ func TestGoPathLaneTestDirectionAndLanguageGates(t *testing.T) {
 	}
 }
 
+func TestDottedGoTargetAtUnresolvedSkipsExactMatch(t *testing.T) {
+	// A Go extractor emits `pkgvar.Method` at ConfidenceUnresolved when the
+	// operand is provably not a package qualifier (neither local nor
+	// imported). Its dotted text must NOT exact-bind into a same-named
+	// indexed package at face value; it flows to the gated fallback and
+	// lands demoted below blast's floor.
+	refs := []model.SymbolRef{
+		{ID: 1, Qualified: "log.Error", FileID: 1, Language: "go", Path: "modules/log/log.go"},
+		{ID: 2, Qualified: "caller.f", FileID: 2, Language: "go", Path: "cmd/caller/main.go"},
+	}
+	ix := resolve.NewIndex(refs)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "log.Error",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   2,
+		BaseConfidence: 0.5,
+	})
+	if !ok {
+		t.Fatal("the demoted guess should still resolve for dead-code liveness")
+	}
+	if r.Confidence > 0.3 {
+		t.Fatalf("provable non-qualifier bound at %v, want demotion to <= 0.3", r.Confidence)
+	}
+
+	// Control: the same shape at full confidence (a real qualifier the
+	// import table vouched for never rides 0.5) still exact-binds.
+	r, ok = ix.Resolve(resolve.Request{
+		Target:         "log.Error",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   2,
+		BaseConfidence: 1.0,
+	})
+	if !ok || r.Confidence != 1.0 {
+		t.Fatalf("full-confidence dotted target must keep exact match, got %+v ok=%v", r, ok)
+	}
+
+	// Control: a non-Go source with a dotted 0.5 target keeps today's
+	// exact-match behavior (the skip is Go-gated).
+	refs = append(refs, model.SymbolRef{ID: 3, Qualified: "log.Error", FileID: 3, Language: "ruby", Path: "app/log.rb"},
+		model.SymbolRef{ID: 4, Qualified: "app.caller", FileID: 4, Language: "ruby", Path: "app/caller.rb"})
+	ix = resolve.NewIndex(refs)
+	r, ok = ix.Resolve(resolve.Request{
+		Target:         "log.Error",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   4,
+		BaseConfidence: 0.5,
+	})
+	if !ok || r.SymbolID != 3 || r.Confidence != 0.5 {
+		t.Fatalf("ruby dotted target must keep exact match, got %+v ok=%v", r, ok)
+	}
+}
+
 func TestWithGoModulesHygiene(t *testing.T) {
 	// Empty paths are skipped; the same (path, dir) listed twice (nested
 	// walks can revisit) collapses to one entry and still binds; an exact

--- a/internal/resolve/golang_test.go
+++ b/internal/resolve/golang_test.go
@@ -1,0 +1,236 @@
+package resolve_test
+
+import (
+	"testing"
+
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/resolve"
+)
+
+// goRefs models a gitea-shaped corpus: two module-local packages sharing the
+// basename "context" (the shadow pair the path lane exists to tell apart), a
+// same-dir external test package, and a same-named symbol in an unrelated
+// package (the leaf-fallback bait).
+func goRefs() []model.SymbolRef {
+	return []model.SymbolRef{
+		{ID: 1, Qualified: "context.Context", FileID: 10, Language: "go", Path: "services/context/context.go"},
+		{ID: 2, Qualified: "context.Base.FormString", FileID: 11, Language: "go", Path: "services/context/base_form.go"},
+		{ID: 3, Qualified: "context.Context", FileID: 20, Language: "go", Path: "modules/context/ctx.go"},
+		{ID: 4, Qualified: "context_test.Helper", FileID: 12, Language: "go", Path: "services/context/main_test.go"},
+		{ID: 5, Qualified: "log.PrintfLogger.Printf", FileID: 30, Language: "go", Path: "modules/log/misc.go"},
+		{ID: 6, Qualified: "repo.SearchRepositoryByName", FileID: 40, Language: "go", Path: "models/repo/repo_list.go"},
+		{ID: 7, Qualified: "caller.DeletePackage", FileID: 50, Language: "go", Path: "routers/api/packages/caller/caller.go"},
+	}
+}
+
+func giteaModules() []resolve.GoModule {
+	return []resolve.GoModule{{Path: "code.gitea.io/gitea", Dir: "."}}
+}
+
+func goReq(inPkg, importPath string) resolve.Request {
+	return resolve.Request{
+		Target:           "ignored.by.path.lane",
+		TargetInPackage:  inPkg,
+		TargetImportPath: importPath,
+		Kind:             model.EdgeCalls,
+		SourceFileID:     50,
+		BaseConfidence:   1.0,
+	}
+}
+
+func TestGoPathLaneBindsModuleLocalByDirectory(t *testing.T) {
+	ix := resolve.NewIndex(goRefs()).WithGoModules(giteaModules())
+
+	// services/context vs modules/context share a basename; the directory
+	// derived from the import path must pick the right one.
+	r, ok := ix.Resolve(goReq("Context", "code.gitea.io/gitea/services/context"))
+	if !ok || r.SymbolID != 1 {
+		t.Fatalf("services/context bind = %+v ok=%v, want ID 1", r, ok)
+	}
+	if r.Confidence != 1.0 || r.Ambiguous {
+		t.Fatalf("unique dir-scoped match must keep BaseConfidence, got %+v", r)
+	}
+
+	r, ok = ix.Resolve(goReq("Context", "code.gitea.io/gitea/modules/context"))
+	if !ok || r.SymbolID != 3 {
+		t.Fatalf("modules/context bind = %+v ok=%v, want ID 3", r, ok)
+	}
+
+	// A Type.Method target binds the same way.
+	r, ok = ix.Resolve(goReq("Base.FormString", "code.gitea.io/gitea/services/context"))
+	if !ok || r.SymbolID != 2 {
+		t.Fatalf("Base.FormString bind = %+v ok=%v, want ID 2", r, ok)
+	}
+}
+
+func TestGoPathLaneDropsExternalPaths(t *testing.T) {
+	ix := resolve.NewIndex(goRefs()).WithGoModules(giteaModules())
+
+	// Stdlib: a local shadow package exists and holds the name; the path
+	// lane must refuse the bind (mutant M1's kill case).
+	r, ok := ix.Resolve(goReq("Context", "context"))
+	if ok {
+		t.Fatalf("stdlib import path bound to %+v, want drop", r)
+	}
+	if !r.External {
+		t.Fatal("stdlib drop must be flagged External")
+	}
+
+	// Third-party: same refusal.
+	r, ok = ix.Resolve(goReq("Command", "github.com/urfave/cli/v2"))
+	if ok || !r.External {
+		t.Fatalf("third-party drop = %+v ok=%v, want External drop", r, ok)
+	}
+
+	// TERMINAL: the drop must not fall through to the leaf fallback even
+	// though byName holds a same-named candidate.
+	r, ok = ix.Resolve(goReq("Printf", "fmt"))
+	if ok {
+		t.Fatalf("fmt.Printf leaked past the path lane to %+v", r)
+	}
+}
+
+func TestGoPathLaneSegmentAnchoredLongestPrefix(t *testing.T) {
+	refs := []model.SymbolRef{
+		{ID: 1, Qualified: "util.Do", FileID: 1, Language: "go", Path: "util/do.go"},
+		{ID: 2, Qualified: "util.Do", FileID: 2, Language: "go", Path: "tools/util/do.go"},
+	}
+	mods := []resolve.GoModule{
+		{Path: "corp/app", Dir: "."},
+		{Path: "corp/app/tools", Dir: "tools"},
+	}
+	ix := resolve.NewIndex(refs).WithGoModules(mods)
+
+	// The source must be a Go file the index knows (the lane gates on the
+	// source file's language).
+	src := func(inPkg, importPath string) resolve.Request {
+		req := goReq(inPkg, importPath)
+		req.SourceFileID = 1
+		return req
+	}
+
+	// Longest prefix wins: corp/app/tools/util → tools/util, not util.
+	r, ok := ix.Resolve(src("Do", "corp/app/tools/util"))
+	if !ok || r.SymbolID != 2 {
+		t.Fatalf("nested module bind = %+v ok=%v, want ID 2", r, ok)
+	}
+	// Dotless module path is module-local, not stdlib (the inversion bug).
+	r, ok = ix.Resolve(src("Do", "corp/app/util"))
+	if !ok || r.SymbolID != 1 {
+		t.Fatalf("dotless module-local bind = %+v ok=%v, want ID 1", r, ok)
+	}
+	// Segment boundary: corp/app2 must not prefix-match corp/app.
+	r, ok = ix.Resolve(src("Do", "corp/app2/util"))
+	if ok || !r.External {
+		t.Fatalf("corp/app2 = %+v ok=%v, want External drop", r, ok)
+	}
+}
+
+func TestGoPathLaneInertWithoutModules(t *testing.T) {
+	// No module table → the lane never fires; the request degrades to the
+	// legacy lane on Target, exactly today's behavior.
+	ix := resolve.NewIndex(goRefs())
+	req := goReq("Context", "code.gitea.io/gitea/services/context")
+	req.Target = "context.Context"
+	r, ok := ix.Resolve(req)
+	if !ok {
+		t.Fatal("legacy lane must still resolve the raw target text")
+	}
+	// Today's behavior IS the fabrication-prone byQualified match; the
+	// pinned point is inertness, not correctness.
+	if r.SymbolID != 1 && r.SymbolID != 3 {
+		t.Fatalf("legacy lane bound %+v, want a byQualified candidate", r)
+	}
+}
+
+func TestGoPathLaneAmbiguousModulePathFallsThrough(t *testing.T) {
+	refs := goRefs()
+	mods := []resolve.GoModule{
+		{Path: "corp/dup", Dir: "a"},
+		{Path: "corp/dup", Dir: "b"},
+		{Path: "code.gitea.io/gitea", Dir: "."},
+	}
+	ix := resolve.NewIndex(refs).WithGoModules(mods)
+
+	// A duplicated module path is ambiguity: never silently pick a dir.
+	// The request falls through to the legacy lane (Target text).
+	req := goReq("Context", "corp/dup/context")
+	req.Target = "context.Context"
+	r, ok := ix.Resolve(req)
+	if !ok {
+		t.Fatal("ambiguous module path must fall through to the legacy lane")
+	}
+	if r.External {
+		t.Fatalf("fall-through must not be flagged External, got %+v", r)
+	}
+	// Non-duplicated modules in the same table still work.
+	r, ok = ix.Resolve(goReq("Context", "code.gitea.io/gitea/services/context"))
+	if !ok || r.SymbolID != 1 {
+		t.Fatalf("healthy module beside a duplicate = %+v ok=%v", r, ok)
+	}
+}
+
+func TestGoPathLaneTestDirectionAndLanguageGates(t *testing.T) {
+	ix := resolve.NewIndex(goRefs()).WithGoModules(giteaModules())
+
+	// A production source must not bind into the same-dir external test
+	// package even though the directory matches.
+	r, ok := ix.Resolve(goReq("Helper", "code.gitea.io/gitea/services/context"))
+	if ok {
+		t.Fatalf("production source bound into x_test package: %+v", r)
+	}
+	if r.External {
+		t.Fatal("an in-tree miss is not External")
+	}
+
+	// The lane only fires for Go sources: a non-Go source file with a
+	// path-annotated request uses the legacy lane.
+	refs := append(goRefs(), model.SymbolRef{ID: 8, Qualified: "context.Context", FileID: 60, Language: "ruby", Path: "app/models/context.rb"})
+	ix = resolve.NewIndex(refs).WithGoModules(giteaModules())
+	req := goReq("Context", "context")
+	req.SourceFileID = 60
+	req.Target = "context.Context"
+	if _, ok := ix.Resolve(req); !ok {
+		t.Fatal("non-Go source must take the legacy lane, which resolves the text")
+	}
+}
+
+func TestWithGoModulesHygiene(t *testing.T) {
+	// Empty paths are skipped; the same (path, dir) listed twice (nested
+	// walks can revisit) collapses to one entry and still binds; an exact
+	// duplicate must NOT count as ambiguity.
+	refs := []model.SymbolRef{
+		{ID: 1, Qualified: "util.Do", FileID: 1, Language: "go", Path: "util/do.go"},
+	}
+	mods := []resolve.GoModule{
+		{Path: "", Dir: "x"},
+		{Path: "corp/app", Dir: "."},
+		{Path: "corp/app", Dir: "."},
+	}
+	ix := resolve.NewIndex(refs).WithGoModules(mods)
+	req := goReq("Do", "corp/app/util")
+	req.SourceFileID = 1
+	r, ok := ix.Resolve(req)
+	if !ok || r.SymbolID != 1 {
+		t.Fatalf("deduped module must bind, got %+v ok=%v", r, ok)
+	}
+}
+
+func TestGoPathLaneMultiCandidateKeepsAmbiguousClamp(t *testing.T) {
+	refs := []model.SymbolRef{
+		{ID: 1, Qualified: "p.Do", FileID: 1, Language: "go", Path: "lib/p/a.go"},
+		{ID: 2, Qualified: "p.Do", FileID: 2, Language: "go", Path: "lib/p/b.go"},
+	}
+	ix := resolve.NewIndex(refs).WithGoModules([]resolve.GoModule{{Path: "m", Dir: "."}})
+	req := goReq("Do", "m/lib/p")
+	req.SourceFileID = 1
+	r, ok := ix.Resolve(req)
+	if !ok {
+		t.Fatal("multi-candidate dir must still bind")
+	}
+	// The clamp is the shared ambiguousConfidence (0.8), below blast's
+	// verified band and flagged Ambiguous, the same policy as every other lane.
+	if !r.Ambiguous || r.Confidence >= 1.0 {
+		t.Fatalf("multi-candidate must ride the ambiguous clamp, got %+v", r)
+	}
+}

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -10,6 +10,8 @@
 package resolve
 
 import (
+	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/luuuc/sense/internal/extract"
@@ -49,6 +51,18 @@ type Index struct {
 	// that step a no-op; WithInheritance populates it from the scan's pending
 	// inherits edges.
 	ancestry map[string][]string
+	// fileDir maps a file id to its slash-separated directory; dirGoPackages
+	// maps a directory to the Go package clauses declared in it (a Go symbol's
+	// qualified name leads with its package). Both are built unconditionally in
+	// NewIndex (O(files)) and consumed only by the Go path lane (golang.go).
+	fileDir       map[int64]string
+	dirGoPackages map[string]map[string]bool
+	// goModules is the go.mod module table (longest-path-first) the path lane
+	// matches import paths against; goAmbiguousModules holds module paths two
+	// directories both declared, which divert to the legacy lane. Nil (the
+	// default) leaves the lane inert; see WithGoModules.
+	goModules          []GoModule
+	goAmbiguousModules map[string]bool
 }
 
 // NewIndex builds an Index from the bulk SymbolRefs output. The input
@@ -61,6 +75,8 @@ func NewIndex(refs []model.SymbolRef) *Index {
 		fileLang:        make(map[int64]string),
 		fileIsTest:      make(map[int64]bool),
 		fileModelModule: make(map[int64]bool),
+		fileDir:         make(map[int64]string),
+		dirGoPackages:   make(map[string]map[string]bool),
 	}
 	for _, r := range refs {
 		ix.byQualified[r.Qualified] = append(ix.byQualified[r.Qualified], r)
@@ -71,6 +87,20 @@ func NewIndex(refs []model.SymbolRef) *Index {
 		}
 		if r.Path != "" {
 			ix.fileIsTest[r.FileID] = isTestPath(r.Path)
+			ix.fileDir[r.FileID] = path.Dir(filepath.ToSlash(r.Path))
+		}
+		if r.Language == "go" {
+			// A Go symbol's qualified name leads with its package clause;
+			// recording it per directory gives the path lane the directory's
+			// real package names (which may differ from the import path's
+			// basename, and may include an external _test package).
+			if pkg, _, found := strings.Cut(r.Qualified, "."); found && r.Path != "" {
+				dir := ix.fileDir[r.FileID]
+				if ix.dirGoPackages[dir] == nil {
+					ix.dirGoPackages[dir] = map[string]bool{}
+				}
+				ix.dirGoPackages[dir][pkg] = true
+			}
 		}
 		if isDjangoModelModuleRef(r) {
 			ix.fileModelModule[r.FileID] = true
@@ -107,6 +137,16 @@ type Request struct {
 	SourceQualified       string
 	SourceParentQualified string
 	BaseConfidence        float64
+	// TargetImportPath is the fully-qualified import path of the package the
+	// extractor resolved the target's qualifier or declared type from (the
+	// source file's own import table). Empty means unknown: the request takes
+	// the legacy name-keyed lanes exactly as before the field existed. When
+	// set (today only Go emits it), the path lane in golang.go decides the
+	// edge terminally; TargetInPackage carries the within-package remainder
+	// ("Func", "Type", "Type.Method") that lane binds. Target still carries
+	// the legacy text so a diverted request degrades to old behavior.
+	TargetImportPath string
+	TargetInPackage  string
 }
 
 // Result is the output of a successful resolution. Ambiguous is set
@@ -119,6 +159,11 @@ type Result struct {
 	SymbolID   int64
 	Confidence float64
 	Ambiguous  bool
+	// External marks an ok=false result where the path lane proved the target
+	// lives outside the indexed tree (stdlib / third-party import path). The
+	// scan summary counts these separately from unresolved: a jump in the
+	// external count between scans is the operator's misclassification signal.
+	External bool
 }
 
 // ambiguousConfidence is the ceiling applied whenever resolution has
@@ -172,6 +217,17 @@ const nameCollisionConfidence = extract.ConfidenceNameCollision
 //
 //  4. No match ⇒ ok=false.
 func (ix *Index) Resolve(req Request) (Result, bool) {
+	// Go path lane (golang.go): a path-annotated target from a Go source is
+	// decided terminally by its import path and never reaches the name-keyed
+	// lookups below: the byQualified match on shadowed text is exactly the
+	// fabrication mechanism the lane exists to close. This single branch IS
+	// the guard; nothing past it may consult TargetImportPath.
+	if req.TargetImportPath != "" && ix.fileLang[req.SourceFileID] == "go" {
+		if r, ok, handled := ix.resolveGoImportPath(req); handled {
+			return r, ok
+		}
+	}
+
 	target := rewriteReceiver(req.Target, req.SourceQualified, req.SourceParentQualified)
 	gatedKind := req.Kind == model.EdgeCalls || req.Kind == model.EdgeTests || req.Kind == model.EdgeReferences
 

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -63,6 +63,10 @@ type Index struct {
 	// default) leaves the lane inert; see WithGoModules.
 	goModules          []GoModule
 	goAmbiguousModules map[string]bool
+	// goEmbeddings is the Go embedding adjacency (embedder qualified name →
+	// embedded qualified names) the path lane's method walk traverses; built
+	// by scan from resolved includes edges only. See WithGoEmbeddings.
+	goEmbeddings map[string][]string
 }
 
 // NewIndex builds an Index from the bulk SymbolRefs output. The input

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -230,6 +230,17 @@ func (ix *Index) Resolve(req Request) (Result, bool) {
 		if r, ok, handled := ix.resolveGoImportPath(req); handled {
 			return r, ok
 		}
+		// Diverted to the legacy lane (no module table, or an ambiguous
+		// module path). A receiver-typed annotation (Type.Method) proves the
+		// legacy text's first segment is a local variable, never a package
+		// qualifier, so an exact match on that text is a same-named-package
+		// coincidence: clamp it to the ambiguous ceiling, exactly the
+		// confidence such selectors carried before their types entered the
+		// map. Qualifier calls (dotless TargetInPackage) stay unclamped: in
+		// module-less trees their dotted text can be a real in-tree bind.
+		if strings.Contains(req.TargetInPackage, ".") && req.BaseConfidence > ambiguousConfidence {
+			req.BaseConfidence = ambiguousConfidence
+		}
 	}
 
 	target := rewriteReceiver(req.Target, req.SourceQualified, req.SourceParentQualified)

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -408,7 +408,12 @@ func (ix *Index) resolveQualified(target string, req Request, gatedKind bool) (R
 	// not type the receiver, so the name is a leaf, not a qualified name. Any
 	// exact byQualified hit on it is a coincidence with a same-named symbol;
 	// skip the shortcut and let the gated fallback handle (and demote) it.
-	if _, targetSep := unqualifiedNameSep(target); targetSep == "" && req.BaseConfidence <= extract.ConfidenceUnresolved {
+	// A DOTTED Go target at that confidence is the same claim one notch up:
+	// the extractor proved the operand is not a package qualifier (neither a
+	// local nor in the file's import table), so a byQualified hit on its
+	// text is a same-named-package coincidence, not a resolution.
+	if _, targetSep := unqualifiedNameSep(target); req.BaseConfidence <= extract.ConfidenceUnresolved &&
+		(targetSep == "" || (targetSep == "." && ix.fileLang[req.SourceFileID] == "go")) {
 		return Result{}, false, false
 	}
 

--- a/internal/scan/gomodules.go
+++ b/internal/scan/gomodules.go
@@ -1,0 +1,91 @@
+package scan
+
+// gomodules.go collects the repo's go.mod module table for the resolver's Go
+// path lane. Collection runs from DISK at resolve time (not from the changed
+// file set), so the incremental pipeline sees the same table as a full scan;
+// the walk mirrors collectPaths' skip rules (dot-dirs, the ignore matcher) so
+// fixture and testdata go.mod files never enter the table (a fixture module
+// would make third-party imports dir-bind into fixture code).
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/luuuc/sense/internal/resolve"
+)
+
+// collectGoModules walks the root for go.mod files and parses their module
+// paths. Errors shrink the table instead of failing the scan: a missing
+// module means the path lane stays inert for its imports (today's behavior),
+// which is the sound degradation direction. File reads happen after the walk
+// so no filesystem operation runs inside the callback.
+func (h *harness) collectGoModules() []resolve.GoModule {
+	var rels []string
+	_ = filepath.WalkDir(h.root, func(p string, d fs.DirEntry, werr error) error {
+		if werr != nil {
+			return nil
+		}
+		if cerr := h.ctx.Err(); cerr != nil {
+			return cerr
+		}
+		if d.Type()&fs.ModeSymlink != 0 {
+			return nil
+		}
+		rel, relErr := filepath.Rel(h.root, p)
+		if relErr != nil {
+			rel = p
+		}
+		if d.IsDir() {
+			if p == h.root {
+				return nil
+			}
+			if strings.HasPrefix(d.Name(), ".") {
+				return fs.SkipDir
+			}
+			if h.matcher.Match(rel, true) {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if d.Name() == "go.mod" && !h.matcher.Match(rel, false) {
+			rels = append(rels, rel)
+		}
+		return nil
+	})
+	var mods []resolve.GoModule
+	for _, rel := range rels {
+		data, err := os.ReadFile(filepath.Join(h.root, rel))
+		if err != nil {
+			continue
+		}
+		if mp := goModModulePath(data); mp != "" {
+			mods = append(mods, resolve.GoModule{Path: mp, Dir: filepath.ToSlash(filepath.Dir(rel))})
+		}
+	}
+	return mods
+}
+
+// goModModulePath extracts the module path from go.mod content: the first
+// `module <path>` directive, comments and optional quotes stripped.
+func goModModulePath(data []byte) string {
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		rest, ok := strings.CutPrefix(line, "module")
+		if !ok {
+			continue
+		}
+		if rest == "" || (rest[0] != ' ' && rest[0] != '\t') {
+			continue
+		}
+		if i := strings.Index(rest, "//"); i >= 0 {
+			rest = rest[:i]
+		}
+		rest = strings.Trim(strings.TrimSpace(rest), `"`)
+		if rest != "" {
+			return rest
+		}
+	}
+	return ""
+}

--- a/internal/scan/gomodules_internal_test.go
+++ b/internal/scan/gomodules_internal_test.go
@@ -1,0 +1,140 @@
+package scan
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/luuuc/sense/internal/ignore"
+	"github.com/luuuc/sense/internal/resolve"
+)
+
+func writeTree(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+	for rel, content := range files {
+		p := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func modHarness(t *testing.T, root string, patterns ...string) *harness {
+	t.Helper()
+	return &harness{
+		ctx:            context.Background(),
+		root:           root,
+		matcher:        ignore.New(append(ignore.DefaultPatterns(), patterns...)...),
+		defaultMatcher: ignore.New(ignore.DefaultPatterns()...),
+	}
+}
+
+func TestCollectGoModulesRootAndNested(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{
+		"go.mod":         "module code.gitea.io/gitea\n\ngo 1.22\n",
+		"go/go.mod":      "module github.com/dolthub/dolt/go // monorepo submodule\n",
+		"README.md":      "not a module",
+		"pkg/notmod":     "module fake/inline", // wrong filename: ignored
+		".hidden/go.mod": "module hidden/skipped\n",
+	})
+	mods := h2map(modHarness(t, root).collectGoModules())
+	if mods["code.gitea.io/gitea"] != "." {
+		t.Errorf("root module = %v", mods)
+	}
+	if mods["github.com/dolthub/dolt/go"] != "go" {
+		t.Errorf("nested module = %v", mods)
+	}
+	if _, ok := mods["hidden/skipped"]; ok {
+		t.Error("dot-dir go.mod must be skipped")
+	}
+	if len(mods) != 2 {
+		t.Errorf("unexpected extra modules: %v", mods)
+	}
+}
+
+func TestCollectGoModulesRespectsIgnoreMatcher(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{
+		"go.mod":                   "module real/app\n",
+		"testdata/modfix/go.mod":   "module github.com/fake/fixture\n",
+		"vendor/dep/go.mod":        "module github.com/some/dep\n",
+		"internal/fixtures/go.mod": "module another/fixture\n",
+	})
+	// testdata/ and vendor/ ride the default patterns; internal/fixtures via
+	// a project ignore rule.
+	mods := h2map(modHarness(t, root, "internal/fixtures/").collectGoModules())
+	if len(mods) != 1 || mods["real/app"] != "." {
+		t.Fatalf("fixture/vendored go.mod leaked into the module table: %v", mods)
+	}
+}
+
+func TestCollectGoModulesSkipsSymlinksAndUnreadable(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	writeTree(t, root, map[string]string{
+		"go.mod":        "module real/app\n",
+		"locked/go.mod": "module locked/out\n",
+	})
+	writeTree(t, outside, map[string]string{"go.mod": "module outside/linked\n"})
+	if err := os.Symlink(outside, filepath.Join(root, "linked")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if err := os.Chmod(filepath.Join(root, "locked", "go.mod"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(root, "locked", "go.mod"), 0o644) })
+
+	mods := h2map(modHarness(t, root).collectGoModules())
+	if _, ok := mods["outside/linked"]; ok {
+		t.Error("symlinked go.mod must be skipped")
+	}
+	if _, ok := mods["locked/out"]; ok {
+		t.Error("unreadable go.mod must shrink the table, not fail")
+	}
+	if mods["real/app"] != "." || len(mods) != 1 {
+		t.Fatalf("table = %v", mods)
+	}
+}
+
+func TestCollectGoModulesCancelledContext(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root, map[string]string{"go.mod": "module real/app\n", "sub/keep.go": "package sub\n"})
+	h := modHarness(t, root)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	h.ctx = ctx
+	if mods := h.collectGoModules(); len(mods) != 0 {
+		t.Fatalf("cancelled context must abort the walk, got %v", mods)
+	}
+}
+
+func TestGoModModulePath(t *testing.T) {
+	cases := map[string]string{
+		"module foo/bar\n":             "foo/bar",
+		"// c\n\nmodule\tfoo/tabbed\n": "foo/tabbed",
+		"module \"quoted/path\"\n":     "quoted/path",
+		"module foo/bar // trailing\n": "foo/bar",
+		"modulefoo/nospace\n":          "",
+		"go 1.22\n":                    "",
+		"":                             "",
+		"// module commented/out\nmodule real/x\n": "real/x",
+	}
+	for in, want := range cases {
+		if got := goModModulePath([]byte(in)); got != want {
+			t.Errorf("goModModulePath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func h2map(mods []resolve.GoModule) map[string]string {
+	m := map[string]string{}
+	for _, mod := range mods {
+		m[mod.Path] = mod.Dir
+	}
+	return m
+}

--- a/internal/scan/import_aware_internal_test.go
+++ b/internal/scan/import_aware_internal_test.go
@@ -1,0 +1,135 @@
+package scan
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/internal/ignore"
+	"github.com/luuuc/sense/internal/model"
+)
+
+// faultEdgesOfKindStore fails the includes-adjacency load, proving the Go
+// embedding map's DB half fails the resolve pass loudly instead of silently
+// starving the walk (a quiet miss would nondeterministically demote healed
+// bands, the exact class the incremental leg exists to prevent).
+type faultEdgesOfKindStore struct {
+	indexStore
+}
+
+func (f *faultEdgesOfKindStore) EdgesOfKind(context.Context, model.EdgeKind) ([]model.Edge, error) {
+	return nil, errors.New("boom")
+}
+
+func TestResolvePassFailsLoudWhenAdjacencyLoadFails(t *testing.T) {
+	dir := t.TempDir()
+	writeSource(t, dir, "go.mod", "module corp/app\n")
+	writeSource(t, dir, "a.go", "package p\n\ntype B struct{}\n\ntype S struct {\n\tB\n}\n")
+
+	adapter := openIndex(t, dir)
+	h := &harness{
+		ctx:            context.Background(),
+		idx:            &faultEdgesOfKindStore{indexStore: adapter},
+		out:            io.Discard,
+		warn:           io.Discard,
+		root:           dir,
+		matcher:        ignore.New(ignore.DefaultPatterns()...),
+		defaultMatcher: ignore.New(ignore.DefaultPatterns()...),
+		collector:      newWarningCollector(),
+		progress:       &progress{},
+		seenPaths:      map[string]bool{},
+	}
+	// A pending includes edge with an import annotation activates the Go
+	// lane, which needs the DB adjacency; the load failure must surface.
+	h.pendingEdges = []pendingEdge{
+		{SourceID: 1, TargetName: "ctx.Do", Kind: model.EdgeCalls, FileID: 1,
+			Confidence: 1.0, TargetImportPath: "corp/app/p", TargetInPackage: "T.Do"},
+		{SourceID: 1, TargetName: "p.B", Kind: model.EdgeIncludes, FileID: 1, Confidence: 1.0},
+	}
+	err := h.resolveAndWriteEdges()
+	if err == nil {
+		t.Fatal("adjacency load failure must fail the resolve pass")
+	}
+	if got := err.Error(); !strings.Contains(got, "load includes adjacency") {
+		t.Fatalf("error must name the failing leg, got %q", got)
+	}
+}
+
+// cancellingStore cancels the pass's context from inside the adjacency load,
+// so the next prepared-statement edge write fails: the only seam that can
+// reach ExecEdgeStmt's error leg.
+type cancellingStore struct {
+	indexStore
+	cancel context.CancelFunc
+}
+
+func (c *cancellingStore) EdgesOfKind(_ context.Context, _ model.EdgeKind) ([]model.Edge, error) {
+	c.cancel()
+	return nil, nil
+}
+
+func TestResolvePassSurfacesStatementWriteFailure(t *testing.T) {
+	dir := t.TempDir()
+	writeSource(t, dir, "go.mod", "module corp/app\n")
+	writeSource(t, dir, "a.go", "package p\n\ntype B struct{}\n\ntype S struct {\n\tB\n}\n")
+	adapter := openIndex(t, dir)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	fid, err := adapter.WriteFile(ctx, &model.File{Path: "a.go", Language: "go"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sid, err := adapter.WriteSymbol(ctx, &model.Symbol{FileID: fid, Name: "B", Qualified: "p.B", Kind: model.KindClass, LineStart: 3, LineEnd: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := &harness{
+		ctx:            ctx,
+		idx:            &cancellingStore{indexStore: adapter, cancel: cancel},
+		out:            io.Discard,
+		warn:           io.Discard,
+		root:           dir,
+		matcher:        ignore.New(ignore.DefaultPatterns()...),
+		defaultMatcher: ignore.New(ignore.DefaultPatterns()...),
+		collector:      newWarningCollector(),
+		progress:       &progress{},
+		seenPaths:      map[string]bool{},
+	}
+	h.pendingEdges = []pendingEdge{
+		{SourceID: sid, TargetName: "p.B", Kind: model.EdgeIncludes, FileID: fid, Confidence: 1.0,
+			TargetImportPath: "corp/app", TargetInPackage: "B"},
+	}
+	if err := h.resolveAndWriteEdges(); err == nil {
+		t.Fatal("a failing edge statement must fail the resolve pass")
+	}
+}
+
+func TestDBGoEmbeddingsSkipsFileLevelEdges(t *testing.T) {
+	dir := t.TempDir()
+	writeSource(t, dir, "a.go", "package p\n")
+	adapter := openIndex(t, dir)
+	ctx := context.Background()
+	fid, err := adapter.WriteFile(ctx, &model.File{Path: "a.go", Language: "go"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sid, err := adapter.WriteSymbol(ctx, &model.Symbol{FileID: fid, Name: "B", Qualified: "p.B", Kind: model.KindClass, LineStart: 1, LineEnd: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A file-level (NULL-source) includes edge carries no embedder identity
+	// and must contribute nothing to the walk map.
+	if _, err := adapter.WriteEdge(ctx, &model.Edge{TargetID: sid, Kind: model.EdgeIncludes, FileID: fid, Confidence: 1.0}); err != nil {
+		t.Fatal(err)
+	}
+	h := &harness{ctx: ctx, idx: adapter}
+	m, err := h.dbGoEmbeddings(map[int64]string{sid: "p.B"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m) != 0 {
+		t.Fatalf("file-level edge entered the walk map: %v", m)
+	}
+}

--- a/internal/scan/import_aware_internal_test.go
+++ b/internal/scan/import_aware_internal_test.go
@@ -124,12 +124,23 @@ func TestDBGoEmbeddingsSkipsFileLevelEdges(t *testing.T) {
 	if _, err := adapter.WriteEdge(ctx, &model.Edge{TargetID: sid, Kind: model.EdgeIncludes, FileID: fid, Confidence: 1.0}); err != nil {
 		t.Fatal(err)
 	}
+	// A satisfaction edge is inherits-kind: it must NEVER enter the walk map
+	// (a struct does not acquire methods from interfaces it satisfies; a
+	// union with inherits would launder satisfaction into the verified band;
+	// mutant M2's kill case, at the construction seam).
+	sid2, err := adapter.WriteSymbol(ctx, &model.Symbol{FileID: fid, Name: "S", Qualified: "p.S", Kind: model.KindClass, LineStart: 2, LineEnd: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := adapter.WriteEdge(ctx, &model.Edge{SourceID: &sid2, TargetID: sid, Kind: model.EdgeInherits, FileID: fid, Confidence: 0.9}); err != nil {
+		t.Fatal(err)
+	}
 	h := &harness{ctx: ctx, idx: adapter}
-	m, err := h.dbGoEmbeddings(map[int64]string{sid: "p.B"})
+	m, err := h.dbGoEmbeddings(map[int64]string{sid: "p.B", sid2: "p.S"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(m) != 0 {
-		t.Fatalf("file-level edge entered the walk map: %v", m)
+		t.Fatalf("non-includes or file-level edges entered the walk map: %v", m)
 	}
 }

--- a/internal/scan/import_aware_resolution_test.go
+++ b/internal/scan/import_aware_resolution_test.go
@@ -1,0 +1,191 @@
+package scan_test
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/luuuc/sense/internal/ignore"
+	"github.com/luuuc/sense/internal/scan"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// These tests pin import-aware Go resolution end to end: a cross-package
+// declared receiver heals through the embedding chain into the verified
+// band; a stdlib-typed field stops fabricating a composes edge into a
+// same-basename local package; a stdlib qualifier call stops binding at all;
+// and an incremental rescan of the caller file alone preserves the healed
+// band (the maps must build from persisted state, not pending edges only).
+
+func writeImportAwareRepo(t *testing.T, root string) {
+	t.Helper()
+	files := map[string]string{
+		"go.mod": "module corp/app\n\ngo 1.22\n",
+		"services/context/base.go": `package context
+
+type Base struct{}
+
+func (b *Base) FormString(key string) string { return key }
+`,
+		"services/context/context.go": `package context
+
+type Context struct {
+	*Base
+}
+`,
+		"services/context/api.go": `package context
+
+type APIContext struct {
+	*Context
+}
+`,
+		// A local package whose basename collides with stdlib context: the
+		// fabrication magnet.
+		"modules/logimpl/logger.go": `package logimpl
+
+import "context"
+
+type LoggerImpl struct {
+	ctx context.Context
+}
+`,
+		"routers/caller.go": `package routers
+
+import (
+	"fmt"
+
+	sctx "corp/app/services/context"
+)
+
+func ListHooks(ctx *sctx.APIContext) {
+	v := ctx.FormString("type")
+	fmt.Println(v)
+}
+`,
+	}
+	for rel, content := range files {
+		writeFile(t, filepath.Join(root, rel), content)
+	}
+}
+
+func openIndex(t *testing.T, root string) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite", filepath.Join(root, ".sense", "index.db"))
+	if err != nil {
+		t.Fatalf("open index: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// edgeConfidence returns the confidence of the edge source→target of kind,
+// or -1 when no such edge exists.
+func edgeConfidence(t *testing.T, db *sql.DB, source, target, kind string) float64 {
+	t.Helper()
+	row := db.QueryRow(`
+		SELECT e.confidence FROM sense_edges e
+		JOIN sense_symbols s ON e.source_id = s.id
+		JOIN sense_symbols tg ON e.target_id = tg.id
+		WHERE s.qualified = ? AND tg.qualified = ? AND e.kind = ?`,
+		source, target, kind)
+	var conf float64
+	if err := row.Scan(&conf); err != nil {
+		if err == sql.ErrNoRows {
+			return -1
+		}
+		t.Fatalf("edge query: %v", err)
+	}
+	return conf
+}
+
+func TestImportAwareGoResolutionEndToEnd(t *testing.T) {
+	root := t.TempDir()
+	writeImportAwareRepo(t, root)
+	if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	db := openIndex(t, root)
+
+	// The heal: ctx *sctx.APIContext, FormString declared on Base: a
+	// two-hop embedding walk binds it in the verified band.
+	if conf := edgeConfidence(t, db, "routers.ListHooks", "context.Base.FormString", "calls"); conf < 0.7 {
+		t.Errorf("declared-receiver call = %v, want verified band (>= 0.7)", conf)
+	}
+
+	// The fabrication kill: LoggerImpl's field is STDLIB context.Context;
+	// no composes edge may reach the local shadow package.
+	var n int
+	if err := db.QueryRow(`
+		SELECT count(*) FROM sense_edges e
+		JOIN sense_symbols s ON e.source_id = s.id
+		JOIN sense_symbols tg ON e.target_id = tg.id
+		WHERE s.qualified = 'logimpl.LoggerImpl' AND tg.qualified = 'context.Context'
+		AND e.kind = 'composes'`).Scan(&n); err != nil {
+		t.Fatalf("composes query: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("stdlib field fabricated %d composes edge(s) into the local shadow", n)
+	}
+
+	// The qualifier kill: fmt.Println must bind nothing.
+	if err := db.QueryRow(`
+		SELECT count(*) FROM sense_edges e
+		JOIN sense_symbols s ON e.source_id = s.id
+		WHERE s.qualified = 'routers.ListHooks' AND e.kind = 'calls'
+		AND e.target_id IN (SELECT id FROM sense_symbols WHERE name = 'Println')`).Scan(&n); err != nil {
+		t.Fatalf("println query: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("stdlib qualifier call bound %d edge(s)", n)
+	}
+}
+
+func TestImportAwareGoResolutionSurvivesIncremental(t *testing.T) {
+	root := t.TempDir()
+	writeImportAwareRepo(t, root)
+	if _, err := scan.Run(context.Background(), quietOpts(root)); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Touch ONLY the caller file: the embedding chain and module table live
+	// in untouched files, so a pending-only map would starve and the healed
+	// edge would regress to the demoted band (the load-bearing incremental
+	// leg; mutant M3's kill case).
+	writeFile(t, filepath.Join(root, "routers/caller.go"), `package routers
+
+import (
+	"fmt"
+
+	sctx "corp/app/services/context"
+)
+
+func ListHooks(ctx *sctx.APIContext) {
+	v := ctx.FormString("kind")
+	fmt.Println(v, "edited")
+}
+`)
+	ctx := context.Background()
+	idx, err := sqlite.Open(ctx, filepath.Join(root, ".sense", "index.db"))
+	if err != nil {
+		t.Fatalf("open adapter: %v", err)
+	}
+	defer func() { _ = idx.Close() }()
+	matcher, err := ignore.Build(root, nil)
+	if err != nil {
+		t.Fatalf("build matcher: %v", err)
+	}
+	if _, err := scan.RunIncremental(ctx, scan.IncrementalOptions{
+		Root:    root,
+		Idx:     idx,
+		Matcher: matcher,
+		Changed: []string{"routers/caller.go"},
+	}); err != nil {
+		t.Fatalf("RunIncremental: %v", err)
+	}
+
+	db := openIndex(t, root)
+	if conf := edgeConfidence(t, db, "routers.ListHooks", "context.Base.FormString", "calls"); conf < 0.7 {
+		t.Errorf("healed band regressed to %v on incremental rescan of the caller alone", conf)
+	}
+}

--- a/internal/scan/incremental.go
+++ b/internal/scan/incremental.go
@@ -174,6 +174,7 @@ func buildIncrementalResult(h *harness, opts IncrementalOptions, elapsed time.Du
 		Edges:      h.edges,
 		Embedded:   h.embedded,
 		Unresolved: h.unresolved,
+		External:   h.droppedExternal,
 		Warnings:   h.collector.count(),
 		Duration:   elapsed,
 		Phases:     phases,

--- a/internal/scan/incremental.go
+++ b/internal/scan/incremental.go
@@ -47,10 +47,15 @@ func RunIncremental(ctx context.Context, opts IncrementalOptions) (*Result, erro
 	}
 
 	h := &harness{
-		ctx:           ctx,
-		idx:           opts.Idx,
-		out:           out,
-		warn:          warn,
+		ctx:  ctx,
+		idx:  opts.Idx,
+		out:  out,
+		warn: warn,
+		// root anchors the go.mod module-table walk; without it the Go path
+		// lane would be inert on incremental rescans and healed bands would
+		// regress on the first touched caller file (the load-bearing
+		// incremental leg).
+		root:          opts.Root,
 		progress:      newProgress(out, true),
 		collector:     newWarningCollector(),
 		parsers:       parsers.parsers,

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -574,6 +574,11 @@ type harness struct {
 	// resolveAndWriteEdges.
 	pendingEdges []pendingEdge
 
+	// goLaneActive records (set by buildResolver) that some pending edge
+	// carries an import-path annotation, so the resolve pass builds the Go
+	// module table and embedding adjacency. Always false for non-Go repos.
+	goLaneActive bool
+
 	// pendingParents holds symbols whose ParentQualified missed the
 	// per-file map in writeFileInner (cross-file receiver methods).
 	// Appended only from writeFileInner — the parse phase is parallel —
@@ -1320,54 +1325,37 @@ func (h *harness) resolveAndWriteEdges() error {
 	macroCallers := map[int64][]int64{}       // macro symbol ID -> model source IDs
 	macroCollaborators := map[int64][]int64{} // macro symbol ID -> collaborator class IDs
 
-	var written, ambiguous int
-	var drops dropCounts
+	st := &edgeResolveState{
+		resolver:           resolver,
+		qualByID:           qualByID,
+		macroCallers:       macroCallers,
+		macroCollaborators: macroCollaborators,
+	}
 	err = h.idx.InTx(h.ctx, func() error {
 		edgeStmt, serr := h.idx.PrepareEdgeStmt(h.ctx)
 		if serr != nil {
 			return fmt.Errorf("prepare edge stmt: %w", serr)
 		}
 		defer func() { _ = edgeStmt.Close() }()
+		st.edgeStmt = edgeStmt
 
+		// Phase 1: includes edges resolve and write first: their resolved
+		// pairs, unioned with the persisted adjacency, are the Go embedding
+		// map phase 2's method calls walk. Non-Go scans skip the union (no
+		// pending edge carries an import annotation) and both phases behave
+		// as the single loop always did.
+		if err := h.resolveIncludesPhase(st); err != nil {
+			return err
+		}
+
+		// Phase 2: everything else.
 		for _, pe := range h.pendingEdges {
-			r, ok := resolver.Resolve(resolve.Request{
-				Target:                pe.TargetName,
-				Kind:                  pe.Kind,
-				SourceFileID:          pe.FileID,
-				SourceQualified:       pe.SourceQualified,
-				SourceParentQualified: pe.SourceParentQualified,
-				BaseConfidence:        pe.Confidence,
-				TargetImportPath:      pe.TargetImportPath,
-				TargetInPackage:       pe.TargetInPackage,
-			})
-			if !ok {
-				drops.record(r.External)
+			if pe.Kind == model.EdgeIncludes {
 				continue
 			}
-			if r.Ambiguous {
-				ambiguous++
+			if _, err := h.resolveOnePending(st, pe); err != nil {
+				return err
 			}
-			// Bucket the edge for mixin expansion (model -> macro / macro ->
-			// collaborator), both keyed by the macro's symbol ID.
-			recordMixinEdge(pe.SourceID, r.SymbolID, pe.SourceQualified, qualByID, macroCallers, macroCollaborators)
-			edge := &model.Edge{
-				SourceID:   int64Ptr(pe.SourceID),
-				TargetID:   r.SymbolID,
-				Kind:       pe.Kind,
-				FileID:     pe.FileID,
-				Line:       pe.Line,
-				Confidence: r.Confidence,
-			}
-			if edge.SourceID != nil {
-				if _, werr := sqlite.ExecEdgeStmt(h.ctx, edgeStmt, edge); werr != nil {
-					return fmt.Errorf("write edge source=%d target=%s: %w", pe.SourceID, pe.TargetName, werr)
-				}
-			} else {
-				if _, werr := h.idx.WriteEdge(h.ctx, edge); werr != nil {
-					return fmt.Errorf("write edge source=%d target=%s: %w", pe.SourceID, pe.TargetName, werr)
-				}
-			}
-			written++
 		}
 
 		// Synthesize the direct model -> collaborator edges bridged by each
@@ -1376,17 +1364,135 @@ func (h *harness) resolveAndWriteEdges() error {
 		if werr != nil {
 			return werr
 		}
-		written += n
+		st.written += n
 		return nil
 	})
 	if err != nil {
 		return err
 	}
-	h.edges += written
-	h.unresolved += drops.unresolved
-	h.droppedExternal += drops.external
-	h.ambiguous += ambiguous
+	h.edges += st.written
+	h.unresolved += st.drops.unresolved
+	h.droppedExternal += st.drops.external
+	h.ambiguous += st.ambiguous
 	return nil
+}
+
+// edgeResolveState bundles the resolve pass's per-edge loop state so the
+// includes-first and remainder phases run an identical body.
+type edgeResolveState struct {
+	resolver           *resolve.Index
+	edgeStmt           *sql.Stmt
+	qualByID           map[int64]string
+	macroCallers       map[int64][]int64
+	macroCollaborators map[int64][]int64
+	written, ambiguous int
+	drops              dropCounts
+}
+
+// resolveIncludesPhase resolves and writes every pending includes edge, and,
+// when the Go path lane is active, attaches the embedding adjacency to the
+// resolver: persisted includes edges (excluding files re-scanned this run,
+// whose DB rows may be stale pre-edit state) unioned with the pairs this
+// phase just resolved. Built from resolved symbol pairs, the map admits only
+// binds the path lane verified: a stdlib/third-party embed was dropped and
+// contributes no hop, and satisfaction edges (inherits kind) never enter.
+func (h *harness) resolveIncludesPhase(st *edgeResolveState) error {
+	var goEmb map[string][]string
+	if h.goLaneActive {
+		var err error
+		if goEmb, err = h.dbGoEmbeddings(st.qualByID); err != nil {
+			return err
+		}
+	}
+	for _, pe := range h.pendingEdges {
+		if pe.Kind != model.EdgeIncludes {
+			continue
+		}
+		targetID, err := h.resolveOnePending(st, pe)
+		if err != nil {
+			return err
+		}
+		if targetID != 0 && goEmb != nil {
+			src, dst := st.qualByID[pe.SourceID], st.qualByID[targetID]
+			if src != "" && dst != "" {
+				goEmb[src] = append(goEmb[src], dst)
+			}
+		}
+	}
+	if goEmb != nil {
+		st.resolver.WithGoEmbeddings(goEmb)
+	}
+	return nil
+}
+
+// dbGoEmbeddings loads the persisted includes adjacency (embedder qualified
+// name → embedded qualified names) for the walk map. Edges owned by files
+// re-scanned this run are excluded: their fresh rows are in pendingEdges and
+// their DB rows may reflect the pre-edit file.
+func (h *harness) dbGoEmbeddings(qualByID map[int64]string) (map[string][]string, error) {
+	m := map[string][]string{}
+	edges, err := h.idx.EdgesOfKind(h.ctx, model.EdgeIncludes)
+	if err != nil {
+		return nil, fmt.Errorf("load includes adjacency: %w", err)
+	}
+	changed := make(map[int64]bool, len(h.changedFileIDs))
+	for _, id := range h.changedFileIDs {
+		changed[id] = true
+	}
+	for _, e := range edges {
+		if e.SourceID == nil || changed[e.FileID] {
+			continue
+		}
+		src, dst := qualByID[*e.SourceID], qualByID[e.TargetID]
+		if src != "" && dst != "" {
+			m[src] = append(m[src], dst)
+		}
+	}
+	return m, nil
+}
+
+// resolveOnePending resolves and writes one pending edge, returning the
+// bound target symbol id (0 when the edge dropped).
+func (h *harness) resolveOnePending(st *edgeResolveState, pe pendingEdge) (int64, error) {
+	r, ok := st.resolver.Resolve(resolve.Request{
+		Target:                pe.TargetName,
+		Kind:                  pe.Kind,
+		SourceFileID:          pe.FileID,
+		SourceQualified:       pe.SourceQualified,
+		SourceParentQualified: pe.SourceParentQualified,
+		BaseConfidence:        pe.Confidence,
+		TargetImportPath:      pe.TargetImportPath,
+		TargetInPackage:       pe.TargetInPackage,
+	})
+	if !ok {
+		st.drops.record(r.External)
+		return 0, nil
+	}
+	if r.Ambiguous {
+		st.ambiguous++
+	}
+	// Bucket the edge for mixin expansion (model -> macro / macro ->
+	// collaborator), both keyed by the macro's symbol ID.
+	recordMixinEdge(pe.SourceID, r.SymbolID, pe.SourceQualified, st.qualByID, st.macroCallers, st.macroCollaborators)
+	edge := &model.Edge{
+		SourceID:   int64Ptr(pe.SourceID),
+		TargetID:   r.SymbolID,
+		Kind:       pe.Kind,
+		FileID:     pe.FileID,
+		Line:       pe.Line,
+		Confidence: r.Confidence,
+	}
+	if edge.SourceID != nil {
+		if _, werr := sqlite.ExecEdgeStmt(h.ctx, st.edgeStmt, edge); werr != nil {
+			return 0, fmt.Errorf("write edge source=%d target=%s: %w", pe.SourceID, pe.TargetName, werr)
+		}
+	} else {
+		if _, werr := h.idx.WriteEdge(h.ctx, edge); werr != nil {
+			return 0, fmt.Errorf("write edge source=%d target=%s: %w", pe.SourceID, pe.TargetName, werr)
+		}
+	}
+	st.written++
+	return r.SymbolID, nil
 }
 
 // dropCounts separates the two ok=false outcomes of Resolve: a name that
@@ -1410,8 +1516,10 @@ func (d *dropCounts) record(external bool) {
 // entirely for non-Go repos and pre-annotation extractors).
 func (h *harness) buildResolver(refs []model.SymbolRef) *resolve.Index {
 	resolver := resolve.NewIndex(refs).WithInheritance(h.buildAncestry())
+	h.goLaneActive = false
 	for i := range h.pendingEdges {
 		if h.pendingEdges[i].TargetImportPath != "" {
+			h.goLaneActive = true
 			return resolver.WithGoModules(h.collectGoModules())
 		}
 	}

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -83,6 +83,7 @@ type Result struct {
 	Embedded       int // symbols whose embeddings were generated/updated
 	EmbeddingDebt  int // symbols needing embeddings (deferred to background)
 	Unresolved     int // edges whose target name matched no symbol; dropped
+	External       int // edges whose import path proved the target lives outside the tree; dropped
 	Ambiguous      int // edges resolved via ambiguous (multi-match) fallback
 	Warnings       int // per-file failures logged; scan continues past them
 	DefaultIgnored int // directories skipped by default ignore patterns
@@ -476,6 +477,7 @@ func buildResult(h *harness, embeddingDebt int, elapsed time.Duration, phases Ph
 		Embedded:       h.embedded,
 		EmbeddingDebt:  embeddingDebt,
 		Unresolved:     h.unresolved,
+		External:       h.droppedExternal,
 		Ambiguous:      h.ambiguous,
 		Warnings:       h.collector.count(),
 		DefaultIgnored: h.defaultIgnored,
@@ -491,8 +493,17 @@ func printScanSummary(out io.Writer, opts Options, res *Result, elapsed time.Dur
 	_, _ = fmt.Fprintf(out, "scanned %d files (%d indexed, %d changed, %d skipped) in %s\n",
 		res.Files, res.Indexed, res.Changed, res.Skipped, elapsed)
 	if res.Edges > 0 || res.Unresolved > 0 {
-		_, _ = fmt.Fprintf(out, "edges: %d resolved, %d unresolved, %d ambiguous\n",
-			res.Edges, res.Unresolved, res.Ambiguous)
+		// The external count prints only when non-zero so non-Go scans keep
+		// their exact historical summary line; a JUMP in this number between
+		// scans of the same repo is the operator's signal that import-path
+		// classification regressed.
+		if res.External > 0 {
+			_, _ = fmt.Fprintf(out, "edges: %d resolved, %d unresolved, %d ambiguous, %d external (dropped)\n",
+				res.Edges, res.Unresolved, res.Ambiguous, res.External)
+		} else {
+			_, _ = fmt.Fprintf(out, "edges: %d resolved, %d unresolved, %d ambiguous\n",
+				res.Edges, res.Unresolved, res.Ambiguous)
+		}
 	}
 	if res.DefaultIgnored > 0 {
 		_, _ = fmt.Fprintf(out, "skipped %d directories (default ignores: %s)\n",
@@ -669,17 +680,18 @@ type harness struct {
 	changedFileIDs []int64
 
 	// Tallies for Result.
-	files          int
-	indexed        int
-	changed        int
-	skipped        int
-	removed        int
-	symbols        int
-	edges          int
-	embedded       int
-	unresolved     int
-	ambiguous      int
-	defaultIgnored int
+	files           int
+	indexed         int
+	changed         int
+	skipped         int
+	removed         int
+	symbols         int
+	edges           int
+	embedded        int
+	unresolved      int
+	droppedExternal int
+	ambiguous       int
+	defaultIgnored  int
 }
 
 // indexedFile is the minimum the test-association pass needs to know
@@ -710,6 +722,10 @@ type pendingEdge struct {
 	FileID                int64
 	Line                  *int
 	Confidence            float64
+	// TargetImportPath/TargetInPackage mirror extract.EmittedEdge: the
+	// import-path annotation the resolver's Go path lane binds terminally.
+	TargetImportPath string
+	TargetInPackage  string
 }
 
 func (h *harness) closeParsers() {
@@ -1157,6 +1173,8 @@ func (h *harness) writeFileInner(fr *fileResult) (int, error) {
 			FileID:                fileID,
 			Line:                  e.Line,
 			Confidence:            e.Confidence,
+			TargetImportPath:      e.TargetImportPath,
+			TargetInPackage:       e.TargetInPackage,
 		})
 	}
 
@@ -1284,7 +1302,7 @@ func (h *harness) resolveAndWriteEdges() error {
 	if err != nil {
 		return fmt.Errorf("load symbols for edge resolution: %w", err)
 	}
-	resolver := resolve.NewIndex(refs).WithInheritance(h.buildAncestry())
+	resolver := h.buildResolver(refs)
 
 	qualByID := make(map[int64]string, len(refs))
 	fileByID := make(map[int64]int64, len(refs))
@@ -1302,7 +1320,8 @@ func (h *harness) resolveAndWriteEdges() error {
 	macroCallers := map[int64][]int64{}       // macro symbol ID -> model source IDs
 	macroCollaborators := map[int64][]int64{} // macro symbol ID -> collaborator class IDs
 
-	var written, unresolved, ambiguous int
+	var written, ambiguous int
+	var drops dropCounts
 	err = h.idx.InTx(h.ctx, func() error {
 		edgeStmt, serr := h.idx.PrepareEdgeStmt(h.ctx)
 		if serr != nil {
@@ -1318,9 +1337,11 @@ func (h *harness) resolveAndWriteEdges() error {
 				SourceQualified:       pe.SourceQualified,
 				SourceParentQualified: pe.SourceParentQualified,
 				BaseConfidence:        pe.Confidence,
+				TargetImportPath:      pe.TargetImportPath,
+				TargetInPackage:       pe.TargetInPackage,
 			})
 			if !ok {
-				unresolved++
+				drops.record(r.External)
 				continue
 			}
 			if r.Ambiguous {
@@ -1362,9 +1383,39 @@ func (h *harness) resolveAndWriteEdges() error {
 		return err
 	}
 	h.edges += written
-	h.unresolved += unresolved
+	h.unresolved += drops.unresolved
+	h.droppedExternal += drops.external
 	h.ambiguous += ambiguous
 	return nil
+}
+
+// dropCounts separates the two ok=false outcomes of Resolve: a name that
+// matched nothing (unresolved) and a target the path lane proved external.
+type dropCounts struct {
+	unresolved int
+	external   int
+}
+
+func (d *dropCounts) record(external bool) {
+	if external {
+		d.external++
+		return
+	}
+	d.unresolved++
+}
+
+// buildResolver assembles the resolve pass's Index: the name maps from refs,
+// the inherits ancestry, and, only when some pending edge carries an
+// import-path annotation, the go.mod module table (the disk walk is skipped
+// entirely for non-Go repos and pre-annotation extractors).
+func (h *harness) buildResolver(refs []model.SymbolRef) *resolve.Index {
+	resolver := resolve.NewIndex(refs).WithInheritance(h.buildAncestry())
+	for i := range h.pendingEdges {
+		if h.pendingEdges[i].TargetImportPath != "" {
+			return resolver.WithGoModules(h.collectGoModules())
+		}
+	}
+	return resolver
 }
 
 // recordMixinEdge buckets a resolved edge for later mixin expansion, keyed by


### PR DESCRIPTION
Sense now reads each Go file's import table, so cross-package relationships resolve the way Go itself resolves them. Method calls on receivers declared with a qualified type (`ctx *context.Context`) bind through the declared type and its embedding chain into the verified confidence band instead of languishing as low-confidence name guesses, and names that actually point at the standard library or a third-party dependency stop binding to same-named local packages entirely. On gitea, the verified call band grows from 27,650 to 39,973 edges while roughly 8,000 provably-wrong edges disappear; struct fields typed by stdlib `context.Context` no longer fabricate has-a edges into a local package that happens to be named `context`.

## What changed

- **Per-file import tables (extract):** alias-aware `name → path` capture; dot and blank imports bind no name; inferred names strip version suffixes and drop on collision, so a wrong guess is a miss, never a wrong bind.
- **The import-path lane (resolve):** one invariant, decided terminally: a path-annotated target binds iff its import path lands in an indexed directory (module paths from every `go.mod`, longest-prefix, segment-anchored; dir-scoped binds keyed by real package clauses). No `go.mod` means the lane is fully inert: GOPATH-era repos keep today's behavior byte for byte.
- **Qualified types flow through every type-map collector** (params, vars, composites, range elements), plus two collectors that were wrong-bind holes: func-literal parameters and named results.
- **Selector calls follow Go's scope nesting** (function scope, then the file's imports, then package fallthrough). An operand matching neither a local nor an import is provably not a package qualifier; its dotted text now demotes below the blast floor instead of exact-binding a same-named package at full confidence.
- **Embedded-method calls walk the embedding chain** (a two-hop `APIContext > Context > Base` call binds the declared method), over an adjacency built only from resolved includes edges; satisfaction edges never enter, and the map is rebuilt identically on incremental rescans so a healed band survives editing a caller file.
- Scan summaries count externally-proven drops separately from unresolved (printed only when non-zero).

## Verification

- Full acceptance battery on fresh scratch indexes: the flagship starved-method surface heals 205/205 into the verified band with no count inflation; the fabricated composes set collapses to its single real edge; stdlib qualifier binds are gone; 20/20 seeded receiver spot-checks verify at the construction site; a re-run of the sizing classifier shows the remaining low band is 83% multi-hop shapes (out of scope) with under 3% addressable residue.
- Ruby and Python controls byte-identical between this branch and the released binary (16,578 and 6,702 edges); the Rust extractor is untouched and the lane is language-gated.
- Dual code-review council, both passes 7/7; the diff pass ran the three must-die mutants for real and both of its blocking findings (a surviving walk-map mutant, a confidence regression on module-less trees) are fixed and mutant-verified.
- Side-effect bench runs green on both benched verticals (llm.rb in its frozen band; healthchecks at its frozen 1.0; grounding 1.0 on both, zero hallucinated citations).
- `make ci` green: per-file coverage gate, lint 0, complexity ledger 0, smoke.

## Upgrade note

This is a scan/resolve-layer change: run one full `sense scan -rebuild` after upgrading. A plain scan skips unchanged files and keeps the fabricated high-confidence edges; note that `sense dead` output may grow on Go repos afterward, because symbols that were only kept alive by wrong edges surface honestly (verify before deleting; the usual closed-world caveat applies).
