### PR TITLE
enhance(php): index holder relationships, so PHP has a composition graph

### DIFF
--- a/internal/extract/php/php.go
+++ b/internal/extract/php/php.go
@@ -369,6 +369,61 @@ func declaredMethodNames(body *sitter.Node, source []byte) map[string]bool {
 	return names
 }
 
+// emitAssignedHolders finds `$this-><prop> = $<param>` where the parameter carries a
+// resolved class type, and records that the class holds it.
+//
+// Deliberately narrow. The right-hand side must be a plain variable whose type the
+// parameter environment already resolved, and the left must be a property on $this. An
+// assignment to a local, or from an untyped or unknown variable, yields nothing: a holder
+// edge invented from a guess is indistinguishable downstream from one the source declared,
+// which is worse than having none.
+func (w *walker) emitAssignedHolders(body *sitter.Node, classQualified string, env map[string]string) {
+	if body == nil || classQualified == "" || len(env) == 0 {
+		return
+	}
+	_ = extract.WalkNamedDescendants(body, "assignment_expression", func(a *sitter.Node) error {
+		left, right := a.ChildByFieldName("left"), a.ChildByFieldName("right")
+		if left == nil || right == nil || right.Kind() != "variable_name" {
+			return nil
+		}
+		// left must be $this-><prop>, not a local and not another object's property
+		if left.Kind() != "member_access_expression" {
+			return nil
+		}
+		obj := left.ChildByFieldName("object")
+		if obj == nil || obj.Kind() != "variable_name" ||
+			extract.Text(obj.NamedChild(0), w.source) != "this" {
+			return nil
+		}
+		typ := env[extract.Text(right.NamedChild(0), w.source)]
+		if typ == "" {
+			return nil
+		}
+		if prop := extract.Text(left.ChildByFieldName("name"), w.source); prop != "" {
+			w.setPropType(classQualified, prop, typ)
+		}
+		w.emitHolds(a, classQualified, typ)
+		return nil
+	})
+}
+
+// emitHolds records that a class holds a value of another class - the composition edge Go
+// gets for free from a field declaration. Confidence is Static: the type is declared in
+// source and resolved through the alias table, not inferred from a name or a docblock.
+func (w *walker) emitHolds(n *sitter.Node, classQualified, typ string) {
+	if classQualified == "" || typ == "" || typ == classQualified {
+		return
+	}
+	line := extract.Line(n.StartPosition())
+	_ = w.emit.Edge(extract.EmittedEdge{
+		SourceQualified: classQualified,
+		TargetQualified: typ,
+		Kind:            model.EdgeComposes,
+		Line:            &line,
+		Confidence:      extract.ConfidenceStatic,
+	})
+}
+
 // collectPropTypes records `private Logger $log;` style typed properties so
 // `$this->log->info()` can resolve its receiver.
 func (w *walker) collectPropTypes(body *sitter.Node, qualified string) {
@@ -387,6 +442,10 @@ func (w *walker) collectPropTypes(body *sitter.Node, qualified string) {
 			}
 			return nil
 		})
+		// The class HOLDS this type. Recording the type for receiver resolution was
+		// already happening; the edge was not, so php codebases carried almost no
+		// composition graph and the retention question could not be asked of them.
+		w.emitHolds(member, qualified, typ)
 	}
 }
 
@@ -455,6 +514,11 @@ func (w *walker) handleMethod(n *sitter.Node, classQualified string, declared ma
 		return err
 	}
 	env := w.paramTypes(n, classQualified)
+	// `__construct(Gateway $g) { $this->gateway = $g; }` is how php declares a holder:
+	// the type is on the parameter and the link is the assignment. Measured on
+	// laravel-framework/src, that shape outnumbers typed properties 235 to 52, so
+	// without it the composition graph stays essentially empty.
+	w.emitAssignedHolders(n.ChildByFieldName("body"), classQualified, env)
 	return w.walkCalls(n.ChildByFieldName("body"), qualified, env, classQualified)
 }
 
@@ -516,6 +580,7 @@ func (w *walker) paramTypes(n *sitter.Node, classQualified string) map[string]st
 		env[name] = typ
 		if kind == "property_promotion_parameter" && classQualified != "" {
 			w.setPropType(classQualified, name, typ)
+			w.emitHolds(p, classQualified, typ)
 		}
 	}
 	return env

