### PR TITLE
fix(cli): reject positional arguments to sense scan

### DIFF
--- a/cmd/sense/main.go
+++ b/cmd/sense/main.go
@@ -161,6 +161,15 @@ func runScan(args []string, stderr io.Writer) int {
 	if err := fs.Parse(args); err != nil {
 		return 1
 	}
+	// `sense scan` takes no positional arguments: the project root is the -dir
+	// flag. Go's flag parser silently drops a bare path (`sense scan some/path`
+	// leaves -dir at "." and scans the CWD instead), which has misled users into
+	// rescanning the wrong tree. Reject it loudly rather than pretend the path
+	// was honored.
+	if fs.NArg() > 0 {
+		_, _ = fmt.Fprintf(stderr, "sense scan: unexpected argument %q; use -dir %s to set the project root\n", fs.Arg(0), fs.Arg(0))
+		return 1
+	}
 
 	// stopProfile is non-nil only when CPU profiling is active. It is invoked
 	// explicitly on the success path (never via defer) so an error return leaves

--- a/cmd/sense/main_test.go
+++ b/cmd/sense/main_test.go
@@ -145,6 +145,19 @@ func TestRunScanFlagParseError(t *testing.T) {
 	}
 }
 
+func TestRunScanRejectsPositionalArg(t *testing.T) {
+	// A bare path is silently dropped by flag.Parse (it leaves -dir at ".");
+	// runScan must reject it instead of scanning the CWD. Regression guard for
+	// the repeated `sense scan some/path` slip.
+	var errb bytes.Buffer
+	if code := runScan([]string{"some/path"}, &errb); code != 1 {
+		t.Fatalf("scan positional-arg exit = %d, want 1", code)
+	}
+	if !strings.Contains(errb.String(), "unexpected argument") || !strings.Contains(errb.String(), "-dir") {
+		t.Errorf("stderr = %q, want it to name the unexpected argument and point to -dir", errb.String())
+	}
+}
+
 func TestRunScanCPUProfileCreateError(t *testing.T) {
 	// Parent directory does not exist, so os.Create fails.
 	bad := filepath.Join(t.TempDir(), "missing", "cpu.prof")


### PR DESCRIPTION
Running `sense scan some/path` looks like it indexes that path, but it does nothing of the sort: the command only reads the `-dir` flag, so a bare path is silently discarded and the current directory is scanned instead. This change makes Sense reject the mistake loudly instead of quietly indexing the wrong tree.

## Problem
`sense scan` takes its project root from the `-dir` flag. Go's flag parser stops at the first non-flag argument, so `sense scan some/path` leaves `-dir` at its default `.` and scans the working directory, with no hint that the path was ignored. In practice this has silently rescanned the wrong tree and, in one case, partially overwrote a live project index. Every user who reaches for the natural positional form hits the same trap.

## Summary
`runScan` now rejects unexpected positional arguments: if any are present it prints an error that names the argument and points to `-dir`, and exits non-zero instead of scanning the CWD.

## Changes
- `cmd/sense/main.go`: after flag parsing, `runScan` errors when `fs.NArg() > 0`, naming the offending argument and suggesting `-dir <path>`.
- `cmd/sense/main_test.go`: `TestRunScanRejectsPositionalArg` covers the new guard (exit code and message).

## Notes
- The flag set is unchanged, so this is a defect fix rather than a surface change: the CLI simply stops pretending an ignored path was honored.

## Test Plan
- [x] `TestRunScanRejectsPositionalArg` asserts `sense scan some/path` exits 1 and the message names the argument and `-dir`
- [x] Existing `-dir` path still scans normally (verified: `sense scan -dir <path>` unaffected)
- [x] `go test ./...` / `make ci` passes (coverage 95.5%, lint 0, ledger 0)
- [x] sense binary builds cleanly
