### PR TITLE
fix(resolve): PHP bare function calls must not bind same-named methods

### DIFF
--- a/internal/resolve/bare_call_test.go
+++ b/internal/resolve/bare_call_test.go
@@ -3,6 +3,7 @@ package resolve_test
 import (
 	"testing"
 
+	"github.com/luuuc/sense/internal/extract"
 	"github.com/luuuc/sense/internal/model"
 	"github.com/luuuc/sense/internal/resolve"
 )
@@ -142,6 +143,81 @@ func TestResolveGoDottedLeafStillBindsMethod(t *testing.T) {
 	}
 	if r.SymbolID != 2 {
 		t.Errorf("SymbolID = %d, want 2", r.SymbolID)
+	}
+}
+
+// phpBareRefs models F-3: PHP has no implicit-self method dispatch, so a bare
+// `count(...)` call is a builtin/function call and must never bind the
+// same-named method - the exact shape that bound `Webkul\Core\Eloquent\
+// Repository::count` to 14 files whose only tie was a PHP builtin `count()`.
+// File 30 is a PHP production file.
+func phpBareRefs() []model.SymbolRef {
+	return []model.SymbolRef{
+		{ID: 1, Qualified: `App\Repository`, FileID: 30, Language: "php", Path: "Repository.php", Kind: model.KindType},
+		{ID: 2, Qualified: `App\Repository\count`, FileID: 30, Language: "php", Path: "Repository.php", Kind: model.KindMethod},
+	}
+}
+
+// The defect itself (F-3): a bare PHP call `count(...)` emitted at static
+// confidence must NOT bind the same-named method - PHP method dispatch requires
+// a receiver (`$x->count()`), so a receiverless `count(` is a builtin/function.
+func TestResolvePHPBareFunctionCallNeverBindsMethod(t *testing.T) {
+	ix := resolve.NewIndex(phpBareRefs())
+	_, ok := ix.Resolve(resolve.Request{
+		Target:         "count",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   30,
+		BaseConfidence: extract.ConfidenceStatic,
+	})
+	if ok {
+		t.Fatal("bare PHP call bound a method symbol - illegal by PHP grammar (no implicit-self dispatch; count() is a builtin/function)")
+	}
+}
+
+// Mutation guard: a bare PHP call to an indexed FUNCTION is the legitimate case
+// the fallback exists for (a Laravel global helper like `collect()`). Kills the
+// "drop all bare PHP calls" over-fix mutant.
+func TestResolvePHPBareCallKeepsFunctionBind(t *testing.T) {
+	rs := append(phpBareRefs(),
+		model.SymbolRef{ID: 5, Qualified: `App\Support\collect`, FileID: 30, Language: "php", Path: "helpers.php", Kind: model.KindFunction},
+	)
+	ix := resolve.NewIndex(rs)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "collect",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   30,
+		BaseConfidence: extract.ConfidenceStatic,
+	})
+	if !ok {
+		t.Fatal("bare PHP call to an indexed function must resolve")
+	}
+	if r.SymbolID != 5 {
+		t.Errorf("SymbolID = %d, want 5 (the function)", r.SymbolID)
+	}
+}
+
+// Mutation guard: PHP's unknown-receiver member fallback (decision 0003 clause
+// 1) emits the bare method name at ConfidenceNameCollision - a genuine dispatch
+// that must KEEP binding the method, demoted below blast's floor for liveness.
+// The gate is confidence-aware for PHP: only ABOVE the collision band (a
+// function call) are methods dropped. Kills the "put PHP in the Go/Rust camp"
+// over-fix that would wipe this liveness edge.
+func TestResolvePHPMemberFallbackKeepsMethodDemoted(t *testing.T) {
+	ix := resolve.NewIndex(phpBareRefs())
+	r, ok := ix.Resolve(resolve.Request{
+		Target:         "count",
+		Kind:           model.EdgeCalls,
+		SourceFileID:   30,
+		BaseConfidence: extract.ConfidenceNameCollision,
+	})
+	if !ok {
+		t.Fatal("PHP member fallback at the collision band must keep binding the method (decision 0003 clause 1 liveness)")
+	}
+	if r.SymbolID != 2 {
+		t.Errorf("SymbolID = %d, want 2 (the method)", r.SymbolID)
+	}
+	if r.Confidence >= extract.ConfidenceUnresolved {
+		t.Errorf("Confidence = %v, want below blast's floor (a demoted guess)", r.Confidence)
 	}
 }
 

