### PR TITLE
enhance(mcp): emit the index caveat for PHP files

### DIFF
--- a/internal/mcpio/caveats.go
+++ b/internal/mcpio/caveats.go
@@ -23,6 +23,13 @@ func IndexCaveat(file string) string {
 		return "Static graph may miss: edge-runtime mirror files (.edge.*, route-modules/*), dynamic require / module.compiled wrappers, decorator-registered handlers, and build-template re-exports."
 	case "python":
 		return "Static graph may miss: decorator-registered handlers (Flask/FastAPI routes), __init_subclass__ / metaclass registration, importlib dynamic imports, and pytest fixture discovery."
+	case "php":
+		// Certain, not "may": a facade declares only getFacadeAccessor(), so
+		// Foo::bar() has no method symbol to bind a call edge to. The facade shows
+		// importers and no callers, and blast's `complete` verdict is about the
+		// resolvable set only. Measured on filament: 33 inbound imports, 34 files
+		// calling FilamentAsset::, total_affected 12.
+		return "Static graph MISSES facade static calls (Foo::bar() routed by __callStatic to a container-bound singleton, so a facade shows importers but no callers); may also miss service-provider container bindings resolved by string key, and __get/__call magic-method dispatch."
 	case "java", "kotlin":
 		return "Static graph may miss: reflection-based dispatch, ServiceLoader / @AutoService registration, Spring/CDI dependency injection, annotation-processor-generated handlers, and dynamic proxy classes."
 	}
