### PR TITLE
enhance(blast): rank equal-confidence cap ties by caller in-degree

### DIFF
--- a/internal/blast/engine.go
+++ b/internal/blast/engine.go
@@ -178,6 +178,13 @@ type Result struct {
 	// relevant callers, not an arbitrary (ID-ordered) prefix.
 	DirectConfidence map[int64]float64
 
+	// CallerFan records each capped caller's in-degree, keyed by symbol ID.
+	// Populated only when the result cap engaged (nil otherwise): the same
+	// tie-break capResults uses among equal-confidence callers, exported so
+	// response shapers rank a fan-carrier (a caller worth pivoting to, e.g.
+	// laravel's app() helper) above leaf callers within an enumeration cap.
+	CallerFan map[int64]int
+
 	EdgesTraversed    int
 	SubjectHasCallees bool
 	// ViewReached is true when a view template (ERB) reaches the subject via a
@@ -272,7 +279,9 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 	// over maps and the common under-cap blast never pays the lookup.
 	var testFlags map[int64]bool
 	if totalAffectedCount > opts.MaxResults {
-		testFlags = testFileFlags(ctx, db, append(append(make([]int64, 0, totalAffectedCount), directIDs...), indirectIDs...))
+		allIDs := append(append(make([]int64, 0, totalAffectedCount), directIDs...), indirectIDs...)
+		testFlags = testFileFlags(ctx, db, allIDs)
+		state.fanIn = incomingEdgeCounts(ctx, db, allIDs)
 	}
 	directIDs, indirectIDs = state.capResults(directIDs, indirectIDs, testFlags, opts.MaxResults)
 
@@ -320,6 +329,7 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 		DirectTemporalIDs:      directTemporalIDs,
 		DirectEdgeSites:        directEdgeSites,
 		DirectConfidence:       directConfidence,
+		CallerFan:              state.fanIn,
 		AffectedSubclasses:     subclasses,
 		AffectedViaComposition: viaComposition,
 		AffectedViaIncludes:    viaIncludes,
@@ -369,14 +379,17 @@ func (s *bfsState) loadEdgeTableGroups(ctx context.Context, db *sql.DB, subject 
 // the frontier but are excluded from output, the current frontier, and the
 // running edge/truncation counters.
 type bfsState struct {
-	visited        map[int64]int
-	predecessor    map[int64]int64
-	viaTemporal    map[int64]bool
-	visitedKind    map[int64]string
-	pathConf       map[int64]float64
-	edgeSites      map[int64]EdgeSite
-	frontier       []int64
-	childSet       map[int64]struct{}
+	visited     map[int64]int
+	predecessor map[int64]int64
+	viaTemporal map[int64]bool
+	visitedKind map[int64]string
+	pathConf    map[int64]float64
+	edgeSites   map[int64]EdgeSite
+	frontier    []int64
+	childSet    map[int64]struct{}
+	// fanIn holds per-caller in-degree, populated only when the result cap
+	// bites (see Compute); capResults reads a nil map as all-zero.
+	fanIn          map[int64]int
 	truncated      bool
 	edgesTraversed int
 }
@@ -448,7 +461,7 @@ func (s *bfsState) expandOneHop(ctx context.Context, db *sql.DB, hop int, opts O
 
 	bySource, order := s.groupBySource(pairs, opts)
 	next := s.admitSources(order, bySource, hop)
-	s.frontier = s.capFrontier(next)
+	s.frontier = s.capFrontier(ctx, db, next)
 	return nil
 }
 
@@ -539,17 +552,27 @@ func (s *bfsState) admitSources(order []int64, bySource map[int64][]hopCand, hop
 	return next
 }
 
-// capFrontier caps the next frontier to MaxFrontierWidth, keeping the
-// highest-confidence nodes. Evicted nodes are removed from visited so they may
-// be re-discovered via a stronger path in a later hop — this preserves the
-// highest-confidence paths. It records truncation when eviction happens.
-func (s *bfsState) capFrontier(next []int64) []int64 {
+// capFrontier caps the next frontier to MaxFrontierWidth: keep the highest
+// path confidence; among the equal-confidence band straddling the cut, keep
+// the nodes most likely to carry undiscovered callers (highest in-degree);
+// among those, lowest symbol ID for determinism. Evicting a node deletes its
+// entire unexplored subtree from the radius (laravel Container/app(): the
+// app() helper carried a 110-caller fan, all silently dropped by a
+// confidence-only tie), so in-degree, an upper bound on what the eviction
+// discards next hop, is the tie-break. Evicted nodes are removed from
+// visited so they may be re-discovered via a stronger path in a later hop.
+// It records truncation when eviction happens.
+func (s *bfsState) capFrontier(ctx context.Context, db *sql.DB, next []int64) []int64 {
 	if len(next) <= MaxFrontierWidth {
 		return next
 	}
 	sort.Slice(next, func(i, j int) bool {
-		return s.pathConf[next[i]] > s.pathConf[next[j]]
+		if s.pathConf[next[i]] != s.pathConf[next[j]] {
+			return s.pathConf[next[i]] > s.pathConf[next[j]]
+		}
+		return next[i] < next[j]
 	})
+	s.rankTieBand(ctx, db, next)
 	evicted := next[MaxFrontierWidth:]
 	next = next[:MaxFrontierWidth]
 	for _, id := range evicted {
@@ -561,6 +584,32 @@ func (s *bfsState) capFrontier(next []int64) []int64 {
 	}
 	s.truncated = true
 	return next
+}
+
+// rankTieBand reorders the equal-confidence run straddling the frontier cap
+// cut by in-degree (then ID), so the cap keeps fan-carriers. Only that band is
+// re-ranked: nodes above it survive regardless, nodes below are evicted
+// regardless, so the in-degree lookup is paid only for the contested slice and
+// only when the cap bites. A nil count map (query failure) leaves the
+// confidence+ID order, the same degradation contract as testFileFlags.
+func (s *bfsState) rankTieBand(ctx context.Context, db *sql.DB, next []int64) {
+	cut := s.pathConf[next[MaxFrontierWidth-1]]
+	lo := sort.Search(len(next), func(i int) bool { return s.pathConf[next[i]] <= cut })
+	hi := sort.Search(len(next), func(i int) bool { return s.pathConf[next[i]] < cut })
+	if hi <= MaxFrontierWidth {
+		return
+	}
+	band := next[lo:hi]
+	fan := incomingEdgeCounts(ctx, db, band)
+	if fan == nil {
+		return
+	}
+	sort.Slice(band, func(i, j int) bool {
+		if fan[band[i]] != fan[band[j]] {
+			return fan[band[i]] > fan[band[j]]
+		}
+		return band[i] < band[j]
+	})
 }
 
 // partition splits the visited set into direct callers (hop ≤1) and indirect
@@ -615,6 +664,11 @@ func (s *bfsState) capResults(directIDs, indirectIDs []int64, testFlags map[int6
 	//     Device: 49 setUpTestData callers vs the scattered cross-app ones);
 	//   - direct-over-indirect keeps the "what breaks?" signal — a direct
 	//     caller must not be evicted to make room for a weaker indirect one;
+	//   - fan-carriers over leaves among remaining ties: a caller that itself
+	//     has callers is the one worth surfacing on a hub anchor, because the
+	//     agent can pivot to its fan (laravel Container: the app() helper and
+	//     its 110 callers could never appear among 449 equal-confidence
+	//     production direct callers under an ID-only tie-break);
 	//   - the ID tie-break makes the kept set deterministic, so repeated
 	//     blasts of the same symbol return the same callers (without it an
 	//     unstable sort keeps an arbitrary subset that varies run to run and
@@ -628,6 +682,9 @@ func (s *bfsState) capResults(directIDs, indirectIDs []int64, testFlags map[int6
 		}
 		if all[i].direct != all[j].direct {
 			return all[i].direct
+		}
+		if s.fanIn[all[i].id] != s.fanIn[all[j].id] {
+			return s.fanIn[all[i].id] > s.fanIn[all[j].id]
 		}
 		return all[i].id < all[j].id
 	})
@@ -963,6 +1020,24 @@ func expandFrontier(ctx context.Context, db *sql.DB, frontier []int64) ([]edgePa
 		_ = rows.Close()
 	}
 	return out, nil
+}
+
+// incomingEdgeCounts returns each id's in-degree under the same edge
+// predicate the BFS traverses: it reuses expandFrontier (same filter, same
+// parameter chunking) and tallies pairs per target, so the count is exactly
+// "how many callers would the BFS discover behind this node". Returns nil on
+// query error; callers degrade to their in-degree-free ordering, mirroring
+// the testFileFlags contract.
+func incomingEdgeCounts(ctx context.Context, db *sql.DB, ids []int64) map[int64]int {
+	pairs, err := expandFrontier(ctx, db, ids)
+	if err != nil {
+		return nil
+	}
+	counts := make(map[int64]int, len(ids))
+	for _, p := range pairs {
+		counts[p.target]++
+	}
+	return counts
 }
 
 // Risk tier labels. Exported so CLI / MCP consumers can compare

--- a/internal/blast/engine_internal_test.go
+++ b/internal/blast/engine_internal_test.go
@@ -3,6 +3,7 @@ package blast
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"testing"
 	"time"
 
@@ -408,5 +409,144 @@ func TestHasTemporal(t *testing.T) {
 	}
 	if hasTemporal(nil, []CallerHop{{ViaTemporal: false}}) {
 		t.Error("no temporal edges should report none")
+	}
+}
+
+// In-degree is a TIE-BREAK, not a rank: it sits after production-over-test,
+// confidence, and direct-over-indirect, and only displaces the ID order. A
+// test-file caller or an indirect caller with a huge fan must never evict a
+// production direct caller. If a future edit promotes the fan key, this test
+// is what notices.
+func TestCapResultsFanBreaksTiesButNeverOutranks(t *testing.T) {
+	// Direct leaf (no fan) vs indirect fan-carrier: direct wins.
+	s := &bfsState{
+		pathConf: map[int64]float64{1: 1.0, 2: 1.0},
+		fanIn:    map[int64]int{2: 100},
+	}
+	direct, indirect := s.capResults([]int64{1}, []int64{2}, nil, 1)
+	if len(direct) != 1 || direct[0] != 1 || len(indirect) != 0 {
+		t.Errorf("directness must outrank fan: got direct=%v indirect=%v, want direct=[1]", direct, indirect)
+	}
+
+	// Production leaf vs test-file fan-carrier: production wins.
+	s = &bfsState{
+		pathConf: map[int64]float64{1: 1.0, 2: 1.0},
+		fanIn:    map[int64]int{2: 100},
+	}
+	direct, _ = s.capResults([]int64{1, 2}, nil, map[int64]bool{2: true}, 1)
+	if len(direct) != 1 || direct[0] != 1 {
+		t.Errorf("production must outrank fan: got %v, want [1]", direct)
+	}
+
+	// Equal everything: fan displaces the lower-ID leaf.
+	s = &bfsState{
+		pathConf: map[int64]float64{1: 1.0, 2: 1.0},
+		fanIn:    map[int64]int{2: 3},
+	}
+	direct, _ = s.capResults([]int64{1, 2}, nil, nil, 1)
+	if len(direct) != 1 || direct[0] != 2 {
+		t.Errorf("among full ties the fan-carrier must survive the cap: got %v, want [2]", direct)
+	}
+}
+
+// rankTieBand's two degradation paths: a tie band fully inside the kept
+// prefix needs no in-degree lookup (the db is never touched), and a failed
+// count query leaves the confidence+ID order intact instead of erroring the
+// blast, the same degrade contract as testFileFlags.
+func TestRankTieBandDegradations(t *testing.T) {
+	t.Run("band-inside-kept-prefix", func(t *testing.T) {
+		s := &bfsState{pathConf: map[int64]float64{}}
+		next := make([]int64, MaxFrontierWidth+1)
+		for i := range next {
+			id := int64(i + 1)
+			next[i] = id
+			s.pathConf[id] = 1.0
+		}
+		// Unique confidence at the cut, everything after strictly weaker:
+		// the tie band around the cut ends inside the kept prefix.
+		s.pathConf[next[MaxFrontierWidth-1]] = 0.9
+		s.pathConf[next[MaxFrontierWidth]] = 0.5
+		before := append([]int64{}, next...)
+		s.rankTieBand(context.Background(), nil, next) // nil db: must not be touched
+		for i := range next {
+			if next[i] != before[i] {
+				t.Fatalf("order changed at %d: got %d, want %d", i, next[i], before[i])
+			}
+		}
+	})
+
+	t.Run("nil-counts-keeps-order", func(t *testing.T) {
+		db, err := sql.Open("sqlite", ":memory:")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = db.Close() // closed db: incomingEdgeCounts returns nil
+		s := &bfsState{pathConf: map[int64]float64{}}
+		next := make([]int64, MaxFrontierWidth+10)
+		for i := range next {
+			id := int64(i + 1)
+			next[i] = id
+			s.pathConf[id] = 1.0 // every node ties: band straddles the cut
+		}
+		before := append([]int64{}, next...)
+		s.rankTieBand(context.Background(), db, next)
+		for i := range next {
+			if next[i] != before[i] {
+				t.Fatalf("order changed at %d: got %d, want %d", i, next[i], before[i])
+			}
+		}
+	})
+}
+
+// incomingEdgeCounts chunks its IN() list at 500 parameters; a request over
+// the chunk size must count across both batches.
+func TestIncomingEdgeCountsChunks(t *testing.T) {
+	ctx := context.Background()
+	adapter, err := sqlite.Open(ctx, ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = adapter.Close() }()
+	fid, err := adapter.WriteFile(ctx, &model.File{
+		Path: "f.rb", Language: "ruby", Hash: "h", Symbols: 1, IndexedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	newSym := func(name string) int64 {
+		id, err := adapter.WriteSymbol(ctx, &model.Symbol{
+			FileID: fid, Name: name, Qualified: name, Kind: model.KindClass, LineStart: 1, LineEnd: 2,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return id
+	}
+	caller := newSym("Caller")
+	first := newSym("First") // lands in chunk 1
+	var last int64
+	ids := make([]int64, 0, 502)
+	ids = append(ids, first)
+	for i := 0; i < 501; i++ {
+		last = newSym(fmt.Sprintf("Filler%03d", i))
+		ids = append(ids, last) // last lands in chunk 2
+	}
+	caller2 := newSym("Caller2")
+	for _, e := range []struct{ src, dst int64 }{{caller, first}, {caller, last}, {caller2, last}} {
+		src := e.src
+		if _, err := adapter.WriteEdge(ctx, &model.Edge{
+			SourceID: &src, TargetID: e.dst, Kind: model.EdgeCalls, FileID: fid, Confidence: 1.0,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	db := adapter.DB()
+	counts := incomingEdgeCounts(ctx, db, ids)
+	if counts == nil {
+		t.Fatal("expected counts, got nil")
+	}
+	if counts[first] != 1 || counts[last] != 2 {
+		t.Errorf("counts = first:%d last:%d, want 1 and 2 (across chunks)", counts[first], counts[last])
 	}
 }

--- a/internal/blast/engine_test.go
+++ b/internal/blast/engine_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -1789,4 +1790,150 @@ func TestComputeExpandFrontierErrors(t *testing.T) {
 			t.Error("expected error when context is cancelled, got nil")
 		}
 	})
+}
+
+// TestBlastFrontierEvictionKeepsFanCarriers reproduces the laravel-framework
+// Container/app() gap (F-4): when hop-1 sources exceed MaxFrontierWidth with
+// equal path confidence, the frontier cap must not evict a fan-carrier (a
+// caller that itself has callers) in favor of leaf callers, because eviction
+// deletes the carrier's entire undiscovered subtree from the radius. On the
+// real index, `app` (in-degree 110) was dropped among 685 confidence-1.0 ties
+// and 38 files of helper-reached consumers exited total_affected.
+func TestBlastFrontierEvictionKeepsFanCarriers(t *testing.T) {
+	fix := newFixtureDB(t)
+	hub := fix.addSymbol(t, "Hub")
+
+	// Leaf callers first, so the fan-carrier lands last (highest symbol ID)
+	// and loses any insertion-order or ID-order tie-break.
+	callerCount := blast.MaxFrontierWidth + 100
+	for i := 0; i < callerCount; i++ {
+		caller := fix.addSymbol(t, fmt.Sprintf("Leaf%d", i))
+		fix.addEdge(t, caller, hub, model.EdgeCalls, 1.0)
+	}
+	carrier := fix.addSymbol(t, "Carrier")
+	fix.addEdge(t, carrier, hub, model.EdgeCalls, 1.0)
+	downstream := fix.addSymbol(t, "Downstream")
+	fix.addEdge(t, downstream, carrier, model.EdgeCalls, 1.0)
+	// A weaker caller exercises the confidence branch of the frontier
+	// sort (everything above ties at 1.0).
+	weak := fix.addSymbol(t, "WeakCaller")
+	fix.addEdge(t, weak, hub, model.EdgeCalls, 0.8)
+
+	res, err := blast.Compute(context.Background(), fix.db, []int64{hub}, blast.Options{
+		MaxHops:    2,
+		MaxResults: callerCount + 10,
+	})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+
+	found := map[int64]bool{}
+	for _, c := range res.DirectCallers {
+		found[c.ID] = true
+	}
+	for _, hop := range res.IndirectCallers {
+		found[hop.Symbol.ID] = true
+	}
+	if !found[carrier] {
+		t.Error("fan-carrier evicted from the frontier despite having downstream callers")
+	}
+	if !found[downstream] {
+		t.Error("downstream caller missing: its carrier's eviction deleted the subtree from the radius")
+	}
+}
+
+// TestBlastCapResultsSurfacesFanCarriers pins the output half of the F-4 fix:
+// when shown callers are capped among equal-confidence production direct
+// callers, a fan-carrier must rank above leaf callers (in-degree before the ID
+// tie-break), so an agent can see it and pivot to its caller fan. Without it,
+// the shown set is an arbitrary ID-ordered subset and a carrier like `app`
+// (110 callers behind it) can never surface on a hub anchor.
+func TestBlastCapResultsSurfacesFanCarriers(t *testing.T) {
+	fix := newFixtureDB(t)
+	hub := fix.addSymbol(t, "Hub")
+
+	const maxResults = 50
+	callerCount := maxResults + 40 // over the cap, under MaxFrontierWidth
+	for i := 0; i < callerCount; i++ {
+		caller := fix.addSymbol(t, fmt.Sprintf("Leaf%d", i))
+		fix.addEdge(t, caller, hub, model.EdgeCalls, 1.0)
+	}
+	carrier := fix.addSymbol(t, "Carrier")
+	fix.addEdge(t, carrier, hub, model.EdgeCalls, 1.0)
+	for i := 0; i < 3; i++ {
+		sub := fix.addSymbol(t, fmt.Sprintf("Sub%d", i))
+		fix.addEdge(t, sub, carrier, model.EdgeCalls, 1.0)
+	}
+
+	res, err := blast.Compute(context.Background(), fix.db, []int64{hub}, blast.Options{
+		MaxHops:    2,
+		MaxResults: maxResults,
+	})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+
+	for _, c := range res.DirectCallers {
+		if c.ID == carrier {
+			return
+		}
+	}
+	t.Errorf("fan-carrier not in the %d shown direct callers: capped output hides the one caller worth pivoting on", len(res.DirectCallers))
+}
+
+// Compute with no seed IDs is a caller bug surfaced as an error, not a panic.
+func TestComputeEmptySymbolIDs(t *testing.T) {
+	fix := newFixtureDB(t)
+	if _, err := blast.Compute(context.Background(), fix.db, nil, blast.Options{}); err == nil {
+		t.Error("expected error for empty symbolIDs, got nil")
+	}
+}
+
+// errAfterCtx reports no Done channel (so database/sql never cancels a
+// query) but a non-nil Err, exercising Compute's per-hop cancellation
+// check in isolation from the query paths.
+type errAfterCtx struct{ context.Context }
+
+func (errAfterCtx) Err() error                  { return context.Canceled }
+func (errAfterCtx) Done() <-chan struct{}       { return nil }
+func (errAfterCtx) Deadline() (time.Time, bool) { return time.Time{}, false }
+
+func TestComputeCancellationAtHopBoundary(t *testing.T) {
+	fix := newFixtureDB(t)
+	subject := fix.addSymbol(t, "Subject")
+	fix.addEdge(t, fix.addSymbol(t, "Caller"), subject, model.EdgeCalls, 1.0)
+
+	_, err := blast.Compute(errAfterCtx{context.Background()}, fix.db, []int64{subject}, blast.Options{MaxHops: 1})
+	if err == nil || !strings.Contains(err.Error(), "cancelled at hop") {
+		t.Errorf("expected hop-boundary cancellation error, got %v", err)
+	}
+}
+
+// A query failure inside a hop expansion surfaces as an error, not a
+// silent empty radius.
+func TestComputeExpandHopErrorPropagates(t *testing.T) {
+	fix := newFixtureDB(t)
+	subject := fix.addSymbol(t, "Subject")
+	fix.addEdge(t, fix.addSymbol(t, "Caller"), subject, model.EdgeCalls, 1.0)
+	if _, err := fix.db.Exec("DROP TABLE sense_edges"); err != nil {
+		t.Fatalf("drop: %v", err)
+	}
+	if _, err := blast.Compute(context.Background(), fix.db, []int64{subject}, blast.Options{MaxHops: 1}); err == nil {
+		t.Error("expected error when edge expansion fails, got nil")
+	}
+}
+
+// A failed affected-tests lookup surfaces as an error, not a silent empty
+// test list.
+func TestComputeAffectedTestsErrorPropagates(t *testing.T) {
+	fix := newFixtureDB(t)
+	subject := fix.addSymbol(t, "Subject")
+	fix.addEdge(t, fix.addSymbol(t, "Caller"), subject, model.EdgeCalls, 1.0)
+	if _, err := fix.db.Exec("DROP TABLE sense_files"); err != nil {
+		t.Fatalf("drop: %v", err)
+	}
+	_, err := blast.Compute(context.Background(), fix.db, []int64{subject}, blast.Options{MaxHops: 1, IncludeTests: true})
+	if err == nil || !strings.Contains(err.Error(), "load tests") {
+		t.Errorf("expected load-tests error, got %v", err)
+	}
 }

--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -304,7 +304,7 @@ func BuildBlastResponseSeen(ctx context.Context, r blast.Result, files FileLooku
 				seenFiles = append(seenFiles, file)
 				continue
 			}
-			tier1Direct = append(tier1Direct, rankedCaller{entry: entry, area: areaOf(file), id: c.ID, conf: r.DirectConfidence[c.ID]})
+			tier1Direct = append(tier1Direct, rankedCaller{entry: entry, area: areaOf(file), id: c.ID, conf: r.DirectConfidence[c.ID], fan: r.CallerFan[c.ID]})
 		} else {
 			tier2All = append(tier2All, entry)
 		}
@@ -659,12 +659,15 @@ func BuildDiffBlastResponseSeen(ctx context.Context, ref string, results []blast
 
 // rankedCaller pairs a tier-1 direct caller's wire entry with the keys
 // that drive area-stratified enumeration: area groups callers into
-// subsystems, conf/id pick the exemplar within an area.
+// subsystems, conf/fan/id pick the exemplar within an area (fan is the
+// caller's in-degree, see blast.Result.CallerFan, so a fan-carrier the
+// agent can pivot to outranks equal-confidence leaf callers).
 type rankedCaller struct {
 	entry BlastCaller
 	area  string
 	id    int64
 	conf  float64
+	fan   int
 }
 
 // areaOf returns the subsystem key for a file — its parent directory,
@@ -682,7 +685,7 @@ func areaOf(file string) string {
 // citable exemplar instead of being crowded out by a big low-ID area.
 // Areas are visited by descending member count, tiebreak area-name ASC;
 // within an area the exemplar order is the existing signal (confidence
-// DESC, then ID ASC). The returned slice puts production callers before
+// DESC, then in-degree DESC, then ID ASC). The returned slice puts production callers before
 // test-file callers; within each class it stays area-clustered in that
 // same visitation order (a mixed prod/test area appears in both classes).
 // Selection and order are deterministic across builds.
@@ -709,6 +712,9 @@ func enumerateByArea(callers []rankedCaller, limit int) []BlastCaller {
 		sort.SliceStable(b, func(i, j int) bool {
 			if b[i].conf != b[j].conf {
 				return b[i].conf > b[j].conf
+			}
+			if b[i].fan != b[j].fan {
+				return b[i].fan > b[j].fan
 			}
 			return b[i].id < b[j].id
 		})

--- a/internal/mcpio/blast_test.go
+++ b/internal/mcpio/blast_test.go
@@ -608,6 +608,92 @@ func TestBuildBlastResponseAreaExemplarIsHighestConfidence(t *testing.T) {
 	}
 }
 
+// TestBuildBlastResponseFanCarrierExemplar pins the in-degree tie-break:
+// within an area, equal-confidence callers rank by fan (CallerFan) DESC
+// before ID ASC, so a fan-carrier the agent can pivot to is the area's
+// exemplar even when a leaf caller has a lower ID. The hub area holds a
+// leaf (low ID, fan 0) and a carrier (higher ID, fan 14) at EQUAL
+// confidence; 60 single-caller filler areas push the total past
+// directEnumCap so the hub area seats exactly one exemplar. Under the
+// old conf-then-ID order the leaf would win; only the fan key selects
+// the carrier.
+func TestBuildBlastResponseFanCarrierExemplar(t *testing.T) {
+	hubArea := "app/support"
+
+	var directCallers []model.Symbol
+	tiers := make(map[int64]blast.Tier)
+	conf := map[int64]float64{}
+	paths := map[int64]string{}
+	var id int64
+
+	// 60 filler callers, one per area, so the cap binds and the hub area
+	// gets a single seat.
+	for i := 0; i < 60; i++ {
+		id++
+		directCallers = append(directCallers, model.Symbol{ID: id, Qualified: fmt.Sprintf("Filler%d", id), FileID: id})
+		tiers[id] = blast.TierBreaks
+		conf[id] = 0.5
+		paths[id] = fmt.Sprintf("lib/area%02d/file.rb", i)
+	}
+	// Hub area: leaf first (lower ID), carrier second (higher ID), equal
+	// confidence. Only the carrier has fan.
+	leafID := id + 1
+	carrierID := id + 2
+	for _, hc := range []struct {
+		id   int64
+		name string
+	}{{leafID, "LeafCaller"}, {carrierID, "FanCarrier"}} {
+		directCallers = append(directCallers, model.Symbol{ID: hc.id, Qualified: hc.name, FileID: hc.id})
+		tiers[hc.id] = blast.TierBreaks
+		conf[hc.id] = 0.9
+		paths[hc.id] = fmt.Sprintf("%s/file%d.rb", hubArea, hc.id)
+	}
+	files := func(fid int64) (string, bool) { p, ok := paths[fid]; return p, ok }
+
+	total := len(directCallers)
+	r := blast.Result{
+		Symbol:           model.Symbol{ID: 0, Qualified: "Subject"},
+		DirectCallers:    directCallers,
+		AffectedTests:    []string{},
+		TotalAffected:    total,
+		SymbolTiers:      tiers,
+		DirectConfidence: conf,
+		CallerFan:        map[int64]int{carrierID: 14},
+	}
+
+	resp := BuildBlastResponse(context.Background(), r, files, nil)
+
+	if len(resp.DirectCallers) != directEnumCap {
+		t.Fatalf("enumerated = %d, want %d", len(resp.DirectCallers), directEnumCap)
+	}
+
+	// The hub area's single seat goes to the fan-carrier, not the
+	// lower-ID leaf.
+	sawCarrier, sawLeaf := false, false
+	for _, c := range resp.DirectCallers {
+		if c.Symbol == "FanCarrier" {
+			sawCarrier = true
+		}
+		if c.Symbol == "LeafCaller" {
+			sawLeaf = true
+		}
+	}
+	if !sawCarrier {
+		t.Errorf("hub area exemplar should be FanCarrier (fan 14), not enumerated")
+	}
+	if sawLeaf {
+		t.Errorf("LeafCaller enumerated: hub area seated the leaf over the fan-carrier")
+	}
+
+	// by_area sum + total stay truthful over the FULL set.
+	if got := sumAreas(resp.DirectCallersByArea); got != total {
+		t.Errorf("by_area sum = %d, want %d", got, total)
+	}
+	if resp.TotalAffected != total {
+		t.Errorf("TotalAffected = %d, want %d", resp.TotalAffected, total)
+	}
+}
+
 func TestBuildBlastResponseTierPartitioning(t *testing.T) {
 	// 3 Tier-1 callers and 2 Tier-2 callers. Tier-2 items should
 	// appear in References, not DirectCallers.


### PR DESCRIPTION
Blast answers on high-fan-out symbols get more honest and more useful: the radius no longer silently loses whole subtrees behind an arbitrarily evicted caller, and the shown caller list surfaces the callers worth pivoting to instead of an ID-ordered slice.

## Problem

On a hub anchor whose callers tie at the same path confidence (the common case, since call edges are 1.0), both blast cap boundaries broke ties arbitrarily. The BFS frontier cap sorted by confidence alone, so which nodes survived among ties was unstable-sort order, and an evicted node's entire undiscovered subtree silently exited total_affected. The result cap and the per-area exemplar selection fell back to symbol-ID order, so a caller that itself carries a large caller fan could never appear in the shown list. On laravel/framework, `blast Container` reported 897 affected with none of the consumers reached through the `app()` helper, while `blast getInstance` found all of them: the same index held every edge at confidence 1.0.

## Summary

Break equal-confidence ties by caller in-degree (an upper bound on the subtree an eviction discards), then by symbol ID for determinism, at the frontier cap, the result cap, and the per-area enumeration.

## Changes

- `internal/blast/engine.go`: `capFrontier` gains a deterministic ID tie-break and re-ranks the equal-confidence band straddling the cut by in-degree (`rankTieBand`); the in-degree lookup runs only when the cap bites and only over the contested band, chunked like `expandFrontier`. `capResults` adds the in-degree key between direct-over-indirect and the ID tie-break. New `incomingEdgeCounts` helper mirrors the `testFileFlags` degradation contract (query failure degrades to the previous ordering, never errors the blast). `Result.CallerFan` exports the counts.
- `internal/mcpio/blast.go`: the within-area exemplar order becomes confidence, then in-degree, then ID, so a fan-carrier outranks equal-confidence leaf callers in the enumerated subset.
- Ranking keys production-over-test, confidence, and direct-over-indirect are unchanged, now pinned by explicit key-order tests.

## Test Plan

- [x] Red-then-green repro: a hub with more equal-confidence callers than the frontier width must keep a fan-carrier and its downstream caller in the radius (`TestBlastFrontierEvictionKeepsFanCarriers`)
- [x] Capped output surfaces the fan-carrier among equal-confidence production direct callers (`TestBlastCapResultsSurfacesFanCarriers`)
- [x] In-degree never outranks production-over-test, confidence, or directness (`TestCapResultsFanBreaksTiesButNeverOutranks`)
- [x] Determinism across repeated computations holds (`TestBlastCapResultsDeterministic`)
- [x] Degradation paths: tie band inside the kept prefix touches no DB; failed count query keeps the confidence+ID order; chunking counts across 500-parameter batches
- [x] `make ci` green (coverage floor, lint, complexity ledger), `make smoke` green
- [x] Live index check on laravel/framework: `blast Container` total_affected 897 to 1420, helper-reached consumers present, `app()` enumerated; verified over MCP stdio at min_confidence 0.3 and 0.7
- [x] No-regress side-effect runs on three benched verticals (healthchecks, llm.rb, pebble): adoption and cited recall at or above the frozen cells