--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -475,7 +475,7 @@ func (ix *Index) resolveByLeaf(target string, req Request) (Result, bool) {
 	matches := ix.byName[name]
 	matches = filterByLanguage(matches, ix.fileLang[req.SourceFileID])
 	matches = filterByTestDirection(matches, ix.fileIsTest[req.SourceFileID], ix.fileIsTest)
-	if sep == "" && !bareCallBindsMethods(ix.fileLang[req.SourceFileID]) {
+	if sep == "" && !bareCallBindsMethods(ix.fileLang[req.SourceFileID], req.BaseConfidence) {
 		matches = filterOutMethods(matches)
 	}
 	matches, receiverContradicted := filterByReceiver(matches, sep)
@@ -794,11 +794,29 @@ func isViewLanguage(lang string) bool {
 // `Type::m(recv)`), and the extractors for both emit dotted/pathed targets on
 // every selector path, so a bare target is a genuinely bare call — builtins
 // (`append`, `len`), conversions (`int(…)`), functions, and local closures
-// are its only legal callees, none of which is a method symbol. Ruby's bare
-// calls ARE implicit-self method dispatch, so it (and any unknown language)
-// answers true and the gate fails open.
-func bareCallBindsMethods(lang string) bool {
-	return lang != "go" && lang != "rust"
+// are its only legal callees, none of which is a method symbol.
+//
+// PHP has no implicit-self method dispatch either - a method call always names
+// its receiver (`$this->m()`, `self::m()`), so a bare target from a PHP
+// *function* call (`count(...)`, emitted at ConfidenceStatic) is a
+// builtin/function and must NOT bind a same-named method (F-3: PHP's builtin
+// `count()` bound `Repository::count` across 14 unrelated files). But PHP's
+// unknown-receiver member fallback (decision 0003 clause 1) also emits a bare
+// method name, at ConfidenceNameCollision - a genuine dispatch whose receiver
+// type was merely unknown. The two are separable by confidence alone: at or
+// below the collision band the bare target is that member fallback (keep the
+// method bind, it is demoted below blast's floor anyway); above it, the target
+// is a function call (drop methods). Ruby's bare calls ARE implicit-self
+// dispatch at full confidence, so it (and any unknown language) answers true
+// and the gate fails open.
+func bareCallBindsMethods(lang string, baseConfidence float64) bool {
+	switch lang {
+	case "go", "rust":
+		return false
+	case "php":
+		return baseConfidence <= extract.ConfidenceNameCollision
+	}
+	return true
 }
 
 // filterOutMethods drops method-kind candidates from a bare-target fallback


### PR DESCRIPTION
## What

PHP has no implicit-self method dispatch: a receiverless call like `count(...)` is a builtin or free function, never a method. But `bareCallBindsMethods` treated every non-Go/Rust language alike, lumping PHP with Ruby (whose bare calls *are* implicit-self dispatch). So a bare `count(...)` bound a same-named class method at static confidence.

On a base class carrying Eloquent-generic method names (`count`/`find`/`where`/`get`), this fabricated grep-invisible "dependents" from every file that merely called one of those names — including PHP's builtin `count()` — surviving to the 0.7 verified band and inflating the class's apparent reach.

## Fix

`bareCallBindsMethods` is now confidence-aware for PHP:

- **above** the name-collision band → the bare target is a function/builtin call, so method candidates are dropped (the bug path);
- **at** the band (`ConfidenceNameCollision`) → it is decision-0003's unknown-receiver member fallback, a genuine dispatch that stays bound and demoted below blast's floor for liveness.

Go/Rust (method-free bare grammar) and Ruby (implicit-self dispatch at full confidence) are unchanged.

## Tests

Three PHP cases added to the shared `bare_call_test.go` harness, mirroring the Go/Rust fixtures:

- `TestResolvePHPBareFunctionCallNeverBindsMethod` — the defect repro (bare `count` at static confidence must not bind the method).
- `TestResolvePHPBareCallKeepsFunctionBind` — a bare call to an indexed free function still resolves (over-fix guard).
- `TestResolvePHPMemberFallbackKeepsMethodDemoted` — the 0.3 member fallback keeps binding, demoted (kills the "put PHP in the Go/Rust camp" over-fix).

## Verification

- Reproduced on a Konekt/concord repository base class: 14 grep-invisible "dependents" were all common-name binds; after the fix invisibility drops **0.36 → 0.0**.
- Genuine typed-receiver reach is **byte-stable** across a full rescan (Eloquent `Builder` 666/0.355, `Container` 970/0.333, and the other PHP anchors unchanged).
- `make ci` green (coverage floor, complexity ledger 0, lint clean); `bareCallBindsMethods`/`filterOutMethods` at 100% func coverage.
