### PR TITLE
fix(ci): push metrics snapshot with GITHUB_TOKEN, not the read-scoped PAT

### DIFF
--- a/.github/workflows/metrics-snapshot.yml
+++ b/.github/workflows/metrics-snapshot.yml
@@ -37,7 +37,9 @@ jobs:
 
       - name: Commit
         env:
-          GH_TOKEN: ${{ secrets.METRICS_TOKEN || github.token }}
+          # Push needs contents:write, which the workflow's GITHUB_TOKEN has.
+          # METRICS_TOKEN is a read-scoped PAT (traffic API only) and 403s on push.
+          GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Problem
The `Metrics snapshot` workflow has been failing on push since #231 ([run](https://github.com/luuuc/sense/actions/runs/29931493655)):

```
remote: Permission to luuuc/sense.git denied to luuuc.
fatal: ... The requested URL returned error: 403
```

## Root cause
The Commit step pushed via `GH_TOKEN: ${{ secrets.METRICS_TOKEN || github.token }}`. `METRICS_TOKEN` is a fine-grained PAT scoped for the **traffic API reads** (clones/views 403 under the default token) — it has no `contents: write`, so the push is denied ("denied to luuuc" = authenticated as the PAT owner, not the bot).

Before #231, `persist-credentials` defaulted to `true`, so checkout persisted the workflow `GITHUB_TOKEN` (which *does* have `contents: write`) and the push used those. Switching to `persist-credentials: false` + an explicit `x-access-token` remote moved the push onto the wrong token.

## Fix
Push with `github.token` (carries the workflow's `contents: write`). `METRICS_TOKEN` stays on the Append step for the traffic endpoints.

## Security — #231 findings stay resolved
- `persist-credentials: false` is preserved.
- The token is still never written to `.git/config` — it's inline on the push URL only.
- The toolchain / dependency bumps from #231 are untouched.