### PR TITLE
fix(query): complete class caller answers and resolve concord proxies

### DIFF
--- a/internal/extract/php/eloquent.go
+++ b/internal/extract/php/eloquent.go
@@ -40,6 +40,9 @@ func (w *walker) emitRelation(n *sitter.Node, name, class string) (bool, error) 
 	}
 	related := w.classConstant(argExpr(n, 0))
 	if related == "" {
+		related = w.proxyModelClassArg(argExpr(n, 0))
+	}
+	if related == "" {
 		return false, nil
 	}
 	line := extract.Line(n.StartPosition())
@@ -50,6 +53,33 @@ func (w *walker) emitRelation(n *sitter.Node, name, class string) (bool, error) 
 		Line:            &line,
 		Confidence:      extract.ConfidenceConvention,
 	})
+}
+
+// proxyModelClassArg resolves the concord spelling of a relation target:
+// `<X>Proxy::modelClass()` stands for `<X>::class` (concord repos express
+// every relation this way, so without it a concord model carries no
+// composes edges at all). Returns "" for any other expression.
+func (w *walker) proxyModelClassArg(arg *sitter.Node) string {
+	if arg == nil || arg.Kind() != "scoped_call_expression" {
+		return ""
+	}
+	if extract.Text(arg.ChildByFieldName("name"), w.source) != "modelClass" {
+		return ""
+	}
+	scope := arg.ChildByFieldName("scope")
+	if scope == nil || (scope.Kind() != "name" && scope.Kind() != "qualified_name") {
+		return ""
+	}
+	written := extract.Text(scope, w.source)
+	if !strings.HasSuffix(written, "Proxy") {
+		return ""
+	}
+	resolved := w.resolveName(written)
+	base := strings.TrimSuffix(resolved, "Proxy")
+	if base == "" || base == resolved || strings.HasSuffix(base, `\`) {
+		return ""
+	}
+	return base
 }
 
 // scopeAlias returns the call-site name a `scopeX` method declares

--- a/internal/extract/php/eloquent.go
+++ b/internal/extract/php/eloquent.go
@@ -70,11 +70,10 @@ func (w *walker) proxyModelClassArg(arg *sitter.Node) string {
 	if scope == nil || (scope.Kind() != "name" && scope.Kind() != "qualified_name") {
 		return ""
 	}
-	written := extract.Text(scope, w.source)
-	if !strings.HasSuffix(written, "Proxy") {
-		return ""
-	}
-	resolved := w.resolveName(written)
+	// The Proxy suffix is a property of the RESOLVED class, not the
+	// written spelling: an aliased import (`use ...ProductProxy as
+	// ProductModel`) must still fold onto the model.
+	resolved := w.resolveName(extract.Text(scope, w.source))
 	base := strings.TrimSuffix(resolved, "Proxy")
 	if base == "" || base == resolved || strings.HasSuffix(base, `\`) {
 		return ""

--- a/internal/extract/php/eloquent_test.go
+++ b/internal/extract/php/eloquent_test.go
@@ -178,3 +178,35 @@ class Order {
 	}
 	em.symbol(t, `Order\shipped`) // uncontested scope still aliases
 }
+
+// A concord repo expresses relations as `<X>Proxy::modelClass()`; the
+// composes edge lands on the model class the proxy stands for. A
+// non-proxy scope or a different static method resolves to nothing.
+func TestEloquentRelationsThroughConcordProxy(t *testing.T) {
+	em := mustRun(t, `<?php
+namespace Webkul\Attribute\Models;
+use Webkul\Product\Models\ProductProxy;
+class AttributeFamily extends Model {
+    public function products() { return $this->hasMany(ProductProxy::modelClass()); }
+    public function local() { return $this->belongsTo(GroupProxy::modelClass()); }
+    public function other() { return $this->hasMany(Helper::tableName()); }
+    public function plain() { return $this->belongsTo(Proxy::modelClass()); }
+    public function bare() { return $this->hasMany('products'); }
+    public function relative() { return $this->belongsTo(static::modelClass()); }
+    public function notProxy() { return $this->hasMany(Helper::modelClass()); }
+}
+`)
+	e := em.edge(t, model.EdgeComposes, `Webkul\Attribute\Models\AttributeFamily`, `Webkul\Product\Models\Product`)
+	if e.Confidence != extract.ConfidenceConvention {
+		t.Errorf("proxy relation conf = %v", e.Confidence)
+	}
+	em.edge(t, model.EdgeComposes, `Webkul\Attribute\Models\AttributeFamily`, `Webkul\Attribute\Models\Group`)
+	for _, edge := range em.edges {
+		if edge.Kind == model.EdgeComposes &&
+			(edge.TargetQualified == `Webkul\Attribute\Models\Helper` ||
+				edge.TargetQualified == `Webkul\Attribute\Models\` ||
+				edge.TargetQualified == "") {
+			t.Errorf("non-proxy static arg composed: %+v", edge)
+		}
+	}
+}

--- a/internal/extract/php/eloquent_test.go
+++ b/internal/extract/php/eloquent_test.go
@@ -210,3 +210,21 @@ class AttributeFamily extends Model {
 		}
 	}
 }
+
+// An aliased proxy import (`use ...ProductProxy as ProductModel`) still
+// resolves the relation onto the model: the Proxy suffix is a property of
+// the RESOLVED class, not of the written alias. A fully-qualified spelling
+// (`\Webkul\...\GroupProxy::modelClass()`) rides the qualified_name scope
+// branch to the same answer.
+func TestEloquentRelationsThroughAliasedAndQualifiedProxy(t *testing.T) {
+	em := mustRun(t, `<?php
+namespace Webkul\Attribute\Models;
+use Webkul\Product\Models\ProductProxy as ProductModel;
+class Family extends Model {
+    public function products() { return $this->hasMany(ProductModel::modelClass()); }
+    public function groups() { return $this->belongsTo(\Webkul\Product\Models\GroupProxy::modelClass()); }
+}
+`)
+	em.edge(t, model.EdgeComposes, `Webkul\Attribute\Models\Family`, `Webkul\Product\Models\Product`)
+	em.edge(t, model.EdgeComposes, `Webkul\Attribute\Models\Family`, `Webkul\Product\Models\Group`)
+}

--- a/internal/extract/php/laravel.go
+++ b/internal/extract/php/laravel.go
@@ -201,6 +201,41 @@ func (w *walker) accessorReturn(method *sitter.Node) string {
 	return accessor
 }
 
+// concordProxyModel returns the sibling model class a Konekt-Concord model
+// proxy stands for: a class named `<X>Proxy` extending ModelProxy is a
+// static proxy for `<X>` in its own namespace (the concord registry binds
+// them by that naming pair). Anything else returns "".
+func (w *walker) concordProxyModel(qualified string) string {
+	parent := w.parents[qualified]
+	if parent != "ModelProxy" && !strings.HasSuffix(parent, `\ModelProxy`) {
+		return ""
+	}
+	base := strings.TrimSuffix(qualified, "Proxy")
+	if base == qualified || strings.HasSuffix(base, `\`) {
+		return ""
+	}
+	return base
+}
+
+// emitConcordProxy emits the proxy-IS-A inherits edge for a concord model
+// proxy declaration, or nothing for a non-proxy. Mirrors the facade lane:
+// the proxy is a static stand-in for its model, so calls through the proxy
+// ride the resolver's ancestry walk onto the model.
+func (w *walker) emitConcordProxy(n *sitter.Node, qualified string) error {
+	target := w.concordProxyModel(qualified)
+	if target == "" {
+		return nil
+	}
+	line := extract.Line(n.StartPosition())
+	return w.emit.Edge(extract.EmittedEdge{
+		SourceQualified: qualified,
+		TargetQualified: target,
+		Kind:            model.EdgeInherits,
+		Line:            &line,
+		Confidence:      extract.ConfidenceConvention,
+	})
+}
+
 // emitFacadeAccessor emits the proxy-IS-A inherits edge for a facade
 // declaration, or nothing for a non-facade.
 func (w *walker) emitFacadeAccessor(n *sitter.Node, qualified string) error {

--- a/internal/extract/php/laravel_test.go
+++ b/internal/extract/php/laravel_test.go
@@ -1,6 +1,8 @@
 package php
 
 import (
+	"errors"
+
 	"testing"
 
 	"github.com/luuuc/sense/internal/extract"
@@ -301,5 +303,63 @@ class OrderProxy extends SomethingElse {}
 				t.Errorf("non-concord proxy folded: %+v", edge)
 			}
 		}
+	}
+}
+
+// The concord proxy inherits emit propagates emitter errors through
+// handleType. The edge index is discovered from a clean run so the test
+// stays stable if unrelated edges shift.
+func TestConcordProxyEmitterErrorPropagates(t *testing.T) {
+	src := `<?php
+namespace Webkul\Product\Models;
+class ProductProxy extends ModelProxy {}
+`
+	clean := mustRun(t, src)
+	at := 0
+	for i, e := range clean.edges {
+		if e.Kind == model.EdgeInherits && e.TargetQualified == `Webkul\Product\Models\Product` {
+			at = i + 1
+		}
+	}
+	if at == 0 {
+		t.Fatalf("no concord proxy edge in clean run: %v", clean.edges)
+	}
+	if err := run(t, src, &rec{failEdgeAt: at}); !errors.Is(err, errBoom) {
+		t.Errorf("expected errBoom from the concord edge emit, got %v", err)
+	}
+}
+
+// The concord naming-pair contract, pinned at its edges: a bare
+// `extends ModelProxy` with no import still fires (the pair is a naming
+// convention, not a Konekt import check); an aliased Concord import
+// (`use ... as Base`) fires because parents stores resolved names; and a
+// proxy literally named ModelProxy is the pair for a model named Model.
+func TestConcordProxyNamingPairEdges(t *testing.T) {
+	bare := mustRun(t, `<?php
+namespace App\Models;
+class OrderProxy extends ModelProxy {}
+`)
+	bare.edge(t, model.EdgeInherits, `App\Models\OrderProxy`, `App\Models\Order`)
+
+	aliased := mustRun(t, `<?php
+namespace App\Models;
+use Konekt\Concord\Proxies\ModelProxy as Base;
+class OrderProxy extends Base {}
+`)
+	aliased.edge(t, model.EdgeInherits, `App\Models\OrderProxy`, `App\Models\Order`)
+
+	self := mustRun(t, `<?php
+namespace App\Models;
+use Konekt\Concord\Proxies\ModelProxy;
+class ModelProxy extends ModelProxy {}
+`)
+	found := false
+	for _, e := range self.edges {
+		if e.Kind == model.EdgeInherits && e.SourceQualified == `App\Models\ModelProxy` && e.TargetQualified == `App\Models\Model` {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("a proxy named ModelProxy pairs with a model named Model (concord naming-pair semantics)")
 	}
 }

--- a/internal/extract/php/laravel_test.go
+++ b/internal/extract/php/laravel_test.go
@@ -277,3 +277,29 @@ func TestLaravelDegenerateNodes(t *testing.T) {
 		t.Errorf("facadeAccessor(bodyless) = %q", got)
 	}
 }
+
+// A concord model proxy (`class XProxy extends ModelProxy {}`) is a static
+// stand-in for its sibling model: an inherits edge proxy -> model rides the
+// ancestry walk, exactly like the facade lane. A Proxy-suffixed class with a
+// different parent, or a bare `Proxy` class, emits nothing.
+func TestConcordProxyInheritsModel(t *testing.T) {
+	em := mustRun(t, `<?php
+namespace Webkul\Product\Models;
+use Konekt\Concord\Proxies\ModelProxy;
+class ProductProxy extends ModelProxy {}
+class Proxy extends ModelProxy {}
+class OrderProxy extends SomethingElse {}
+`)
+	e := em.edge(t, model.EdgeInherits, `Webkul\Product\Models\ProductProxy`, `Webkul\Product\Models\Product`)
+	if e.Confidence != extract.ConfidenceConvention {
+		t.Errorf("proxy inherits conf = %v", e.Confidence)
+	}
+	for _, edge := range em.edges {
+		if edge.Kind == model.EdgeInherits && edge.Confidence == extract.ConfidenceConvention {
+			if edge.SourceQualified == `Webkul\Product\Models\Proxy` ||
+				edge.SourceQualified == `Webkul\Product\Models\OrderProxy` {
+				t.Errorf("non-concord proxy folded: %+v", edge)
+			}
+		}
+	}
+}

--- a/internal/extract/php/php.go
+++ b/internal/extract/php/php.go
@@ -267,6 +267,9 @@ func (w *walker) handleType(n *sitter.Node) error {
 	if err := w.emitFacadeAccessor(n, qualified); err != nil {
 		return err
 	}
+	if err := w.emitConcordProxy(n, qualified); err != nil {
+		return err
+	}
 	if err := w.emitObservedBy(n, qualified); err != nil {
 		return err
 	}

--- a/internal/mcpserver/graph_member_fold_test.go
+++ b/internal/mcpserver/graph_member_fold_test.go
@@ -1,0 +1,139 @@
+package mcpserver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/internal/mcpio"
+	"github.com/luuuc/sense/internal/metrics"
+	"github.com/luuuc/sense/internal/model"
+	"github.com/luuuc/sense/internal/profile"
+	"github.com/luuuc/sense/internal/search"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// setupMemberFoldFixture seeds the laravelio Thread shape: a class with ONE
+// class-level caller and twelve method-level callers. Pre-fix, the rendered
+// tool answer was called_by=1 with completeness "complete", the exact lie
+// the member-caller fold exists to prevent, observed at this layer.
+func setupMemberFoldFixture(t *testing.T) *handlers {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".sense"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, filepath.Join(dir, ".sense", "index.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	fid, err := adapter.WriteFile(ctx, &model.File{
+		Path: "app/Models/Thread.php", Language: "php", Hash: "t1", Symbols: 2, IndexedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	classID, err := adapter.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid, Name: "Thread", Qualified: `App\Models\Thread`,
+		Kind: model.KindClass, LineStart: 1, LineEnd: 300,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	methodID, err := adapter.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid, Name: "feed", Qualified: `App\Models\Thread\feed`,
+		Kind: model.KindMethod, ParentID: &classID, LineStart: 5, LineEnd: 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	directID, err := adapter.WriteSymbol(ctx, &model.Symbol{
+		FileID: fid, Name: "handle", Qualified: `App\Jobs\CreateThread\handle`,
+		Kind: model.KindFunction, LineStart: 30, LineEnd: 40,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := adapter.WriteEdge(ctx, &model.Edge{
+		SourceID: model.Int64Ptr(directID), TargetID: classID, Kind: model.EdgeCalls,
+		FileID: fid, Line: intPtr(31), Confidence: 1.0,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 12; i++ {
+		callerID, err := adapter.WriteSymbol(ctx, &model.Symbol{
+			FileID: fid, Name: fmt.Sprintf("caller%d", i), Qualified: fmt.Sprintf(`App\Http\C%d\index`, i),
+			Kind: model.KindFunction, LineStart: 50 + 5*i, LineEnd: 53 + 5*i,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := adapter.WriteEdge(ctx, &model.Edge{
+			SourceID: model.Int64Ptr(callerID), TargetID: methodID, Kind: model.EdgeCalls,
+			FileID: fid, Line: intPtr(50 + 5*i), Confidence: 1.0,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tracker := metrics.NewTracker(adapter.DB())
+	t.Cleanup(func() { tracker.Close() })
+	return &handlers{
+		adapter:     adapter,
+		db:          adapter.DB(),
+		dir:         dir,
+		search:      search.NewEngine(adapter, nil, nil),
+		tracker:     tracker,
+		defaults:    profile.DefaultParams(),
+		seenSymbols: make(map[int64]bool),
+	}
+}
+
+// The layer agents actually hit: the rendered sense_graph caller list for a
+// class must carry the method-derived callers alongside the class-level one,
+// and the completeness verdict must describe THAT list, not the pre-fold one.
+func TestHandleGraphRendersFoldedMemberCallers(t *testing.T) {
+	h := setupMemberFoldFixture(t)
+	ctx := context.Background()
+
+	result, err := h.handleGraph(ctx, toolReq(map[string]any{
+		"symbol":    "Thread",
+		"direction": "callers",
+	}))
+	if err != nil {
+		t.Fatalf("handleGraph: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("tool error: %s", resultText(t, result))
+	}
+	var resp mcpio.GraphResponse
+	if err := json.Unmarshal([]byte(resultText(t, result)), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(resp.Edges.CalledBy) != 13 {
+		t.Fatalf("rendered called_by = %d, want 13 (1 class-level + 12 folded)", len(resp.Edges.CalledBy))
+	}
+	var direct, folded bool
+	for _, e := range resp.Edges.CalledBy {
+		if e.Symbol == `App\Jobs\CreateThread\handle` {
+			direct = true
+		}
+		if e.Symbol == `App\Http\C0\index` {
+			folded = true
+		}
+	}
+	if !direct {
+		t.Error("class-level caller missing from the rendered list")
+	}
+	if !folded {
+		t.Error("method-derived caller missing from the rendered list")
+	}
+}

--- a/internal/sqlite/foldcallees_internal_test.go
+++ b/internal/sqlite/foldcallees_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/luuuc/sense/internal/model"
 )
@@ -23,5 +24,38 @@ func TestFoldMemberCalleesChildQueryError(t *testing.T) {
 	sc := &model.SymbolContext{Symbol: model.Symbol{ID: 1, Kind: model.KindClass}}
 	if err := a.foldMemberCallees(ctx, sc); err == nil {
 		t.Fatal("foldMemberCallees on closed adapter: want error, got nil")
+	}
+}
+
+// foldMemberCallers surfaces a DB error from the member-edge collection:
+// the child-symbol lookup succeeds (sense_symbols intact) but loading a
+// member's inbound edges fails (sense_edges dropped), so the error rides
+// collectMemberCallerEdges back through foldMemberCallers.
+func TestFoldMemberCallersEdgeLoadError(t *testing.T) {
+	ctx := context.Background()
+	a, err := Open(ctx, filepath.Join(t.TempDir(), "fold.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer func() { _ = a.Close() }()
+
+	fid, err := a.WriteFile(ctx, &model.File{Path: "c.php", Language: "php", Hash: "h", Symbols: 2, IndexedAt: time.Now()})
+	if err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	classID, err := a.WriteSymbol(ctx, &model.Symbol{FileID: fid, Name: "C", Qualified: "C", Kind: model.KindClass, LineStart: 1, LineEnd: 9})
+	if err != nil {
+		t.Fatalf("WriteSymbol class: %v", err)
+	}
+	if _, err := a.WriteSymbol(ctx, &model.Symbol{FileID: fid, Name: "m", Qualified: "C\\m", Kind: model.KindMethod, ParentID: &classID, LineStart: 2, LineEnd: 4}); err != nil {
+		t.Fatalf("WriteSymbol method: %v", err)
+	}
+	if _, err := a.db.ExecContext(ctx, `DROP TABLE sense_edges`); err != nil {
+		t.Fatalf("drop sense_edges: %v", err)
+	}
+
+	sc := &model.SymbolContext{Symbol: model.Symbol{ID: classID, Kind: model.KindClass}}
+	if err := a.foldMemberCallers(ctx, sc); err == nil {
+		t.Fatal("foldMemberCallers with dropped edges table: want error, got nil")
 	}
 }

--- a/internal/sqlite/foldcallers_test.go
+++ b/internal/sqlite/foldcallers_test.go
@@ -323,3 +323,44 @@ func TestReadSymbolGraphRealCallerStillSuppressesFoldBesideSynthetic(t *testing.
 		t.Error("a genuine direct caller must still suppress the method-caller fold")
 	}
 }
+
+// A class-level caller set at the sufficient-evidence floor is still folded
+// when the member-derived set dwarfs it (the ratio guard). Regression:
+// pelican Server carried exactly 3 direct callers, which suppressed a fold
+// hiding 28 method-derived callers and re-created the collapse one notch up.
+func TestReadSymbolGraphDwarfedDirectCallersStillFold(t *testing.T) {
+	a, fileID := newFoldAdapter(t)
+	ctx := context.Background()
+
+	classID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "Server", Qualified: "App\\Models\\Server", Kind: model.KindClass, LineStart: 1, LineEnd: 400})
+	methodID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "status", Qualified: "App\\Models\\Server\\status", Kind: model.KindMethod, ParentID: &classID, LineStart: 5, LineEnd: 12})
+
+	for i := 0; i < 3; i++ {
+		id := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "D" + string(rune('A'+i)), Qualified: "D" + string(rune('A'+i)), Kind: model.KindFunction, LineStart: 20 + 10*i, LineEnd: 25 + 10*i})
+		mustEdge(t, a, &model.Edge{SourceID: &id, TargetID: classID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 1.0})
+	}
+	memberIDs := make([]int64, 0, 30)
+	for i := 0; i < 30; i++ {
+		id := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "M" + string(rune('A'+i%26)) + string(rune('a'+i/26)), Qualified: "M" + string(rune('A'+i%26)) + string(rune('a'+i/26)), Kind: model.KindFunction, LineStart: 60 + 5*i, LineEnd: 63 + 5*i})
+		mustEdge(t, a, &model.Edge{SourceID: &id, TargetID: methodID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 1.0})
+		memberIDs = append(memberIDs, id)
+	}
+
+	gr, err := a.ReadSymbolGraph(ctx, classID, 1, model.DirectionCallers, 0)
+	if err != nil {
+		t.Fatalf("ReadSymbolGraph: %v", err)
+	}
+	got := map[int64]bool{}
+	for _, e := range gr.Root.Inbound {
+		got[e.Target.ID] = true
+	}
+	folded := 0
+	for _, id := range memberIDs {
+		if got[id] {
+			folded++
+		}
+	}
+	if folded != 30 {
+		t.Errorf("dwarfed direct set must not suppress the fold: folded %d of 30 member callers", folded)
+	}
+}

--- a/internal/sqlite/foldcallers_test.go
+++ b/internal/sqlite/foldcallers_test.go
@@ -2,6 +2,7 @@ package sqlite_test
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -336,12 +337,12 @@ func TestReadSymbolGraphDwarfedDirectCallersStillFold(t *testing.T) {
 	methodID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "status", Qualified: "App\\Models\\Server\\status", Kind: model.KindMethod, ParentID: &classID, LineStart: 5, LineEnd: 12})
 
 	for i := 0; i < 3; i++ {
-		id := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "D" + string(rune('A'+i)), Qualified: "D" + string(rune('A'+i)), Kind: model.KindFunction, LineStart: 20 + 10*i, LineEnd: 25 + 10*i})
+		id := mustSym(t, a, &model.Symbol{FileID: fileID, Name: fmt.Sprintf("D%d", i), Qualified: fmt.Sprintf("D%d", i), Kind: model.KindFunction, LineStart: 20 + 10*i, LineEnd: 25 + 10*i})
 		mustEdge(t, a, &model.Edge{SourceID: &id, TargetID: classID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 1.0})
 	}
 	memberIDs := make([]int64, 0, 30)
 	for i := 0; i < 30; i++ {
-		id := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "M" + string(rune('A'+i%26)) + string(rune('a'+i/26)), Qualified: "M" + string(rune('A'+i%26)) + string(rune('a'+i/26)), Kind: model.KindFunction, LineStart: 60 + 5*i, LineEnd: 63 + 5*i})
+		id := mustSym(t, a, &model.Symbol{FileID: fileID, Name: fmt.Sprintf("M%d", i), Qualified: fmt.Sprintf("M%d", i), Kind: model.KindFunction, LineStart: 60 + 5*i, LineEnd: 63 + 5*i})
 		mustEdge(t, a, &model.Edge{SourceID: &id, TargetID: methodID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 1.0})
 		memberIDs = append(memberIDs, id)
 	}
@@ -362,5 +363,73 @@ func TestReadSymbolGraphDwarfedDirectCallersStillFold(t *testing.T) {
 	}
 	if folded != 30 {
 		t.Errorf("dwarfed direct set must not suppress the fold: folded %d of 30 member callers", folded)
+	}
+	directListed := 0
+	for _, e := range gr.Root.Inbound {
+		if e.Target.Name != "" && len(e.Target.Name) > 1 && e.Target.Name[0] == 'D' {
+			directListed++
+		}
+	}
+	if directListed != 3 {
+		t.Errorf("the 3 direct callers must stay listed alongside the fold, got %d", directListed)
+	}
+}
+
+// The suppression constants, pinned at their boundaries. Any drift of the
+// sufficient-evidence floor (3) or the dwarf ratio (5) flips at least one
+// of these rows: 2 direct callers are below the floor and always fold;
+// 3 direct with 14 member callers sit just inside the ratio and keep the
+// precise answer; 3 direct with 15 member callers are exactly dwarfed and
+// fold.
+func TestReadSymbolGraphFoldBoundaries(t *testing.T) {
+	cases := []struct {
+		name     string
+		direct   int
+		member   int
+		wantFold bool
+	}{
+		{"below floor always folds", 2, 1, true},
+		{"at floor, inside ratio, suppressed", 3, 14, false},
+		{"at floor, exactly dwarfed, folds", 3, 15, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			a, fileID := newFoldAdapter(t)
+			ctx := context.Background()
+
+			classID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "K", Qualified: "K", Kind: model.KindClass, LineStart: 1, LineEnd: 900})
+			methodID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "run", Qualified: "K\\run", Kind: model.KindMethod, ParentID: &classID, LineStart: 2, LineEnd: 4})
+			for i := 0; i < c.direct; i++ {
+				id := mustSym(t, a, &model.Symbol{FileID: fileID, Name: fmt.Sprintf("D%d", i), Qualified: fmt.Sprintf("D%d", i), Kind: model.KindFunction, LineStart: 10 + 4*i, LineEnd: 12 + 4*i})
+				mustEdge(t, a, &model.Edge{SourceID: &id, TargetID: classID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 1.0})
+			}
+			memberIDs := make([]int64, 0, c.member)
+			for i := 0; i < c.member; i++ {
+				id := mustSym(t, a, &model.Symbol{FileID: fileID, Name: fmt.Sprintf("M%d", i), Qualified: fmt.Sprintf("M%d", i), Kind: model.KindFunction, LineStart: 100 + 4*i, LineEnd: 102 + 4*i})
+				mustEdge(t, a, &model.Edge{SourceID: &id, TargetID: methodID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 1.0})
+				memberIDs = append(memberIDs, id)
+			}
+
+			gr, err := a.ReadSymbolGraph(ctx, classID, 1, model.DirectionCallers, 0)
+			if err != nil {
+				t.Fatalf("ReadSymbolGraph: %v", err)
+			}
+			got := map[int64]bool{}
+			for _, e := range gr.Root.Inbound {
+				got[e.Target.ID] = true
+			}
+			folded := 0
+			for _, id := range memberIDs {
+				if got[id] {
+					folded++
+				}
+			}
+			if c.wantFold && folded != c.member {
+				t.Errorf("want all %d member callers folded, got %d", c.member, folded)
+			}
+			if !c.wantFold && folded != 0 {
+				t.Errorf("want fold suppressed, got %d member callers", folded)
+			}
+		})
 	}
 }

--- a/internal/sqlite/foldcallers_test.go
+++ b/internal/sqlite/foldcallers_test.go
@@ -78,18 +78,23 @@ func TestReadSymbolGraphFoldsMemberCallers(t *testing.T) {
 	}
 }
 
-// When a class already has direct callers, the precise answer is kept — method
-// callers are not folded in to dilute it.
+// When a class already has enough direct callers of its own (the sufficient-
+// evidence floor), the precise answer is kept; method callers are not folded
+// in to dilute it.
 func TestReadSymbolGraphDirectCallersNotDiluted(t *testing.T) {
 	a, fileID := newFoldAdapter(t)
 	ctx := context.Background()
 
 	classID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "Acct", Qualified: "Acct", Kind: model.KindClass, LineStart: 1, LineEnd: 30})
 	methodID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "debit", Qualified: "Acct#debit", Kind: model.KindMethod, ParentID: &classID, LineStart: 3, LineEnd: 6})
-	directID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "Direct", Qualified: "Direct", Kind: model.KindFunction, LineStart: 10, LineEnd: 14})
 	indirectID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "Indirect", Qualified: "Indirect", Kind: model.KindFunction, LineStart: 16, LineEnd: 20})
 
-	mustEdge(t, a, &model.Edge{SourceID: &directID, TargetID: classID, Kind: model.EdgeReferences, FileID: fileID, Confidence: 1.0})
+	var directIDs []int64
+	for i, name := range []string{"DirectA", "DirectB", "DirectC"} {
+		id := mustSym(t, a, &model.Symbol{FileID: fileID, Name: name, Qualified: name, Kind: model.KindFunction, LineStart: 10 + 10*i, LineEnd: 14 + 10*i})
+		mustEdge(t, a, &model.Edge{SourceID: &id, TargetID: classID, Kind: model.EdgeReferences, FileID: fileID, Confidence: 1.0})
+		directIDs = append(directIDs, id)
+	}
 	mustEdge(t, a, &model.Edge{SourceID: &indirectID, TargetID: methodID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 1.0})
 
 	gr, err := a.ReadSymbolGraph(ctx, classID, 1, model.DirectionCallers, 0)
@@ -98,7 +103,7 @@ func TestReadSymbolGraphDirectCallersNotDiluted(t *testing.T) {
 	}
 	var direct, indirect bool
 	for _, e := range gr.Root.Inbound {
-		if e.Target.ID == directID {
+		if e.Target.ID == directIDs[0] {
 			direct = true
 		}
 		if e.Target.ID == indirectID {
@@ -109,7 +114,47 @@ func TestReadSymbolGraphDirectCallersNotDiluted(t *testing.T) {
 		t.Error("direct caller missing")
 	}
 	if indirect {
-		t.Error("method-caller should not be folded when direct callers already exist")
+		t.Error("method-caller should not be folded when the class has enough direct callers")
+	}
+}
+
+// A container with only ONE direct caller still folds its member callers in:
+// a single class-level edge is not sufficient evidence that the caller set is
+// complete. Regression: laravelio's Thread had 1 class-level call edge
+// (CreateThread) and 66 method-level caller edges; graph answered
+// called_by=1 with completeness "complete" while blast's verified band held
+// 12 dependents: the PHP shape, where good method resolution starves the
+// class node.
+func TestReadSymbolGraphFewDirectCallersStillFold(t *testing.T) {
+	a, fileID := newFoldAdapter(t)
+	ctx := context.Background()
+
+	classID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "Thread", Qualified: "App\\Models\\Thread", Kind: model.KindClass, LineStart: 1, LineEnd: 90})
+	methodID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "feed", Qualified: "App\\Models\\Thread\\feed", Kind: model.KindMethod, ParentID: &classID, LineStart: 5, LineEnd: 12})
+	directID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "handle", Qualified: "App\\Jobs\\CreateThread\\handle", Kind: model.KindFunction, LineStart: 20, LineEnd: 30})
+	methodCallerID := mustSym(t, a, &model.Symbol{FileID: fileID, Name: "index", Qualified: "ForumController\\index", Kind: model.KindFunction, LineStart: 32, LineEnd: 40})
+
+	mustEdge(t, a, &model.Edge{SourceID: &directID, TargetID: classID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 1.0})
+	mustEdge(t, a, &model.Edge{SourceID: &methodCallerID, TargetID: methodID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 1.0})
+
+	gr, err := a.ReadSymbolGraph(ctx, classID, 1, model.DirectionCallers, 0)
+	if err != nil {
+		t.Fatalf("ReadSymbolGraph: %v", err)
+	}
+	var direct, folded bool
+	for _, e := range gr.Root.Inbound {
+		if e.Target.ID == directID {
+			direct = true
+		}
+		if e.Target.ID == methodCallerID {
+			folded = true
+		}
+	}
+	if !direct {
+		t.Error("the class-level caller must be listed")
+	}
+	if !folded {
+		t.Error("one class-level caller must not suppress the member-caller fold")
 	}
 }
 
@@ -236,9 +281,10 @@ func TestReadSymbolGraphSyntheticCallerDoesNotSuppressFold(t *testing.T) {
 	}
 }
 
-// A real (non-synthetic) direct caller still suppresses the fold when it
-// arrives alongside a synthetic one — the synthetic edge neither suppresses
-// nor un-suppresses; only genuine usage does.
+// Real (non-synthetic) direct callers at the sufficient-evidence floor still
+// suppress the fold when they arrive alongside a synthetic one; the synthetic
+// edge neither suppresses nor un-suppresses; only genuine usage counts toward
+// the floor.
 func TestReadSymbolGraphRealCallerStillSuppressesFoldBesideSynthetic(t *testing.T) {
 	a, fileID := newFoldAdapter(t)
 	ctx := context.Background()
@@ -251,6 +297,10 @@ func TestReadSymbolGraphRealCallerStillSuppressesFoldBesideSynthetic(t *testing.
 
 	mustEdge(t, a, &model.Edge{SourceID: &accessorID, TargetID: classID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 0.8})
 	mustEdge(t, a, &model.Edge{SourceID: &directID, TargetID: classID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 0.9})
+	for i, name := range []string{"FilterB", "FilterC"} {
+		id := mustSym(t, a, &model.Symbol{FileID: fileID, Name: name, Qualified: name, Kind: model.KindFunction, LineStart: 42 + 10*i, LineEnd: 48 + 10*i})
+		mustEdge(t, a, &model.Edge{SourceID: &id, TargetID: classID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 0.9})
+	}
 	mustEdge(t, a, &model.Edge{SourceID: &methodCallerID, TargetID: methodID, Kind: model.EdgeCalls, FileID: fileID, Confidence: 1.0})
 
 	gr, err := a.ReadSymbolGraph(ctx, classID, 1, model.DirectionCallers, 0)

--- a/internal/sqlite/graph.go
+++ b/internal/sqlite/graph.go
@@ -216,6 +216,13 @@ func isUsageEdge(k model.EdgeKind) bool {
 // mcpserver.InterfaceResolutionThreshold, which this mirrors in value.
 const memberFoldSufficientCallers = 3
 
+// memberFoldDwarfRatio guards the suppression itself: even at the floor,
+// a class-level caller set dwarfed by this many times more member-derived
+// callers is not the complete answer (pelican Server: exactly 3 direct
+// callers suppressed a fold hiding 28 method callers, a 9.3x gap that a
+// ratio of 10 missed by two edges).
+const memberFoldDwarfRatio = 5
+
 // countUsageEdges counts above-floor usage edges: real call/reference
 // signals, as opposed to structural edges or low-confidence resolution
 // guesses. A synthetic counterpart (django-related:*, route:*, i18n:*, …)
@@ -248,15 +255,6 @@ func (a *Adapter) foldMemberCallers(ctx context.Context, sc *model.SymbolContext
 	if !isContainerExpandKind(sc.Symbol.Kind) {
 		return nil
 	}
-	// Only skip enrichment when the container already has enough real direct
-	// callers of its own to stand as the answer; below the floor, the
-	// class-level set is incidental (the "a referenced class looks unused"
-	// case, and its PHP sibling where one constructor edge hid every
-	// method-derived caller). A structural edge (inherits/composes) or a
-	// low-confidence name-collision guess never counts toward the floor.
-	if countUsageEdges(sc.Inbound) >= memberFoldSufficientCallers {
-		return nil
-	}
 	childIDs, err := a.childSymbolIDs(ctx, sc.Symbol.ID)
 	if err != nil {
 		return err
@@ -273,6 +271,7 @@ func (a *Adapter) foldMemberCallers(ctx context.Context, sc *model.SymbolContext
 	for _, e := range sc.Inbound {
 		seen[e.Target.ID] = struct{}{}
 	}
+	var folded []model.EdgeRef
 	for _, cid := range childIDs {
 		refs, err := a.loadEdges(ctx, cid, false)
 		if err != nil {
@@ -295,9 +294,19 @@ func (a *Adapter) foldMemberCallers(ctx context.Context, sc *model.SymbolContext
 				continue
 			}
 			seen[e.Target.ID] = struct{}{}
-			sc.Inbound = append(sc.Inbound, e)
+			folded = append(folded, e)
 		}
 	}
+	// Keep the precise class-level answer only when it is sufficient
+	// evidence (at the floor) AND not dwarfed by the member-derived set;
+	// a class-level list one tenth the size of what its methods carry is
+	// incidental, not complete (pelican Server: 3 direct vs 28 folded).
+	direct := countUsageEdges(sc.Inbound)
+	if direct >= memberFoldSufficientCallers &&
+		len(folded) < memberFoldDwarfRatio*direct {
+		return nil
+	}
+	sc.Inbound = append(sc.Inbound, folded...)
 	return nil
 }
 

--- a/internal/sqlite/graph.go
+++ b/internal/sqlite/graph.go
@@ -205,22 +205,37 @@ func isUsageEdge(k model.EdgeKind) bool {
 	return k == model.EdgeCalls || k == model.EdgeReferences
 }
 
-// hasUsageEdge reports whether edges contains at least one above-floor
-// usage edge — a real call/reference signal, as opposed to a structural
-// edge or a low-confidence resolution guess. Used by both fold paths:
-// against Inbound it means "has a real caller", against Outbound it means
-// "has a real callee". A synthetic counterpart (django-related:*, route:*,
-// i18n:*, …) is declaration-site plumbing, not real usage, so it neither
-// counts as a caller nor as a callee here — one such edge must not starve
-// the fold of every method-derived caller.
-func hasUsageEdge(edges []model.EdgeRef) bool {
+// memberFoldSufficientCallers is the floor at which a container's own
+// usage callers count as sufficient evidence to skip the member-caller
+// fold. Below it, the class-level caller set is treated as incidental
+// rather than complete: a class whose consumers reach it through resolved
+// methods (the PHP shape: laravelio Thread carried 1 class-level call
+// edge against 66 method-level ones) may still collect one or two direct
+// edges (a constructor call, a static create), and those must not hide
+// every method-derived caller. Same "sufficient evidence" notion as
+// mcpserver.InterfaceResolutionThreshold, which this mirrors in value.
+const memberFoldSufficientCallers = 3
+
+// countUsageEdges counts above-floor usage edges: real call/reference
+// signals, as opposed to structural edges or low-confidence resolution
+// guesses. A synthetic counterpart (django-related:*, route:*, i18n:*, …)
+// is declaration-site plumbing, not real usage, so it does not count.
+func countUsageEdges(edges []model.EdgeRef) int {
+	n := 0
 	for _, e := range edges {
 		if isUsageEdge(e.Edge.Kind) && e.Edge.Confidence >= extract.ConfidenceUnresolved &&
 			!extract.IsSyntheticQualified(e.Target.Qualified) {
-			return true
+			n++
 		}
 	}
-	return false
+	return n
+}
+
+// hasUsageEdge reports whether edges contains at least one above-floor
+// usage edge. Used by the callee fold path: against Outbound it means
+// "has a real callee".
+func hasUsageEdge(edges []model.EdgeRef) bool {
+	return countUsageEdges(edges) > 0
 }
 
 // foldMemberCallers enriches a container symbol's inbound edges with the
@@ -233,12 +248,13 @@ func (a *Adapter) foldMemberCallers(ctx context.Context, sc *model.SymbolContext
 	if !isContainerExpandKind(sc.Symbol.Kind) {
 		return nil
 	}
-	// Only enrich when the container has no real direct caller of its own —
-	// the "a referenced class looks unused" case (graph returned [] while
-	// blast found callers via the class's methods). A structural edge
-	// (inherits/composes) or a low-confidence name-collision guess is not a
-	// real caller, so those do not suppress enrichment.
-	if hasUsageEdge(sc.Inbound) {
+	// Only skip enrichment when the container already has enough real direct
+	// callers of its own to stand as the answer; below the floor, the
+	// class-level set is incidental (the "a referenced class looks unused"
+	// case, and its PHP sibling where one constructor edge hid every
+	// method-derived caller). A structural edge (inherits/composes) or a
+	// low-confidence name-collision guess never counts toward the floor.
+	if countUsageEdges(sc.Inbound) >= memberFoldSufficientCallers {
 		return nil
 	}
 	childIDs, err := a.childSymbolIDs(ctx, sc.Symbol.ID)

--- a/internal/sqlite/graph.go
+++ b/internal/sqlite/graph.go
@@ -271,19 +271,40 @@ func (a *Adapter) foldMemberCallers(ctx context.Context, sc *model.SymbolContext
 	for _, e := range sc.Inbound {
 		seen[e.Target.ID] = struct{}{}
 	}
+	folded, err := a.collectMemberCallerEdges(ctx, childIDs, exclude, seen)
+	if err != nil {
+		return err
+	}
+	// Keep the precise class-level answer only when it is sufficient
+	// evidence (at the floor) AND not dwarfed by the member-derived set;
+	// a class-level list one tenth the size of what its methods carry is
+	// incidental, not complete (pelican Server: 3 direct vs 28 folded).
+	direct := countUsageEdges(sc.Inbound)
+	if direct >= memberFoldSufficientCallers &&
+		len(folded) < memberFoldDwarfRatio*direct {
+		return nil
+	}
+	sc.Inbound = append(sc.Inbound, folded...)
+	return nil
+}
+
+// collectMemberCallerEdges gathers the deduped inbound caller edges of the
+// given member symbols, applying the same filters blast uses: temporal
+// edges and low-confidence guesses (name-collision fallbacks stamped below
+// the traversal floor) are dropped, excluded ids (the container and its
+// own members) never count, and seen is updated so each caller appears
+// once.
+func (a *Adapter) collectMemberCallerEdges(ctx context.Context, childIDs []int64, exclude, seen map[int64]struct{}) ([]model.EdgeRef, error) {
 	var folded []model.EdgeRef
 	for _, cid := range childIDs {
 		refs, err := a.loadEdges(ctx, cid, false)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		for _, e := range refs {
 			if e.Target.ID == 0 || e.Edge.Kind == model.EdgeTemporal {
 				continue
 			}
-			// Don't fold low-confidence guesses (e.g. name-collision
-			// fallbacks stamped below the traversal floor) into the class's
-			// callers — that would re-admit exactly what blast filters out.
 			if e.Edge.Confidence < extract.ConfidenceUnresolved {
 				continue
 			}
@@ -297,17 +318,7 @@ func (a *Adapter) foldMemberCallers(ctx context.Context, sc *model.SymbolContext
 			folded = append(folded, e)
 		}
 	}
-	// Keep the precise class-level answer only when it is sufficient
-	// evidence (at the floor) AND not dwarfed by the member-derived set;
-	// a class-level list one tenth the size of what its methods carry is
-	// incidental, not complete (pelican Server: 3 direct vs 28 folded).
-	direct := countUsageEdges(sc.Inbound)
-	if direct >= memberFoldSufficientCallers &&
-		len(folded) < memberFoldDwarfRatio*direct {
-		return nil
-	}
-	sc.Inbound = append(sc.Inbound, folded...)
-	return nil
+	return folded, nil
 }
 
 // foldMemberCallees enriches a container symbol's outbound edges with the


### PR DESCRIPTION
Asking Sense "who calls this class" in a PHP codebase now returns the real caller set, and Laravel projects built on Konekt Concord model proxies get their model relations resolved instead of a blind spot.

## Problem
On PHP class symbols, `sense_graph` callers collapsed to one or two entries while `sense_blast` saw dozens of verified dependents, and the response still claimed a complete edge set. The member-caller fold was suppressed by any genuine class-level usage edge, and PHP resolution binds consumer calls to method symbols, so one incidental constructor edge hid every method-derived caller (measured: a central model with 24 importers answered called_by=1). Separately, Concord-based Laravel apps spell every model reference through proxies (`ProductProxy::modelClass()`, `class ProductProxy extends ModelProxy {}`); neither form resolved, so a central model carried zero usage edges and an empty verified band.

## Summary
Turn the fold suppression into a counted sufficient-evidence floor with a dwarf-ratio guard, and resolve the Concord proxy spellings (including aliased and fully-qualified imports) onto their models.

Scope note: the fold change is language-agnostic query-layer behavior, motivated by PHP but affecting every indexed language; the pre/post stability probe below is the cross-language evidence. The Concord change is PHP-only. The callee-side fold is untouched and its coverage is unchanged; the caller fold now loads member edges before deciding suppression (needed for the ratio), a per-query cost on very method-heavy classes.

## Changes
- `internal/sqlite/graph.go`: member-caller fold now fires unless the class already has `memberFoldSufficientCallers` (3) real direct callers AND the member-derived set is smaller than `memberFoldDwarfRatio` (5) times the direct set; a class-level list dwarfed by what its methods carry is incidental, not complete
- `internal/extract/php`: a class named `<X>Proxy` extending `ModelProxy` emits a proxy inherits edge to its sibling model `<X>` (same lane as the facade accessor); relation arguments written `<X>Proxy::modelClass()` compose onto `<X>`
- admission-gate bench instrument: PHP covering-pattern rows (`use ...\X;` and the `use <NS>\` superset), plus two measurement fixes (multiline import-cover matching, scatter counted after stripping the deps' common directory prefix)

## Test Plan
- [x] failing-first regression: one class-level caller must not suppress the fold (`TestReadSymbolGraphFewDirectCallersStillFold`)
- [x] suppression tests re-anchored at the floor (3 direct callers still keep the precise answer)
- [x] Concord proxy inherits + `modelClass()` relation tests, including non-proxy and bare-`Proxy` negatives
- [x] live verification on real indexes: laravelio `Thread` called_by 1 to 12, koel `Song` 1 to 48, pelican `Server` 3 to 31 (MCP stdio); bagisto `Product` composes 0 to 25, verified band 1 to 53 after rescan
- [x] dwarf-ratio regression: 3 direct callers plus 30 member callers must fold, and the 3 direct stay listed (`TestReadSymbolGraphDwarfedDirectCallersStillFold`)
- [x] constants pinned at their boundaries: 2 direct always fold; 3 direct + 14 member suppressed; 3 direct + 15 folds (`TestReadSymbolGraphFoldBoundaries`) - any drift of the floor or ratio flips a row
- [x] the rendered tool answer is tested at the mcpserver layer: 1 class-level + 12 method callers renders called_by=13 (`TestHandleGraphRendersFoldedMemberCallers`)
- [x] aliased + fully-qualified proxy spellings compose onto the model (`TestEloquentRelationsThroughAliasedAndQualifiedProxy`); naming-pair edge cases pinned (`TestConcordProxyNamingPairEdges`)
- [x] error paths covered: member-edge load failure through the fold, emitter failure through the concord emit
- [x] cross-language stability probe pre/post on frozen indexes: chatwoot `Inbox` 32=32, sentry `Group` 91=91, dolt `DoltDB` 61=61, gin `Context` 117=117
- [x] `make ci` green (coverage 95.5%, lint 0, ledger 0) and `make smoke` green
