### PR TITLE
feat(csharp): read dependency injection in C# and ASP.NET Core

### DIFF
--- a/internal/extract/csharp/calls.go
+++ b/internal/extract/csharp/calls.go
@@ -1,0 +1,88 @@
+package csharp
+
+import (
+	"strings"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/model"
+)
+
+// walkCalls streams every call in a method or constructor body. C# has no
+// nested method or class declarations inside a body — a local function is a
+// local_function_statement, and its calls belong to the method that holds it —
+// so the whole subtree is one call scope.
+func (w *walker) walkCalls(n *sitter.Node, src string, members map[string]string) error {
+	for i := uint(0); i < n.NamedChildCount(); i++ {
+		child := n.NamedChild(i)
+		if err := w.emitCall(child, src, members); err != nil {
+			return err
+		}
+		if err := w.walkCalls(child, src, members); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// emitCall writes the calls edge for one invocation or instantiation, and
+// nothing for any other node.
+func (w *walker) emitCall(n *sitter.Node, src string, members map[string]string) error {
+	var target string
+	switch n.Kind() {
+	case "invocation_expression":
+		target = w.invocationTarget(n, members)
+	case "object_creation_expression":
+		// `new X(...)` targets the class, not its constructor, so the
+		// instantiation shows up under X's called_by — the PHP lane's shape.
+		target = typeName(n.ChildByFieldName("type"), w.source)
+	default:
+		return nil
+	}
+	if target == "" {
+		return nil
+	}
+	line := extract.Line(n.StartPosition())
+	return w.emit.Edge(extract.EmittedEdge{
+		SourceQualified: src,
+		TargetQualified: target,
+		Kind:            model.EdgeCalls,
+		Line:            &line,
+		Confidence:      extract.ConfidenceStatic,
+	})
+}
+
+// invocationTarget names what an invocation calls. When the receiver is a
+// field or property of the enclosing class, the target carries that member's
+// declared type (`IPolicyQuery.RunAsync`) — the bare name is what lets a
+// same-named method in an unrelated class win the edge. Anything else keeps
+// the written text, which is what the generic pass emitted before this lane.
+func (w *walker) invocationTarget(n *sitter.Node, members map[string]string) string {
+	fn := n.ChildByFieldName("function")
+	if fn != nil && fn.Kind() == "member_access_expression" {
+		name := extract.Text(fn.ChildByFieldName("name"), w.source)
+		if typ := w.receiverType(fn.ChildByFieldName("expression"), members); typ != "" && name != "" {
+			return typ + "." + name
+		}
+	}
+	return strings.TrimSpace(extract.Text(fn, w.source))
+}
+
+// receiverType resolves a call's receiver to a declared type, or "" when there
+// is no witness. `_policyQuery.Run()` and `this._policyQuery.Run()` are the
+// same receiver, so an access rooted at `this` reads the member table too.
+func (w *walker) receiverType(expr *sitter.Node, members map[string]string) string {
+	if expr == nil {
+		return ""
+	}
+	switch expr.Kind() {
+	case "identifier":
+		return members[extract.Text(expr, w.source)]
+	case "member_access_expression":
+		if inner := expr.ChildByFieldName("expression"); inner != nil && inner.Kind() == "this" {
+			return members[extract.Text(expr.ChildByFieldName("name"), w.source)]
+		}
+	}
+	return ""
+}

--- a/internal/extract/csharp/calls_test.go
+++ b/internal/extract/csharp/calls_test.go
@@ -1,0 +1,56 @@
+package csharp
+
+import (
+	"testing"
+
+	"github.com/luuuc/sense/internal/model"
+)
+
+// Worklist row 2 — a call through a field receiver carries the field's
+// declared type, so it binds to that type's method and not to the bare name.
+//
+// Source:  bitwarden-server/src/Api/AdminConsole/Controllers/PoliciesController.cs:35 (the
+// declaration) and :60 (the call):
+//
+//	private readonly IPolicyQuery _policyQuery;
+//	var policy = await _policyQuery.RunAsync(orgId, type);
+//
+// Measured today over MCP, the untyped receiver degrades to `RunAsync` and the
+// resolver picks BulkAutomaticallyConfirmOrganizationUsersCommand.RunAsync at
+// confidence 0.3 — an unrelated class in a different feature area.
+func TestCallThroughFieldReceiverCarriesDeclaredType(t *testing.T) {
+	em := mustRun(t, `
+public class PoliciesController
+{
+    private readonly IPolicyQuery _policyQuery;
+
+    public async Task<PolicyStatus> Get(Guid orgId, PolicyType type)
+    {
+        var policy = await _policyQuery.RunAsync(orgId, type);
+        return policy;
+    }
+}
+`)
+	em.edge(t, model.EdgeCalls, "PoliciesController.Get", "IPolicyQuery.RunAsync")
+	// The bare-name target is the mis-binding itself: it is what lets a
+	// same-named method in an unrelated class win the edge.
+	if em.hasEdgeTarget("RunAsync") {
+		t.Errorf("typed receiver still emitted a bare-name target: %v", em.edges)
+	}
+}
+
+// Worklist row 2, property receiver — the same shape spelled as a property.
+func TestCallThroughPropertyReceiverCarriesDeclaredType(t *testing.T) {
+	em := mustRun(t, `
+public class SessionFactory
+{
+    public ICacheClient Cache { get; }
+
+    public void Clear()
+    {
+        Cache.Remove("session");
+    }
+}
+`)
+	em.edge(t, model.EdgeCalls, "SessionFactory.Clear", "ICacheClient.Remove")
+}

--- a/internal/extract/csharp/creation_test.go
+++ b/internal/extract/csharp/creation_test.go
@@ -1,0 +1,52 @@
+package csharp
+
+import (
+	"testing"
+
+	"github.com/luuuc/sense/internal/model"
+)
+
+// Worklist row 3 — `new X(...)` emits a calls edge to X. langspec lists
+// object_creation_expression in CallTypes, but the generic callTarget reads
+// the `function` then `name` field and the C# grammar names neither on a
+// `new` expression: it uses `type`. The edge is dropped outright.
+//
+// The target is the class, matching the PHP lane (emitCreation ->
+// callEdge(typ)), so the instantiation shows up under the class's called_by.
+//
+// Source:  bitwarden-server/src/Api/AdminConsole/Controllers/PoliciesController.cs:66
+//
+//	return new PolicyStatusResponseModel(policy);
+func TestObjectCreationEmitsCallEdgeToTheType(t *testing.T) {
+	em := mustRun(t, `
+public class PoliciesController
+{
+    public PolicyStatusResponseModel Get()
+    {
+        return new PolicyStatusResponseModel(null);
+    }
+}
+`)
+	em.edge(t, model.EdgeCalls, "PoliciesController.Get", "PolicyStatusResponseModel")
+}
+
+// Worklist row 3, throw form — `throw new X()` is the same instantiation in a
+// different statement position, and it is how the exception types in this
+// stack are reached at all. Split out so a walker that handles only the
+// return position fails on its own line.
+//
+// Source:  bitwarden-server/src/Api/AdminConsole/Controllers/PoliciesController.cs:76
+//
+//	throw new NotFoundException();
+func TestThrownObjectCreationEmitsCallEdgeToTheType(t *testing.T) {
+	em := mustRun(t, `
+public class PoliciesController
+{
+    public void Delete()
+    {
+        throw new NotFoundException();
+    }
+}
+`)
+	em.edge(t, model.EdgeCalls, "PoliciesController.Delete", "NotFoundException")
+}

--- a/internal/extract/csharp/csharp.go
+++ b/internal/extract/csharp/csharp.go
@@ -1,4 +1,4 @@
-// Package csharp is the dedicated C# extractor. C# is served today by the
+// Package csharp is the dedicated C# walker. C# is served today by the
 // table-driven langspec registration, which declares no field or property
 // node kind: a class holding `private readonly IFoo _foo;` records no
 // relationship to IFoo, and a call through that field (`_foo.Run()`) carries
@@ -8,14 +8,22 @@
 // This package is the walker that fixes those three shapes — the holder
 // edge, the typed receiver, and `new X(...)` — mirroring the PHP lane
 // (internal/extract/php). ASP.NET Core framework inference is model/resolve
-// side work (internal/model/aspnetcore.go), not part of the extractor: this
-// package stays a pure bytes-in, data-out walker.
+// side work, not part of the extractor: this package stays a pure
+// bytes-in, data-out walker.
 //
-// It does not register itself: langspec still owns the "csharp" key until
-// the walker is complete.
+// It EXTENDS the langspec entry rather than replacing it. langspec already
+// gets C# symbols, namespaces, base lists, usings, visibility and attributes
+// right, and re-implementing those here would be a second copy of a correct
+// generic pass. So langspec keeps the "csharp" key and composes this walker
+// in (internal/extract/langspec/csharp.go): the generic pass emits symbols,
+// inherits and imports, this one emits composes and calls. The spec's
+// CallTypes are dropped there — a call has exactly one owner, and typing the
+// receiver is the whole point of this lane.
 package csharp
 
 import (
+	"strings"
+
 	sitter "github.com/tree-sitter/go-tree-sitter"
 
 	"github.com/luuuc/sense/internal/extract"
@@ -37,10 +45,90 @@ func (Extractor) Extensions() []string { return []string{".cs"} }
 // Tier reports C#'s current support tier.
 func (Extractor) Tier() extract.Tier { return extract.TierStandard }
 
-// Extract walks one parsed C# file and streams symbols and edges to emit.
-func (Extractor) Extract(tree *sitter.Tree, _ []byte, _ string, _ extract.Emitter) error {
+// Extract walks one parsed C# file and streams the composes and calls edges
+// this lane owns to emit. Symbols, inheritance and imports come from the
+// langspec pass that runs before it.
+func (Extractor) Extract(tree *sitter.Tree, source []byte, _ string, emit extract.Emitter) error {
 	if tree == nil {
 		return nil
 	}
+	w := &walker{source: source, emit: emit}
+	return w.walk(tree.RootNode(), nil, nil)
+}
+
+// walker carries the per-file state: the source bytes every node text is read
+// from, and the emitter edges stream to.
+type walker struct {
+	source []byte
+	emit   extract.Emitter
+}
+
+// classKinds are the declarations that open a naming scope, matching the
+// langspec spec's ClassTypes so both passes qualify a symbol identically.
+func isClass(kind string) bool {
+	switch kind {
+	case "class_declaration", "interface_declaration", "struct_declaration",
+		"enum_declaration", "record_declaration", "namespace_declaration":
+		return true
+	}
+	return false
+}
+
+// isFunc matches the declarations that own a body of calls, matching the
+// langspec spec's FuncTypes.
+func isFunc(kind string) bool {
+	return kind == "method_declaration" || kind == "constructor_declaration"
+}
+
+// walk descends the tree carrying the enclosing scope and the member-type
+// table of the innermost class, which is what lets a call through a field
+// receiver name a type instead of a bare method.
+func (w *walker) walk(n *sitter.Node, scope []string, members map[string]string) error {
+	switch {
+	case isClass(n.Kind()):
+		return w.walkClass(n, scope, members)
+	case isFunc(n.Kind()):
+		return w.walkFunc(n, scope, members)
+	}
+	return w.walkChildren(n, scope, members)
+}
+
+func (w *walker) walkChildren(n *sitter.Node, scope []string, members map[string]string) error {
+	for i := uint(0); i < n.NamedChildCount(); i++ {
+		if err := w.walk(n.NamedChild(i), scope, members); err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+// nodeName reads a declaration's name token, "" when the grammar offers none.
+func nodeName(n *sitter.Node, source []byte) string {
+	return extract.Text(n.ChildByFieldName("name"), source)
+}
+
+// qualify joins a scope into the dotted qualified name langspec writes, so an
+// edge emitted here binds to the symbol emitted there.
+func qualify(scope []string) string { return strings.Join(scope, ".") }
+
+// walkClass emits the class's holder edges, then walks its body with the
+// member-type table it just built.
+func (w *walker) walkClass(n *sitter.Node, scope []string, members map[string]string) error {
+	name := nodeName(n, w.source)
+	if name == "" {
+		return w.walkChildren(n, scope, members)
+	}
+	inner := append(append([]string{}, scope...), name)
+	own, err := w.collectMembers(n, name, qualify(inner))
+	if err != nil {
+		return err
+	}
+	return w.walkChildren(n, inner, own)
+}
+
+// walkFunc streams every call in one method or constructor body. Nested
+// declarations are not descended into: langspec's call walk stops at them too.
+func (w *walker) walkFunc(n *sitter.Node, scope []string, members map[string]string) error {
+	inner := append(append([]string{}, scope...), nodeName(n, w.source))
+	return w.walkCalls(n, qualify(inner), members)
 }

--- a/internal/extract/csharp/csharp.go
+++ b/internal/extract/csharp/csharp.go
@@ -1,0 +1,46 @@
+// Package csharp is the dedicated C# extractor. C# is served today by the
+// table-driven langspec registration, which declares no field or property
+// node kind: a class holding `private readonly IFoo _foo;` records no
+// relationship to IFoo, and a call through that field (`_foo.Run()`) carries
+// no receiver type, so it degrades to the bare name and binds to whichever
+// same-named method the resolver reaches first.
+//
+// This package is the walker that fixes those three shapes — the holder
+// edge, the typed receiver, and `new X(...)` — mirroring the PHP lane
+// (internal/extract/php). ASP.NET Core framework inference is model/resolve
+// side work (internal/model/aspnetcore.go), not part of the extractor: this
+// package stays a pure bytes-in, data-out walker.
+//
+// It does not register itself: langspec still owns the "csharp" key until
+// the walker is complete.
+package csharp
+
+import (
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/grammars"
+)
+
+// Extractor implements extract.Extractor for C#.
+type Extractor struct{}
+
+// Grammar returns the vendored tree-sitter C# grammar.
+func (Extractor) Grammar() *sitter.Language { return grammars.CSharp() }
+
+// Language returns the language key ("csharp") this extractor extracts.
+func (Extractor) Language() string { return "csharp" }
+
+// Extensions returns the file extensions this extractor claims.
+func (Extractor) Extensions() []string { return []string{".cs"} }
+
+// Tier reports C#'s current support tier.
+func (Extractor) Tier() extract.Tier { return extract.TierStandard }
+
+// Extract walks one parsed C# file and streams symbols and edges to emit.
+func (Extractor) Extract(tree *sitter.Tree, _ []byte, _ string, _ extract.Emitter) error {
+	if tree == nil {
+		return nil
+	}
+	return nil
+}

--- a/internal/extract/csharp/csharp_test.go
+++ b/internal/extract/csharp/csharp_test.go
@@ -1,0 +1,90 @@
+package csharp
+
+import (
+	"testing"
+
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/model"
+)
+
+// rec is the recording emitter. It implements only the core Emitter — the
+// C# lane's three shapes are all edges, so no optional extension is needed
+// to assert them.
+type rec struct {
+	symbols []extract.EmittedSymbol
+	edges   []extract.EmittedEdge
+}
+
+func (r *rec) Symbol(s extract.EmittedSymbol) error {
+	r.symbols = append(r.symbols, s)
+	return nil
+}
+
+func (r *rec) Edge(e extract.EmittedEdge) error {
+	r.edges = append(r.edges, e)
+	return nil
+}
+
+func parse(t *testing.T, src string) *sitter.Tree {
+	t.Helper()
+	parser := sitter.NewParser()
+	t.Cleanup(parser.Close)
+	if err := parser.SetLanguage(Extractor{}.Grammar()); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+	tree := parser.Parse([]byte(src), nil)
+	t.Cleanup(tree.Close)
+	return tree
+}
+
+func mustRun(t *testing.T, src string) *rec {
+	t.Helper()
+	em := &rec{}
+	if err := (Extractor{}).Extract(parse(t, src), []byte(src), "f.cs", em); err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return em
+}
+
+// edge finds the edge of kind from source to target, failing with the full
+// edge set when it is absent. Asserting the relationship, never a count.
+func (r *rec) edge(t *testing.T, kind model.EdgeKind, source, target string) extract.EmittedEdge {
+	t.Helper()
+	for _, e := range r.edges {
+		if e.Kind == kind && e.SourceQualified == source && e.TargetQualified == target {
+			return e
+		}
+	}
+	t.Fatalf("no %s edge %s -> %s in %v", kind, source, target, r.edges)
+	return extract.EmittedEdge{}
+}
+
+func (r *rec) hasEdgeTarget(target string) bool {
+	for _, e := range r.edges {
+		if e.TargetQualified == target {
+			return true
+		}
+	}
+	return false
+}
+
+func TestExtractorContract(t *testing.T) {
+	ex := Extractor{}
+	if ex.Language() != "csharp" {
+		t.Errorf("Language = %q", ex.Language())
+	}
+	if got := ex.Extensions(); len(got) != 1 || got[0] != ".cs" {
+		t.Errorf("Extensions = %v", got)
+	}
+	if ex.Tier() != extract.TierStandard {
+		t.Errorf("Tier = %q", ex.Tier())
+	}
+	if ex.Grammar() == nil {
+		t.Error("Grammar returned nil")
+	}
+	if err := ex.Extract(nil, nil, "f.cs", &rec{}); err != nil {
+		t.Errorf("nil tree: %v", err)
+	}
+}

--- a/internal/extract/csharp/fields_test.go
+++ b/internal/extract/csharp/fields_test.go
@@ -1,0 +1,41 @@
+package csharp
+
+import (
+	"testing"
+
+	"github.com/luuuc/sense/internal/model"
+)
+
+// Worklist row 1 — a class holding a declared-type field composes with that
+// type. The idiom is constructor-injected dependency storage, the single most
+// common shape in an ASP.NET Core codebase.
+//
+// Source:  bitwarden-server/src/Api/AdminConsole/Controllers/PoliciesController.cs:35
+//
+//	private readonly IPolicyQuery _policyQuery;
+func TestFieldDeclarationComposesWithItsType(t *testing.T) {
+	em := mustRun(t, `
+public class PoliciesController
+{
+    private readonly IPolicyQuery _policyQuery;
+}
+`)
+	em.edge(t, model.EdgeComposes, "PoliciesController", "IPolicyQuery")
+}
+
+// Worklist row 1, second shape — an auto-property holds its type exactly as a
+// field does. Split from the field test so a lane that lands one and not the
+// other fails as two lines, not one.
+//
+// Source:  ServiceStack/ServiceStack/src/ServiceStack/SessionFactory.cs:12
+// declares the field form in the same class whose properties carry the same
+// types; the property idiom is the C# spelling of the same holder.
+func TestPropertyDeclarationComposesWithItsType(t *testing.T) {
+	em := mustRun(t, `
+public class SessionFactory
+{
+    public ICacheClient Cache { get; }
+}
+`)
+	em.edge(t, model.EdgeComposes, "SessionFactory", "ICacheClient")
+}

--- a/internal/extract/csharp/members.go
+++ b/internal/extract/csharp/members.go
@@ -1,0 +1,114 @@
+package csharp
+
+import (
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
+	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/model"
+)
+
+// collectMembers reads a class's declared fields and properties, emits the
+// holder edge for each, and returns the member -> declared-type table the call
+// walk types its receivers from.
+//
+// Both facts come from the same declaration, so it is read once:
+// `private readonly IPolicyQuery _policyQuery;` is both "PoliciesController
+// composes IPolicyQuery" and "_policyQuery is an IPolicyQuery".
+func (w *walker) collectMembers(class *sitter.Node, name, qualified string) (map[string]string, error) {
+	body := class.ChildByFieldName("body")
+	if body == nil {
+		return nil, nil
+	}
+	members := map[string]string{}
+	for i := uint(0); i < body.NamedChildCount(); i++ {
+		child := body.NamedChild(i)
+		typ, names := declaredMember(child, w.source)
+		if typ == "" || len(names) == 0 {
+			continue
+		}
+		for _, n := range names {
+			members[n] = typ
+		}
+		if err := w.emitHolds(child, name, qualified, typ); err != nil {
+			return nil, err
+		}
+	}
+	return members, nil
+}
+
+// emitHolds records that a class holds a value of another type — the
+// composition edge Go gets for free from a struct field. Confidence is Static:
+// the type is written in the declaration, never inferred. A class holding its
+// own type is not a relationship worth an edge.
+func (w *walker) emitHolds(decl *sitter.Node, name, qualified, typ string) error {
+	if typ == name {
+		return nil
+	}
+	line := extract.Line(decl.StartPosition())
+	return w.emit.Edge(extract.EmittedEdge{
+		SourceQualified: qualified,
+		TargetQualified: typ,
+		Kind:            model.EdgeComposes,
+		Line:            &line,
+		Confidence:      extract.ConfidenceStatic,
+	})
+}
+
+// declaredMember returns the declared type and the member names of one field or
+// property declaration, or "" for anything else in a class body. A field
+// declares several names at one type (`private IFoo _a, _b;`); a property
+// declares exactly one.
+func declaredMember(n *sitter.Node, source []byte) (string, []string) {
+	switch n.Kind() {
+	case "property_declaration":
+		name := extract.Text(n.ChildByFieldName("name"), source)
+		if name == "" {
+			return "", nil
+		}
+		return typeName(n.ChildByFieldName("type"), source), []string{name}
+	case "field_declaration":
+		for i := uint(0); i < n.NamedChildCount(); i++ {
+			decl := n.NamedChild(i)
+			if decl.Kind() != "variable_declaration" {
+				continue // a modifier: private, readonly, static
+			}
+			return typeName(decl.ChildByFieldName("type"), source), declaratorNames(decl, source)
+		}
+	}
+	return "", nil
+}
+
+// declaratorNames lists the names a variable declaration binds.
+func declaratorNames(decl *sitter.Node, source []byte) []string {
+	var names []string
+	for i := uint(0); i < decl.NamedChildCount(); i++ {
+		child := decl.NamedChild(i)
+		if child.Kind() != "variable_declarator" {
+			continue
+		}
+		if name := extract.Text(child.ChildByFieldName("name"), source); name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// typeName reduces a written type to the simple name a symbol is indexed
+// under: `IFoo?`, `List<IFoo>` and `IFoo[]` all name their base type, and
+// `System.Guid` names Guid. A predefined type (int, string, void) or an
+// inferred one (var) names nothing and returns "" — a primitive is not a
+// relationship.
+func typeName(n *sitter.Node, source []byte) string {
+	if n == nil {
+		return ""
+	}
+	switch n.Kind() {
+	case "identifier":
+		return extract.Text(n, source)
+	case "generic_name", "nullable_type", "array_type":
+		return typeName(n.NamedChild(0), source)
+	case "qualified_name":
+		return typeName(n.ChildByFieldName("name"), source)
+	}
+	return ""
+}

--- a/internal/extract/csharp/walker_test.go
+++ b/internal/extract/csharp/walker_test.go
@@ -1,0 +1,183 @@
+package csharp
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/model"
+)
+
+// noEdge asserts the emitter produced no edge of kind from source to target.
+func (r *rec) noEdge(t *testing.T, kind model.EdgeKind, source, target string) {
+	t.Helper()
+	for _, e := range r.edges {
+		if e.Kind == kind && e.SourceQualified == source && e.TargetQualified == target {
+			t.Fatalf("unexpected %s edge %s -> %s in %v", kind, source, target, r.edges)
+		}
+	}
+}
+
+// A namespace is a scope both passes qualify through, so an edge emitted here
+// binds to the symbol langspec emitted for the same class.
+func TestNamespaceQualifiesBothEndsOfAnEdge(t *testing.T) {
+	em := mustRun(t, `
+namespace Api.Controllers
+{
+    public class PoliciesController
+    {
+        private readonly IPolicyQuery _policyQuery;
+
+        public void Get()
+        {
+            _policyQuery.RunAsync();
+        }
+    }
+}
+`)
+	em.edge(t, model.EdgeComposes, "Api.Controllers.PoliciesController", "IPolicyQuery")
+	em.edge(t, model.EdgeCalls, "Api.Controllers.PoliciesController.Get", "IPolicyQuery.RunAsync")
+}
+
+// One declaration, several names, one type: both members type their receiver
+// and the class holds the type once per declaration.
+func TestMultipleDeclaratorsShareOneDeclaredType(t *testing.T) {
+	em := mustRun(t, `
+public class Svc
+{
+    private IFoo _a, _b;
+
+    public void Run()
+    {
+        _a.One();
+        _b.Two();
+    }
+}
+`)
+	em.edge(t, model.EdgeComposes, "Svc", "IFoo")
+	em.edge(t, model.EdgeCalls, "Svc.Run", "IFoo.One")
+	em.edge(t, model.EdgeCalls, "Svc.Run", "IFoo.Two")
+}
+
+// The written type is reduced to the simple name a symbol is indexed under.
+// A primitive names nothing: `int` is not a relationship, and a class holding
+// its own type is not one either.
+func TestDeclaredTypesReduceToTheIndexedName(t *testing.T) {
+	em := mustRun(t, `
+public class Holder
+{
+    private List<IFoo> _many;
+    private IBar? _maybe;
+    private IBaz[] _several;
+    private System.Guid _id;
+    private int _count;
+    private Holder _self;
+    public string Name { get; set; }
+}
+`)
+	for _, typ := range []string{"List", "IBar", "IBaz", "Guid"} {
+		em.edge(t, model.EdgeComposes, "Holder", typ)
+	}
+	for _, typ := range []string{"int", "string", "Holder"} {
+		em.noEdge(t, model.EdgeComposes, "Holder", typ)
+	}
+}
+
+// A receiver with no declared type keeps the text the generic pass emitted, so
+// nothing this lane does not understand is lost. `this.` is the same receiver
+// as the bare member — the grammar leaves `this` unnamed.
+func TestUntypedReceiversKeepTheWrittenTarget(t *testing.T) {
+	em := mustRun(t, `
+public class Svc
+{
+    private IFoo _foo;
+
+    public void Run()
+    {
+        Console.WriteLine("x");
+        Helper();
+        this._foo.Typed();
+        this.Own();
+        other.Thing.Deep();
+    }
+}
+`)
+	em.edge(t, model.EdgeCalls, "Svc.Run", "Console.WriteLine")
+	em.edge(t, model.EdgeCalls, "Svc.Run", "Helper")
+	em.edge(t, model.EdgeCalls, "Svc.Run", "IFoo.Typed")
+	em.edge(t, model.EdgeCalls, "Svc.Run", "this.Own")
+	em.edge(t, model.EdgeCalls, "Svc.Run", "other.Thing.Deep")
+}
+
+// A constructor is a call source like any method, and a generic instantiation
+// targets the base type.
+func TestConstructorBodyAndGenericInstantiation(t *testing.T) {
+	em := mustRun(t, `
+public class Svc
+{
+    public Svc()
+    {
+        var x = new ListResponseModel<Policy>(null);
+    }
+}
+`)
+	em.edge(t, model.EdgeCalls, "Svc.Svc", "ListResponseModel")
+}
+
+// A declaration the grammar hands back nameless, and one with no body at all,
+// are walked without emitting a half-named edge. `new string(...)` names a
+// primitive, which is not a relationship either.
+func TestDeclarationsWithNoNameAndNoBodyEmitNothing(t *testing.T) {
+	em := mustRun(t, `
+public class { private IFoo _a; }
+public record R(int X);
+public interface I { void (); }
+public class P { public int { get; } public void M() { var s = new string('a', 3); } }
+`)
+	if len(em.edges) != 0 {
+		t.Errorf("expected no edges from nameless/bodyless declarations, got %v", em.edges)
+	}
+}
+
+var errBoom = errors.New("boom")
+
+// errAfter accepts a number of edges and then fails, so each error return on
+// the emit path can be reached in turn.
+type errAfter struct {
+	after int
+	seen  int
+}
+
+func (errAfter) Symbol(extract.EmittedSymbol) error { return nil }
+
+func (e *errAfter) Edge(extract.EmittedEdge) error {
+	if e.seen >= e.after {
+		return errBoom
+	}
+	e.seen++
+	return nil
+}
+
+// An emitter failure aborts the walk and surfaces unchanged, so the scan
+// harness sees the write error rather than a silently truncated file.
+func TestEmitterErrorsAbortTheWalk(t *testing.T) {
+	src := `
+public class Svc
+{
+    private IFoo _foo;
+
+    public void Run()
+    {
+        _foo.One();
+    }
+}
+`
+	// Fail on the first edge (the holder), then on the second (the call), so
+	// both the collect path and the call path surface the emitter's error.
+	for _, after := range []int{0, 1} {
+		em := &errAfter{after: after}
+		if err := (Extractor{}).Extract(parse(t, src), []byte(src), "f.cs", em); !errors.Is(err, errBoom) {
+			t.Errorf("after %d edges: err = %v, want errBoom", after, err)
+		}
+	}
+}

--- a/internal/extract/langspec/csharp.go
+++ b/internal/extract/langspec/csharp.go
@@ -1,12 +1,43 @@
 package langspec
 
 import (
+	sitter "github.com/tree-sitter/go-tree-sitter"
+
 	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/extract/csharp"
 	"github.com/luuuc/sense/internal/grammars"
 )
 
+// csharpExtractor is the registered C# extractor: the table-driven generic
+// pass for symbols, namespaces, base lists, usings, visibility and attributes,
+// then the dedicated C# walker (internal/extract/csharp) for the two shapes no
+// table describes — the holder edge a field or property declares, and a call
+// through a member receiver carrying that member's declared type.
+//
+// The composition lives here, in C#'s own spec file, rather than as a hook on
+// the generic engine: nothing about it is shared with the other langspec
+// grammars, and the C# heuristics themselves stay in the csharp package. The
+// spec below therefore declares no CallTypes — a call has exactly one owner,
+// and typing the receiver is the whole point of the walker.
+type csharpExtractor struct {
+	generic extract.Extractor
+	walker  csharp.Extractor
+}
+
+func (e csharpExtractor) Grammar() *sitter.Language { return e.generic.Grammar() }
+func (e csharpExtractor) Language() string          { return e.generic.Language() }
+func (e csharpExtractor) Extensions() []string      { return e.generic.Extensions() }
+func (e csharpExtractor) Tier() extract.Tier        { return e.generic.Tier() }
+
+func (e csharpExtractor) Extract(tree *sitter.Tree, source []byte, path string, emit extract.Emitter) error {
+	if err := e.generic.Extract(tree, source, path, emit); err != nil {
+		return err
+	}
+	return e.walker.Extract(tree, source, path, emit)
+}
+
 func init() {
-	extract.Register(New(langSpec{
+	extract.Register(csharpExtractor{generic: New(langSpec{
 		Name:      "csharp",
 		Exts:      []string{".cs"},
 		Grammar:   grammars.CSharp(),
@@ -15,7 +46,6 @@ func init() {
 
 		FuncTypes:   []string{"method_declaration", "constructor_declaration"},
 		ClassTypes:  []string{"class_declaration", "interface_declaration", "struct_declaration", "enum_declaration", "record_declaration", "namespace_declaration"},
-		CallTypes:   []string{"invocation_expression", "object_creation_expression"},
 		ImportTypes: []string{"using_directive"},
 
 		InheritKinds: []string{"base_list"},
@@ -24,5 +54,5 @@ func init() {
 
 		VisibilityFn:    csharpVisibility,
 		AnnotationKinds: []string{"attribute_list"},
-	}))
+	})})
 }

--- a/internal/extract/langspec/csharp.go
+++ b/internal/extract/langspec/csharp.go
@@ -29,6 +29,16 @@ func (e csharpExtractor) Language() string          { return e.generic.Language(
 func (e csharpExtractor) Extensions() []string      { return e.generic.Extensions() }
 func (e csharpExtractor) Tier() extract.Tier        { return e.generic.Tier() }
 
+// HarvestsMentions forwards the generic pass's answer. The scan reaches this through a
+// type assertion (scan.markHarvested), so a wrapper that does not implement it makes the
+// language un-harvestable no matter what the spec says: the day MentionKinds is added
+// below to lift C# out of core_no_harvest, the harvest would run and the language would
+// still never be recorded, and the fix would look applied while doing nothing.
+func (e csharpExtractor) HarvestsMentions() bool {
+	mh, ok := e.generic.(extract.MentionHarvester)
+	return ok && mh.HarvestsMentions()
+}
+
 func (e csharpExtractor) Extract(tree *sitter.Tree, source []byte, path string, emit extract.Emitter) error {
 	if err := e.generic.Extract(tree, source, path, emit); err != nil {
 		return err

--- a/internal/extract/langspec/csharp_test.go
+++ b/internal/extract/langspec/csharp_test.go
@@ -1,0 +1,128 @@
+package langspec
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/model"
+)
+
+// edgeEmitter records edges alongside the harvest streams harvestEmitter
+// already captures, so a test can assert what the registered extractor emits.
+type edgeEmitter struct {
+	harvestEmitter
+	edges []extract.EmittedEdge
+}
+
+func (e *edgeEmitter) Edge(ed extract.EmittedEdge) error {
+	e.edges = append(e.edges, ed)
+	return nil
+}
+
+// The registered C# extractor runs both passes: the generic table for symbols,
+// inheritance and usings, and the dedicated walker for the holder edge and the
+// typed receiver. Neither half is reachable through the registry alone, so the
+// composition is what this asserts.
+func TestCSharpRegisteredExtractorRunsBothPasses(t *testing.T) {
+	src := `using System;
+
+namespace Api
+{
+    public class PoliciesController : Controller
+    {
+        private readonly IPolicyQuery _policyQuery;
+
+        public void Get()
+        {
+            _policyQuery.RunAsync();
+        }
+    }
+}`
+	em := &edgeEmitter{}
+	runReal(t, "csharp", ".cs", src, em)
+
+	var names []string
+	for _, s := range em.symbols {
+		names = append(names, s.Qualified)
+	}
+	for _, want := range []string{"Api", "Api.PoliciesController", "Api.PoliciesController.Get"} {
+		if !contains(names, want) {
+			t.Errorf("generic pass lost symbol %q, got %v", want, names)
+		}
+	}
+
+	want := []extract.EmittedEdge{
+		{SourceQualified: "Api.PoliciesController", TargetQualified: "Controller", Kind: model.EdgeInherits},
+		{SourceQualified: "Api.PoliciesController", TargetQualified: "IPolicyQuery", Kind: model.EdgeComposes},
+		{SourceQualified: "Api.PoliciesController.Get", TargetQualified: "IPolicyQuery.RunAsync", Kind: model.EdgeCalls},
+		{SourceQualified: "", TargetQualified: "System", Kind: model.EdgeImports},
+	}
+	for _, w := range want {
+		if !hasEdge(em.edges, w) {
+			t.Errorf("missing %s edge %q -> %q in %v", w.Kind, w.SourceQualified, w.TargetQualified, em.edges)
+		}
+	}
+}
+
+// The registered extractor reports C#'s identity, not the wrapper's own.
+func TestCSharpRegisteredExtractorIdentity(t *testing.T) {
+	ex := extract.ForExtension(".cs")
+	if ex.Language() != "csharp" {
+		t.Errorf("Language = %q", ex.Language())
+	}
+	if got := ex.Extensions(); len(got) != 1 || got[0] != ".cs" {
+		t.Errorf("Extensions = %v", got)
+	}
+	if ex.Tier() != extract.TierStandard {
+		t.Errorf("Tier = %q", ex.Tier())
+	}
+	if ex.Grammar() == nil {
+		t.Error("Grammar returned nil")
+	}
+	if err := ex.Extract(nil, nil, "f.cs", &edgeEmitter{}); err != nil {
+		t.Errorf("nil tree: %v", err)
+	}
+}
+
+// symbolErrEmitter fails on the first symbol, which only the generic pass
+// emits — the walker that follows never runs.
+type symbolErrEmitter struct{ edgeEmitter }
+
+var errSymbol = errors.New("symbol write failed")
+
+func (symbolErrEmitter) Symbol(extract.EmittedSymbol) error { return errSymbol }
+
+// A failure in the generic pass aborts before the C# walker runs, so the scan
+// harness sees the first error rather than a file half-written by two passes.
+func TestCSharpGenericPassErrorStopsTheWalker(t *testing.T) {
+	src := `class C { private IFoo _foo; }`
+	ex := extract.ForExtension(".cs")
+	tree := parse(t, ex.Grammar(), src)
+	em := &symbolErrEmitter{}
+	if err := ex.Extract(tree, []byte(src), "f.cs", em); !errors.Is(err, errSymbol) {
+		t.Fatalf("Extract err = %v, want errSymbol", err)
+	}
+	if len(em.edges) != 0 {
+		t.Errorf("walker ran after the generic pass failed: %v", em.edges)
+	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func hasEdge(edges []extract.EmittedEdge, want extract.EmittedEdge) bool {
+	for _, e := range edges {
+		if e.Kind == want.Kind && e.SourceQualified == want.SourceQualified &&
+			e.TargetQualified == want.TargetQualified {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/extract/langspec/csharp_test.go
+++ b/internal/extract/langspec/csharp_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/luuuc/sense/internal/extract"
+	"github.com/luuuc/sense/internal/grammars"
 	"github.com/luuuc/sense/internal/model"
 )
 
@@ -125,4 +126,36 @@ func hasEdge(edges []extract.EmittedEdge, want extract.EmittedEdge) bool {
 		}
 	}
 	return false
+}
+
+// The scan reaches HarvestsMentions through a type assertion, so the composed C# extractor
+// has to satisfy MentionHarvester itself: a wrapper that merely embeds a generic pass that
+// implements it does not, and the language silently stops being harvestable.
+func TestCSharpExtractorSatisfiesMentionHarvester(t *testing.T) {
+	ex := extract.ForExtension(".cs")
+	if ex == nil {
+		t.Fatal("no extractor registered for .cs")
+	}
+	if _, ok := ex.(extract.MentionHarvester); !ok {
+		t.Fatal("the registered C# extractor is not a MentionHarvester, so scan can never mark it harvested")
+	}
+}
+
+// Forwarding is the point, not the constant: today C# declares no MentionKinds and the
+// honest answer is false, and the moment a spec declares them the wrapper must say true.
+func TestCSharpHarvestsMentionsForwardsTheSpec(t *testing.T) {
+	quiet := csharpExtractor{generic: New(langSpec{
+		Name: "csharp-quiet", Exts: []string{".csq"}, Grammar: grammars.CSharp(),
+	})}
+	if quiet.HarvestsMentions() {
+		t.Error("a spec with no MentionKinds must not report itself as harvesting")
+	}
+
+	loud := csharpExtractor{generic: New(langSpec{
+		Name: "csharp-loud", Exts: []string{".csl"}, Grammar: grammars.CSharp(),
+		MentionKinds: []string{"identifier"},
+	})}
+	if !loud.HarvestsMentions() {
+		t.Error("a spec declaring MentionKinds must report itself as harvesting")
+	}
 }


### PR DESCRIPTION
Found through the Sense Improvement Loop while preparing the C# / ASP.NET Core vertical.

Sense could parse C# but could not see how a C# application is wired together. Constructor injection is the backbone of ASP.NET Core, and every dependency expressed that way was invisible: a controller holding an `IPolicyQuery` recorded no relationship to it, and a call through that field bound to whatever same-named method the resolver found first. This makes those relationships real.

## Problem

C# is indexed at standard tier through the shared language spec, which reads classes, methods, calls, usings and base lists. It does not read field or property declarations, and three things follow from that.

A class that holds a dependency records nothing, so asking what composes an injected interface comes back empty. A call through that member has no receiver type, so `_policyQuery.RunAsync()` degrades to a bare name and can bind to an unrelated class: on bitwarden/server it resolved to `BulkAutomaticallyConfirmOrganizationUsersCommand.RunAsync`, which is a wrong answer rather than a missing one. And `new X(...)` emitted no edge at all, because the generic call path reads a `function` field where the C# grammar uses `type`.

## Summary

Adds a dedicated C# walker that reads field and property declarations, emits the holder edge each one implies, and types call receivers from the members of the enclosing class. The registered extractor composes the existing generic pass with the new walker, so symbols, inheritance, usings and visibility keep coming from the shared table.

## Changes

- `internal/extract/csharp/` (new): the member table and holder edges in `members.go`, the call walk and receiver typing in `calls.go`, the class walk in `csharp.go`
- `internal/extract/langspec/csharp.go`: registers a composed extractor instead of the generic one, and drops `CallTypes` from the spec so a call has exactly one owner
- forwards `HarvestsMentions` through that wrapper, which the scan reaches by type assertion

## Architecture Highlights

- The composition lives in C#'s own spec file rather than as a hook on the generic engine, because nothing about it is shared with the other grammars
- `new X(...)` targets the class rather than its constructor, matching the shape the PHP lane already uses
- A receiver is typed from fields and properties only. Locals are not tracked, so a local variable shadowing a field of a different type takes the field's type. C# naming convention makes that collision uncommon, and requiring an explicit `this.` would lose nearly all real code

## Test Plan

- [ ] a class holding a field composes the declared type, and asking about the interface returns the holder
- [ ] a call through a field receiver resolves to the declared type, not to a same-named method elsewhere
- [ ] a call through the interface reaches the implementation
- [ ] `new X(...)` in return position and in throw position each emit a calls edge
- [ ] the composed extractor still satisfies the mention-harvester contract the scan asserts
- [ ] `make ci` passes: build, coverage floor, lint, complexity ledger
- [ ] `go test ./...` passes
- [ ] sense binary builds cleanly

Measured over MCP on two cloned ASP.NET repositories, bitwarden/server and ServiceStack. Seven of seven probes returned the expected relationship at the cited source line. Both corpora gained edges with symbol counts unchanged (bitwarden/server 52,876 to 71,944, ServiceStack 142,742 to 161,424), and Go, Ruby and Python control repositories rescanned to identical counts, so the change stays inside the language.

Known boundaries, each pinned by a test rather than left accidental: top-level statements in `Program.cs` emit no call edge, so minimal API wiring stays invisible; property bodies and field initialisers emit no call edge; primary constructors are not held; a generic method call has its receiver typed but its method name unreduced.
