### PR TITLE
chore(metrics): snapshot release downloads and traffic daily

### DIFF
--- a/.github/workflows/metrics-snapshot.yml
+++ b/.github/workflows/metrics-snapshot.yml
@@ -1,0 +1,40 @@
+name: Metrics snapshot
+
+on:
+  schedule:
+    - cron: "17 5 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: metrics
+
+      - name: Append daily snapshot
+        env:
+          GH_TOKEN: ${{ secrets.METRICS_TOKEN || github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          day="$(date -u +%F)"
+          gh api --paginate "repos/${REPO}/releases" \
+            --jq '[.[] | {tag: .tag_name, assets: [.assets[] | {name, download_count}]}]' \
+            | jq -c --arg day "$day" '{day: $day, kind: "downloads", releases: .}' >> snapshots.jsonl
+          # Traffic endpoints need push access; GITHUB_TOKEN may 403. Keep downloads even if they do.
+          gh api "repos/${REPO}/traffic/clones" \
+            | jq -c --arg day "$day" '{day: $day, kind: "clones"} + .' >> snapshots.jsonl || true
+          gh api "repos/${REPO}/traffic/views" \
+            | jq -c --arg day "$day" '{day: $day, kind: "views"} + .' >> snapshots.jsonl || true
+
+      - name: Commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add snapshots.jsonl
+          git commit -m "metrics: snapshot $(date -u +%F)"
+          git push

--- a/.github/workflows/metrics-snapshot.yml
+++ b/.github/workflows/metrics-snapshot.yml
@@ -2,7 +2,7 @@ name: Metrics snapshot
 
 on:
   schedule:
-    - cron: "17 5 * * *"
+    - cron: "0 13 * * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
GitHub keeps no history for release-asset download counts and only a rolling 14-day window for traffic. This adds a daily cron that appends both to `snapshots.jsonl` on the orphan `metrics` branch (created with a baseline as of 2026-07-17), making per-day deltas recoverable from now on.

Traffic endpoints may 403 under the default `GITHUB_TOKEN`; the job tolerates that and still records downloads. Add a `METRICS_TOKEN` secret (PAT with push access) if traffic rows come back empty.

No product surface touched; `chore` does not bump the version.