### PR TITLE
enhance(blast): name the importers no call edge reaches

### DIFF
--- a/internal/blast/engine.go
+++ b/internal/blast/engine.go
@@ -99,6 +99,26 @@ func shouldExpandChildren(kind model.SymbolKind) bool {
 	}
 }
 
+// ImportersCap bounds the ImportersNotReached list. Past it the list is SUPPRESSED
+// rather than truncated: a partial list of dependents is a prompt to go grep, which
+// defeats the group's purpose, while the count alone still states the scale honestly.
+//
+// The value is a JUDGEMENT, and the honest reasoning is recorded here rather than implied.
+// Two inputs. The retention ring's history says an impure list converts into acted-upon
+// evidence when small and complete (it did at 14 rows) and dies when large and truncated.
+// And the measured distribution over filament's 969 importable symbols: 765 have 1-5
+// importers, 110 have 6-13, 48 have 14-24, 24 have 25-40, 14 have 41-84, 8 have 85+ - a
+// continuous distribution with no natural gap to sit in.
+//
+// 24 is p95 of that distribution. It is set higher than the ring's 14 because a row here
+// is a bare file path, roughly an order of magnitude cheaper per row than a ring row
+// carrying carrier and chain enrichments, so the token argument for a tight cap is weaker.
+//
+// Disclosure, so a reader can judge the choice: the facade that motivated this group has
+// 22 unreached importers, so this cap includes it and a p90 cap (13) would have suppressed
+// it. The distribution came first, but the coincidence is real and worth stating.
+const ImportersCap = 24
+
 const (
 	// InheritsDecay — type hierarchy is a strong structural signal.
 	InheritsDecay = 0.7
@@ -238,6 +258,28 @@ type Result struct {
 	// mismatch means the index moved and the pages must not be merged.
 	RetainedFingerprint string
 
+	// ImportersNotReached lists FILES that carry an inbound `imports` edge to the
+	// subject and appear nowhere in the caller lists. On a Laravel facade this is the
+	// real dependent set: the facade declares only getFacadeAccessor(), so a
+	// `Foo::bar()` static call binds to no method symbol and produces no call edge,
+	// leaving the `use` import as the only recorded evidence. Measured on filament's
+	// FilamentAsset: 32 importers, 12 affected, 22 unreported, and 22 of 22 verified
+	// to make a genuine static call.
+	//
+	// Like RetainedViaInterfaces this is a WEAKER claim than a call edge, so it never
+	// feeds TotalAffected and never moves the completeness verdict. Adding these rows
+	// to the radius was tried and measured: it tripled total_affected and flipped the
+	// verdict to `partial`, which is the "Sense is unsure, re-grep everything" failure
+	// this group exists to prevent.
+	//
+	// FILES, not symbols, and no synthetic line numbers: there is no call site to cite
+	// (that is the whole reason the group exists), and PHP attributes an import to the
+	// file's namespace symbol, so several importers share one symbol name.
+	ImportersNotReached []string
+	// ImportersNotReachedCount is the true number of such files even when the list is
+	// SUPPRESSED for exceeding ImportersCap, so the count never lies about scale.
+	ImportersNotReachedCount int
+
 	Truncated bool
 }
 
@@ -334,32 +376,149 @@ func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (
 	// total so total_affected never under-reports what the response surfaces.
 	totalAffectedCount += countUnvisited(viaComposition, affectedSet)
 
+	// The importer group is defined against what the traversal REACHED, so it is
+	// computed here rather than inside the BFS.
+	reached := make([]int64, 0, len(directIDs)+len(indirectIDs)+len(symbolIDs))
+	reached = append(reached, directIDs...)
+	reached = append(reached, indirectIDs...)
+	reached = append(reached, symbolIDs...) // the subject's own file is not a dependent
+	importerFiles, importerCount, err := importersNotReached(ctx, db, symbolIDs, reached)
+	if err != nil {
+		return Result{}, fmt.Errorf("blast: importers not reached: %w", err)
+	}
+
 	return Result{
-		Symbol:                 subject,
-		Risk:                   risk,
-		RiskReasons:            reasons,
-		DirectCallers:          directCallers,
-		IndirectCallers:        indirectCallers,
-		AffectedTests:          affectedTests,
-		TotalAffected:          totalAffectedCount,
-		EdgesTraversed:         state.edgesTraversed,
-		SubjectHasCallees:      hasCallees,
-		ViewReached:            viewReached,
-		DirectTemporalIDs:      directTemporalIDs,
-		DirectEdgeSites:        directEdgeSites,
-		DirectConfidence:       directConfidence,
-		CallerFan:              state.fanIn,
-		AffectedSubclasses:     subclasses,
-		AffectedViaComposition: viaComposition,
-		AffectedViaIncludes:    viaIncludes,
-		RetainedViaInterfaces:  retention.holders,
-		RetainedCount:          retention.count,
-		RetainedPurity:         retention.purity,
-		RetainedOffset:         retention.offset,
-		RetainedFingerprint:    retention.fingerprint,
-		SymbolTiers:            symbolTiers,
-		Truncated:              state.truncated,
+		Symbol:                   subject,
+		Risk:                     risk,
+		RiskReasons:              reasons,
+		DirectCallers:            directCallers,
+		IndirectCallers:          indirectCallers,
+		AffectedTests:            affectedTests,
+		TotalAffected:            totalAffectedCount,
+		EdgesTraversed:           state.edgesTraversed,
+		SubjectHasCallees:        hasCallees,
+		ViewReached:              viewReached,
+		DirectTemporalIDs:        directTemporalIDs,
+		DirectEdgeSites:          directEdgeSites,
+		DirectConfidence:         directConfidence,
+		CallerFan:                state.fanIn,
+		AffectedSubclasses:       subclasses,
+		AffectedViaComposition:   viaComposition,
+		AffectedViaIncludes:      viaIncludes,
+		RetainedViaInterfaces:    retention.holders,
+		RetainedCount:            retention.count,
+		RetainedPurity:           retention.purity,
+		RetainedOffset:           retention.offset,
+		RetainedFingerprint:      retention.fingerprint,
+		SymbolTiers:              symbolTiers,
+		ImportersNotReached:      importerFiles,
+		ImportersNotReachedCount: importerCount,
+		Truncated:                state.truncated,
 	}, nil
+}
+
+// importersNotReached returns the FILES holding an inbound `imports` edge to the
+// subject that the traversal never reached, plus the true count before suppression.
+//
+// Exclusion is per FILE, not per symbol, and that distinction is the whole correctness
+// of this function. PHP attributes an import to the file's NAMESPACE symbol, so the
+// symbol an imports edge starts from is never the class symbol a call edge would find.
+// Matching on symbol id therefore excludes nothing: measured on filament's FilamentAsset
+// it reported all 32 importers instead of the 22 the caller lists had not already
+// covered, i.e. it re-listed rows sitting in the answer.
+//
+// Runs AFTER the traversal because "reached" is defined by the caller lists. `imports` is
+// emitted by the PHP extractor only, so every other language gets an empty group.
+// Past ImportersCap the list is suppressed and only the count is returned.
+func importersNotReached(ctx context.Context, db *sql.DB, symbolIDs []int64, reached []int64) ([]string, int, error) {
+	if len(symbolIDs) == 0 {
+		return nil, 0, nil
+	}
+	reachedFiles, err := fileIDsOf(ctx, db, reached)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	placeholders := strings.Repeat("?,", len(symbolIDs))
+	placeholders = placeholders[:len(placeholders)-1]
+	q := `SELECT DISTINCT s.file_id, f.path
+	      FROM sense_edges e
+	      JOIN sense_symbols s ON s.id = e.source_id
+	      JOIN sense_files f ON f.id = s.file_id
+	      WHERE e.target_id IN (` + placeholders + `)
+	        AND e.kind = 'imports'
+	        AND e.source_id IS NOT NULL
+	      ORDER BY f.path`
+	args := make([]any, 0, len(symbolIDs))
+	for _, id := range symbolIDs {
+		args = append(args, id)
+	}
+	rows, err := db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var files []string
+	for rows.Next() {
+		var fileID int64
+		var path string
+		if err := rows.Scan(&fileID, &path); err != nil {
+			return nil, 0, err
+		}
+		if _, ok := reachedFiles[fileID]; ok {
+			continue // a call edge already put this file in the answer
+		}
+		files = append(files, path)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, err
+	}
+
+	count := len(files)
+	if count > ImportersCap {
+		return nil, count, nil
+	}
+	return files, count, nil
+}
+
+// fileIDsOf resolves symbol ids to the set of files they live in, chunked to stay under
+// SQLite's SQLITE_MAX_VARIABLE_NUMBER like expandFrontier does.
+func fileIDsOf(ctx context.Context, db *sql.DB, symbolIDs []int64) (map[int64]struct{}, error) {
+	out := make(map[int64]struct{}, len(symbolIDs))
+	const chunk = 500
+	for start := 0; start < len(symbolIDs); start += chunk {
+		end := start + chunk
+		if end > len(symbolIDs) {
+			end = len(symbolIDs)
+		}
+		batch := symbolIDs[start:end]
+		placeholders := strings.Repeat("?,", len(batch))
+		placeholders = placeholders[:len(placeholders)-1]
+		args := make([]any, 0, len(batch))
+		for _, id := range batch {
+			args = append(args, id)
+		}
+		rows, err := db.QueryContext(ctx,
+			`SELECT DISTINCT file_id FROM sense_symbols WHERE id IN (`+placeholders+`)`, args...)
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			var fid int64
+			if err := rows.Scan(&fid); err != nil {
+				_ = rows.Close()
+				return nil, err
+			}
+			out[fid] = struct{}{}
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		_ = rows.Close()
+	}
+	return out, nil
 }
 
 // loadEdgeTableGroups computes the two edge-table-derived groups after the

--- a/internal/blast/importers_test.go
+++ b/internal/blast/importers_test.go
@@ -1,0 +1,224 @@
+package blast_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/luuuc/sense/internal/blast"
+	"github.com/luuuc/sense/internal/scan"
+	"github.com/luuuc/sense/internal/sqlite"
+)
+
+// writeFile and idOf come from engine_test.go, same package.
+//
+// setupFacadeGraph builds the minimal shape a Laravel facade produces: a class
+// declaring only getFacadeAccessor(), and N files that `use` it and call a method
+// it does not declare. The static call binds to nothing, so the ONLY edges in the
+// index are `imports` - which is exactly why blast reported total_affected 0 while
+// every importer was a real caller.
+func setupFacadeGraph(t *testing.T, importers int) (*sql.DB, *sqlite.Adapter) {
+	t.Helper()
+	root := t.TempDir()
+
+	writeFile(t, filepath.Join(root, "src", "Facades", "Thing.php"), `<?php
+namespace App\Facades;
+
+class Thing
+{
+    protected static function getFacadeAccessor()
+    {
+        return 'thing';
+    }
+}
+`)
+	for i := 0; i < importers; i++ {
+		name := fmt.Sprintf("Widget%d", i)
+		writeFile(t, filepath.Join(root, "src", "Widgets", name+".php"), fmt.Sprintf(`<?php
+namespace App\Widgets;
+
+use App\Facades\Thing;
+
+class %s
+{
+    public function render()
+    {
+        return Thing::go('%s');
+    }
+}
+`, name, name))
+	}
+
+	ctx := context.Background()
+	if _, err := scan.Run(ctx, scan.Options{
+		Root:     root,
+		Output:   &bytes.Buffer{},
+		Warnings: io.Discard,
+	}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+
+	dbPath := filepath.Join(root, ".sense", "index.db")
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db, adapter
+}
+
+// TestImportersNotReachedAreNamed is the repro. Before this group existed, blast on a
+// facade returned total_affected 0 with verdict "complete" while the index held an
+// `imports` edge from every calling file. Measured on a real clone: 32 importers, 12
+// affected, 22 unreported, and 22 of 22 made a genuine static call.
+func TestImportersNotReachedAreNamed(t *testing.T) {
+	db, adapter := setupFacadeGraph(t, 3)
+	id := idOf(t, adapter, `App\Facades\Thing`)
+
+	res, err := blast.Compute(context.Background(), db, []int64{id}, blast.Options{})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+
+	if len(res.ImportersNotReached) != 3 {
+		t.Fatalf("ImportersNotReached = %d files, want 3 (the index holds an imports edge from each)",
+			len(res.ImportersNotReached))
+	}
+	if res.ImportersNotReachedCount != 3 {
+		t.Errorf("ImportersNotReachedCount = %d, want 3", res.ImportersNotReachedCount)
+	}
+	// The load-bearing invariant: this group is a WEAKER claim than a call edge, so it
+	// must never inflate the radius. Anything else flips the completeness verdict and
+	// reproduces the "Sense is unsure, re-grep everything" failure.
+	if res.TotalAffected != 0 {
+		t.Errorf("TotalAffected = %d, want 0: the importer group must never feed the radius",
+			res.TotalAffected)
+	}
+}
+
+// TestImportersSuppressedWhenOverCap pins the council's ruling that a truncated list is
+// worse than none: a partial list is a prompt to go grep, which is the behaviour this
+// group exists to prevent. Over the cap the group is ABSENT, and the count still tells
+// the truth about how many exist.
+func TestImportersSuppressedWhenOverCap(t *testing.T) {
+	db, adapter := setupFacadeGraph(t, blast.ImportersCap+2)
+	id := idOf(t, adapter, `App\Facades\Thing`)
+
+	res, err := blast.Compute(context.Background(), db, []int64{id}, blast.Options{})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	if len(res.ImportersNotReached) != 0 {
+		t.Errorf("ImportersNotReached = %d rows past the cap, want 0 (suppressed, not truncated)",
+			len(res.ImportersNotReached))
+	}
+	if res.ImportersNotReachedCount != blast.ImportersCap+2 {
+		t.Errorf("ImportersNotReachedCount = %d, want %d: the count must stay honest when the list is suppressed",
+			res.ImportersNotReachedCount, blast.ImportersCap+2)
+	}
+}
+
+// TestNoImportersGroupWithoutImportEdges is the no-regress guard. `imports` is emitted
+// by the PHP extractor only; every other language's blast output must be untouched.
+func TestNoImportersGroupWithoutImportEdges(t *testing.T) {
+	db, adapter := setupGraph(t) // the ruby fixture: calls edges, no imports
+	id := idOf(t, adapter, "C#leaf")
+
+	res, err := blast.Compute(context.Background(), db, []int64{id}, blast.Options{})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	if len(res.ImportersNotReached) != 0 || res.ImportersNotReachedCount != 0 {
+		t.Errorf("a graph with no imports edges produced an importer group: %d rows, count %d",
+			len(res.ImportersNotReached), res.ImportersNotReachedCount)
+	}
+}
+
+// TestImporterAlreadyReachedIsNotDoubleListed pins the per-FILE exclusion. PHP attributes
+// an import to the file's namespace symbol, never the class symbol a call edge finds, so
+// an earlier symbol-id exclusion matched nothing: on filament's FilamentAsset it reported
+// all 32 importers instead of the 22 the caller lists had not already covered, re-listing
+// rows that were sitting in the answer. Here Caller.php both imports the facade AND calls
+// a method the facade really declares, so a call edge reaches it and it must NOT appear.
+func TestImporterAlreadyReachedIsNotDoubleListed(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "src", "Facades", "Thing.php"), `<?php
+namespace App\Facades;
+
+class Thing
+{
+    public static function declared()
+    {
+        return 1;
+    }
+}
+`)
+	// imports AND calls a declared method -> a real call edge reaches this file
+	writeFile(t, filepath.Join(root, "src", "Widgets", "Caller.php"), `<?php
+namespace App\Widgets;
+
+use App\Facades\Thing;
+
+class Caller
+{
+    public function run()
+    {
+        return Thing::declared();
+    }
+}
+`)
+	// imports only, calls an undeclared method -> no call edge, belongs in the group
+	writeFile(t, filepath.Join(root, "src", "Widgets", "Importer.php"), `<?php
+namespace App\Widgets;
+
+use App\Facades\Thing;
+
+class Importer
+{
+    public function run()
+    {
+        return Thing::undeclared();
+    }
+}
+`)
+
+	ctx := context.Background()
+	if _, err := scan.Run(ctx, scan.Options{Root: root, Output: &bytes.Buffer{}, Warnings: io.Discard}); err != nil {
+		t.Fatalf("scan.Run: %v", err)
+	}
+	dbPath := filepath.Join(root, ".sense", "index.db")
+	adapter, err := sqlite.Open(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+	db, err := sql.Open("sqlite", "file:"+dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	res, err := blast.Compute(ctx, db, []int64{idOf(t, adapter, `App\Facades\Thing`)}, blast.Options{})
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	for _, f := range res.ImportersNotReached {
+		if strings.Contains(f, "Caller.php") {
+			t.Errorf("Caller.php is reached by a call edge but was listed as an unreached importer: %v",
+				res.ImportersNotReached)
+		}
+	}
+}

--- a/internal/blast/symbols_faults_test.go
+++ b/internal/blast/symbols_faults_test.go
@@ -284,3 +284,80 @@ func TestLoadReverseCompositionPropagatesQueryError(t *testing.T) {
 		t.Fatal("loadReverseComposition: expected propagated query error, got nil")
 	}
 }
