### PR TITLE
feat(blast): purify and page the retention ring on sense_blast

### DIFF
--- a/internal/blast/engine.go
+++ b/internal/blast/engine.go
@@ -56,6 +56,13 @@ type Options struct {
 	MinConfidence float64
 	MaxResults    int
 	IncludeTests  bool
+	// RetainedOffset skips that many rows of the retention ring, which is
+	// returned in a total order (see orderRetained). It pages ONLY the ring:
+	// a ring larger than the cap used to be silently trimmed, and a large
+	// truncated list is the shape that costs an agent its trust in the whole
+	// group (measured on teleport: 100 of 455 shown, 135 hidden). The caller
+	// lists are unaffected: they carry their own magnitude fields.
+	RetainedOffset int
 }
 
 // Tier classifies a blast result by its relevance to breakage.
@@ -218,6 +225,18 @@ type Result struct {
 	// so a capped RetainedViaInterfaces list is self-evident from
 	// RetainedCount > len(RetainedViaInterfaces).
 	RetainedCount int
+	// RetainedPurity records the test-file satisfiers the ring refused to
+	// launder through (see RetentionPurity), so the exclusion is auditable
+	// instead of looking like an empty or short ring.
+	RetainedPurity RetentionPurity
+	// RetainedOffset echoes how many ring rows this response skipped, so a
+	// page is self-locating: rows RetainedOffset+1 .. RetainedOffset+len of
+	// RetainedCount.
+	RetainedOffset int
+	// RetainedFingerprint identifies the index generation the ring was cut
+	// from (see indexFingerprint). Pages sharing it are unionable; a
+	// mismatch means the index moved and the pages must not be merged.
+	RetainedFingerprint string
 
 	Truncated bool
 }
@@ -307,7 +326,7 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 	symbolTiers := state.buildTiers(directIDs, indirectIDs, symbolsByID, isSelf)
 	subclasses, viaIncludes := state.buildEdgeKindGroups(directIDs, indirectIDs, symbolsByID, isSelf)
 
-	viaComposition, retained, retainedCount, err := state.loadEdgeTableGroups(ctx, db, subject, symbolIDs, seedSet, subclasses, viaIncludes, isSelf, opts.MaxResults)
+	viaComposition, retention, err := state.loadEdgeTableGroups(ctx, db, subject, symbolIDs, seedSet, subclasses, viaIncludes, isSelf, opts)
 	if err != nil {
 		return Result{}, err
 	}
@@ -333,8 +352,11 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 		AffectedSubclasses:     subclasses,
 		AffectedViaComposition: viaComposition,
 		AffectedViaIncludes:    viaIncludes,
-		RetainedViaInterfaces:  retained,
-		RetainedCount:          retainedCount,
+		RetainedViaInterfaces:  retention.holders,
+		RetainedCount:          retention.count,
+		RetainedPurity:         retention.purity,
+		RetainedOffset:         retention.offset,
+		RetainedFingerprint:    retention.fingerprint,
 		SymbolTiers:            symbolTiers,
 		Truncated:              state.truncated,
 	}, nil
@@ -352,24 +374,25 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 // one-node-one-group invariant against the inherits/includes buckets. The
 // composer IDs are fetched once and shared: the composition group and the
 // retention closure's fixpoint level 1 read the same reverse-composes set.
