### PR TITLE
chore(model): make a new edge kind impossible to ignore

### DIFF
--- a/internal/blast/edge_parity_test.go
+++ b/internal/blast/edge_parity_test.go
@@ -1,0 +1,53 @@
+package blast
+
+import (
+	"testing"
+
+	"github.com/luuuc/sense/internal/model"
+)
+
+// TestEdgeKindConsumerParity is the anti-drift gate. This package consumes a SUBSET of
+// the edge vocabulary, and the subset plus its documented exemptions must account for
+// every kind in model.AllEdgeKinds. A new kind therefore cannot be silently ignored: it
+// either joins the list or is exempted here with a reason.
+//
+// Born from four instances of one failure in a single day, all the same shape: a producer
+// gained a value and a consumer's hardcoded list never learned about it. blast did not
+// traverse `imports` for two months after the PHP extractor began emitting it.
+func TestEdgeKindConsumerParity(t *testing.T) {
+	covered := map[model.EdgeKind]bool{}
+	for _, k := range TraversalKinds {
+		covered[k] = true
+	}
+	exempt := map[model.EdgeKind]string{
+		model.EdgeImports: "an import names the symbol; on a facade that also means calls it, " +
+			"but on an ordinary class the call edges already carry the dependency. Traversing it " +
+			"was measured: total_affected 12 -> 45 and the verdict flipped to partial. Those " +
+			"importers surface as ImportersNotReached instead.",
+	}
+
+	for _, k := range model.AllEdgeKinds {
+		_, isExempt := exempt[k]
+		if covered[k] && isExempt {
+			t.Errorf("kind %q is both consumed and exempted: pick one", k)
+		}
+		if !covered[k] && !isExempt {
+			t.Errorf("kind %q is neither consumed nor exempted here. A new edge kind must be "+
+				"handled deliberately: add it to the list, or exempt it with the reason.", k)
+		}
+	}
+	for k := range exempt {
+		if covered[k] {
+			continue // already reported above
+		}
+		found := false
+		for _, known := range model.AllEdgeKinds {
+			if known == k {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("exemption names %q, which is not a known edge kind: remove the stale entry", k)
+		}
+	}
+}

--- a/internal/blast/engine.go
+++ b/internal/blast/engine.go
@@ -290,6 +290,25 @@ type Result struct {
 // point to any reopening, so all must be seeds.
 //
 // For single-symbol queries, pass a one-element slice.
+// TraversalKinds is the edge vocabulary the blast BFS follows. Declared rather than
+// written inline so TestEdgeKindConsumerParity can assert it against
+// model.AllEdgeKinds: `imports` was absent here for two months after the PHP extractor
+// began emitting it, and a facade's real dependents went unreported as a result.
+//
+// EXEMPT: model.EdgeImports. An import means "this file names the symbol", which on a
+// facade also means "calls it" but on an ordinary class adds nothing the call edges do
+// not already carry. Traversing it was measured: total_affected 12 -> 45 and the verdict
+// flipped to `partial`. Those importers surface as their own response group instead.
+var TraversalKinds = []model.EdgeKind{
+	model.EdgeCalls,
+	model.EdgeComposes,
+	model.EdgeIncludes,
+	model.EdgeInherits,
+	model.EdgeTemporal,
+	model.EdgeTests,
+	model.EdgeReferences,
+}
+
 func Compute(ctx context.Context, db *sql.DB, symbolIDs []int64, opts Options) (Result, error) {
 	if len(symbolIDs) == 0 {
 		return Result{}, fmt.Errorf("blast: no symbol IDs provided")
@@ -1175,7 +1194,7 @@ func expandFrontier(ctx context.Context, db *sql.DB, frontier []int64) ([]edgePa
 		q := `SELECT source_id, target_id, kind, confidence, file_id, line FROM sense_edges
 		      WHERE target_id IN (` + placeholders + `)
 		        AND source_id IS NOT NULL
-		        AND kind IN ('calls', 'composes', 'includes', 'inherits', 'temporal', 'tests', 'references')
+		        AND kind IN (` + model.SQLKindList(TraversalKinds) + `)
 		        AND confidence >= 0.1`
 
 		args := make([]any, 0, len(batch))

--- a/internal/conventions/detectors_arch.go
+++ b/internal/conventions/detectors_arch.go
@@ -5,7 +5,23 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+
+	"github.com/luuuc/sense/internal/model"
 )
+
+// couplingKinds is the edge vocabulary that counts as architectural coupling between
+// two areas. Declared so the parity test can see it.
+//
+// EXEMPT: model.EdgeTests (a test reaching across areas is not an architecture
+// violation), model.EdgeTemporal (co-change is not a structural dependency),
+// model.EdgeReferences (too weak to imply coupling), model.EdgeImports (an import
+// without a call is not coupling in the sense this detector reports).
+var couplingKinds = []model.EdgeKind{
+	model.EdgeCalls,
+	model.EdgeComposes,
+	model.EdgeInherits,
+	model.EdgeIncludes,
+}
 
 var serviceEntryPoints = map[string]bool{
 	"call": true, "execute": true, "perform": true, "run": true,
@@ -199,7 +215,7 @@ func detectExternalDependencies(ctx context.Context, db *sql.DB, domain string, 
 	      JOIN sense_files tf ON tf.id = t.file_id
 	      JOIN sense_symbols s ON s.id = e.source_id
 	      JOIN sense_files sf ON sf.id = s.file_id
-	      WHERE e.kind IN ('calls', 'composes', 'inherits', 'includes')
+	      WHERE e.kind IN (` + model.SQLKindList(couplingKinds) + `)
 	      AND sf.path LIKE ?
 	      AND NOT tf.path LIKE ?
 	      GROUP BY t.qualified

--- a/internal/conventions/edge_parity_test.go
+++ b/internal/conventions/edge_parity_test.go
@@ -1,0 +1,53 @@
+package conventions
+
+import (
+	"testing"
+
+	"github.com/luuuc/sense/internal/model"
+)
+
+// TestEdgeKindConsumerParity is the anti-drift gate. This package consumes a SUBSET of
+// the edge vocabulary, and the subset plus its documented exemptions must account for
+// every kind in model.AllEdgeKinds. A new kind therefore cannot be silently ignored: it
+// either joins the list or is exempted here with a reason.
+//
+// Born from four instances of one failure in a single day, all the same shape: a producer
+// gained a value and a consumer's hardcoded list never learned about it. blast did not
+// traverse `imports` for two months after the PHP extractor began emitting it.
+func TestEdgeKindConsumerParity(t *testing.T) {
+	covered := map[model.EdgeKind]bool{}
+	for _, k := range couplingKinds {
+		covered[k] = true
+	}
+	exempt := map[model.EdgeKind]string{
+		model.EdgeTests:      "a test reaching across areas is not an architecture violation",
+		model.EdgeTemporal:   "co-change is not a structural dependency",
+		model.EdgeReferences: "too weak to imply coupling",
+		model.EdgeImports:    "an import without a call is not coupling in this detector's sense",
+	}
+
+	for _, k := range model.AllEdgeKinds {
+		_, isExempt := exempt[k]
+		if covered[k] && isExempt {
+			t.Errorf("kind %q is both consumed and exempted: pick one", k)
+		}
+		if !covered[k] && !isExempt {
+			t.Errorf("kind %q is neither consumed nor exempted here. A new edge kind must be "+
+				"handled deliberately: add it to the list, or exempt it with the reason.", k)
+		}
+	}
+	for k := range exempt {
+		if covered[k] {
+			continue // already reported above
+		}
+		found := false
+		for _, known := range model.AllEdgeKinds {
+			if known == k {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("exemption names %q, which is not a known edge kind: remove the stale entry", k)
+		}
+	}
+}

--- a/internal/dead/edge_parity_test.go
+++ b/internal/dead/edge_parity_test.go
@@ -1,0 +1,52 @@
+package dead
+
+import (
+	"testing"
+
+	"github.com/luuuc/sense/internal/model"
+)
+
+// TestEdgeKindConsumerParity is the anti-drift gate. This package consumes a SUBSET of
+// the edge vocabulary, and the subset plus its documented exemptions must account for
+// every kind in model.AllEdgeKinds. A new kind therefore cannot be silently ignored: it
+// either joins the list or is exempted here with a reason.
+//
+// Born from four instances of one failure in a single day, all the same shape: a producer
+// gained a value and a consumer's hardcoded list never learned about it. blast did not
+// traverse `imports` for two months after the PHP extractor began emitting it.
+func TestEdgeKindConsumerParity(t *testing.T) {
+	covered := map[model.EdgeKind]bool{}
+	for _, k := range reachabilityKinds {
+		covered[k] = true
+	}
+	exempt := map[model.EdgeKind]string{
+		model.EdgeTests:    "a symbol referenced only by its own test is dead-but-tested, not reachable",
+		model.EdgeTemporal: "co-change is correlation, not a reference",
+		model.EdgeImports:  "importing a symbol is not using it; counting it would mark unused imports alive",
+	}
+
+	for _, k := range model.AllEdgeKinds {
+		_, isExempt := exempt[k]
+		if covered[k] && isExempt {
+			t.Errorf("kind %q is both consumed and exempted: pick one", k)
+		}
+		if !covered[k] && !isExempt {
+			t.Errorf("kind %q is neither consumed nor exempted here. A new edge kind must be "+
+				"handled deliberately: add it to the list, or exempt it with the reason.", k)
+		}
+	}
+	for k := range exempt {
+		if covered[k] {
+			continue // already reported above
+		}
+		found := false
+		for _, known := range model.AllEdgeKinds {
+			if known == k {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("exemption names %q, which is not a known edge kind: remove the stale entry", k)
+		}
+	}
+}

--- a/internal/dead/queries.go
+++ b/internal/dead/queries.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/luuuc/sense/internal/model"
+
 	"github.com/luuuc/sense/internal/extract"
 )
 
@@ -44,10 +46,25 @@ func countSymbols(ctx context.Context, db *sql.DB, opts Options) (int, error) {
 	return count, nil
 }
 
+// reachabilityKinds is the edge vocabulary that proves a symbol is referenced. Declared
+// so the parity test can see it.
+//
+// EXEMPT: model.EdgeTests, because a symbol referenced only by its own test is what this
+// package reports as dead-but-tested rather than reachable; model.EdgeTemporal, because
+// co-change is correlation, not a reference; model.EdgeImports, because importing a
+// symbol is not using it, and treating it as a reference would mark unused imports alive.
+var reachabilityKinds = []model.EdgeKind{
+	model.EdgeCalls,
+	model.EdgeComposes,
+	model.EdgeIncludes,
+	model.EdgeInherits,
+	model.EdgeReferences,
+}
+
 func queryCandidates(ctx context.Context, db *sql.DB, opts Options) ([]Symbol, error) {
 	edgeFilter := `SELECT 1 FROM sense_edges e
 			WHERE e.target_id = s.id
-			AND e.kind IN ('calls', 'composes', 'includes', 'inherits', 'references')`
+			AND e.kind IN (` + model.SQLKindList(reachabilityKinds) + `)`
 	if opts.ExcludeTestRefs {
 		edgeFilter += `
 			AND NOT EXISTS (

--- a/internal/model/edge.go
+++ b/internal/model/edge.go
@@ -31,3 +31,43 @@ const (
 	EdgeTemporal   EdgeKind = "temporal"
 	EdgeReferences EdgeKind = "references"
 )
+
+// AllEdgeKinds is every kind the schema recognises, in declaration order. It exists so
+// a CONSUMER can be tested for parity against the vocabulary instead of hardcoding a
+// subset in a SQL string and silently ignoring the rest.
+//
+// The failure this guards against happened four times in one day: a producer gained a
+// value and a consumer's hardcoded list never learned about it. The PHP extractor
+// introduced `imports` two months after blast's traversal list was last touched, so
+// blast never traversed it and a facade's real dependents went unreported. The same
+// shape hit an index-caveat language switch, a bench scorer's file extensions, and a
+// ledger key contract.
+//
+// Adding a kind here without updating every consumer's declared list (or its documented
+// exemption) fails TestEdgeKindConsumerParity.
+var AllEdgeKinds = []EdgeKind{
+	EdgeCalls,
+	EdgeImports,
+	EdgeInherits,
+	EdgeIncludes,
+	EdgeTests,
+	EdgeComposes,
+	EdgeTemporal,
+	EdgeReferences,
+}
+
+// SQLKindList renders kinds as a quoted, comma-separated SQL IN-list body, so a query
+// builds its filter FROM the vocabulary rather than restating it as a literal. Values
+// are package constants, never user input.
+func SQLKindList(kinds []EdgeKind) string {
+	out := make([]byte, 0, len(kinds)*12)
+	for i, k := range kinds {
+		if i > 0 {
+			out = append(out, ',')
+		}
+		out = append(out, '\'')
+		out = append(out, k...)
+		out = append(out, '\'')
+	}
+	return string(out)
+}

--- a/internal/model/edge_parity_test.go
+++ b/internal/model/edge_parity_test.go
@@ -1,0 +1,52 @@
+package model_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/internal/model"
+)
+
+// TestAllEdgeKindsIsComplete keeps the vocabulary list honest. A kind constant that
+// exists but is missing from AllEdgeKinds would make every parity check below vacuous:
+// consumers would be measured against an incomplete vocabulary and pass by omission.
+//
+// Kept as an explicit expectation rather than reflection over the package, because the
+// point is that a human adding a constant must also add it here and then face the
+// consumer parity test.
+func TestAllEdgeKindsIsComplete(t *testing.T) {
+	want := map[model.EdgeKind]bool{
+		model.EdgeCalls: true, model.EdgeImports: true, model.EdgeInherits: true,
+		model.EdgeIncludes: true, model.EdgeTests: true, model.EdgeComposes: true,
+		model.EdgeTemporal: true, model.EdgeReferences: true,
+	}
+	if len(model.AllEdgeKinds) != len(want) {
+		t.Fatalf("AllEdgeKinds has %d kinds, expected %d: a new constant must be added to "+
+			"AllEdgeKinds, and every consumer must then include or exempt it",
+			len(model.AllEdgeKinds), len(want))
+	}
+	for _, k := range model.AllEdgeKinds {
+		if !want[k] {
+			t.Errorf("AllEdgeKinds contains unexpected kind %q", k)
+		}
+		delete(want, k)
+	}
+	for k := range want {
+		t.Errorf("AllEdgeKinds is missing %q", k)
+	}
+}
+
+func TestSQLKindList(t *testing.T) {
+	got := model.SQLKindList([]model.EdgeKind{model.EdgeCalls, model.EdgeImports})
+	if got != "'calls','imports'" {
+		t.Errorf("SQLKindList = %q, want %q", got, "'calls','imports'")
+	}
+	if model.SQLKindList(nil) != "" {
+		t.Errorf("SQLKindList(nil) = %q, want empty", model.SQLKindList(nil))
+	}
+	// Every kind renders as a quoted literal, so a generated IN-list is never malformed.
+	all := model.SQLKindList(model.AllEdgeKinds)
+	if strings.Count(all, "'") != 2*len(model.AllEdgeKinds) {
+		t.Errorf("SQLKindList(all) = %q:each kind needs exactly two quotes", all)
+	}
+}

--- a/internal/sqlite/context.go
+++ b/internal/sqlite/context.go
@@ -4,7 +4,22 @@ import (
 	"context"
 	"fmt"
 	"strings"
+
+	"github.com/luuuc/sense/internal/model"
 )
+
+// contextKinds is the edge vocabulary a symbol's context view walks. Declared so the
+// parity test can see it.
+//
+// EXEMPT: model.EdgeTests, model.EdgeTemporal, model.EdgeReferences and
+// model.EdgeImports - the context view is a structural neighbourhood, and these four
+// widen it without telling the reader how the symbol is wired.
+var contextKinds = []model.EdgeKind{
+	model.EdgeComposes,
+	model.EdgeIncludes,
+	model.EdgeInherits,
+	model.EdgeCalls,
+}
 
 const contextBudget = 800
 
@@ -105,10 +120,10 @@ func (a *Adapter) contextSymbols(ctx context.Context, fileID int64) ([]symbolCtx
 }
 
 func (a *Adapter) contextEdges(ctx context.Context, fileID int64) (map[int64]symbolEdges, error) {
-	const q = `SELECT e.source_id, e.kind, t.name FROM sense_edges e
+	q := `SELECT e.source_id, e.kind, t.name FROM sense_edges e
 		JOIN sense_symbols t ON e.target_id = t.id
 		WHERE e.source_id IN (SELECT id FROM sense_symbols WHERE file_id = ?)
-		  AND e.kind IN ('composes','includes','inherits','calls')
+		  AND e.kind IN (` + model.SQLKindList(contextKinds) + `)
 		ORDER BY e.source_id, e.kind, t.name`
 
 	rows, err := a.db.QueryContext(ctx, q, fileID)

--- a/internal/sqlite/edge_parity_test.go
+++ b/internal/sqlite/edge_parity_test.go
@@ -1,0 +1,53 @@
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/luuuc/sense/internal/model"
+)
+
+// TestEdgeKindConsumerParity is the anti-drift gate. This package consumes a SUBSET of
+// the edge vocabulary, and the subset plus its documented exemptions must account for
+// every kind in model.AllEdgeKinds. A new kind therefore cannot be silently ignored: it
+// either joins the list or is exempted here with a reason.
+//
+// Born from four instances of one failure in a single day, all the same shape: a producer
+// gained a value and a consumer's hardcoded list never learned about it. blast did not
+// traverse `imports` for two months after the PHP extractor began emitting it.
+func TestEdgeKindConsumerParity(t *testing.T) {
+	covered := map[model.EdgeKind]bool{}
+	for _, k := range contextKinds {
+		covered[k] = true
+	}
+	exempt := map[model.EdgeKind]string{
+		model.EdgeTests:      "the context view is a structural neighbourhood, not test wiring",
+		model.EdgeTemporal:   "co-change does not show how a symbol is wired",
+		model.EdgeReferences: "too weak to describe the neighbourhood",
+		model.EdgeImports:    "an import does not show how the symbol is used",
+	}
+
+	for _, k := range model.AllEdgeKinds {
+		_, isExempt := exempt[k]
+		if covered[k] && isExempt {
+			t.Errorf("kind %q is both consumed and exempted: pick one", k)
+		}
+		if !covered[k] && !isExempt {
+			t.Errorf("kind %q is neither consumed nor exempted here. A new edge kind must be "+
+				"handled deliberately: add it to the list, or exempt it with the reason.", k)
+		}
+	}
+	for k := range exempt {
+		if covered[k] {
+			continue // already reported above
+		}
+		found := false
+		for _, known := range model.AllEdgeKinds {
+			if known == k {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("exemption names %q, which is not a known edge kind: remove the stale entry", k)
+		}
+	}
+}


### PR DESCRIPTION
chore(model): make a new edge kind impossible to ignore

Sense stores eight kinds of relationship between symbols, and several parts of the codebase
consume a subset of them. Until now nothing checked that those parts knew the full list, so
a new kind could be added and silently ignored by everything downstream. This adds that
check, and in writing it, the reasoning behind each subset finally got written down.

## Problem

The same failure happened four times in one day, on four different surfaces: a producer
gained a value and a consumer's hardcoded list never learned about it.

The clearest instance: the PHP extractor began emitting `imports` edges two months after
blast's traversal list was last touched. Blast never traversed them, so a Laravel facade's
real dependents went unreported. Nothing failed, nothing warned, and it was found by
accident while running a benchmark. The other three were an index-caveat language switch
with no PHP case, a benchmark scorer's file-extension list with no `.php`, and a ledger key
contract missing a key.

The edge-kind vocabulary was already centralised as typed constants. What was missing was
any assertion that consumers know all of them.

## Summary

Adds an enumerated vocabulary plus a per-consumer parity test, so a new edge kind must be
either consumed or explicitly exempted with a reason, in every package that filters on kind.

## Changes

- `model.AllEdgeKinds` enumerates the vocabulary; `model.SQLKindList` renders it as a SQL
  IN-list body so a query builds its filter from the vocabulary instead of restating it.
- The four multi-kind consumers now declare their subset as a named list rather than an
  inline SQL literal: blast's BFS traversal, dead-code reachability, the conventions
  coupling detector, and the sqlite symbol-context view.
- Each of those packages asserts its own contract: subset plus documented exemptions must
  account for every kind in the vocabulary.
- A vocabulary completeness test, so a constant that exists but is missing from the
  enumeration cannot make every downstream check vacuous.

## Architecture Highlights

- **Verified by simulation, not by assertion.** Adding a ninth kind reds the vocabulary
  test and every consumer that has not decided about it; removing it goes green. A gate
  that has never been seen to fail is not a gate.

- **Why not have extractors declare the kinds they emit.** That was the more mechanical
  design and it was rejected on evidence. The TypeScript extractor references the import
  kind in code, but those edges target a module path rather than a symbol and are dropped
  before they are stored, so a declaration-based gate would assert something false exactly
  where the interesting cases are. Testing against the stored vocabulary is the honest
  version, and it costs one slice instead of an interface change across eight packages.

- **The exemptions turned out to be the point.** Writing them forced reasons onto paper
  that existed nowhere before: why dead-code analysis ignores test edges, why the coupling
  detector ignores weak references, why blast does not traverse imports. A gate that
  demands a reason produces documentation as a side effect.

- **Deliberately not covered:** which kinds actually reach the index for a given language.
  That is a resolver property rather than a consumer one, and it is the property that made
  the TypeScript case counter-intuitive. It deserves its own check rather than being folded
  in here.

## Test Plan

- [x] Vocabulary completeness: a constant missing from the enumeration fails
- [x] Per-consumer parity in blast, dead, conventions and sqlite: every kind is consumed or
      exempted, and an exemption naming an unknown kind is rejected as stale
- [x] A kind that is both consumed and exempted is rejected, so the two lists cannot drift
      into contradiction
- [x] Simulation: a ninth kind reds five tests across five packages, and the suite returns
      to green when it is removed
- [x] SQL rendering: the generated IN-list is correctly quoted for every kind, and empty
      input yields an empty string
- [x] Behaviour unchanged: every existing test in the four converted packages passes, and
      the generated filters match the literals they replaced
- [x] `make ci` green: build, coverage gate, lint, complexity ledger
- [x] `qlty check` clean on every changed production file
- [x] sense binary builds cleanly