+
+// The importer group's DB-error branches. A healthy database never reaches them, so
+// they are driven through the same fault harness as the rest of this file.
+
+func TestImportersNotReachedQueryError(t *testing.T) {
+	db := openBlastFaultDB(t)
+	armBlastQueryFault("AND e.kind = 'imports'")
+	t.Cleanup(disarmBlastFaults)
+	if _, _, err := importersNotReached(context.Background(), db, []int64{1}, nil); err == nil {
+		t.Fatal("importersNotReached: expected query error, got nil")
+	}
+}
+
+func TestImportersNotReachedScanError(t *testing.T) {
+	db := openBlastFaultDB(t)
+	armBlastRowsFault("AND e.kind = 'imports'", blastRowsScan)
+	t.Cleanup(disarmBlastFaults)
+	if _, _, err := importersNotReached(context.Background(), db, []int64{1}, nil); err == nil {
+		t.Fatal("importersNotReached: expected scan error, got nil")
+	}
+}
+
+func TestImportersNotReachedRowsIterationError(t *testing.T) {
+	db := openBlastFaultDB(t)
+	armBlastRowsFault("AND e.kind = 'imports'", blastRowsNext)
+	t.Cleanup(disarmBlastFaults)
+	if _, _, err := importersNotReached(context.Background(), db, []int64{1}, nil); err == nil {
+		t.Fatal("importersNotReached: expected rows.Err iteration error, got nil")
+	}
+}
+
+// No symbol ids means no subject, so the group is empty without touching the DB.
+func TestImportersNotReachedEmptySubject(t *testing.T) {
+	db := openBlastFaultDB(t)
+	files, count, err := importersNotReached(context.Background(), db, nil, nil)
+	if err != nil || files != nil || count != 0 {
+		t.Fatalf("importersNotReached(no ids) = %v, %d, %v; want nil, 0, nil", files, count, err)
+	}
+}
+
+func TestFileIDsOfQueryError(t *testing.T) {
+	db := openBlastFaultDB(t)
+	armBlastQueryFault("SELECT DISTINCT file_id FROM sense_symbols")
+	t.Cleanup(disarmBlastFaults)
+	if _, err := fileIDsOf(context.Background(), db, []int64{1}); err == nil {
+		t.Fatal("fileIDsOf: expected query error, got nil")
+	}
+}
+
+func TestFileIDsOfScanError(t *testing.T) {
+	db := openBlastFaultDB(t)
+	armBlastRowsFault("SELECT DISTINCT file_id FROM sense_symbols", blastRowsBadValue)
+	t.Cleanup(disarmBlastFaults)
+	if _, err := fileIDsOf(context.Background(), db, []int64{1}); err == nil {
+		t.Fatal("fileIDsOf: expected scan error, got nil")
+	}
+}
+
+func TestFileIDsOfRowsIterationError(t *testing.T) {
+	db := openBlastFaultDB(t)
+	armBlastRowsFault("SELECT DISTINCT file_id FROM sense_symbols", blastRowsNext)
+	t.Cleanup(disarmBlastFaults)
+	if _, err := fileIDsOf(context.Background(), db, []int64{1}); err == nil {
+		t.Fatal("fileIDsOf: expected rows.Err iteration error, got nil")
+	}
+}
+
+// The fileIDsOf failure has to propagate out of importersNotReached rather than be
+// swallowed into an empty group, which would silently report every importer as unreached.
+func TestImportersNotReachedFileIDsError(t *testing.T) {
+	db := openBlastFaultDB(t)
+	armBlastQueryFault("SELECT DISTINCT file_id FROM sense_symbols")
+	t.Cleanup(disarmBlastFaults)
+	if _, _, err := importersNotReached(context.Background(), db, []int64{1}, []int64{2}); err == nil {
+		t.Fatal("importersNotReached: expected the fileIDsOf error to propagate, got nil")
+	}
+}