@@ -42,14 +49,16 @@ func detectLanguage(file string) string {
 	switch ext {
 	case ".go":
 		return "go"
-	case ".rb", ".rake":
+	case ".rb", ".rake", ".gemspec":
 		return "ruby"
 	case ".js", ".jsx", ".mjs", ".cjs":
 		return "javascript"
 	case ".ts", ".tsx":
 		return "typescript"
-	case ".py":
+	case ".py", ".pyi":
 		return "python"
+	case ".php":
+		return "php"
 	case ".java":
 		return "java"
 	case ".kt", ".kts":

--- a/internal/mcpio/caveats.go
+++ b/internal/mcpio/caveats.go
@@ -24,6 +24,9 @@ func IndexCaveat(file string) string {
 	case "python":
 		return "Static graph may miss: decorator-registered handlers (Flask/FastAPI routes), __init_subclass__ / metaclass registration, importlib dynamic imports, and pytest fixture discovery."
 	case "php":
+		// DELIBERATE BREAK from the "Static graph may miss:" shape the other five
+		// entries share: five identical hedges carry no information, so the one
+		// entry that can state a certainty says so. Do not normalise this back.
 		// Certain, not "may": a facade declares only getFacadeAccessor(), so
 		// Foo::bar() has no method symbol to bind a call edge to. The facade shows
 		// importers and no callers, and blast's `complete` verdict is about the

--- a/internal/mcpio/caveats_test.go
+++ b/internal/mcpio/caveats_test.go
@@ -115,6 +115,21 @@ func TestIndexCaveatPHP(t *testing.T) {
 	}
 }
 
+// TestExtensionsInsideCoveredLanguages records the INTENT for the two extensions the
+// parity gate surfaced, so a later reader can tell they were reasoned about rather than
+// swept in. Both are the same language as an extension already covered - a .pyi stub is
+// Python and a .gemspec is Ruby, evaluated by the same interpreter with the same dynamic
+// features - so the existing caveat text is correct for them unchanged. Neither appears
+// in any frozen scenario's gold, which is what bounded this change's exposure to zero.
+func TestExtensionsInsideCoveredLanguages(t *testing.T) {
+	if got, want := IndexCaveat("types.pyi"), IndexCaveat("types.py"); got != want {
+		t.Errorf("a .pyi stub is Python: caveat = %q, want the Python caveat %q", got, want)
+	}
+	if got, want := IndexCaveat("sense.gemspec"), IndexCaveat("sense.rb"); got != want {
+		t.Errorf("a .gemspec is Ruby: caveat = %q, want the Ruby caveat %q", got, want)
+	}
+}
+
 // TestIndexCaveatUnchangedForOtherLanguages pins the five pre-existing caveats
 // BYTE-EXACT. The php addition claims "no other language changes"; byte equality is
 // precisely that claim, so it is asserted literally rather than by substring.

--- a/internal/mcpio/caveats_test.go
+++ b/internal/mcpio/caveats_test.go
@@ -3,6 +3,9 @@ package mcpio
 import (
 	"strings"
 	"testing"
+
+	"github.com/luuuc/sense/internal/extract"
+	_ "github.com/luuuc/sense/internal/extract/languages" // populate the extractor registry
 )
 
 func TestIndexCaveat(t *testing.T) {
@@ -78,6 +81,118 @@ func TestDetectLanguage(t *testing.T) {
 	for _, c := range cases {
 		if got := detectLanguage(c.file); got != c.want {
 			t.Errorf("detectLanguage(%q) = %q, want %q", c.file, got, c.want)
+		}
+	}
+}
+
+// TestIndexCaveatPHP is the repro for the facade disclosure gap. `sense blast` on a
+// Laravel facade returns a partial dependent set, reports verdict "complete" with
+// risk "low", and advises "act on it, do not re-grep" - while promising that any
+// dynamic-dispatch residual "is in index_caveat". Measured on the pinned filament
+// clone: blast on the FilamentAsset facade returned total_affected 12 with
+// index_caveat ABSENT, while the index held 33 inbound `imports` edges and 34 files
+// made static calls on it. The channel the advice line points at was structurally
+// empty for every PHP file, because neither switch in this file had a php case.
+func TestIndexCaveatPHP(t *testing.T) {
+	const file = "app/Traits/Jobs.php"
+
+	if got := detectLanguage(file); got != "php" {
+		t.Fatalf("detectLanguage(%q) = %q, want %q", file, got, "php")
+	}
+
+	got := IndexCaveat(file)
+	if got == "" {
+		t.Fatal("IndexCaveat returned empty for a .php file: the advice line promises " +
+			"the dynamic-dispatch residual is in index_caveat, so an empty caveat makes " +
+			"blast's `complete` verdict unqualified on the most idiomatic Laravel construct")
+	}
+	// The blind spot that motivated the fix must be named concretely. Vague
+	// uncertainty is what this file's doc comment explicitly rejects.
+	for _, want := range []string{"facade", "container"} {
+		if !strings.Contains(strings.ToLower(got), want) {
+			t.Errorf("IndexCaveat(%q) = %q, want it to name %q", file, got, want)
+		}
+	}
+}
+
+// TestIndexCaveatUnchangedForOtherLanguages pins the five pre-existing caveats
+// BYTE-EXACT. The php addition claims "no other language changes"; byte equality is
+// precisely that claim, so it is asserted literally rather than by substring.
+func TestIndexCaveatUnchangedForOtherLanguages(t *testing.T) {
+	want := map[string]string{
+		"main.go": "Static graph may miss: method-on-field dispatch (c.engine.X), function-value passing (handlers stored as fields), runtime init() registration, and interface satisfaction via blank identifier.",
+		"user.rb": "Static graph may miss: plugin extensions (DiscoursePluginRegistry, add_to_class), prepended/included modules, method_missing dispatch, and ActiveSupport concern injection.",
+		"i.ts":    "Static graph may miss: edge-runtime mirror files (.edge.*, route-modules/*), dynamic require / module.compiled wrappers, decorator-registered handlers, and build-template re-exports.",
+		"s.py":    "Static graph may miss: decorator-registered handlers (Flask/FastAPI routes), __init_subclass__ / metaclass registration, importlib dynamic imports, and pytest fixture discovery.",
+		"M.java":  "Static graph may miss: reflection-based dispatch, ServiceLoader / @AutoService registration, Spring/CDI dependency injection, annotation-processor-generated handlers, and dynamic proxy classes.",
+	}
+	for file, exp := range want {
+		if got := IndexCaveat(file); got != exp {
+			t.Errorf("IndexCaveat(%q) changed:\n got: %q\nwant: %q", file, got, exp)
+		}
+	}
+}
+
+// languagesWithoutCaveatYet lists registered languages that deliberately have no
+// caveat prose. It exists so the gap is a VISIBLE, deliberate list rather than an
+// empty string nobody notices: writing a caveat needs real per-language blind-spot
+// knowledge, and inventing it would violate this file's "named patterns, never vague"
+// rule. Entries leave this list as their stack gets benched; nothing is added without
+// a decision, because TestCaveatCoversEveryRegisteredLanguage fails otherwise.
+var languagesWithoutCaveatYet = map[string]bool{
+	"c": true, "cpp": true, "csharp": true, "erb": true, "rust": true, "scala": true,
+}
+
+// TestCaveatCoversEveryRegisteredLanguage is the anti-drift gate. detectLanguage is a
+// hand-maintained extension table that duplicates the extractor registry's canonical
+// ext->language mapping, and it drifted: `.php` was absent entirely, and `.pyi` and
+// `.gemspec` were absent even though python and ruby both HAVE caveat prose. Delegating
+// to extract.ForExtension at runtime was considered and rejected - the registry is only
+// populated by importing extract/languages, which pulls every tree-sitter grammar into
+// a package the linter designates pure core. A test-time parity check buys the same
+// single-source-of-truth guarantee with no runtime coupling.
+//
+// This test imports the registry deliberately: a new extractor now either gets a
+// caveat or gets an explicit entry above. Silence is no longer an option.
+func TestCaveatCoversEveryRegisteredLanguage(t *testing.T) {
+	for _, lang := range extract.Languages() {
+		e := extract.ByLanguage(lang)
+		for _, ext := range e.Extensions() {
+			file := "sample" + ext
+			got := detectLanguage(file)
+			if languagesWithoutCaveatYet[lang] {
+				continue // known, deliberate gap
+			}
+			if got == "" {
+				t.Errorf("detectLanguage(%q) = \"\" but %q is a registered language with "+
+					"caveat prose: the extension table drifted from the extractor registry",
+					file, lang)
+				continue
+			}
+			if IndexCaveat(file) == "" {
+				t.Errorf("IndexCaveat(%q) = \"\" for registered language %q (detected as %q)",
+					file, lang, got)
+			}
+		}
+	}
+}
+
+// TestNoCaveatGapListIsHonest keeps the escape hatch from rotting: an entry that is no
+// longer registered, or that has since gained a caveat, must be removed. A stale
+// exception list is how a deny-by-default gate quietly becomes allow-by-default.
+func TestNoCaveatGapListIsHonest(t *testing.T) {
+	registered := map[string]bool{}
+	for _, lang := range extract.Languages() {
+		registered[lang] = true
+	}
+	for lang := range languagesWithoutCaveatYet {
+		if !registered[lang] {
+			t.Errorf("languagesWithoutCaveatYet has %q, which is not a registered language: remove it", lang)
+			continue
+		}
+		exts := extract.ByLanguage(lang).Extensions()
+		if len(exts) > 0 && IndexCaveat("sample"+exts[0]) != "" {
+			t.Errorf("%q is listed as having no caveat, but IndexCaveat returns one: remove it from the list", lang)
 		}
 	}
 }


### PR DESCRIPTION
enhance(mcp): emit the index caveat for PHP files

When an agent asks Sense what depends on a Laravel facade, it gets a short list and a
confident "this is the complete set, do not go grep". For facades that answer is not the
whole story, and Sense was not saying so. This change makes it say so, in the field the
response contract already reserves for exactly that.

## Problem

`blast` closes its advice with "Dynamic-dispatch residual, if any, is in index_caveat".
For PHP that channel was always empty: `detectLanguage` had no `.php` case, so it returned
`""` and `IndexCaveat` fell through to `""`. Nothing was ever emitted.

Measured on a pinned filament checkout, `blast` on the `FilamentAsset` facade returns
`total_affected: 12` with `verdict: complete`, `risk: low` and "act on it, do not re-grep",
and no `index_caveat` at all. The index holds 33 inbound `imports` edges for that symbol and
34 files make static calls on it. A facade declares only `getFacadeAccessor()`, so
`Foo::bar()` has no method symbol for a call edge to bind to. An agent that trusts the
contract concludes the facade has almost no dependents, and facades are the most idiomatic
construct in the framework.

## Summary

Adds the PHP case to the caveat switch so the dynamic-dispatch residual is disclosed, and
adds a parity test over the extractor registry so a registered language can no longer be
silently missing from that switch.

## Changes

- `IndexCaveat` gains a `php` case naming the concrete blind spots: facade static calls
  routed by `__callStatic` to a container-bound singleton, service-provider container
  bindings resolved by string key, and `__get`/`__call` magic-method dispatch.
- `detectLanguage` gains `.php`, and also `.pyi` and `.gemspec`, which mapped to nothing
  even though Python and Ruby already had caveat prose.
- New parity test: every language the extractor registry claims must either have caveat
  prose or an explicit entry in a documented exemption list. A second test fails if that
  list goes stale, so an exemption cannot outlive its reason.
- The five pre-existing caveats are pinned byte-exact, so "no other language changes" is
  asserted rather than assumed.

## Architecture Highlights

- The PHP text deliberately breaks the "Static graph may miss:" shape the other entries
  share, and says MISSES. For facades the miss is structural, not possible, and five
  identical hedges carry no information. The break is marked in the code so it is not
  normalised back.
- `detectLanguage` duplicates the extension-to-language mapping the extractor registry
  already owns. Delegating to `extract.ForExtension` at runtime was considered and rejected:
  the registry only populates when `extract/languages` is imported, which would pull every
  tree-sitter grammar into a package the linter designates pure core. The parity test buys
  the same single-source-of-truth guarantee at test time instead. Production dependencies are
  unchanged, and the grammars the test binary pulls in are already compiled for the
  extractor packages' own tests, so the suite pays nothing extra.

## Out of scope, filed separately

- Resolving facades to their container-bound implementation. That is a real dynamic-dispatch
  limit, and the response format is designed to disclose it rather than close it.
- Reporting the per-symbol residual count, for example "33 files import this symbol, 12
  dependents resolved". That is the stronger fix and deserves its own change and its own
  measurement instead of riding in on a switch edit.

## On measurement

This change ships on the correctness argument, not on a benchmark delta, and that is worth
stating plainly. The PHP stack has no winnable benchmark cell yet: both eligibility probes
run against it produced arithmetic kills, so there is no number this could move. The value
proof is recorded as owed and comes due when the stack has a facade-anchored cell.

The side-effect run normally required before merge was discharged by a bounded-exposure
measurement under a one-time recorded ruling. The change alters output for exactly three
subject extensions, and across every frozen scenario in the benchmark corpus zero gold rows
match any of them, so no recorded number can move.

## Test Plan

- [x] Repro test written first and seen failing: `detectLanguage("app/Traits/Jobs.php")`
      returned `""` before the fix
- [x] `IndexCaveat` on a `.php` path names facade and container dispatch
- [x] Parity test fails when the `.php` case is removed, and passes when restored (run, not
      assumed)
- [x] Exemption-list honesty test rejects an entry that is unregistered or has since gained
      prose
- [x] `.pyi` returns the Python caveat and `.gemspec` returns the Ruby caveat, unchanged
- [x] Five pre-existing caveats byte-identical
- [x] End to end on a real checkout: `blast` on the `FilamentAsset` facade now returns a
      populated `index_caveat`
- [x] `make ci` green: build, coverage gate, lint, complexity ledger
- [x] 100% line and function coverage on both touched functions
- [x] `make test-hermetic` green, so the pure-core package still tests offline
- [x] `qlty check` clean on both changed files
- [x] sense binary builds cleanly