--- a/internal/extract/php/php_test.go
+++ b/internal/extract/php/php_test.go
@@ -457,3 +457,107 @@ func hasParityEdge(em *rec, want parityEdge) bool {
 func qualifiedSuffix(got, base string) bool {
 	return got == base || strings.HasSuffix(got, `\`+base)
 }
+
+// TestHolderComposition is the repro for the missing PHP holder graph.
+//
+// Go declares a holder on the field (`f io.Closer`) so the composition edge falls out of
+// the declaration. PHP puts the type on the CONSTRUCTOR PARAMETER and links it by
+// assignment, so the same fact needs two nodes joined by a name. Sense resolved those types
+// already - paramTypes builds a `$var -> type` environment and promoted parameters record a
+// property type - but never emitted an edge, so composition was invisible.
+//
+// Measured on laravel-framework/src the day this landed: 52 typed properties, 11 promoted
+// parameters, 235 typed constructor parameters and 1,343 `$this->x = $param` assignments,
+// against 297 composes edges repo-wide (nearly all Eloquent test relations) and ZERO into
+// `Application`. Go sits at 3.3-5.5% of edges being composes; php at 0.06-0.31%. That
+// missing density is why the retention question shape - the shape behind all four banked go
+// wins - could not be asked of a php codebase at all.
+func TestHolderComposition(t *testing.T) {
+	em := mustRun(t, `<?php
+namespace App;
+
+use App\Services\Gateway;
+use App\Services\Logger;
+use App\Services\Mailer;
+
+class Checkout
+{
+    private Logger $log;
+
+    public function __construct(Gateway $gateway, private Mailer $mailer, string $label)
+    {
+        $this->gateway = $gateway;
+        $this->label = $label;
+    }
+}
+`)
+	// typed property: the type is on the declaration, as in Go
+	em.edge(t, model.EdgeComposes, `App\Checkout`, `App\Services\Logger`)
+	// promoted constructor parameter: declaration and assignment in one node
+	em.edge(t, model.EdgeComposes, `App\Checkout`, `App\Services\Mailer`)
+	// the dominant laravel shape: typed parameter assigned to a property
+	em.edge(t, model.EdgeComposes, `App\Checkout`, `App\Services\Gateway`)
+}
+
+// TestHolderCompositionNegatives pins what must NOT become a holder edge. An inference that
+// fires on the wrong assignment is worse than no inference, because it is indistinguishable
+// from a real one downstream.
+func TestHolderCompositionNegatives(t *testing.T) {
+	em := mustRun(t, `<?php
+namespace App;
+
+use App\Services\Gateway;
+use App\Services\Other;
+
+class Checkout
+{
+    public function __construct(Gateway $gateway, Other $other)
+    {
+        $local = $gateway;          // assigned to a LOCAL, the class holds nothing
+        $this->thing = $unrelated;  // property assigned an UNTYPED, unknown variable
+    }
+}
+`)
+	// Scoped to composes: `imports` edges for these classes legitimately exist from the
+	// `use` lines, so a kind-agnostic check would pass for the wrong reason.
+	composes := func(target string) bool {
+		for _, e := range em.edges {
+			if e.Kind == model.EdgeComposes && e.TargetQualified == target {
+				return true
+			}
+		}
+		return false
+	}
+	if composes(`App\Services\Gateway`) {
+		t.Error("a constructor parameter assigned to a local must not compose the class")
+	}
+	if composes(`App\Services\Other`) {
+		t.Error("a parameter that is never assigned to a property must not compose the class")
+	}
+}
+
+// TestHolderCompositionSelfReference pins the guard in emitHolds. A node type holding its
+// own class is a real relationship in the source, but as a graph edge it makes the class its
+// own dependent, which is noise in every consumer of the composition graph: blast would list
+// the subject inside its own radius. The edge is suppressed deliberately, not by accident.
+func TestHolderCompositionSelfReference(t *testing.T) {
+	em := mustRun(t, `<?php
+namespace App;
+
+class Node
+{
+    private Node $next;
+    private $untyped;
+
+    public function __construct(Node $parent)
+    {
+        $this->parent = $parent;
+    }
+}
+`)
+	for _, e := range em.edges {
+		if e.Kind == model.EdgeComposes {
+			t.Errorf("self-composition emitted an edge: %s -> %s", e.SourceQualified, e.TargetQualified)
+		}
+	}
+}

--- a/internal/extract/testdata/php/laravel.golden.json
+++ b/internal/extract/testdata/php/laravel.golden.json
@@ -121,6 +121,13 @@
     },
     {
       "source": "App\\Services\\Checkout",
+      "target": "App\\Contracts\\Gateway",
+      "kind": "composes",
+      "line": 14,
+      "confidence": 1
+    },
+    {
+      "source": "App\\Services\\Checkout",
       "target": "App\\Services\\BaseService",
       "kind": "inherits",
       "line": 9,
@@ -138,6 +145,13 @@
       "target": "App\\Services\\Chargeable",
       "kind": "inherits",
       "line": 9,
+      "confidence": 1
+    },
+    {
+      "source": "App\\Services\\Checkout",
+      "target": "App\\Support\\Logger",
+      "kind": "composes",
+      "line": 12,
       "confidence": 1
     },
     {


### PR DESCRIPTION
enhance(php): index holder relationships, so PHP has a composition graph

Ask Sense what holds a PHP object and until now it had nothing to say. The question
"what retains this object, and what breaks if I rework its lifecycle" is one of the most
useful things a code index can answer, and on PHP it came back empty. Not because the
relationships were missing from the code, but because of where PHP writes them down.

## Problem

Go declares a holder on the field, so `f io.Closer` is itself the composition edge. PHP puts
the type on the constructor parameter and links it to the property by assignment, which is two
facts joined by a name. Sense had already resolved both halves, it just never made the join:
the parameter-type environment existed for receiver resolution, and no edge was emitted.

Measured on the Laravel framework source, the shape that was not indexed is the dominant one:
235 typed constructor parameters and 1,343 property assignments, against 52 typed properties.

The consequence was not subtle. Laravel's `Application` is the object every subsystem holds,
and it had **zero** inbound composition edges. `retained_via_interfaces` returned **zero rows**.
The whole retention family of questions was unavailable on PHP, and the emptiness looked
exactly like a clean answer.

## Summary

Emits a composition edge for the three ways PHP declares a holder: a typed property, a
promoted constructor parameter, and a typed constructor parameter assigned to a property.

## Changes

- Typed property (`private Logger $log`) emits a holder edge. The type was already resolved
  here for receiver dispatch; only the edge was missing.
- Promoted constructor parameter (`__construct(private Mailer $m)`) does the same.
- Typed constructor parameter assigned to a property (`__construct(Gateway $g) { $this->g = $g; }`)
  is inferred from the assignment. This is the high-yield case.
- Self-composition is suppressed: a class holding its own type would otherwise appear inside
  its own blast radius.

## Effect, measured on the Laravel framework index

| | before | after |
|---|---|---|
| composes edges | 297 (0.31% of edges) | 689 (0.71%) |
| composes into `Application` | 0 | 13 |
| `retained_via_interfaces` on `Application` | 0 rows | 8 rows |
| `total_affected` for `Application` | 285 | 289 |

The last row matters as much as the others: this is not a radius explosion. It is a class of
edge that was structurally absent now being present.

## Architecture Highlights

- **Deliberately narrow.** The right-hand side must be a plain variable whose type is already
  resolved, and the left must be a property on `$this`. An assignment to a local, or from an
  untyped variable, yields nothing. A holder edge invented from a guess is indistinguishable
  downstream from one the source declared, which is worse than having none. Two negative
  fixtures pin exactly those cases.

- **Docblocks were considered and left out.** There are 623 `@var` annotations in the same
  tree, so including them would have roughly doubled the yield again. They were rejected on
  review: a stale `@var` is weaker evidence than a type the parser enforces, and mixing the two
  silently would make the graph mean two different things. If they are ever added they need a
  distinguishable confidence.

- **Honest limit.** 0.71% of edges against 3.3 to 5.5% in comparable Go repositories. The
  question shape is now available on PHP, roughly five times thinner. Whether that is enough in
  practice is a measurement, and this change does not predict it.

- **Scan layer, so indexes must rebuild.** Verified PHP-only rather than assumed: three
  non-PHP repositories (Go, Ruby, Python) were rescanned with the branch binary and their edge
  counts are byte identical.

## Test Plan

- [x] Repro seen failing first: a class with a typed property, a promoted parameter and an
      assigned parameter produced no composition edges
- [x] All three inference sites emit the expected edge
- [x] Negative: a parameter assigned to a local produces nothing
- [x] Negative: a property assigned an untyped variable produces nothing
- [x] Negative: a class holding its own type produces nothing
- [x] Golden fixture reviewed line by line before regenerating: two edges added, nothing
      removed or altered
- [x] Cross-language no-regress: Go, Ruby and Python repositories rescanned, edge counts
      byte identical
- [x] End to end on a real checkout: the retention ring populates for the first time on PHP
- [x] `make ci` green: build, coverage gate, lint, complexity ledger
- [x] Coverage on the new functions: 100% and 94.4%
- [x] `qlty check` clean
- [x] sense binary builds cleanly