--- a/internal/mcpio/blast.go
+++ b/internal/mcpio/blast.go
@@ -450,6 +450,14 @@ func BuildBlastResponseSeen(ctx context.Context, r blast.Result, files FileLooku
 	// they stay out of tier2All (references.count), the production/test
 	// segmentation, affected_files, and the completeness arithmetic — their
 	// own count field is the only place they are tallied.
+	resp.ImportersNotReached = r.ImportersNotReached
+	resp.ImportersNotReachedCount = r.ImportersNotReachedCount
+	if r.ImportersNotReachedCount > 0 {
+		resp.ImportersNote = "These files import the subject and no call edge reaches them; " +
+			"on a facade the static call is routed by __callStatic, so the import is the only " +
+			"recorded evidence. Not counted in total_affected."
+	}
+
 	for _, rh := range r.RetainedViaInterfaces {
 		var file string
 		if path, ok := files(rh.Symbol.FileID); ok {

--- a/internal/mcpio/blast_importers_test.go
+++ b/internal/mcpio/blast_importers_test.go
@@ -1,0 +1,52 @@
+package mcpio
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luuuc/sense/internal/blast"
+)
+
+// TestImporterGroupNeverFlipsTheVerdict is named for the failure it prevents, not the
+// field it touches. Adding importer rows to the radius was tried and measured: at
+// min_confidence 0.3 it took total_affected 12 -> 45 and flipped completeness from
+// `complete` to `partial`, which is the "Sense is unsure, re-grep everything" behaviour
+// that cost us once already. The group must be inert with respect to both numbers.
+func TestImporterGroupNeverFlipsTheVerdict(t *testing.T) {
+	base := blast.Result{TotalAffected: 0}
+	withGroup := blast.Result{
+		TotalAffected:            0,
+		ImportersNotReached:      []string{"src/Widgets/Alpha.php", "src/Widgets/Beta.php"},
+		ImportersNotReachedCount: 2,
+	}
+
+	// A real caller always supplies a FileLookup; nil panics at the subject-file
+	// lookup, so the stub keeps this test about the verdict rather than about nils.
+	files := func(int64) (string, bool) { return "src/Facades/Thing.php", true }
+
+	plain := BuildBlastResponse(context.Background(), base, files, nil)
+	grouped := BuildBlastResponse(context.Background(), withGroup, files, nil)
+
+	if plain.TotalAffected != grouped.TotalAffected {
+		t.Errorf("total_affected moved: %d -> %d", plain.TotalAffected, grouped.TotalAffected)
+	}
+	if plain.Completeness == nil || grouped.Completeness == nil {
+		t.Fatal("completeness missing")
+	}
+	if plain.Completeness.Verdict != grouped.Completeness.Verdict {
+		t.Errorf("verdict moved: %q -> %q", plain.Completeness.Verdict, grouped.Completeness.Verdict)
+	}
+	if plain.Completeness.Resolved != grouped.Completeness.Resolved {
+		t.Errorf("resolved moved: %d -> %d", plain.Completeness.Resolved, grouped.Completeness.Resolved)
+	}
+	if len(grouped.ImportersNotReached) != 2 || grouped.ImportersNotReachedCount != 2 {
+		t.Errorf("the group itself did not surface: %v / %d",
+			grouped.ImportersNotReached, grouped.ImportersNotReachedCount)
+	}
+	if grouped.ImportersNote == "" {
+		t.Error("a populated group must carry its shared note")
+	}
+	if plain.ImportersNote != "" {
+		t.Error("an empty group must not carry a note")
+	}
+}

--- a/internal/mcpio/types.go
+++ b/internal/mcpio/types.go
@@ -357,6 +357,19 @@ type BlastResponse struct {
 	RetainedViaInterfaces []BlastRetained `json:"retained_via_interfaces,omitempty"`
 	RetainedCount         int             `json:"retained_via_interfaces_count,omitempty"`
 	RetainedNote          string          `json:"retained_note,omitempty"`
+	// ImportersNotReached lists FILES that import the subject and that no call
+	// edge reaches. On a facade this is the real dependent set: the class declares
+	// only getFacadeAccessor(), so a static call binds to no method symbol and the
+	// `use` import is the only recorded evidence. Like retained_via_interfaces it is
+	// a weaker claim than the affected_* groups and never feeds total_affected or
+	// the completeness verdict; adding these rows to the radius was measured and it
+	// flipped the verdict to `partial`, which sends the agent back to grep.
+	// Files, not symbols, and no synthetic line numbers: there is no call site to
+	// cite. Suppressed entirely past the engine's cap so a partial list never
+	// masquerades as the set, with the count still stating the true scale.
+	ImportersNotReached      []string `json:"importers_not_reached,omitempty"`
+	ImportersNotReachedCount int      `json:"importers_not_reached_count,omitempty"`
+	ImportersNote            string   `json:"importers_note,omitempty"`
 	// RetainedTrimmed is true when the budget stripped carrier/chain
 	// enrichments from retained rows: an absent enrichment on a row is
 	// then trimmed, not unknown. A flag rather than note prose so it is


### PR DESCRIPTION
enhance(blast): name the importers no call edge reaches

When an agent asks what depends on a Laravel facade, Sense knew about more dependents than
it was willing to say. The files were sitting in the index the whole time. This change hands
them over by name, without touching the number the agent is told to trust.

## Problem

A facade declares only `getFacadeAccessor()`. A call like `Foo::bar()` therefore binds to no
method symbol and produces no call edge, leaving the `use` import as the only recorded
evidence of the dependency. Blast never looked at import edges.

Measured on a pinned filament checkout, `blast` on the `FilamentAsset` facade returns
`total_affected: 12` with verdict `complete`. The index holds an inbound import edge from 32
files. Ten of those are already in the answer; the other **22 are not reported at all**, and
all 22 make a real `FilamentAsset::` static call, verified by hand.

So this is not a dynamic dispatch limit and not a guess. The dependents were indexed and
discarded.

## Summary

Adds a sibling group to `retained_via_interfaces`, which already solves this exact shape:
real rows of a weaker kind, listed for the agent but never folded into the radius.

## Changes

- New `importers_not_reached` group listing the FILES that import the subject and that no
  call edge reaches, with a count and a shared note explaining what the rows mean.
- The group never feeds `total_affected` and never moves the completeness verdict.
- Past a 24 file cap the list is suppressed rather than truncated, and the count still
  reports the true scale.
- Exclusion is computed per file, not per symbol.

## Architecture Highlights

- **Why a list and not a warning.** A count alone tells the agent that dependents exist
  somewhere, which is an invitation to go grep. Naming the files replaces the grep. That is
  also why the rows are files with no synthetic line numbers: there is no call site to cite,
  which is the whole reason the group exists.

- **Why the radius is untouched, measured rather than assumed.** The first version of this
  change made blast traverse import edges. It was reviewed, approved, and then measured: at
  the default confidence it changed nothing at all, and at `--min-confidence 0.3` it took
  `total_affected` from 12 to 45 and flipped the verdict from `complete` to `partial`. That
  is the "Sense is unsure, go grep everything" behaviour, which is the exact failure this
  group exists to prevent. The design was discarded on that measurement. A test now pins the
  verdict and the resolved count against it.

- **Why suppression, not truncation.** A partial list of dependents is worse than none: it
  teaches the agent that the lists are incomplete, and that lesson generalises to every other
  group in the response. The cap value is a judgement, and the reasoning is recorded at the
  constant, including the measured distribution it came from and the fact that it includes
  the case that motivated the change.

- **Why per file and not per symbol.** PHP attributes an import to the file's namespace
  symbol, never the class symbol a call edge would find, so a symbol based exclusion matched
  nothing: it reported all 32 importers instead of the 22 the caller lists had not already
  covered, re-listing rows that were already in the answer. There is a regression test for
  exactly that.

- **Reach, stated precisely.** Five extractors reference the import edge kind in code: PHP,
  Ruby, Python, TypeScript and the language-spec harness. In practice only PHP's survive
  resolution and reach the index, and the mechanism is the reason: PHP resolves a `use`
  statement to a fully qualified class name, which is a real symbol, while TypeScript targets
  a module path and Ruby's targets an importmap pin, neither of which resolves to a symbol,
  so those edges are dropped before they are stored.

  Measured rather than assumed: 7,678 import edges in the filament index; zero in the Ruby,
  Python and Go indexes checked, including this repository's own; and zero in a TypeScript
  fixture built specifically with a barrel re-export and a dynamic import, the two
  constructs its extractor emits import edges for. So no other language's output changes
  today, and a fixture with no import edges asserts the empty case. If a future resolver
  change makes another language's import edges resolvable, this group would begin appearing
  there, which is a reason for the edge-kind parity work rather than an argument against
  this change.

## On measurement

This ships on correctness, not on a benchmark delta, and that is worth saying plainly. The
PHP stack has no winnable benchmark cell yet: both eligibility probes run against it produced
arithmetic kills, so there is no number this could move. The value proof is recorded as owed,
tracked together with the one owed by the index caveat change that shipped in v1.13.3.

The side effect run normally required before merge was discharged by a bounded exposure
measurement under a recorded one time ruling, on the same grounds as that change: one
emitting language, no frozen cells for it, and both the radius and the verdict pinned
unchanged by test.

## Test Plan

- [x] Repro on a facade fixture whose only edges are imports: the importing files are named,
      and `total_affected` stays 0
- [x] Verdict stability: completeness verdict and resolved count byte identical with the
      group populated and empty
- [x] Suppression: past the cap the list is absent, not trimmed, and the count still reports
      the full number
- [x] Per file exclusion: a file that both imports the subject and calls a declared method is
      reached by a call edge and must not appear in the group
- [x] No regress: a graph with no import edges produces no group
- [x] Database error paths driven through the existing fault harness: query, scan, row
      iteration, and the propagation of the file lookup failure
- [x] End to end on a real checkout: the facade lists its 22 files, a 192 importer hub
      suppresses the list and keeps the count, and neither moves `total_affected`
- [x] Both new functions at 100 percent line and function coverage
- [x] `make ci` green: build, coverage gate, lint, complexity ledger
- [x] `qlty check` clean on all six changed files
- [x] The response oracle digest test passes, so no existing response string moved
- [x] sense binary builds cleanly