-func (s *bfsState) loadEdgeTableGroups(ctx context.Context, db *sql.DB, subject model.Symbol, symbolIDs []int64, seedSet map[int64]struct{}, subclasses, viaIncludes []model.Symbol, isSelf selfMethodFn, maxResults int) ([]model.Symbol, []RetainedHolder, int, error) {
+func (s *bfsState) loadEdgeTableGroups(ctx context.Context, db *sql.DB, subject model.Symbol, symbolIDs []int64, seedSet map[int64]struct{}, subclasses, viaIncludes []model.Symbol, isSelf selfMethodFn, opts Options) ([]model.Symbol, retentionOutcome, error) {
 	excludeGrouped := symbolIDSet(subclasses, viaIncludes)
 	composerIDs, err := inboundComposers(ctx, db, symbolIDs)
 	if err != nil {
-		return nil, nil, 0, fmt.Errorf("blast: reverse composition: %w", err)
+		return nil, retentionOutcome{}, fmt.Errorf("blast: reverse composition: %w", err)
 	}
-	viaComposition, err := s.loadReverseComposition(ctx, db, composerIDs, seedSet, excludeGrouped, isSelf, maxResults)
+	viaComposition, err := s.loadReverseComposition(ctx, db, composerIDs, seedSet, excludeGrouped, isSelf, opts.MaxResults)
 	if err != nil {
-		return nil, nil, 0, fmt.Errorf("blast: reverse composition: %w", err)
+		return nil, retentionOutcome{}, fmt.Errorf("blast: reverse composition: %w", err)
 	}
-	retained, retainedCount, retainedTruncated, err := loadRetention(ctx, db, subject, symbolIDs, composerIDs, s.childSet, excludeGrouped, isSelf, maxResults)
+	retention, err := loadRetention(ctx, db, subject, symbolIDs, composerIDs, s.childSet, excludeGrouped, isSelf,
+		retentionPage{offset: opts.RetainedOffset, limit: opts.MaxResults})
 	if err != nil {
-		return nil, nil, 0, fmt.Errorf("blast: retention closure: %w", err)
+		return nil, retentionOutcome{}, fmt.Errorf("blast: retention closure: %w", err)
 	}
-	if retainedTruncated {
+	if retention.truncated {
 		s.truncated = true
 	}
-	return viaComposition, retained, retainedCount, nil
+	return viaComposition, retention, nil
 }
 
 // bfsState carries the mutable traversal state of one blast computation: the

--- a/internal/blast/engine_test.go
+++ b/internal/blast/engine_test.go
@@ -919,10 +919,13 @@ func writeFile(t *testing.T, path, content string) {
 // --- Pitch 13-05 fixture tests ---
 
 type fixtureDB struct {
-	db       *sql.DB
-	adapter  *sqlite.Adapter
-	fileID   int64
-	nextLine int
+	db      *sql.DB
+	adapter *sqlite.Adapter
+	fileID  int64
+	// testFileID is the lazily-created test-file row used by symbols that
+	// must read as test-declared (see addTestFileSymbol).
+	testFileID int64
+	nextLine   int
 }
 
 func newFixtureDB(t *testing.T) *fixtureDB {

--- a/internal/blast/retention.go
+++ b/internal/blast/retention.go
@@ -42,6 +42,14 @@ type RetainedHolder struct {
 	// re-derive it with a per-interface graph join. When several carriers
 	// satisfy Via, the lowest-ID one is recorded (mirrors the Via rule).
 	Carrier model.Symbol
+	// ViaSatisfiers is how many concrete types satisfy Via index-wide: the
+	// bare promiscuity fact, no threshold and no verdict. A row on an
+	// interface hundreds of unrelated types satisfy is far likelier to be a
+	// coincidence of shape than one on a two-implementation contract, and the
+	// consumer is the one who can judge which. It is never a reason to DROP a
+	// row: real retention rides generic interfaces too (measured on pebble,
+	// whose paid-win ring runs through InternalIterator).
+	ViaSatisfiers int
 	// Chain is a declared containment path from Carrier down to the
 	// subject (inclusive on both ends): every hop is a composes/includes
 	// edge the index holds, so the whole path is a statable structural
@@ -57,6 +65,24 @@ type retainedRoute struct {
 	via     int64
 	carrier int64
 }
+
+// RetentionPurity records the satisfiers the ring refused to launder through:
+// carriers declared in test files. A test-only satisfier proves nothing about
+// production retention, and one such struct embedding both the subject and a
+// dozen interfaces fabricates every composer of all twelve as a may-retain
+// holder (measured on temporal: 52 of 100 rows). Excluded is how many distinct
+// satisfiers were refused; Names carries up to retentionExcludedNamesCap of
+// them so the exclusion is auditable rather than a silent filter.
+type RetentionPurity struct {
+	Excluded int
+	Names    []string
+}
+
+// retentionExcludedNamesCap bounds the excluded-satisfier names disclosed in
+// the note. Five names is enough to recognise the shape (one test harness
+// struct, a couple of fakes) without spending the ring's token budget on an
+// exclusion list the consumer never acts on; Excluded carries the true count.
+const retentionExcludedNamesCap = 5
 
 const (
 	// retentionMaxLevels bounds the carrier fixpoint depth. Measured worst
@@ -95,29 +121,81 @@ func retentionSubjectKind(kind model.SymbolKind) bool {
 	}
 }
 
+// retentionOutcome is one retention computation's full answer: the shown
+// holders plus everything the consumer needs to judge them: the full count
+// behind the shown slice, whether a cap truncated the computation, and the
+// purity exclusions the ring applied.
+type retentionOutcome struct {
+	holders     []RetainedHolder
+	count       int
+	offset      int
+	truncated   bool
+	purity      RetentionPurity
+	fingerprint string
+}
+
 // loadRetention computes the retention group for the subject: the carrier
 // fixpoint (internal), one laundering round over it, then exclusion,
-// hydration, ordering, and the result cap. Returns the holders, the full
-// post-exclusion count (never reduced by the cap), and whether any cap
-// truncated the computation.
-func loadRetention(ctx context.Context, db *sql.DB, subject model.Symbol, seedIDs, directComposerIDs []int64, childSet, excludeGrouped map[int64]struct{}, isSelf selfMethodFn, maxResults int) ([]RetainedHolder, int, bool, error) {
+// hydration, ordering, and the result cap. The returned count is the full
+// post-exclusion size, never reduced by the cap.
+func loadRetention(ctx context.Context, db *sql.DB, subject model.Symbol, seedIDs, directComposerIDs []int64, childSet, excludeGrouped map[int64]struct{}, isSelf selfMethodFn, page retentionPage) (retentionOutcome, error) {
 	if !retentionSubjectKind(subject.Kind) {
-		return nil, 0, false, nil
+		return retentionOutcome{}, nil
 	}
 	carriers, parents, truncated, err := carrierClosure(ctx, db, seedIDs, directComposerIDs)
 	if err != nil {
-		return nil, 0, false, err
+		return retentionOutcome{}, err
 	}
-	holderVia, err := launderOneRound(ctx, db, carriers)
+	holderVia, purity, err := launderOneRound(ctx, db, carriers)
 	if err != nil {
-		return nil, 0, false, err
+		return retentionOutcome{}, err
 	}
 	kept := excludeRetained(holderVia, carriers, childSet, excludeGrouped)
-	holders, fullCount, capped, err := hydrateRetained(ctx, db, kept, holderVia, newChainTree(parents, seedIDs), isSelf, maxResults)
+	holders, fullCount, capped, err := hydrateRetained(ctx, db, kept, holderVia, newChainTree(parents, seedIDs), isSelf, page)
 	if err != nil {
-		return nil, 0, false, err
+		return retentionOutcome{}, err
 	}
-	return holders, fullCount, truncated || capped, nil
+	out := retentionOutcome{
+		holders:   holders,
+		count:     fullCount,
+		offset:    page.offset,
+		truncated: truncated || capped,
+		purity:    purity,
+	}
+	if fullCount > 0 {
+		// Only a ring that exists can be paged, and only a paged ring needs
+		// the generation stamp: a subject with no holders never pays for it.
+		out.fingerprint = indexFingerprint(ctx, db)
+	}
+	return out, nil
+}
+
+// retentionPage is the window the caller wants of the ring: how many rows to
+// skip, and how many to return. The ring's order is total (see orderRetained),
+// so consecutive windows over one index generation cover the set exactly.
+type retentionPage struct {
+	offset int
+	limit  int
+}
+
+// indexFingerprint identifies the index generation a page was cut from: the
+// file count plus the newest indexed_at stamp, which the watch daemon moves on
+// every rescan that touches anything. Two pages carrying the same fingerprint
+// were cut from the same graph; a mismatch means the ring shifted underneath
+// the cursor and the pages cannot be unioned: the exact silent-incompleteness
+// class the ring must never produce, so it is disclosed, never papered over.
+//
+// Best-effort like the other advisory lookups here: an unreadable stamp yields
+// an empty fingerprint, which claims nothing rather than claiming sameness.
+func indexFingerprint(ctx context.Context, db *sql.DB) string {
+	var files int
+	var newest sql.NullString
+	err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*), MAX(indexed_at) FROM sense_files`).Scan(&files, &newest)
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("f%d@%s", files, newest.String)
 }
 
 // carrierClosure walks the reverse composes/includes fixpoint from the seeds:
@@ -267,28 +345,37 @@ func liveFrontierRemains(carriers map[int64]struct{}, level []int64) bool {
 // those interfaces' reverse composers/embedders. Returns holder → lowest-ID
 // via-interface so a holder reachable through several interfaces appears
 // once, deterministically.
-func launderOneRound(ctx context.Context, db *sql.DB, carriers map[int64]struct{}) (map[int64]retainedRoute, error) {
+// The satisfaction pairs are purified first: a satisfier declared in a test
+// file is never nominated as a carrier, and an interface left with no
+// production satisfier stops laundering entirely: its composers are
+// fabrications of the test harness, not of the production graph.
+func launderOneRound(ctx context.Context, db *sql.DB, carriers map[int64]struct{}) (map[int64]retainedRoute, RetentionPurity, error) {
 	base := sortedIDSet(carriers)
-	ifaces, ifaceCarrier, err := forwardInterfaceTargets(ctx, db, base)
+	satisfies, err := forwardInterfacePairs(ctx, db, base)
 	if err != nil {
-		return nil, err
+		return nil, RetentionPurity{}, err
 	}
+	satisfies, purity, err := dropTestSatisfiers(ctx, db, satisfies)
+	if err != nil {
+		return nil, RetentionPurity{}, err
+	}
+	ifaces, ifaceCarrier := nominateCarriers(satisfies)
 	if len(ifaces) == 0 {
-		return nil, nil
+		return nil, purity, nil
 	}
 	// Screen BEFORE expanding composers — load-bearing ordering: a junk
 	// interface like Closer can carry hundreds of composers that must never
 	// be fetched, so the screen is the perf guard as well as the truth guard.
 	ifaces, err = screenJunkInterfaces(ctx, db, ifaces)
 	if err != nil {
-		return nil, err
+		return nil, purity, err
 	}
 	if len(ifaces) == 0 {
-		return nil, nil
+		return nil, purity, nil
 	}
 	pairs, err := inboundHolderPairs(ctx, db, ifaces, false)
 	if err != nil {
-		return nil, err
+		return nil, purity, err
 	}
 	holderVia := make(map[int64]retainedRoute, len(pairs))
 	for _, p := range pairs {
@@ -296,7 +383,81 @@ func launderOneRound(ctx context.Context, db *sql.DB, carriers map[int64]struct{
 			holderVia[p.source] = retainedRoute{via: p.target, carrier: ifaceCarrier[p.target]}
 		}
 	}
-	return holderVia, nil
+	return holderVia, purity, nil
+}
+
+// dropTestSatisfiers removes satisfaction pairs whose satisfier is declared in
+// a test file, and reports which ones were refused. A test double satisfies
+// interfaces it will never satisfy in production, so laundering through it
+// fabricates holders; the refusal is disclosed rather than silent because the
+// consumer cannot otherwise tell a purified ring from a small one.
+//
+// The flag lookup is best-effort like everywhere else in this package: a
+// failed query yields a nil map, which refuses nothing and degrades to the
+// unpurified ring instead of failing the blast.
+func dropTestSatisfiers(ctx context.Context, db *sql.DB, pairs []holderPair) ([]holderPair, RetentionPurity, error) {
+	if len(pairs) == 0 {
+		return pairs, RetentionPurity{}, nil
+	}
+	sources := make(map[int64]struct{}, len(pairs))
+	for _, p := range pairs {
+		sources[p.source] = struct{}{}
+	}
+	testFlags := testFileFlags(ctx, db, sortedIDSet(sources))
+	kept := make([]holderPair, 0, len(pairs))
+	excluded := make(map[int64]struct{})
+	for _, p := range pairs {
+		if testFlags[p.source] {
+			excluded[p.source] = struct{}{}
+			continue
+		}
+		kept = append(kept, p)
+	}
+	if len(excluded) == 0 {
+		return kept, RetentionPurity{}, nil
+	}
+	names, err := excludedSatisfierNames(ctx, db, sortedIDSet(excluded))
+	if err != nil {
+		return nil, RetentionPurity{}, err
+	}
+	return kept, RetentionPurity{Excluded: len(excluded), Names: names}, nil
+}
+
+// excludedSatisfierNames hydrates the first retentionExcludedNamesCap refused
+// satisfiers (ID-ascending, so the sample is stable run to run) into display
+// names. A satisfier that failed to hydrate is skipped rather than rendered as
+// a blank name: the count already carries the magnitude.
+func excludedSatisfierNames(ctx context.Context, db *sql.DB, ids []int64) ([]string, error) {
+	sample := ids
+	if len(sample) > retentionExcludedNamesCap {
+		sample = sample[:retentionExcludedNamesCap]
+	}
+	syms, err := loadSymbols(ctx, db, sample)
+	if err != nil {
+		return nil, fmt.Errorf("blast: excluded satisfiers: %w", err)
+	}
+	names := make([]string, 0, len(sample))
+	for _, id := range sample {
+		if s, ok := syms[id]; ok {
+			names = append(names, s.Name)
+		}
+	}
+	return names, nil
+}
+
+// nominateCarriers reduces purified satisfaction pairs to the candidate
+// via-interfaces plus each interface's nominated carrier: the lowest-ID
+// satisfier, the laundering proof that rides into RetainedHolder.Carrier.
+func nominateCarriers(pairs []holderPair) ([]int64, map[int64]int64) {
+	set := make(map[int64]struct{}, len(pairs))
+	carrier := make(map[int64]int64, len(pairs))
+	for _, p := range pairs {
+		set[p.target] = struct{}{}
+		if lowest, ok := carrier[p.target]; !ok || p.source < lowest {
+			carrier[p.target] = p.source
+		}
+	}
+	return sortedIDSet(set), carrier
 }
 
 // excludeRetained drops holders that already have a stronger home: carriers
@@ -322,10 +483,10 @@ func excludeRetained(holderVia map[int64]retainedRoute, carriers, childSet, excl
 }
 
 // hydrateRetained loads the holder and via-interface symbols, filters the
-// subject's self-members, orders production-first then by ID, and applies the
-// result cap. The returned count is the full post-exclusion size, never the
-// capped one, so a capped list is self-evident to the consumer.
-func hydrateRetained(ctx context.Context, db *sql.DB, kept []int64, holderVia map[int64]retainedRoute, chains chainTree, isSelf selfMethodFn, maxResults int) ([]RetainedHolder, int, bool, error) {
+// subject's self-members, orders production-first then by ID, and cuts the
+// requested page. The returned count is the full post-exclusion size, never
+// the page's, so a partial page is self-evident to the consumer.
+func hydrateRetained(ctx context.Context, db *sql.DB, kept []int64, holderVia map[int64]retainedRoute, chains chainTree, isSelf selfMethodFn, page retentionPage) ([]RetainedHolder, int, bool, error) {
 	if len(kept) == 0 {
 		return nil, 0, false, nil
 	}
@@ -352,12 +513,68 @@ func hydrateRetained(ctx context.Context, db *sql.DB, kept []int64, holderVia ma
 	}
 	fullCount := len(holders)
 	orderRetained(ctx, db, holders)
-	capped := false
-	if len(holders) > maxResults {
-		holders = holders[:maxResults]
-		capped = true
+	holders, capped := cutRetentionPage(holders, page)
+	// Stamped after the cap so the count query is scoped to the vias actually
+	// shown: on a hub subject the pre-cap ring can be several hundred rows.
+	if err := stampViaSatisfiers(ctx, db, holders); err != nil {
+		return nil, 0, false, err
 	}
 	return holders, fullCount, capped, nil
+}
+
+// cutRetentionPage takes the requested window out of the ordered ring and
+// reports whether rows exist past its end. An offset beyond the ring yields no
+// rows rather than an error: the count and the note still tell the consumer
+// where the ring actually ends, which is more useful than a rejected call.
+func cutRetentionPage(holders []RetainedHolder, page retentionPage) ([]RetainedHolder, bool) {
+	if page.offset >= len(holders) {
+		// Past the end. There is more ring behind this window whenever the
+		// window skipped a non-empty ring: the caller over-shot the cursor.
+		overshot := page.offset > 0 && len(holders) > 0
+		return nil, overshot
+	}
+	holders = holders[page.offset:]
+	if page.limit > 0 && len(holders) > page.limit {
+		return holders[:page.limit], true
+	}
+	return holders, false
+}
+
+// stampViaSatisfiers annotates each shown row with how many concrete types
+// satisfy its via-interface index-wide (see RetainedHolder.ViaSatisfiers).
+// Interface-kind sources are not counted: an interface embedding an interface
+// extends a contract, it does not satisfy one, so counting it would inflate
+// the stamp with symbols that can never be the runtime value of the field.
+func stampViaSatisfiers(ctx context.Context, db *sql.DB, holders []RetainedHolder) error {
+	vias := make(map[int64]struct{}, len(holders))
+	for _, h := range holders {
+		if h.Via.ID != 0 {
+			vias[h.Via.ID] = struct{}{}
+		}
+	}
+	if len(vias) == 0 {
+		return nil
+	}
+	query := func(placeholders string) string {
+		return `SELECT e.target_id, COUNT(DISTINCT e.source_id) FROM sense_edges e
+		        JOIN sense_symbols s ON s.id = e.source_id
+		        WHERE e.target_id IN (` + placeholders + `)
+		          AND e.kind = 'inherits'
+		          AND s.kind != 'interface'
+		        GROUP BY e.target_id`
+	}
+	pairs, err := queryHolderPairs(ctx, db, sortedIDSet(vias), query)
+	if err != nil {
+		return fmt.Errorf("blast: via satisfier counts: %w", err)
+	}
+	counts := make(map[int64]int64, len(pairs))
+	for _, p := range pairs {
+		counts[p.source] = p.target
+	}
+	for i := range holders {
+		holders[i].ViaSatisfiers = int(counts[holders[i].Via.ID])
+	}
+	return nil
 }
 
 // assembleChain hydrates a chain's IDs whole or not at all: splicing over a
@@ -382,6 +599,15 @@ func assembleChain(syms map[int64]model.Symbol, ids []int64) []model.Symbol {
 // holder but matters less to a lifecycle audit, so it must not crowd the cap.
 // testFileFlags is best-effort: a nil map degrades to pure ID order, still
 // deterministic.
+//
+// This is a TOTAL order and paging depends on it : symbol IDs are
+// unique, so no two rows can compare equal and no pair can swap between two
+// calls on one index: a cursor over the ring therefore covers the set exactly,
+// with no dup and no gap. Blast output order has a recorded nondeterminism
+// history (project ledger), so the property is pinned by an explicit
+// exact-sequence test, not assumed from the comparator's shape. Any new key
+// must be inserted ABOVE the ID tiebreak and re-pinned: adding one below it is
+// dead code, and adding one above reorders every shipped ring.
 func orderRetained(ctx context.Context, db *sql.DB, holders []RetainedHolder) {
 	ids := make([]int64, len(holders))
 	for i, h := range holders {
@@ -593,13 +819,13 @@ func inboundHolderPairs(ctx context.Context, db *sql.DB, ids []int64, includesOn
 	return queryHolderPairs(ctx, db, ids, query)
 }
 
-// forwardInterfaceTargets returns the distinct interface-kind symbols any of
-// ids satisfies or implements (forward inherits edges), plus each interface's
-// lowest-ID satisfying carrier, the laundering proof that rides into
-// RetainedHolder.Carrier. The filter is on the TARGET's symbol kind, never on
-// edge confidence: Go satisfaction edges ride convention confidence but
-// Rust/TS declared implements are full-confidence, and both launder.
-func forwardInterfaceTargets(ctx context.Context, db *sql.DB, ids []int64) ([]int64, map[int64]int64, error) {
+// forwardInterfacePairs returns the (satisfier, interface) rows for every
+// interface-kind symbol any of ids satisfies or implements (forward inherits
+// edges). The filter is on the TARGET's symbol kind, never on edge confidence:
+// Go satisfaction edges ride convention confidence but Rust/TS declared
+// implements are full-confidence, and both launder. The pairs stay unreduced
+// so purity can refuse individual satisfiers before any carrier is nominated.
+func forwardInterfacePairs(ctx context.Context, db *sql.DB, ids []int64) ([]holderPair, error) {
 	query := func(placeholders string) string {
 		return `SELECT DISTINCT e.source_id, e.target_id FROM sense_edges e
 		        JOIN sense_symbols s ON s.id = e.target_id
@@ -607,19 +833,7 @@ func forwardInterfaceTargets(ctx context.Context, db *sql.DB, ids []int64) ([]in
 		          AND e.kind = 'inherits'
 		          AND s.kind = 'interface'`
 	}
-	pairs, err := queryHolderPairs(ctx, db, ids, query)
-	if err != nil {
-		return nil, nil, err
-	}
-	set := make(map[int64]struct{}, len(pairs))
-	carrier := make(map[int64]int64, len(pairs))
-	for _, p := range pairs {
-		set[p.target] = struct{}{}
-		if lowest, ok := carrier[p.target]; !ok || p.source < lowest {
-			carrier[p.target] = p.source
-		}
-	}
-	return sortedIDSet(set), carrier, nil
+	return queryHolderPairs(ctx, db, ids, query)
 }
 
 // nonInterfaceIDs filters ids down to symbols whose kind is not interface.

--- a/internal/blast/retention_faults_test.go
+++ b/internal/blast/retention_faults_test.go
@@ -20,6 +20,15 @@ import (
 // query executes.
 func openRetentionFaultDB(t *testing.T) (*sql.DB, model.Symbol, []int64) {
 	t.Helper()
+	return openRetentionFaultDBSeeded(t, false)
+}
+
+// openRetentionFaultDBSeeded is openRetentionFaultDB with a switch for the
+// purity path: withTestSatisfier adds a second satisfier declared in a test
+// file, so the refusal (and the name hydration it triggers) actually runs and
+// its failure modes can be armed.
+func openRetentionFaultDBSeeded(t *testing.T, withTestSatisfier bool) (*sql.DB, model.Symbol, []int64) {
+	t.Helper()
 	ctx := context.Background()
 	dbPath := t.TempDir() + "/retention.db"
 	adapter, err := sqlite.Open(ctx, dbPath)
@@ -30,6 +39,7 @@ func openRetentionFaultDB(t *testing.T) (*sql.DB, model.Symbol, []int64) {
 
 	var subject model.Symbol
 	var composerIDs []int64
+	var testSatisfierID int64
 	err = adapter.InTx(ctx, func() error {
 		f, err := adapter.WriteFile(ctx, &model.File{
 			Path: "widget.go", Language: "go", Hash: "h1", Symbols: 5, IndexedAt: time.Now().UTC(),
@@ -65,6 +75,27 @@ func openRetentionFaultDB(t *testing.T) (*sql.DB, model.Symbol, []int64) {
 		edge(carrier, subjectID, model.EdgeComposes)
 		edge(carrier, iface, model.EdgeInherits)
 		edge(holder, iface, model.EdgeComposes)
+		if withTestSatisfier {
+			tf, ferr := adapter.WriteFile(ctx, &model.File{
+				Path: "widget_test.go", Language: "go", Hash: "h2", Symbols: 1, IndexedAt: time.Now().UTC(),
+			})
+			if ferr != nil {
+				return ferr
+			}
+			fake, werr := adapter.WriteSymbol(ctx, &model.Symbol{
+				FileID: tf, Name: "FakeCarrier", Qualified: "FakeCarrier",
+				Kind: model.KindClass, LineStart: 1, LineEnd: 2,
+			})
+			if werr != nil {
+				return werr
+			}
+			edge(fake, subjectID, model.EdgeComposes)
+			edge(fake, iface, model.EdgeInherits)
+			// The closure's level 1 is the caller-supplied composer list (in
+			// production, inboundComposers finds it), so the fake must be in
+			// it or purity has nothing to refuse.
+			testSatisfierID = fake
+		}
 		if err != nil {
 			return err
 		}
@@ -74,6 +105,9 @@ func openRetentionFaultDB(t *testing.T) (*sql.DB, model.Symbol, []int64) {
 	})
 	if err != nil {
 		t.Fatalf("seed: %v", err)
+	}
+	if testSatisfierID != 0 {
+		composerIDs = append(composerIDs, testSatisfierID)
 	}
 
 	blastFaultOnce.Do(func() {
@@ -200,5 +234,44 @@ func TestComputePropagatesEdgeTableGroupFault(t *testing.T) {
 	t.Cleanup(disarmBlastFaults)
 	if _, err := Compute(context.Background(), db, []int64{subject.ID}, Options{MaxHops: 1}); err == nil {
 		t.Fatal("Compute: expected propagated edge-table-group error, got nil")
+	}
+}
+
+// TestRetentionExcludedNamesPropagateFault: the purity refusal hydrates the
+// refused satisfiers' names, and a failure there must surface rather than
+// yield a ring whose disclosure silently lost its names.
+func TestRetentionExcludedNamesPropagateFault(t *testing.T) {
+	db, subject, composerIDs := openRetentionFaultDBSeeded(t, true)
+	armBlastQueryFault(`docstring, complexity, snippet`)
+	t.Cleanup(disarmBlastFaults)
+
+	noSelf := func(model.Symbol) bool { return false }
+	_, err := loadRetention(context.Background(), db, subject, []int64{subject.ID},
+		composerIDs, map[int64]struct{}{}, map[int64]struct{}{}, noSelf, retentionPage{limit: 100})
+	if err == nil {
+		t.Fatal("expected the excluded-satisfier hydration fault to propagate")
+	}
+}
+
+// TestRetentionFingerprintDegradesOnFault: the page fingerprint is
+// best-effort. An unreadable index generation yields an EMPTY fingerprint,
+// never a failed blast and never a fabricated stamp that would let two
+// incomparable pages look unionable.
+func TestRetentionFingerprintDegradesOnFault(t *testing.T) {
+	db, subject, composerIDs := openRetentionFaultDB(t)
+	armBlastQueryFault(`MAX(indexed_at)`)
+	t.Cleanup(disarmBlastFaults)
+
+	noSelf := func(model.Symbol) bool { return false }
+	out, err := loadRetention(context.Background(), db, subject, []int64{subject.ID},
+		composerIDs, map[int64]struct{}{}, map[int64]struct{}{}, noSelf, retentionPage{limit: 100})
+	if err != nil {
+		t.Fatalf("a fingerprint fault must not fail the blast: %v", err)
+	}
+	if out.fingerprint != "" {
+		t.Errorf("fingerprint = %q, want empty when the generation is unreadable", out.fingerprint)
+	}
+	if len(out.holders) == 0 {
+		t.Error("the ring itself must survive a fingerprint fault")
 	}
 }

--- a/internal/blast/retention_faults_test.go
+++ b/internal/blast/retention_faults_test.go
@@ -97,8 +97,8 @@ func openRetentionFaultDB(t *testing.T) (*sql.DB, model.Symbol, []int64) {
 func runRetention(t *testing.T, db *sql.DB, subject model.Symbol, composerIDs []int64) error {
 	t.Helper()
 	noSelf := func(model.Symbol) bool { return false }
-	_, _, _, err := loadRetention(context.Background(), db, subject, []int64{subject.ID},
-		composerIDs, map[int64]struct{}{}, map[int64]struct{}{}, noSelf, 100)
+	_, err := loadRetention(context.Background(), db, subject, []int64{subject.ID},
+		composerIDs, map[int64]struct{}{}, map[int64]struct{}{}, noSelf, retentionPage{limit: 100})
 	return err
 }
 
@@ -106,13 +106,14 @@ func runRetention(t *testing.T, db *sql.DB, subject model.Symbol, composerIDs []
 // distinct retention query and expects loadRetention to surface it.
 func TestRetentionPropagatesQueryFaults(t *testing.T) {
 	cases := map[string]string{
-		"level1_embedders":   `e.kind IN ('includes')`,
-		"level1_kind_filter": `AND kind != 'interface'`,
-		"deeper_levels":      `e.kind IN ('composes','includes')`,
-		"forward_interfaces": `e.kind = 'inherits'`,
-		"sole_members":       `AND kind = 'method'`,
-		"name_frequency":     `GROUP BY name`,
-		"hydration":          `docstring, complexity, snippet`,
+		"level1_embedders":    `e.kind IN ('includes')`,
+		"level1_kind_filter":  `AND kind != 'interface'`,
+		"deeper_levels":       `e.kind IN ('composes','includes')`,
+		"forward_interfaces":  `e.kind = 'inherits'`,
+		"sole_members":        `AND kind = 'method'`,
+		"name_frequency":      `GROUP BY name`,
+		"hydration":           `docstring, complexity, snippet`,
+		"via_satisfier_count": `COUNT(DISTINCT e.source_id)`,
 	}
 	for name, sub := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -159,8 +160,8 @@ func TestRetentionCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	noSelf := func(model.Symbol) bool { return false }
-	_, _, _, err := loadRetention(ctx, db, subject, []int64{subject.ID},
-		composerIDs, map[int64]struct{}{}, map[int64]struct{}{}, noSelf, 100)
+	_, err := loadRetention(ctx, db, subject, []int64{subject.ID},
+		composerIDs, map[int64]struct{}{}, map[int64]struct{}{}, noSelf, retentionPage{limit: 100})
 	if err == nil {
 		t.Fatal("expected cancellation error")
 	}
@@ -182,8 +183,8 @@ func TestEdgeTableGroupsPropagateFaults(t *testing.T) {
 			t.Cleanup(disarmBlastFaults)
 			s := &bfsState{childSet: map[int64]struct{}{}}
 			noSelf := func(model.Symbol) bool { return false }
-			_, _, _, err := s.loadEdgeTableGroups(context.Background(), db, subject,
-				[]int64{subject.ID}, map[int64]struct{}{subject.ID: {}}, nil, nil, noSelf, 100)
+			_, _, err := s.loadEdgeTableGroups(context.Background(), db, subject,
+				[]int64{subject.ID}, map[int64]struct{}{subject.ID: {}}, nil, nil, noSelf, Options{MaxResults: 100})
 			if err == nil {
 				t.Fatalf("expected propagated error for %s", name)
 			}

--- a/internal/blast/retention_test.go
+++ b/internal/blast/retention_test.go
@@ -11,6 +11,7 @@ package blast_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -708,4 +709,364 @@ func assertChain(t *testing.T, res blast.Result, holder int64, want []int64) {
 		return
 	}
 	t.Fatalf("holder %d missing from retained rows", holder)
+}
+
+// --- Test-satisfier purity ---
+
+// addTestFileSymbol writes a symbol living in a _test file, so the purity
+// filter's IsTestPath check has something to refuse. The file is created
+// lazily on first use and shared by every later call.
+func (f *fixtureDB) addTestFileSymbol(t *testing.T, name string) int64 {
+	t.Helper()
+	ctx := context.Background()
+	if f.testFileID == 0 {
+		fid, err := f.adapter.WriteFile(ctx, &model.File{
+			Path: "fixture_test.rb", Language: "ruby", Hash: "fixtest",
+			Symbols: 1, IndexedAt: time.Now().UTC(),
+		})
+		if err != nil {
+			t.Fatalf("WriteFile test: %v", err)
+		}
+		f.testFileID = fid
+	}
+	line := f.nextLine
+	f.nextLine += 10
+	id, err := f.adapter.WriteSymbol(ctx, &model.Symbol{
+		FileID: f.testFileID, Name: name, Qualified: name,
+		Kind: model.KindClass, LineStart: line, LineEnd: line + 5,
+	})
+	if err != nil {
+		t.Fatalf("WriteSymbol %s: %v", name, err)
+	}
+	return id
+}
+
+// testHarnessFixture is the minimized temporal shape: a test-only struct that
+// both carries the subject and satisfies a pile of interfaces, so every
+// composer of those interfaces fabricates a may-retain row (52 of 100 on
+// temporal). FakeHarness is written FIRST so it holds the lowest satisfier ID
+// : the carrier nomination is lowest-ID-wins, so a fixture where the
+// production carrier happens to win anyway would not kill the mutant.
+//
+//	subject <-composes- FakeHarness (test file) -inherits-> FakeOnlyIface <-composes- GhostHolder
+//	subject <-composes- RealCarrier             -inherits-> SharedIface   <-composes- RealHolder
+//	                    FakeHarness             -inherits-> SharedIface
+func testHarnessFixture(t *testing.T) (fix *fixtureDB, subject, realCarrier, ghost, realHolder int64) {
+	t.Helper()
+	fix = newFixtureDB(t)
+	subject = fix.addSymbol(t, "SubjectA")
+	fake := fix.addTestFileSymbol(t, "FakeHarness")
+	realCarrier = fix.addSymbol(t, "RealCarrier")
+
+	fakeOnly := fix.addSymbolWith(t, "FakeOnlyIface", model.KindInterface, nil)
+	fix.addSymbolWith(t, "VisitFakeOnlyThing", model.KindMethod, &fakeOnly)
+	shared := fix.addSymbolWith(t, "SharedIface", model.KindInterface, nil)
+	fix.addSymbolWith(t, "VisitSharedThing", model.KindMethod, &shared)
+
+	ghost = fix.addSymbol(t, "GhostHolder")
+	realHolder = fix.addSymbol(t, "RealHolder")
+
+	fix.addEdge(t, fake, subject, model.EdgeComposes, 0.9)
+	fix.addEdge(t, realCarrier, subject, model.EdgeComposes, 0.9)
+	fix.addEdge(t, fake, fakeOnly, model.EdgeInherits, confConvention)
+	fix.addEdge(t, fake, shared, model.EdgeInherits, confConvention)
+	fix.addEdge(t, realCarrier, shared, model.EdgeInherits, confConvention)
+	fix.addEdge(t, ghost, fakeOnly, model.EdgeComposes, 0.9)
+	fix.addEdge(t, realHolder, shared, model.EdgeComposes, 0.9)
+	return fix, subject, realCarrier, ghost, realHolder
+}
+
+// TestRetentionDropsTestOnlySatisfierRows: an interface satisfied only by a
+// test double contributes no rows, and the row that survives is proved by the
+// production carrier: never by the test double, even though the double owns
+// the lower ID the nomination would otherwise pick.
+func TestRetentionDropsTestOnlySatisfierRows(t *testing.T) {
+	fix, subject, realCarrier, ghost, realHolder := testHarnessFixture(t)
+
+	res := computeRetention(t, fix, subject)
+
+	if retainedIDs(res)[ghost] {
+		t.Errorf("holder %d rides a test-only satisfier and must not be in the ring: %+v", ghost, res.RetainedViaInterfaces)
+	}
+	if !retainedIDs(res)[realHolder] {
+		t.Fatalf("holder %d rides a production satisfier and must stay in the ring: %+v", realHolder, res.RetainedViaInterfaces)
+	}
+	if res.RetainedCount != 1 {
+		t.Errorf("RetainedCount = %d, want 1", res.RetainedCount)
+	}
+	for _, rh := range res.RetainedViaInterfaces {
+		if rh.Symbol.ID == realHolder && rh.Carrier.ID != realCarrier {
+			t.Errorf("carrier = %d (%s), want the production carrier %d", rh.Carrier.ID, rh.Carrier.Name, realCarrier)
+		}
+	}
+}
+
+// TestRetentionDisclosesExcludedSatisfiers: the refusal is auditable: the
+// count and the refused names ride out with the result, so a purified ring is
+// distinguishable from a subject nothing launders.
+func TestRetentionDisclosesExcludedSatisfiers(t *testing.T) {
+	fix, subject, _, _, _ := testHarnessFixture(t)
+
+	res := computeRetention(t, fix, subject)
+
+	if res.RetainedPurity.Excluded != 1 {
+		t.Errorf("RetainedPurity.Excluded = %d, want 1", res.RetainedPurity.Excluded)
+	}
+	if len(res.RetainedPurity.Names) != 1 || res.RetainedPurity.Names[0] != "FakeHarness" {
+		t.Errorf("RetainedPurity.Names = %v, want [FakeHarness]", res.RetainedPurity.Names)
+	}
+}
+
+// TestRetentionExcludedNamesCapped: the disclosed sample is bounded at five
+// names while the count keeps the true magnitude, so a harness package with
+// dozens of fakes cannot spend the ring's token budget on its own exclusion.
+func TestRetentionExcludedNamesCapped(t *testing.T) {
+	fix := newFixtureDB(t)
+	subject := fix.addSymbol(t, "SubjectA")
+	iface := fix.addSymbolWith(t, "RareCappedIface", model.KindInterface, nil)
+	fix.addSymbolWith(t, "VisitRareCappedThing", model.KindMethod, &iface)
+	for i := range 7 {
+		fake := fix.addTestFileSymbol(t, fmt.Sprintf("Fake%d", i))
+		fix.addEdge(t, fake, subject, model.EdgeComposes, 0.9)
+		fix.addEdge(t, fake, iface, model.EdgeInherits, confConvention)
+	}
+
+	res := computeRetention(t, fix, subject)
+
+	if res.RetainedPurity.Excluded != 7 {
+		t.Errorf("Excluded = %d, want 7", res.RetainedPurity.Excluded)
+	}
+	if len(res.RetainedPurity.Names) != 5 {
+		t.Errorf("len(Names) = %d, want 5 (capped), got %v", len(res.RetainedPurity.Names), res.RetainedPurity.Names)
+	}
+}
+
+// --- Promiscuity stamp ---
+
+// TestRetentionStampsViaSatisfiers: a row riding an interface many unrelated
+// concretes satisfy is KEPT and stamped with the count. This is the pebble
+// trap in reverse: the paid-win ring there runs through a generic iterator
+// interface, so promiscuity annotates and must never drop.
+func TestRetentionStampsViaSatisfiers(t *testing.T) {
+	fix, subject, _, iface, holder := launderedFixture(t)
+	// Five more concretes satisfy the same interface without carrying the
+	// subject: they change the stamp, not the ring.
+	for i := range 5 {
+		other := fix.addSymbol(t, fmt.Sprintf("Unrelated%d", i))
+		fix.addEdge(t, other, iface, model.EdgeInherits, confConvention)
+	}
+	// An interface embedding the via extends the contract, it cannot be the
+	// runtime value of the field, so it must not inflate the stamp.
+	extender := fix.addSymbolWith(t, "ExtendingIface", model.KindInterface, nil)
+	fix.addEdge(t, extender, iface, model.EdgeInherits, confConvention)
+
+	res := computeRetention(t, fix, subject)
+
+	if !retainedIDs(res)[holder] {
+		t.Fatalf("promiscuous via must keep its row: %+v", res.RetainedViaInterfaces)
+	}
+	for _, rh := range res.RetainedViaInterfaces {
+		if rh.Symbol.ID != holder {
+			continue
+		}
+		if rh.ViaSatisfiers != 6 {
+			t.Errorf("ViaSatisfiers = %d, want 6 (carrier + 5 unrelated concretes, no interfaces)", rh.ViaSatisfiers)
+		}
+	}
+}
+
+// TestRetentionStampsSoleSatisfier pins the low end: a two-party contract
+// stamps 1, so the consumer can tell a narrow via from a promiscuous one.
+func TestRetentionStampsSoleSatisfier(t *testing.T) {
+	fix, subject, _, _, holder := launderedFixture(t)
+
+	res := computeRetention(t, fix, subject)
+
+	for _, rh := range res.RetainedViaInterfaces {
+		if rh.Symbol.ID == holder && rh.ViaSatisfiers != 1 {
+			t.Errorf("ViaSatisfiers = %d, want 1", rh.ViaSatisfiers)
+		}
+	}
+}
+
+// --- Deterministic ring order ---
+
+// orderFixture builds a ring whose creation order, test/production split, and
+// ID order all disagree, so an exact-sequence assertion over it kills any
+// perturbation of the comparator: TestHolder is created FIRST (lowest ID) yet
+// must sort LAST, and the production holders must come out ID-ascending.
+func orderFixture(t *testing.T) (fix *fixtureDB, subject int64, want []int64) {
+	t.Helper()
+	fix = newFixtureDB(t)
+	subject = fix.addSymbol(t, "SubjectA")
+	carrier := fix.addSymbol(t, "CarrierC")
+	iface := fix.addSymbolWith(t, "RareOrderIface", model.KindInterface, nil)
+	fix.addSymbolWith(t, "VisitRareOrderThing", model.KindMethod, &iface)
+	fix.addEdge(t, carrier, subject, model.EdgeComposes, 0.9)
+	fix.addEdge(t, carrier, iface, model.EdgeInherits, confConvention)
+
+	testHolder := fix.addTestFileSymbol(t, "TestHolder")
+	first := fix.addSymbol(t, "HolderA")
+	second := fix.addSymbol(t, "HolderB")
+	for _, h := range []int64{testHolder, first, second} {
+		fix.addEdge(t, h, iface, model.EdgeComposes, 0.9)
+	}
+	return fix, subject, []int64{first, second, testHolder}
+}
+
+// ringOrder renders one computation's ring as its holder ID sequence.
+func ringOrder(res blast.Result) []int64 {
+	out := make([]int64, 0, len(res.RetainedViaInterfaces))
+	for _, rh := range res.RetainedViaInterfaces {
+		out = append(out, rh.Symbol.ID)
+	}
+	return out
+}
+
+// TestRetentionRingOrderIsPinned: the ring comes out in one exact sequence ,
+// production holders ID-ascending, then test-file holders. Paging is a cursor
+// over this order, so a perturbation here silently drops or duplicates rows
+// across pages; the exact sequence is the tripwire.
+func TestRetentionRingOrderIsPinned(t *testing.T) {
+	fix, subject, want := orderFixture(t)
+
+	got := ringOrder(computeRetention(t, fix, subject))
+
+	if len(got) != len(want) {
+		t.Fatalf("ring = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("ring[%d] = %d, want %d (full: %v vs %v)", i, got[i], want[i], got, want)
+		}
+	}
+}
+
+// TestRetentionRingOrderIsRepeatable: two calls on the same index return the
+// ring byte-for-byte identically. The comparator is a total order (symbol IDs
+// are unique), so no pair may swap between runs: the precondition every page
+// boundary rests on.
+func TestRetentionRingOrderIsRepeatable(t *testing.T) {
+	fix, subject, _ := orderFixture(t)
+
+	first, err := json.Marshal(computeRetention(t, fix, subject).RetainedViaInterfaces)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for run := range 5 {
+		again, err := json.Marshal(computeRetention(t, fix, subject).RetainedViaInterfaces)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if string(again) != string(first) {
+			t.Fatalf("run %d differs:\n%s\n%s", run, first, again)
+		}
+	}
+}
+
+// --- Ring paging ---
+
+// pagedFixture builds a ring of five holders on one via-interface, the
+// smallest shape where two pages have a real boundary between them.
+func pagedFixture(t *testing.T) (fix *fixtureDB, subject int64) {
+	t.Helper()
+	fix = newFixtureDB(t)
+	subject = fix.addSymbol(t, "SubjectA")
+	carrier := fix.addSymbol(t, "CarrierC")
+	iface := fix.addSymbolWith(t, "RarePageIface", model.KindInterface, nil)
+	fix.addSymbolWith(t, "VisitRarePageThing", model.KindMethod, &iface)
+	fix.addEdge(t, carrier, subject, model.EdgeComposes, 0.9)
+	fix.addEdge(t, carrier, iface, model.EdgeInherits, confConvention)
+	for i := range 5 {
+		h := fix.addSymbol(t, fmt.Sprintf("PagedHolder%d", i))
+		fix.addEdge(t, h, iface, model.EdgeComposes, 0.9)
+	}
+	return fix, subject
+}
+
+// computePage runs one blast with an explicit ring window.
+func computePage(t *testing.T, fix *fixtureDB, subject int64, offset, limit int) blast.Result {
+	t.Helper()
+	res, err := blast.Compute(context.Background(), fix.db, []int64{subject},
+		blast.Options{MaxHops: 3, MinConfidence: 0.1, MaxResults: limit, RetainedOffset: offset})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	return res
+}
+
+// TestRetentionPagesCoverRingExactly: two consecutive pages cover the whole
+// ring with no duplicate and no gap, and every page reports the FULL count ,
+// the property that makes a truncated ring safe to resume instead of
+// abandon.
+func TestRetentionPagesCoverRingExactly(t *testing.T) {
+	fix, subject := pagedFixture(t)
+
+	whole := ringOrder(computePage(t, fix, subject, 0, 100))
+	if len(whole) != 5 {
+		t.Fatalf("ring = %v, want 5 holders", whole)
+	}
+
+	first := computePage(t, fix, subject, 0, 3)
+	second := computePage(t, fix, subject, 3, 3)
+	union := append(ringOrder(first), ringOrder(second)...)
+
+	if len(union) != len(whole) {
+		t.Fatalf("paged union = %v, want the whole ring %v", union, whole)
+	}
+	for i := range whole {
+		if union[i] != whole[i] {
+			t.Fatalf("union[%d] = %d, want %d (union %v vs whole %v)", i, union[i], whole[i], union, whole)
+		}
+	}
+	for _, page := range []blast.Result{first, second} {
+		if page.RetainedCount != 5 {
+			t.Errorf("page reports count %d, want the full ring size 5", page.RetainedCount)
+		}
+	}
+	if first.RetainedOffset != 0 || second.RetainedOffset != 3 {
+		t.Errorf("offsets = %d/%d, want 0/3", first.RetainedOffset, second.RetainedOffset)
+	}
+}
+
+// TestRetentionPageBeyondRingIsEmpty: an offset past the end returns no rows
+// but still reports where the ring actually ends, so an over-shot cursor is
+// self-correcting rather than an error round trip.
+func TestRetentionPageBeyondRingIsEmpty(t *testing.T) {
+	fix, subject := pagedFixture(t)
+
+	res := computePage(t, fix, subject, 50, 3)
+
+	if len(res.RetainedViaInterfaces) != 0 {
+		t.Errorf("rows = %d, want 0 past the end", len(res.RetainedViaInterfaces))
+	}
+	if res.RetainedCount != 5 {
+		t.Errorf("RetainedCount = %d, want 5", res.RetainedCount)
+	}
+}
+
+// TestRetentionFingerprintIdentifiesGeneration: pages cut from one index
+// carry the same fingerprint, and re-indexing a file moves it: the signal
+// that two pages must not be unioned.
+func TestRetentionFingerprintIdentifiesGeneration(t *testing.T) {
+	fix, subject := pagedFixture(t)
+
+	first := computePage(t, fix, subject, 0, 3)
+	second := computePage(t, fix, subject, 3, 3)
+	if first.RetainedFingerprint == "" {
+		t.Fatal("a paged ring must carry an index fingerprint")
+	}
+	if first.RetainedFingerprint != second.RetainedFingerprint {
+		t.Errorf("same index gave different fingerprints: %q vs %q", first.RetainedFingerprint, second.RetainedFingerprint)
+	}
+
+	if _, err := fix.adapter.WriteFile(context.Background(), &model.File{
+		Path: "later.rb", Language: "ruby", Hash: "later",
+		Symbols: 1, IndexedAt: time.Now().UTC().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if after := computePage(t, fix, subject, 0, 3); after.RetainedFingerprint == first.RetainedFingerprint {
+		t.Errorf("fingerprint %q survived a re-index; a moved index must be visible", after.RetainedFingerprint)
+	}
 }

--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -80,15 +80,39 @@ func spanIndirectByFile(hops []blast.CallerHop, directCallers []model.Symbol) []
 	return append(ordered, deferred...)
 }
 
+// clearRetainedString builds a shed step for one string enrichment field.
+func clearRetainedString(field func(*BlastRetained) *string) func(*BlastRetained) bool {
+	return func(r *BlastRetained) bool {
+		f := field(r)
+		if *f == "" {
+			return false
+		}
+		*f = ""
+		return true
+	}
+}
+
+// clearRetainedStamp is the shed step for the via_satisfiers annotation. It
+// sheds like any other enrichment because it IS one: the row's claim stands
+// without it, and a row is strictly worth more than a caution number about
+// the row (measured the hard way: stamping every row unshed pushed 17 of
+// dolt's 53 holders, 7 of them gold, off a paid-win response).
+func clearRetainedStamp(r *BlastRetained) bool {
+	if r.ViaSatisfiers == 0 {
+		return false
+	}
+	r.ViaSatisfiers = 0
+	return true
+}
+
 // shedRetainedField strips one enrichment field from retained rows,
 // tail-first in trimStep batches, until the response fits the budget or
-// every row's field is empty.
-func shedRetainedField(resp *BlastResponse, budget int, field func(*BlastRetained) *string) {
+// every row's field is already empty.
+func shedRetainedField(resp *BlastResponse, budget int, strip func(*BlastRetained) bool) {
 	i := len(resp.RetainedViaInterfaces) - 1
 	for i >= 0 && estimateBlastWireTokens(resp) > budget {
 		for range trimStep(i + 1) {
-			if f := field(&resp.RetainedViaInterfaces[i]); *f != "" {
-				*f = ""
+			if strip(&resp.RetainedViaInterfaces[i]) {
 				// Set at the first strip so the flag's own bytes are
 				// priced by every estimate from here on; a post-loop set
 				// would break the fit this pass just found and push the
@@ -173,15 +197,30 @@ func ApplyBlastBudget(resp *BlastResponse, budget int) {
 	// Stripping sets retained_trimmed, which is priced through every
 	// subsequent estimate like any other content, so no later stage can be
 	// surprised by it and no revert dance is needed.
-	shedRetainedField(resp, budget, func(r *BlastRetained) *string { return &r.Chain })
-	shedRetainedField(resp, budget, func(r *BlastRetained) *string { return &r.Carrier })
+	shedRetainedField(resp, budget, clearRetainedString(func(r *BlastRetained) *string { return &r.Chain }))
+	shedRetainedField(resp, budget, clearRetainedString(func(r *BlastRetained) *string { return &r.Carrier }))
+	shedRetainedField(resp, budget, clearRetainedStamp)
+	// The stamp shed may have removed the last stamp, which retires the
+	// sentence explaining it: give that budget back to the rows BEFORE the
+	// row shed decides whether any must go.
+	resolveRetainedPage(resp)
 	// 7. Retained holders carry a weaker claim than any direct caller, so
 	// they shed next. RetainedCount is never reduced — a trimmed group is
-	// self-evident from count > len(entries).
+	// self-evident from count > len(entries): and the paging sentence is
+	// re-rendered over the survivors, so a shed page still names the offset
+	// that resumes it. Budget pressure moves the page boundary; it never
+	// makes the ring end silently.
+	// The sentence is re-rendered INSIDE the loop so every estimate prices
+	// the disclosure it will actually ship with; deferring it to after the
+	// loop would grow the response past the fit the loop just found.
 	for estimateBlastWireTokens(resp) > budget && len(resp.RetainedViaInterfaces) > 0 {
-		n := len(resp.RetainedViaInterfaces)
-		resp.RetainedViaInterfaces = resp.RetainedViaInterfaces[:n-trimStep(n)]
+		// ONE row per pass, not the trimStep batch the other lists use: a
+		// batch overshoots by up to 10% of the ring, and on a ring that
+		// saturates the budget exactly (dolt: 53 rows) that overshoot is
+		// measured in gold holders. The extra marshals buy back real answer.
+		resp.RetainedViaInterfaces = resp.RetainedViaInterfaces[:len(resp.RetainedViaInterfaces)-1]
 		resp.Truncated = true
+		resolveRetainedPage(resp)
 	}
 	// 8. Direct callers last; keep at least one. total_affected still
 	// reports how many exist beyond what is shown.
@@ -417,9 +456,10 @@ func BuildBlastResponseSeen(ctx context.Context, r blast.Result, files FileLooku
 			file = path
 		}
 		entry := BlastRetained{
-			Symbol: qualifiedOrName(rh.Symbol),
-			Ref:    FormatRef(file, rh.Symbol.LineStart),
-			Via:    rh.Via.Name,
+			Symbol:        qualifiedOrName(rh.Symbol),
+			Ref:           FormatRef(file, rh.Symbol.LineStart),
+			Via:           rh.Via.Name,
+			ViaSatisfiers: rh.ViaSatisfiers,
 		}
 		if rh.Carrier.ID != 0 {
 			entry.Carrier = qualifiedOrName(rh.Carrier)
@@ -433,12 +473,15 @@ func BuildBlastResponseSeen(ctx context.Context, r blast.Result, files FileLooku
 		}
 		resp.RetainedViaInterfaces = append(resp.RetainedViaInterfaces, entry)
 	}
-	if len(resp.RetainedViaInterfaces) > 0 {
+	// The note is emitted for an excluded-but-empty ring too: a ring emptied
+	// by the purity filter is indistinguishable from a subject nothing
+	// launders, and the difference is exactly what the consumer must see.
+	if len(resp.RetainedViaInterfaces) > 0 || r.RetainedPurity.Excluded > 0 {
 		resp.RetainedCount = r.RetainedCount
-		resp.RetainedNote = "each row may retain " + r.Symbol.Name + ", one interface indirection deep. As indexed: the " +
-			"holder declares a field typed as `via`; `carrier` is a concrete satisfier of `via`; `chain` is a declared " +
-			"containment path from carrier to " + r.Symbol.Name + ". Which satisfier lands at runtime is unverified. " +
-			"Not counted in total_affected; blast a listed holder to go deeper."
+		resp.RetainedOffset = r.RetainedOffset
+		resp.retainedFingerprint = r.RetainedFingerprint
+		resp.retainedBaseNote = retainedNote(r)
+		resolveRetainedPage(&resp)
 	}
 
 	examples := tier2All
@@ -480,6 +523,100 @@ func BuildBlastResponseSeen(ctx context.Context, r blast.Result, files FileLooku
 	}
 	resp.Completeness = blastCompleteness(&resp, r.TotalAffected)
 	return resp
+}
+
+// retainedNote assembles the retention group's shared semantics in the order
+// that lets a reader stop early: the STRUCTURAL FACTS the index actually
+// holds, then the one thing that stays unverified about them, then what the
+// ring refused to launder through. The separation is the point:
+// a group whose facts and guesses read as one paragraph
+// is a group an agent either over-trusts or throws away whole. Kept in one
+// builder so the fact list, the may-claim, and the purity disclosure cannot
+// drift apart.
+func retainedNote(r blast.Result) string {
+	var b strings.Builder
+	if r.RetainedCount > 0 {
+		b.WriteString("as indexed: the holder declares a `via`-typed field; `carrier` concretely satisfies `via`; " +
+			"`chain` is a declared containment path carrier→" + r.Symbol.Name + ". Unverified, and the only " +
+			"unverified part: which satisfier the field holds at runtime, so each row may retain " + r.Symbol.Name +
+			", one interface indirection deep. Not in total_affected; blast a listed holder to go deeper.")
+	}
+	if excl := retainedExclusionClause(r.RetainedPurity); excl != "" {
+		if b.Len() > 0 {
+			b.WriteString(" ")
+		}
+		b.WriteString(excl)
+	}
+	return b.String()
+}
+
+// resolveRetainedPage recomputes everything that depends on WHICH ring rows
+// actually survived: the resume offset, the page fingerprint, and the note.
+// Re-run after every pass that drops rows or annotations, so none of the three
+// can describe rows that are no longer there.
+//
+// Where the page facts live is a deliberate split. The numbers ride structured
+// fields (retained_via_interfaces_count, retained_offset, retained_next_offset,
+// retained_index_fingerprint) and NOT prose: a ring can saturate the token
+// budget exactly (dolt: 53 rows at 8000/8000), and there a sentence restating
+// those fields costs a holder. Prose is reserved for what no field can carry ,
+// the group's semantics and the purity refusal.
+func resolveRetainedPage(resp *BlastResponse) {
+	shown := len(resp.RetainedViaInterfaces)
+	end := resp.RetainedOffset + shown
+	resp.RetainedNextOffset = 0
+	if end < resp.RetainedCount {
+		resp.RetainedNextOffset = end
+	}
+
+	// The fingerprint validates a UNION of pages. A complete ring has no
+	// second page to union with, so publishing it there is pure cost.
+	resp.RetainedFingerprint = ""
+	if resp.RetainedOffset > 0 || resp.RetainedNextOffset > 0 {
+		resp.RetainedFingerprint = resp.retainedFingerprint
+	}
+
+	clauses := []string{resp.retainedBaseNote}
+	if anyRetainedStamped(resp.RetainedViaInterfaces) {
+		clauses = append(clauses, "`via_satisfiers` counts concretes satisfying `via` index-wide (higher = "+
+			"likelier to hold something else).")
+	}
+
+	out := make([]string, 0, len(clauses))
+	for _, c := range clauses {
+		if c != "" {
+			out = append(out, c)
+		}
+	}
+	resp.RetainedNote = strings.Join(out, " ")
+}
+
+// anyRetainedStamped reports whether at least one shown row still carries its
+// via_satisfiers annotation.
+func anyRetainedStamped(rows []BlastRetained) bool {
+	for _, r := range rows {
+		if r.ViaSatisfiers != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// retainedExclusionClause states the purity refusal as a fact plus its
+// reason: satisfiers declared in test files were not nominated as carriers,
+// so interfaces only a test double satisfies contributed no rows at all.
+func retainedExclusionClause(p blast.RetentionPurity) string {
+	if p.Excluded == 0 {
+		return ""
+	}
+	clause := fmt.Sprintf("%d test-file satisfier(s) refused as carriers", p.Excluded)
+	if len(p.Names) > 0 {
+		clause += ": " + strings.Join(p.Names, ", ")
+		if p.Excluded > len(p.Names) {
+			clause += ", …"
+		}
+	}
+	return clause + ". Interfaces they alone satisfy contribute no rows."
 }
 
 // blastCompleteness builds the consolidated stop/verify verdict.

--- a/internal/mcpio/retained_test.go
+++ b/internal/mcpio/retained_test.go
@@ -250,7 +250,11 @@ func TestRetainedCarrierShedsBeforeRows(t *testing.T) {
 	r := retainedResult(true)
 	for i := range r.RetainedViaInterfaces {
 		r.RetainedViaInterfaces[i].Carrier = model.Symbol{
-			ID: 100 + int64(i), Name: "Carrier", Qualified: "pkg.SomeVeryLongCarrierTypeName", FileID: 1,
+			// Long enough that one strip clearly outweighs the truncated +
+			// retained_trimmed flag bytes the strip itself adds; a
+			// near-boundary name makes this a rounding test, not a shed-order
+			// test.
+			ID: 100 + int64(i), Name: "Carrier", Qualified: "pkg.SomeVeryLongCarrierTypeNameThatIsUnmistakablyWorthShedding", FileID: 1,
 		}
 	}
 	full := BuildBlastResponse(ctx, r, retainedFiles, nil)
@@ -409,4 +413,224 @@ func strippedFloor(ctx context.Context, r blast.Result) int {
 	}
 	resp.Truncated = true
 	return estimateBlastWireTokens(&resp)
+}
+
+// --- Purity disclosure on the wire ---
+
+// TestRetainedNoteDisclosesExclusions: the refused test-file satisfiers ride
+// out in the note with their count and a bounded name sample, so a purified
+// ring reads as purified rather than as a short one.
+func TestRetainedNoteDisclosesExclusions(t *testing.T) {
+	r := retainedResult(true)
+	r.RetainedPurity = blast.RetentionPurity{Excluded: 7, Names: []string{"FakeA", "FakeB", "FakeC", "FakeD", "FakeE"}}
+
+	resp := BuildBlastResponse(context.Background(), r, func(int64) (string, bool) { return "widget.go", true }, nil)
+
+	for _, want := range []string{"7 test-file satisfier(s) refused as carriers", "FakeA", "FakeE", "…", "contribute no rows"} {
+		if !strings.Contains(resp.RetainedNote, want) {
+			t.Errorf("retained_note missing %q: %s", want, resp.RetainedNote)
+		}
+	}
+	if !strings.Contains(resp.RetainedNote, "may retain Widget") {
+		t.Errorf("retained_note dropped the may-claim sentence: %s", resp.RetainedNote)
+	}
+}
+
+// TestRetainedNoteFullyExcludedRing: when purity empties the ring, the note is
+// still emitted: an empty ring and a ring emptied by the filter are different
+// facts, and only the note tells them apart.
+func TestRetainedNoteFullyExcludedRing(t *testing.T) {
+	r := retainedResult(false)
+	r.RetainedPurity = blast.RetentionPurity{Excluded: 2, Names: []string{"FakeA", "FakeB"}}
+
+	resp := BuildBlastResponse(context.Background(), r, func(int64) (string, bool) { return "widget.go", true }, nil)
+
+	if len(resp.RetainedViaInterfaces) != 0 {
+		t.Fatalf("expected an empty ring, got %+v", resp.RetainedViaInterfaces)
+	}
+	if !strings.Contains(resp.RetainedNote, "2 test-file satisfier(s) refused as carriers: FakeA, FakeB") {
+		t.Errorf("retained_note = %q, want the exclusion disclosure", resp.RetainedNote)
+	}
+	if strings.Contains(resp.RetainedNote, "may retain") {
+		t.Errorf("no rows, so no may-claim sentence belongs in the note: %q", resp.RetainedNote)
+	}
+}
+
+// --- Promiscuity stamp on the wire ---
+
+// TestRetainedRowCarriesViaSatisfiers: the stamp reaches the wire as a bare
+// count, the note explains what it measures, and a row with no count omits
+// the key rather than claiming zero satisfiers.
+func TestRetainedRowCarriesViaSatisfiers(t *testing.T) {
+	r := retainedResult(true)
+	r.RetainedViaInterfaces[0].ViaSatisfiers = 23
+
+	resp := BuildBlastResponse(context.Background(), r, func(int64) (string, bool) { return "widget.go", true }, nil)
+
+	if resp.RetainedViaInterfaces[0].ViaSatisfiers != 23 {
+		t.Errorf("via_satisfiers = %d, want 23", resp.RetainedViaInterfaces[0].ViaSatisfiers)
+	}
+	if !strings.Contains(resp.RetainedNote, "`via_satisfiers` counts concretes satisfying `via`") {
+		t.Errorf("retained_note does not explain the stamp: %s", resp.RetainedNote)
+	}
+	raw, err := json.Marshal(resp.RetainedViaInterfaces[1])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(raw), "via_satisfiers") {
+		t.Errorf("an unstamped row must omit via_satisfiers, got %s", raw)
+	}
+}
+
+// --- Paging on the wire ---
+
+// pagedResult is a ring page: 2 rows shown starting at offset 3 of 9.
+func pagedResult() blast.Result {
+	r := retainedResult(true)
+	r.RetainedCount = 9
+	r.RetainedOffset = 3
+	r.RetainedFingerprint = "f12@2026-07-20T10:00:00Z"
+	return r
+}
+
+// TestRetainedPageLocatesItself: a page states which rows it is, how many
+// exist, the offset that resumes it, and the generation it was cut from ,
+// entirely in structured fields. A short ring must never be indistinguishable
+// from a complete one, and it must not spend a holder's worth of bytes saying
+// so (the fields cost a fraction of the sentence they replace).
+func TestRetainedPageLocatesItself(t *testing.T) {
+	resp := BuildBlastResponse(context.Background(), pagedResult(), retainedFiles, nil)
+
+	if resp.RetainedOffset != 3 {
+		t.Errorf("retained_offset = %d, want 3", resp.RetainedOffset)
+	}
+	if resp.RetainedNextOffset != 5 {
+		t.Errorf("retained_next_offset = %d, want 5 (3 skipped + 2 shown)", resp.RetainedNextOffset)
+	}
+	if resp.RetainedCount != 9 {
+		t.Errorf("retained_via_interfaces_count = %d, want the full ring size 9", resp.RetainedCount)
+	}
+	if resp.RetainedFingerprint != "f12@2026-07-20T10:00:00Z" {
+		t.Errorf("retained_index_fingerprint = %q, want the generation stamp", resp.RetainedFingerprint)
+	}
+	// The page facts live in fields ONLY: prose restating them would cost a
+	// holder on a ring that saturates the budget.
+	for _, banned := range []string{"rows 4-5", "call again", "offset:5"} {
+		if strings.Contains(resp.RetainedNote, banned) {
+			t.Errorf("paging prose %q must not ride the note: %s", banned, resp.RetainedNote)
+		}
+	}
+}
+
+// TestRetainedLastPageOffersNoNextOffset: a page that ends the ring must not
+// advertise a resume point that would return nothing.
+func TestRetainedLastPageOffersNoNextOffset(t *testing.T) {
+	r := pagedResult()
+	r.RetainedCount = 5 // 3 skipped + 2 shown = the end
+
+	resp := BuildBlastResponse(context.Background(), r, retainedFiles, nil)
+
+	if resp.RetainedNextOffset != 0 {
+		t.Errorf("retained_next_offset = %d, want 0 at the end of the ring", resp.RetainedNextOffset)
+	}
+	// It is still a page (offset 3), so the fingerprint stays: the consumer
+	// needs it to know this page unions with the one before it.
+	if resp.RetainedFingerprint == "" {
+		t.Error("a page must carry its index fingerprint even when it ends the ring")
+	}
+}
+
+// TestBudgetShedReRendersPaging: when the budget sheds ring rows, the page
+// boundary moves with them: the note and retained_next_offset describe the
+// rows that actually shipped, so a squeezed ring is resumable instead of
+// silently short.
+func TestBudgetShedReRendersPaging(t *testing.T) {
+	resp := BuildBlastResponse(context.Background(), pagedResult(), retainedFiles, nil)
+	resp.IndirectCallers = nil
+
+	ApplyBlastBudget(&resp, 1) // force every trim step
+
+	if len(resp.RetainedViaInterfaces) != 0 {
+		t.Fatalf("expected the ring to shed entirely, got %d rows", len(resp.RetainedViaInterfaces))
+	}
+	if resp.RetainedNextOffset != 3 {
+		t.Errorf("retained_next_offset = %d, want 3: the shed page resumes where it started", resp.RetainedNextOffset)
+	}
+	if resp.RetainedFingerprint == "" {
+		t.Error("a shed page still needs its fingerprint to be resumable")
+	}
+	if resp.RetainedCount != 9 {
+		t.Errorf("retained_via_interfaces_count = %d, want 9 (never reduced)", resp.RetainedCount)
+	}
+}
+
+// TestBudgetShedOfOneRowMovesTheBoundary pins the partial case: one row shed
+// moves the resume offset back by exactly one row, never to zero.
+func TestBudgetShedOfOneRowMovesTheBoundary(t *testing.T) {
+	resp := BuildBlastResponse(context.Background(), pagedResult(), retainedFiles, nil)
+	resp.RetainedViaInterfaces = resp.RetainedViaInterfaces[:1]
+	resolveRetainedPage(&resp)
+
+	if resp.RetainedNextOffset != 4 {
+		t.Errorf("retained_next_offset = %d, want 4", resp.RetainedNextOffset)
+	}
+	if resp.RetainedCount != 9 {
+		t.Errorf("retained_via_interfaces_count = %d, want 9 (never reduced)", resp.RetainedCount)
+	}
+}
+
+// --- Facts and the may-claim stay separated ---
+
+// TestRetainedNoteSeparatesFactsFromClaim: the note leads with what the index
+// holds and names exactly one unverified thing. An agent that reads only the
+// first clause must come away with facts, never with a guess dressed as one.
+func TestRetainedNoteSeparatesFactsFromClaim(t *testing.T) {
+	r := retainedResult(true)
+	r.RetainedPurity = blast.RetentionPurity{Excluded: 1, Names: []string{"FakeA"}}
+
+	resp := BuildBlastResponse(context.Background(), r, retainedFiles, nil)
+	note := resp.RetainedNote
+
+	facts := strings.Index(note, "as indexed")
+	claim := strings.Index(note, "Unverified, and the only unverified part")
+	excl := strings.Index(note, "refused as carriers")
+	if facts != 0 {
+		t.Errorf("note must LEAD with the structural facts, got: %s", note)
+	}
+	if claim < facts || excl < claim {
+		t.Errorf("note order must be facts → may-claim → exclusions, got: %s", note)
+	}
+	// The two load-bearing phrases of the shipped group contract.
+	for _, want := range []string{"may retain Widget", "one interface indirection"} {
+		if !strings.Contains(note, want) {
+			t.Errorf("note dropped the pinned phrase %q: %s", want, note)
+		}
+	}
+}
+
+// TestStampShedsBeforeAnyHolder is the shed-hierarchy threshold pin: at a
+// budget ONE token under what the stamped response needs, the
+// via_satisfiers annotation must go and every holder must stay. A row is the
+// answer; the stamp is a caution about the answer. Without this pin the
+// ordering silently regressed and cost dolt 2 of its 12 gold rows.
+func TestStampShedsBeforeAnyHolder(t *testing.T) {
+	r := retainedResult(true)
+	for i := range r.RetainedViaInterfaces {
+		r.RetainedViaInterfaces[i].ViaSatisfiers = 23
+	}
+	resp := BuildBlastResponse(context.Background(), r, retainedFiles, nil)
+	resp.IndirectCallers = nil
+	rows := len(resp.RetainedViaInterfaces)
+
+	ApplyBlastBudget(&resp, estimateBlastWireTokens(&resp)-1)
+
+	if len(resp.RetainedViaInterfaces) != rows {
+		t.Fatalf("holders = %d, want all %d: a stamp must shed before any row", len(resp.RetainedViaInterfaces), rows)
+	}
+	if anyRetainedStamped(resp.RetainedViaInterfaces) {
+		t.Error("the tail stamp must shed at one token over budget")
+	}
+	if strings.Contains(resp.RetainedNote, "via_satisfiers") {
+		t.Errorf("the sentence explaining a shed stamp must retire with it: %s", resp.RetainedNote)
+	}
 }

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -363,6 +363,30 @@ type BlastResponse struct {
 	// sentence-sized disclosure could never fit the lazy shed's boundary
 	// slack; measured: the shed lands within one shed-unit of budget).
 	RetainedTrimmed bool `json:"retained_trimmed,omitempty"`
+	// RetainedOffset is how many ring rows this response skipped, and
+	// RetainedNextOffset is the offset that returns the next page (0 when
+	// the ring ends here). Together with retained_via_interfaces_count they
+	// locate the page exactly: rows offset+1 .. offset+len of count.
+	// RetainedFingerprint identifies the index generation the page was cut
+	// from: pages that share it are unionable, a mismatch means the index
+	// moved and merging them would dup or gap rows. The ring is the one
+	// group that pages instead of silently truncating: a large truncated
+	// list is what costs an agent its trust in the whole group.
+	RetainedOffset      int    `json:"retained_offset,omitempty"`
+	RetainedNextOffset  int    `json:"retained_next_offset,omitempty"`
+	RetainedFingerprint string `json:"retained_index_fingerprint,omitempty"`
+	// retainedBaseNote is RetainedNote without its paging sentence. The
+	// budget pass can shed ring rows, which moves the page's end and its
+	// next offset, so the sentence must be re-rendered from the surviving
+	// rows rather than patched in place: keeping the un-paged prose here is
+	// what makes that re-render exact instead of string surgery. Unexported:
+	// it never reaches the wire and no consumer can set it.
+	retainedBaseNote string
+	// retainedFingerprint is the index generation the ring was cut from,
+	// held back until the response is known to BE a page: the wire field is
+	// page-union metadata, and on a complete ring it would spend budget that
+	// belongs to holders.
+	retainedFingerprint string
 
 	// Tier 2 — references (composes/inherits/includes). Count + top examples.
 	References BlastTierSummary `json:"references"`
@@ -448,6 +472,13 @@ type BlastRetained struct {
 	// tripping its own shed (measured: consumers re-derived this with
 	// ~30 lookups per session when it was absent).
 	Carrier string `json:"carrier,omitempty"`
+	// ViaSatisfiers is how many concrete types satisfy Via index-wide: the
+	// bare fact, no threshold and no verdict, because a row on a
+	// hundred-implementation interface is weaker evidence than one on a
+	// two-implementation contract and only the consumer can judge which it
+	// is looking at. It never removes a row: real retention rides generic
+	// interfaces too (pebble's paid-win ring runs through InternalIterator).
+	ViaSatisfiers int `json:"via_satisfiers,omitempty"`
 	// Chain is a declared containment path from Carrier down to the
 	// subject (">"-joined type names; one deterministic path among possibly
 	// several). Every hop is a composes/includes edge the index holds,

--- a/internal/mcpserver/blast.go
+++ b/internal/mcpserver/blast.go
@@ -36,11 +36,17 @@ func (h *handlers) handleBlast(ctx context.Context, req mcp.CallToolRequest) (*m
 	minConfidence := req.GetFloat("min_confidence", h.defaults.BlastMinConfidence)
 	includeTests := req.GetBool("include_tests", true)
 
+	// A negative offset is a caller mistake, not a request to page backwards:
+	// clamp to the first page rather than error, so the agent gets the ring
+	// instead of a round trip spent on argument validation.
+	offset := max(req.GetInt("offset", 0), 0)
+
 	opts := blast.Options{
-		MaxHops:       maxHops,
-		MinConfidence: minConfidence,
-		MaxResults:    h.defaults.BlastResultCap,
-		IncludeTests:  includeTests,
+		MaxHops:        maxHops,
+		MinConfidence:  minConfidence,
+		MaxResults:     h.defaults.BlastResultCap,
+		IncludeTests:   includeTests,
+		RetainedOffset: offset,
 	}
 
 	contextLines := req.GetInt("context_lines", mcpio.DefaultContextLines)

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -133,6 +133,9 @@ func blastTool() mcp.Tool {
 		mcp.WithNumber("context_lines",
 			mcp.Description("Lines of source context around each call site (default 2, 0 to suppress snippets)"),
 		),
+		mcp.WithNumber("offset",
+			mcp.Description("Skip this many retained_via_interfaces rows (default 0). The ring pages instead of truncating: when retained_next_offset is present, call again with that value to get the rest. Pages are unionable only while retained_index_fingerprint is unchanged. Affects that group only."),
+		),
 	)
 }
 


### PR DESCRIPTION
An agent auditing what keeps a type alive can now trust the rows in
`retained_via_interfaces` and read all of them. Rows that only a test double
justified are gone, every row says how many concrete types satisfy its
interface, and a group too large for one response now pages instead of quietly
stopping short.

## Problem

The retention group could show rows an agent can disprove, and it could stop
short without saying so.

A holder whose only evidence was a struct declared in a test file looked exactly
like a production holder. One test fixture that embeds a dozen interfaces plus
the subject is enough to invent a holder for every composer of all twelve. On a
large subject the group was also trimmed to fit the response budget with no way
to ask for the rest, so a reader could not tell a complete list from a truncated
one.

Those two failures compound. One provably false row is enough to make a careful
reader distrust the whole group, and a reader who cannot check the list because
it is truncated has no way to recover that trust. Measured on a large Go
codebase, 80 of 455 rows rode satisfiers that exist only in test files, and 347
rows were hidden with no cursor to reach them.

## Summary

Refuse test-file satisfiers as carriers, stamp every row with the size of its
interface's satisfier set, and page the group with an offset instead of
truncating it.

## Changes

Retention engine:
- A satisfier declared in a test file is never nominated as a carrier, and an
  interface no production type satisfies stops laundering entirely, so its
  holders leave the group. The refusal is disclosed rather than silent: a count
  plus up to five refused names.
- Every row carries `via_satisfiers`, how many concrete types satisfy its
  interface index-wide. A bare count with no threshold and no verdict.
- The group order is documented and pinned as a total order (production first,
  then symbol id), because paging is a cursor over it.
- Rows are windowed by an offset instead of being cut by the result cap.

MCP surface:
- `sense_blast` accepts `offset`. Responses carry `retained_offset`,
  `retained_next_offset`, and `retained_index_fingerprint`, so a page states
  where it sits and which pages may be combined.
- `retained_note` now leads with the structural facts the index holds, names the
  single unverified part, and discloses the refused satisfiers.
- Under budget pressure annotations shed before holders, and rows shed one at a
  time rather than in batches.

## Architecture Highlights

- Promiscuity annotates, it never removes a row. Real retention rides generic
  interfaces too, so a high satisfier count is reported and left to the reader.
- Dropping is reserved for the one provable class: an interface whose every
  satisfier is test-declared.
- Page validity is scoped to an index generation. The fingerprint changes when
  the index moves, so two pages that must not be combined can be told apart, and
  it ships only on an actual page.
- Page facts live in structured fields rather than prose. On a subject whose
  group fills the response budget exactly, a sentence restating a field costs a
  holder, and holders are the answer.

## Test Plan

- [x] Minimized fixture for the test-fixture shape: an interface satisfied only
      by a test double contributes no rows, while a row with a production
      satisfier survives and names the production carrier
- [x] Deleting the test-path check fails the fixture (mutant check)
- [x] Two consecutive pages cover the group exactly, with no duplicate and no gap
- [x] Repeated calls return the group byte for byte identically, and two
      comparator perturbations break the pinned order
- [x] At one token over budget the annotation sheds and every holder stays
- [x] Fault injection: a failure hydrating refused names surfaces, and an
      unreadable index generation degrades to an empty fingerprint rather than
      failing the call
- [x] `go test ./...` passes
- [x] sense binary builds cleanly
