### PR TITLE
bench(lab): run one hard-coded scenario end to end

### DIFF
--- a/lab/cmd/sense-lab/signal_test.go
+++ b/lab/cmd/sense-lab/signal_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// Installing a signal handler and attaching the run to it are two different
+// things, and getting only the first is silent: the handler fires, the session
+// is not attached to it, and an interrupted campaign leaves the agent running,
+// unowned and still spending, with no record on disk. Because the session sits
+// in its own process group, a second Ctrl-C cannot reach it either.
+//
+// This drives the real binary rather than the cli package, because signalling
+// the test process would pollute handler state for every other test in it, and
+// the production path is the thing worth testing.
+func TestSIGTERMRecordsTheRunAndKillsTheAgentTree(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds and spawns the binary")
+	}
+
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "sense-lab")
+	build := exec.Command("go", "build", "-o", bin, ".")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build sense-lab: %v\n%s", err, out)
+	}
+
+	marker := filepath.Join(dir, "grandchild-still-running")
+	agent := filepath.Join(dir, "fake-agent")
+	// Reads the prompt, backgrounds a grandchild that would fire well after the
+	// signal, then waits. Killing only the direct child leaves the grandchild.
+	script := "#!/bin/sh\ncat >/dev/null\necho started\n(sleep 5; touch " + marker + ") &\nwait\n"
+	if err := os.WriteFile(agent, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	scenario := filepath.Join(dir, "scenario.yaml")
+	if err := os.WriteFile(scenario, []byte("name: t\nsteps:\n  - name: s\n    prompt: go\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out := filepath.Join(dir, "run")
+	lab := exec.Command(bin, "run",
+		"-scenario", scenario, "-repo", dir, "-out", out,
+		"-agent", agent, "-wall", "5m")
+	var labOut strings.Builder
+	lab.Stdout, lab.Stderr = &labOut, &labOut
+	if err := lab.Start(); err != nil {
+		t.Fatalf("start sense-lab: %v", err)
+	}
+
+	// Wait until the agent has actually started before interrupting. A fixed
+	// sleep races the first exec of a freshly built binary, and signalling too
+	// early tests the default handler rather than ours.
+	waitFor(t, func() bool {
+		b, err := os.ReadFile(filepath.Join(out, "raw", "stdout"))
+		return err == nil && strings.Contains(string(b), "started")
+	}, "the agent to start")
+
+	// Interrupt the way a campaign driver would.
+	if err := lab.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("signal: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- lab.Wait() }()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		_ = lab.Process.Kill()
+		t.Fatal("sense-lab ignored SIGTERM and ran on toward its wall")
+	}
+
+	// 1. The run is recorded. A spent run with no record can never be paired.
+	b, err := os.ReadFile(filepath.Join(out, "run-meta.json"))
+	if err != nil {
+		t.Fatalf("no record left by an interrupted run: %v\nsense-lab said:\n%s", err, labOut.String())
+	}
+	var m struct {
+		Outcome string `json:"outcome"`
+	}
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("decode run-meta.json: %v", err)
+	}
+
+	// 2. It is recorded as an interrupt, not as a budget failure. Conflating
+	//    the two puts a row on disk that reads exactly like a stalled arm.
+	if m.Outcome != "interrupted" {
+		t.Errorf("outcome = %q, want interrupted", m.Outcome)
+	}
+
+	// 3. The agent's own children died with it, rather than running on and
+	//    spending against a session nobody is waiting for.
+	time.Sleep(6 * time.Second)
+	if _, err := os.Stat(marker); err == nil {
+		t.Error("the agent's grandchild outlived the interrupt and kept running")
+	}
+
+	// The prompt is still on disk, so the interrupted run is readable.
+	if p, err := os.ReadFile(filepath.Join(out, "prompt.txt")); err != nil || !strings.Contains(string(p), "go") {
+		t.Errorf("prompt.txt = %q, %v", p, err)
+	}
+}
+
+// waitFor polls until cond holds, so a test does not race a process it just
+// started. It fails rather than hanging if the condition never arrives.
+func waitFor(t *testing.T, cond func() bool, what string) {
+	t.Helper()
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}

--- a/lab/internal/cli/cli.go
+++ b/lab/internal/cli/cli.go
@@ -9,8 +9,12 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"os"
+	"os/signal"
+	"syscall"
 )
 
 // Version is set at build time via ldflags. The symbol is sense-lab's own,
@@ -21,18 +25,27 @@ var Version = "0.0.0-dev"
 
 const usage = `sense-lab — the bench instrument for Sense
 
-Usage: sense-lab <command>
+Usage: sense-lab <command> [flags]
 
 Commands:
+  run       Run one scenario against one repository
   version   Print version
 `
 
 // Exit codes. sense-lab keeps its own table rather than sense's: it is a
 // separate binary with a separate surface, and sense already spends 2 on a
 // symbol issue.
+//
+// A run that failed or could not finish inside its budget exits 1: it is a
+// result, and reporting it as success would let a stalled arm pass unnoticed.
 const (
 	exitOK    = 0
+	exitError = 1
 	exitUsage = 2
+	// exitCannotFinish is its own code so a caller can tell a bankable result
+	// from a broken binary without parsing JSON: a run that hit its wall left a
+	// record on disk, a run that exited 1 may not have.
+	exitCannotFinish = 3
 )
 
 // Run dispatches args to a subcommand and returns the process exit code.
@@ -44,6 +57,16 @@ func Run(args []string, stdout, stderr io.Writer) int {
 		return exitUsage
 	}
 	switch args[0] {
+	case "run":
+		// A run must die with the binary. Without this the cancel path the
+		// runner carefully distinguishes can never fire in production:
+		// interrupting a campaign would leave the agent running, unattended,
+		// unowned and still spending, with no record on disk — and because the
+		// session is in its own process group, a second Ctrl-C cannot reach it
+		// either.
+		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		defer stop()
+		return runSession(ctx, args[1:], stdout, stderr)
 	case "version":
 		_, _ = fmt.Fprintln(stdout, Version)
 		return exitOK

--- a/lab/internal/cli/cli_test.go
+++ b/lab/internal/cli/cli_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 )
 
-// run is a test helper: it calls Run with fresh buffers and returns the code
+// dispatch is a test helper: it calls Run with fresh buffers and returns the code
 // plus what landed on each stream.
-func run(t *testing.T, args ...string) (code int, stdout, stderr string) {
+func dispatch(t *testing.T, args ...string) (code int, stdout, stderr string) {
 	t.Helper()
 	var out, errb bytes.Buffer
 	code = Run(args, &out, &errb)
@@ -24,7 +24,7 @@ func TestVersionPrintsTheBuildStampToStdout(t *testing.T) {
 	t.Cleanup(func() { Version = old })
 	Version = "1.2.3-dev+gdeadbee"
 
-	code, stdout, stderr := run(t, "version")
+	code, stdout, stderr := dispatch(t, "version")
 
 	if code != 0 {
 		t.Errorf("exit = %d, want 0", code)
@@ -41,7 +41,7 @@ func TestVersionPrintsTheBuildStampToStdout(t *testing.T) {
 // must not pollute stdout: a caller piping `sense-lab version` into another
 // command would otherwise consume the usage text as data.
 func TestUnknownCommandIsAUsageErrorOnStderr(t *testing.T) {
-	code, stdout, stderr := run(t, "measure")
+	code, stdout, stderr := dispatch(t, "measure")
 
 	if code != 2 {
 		t.Errorf("exit = %d, want 2", code)
@@ -58,7 +58,7 @@ func TestUnknownCommandIsAUsageErrorOnStderr(t *testing.T) {
 }
 
 func TestNoArgsIsAUsageErrorOnStderr(t *testing.T) {
-	code, stdout, stderr := run(t)
+	code, stdout, stderr := dispatch(t)
 
 	if code != 2 {
 		t.Errorf("exit = %d, want 2", code)
@@ -76,7 +76,7 @@ func TestNoArgsIsAUsageErrorOnStderr(t *testing.T) {
 func TestHelpSucceedsOnStdout(t *testing.T) {
 	for _, arg := range []string{"help", "-h", "--help"} {
 		t.Run(arg, func(t *testing.T) {
-			code, stdout, stderr := run(t, arg)
+			code, stdout, stderr := dispatch(t, arg)
 
 			if code != 0 {
 				t.Errorf("exit = %d, want 0", code)
@@ -95,7 +95,7 @@ func TestHelpSucceedsOnStdout(t *testing.T) {
 // dispatcher's: an extra argument must not turn a known command into a usage
 // error.
 func TestTrailingArgumentsDoNotBreakDispatch(t *testing.T) {
-	code, _, stderr := run(t, "version", "--json")
+	code, _, stderr := dispatch(t, "version", "--json")
 
 	if code != 0 {
 		t.Errorf("exit = %d, want 0 (stderr: %q)", code, stderr)

--- a/lab/internal/cli/runcmd.go
+++ b/lab/internal/cli/runcmd.go
@@ -1,0 +1,145 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/luuuc/sense/lab/internal/run"
+	"github.com/luuuc/sense/lab/internal/scenario"
+)
+
+// The walking skeleton's target, hard-coded. Cycle 01 replaces every constant
+// here with config as data; until then the point is to have one path work end
+// to end, not to have it be configurable.
+//
+// The scenario is the two-step probe rather than the seven-step session so a
+// live run stays short, and discourse is banked on the headline model, so the
+// number this produces has something recorded to be checked against.
+const (
+	defaultWall  = 8 * time.Minute
+	defaultAgent = "claude"
+)
+
+// defaultAgentArgs drives the agent CLI headlessly with the prompt on stdin.
+// The prompt goes on stdin rather than as the value of -p because a prompt
+// beginning with a dash is read as an option: that killed a spawn before it ran
+// a single step, and the driver reported the crash as a failing check.
+//
+// Permission prompts are bypassed because there is nobody at the terminal; an
+// unattended session that stops to ask a question just burns its wall.
+var defaultAgentArgs = []string{
+	"-p",
+	"--output-format", "stream-json",
+	"--verbose",
+	"--permission-mode", "bypassPermissions",
+}
+
+// defaultAgentEnv marks the session as unattended. It does NOT isolate it:
+// measured against a real spawn, the operator's own ~/.claude/CLAUDE.md and the
+// subject repository's CLAUDE.md are both still loaded into every benched
+// session, so instructions neither arm was meant to have are in both arms.
+// There is no isolation in this cycle and this env does not provide any; cycle
+// 03 owns it, and 03-02 records what has to be closed.
+var defaultAgentEnv = []string{
+	"IS_SANDBOX=1",
+	"CLAUDE_CODE_DISABLE_AUTO_MEMORY=1",
+}
+
+// runFlags is the parsed form of `sense-lab run`. Every field is a path or a
+// duration the skeleton needs and cycle 01 will take over.
+type runFlags struct {
+	scenario string
+	repo     string
+	out      string
+	agent    string
+	wall     time.Duration
+}
+
+func parseRunFlags(args []string, stderr io.Writer) (runFlags, error) {
+	var f runFlags
+	fs := flag.NewFlagSet("run", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.StringVar(&f.scenario, "scenario", "", "path to the scenario file (required)")
+	fs.StringVar(&f.repo, "repo", "", "path to the repository to run against (required)")
+	fs.StringVar(&f.out, "out", "", "directory to write the run into (required)")
+	fs.StringVar(&f.agent, "agent", defaultAgent, "agent CLI to drive")
+	fs.DurationVar(&f.wall, "wall", defaultWall, "how long the session may take")
+	if err := fs.Parse(args); err != nil {
+		return f, err
+	}
+	for _, required := range []struct {
+		name, value string
+	}{
+		{"-scenario", f.scenario},
+		{"-repo", f.repo},
+		{"-out", f.out},
+	} {
+		if required.value == "" {
+			return f, fmt.Errorf("%s is required", required.name)
+		}
+	}
+	return f, nil
+}
+
+// runSession is the whole skeleton: read the scenario, render it, spawn the
+// agent against the repository under a wall, and leave a run directory behind.
+func runSession(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	f, err := parseRunFlags(args, stderr)
+	if err != nil {
+		if err != flag.ErrHelp {
+			_, _ = fmt.Fprintf(stderr, "sense-lab run: %v\n", err)
+		}
+		return exitUsage
+	}
+
+	s, err := scenario.Load(f.scenario)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab run: %v\n", err)
+		return exitError
+	}
+
+	// The absolute path is what gets recorded, so a run is readable from
+	// anywhere later. Abs only fails when the working directory cannot be
+	// resolved, and it returns the path unchanged when it does, so the Stat
+	// below is the check that matters either way.
+	repo, _ := filepath.Abs(f.repo)
+	if _, err := os.Stat(repo); err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab run: repository: %v\n", err)
+		return exitError
+	}
+
+	_, _ = fmt.Fprintf(stdout, "scenario: %s\nrepo:     %s\nwall:     %s\n\n", s.Name, repo, f.wall)
+
+	m, err := run.Session(ctx, f.out, run.Spec{
+		Dir:   repo,
+		Name:  f.agent,
+		Args:  defaultAgentArgs,
+		Stdin: s.Prompt(),
+		Env:   defaultAgentEnv,
+		Wall:  f.wall,
+	})
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab run: %v\n", err)
+		return exitError
+	}
+
+	_, _ = fmt.Fprintf(stdout, "outcome:  %s\nexit:     %d\ntook:     %.1fs\nrun:      %s\n",
+		m.Outcome, m.ExitCode, m.TookSeconds, f.out)
+
+	// A run that could not finish inside its budget is a result, and the exit
+	// code says so rather than pretending the session succeeded. The wall is
+	// never raised to rescue it.
+	switch m.Outcome {
+	case run.Completed:
+		return exitOK
+	case run.CannotFinishAtBudget:
+		return exitCannotFinish
+	default:
+		return exitError
+	}
+}

--- a/lab/internal/cli/runcmd_test.go
+++ b/lab/internal/cli/runcmd_test.go
@@ -1,0 +1,319 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// These tests drive the real `sense-lab run` path end to end against a fake
+// agent: a shell script that behaves the way an agent CLI does. Nothing here
+// calls a model, touches the network, or spends anything.
+
+const twoStepScenario = `
+name: audit the category contract
+repo: discourse
+description: You are a maintainer about to rework a class.
+steps:
+  - name: Map the contract
+    prompt: Trace the resolution path end to end.
+  - name: Audit the dependents
+    prompt: Find everywhere that would have to change with it.
+`
+
+// fakeAgent writes an executable script that copies its stdin to stdout, so a
+// test can assert what the prompt actually looked like on the other side, then
+// exits with the code it was built for.
+func fakeAgent(t *testing.T, exitCode string, extra string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fake-agent")
+	body := "#!/bin/sh\ncat\n" + extra + "\nexit " + exitCode + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func scenarioFile(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "scenario.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestRunDrivesTheAgentAndLeavesARunDirectory(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "run-1")
+
+	code, stdout, stderr := dispatch(t, "run",
+		"-scenario", scenarioFile(t, twoStepScenario),
+		"-repo", t.TempDir(),
+		"-out", out,
+		"-agent", fakeAgent(t, "0", ""),
+	)
+
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (stderr: %s)", code, stderr)
+	}
+	if !strings.Contains(stdout, "audit the category contract") {
+		t.Errorf("stdout does not name the scenario:\n%s", stdout)
+	}
+
+	// The prompt the agent actually received, recovered from the capture.
+	raw, err := os.ReadFile(filepath.Join(out, "raw", "stdout"))
+	if err != nil {
+		t.Fatalf("raw/stdout: %v", err)
+	}
+	for _, want := range []string{
+		"You are a maintainer about to rework a class.",
+		"Step 1: Map the contract",
+		"Step 2: Audit the dependents",
+	} {
+		if !strings.Contains(string(raw), want) {
+			t.Errorf("the agent never received %q:\n%s", want, raw)
+		}
+	}
+
+	b, err := os.ReadFile(filepath.Join(out, "run-meta.json"))
+	if err != nil {
+		t.Fatalf("run-meta.json: %v", err)
+	}
+	var m struct {
+		Outcome string `json:"outcome"`
+	}
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("decode run-meta.json: %v", err)
+	}
+	if m.Outcome != "completed" {
+		t.Errorf("outcome = %q, want completed", m.Outcome)
+	}
+}
+
+// A run that could not finish inside its budget is a result. Reporting success
+// would let a stalled arm pass unnoticed, which is exactly how a wall gets
+// raised to rescue one.
+func TestARunThatOverrunsItsWallExitsNonZero(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "run-1")
+
+	code, stdout, _ := dispatch(t, "run",
+		"-scenario", scenarioFile(t, twoStepScenario),
+		"-repo", t.TempDir(),
+		"-out", out,
+		"-agent", fakeAgent(t, "0", "sleep 60"),
+		"-wall", "300ms",
+	)
+
+	// Its own code, distinct from a failed agent and from a broken binary: a
+	// run that hit its wall left a record on disk and is bankable as a result.
+	if code != 3 {
+		t.Errorf("exit = %d, want 3 for a run that hit its wall", code)
+	}
+	if !strings.Contains(stdout, "cannot finish at budget") {
+		t.Errorf("stdout does not report the wall:\n%s", stdout)
+	}
+}
+
+func TestAnAgentThatFailsExitsNonZero(t *testing.T) {
+	code, stdout, _ := dispatch(t, "run",
+		"-scenario", scenarioFile(t, twoStepScenario),
+		"-repo", t.TempDir(),
+		"-out", filepath.Join(t.TempDir(), "run-1"),
+		"-agent", fakeAgent(t, "7", ""),
+	)
+
+	if code != 1 {
+		t.Errorf("exit = %d, want 1 for an agent that exited 7", code)
+	}
+	if !strings.Contains(stdout, "failed") {
+		t.Errorf("stdout does not report the failure:\n%s", stdout)
+	}
+}
+
+// Everything below fails before anything is spawned. A run that is going to be
+// rejected must be rejected before the agent starts, not after it has spent
+// eight minutes.
+func TestRunRejectsBadInputBeforeSpawningAnything(t *testing.T) {
+	good := scenarioFile(t, twoStepScenario)
+	agent := fakeAgent(t, "0", "")
+
+	// The code matters as much as the rejection: 2 says you typed it wrong, 1
+	// says the run could not proceed. A caller script branches on that.
+	for _, tc := range []struct {
+		name     string
+		args     []string
+		want     string
+		wantCode int
+	}{
+		{
+			name: "no scenario", wantCode: 2,
+			args: []string{"-repo", t.TempDir(), "-out", t.TempDir()},
+			want: "-scenario is required",
+		},
+		{
+			name: "no repo", wantCode: 2,
+			args: []string{"-scenario", good, "-out", t.TempDir()},
+			want: "-repo is required",
+		},
+		{
+			name: "no out", wantCode: 2,
+			args: []string{"-scenario", good, "-repo", t.TempDir()},
+			want: "-out is required",
+		},
+		{
+			name: "an unknown flag", wantCode: 2,
+			args: []string{"-scenario", good, "-repo", t.TempDir(), "-out", t.TempDir(), "-model", "x"},
+			want: "flag provided but not defined",
+		},
+		{
+			name: "a scenario that does not exist", wantCode: 1,
+			args: []string{"-scenario", "/no/such/scenario.yaml", "-repo", t.TempDir(), "-out", t.TempDir()},
+			want: "read scenario",
+		},
+		{
+			name: "a repository that does not exist", wantCode: 1,
+			args: []string{"-scenario", good, "-repo", "/no/such/repo", "-out", t.TempDir()},
+			want: "repository",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			code, _, stderr := dispatch(t, append([]string{"run", "-agent", agent}, tc.args...)...)
+
+			if code != tc.wantCode {
+				t.Errorf("exit = %d, want %d", code, tc.wantCode)
+			}
+			if !strings.Contains(stderr, tc.want) {
+				t.Errorf("stderr = %q, want it to name %q", stderr, tc.want)
+			}
+		})
+	}
+}
+
+// The session must run inside the repository under study, not wherever the
+// binary happened to be invoked: an agent pointed at the wrong tree produces a
+// plausible answer about the wrong code.
+func TestTheAgentRunsInsideTheRepository(t *testing.T) {
+	repo := t.TempDir()
+	out := filepath.Join(t.TempDir(), "run-1")
+	agent := filepath.Join(t.TempDir(), "fake-agent")
+	if err := os.WriteFile(agent, []byte("#!/bin/sh\ncat >/dev/null\npwd\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if code, _, stderr := dispatch(t, "run",
+		"-scenario", scenarioFile(t, twoStepScenario),
+		"-repo", repo, "-out", out, "-agent", agent,
+	); code != 0 {
+		t.Fatalf("exit = %d (stderr: %s)", code, stderr)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(out, "raw", "stdout"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := filepath.EvalSymlinks(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := filepath.EvalSymlinks(strings.TrimSpace(string(raw)))
+	if err != nil {
+		t.Fatalf("resolve %q: %v", raw, err)
+	}
+	if got != want {
+		t.Errorf("the agent ran in %q, want the repository %q", got, want)
+	}
+}
+
+// A run that cannot be recorded must not be reported as a run that happened.
+func TestARunThatCannotBeRecordedExitsNonZero(t *testing.T) {
+	// -out points inside an existing file, so the run directory cannot be made.
+	blocked := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(blocked, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code, _, stderr := dispatch(t, "run",
+		"-scenario", scenarioFile(t, twoStepScenario),
+		"-repo", t.TempDir(),
+		"-out", filepath.Join(blocked, "run-1"),
+		"-agent", fakeAgent(t, "0", ""),
+	)
+
+	if code == 0 {
+		t.Error("exit = 0 for a run that could not be written")
+	}
+	if !strings.Contains(stderr, "prepare run directory") {
+		t.Errorf("stderr = %q, want it to name the failure", stderr)
+	}
+}
+
+// The two literals in runcmd.go ARE the hard-coded run, and both carry a
+// contract. --permission-mode bypassPermissions is what stops an unattended
+// session stalling on a question until its wall expires, and the env marks the
+// session as a sandbox. Nothing else in the suite notices if either is dropped,
+// and a flag that silently stops being passed costs a whole run to discover.
+func TestTheAgentIsInvokedHeadlessAndUnattended(t *testing.T) {
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "args")
+	envFile := filepath.Join(dir, "env")
+	agent := filepath.Join(dir, "recording-agent")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" >" + argsFile + "\nenv >" + envFile + "\ncat\n"
+	if err := os.WriteFile(agent, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	out := filepath.Join(t.TempDir(), "run-1")
+	if code, _, stderr := dispatch(t, "run",
+		"-scenario", scenarioFile(t, twoStepScenario),
+		"-repo", t.TempDir(), "-out", out, "-agent", agent,
+	); code != 0 {
+		t.Fatalf("exit = %d (stderr: %s)", code, stderr)
+	}
+
+	gotArgs := read(t, argsFile)
+	for _, want := range []string{"-p", "--permission-mode", "bypassPermissions"} {
+		if !strings.Contains(gotArgs, want) {
+			t.Errorf("the agent was not given %q:\n%s", want, gotArgs)
+		}
+	}
+
+	gotEnv := read(t, envFile)
+	for _, want := range []string{"IS_SANDBOX=1", "CLAUDE_CODE_DISABLE_AUTO_MEMORY=1"} {
+		if !strings.Contains(gotEnv, want) {
+			t.Errorf("the agent did not receive %q", want)
+		}
+	}
+	// The env adds to the host's rather than replacing it: an agent CLI needs
+	// PATH and HOME to run at all.
+	if !strings.Contains(gotEnv, "PATH=") {
+		t.Error("the agent lost the host PATH")
+	}
+
+	// Whatever the agent was invoked with must be in the record, or a run
+	// cannot be told apart from one made with different flags.
+	rec := read(t, filepath.Join(out, "run-meta.json"))
+	if !strings.Contains(rec, "bypassPermissions") {
+		t.Errorf("run-meta.json does not record the arguments:\n%s", rec)
+	}
+}
+
+func read(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+// -help on a subcommand is a request, not a mistake: it must not be reported as
+// an error on stderr on top of the usage flag package already printed.
+func TestRunHelpIsNotReportedAsAnError(t *testing.T) {
+	_, _, stderr := dispatch(t, "run", "-help")
+
+	if strings.Contains(stderr, "sense-lab run:") {
+		t.Errorf("asking for help produced an error message:\n%s", stderr)
+	}
+}

--- a/lab/internal/run/proc_unix.go
+++ b/lab/internal/run/proc_unix.go
@@ -1,0 +1,28 @@
+//go:build unix
+
+package run
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setProcessGroup puts the child in its own process group so the whole tree can
+// be signalled at once. An agent CLI spawns children of its own, and killing
+// only the parent leaves them alive holding the output pipe: the wall passes,
+// the run never ends, and the cell's other arm is burned with it. That has
+// already happened once, to a 312-second run reaped by a launcher that looked
+// detached and was not.
+func setProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// killGroup signals the child's whole process group. It runs as cmd.Cancel,
+// which os/exec invokes only after the process has started, so cmd.Process is
+// set and the negative pid is certainly this session's group rather than one
+// the OS has recycled.
+func killGroup(cmd *exec.Cmd) error {
+	// A group that has already gone is the normal race, not a failure.
+	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	return nil
+}

--- a/lab/internal/run/run.go
+++ b/lab/internal/run/run.go
@@ -1,0 +1,253 @@
+// Package run spawns one agent session under a wall and records what happened.
+//
+// It is the effectful half of the walking skeleton and it is deliberately thin:
+// it spawns a command, streams its output to disk, enforces a wall, and writes a
+// run directory. It decides nothing about scenarios, subjects or scores.
+//
+// Everything here is provisional. Cycle 03 replaces it with the isolated
+// executor, and the run directory layout is settled by cycle 02 once the whole
+// corpus has been read through it.
+package run
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Outcome is how a session ended. The wall case is a first-class result, not an
+// error: a run that exceeds its budget has told you something, and the honest
+// record of it is what stops anyone raising the wall to rescue a stalled arm.
+type Outcome string
+
+const (
+	// Completed: the process exited on its own with status 0.
+	Completed Outcome = "completed"
+	// Failed: the process exited on its own with a non-zero status.
+	Failed Outcome = "failed"
+	// CannotFinishAtBudget: the wall expired and the process was killed.
+	CannotFinishAtBudget Outcome = "cannot finish at budget"
+	// Interrupted: the caller's context was cancelled and the process was
+	// killed. This is NOT a budget failure and must never be read as one: an
+	// operator pressing Ctrl-C says nothing about whether the session could
+	// have finished, and a row that conflates the two reads as a stalled arm.
+	Interrupted Outcome = "interrupted"
+)
+
+// Spec is one session to run. Paths are absolute.
+type Spec struct {
+	// Dir is the working directory the command is spawned in.
+	Dir string
+	// Name and Args are the command to spawn.
+	Name string
+	Args []string
+	// Stdin is handed to the process on its standard input. Agent CLIs take
+	// their prompt this way; a prompt beginning with a dash is read as an
+	// option when passed as an argument, which has already killed a spawn.
+	Stdin string
+	// Env is added to the parent environment, as KEY=VALUE. There is no
+	// isolation this cycle: the session inherits the host environment and this
+	// only adds to it. Cycle 03 replaces the whole of that.
+	Env []string
+	// Wall is how long the process may take. It is part of run identity and is
+	// never raised to rescue a stalled arm.
+	Wall time.Duration
+}
+
+// Meta is the self-describing record left in every run directory. It is what a
+// later query answers from, so it records the wall that was set as well as the
+// time actually taken: a run at 481 seconds against a 480 second wall reads
+// very differently from one that finished in 30.
+type Meta struct {
+	Outcome     Outcome  `json:"outcome"`
+	ExitCode    int      `json:"exit_code"`
+	WallSeconds float64  `json:"wall_seconds"`
+	TookSeconds float64  `json:"took_seconds"`
+	Command     string   `json:"command"`
+	Args        []string `json:"args"`
+	StartedAt   string   `json:"started_at"`
+}
+
+// exitCodeKilled is what Meta records when the process was killed from outside.
+// Its real code is meaningless once we sent the signal, and 124 is what
+// timeout(1) uses.
+const exitCodeKilled = 124
+
+// metaFile is the run's self-describing record. Its presence marks a directory
+// as holding a run that already happened.
+const metaFile = "run-meta.json"
+
+// Session runs one Spec to completion, to failure, or to its wall, streaming
+// stdout and stderr to files under dir/raw/ as they arrive. It returns the Meta
+// it wrote. An error means the run could not be recorded at all; a process that
+// failed or hit its wall is a Meta, not an error.
+//
+// One honest limit: a child that exits cleanly having left its own children
+// running is reaped immediately, and those orphans still hold the capture files
+// and can write into them after run-meta.json lands. Every path that kills the
+// session signals the whole group, so this only affects a session that ended by
+// itself. Cycle 03's isolation is what closes it properly.
+func Session(ctx context.Context, dir string, s Spec) (Meta, error) {
+	// A recorded run is paid for and can never be recreated: the model is
+	// nondeterministic and the spend is already gone. Refuse to write over one
+	// rather than silently destroying it, which is what a repeated command with
+	// the same -out would otherwise do.
+	if _, err := os.Stat(filepath.Join(dir, metaFile)); err == nil {
+		return Meta{}, fmt.Errorf("%s already holds a recorded run; runs are immutable, use a new directory", dir)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "raw"), 0o755); err != nil {
+		return Meta{}, fmt.Errorf("prepare run directory: %w", err)
+	}
+
+	// The prompt is the run's input. Without it on disk the directory records
+	// what happened but not what was asked, so it can be neither reproduced nor
+	// invalidated.
+	if err := os.WriteFile(filepath.Join(dir, "prompt.txt"), []byte(s.Stdin), 0o644); err != nil {
+		return Meta{}, fmt.Errorf("write prompt: %w", err)
+	}
+
+	stdout, stderr, err := rawFiles(dir)
+	if err != nil {
+		return Meta{}, err
+	}
+	defer func() { _ = stdout.Close(); _ = stderr.Close() }()
+
+	started := time.Now()
+	code, ended, err := spawn(ctx, s, stdout, stderr)
+	if err != nil {
+		return Meta{}, err
+	}
+
+	m := Meta{
+		Outcome:     outcomeOf(code, ended),
+		ExitCode:    code,
+		WallSeconds: s.Wall.Seconds(),
+		TookSeconds: time.Since(started).Seconds(),
+		Command:     s.Name,
+		Args:        s.Args,
+		StartedAt:   started.UTC().Format(time.RFC3339),
+	}
+	if err := writeMeta(dir, m); err != nil {
+		return Meta{}, err
+	}
+	return m, nil
+}
+
+// endedBy says what stopped the session, when it was not the process itself.
+type endedBy int
+
+const (
+	endedByItself endedBy = iota
+	endedByWall
+	endedByCancel
+)
+
+// outcomeOf maps an exit code plus what ended the session onto an Outcome.
+// Whatever ended the session wins over the exit code: a process killed from
+// outside may exit with any code, including 0 if it happened to finish in the
+// window between the signal and the reap.
+func outcomeOf(code int, ended endedBy) Outcome {
+	switch {
+	case ended == endedByWall:
+		return CannotFinishAtBudget
+	case ended == endedByCancel:
+		return Interrupted
+	case code == 0:
+		return Completed
+	default:
+		return Failed
+	}
+}
+
+// rawFiles opens the two capture files. Output is streamed to them as it
+// arrives rather than buffered, so a run killed on its wall still leaves
+// everything the process managed to say.
+func rawFiles(dir string) (stdout, stderr *os.File, err error) {
+	stdout, err = os.Create(filepath.Join(dir, "raw", "stdout"))
+	if err != nil {
+		return nil, nil, fmt.Errorf("create stdout capture: %w", err)
+	}
+	stderr, err = os.Create(filepath.Join(dir, "raw", "stderr"))
+	if err != nil {
+		_ = stdout.Close()
+		return nil, nil, fmt.Errorf("create stderr capture: %w", err)
+	}
+	return stdout, stderr, nil
+}
+
+// spawn runs the command under the wall and reports its exit code and what
+// ended it. It returns an error only when the command could not be started at
+// all.
+func spawn(ctx context.Context, s Spec, stdout, stderr *os.File) (code int, ended endedBy, err error) {
+	parent := ctx
+	ctx, cancel := context.WithTimeout(ctx, s.Wall)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, s.Name, s.Args...)
+	cmd.Dir = s.Dir
+	// These MUST stay *os.File. os/exec then hands the descriptors straight to
+	// the child and starts no copying goroutines, so Wait returns as soon as
+	// the direct child is reaped. Wrap either one (io.MultiWriter, a tee) and
+	// exec switches to a pipe, Wait blocks until every process holding that
+	// pipe closes it, and the wall silently stops existing — the exact failure
+	// the process-group kill below exists to prevent, reintroduced from the
+	// other side. If a pipe is ever genuinely needed, set cmd.WaitDelay too.
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	cmd.Stdin = strings.NewReader(s.Stdin)
+	if len(s.Env) > 0 {
+		cmd.Env = append(os.Environ(), s.Env...)
+	}
+
+	// Kill the whole process group, not just the child. An agent CLI spawns its
+	// own children, and killing only the parent leaves them holding the pipe:
+	// the wall passes, the run does not end, and the cell's other arm is burned.
+	//
+	// This runs as cmd.Cancel rather than after Run returns, which matters
+	// twice: the child is still alive so its process group id is certainly
+	// valid (signalling a reaped pid can hit whoever the OS handed it to next),
+	// and Cancel fires on the parent's cancellation as well as the wall, so an
+	// interrupted campaign does not leave agents running and spending.
+	setProcessGroup(cmd)
+	cmd.Cancel = func() error { return killGroup(cmd) }
+
+	runErr := cmd.Run()
+
+	// Being stopped from outside and merely failing are indistinguishable from
+	// the error alone, so ask the contexts which one happened. The parent is
+	// checked first: an operator interrupt is not a budget failure.
+	switch {
+	case parent.Err() != nil:
+		return exitCodeKilled, endedByCancel, nil
+	case errors.Is(ctx.Err(), context.DeadlineExceeded):
+		return exitCodeKilled, endedByWall, nil
+	}
+
+	var exitErr *exec.ExitError
+	switch {
+	case runErr == nil:
+		return 0, endedByItself, nil
+	case errors.As(runErr, &exitErr):
+		return exitErr.ExitCode(), endedByItself, nil
+	default:
+		return 0, endedByItself, fmt.Errorf("spawn %s: %w", s.Name, runErr)
+	}
+}
+
+// writeMeta writes the run's self-describing record. This file is what every
+// later query answers from, so it is written last: its presence means the run
+// was recorded.
+func writeMeta(dir string, m Meta) error {
+	// Meta is a fixed struct of scalars, so encoding it cannot fail.
+	b, _ := json.MarshalIndent(m, "", "  ")
+	if err := os.WriteFile(filepath.Join(dir, metaFile), append(b, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write run-meta: %w", err)
+	}
+	return nil
+}

--- a/lab/internal/run/run_test.go
+++ b/lab/internal/run/run_test.go
@@ -1,0 +1,480 @@
+package run
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Every test here spawns a real process, and none of them touch a model or the
+// network. The wall and the supervision are the assumptions most likely to be
+// wrong, and they are the ones a fake would not test at all: the failure mode
+// that has already cost a run is a child that keeps running after the parent is
+// signalled, which only a real process can demonstrate.
+
+func readMeta(t *testing.T, dir string) Meta {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(dir, "run-meta.json"))
+	if err != nil {
+		t.Fatalf("run-meta.json: %v", err)
+	}
+	var m Meta
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("decode run-meta.json: %v", err)
+	}
+	return m
+}
+
+func readRaw(t *testing.T, dir, stream string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(dir, "raw", stream))
+	if err != nil {
+		t.Fatalf("raw/%s: %v", stream, err)
+	}
+	return string(b)
+}
+
+func TestAProcessThatSucceedsIsRecordedAsCompleted(t *testing.T) {
+	dir := t.TempDir()
+
+	m, err := Session(context.Background(), dir, Spec{
+		Name: "sh", Args: []string{"-c", "echo hello; echo trouble >&2"},
+		Wall: 10 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+
+	if m.Outcome != Completed {
+		t.Errorf("outcome = %q, want %q", m.Outcome, Completed)
+	}
+	if m.ExitCode != 0 {
+		t.Errorf("exit code = %d, want 0", m.ExitCode)
+	}
+	if got := readRaw(t, dir, "stdout"); !strings.Contains(got, "hello") {
+		t.Errorf("raw/stdout = %q, want the process's stdout", got)
+	}
+	// stderr is captured separately: an agent CLI's diagnostics must not be
+	// interleaved into the stream the scorer reads.
+	if got := readRaw(t, dir, "stderr"); !strings.Contains(got, "trouble") {
+		t.Errorf("raw/stderr = %q, want the process's stderr", got)
+	}
+
+	// The record has to say what was run and when, or two runs of different
+	// things are indistinguishable on disk afterwards.
+	rec := readMeta(t, dir)
+	if rec.Command != "sh" {
+		t.Errorf("command = %q, want the command that was run", rec.Command)
+	}
+	if len(rec.Args) == 0 || rec.Args[0] != "-c" {
+		t.Errorf("args = %v, want the arguments the process was given", rec.Args)
+	}
+	if _, err := time.Parse(time.RFC3339, rec.StartedAt); err != nil {
+		t.Errorf("started_at = %q, not a timestamp: %v", rec.StartedAt, err)
+	}
+}
+
+// A recorded run is paid for and cannot be recreated. Pointing a second run at
+// the same directory must fail rather than quietly destroy the first.
+func TestARecordedRunIsNeverOverwritten(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := Session(context.Background(), dir, Spec{
+		Name: "sh", Args: []string{"-c", "echo the-original"},
+		Stdin: "the original prompt", Wall: 10 * time.Second,
+	}); err != nil {
+		t.Fatalf("first Session: %v", err)
+	}
+
+	_, err := Session(context.Background(), dir, Spec{
+		Name: "sh", Args: []string{"-c", "echo the-replacement"},
+		Stdin: "the replacement prompt", Wall: 10 * time.Second,
+	})
+
+	if err == nil {
+		t.Fatal("the second run overwrote a recorded run")
+	}
+	if got := readRaw(t, dir, "stdout"); !strings.Contains(got, "the-original") {
+		t.Errorf("raw/stdout = %q, want the first run's output intact", got)
+	}
+	// The refusal has to come before anything is written, not merely before the
+	// record is. A guard that fires after the prompt is overwritten leaves a
+	// paid, unrepeatable run whose recorded output no longer matches its
+	// recorded input — which misattributes silently instead of failing loudly.
+	b, err := os.ReadFile(filepath.Join(dir, "prompt.txt"))
+	if err != nil {
+		t.Fatalf("prompt.txt: %v", err)
+	}
+	if string(b) != "the original prompt" {
+		t.Errorf("prompt.txt = %q, want the first run's prompt untouched", b)
+	}
+}
+
+// A run directory that does not contain its own input records what happened but
+// not what was asked, so it can be neither reproduced nor invalidated.
+func TestTheRunDirectoryKeepsThePromptItWasGiven(t *testing.T) {
+	dir := t.TempDir()
+	prompt := "Step 1: trace the path.\nStep 2: audit the dependents.\n"
+
+	if _, err := Session(context.Background(), dir, Spec{
+		Name: "cat", Stdin: prompt, Wall: 10 * time.Second,
+	}); err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+
+	b, err := os.ReadFile(filepath.Join(dir, "prompt.txt"))
+	if err != nil {
+		t.Fatalf("prompt.txt: %v", err)
+	}
+	if string(b) != prompt {
+		t.Errorf("prompt.txt = %q, want the prompt the agent was given", b)
+	}
+}
+
+func TestAProcessThatFailsIsRecordedWithItsExitCode(t *testing.T) {
+	dir := t.TempDir()
+
+	m, err := Session(context.Background(), dir, Spec{
+		Name: "sh", Args: []string{"-c", "exit 3"},
+		Wall: 10 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+
+	if m.Outcome != Failed {
+		t.Errorf("outcome = %q, want %q", m.Outcome, Failed)
+	}
+	if m.ExitCode != 3 {
+		t.Errorf("exit code = %d, want 3 — the process's own code, not a flattened 1", m.ExitCode)
+	}
+}
+
+// The wall case is the whole reason this package exists first. A run that
+// exceeds its budget is a result, and it must be recorded as one: the pressure
+// this defends against is raising the wall to rescue a stalled arm, which is
+// only resistible if "cannot finish at budget" is a normal thing to read.
+func TestAProcessThatOverrunsItsWallIsRecordedAsCannotFinishAtBudget(t *testing.T) {
+	dir := t.TempDir()
+
+	m, err := Session(context.Background(), dir, Spec{
+		Name: "sleep", Args: []string{"60"},
+		Wall: 200 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+
+	if m.Outcome != CannotFinishAtBudget {
+		t.Errorf("outcome = %q, want %q", m.Outcome, CannotFinishAtBudget)
+	}
+	// Two-sided on purpose. A one-sided "under 30s" check passes for a
+	// hardcoded zero, and TookSeconds is the field that makes 481-against-480
+	// legible later; an unmeasured one would read as a run that finished fast.
+	if m.TookSeconds < 0.2 || m.TookSeconds > 5 {
+		t.Errorf("took %.3fs, want at least the wall (0.2s) and well under 5s", m.TookSeconds)
+	}
+	if m.ExitCode != 124 {
+		t.Errorf("exit code = %d, want 124 — what timeout(1) reports for a killed process", m.ExitCode)
+	}
+	// The wall that was set is part of run identity. Without it, a run at 481
+	// seconds is unreadable: you cannot tell a fast wall from a slow agent.
+	if m.WallSeconds != 0.2 {
+		t.Errorf("wall = %.3fs, want the wall that was set (0.2)", m.WallSeconds)
+	}
+}
+
+// run-meta.json is what every later query answers from, so it has to exist for
+// the killed run too. The instrument being replaced left incomplete artifacts
+// behind on exactly this path, and an arm with no record can never be paired.
+func TestAKilledRunStillLeavesItsRecordOnDisk(t *testing.T) {
+	dir := t.TempDir()
+
+	if _, err := Session(context.Background(), dir, Spec{
+		Name: "sh", Args: []string{"-c", "echo started; sleep 60"},
+		Wall: 200 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+
+	if m := readMeta(t, dir); m.Outcome != CannotFinishAtBudget {
+		t.Errorf("run-meta.json outcome = %q, want %q", m.Outcome, CannotFinishAtBudget)
+	}
+	// Output written before the kill survives: capture streams to disk rather
+	// than buffering, so a killed run is still worth reading.
+	if got := readRaw(t, dir, "stdout"); !strings.Contains(got, "started") {
+		t.Errorf("raw/stdout = %q, want what the process said before it was killed", got)
+	}
+}
+
+// The failure that has actually cost a run: killing the parent and leaving its
+// children alive holding the pipe. A grandchild that outlives the wall means the
+// wall does not really exist.
+func TestTheWallKillsTheChildsChildrenToo(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(t.TempDir(), "grandchild-still-running")
+
+	// sh spawns a background grandchild that would create the marker two
+	// seconds from now, then waits. Killing only sh leaves the grandchild.
+	_, err := Session(context.Background(), dir, Spec{
+		Name: "sh",
+		Args: []string{"-c", "(sleep 2; touch " + marker + ") & echo spawned; wait"},
+		Wall: 200 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+
+	// Wait past the point the grandchild would have fired.
+	time.Sleep(3 * time.Second)
+
+	if _, err := os.Stat(marker); err == nil {
+		t.Fatal("the grandchild outlived the wall: only the direct child was killed, " +
+			"so an agent CLI's subprocesses would survive their budget")
+	}
+}
+
+func TestAPromptIsHandedToTheProcessOnStdin(t *testing.T) {
+	dir := t.TempDir()
+
+	if _, err := Session(context.Background(), dir, Spec{
+		Name: "cat",
+		// A prompt carries newlines, quotes and backticks. Passing it as an
+		// argument is what mangled a model id into a whole lost arm.
+		Stdin: "line one\n`backtick` and \"quotes\"\n",
+		Wall:  10 * time.Second,
+	}); err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+
+	got := readRaw(t, dir, "stdout")
+	if !strings.Contains(got, "`backtick` and \"quotes\"") {
+		t.Errorf("raw/stdout = %q, want the prompt to arrive unmangled", got)
+	}
+}
+
+// Env adds to the host environment rather than replacing it: an agent CLI
+// needs PATH and HOME to run at all, and this cycle has no isolation to give it
+// its own.
+func TestEnvIsAddedToTheHostEnvironmentNotSubstitutedForIt(t *testing.T) {
+	dir := t.TempDir()
+
+	if _, err := Session(context.Background(), dir, Spec{
+		Name: "sh", Args: []string{"-c", "echo added=$LAB_TEST_MARKER path=${PATH:+set}"},
+		Env:  []string{"LAB_TEST_MARKER=present"},
+		Wall: 10 * time.Second,
+	}); err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+
+	got := readRaw(t, dir, "stdout")
+	if !strings.Contains(got, "added=present") {
+		t.Errorf("stdout = %q, want the added variable", got)
+	}
+	if !strings.Contains(got, "path=set") {
+		t.Errorf("stdout = %q, want PATH inherited from the host", got)
+	}
+}
+
+func TestTheSessionRunsInTheDirectoryItWasGiven(t *testing.T) {
+	dir := t.TempDir()
+	target := t.TempDir()
+
+	if _, err := Session(context.Background(), dir, Spec{
+		Dir: target, Name: "pwd", Wall: 10 * time.Second,
+	}); err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+
+	// On macOS /var is a symlink to /private/var and the two sides disagree
+	// about which form to print, so compare fully resolved paths.
+	want, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		t.Fatalf("resolve %s: %v", target, err)
+	}
+	got, err := filepath.EvalSymlinks(strings.TrimSpace(readRaw(t, dir, "stdout")))
+	if err != nil {
+		t.Fatalf("resolve the reported directory: %v", err)
+	}
+	if got != want {
+		t.Errorf("ran in %q, want %q", got, want)
+	}
+}
+
+// A command that does not exist is not a run that failed — it is a run that
+// never happened, and recording it as an ordinary failure would put a scoreable
+// artifact on disk for a session that produced nothing.
+func TestACommandThatCannotBeStartedIsAnErrorNotAFailedRun(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := Session(context.Background(), dir, Spec{
+		Name: "sense-lab-no-such-binary", Wall: 10 * time.Second,
+	})
+
+	if err == nil {
+		t.Fatal("Session succeeded for a binary that does not exist")
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "run-meta.json")); statErr == nil {
+		t.Error("run-meta.json was written for a session that never started")
+	}
+}
+
+// A cancelled parent context must stop the whole tree, not merely return. An
+// earlier version of this test checked only that Session came back quickly, and
+// it passed while every grandchild kept running and kept billing.
+func TestCancellingTheContextKillsTheWholeTree(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(t.TempDir(), "grandchild-still-running")
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+	}()
+
+	started := time.Now()
+	m, err := Session(ctx, dir, Spec{
+		Name: "sh",
+		Args: []string{"-c", "(sleep 2; touch " + marker + ") & echo spawned; wait"},
+		Wall: time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+
+	if took := time.Since(started); took > 30*time.Second {
+		t.Errorf("took %s — cancelling the context did not stop the run", took)
+	}
+
+	time.Sleep(3 * time.Second)
+	if _, err := os.Stat(marker); err == nil {
+		t.Error("the grandchild outlived the cancellation: an interrupted campaign " +
+			"would leave agent sessions running and spending")
+	}
+
+	// An interrupt is not a budget failure. Recording it as one would put a row
+	// on disk that reads exactly like an arm that stalled against its wall.
+	if m.Outcome != Interrupted {
+		t.Errorf("outcome = %q, want %q", m.Outcome, Interrupted)
+	}
+}
+
+// A run that cannot be recorded must not report success. Silently losing the
+// artifact is the worst outcome available here: the session is spent, and a
+// caller that trusted the nil error would score nothing and call it a zero.
+func TestASessionThatCannotBeRecordedReportsAnError(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		arrange func(t *testing.T, dir string)
+		want    string
+	}{
+		{
+			name: "the run directory cannot be made",
+			arrange: func(t *testing.T, dir string) {
+				// A file where raw/ needs to be.
+				if err := os.WriteFile(filepath.Join(dir, "raw"), nil, 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "prepare run directory",
+		},
+		{
+			name: "the capture files cannot be opened",
+			arrange: func(t *testing.T, dir string) {
+				// A directory where raw/stdout needs to be a file.
+				if err := os.MkdirAll(filepath.Join(dir, "raw", "stdout"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "create stdout capture",
+		},
+		{
+			name: "only stderr cannot be opened",
+			arrange: func(t *testing.T, dir string) {
+				if err := os.MkdirAll(filepath.Join(dir, "raw", "stderr"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "create stderr capture",
+		},
+		{
+			name: "the prompt cannot be written",
+			arrange: func(t *testing.T, dir string) {
+				if err := os.MkdirAll(filepath.Join(dir, "prompt.txt"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "write prompt",
+		},
+		{
+			name: "the record cannot be written",
+			arrange: func(t *testing.T, dir string) {
+				// Everything the run creates before the record already exists,
+				// so the only thing left needing a new directory entry is
+				// run-meta.json itself. A read-only directory still permits
+				// rewriting the files inside it.
+				if err := os.MkdirAll(filepath.Join(dir, "raw"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				for _, f := range []string{"prompt.txt", "raw/stdout", "raw/stderr"} {
+					if err := os.WriteFile(filepath.Join(dir, f), nil, 0o644); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if err := os.Chmod(dir, 0o500); err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+			},
+			want: "write run-meta",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			tc.arrange(t, dir)
+
+			_, err := Session(context.Background(), dir, Spec{
+				Name: "true", Wall: 10 * time.Second,
+			})
+
+			if err == nil {
+				t.Fatal("Session reported success for a run it could not record")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q, want it to name %q so the failure is diagnosable", err, tc.want)
+			}
+		})
+	}
+}
+
+// A wall so short it expires before the process is even started still has to
+// produce an honest record rather than a crash: the group-kill runs with no
+// process to signal.
+func TestAWallThatExpiresBeforeTheProcessStartsIsStillRecorded(t *testing.T) {
+	dir := t.TempDir()
+
+	m, err := Session(context.Background(), dir, Spec{
+		Name: "sleep", Args: []string{"60"}, Wall: time.Nanosecond,
+	})
+	if err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+
+	if m.Outcome != CannotFinishAtBudget {
+		t.Errorf("outcome = %q, want %q", m.Outcome, CannotFinishAtBudget)
+	}
+}
+
+func TestOutcomeOfPrefersWhatEndedTheSessionOverTheExitCode(t *testing.T) {
+	// A process killed from outside can still exit 0, if it finished in the
+	// window between the signal and the reap. What killed it is what happened.
+	if got := outcomeOf(0, endedByWall); got != CannotFinishAtBudget {
+		t.Errorf("outcomeOf(0, endedByWall) = %q, want %q", got, CannotFinishAtBudget)
+	}
+	if got := outcomeOf(0, endedByCancel); got != Interrupted {
+		t.Errorf("outcomeOf(0, endedByCancel) = %q, want %q", got, Interrupted)
+	}
+}

--- a/lab/internal/scenario/scenario.go
+++ b/lab/internal/scenario/scenario.go
@@ -1,0 +1,76 @@
+// Package scenario reads a scenario file and renders it into a prompt.
+//
+// It reads only the fields the walking skeleton needs and ignores the rest, so
+// it can read the existing corpus as-is. Cycle 02 settles the real scenario,
+// gold and rubric types; nothing here is meant to survive it.
+package scenario
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Scenario is the subset of a scenario file the skeleton uses.
+type Scenario struct {
+	Name        string `yaml:"name"`
+	Repo        string `yaml:"repo"`
+	Description string `yaml:"description"`
+	Steps       []Step `yaml:"steps"`
+}
+
+// Step is one question in the session.
+type Step struct {
+	Name   string `yaml:"name"`
+	Prompt string `yaml:"prompt"`
+}
+
+// Load reads a scenario file. Unknown fields are ignored on purpose: the corpus
+// carries gold, rubric weights and campaign history this cycle has no use for,
+// and refusing to read a file over a field we do not want would be a gate that
+// buys nothing.
+func Load(path string) (Scenario, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return Scenario{}, fmt.Errorf("read scenario: %w", err)
+	}
+	var s Scenario
+	if err := yaml.Unmarshal(b, &s); err != nil {
+		return Scenario{}, fmt.Errorf("parse scenario %s: %w", path, err)
+	}
+	if err := s.validate(); err != nil {
+		return Scenario{}, fmt.Errorf("scenario %s: %w", path, err)
+	}
+	return s, nil
+}
+
+// validate rejects a scenario that would produce a prompt with nothing in it.
+// A run against an empty prompt costs the same as a real one and scores zero,
+// which reads as a failed arm rather than a broken input.
+func (s Scenario) validate() error {
+	if len(s.Steps) == 0 {
+		return fmt.Errorf("no steps")
+	}
+	for i, step := range s.Steps {
+		if strings.TrimSpace(step.Prompt) == "" {
+			return fmt.Errorf("step %d (%q) has an empty prompt", i+1, step.Name)
+		}
+	}
+	return nil
+}
+
+// Prompt renders the scenario into the text handed to the agent. It concatenates
+// the description and the numbered steps and does nothing else: a template
+// engine here would be guessing at cycle 05's shape from one example.
+func (s Scenario) Prompt() string {
+	var b strings.Builder
+	b.WriteString(strings.TrimSpace(s.Description))
+	b.WriteString("\n\nWork through the following steps in order. ")
+	b.WriteString("Answer each one fully before moving to the next.\n")
+	for i, step := range s.Steps {
+		fmt.Fprintf(&b, "\n## Step %d: %s\n\n%s\n", i+1, step.Name, strings.TrimSpace(step.Prompt))
+	}
+	return b.String()
+}

--- a/lab/internal/scenario/scenario_test.go
+++ b/lab/internal/scenario/scenario_test.go
@@ -1,0 +1,161 @@
+package scenario
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func write(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "scenario.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// The corpus this reads was written for another tool and carries gold, rubric
+// weights and pages of campaign history. Refusing to read a file over a field
+// this cycle has no use for would be a gate that buys nothing, so the reader
+// takes what it needs and ignores the rest.
+func TestAScenarioIsReadableAlongsideFieldsTheSkeletonDoesNotUse(t *testing.T) {
+	path := write(t, `
+name: audit the category contract
+repo: discourse
+contract_symbol: Category
+description: |
+  You are a maintainer about to rework a class.
+weights:
+  correctness: 0.7
+steps:
+  - name: Map the contract
+    prompt: Trace the path end to end.
+    checks:
+      - type: response_richness
+        value: "8"
+gold:
+  - id: contract-model
+    match: [app/models/category.rb]
+`)
+
+	s, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if s.Repo != "discourse" {
+		t.Errorf("repo = %q, want discourse", s.Repo)
+	}
+	if len(s.Steps) != 1 {
+		t.Fatalf("got %d steps, want 1", len(s.Steps))
+	}
+	if s.Steps[0].Name != "Map the contract" {
+		t.Errorf("step name = %q", s.Steps[0].Name)
+	}
+}
+
+// A scenario that renders to an empty prompt costs a full run and scores zero,
+// which reads on the other side as a failed arm rather than a broken input.
+// Both shapes have to be rejected before anything is spent.
+func TestAScenarioThatWouldRenderAnEmptyPromptIsRejected(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "no steps at all",
+			body: "name: empty\ndescription: nothing to do\n",
+			want: "no steps",
+		},
+		{
+			name: "a step with a blank prompt",
+			body: "name: blank\nsteps:\n  - name: Step one\n    prompt: \"   \"\n",
+			want: `step 1 ("Step one") has an empty prompt`,
+		},
+		{
+			name: "a step with no prompt key",
+			body: "name: missing\nsteps:\n  - name: Step one\n",
+			want: `step 1 ("Step one") has an empty prompt`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Load(write(t, tc.body))
+
+			if err == nil {
+				t.Fatal("Load accepted a scenario that renders to nothing")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q, want it to contain %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadReportsWhatIsWrongWithAFileItCannotRead(t *testing.T) {
+	t.Run("missing file", func(t *testing.T) {
+		_, err := Load(filepath.Join(t.TempDir(), "absent.yaml"))
+		if err == nil || !strings.Contains(err.Error(), "read scenario") {
+			t.Errorf("error = %v, want it to name the read", err)
+		}
+	})
+
+	t.Run("malformed yaml", func(t *testing.T) {
+		_, err := Load(write(t, "steps: [oops\n"))
+		if err == nil || !strings.Contains(err.Error(), "parse scenario") {
+			t.Errorf("error = %v, want it to name the parse", err)
+		}
+	})
+}
+
+// The rendered prompt is the only thing the agent ever sees, so everything the
+// scenario means has to survive into it, in order.
+func TestThePromptCarriesTheDescriptionAndEveryStepInOrder(t *testing.T) {
+	s := Scenario{
+		Description: "You are a maintainer.",
+		Steps: []Step{
+			{Name: "First", Prompt: "Trace the path."},
+			{Name: "Second", Prompt: "Audit the dependents."},
+		},
+	}
+
+	got := s.Prompt()
+
+	for _, want := range []string{
+		"You are a maintainer.",
+		// Without this sentence a two-step scenario reads as one question, and
+		// an agent that answers step one and stops scores as a weak arm rather
+		// than a half-run.
+		"Work through the following steps in order.",
+		"Step 1: First", "Trace the path.",
+		"Step 2: Second", "Audit the dependents.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("prompt is missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Index(got, "Step 1") > strings.Index(got, "Step 2") {
+		t.Error("the steps are rendered out of order")
+	}
+}
+
+// Step prompts in the corpus are YAML folded scalars, which arrive with a
+// trailing newline and inconsistent leading space. The agent should not be
+// asked to read around that.
+func TestThePromptDoesNotInheritTheFilesIncidentalWhitespace(t *testing.T) {
+	s := Scenario{
+		Description: "\n  A description.\n\n",
+		Steps:       []Step{{Name: "Only", Prompt: "\n  Do the thing.\n\n"}},
+	}
+
+	got := s.Prompt()
+
+	if strings.HasPrefix(got, "\n") || strings.HasPrefix(got, " ") {
+		t.Errorf("prompt starts with whitespace: %q", got[:10])
+	}
+	if strings.Contains(got, "\n\n\n") {
+		t.Errorf("prompt has a run of blank lines:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Problem

Every effect-layer assumption in the sense-lab design was unvalidated: nobody had driven an agent session from Go. The design assumed a prompt can be handed to the CLI cleanly, its streamed output captured without loss, a wall enforced with the process actually dying, and enough landing on disk to score. Until one real session ran, every later cycle was built on a guess about the layer nobody had touched.

## Summary

`sense-lab run` reads a scenario, renders it into a prompt, spawns an agent CLI against a repository under a wall, captures the stream byte for byte, and leaves a run directory behind.

Built inside out, starting with the assumption most likely to be wrong. The wall and the supervision were proven against real processes before any model was involved, and that order paid for itself immediately — it found three defects that only a real run could show.

**The wall did not exist on the cancel path.** Cancelling the parent context left the whole agent tree alive and still spending; only the wall path killed the process group. The kill now runs as `cmd.Cancel`, which fires on both paths and, because the child is still unreaped when it runs, cannot signal a process group the OS has since recycled.

**The binary installed no signal handler**, so that cancel path could never fire in production. Measured: SIGTERM to a live run left no `run-meta.json` and three surviving paid processes. That is the half-pair hazard exactly — a spent arm that can never be paired. After the fix, the same signal leaves a complete record and reaps the tree.

**An interrupt is not a budget failure.** Recording one as the other puts a row on disk that reads exactly like a stalled arm, so it has its own outcome.

## Changes

- `lab/internal/run` — spawn, wall, process-group kill, streamed capture, `run-meta.json`. Stdout and stderr are `*os.File` deliberately: that is what lets `Wait` return without blocking on a pipe a surviving grandchild still holds, which is the mechanism the wall rests on, and it is commented as such.
- `lab/internal/scenario` — reads a scenario file, ignoring the fields this cycle has no use for, and renders the prompt by concatenation. No template engine.
- `lab/internal/cli/runcmd.go` — the `run` subcommand, with the target hard-coded. The prompt goes to the agent on stdin, never as the value of `-p`: a prompt beginning with a dash is read as an option, which has already killed a spawn before it ran a step.
- Runs are immutable: a directory already holding a record is refused before anything is written, rather than silently destroying a paid run that cannot be recreated. The prompt is kept beside the capture so a run directory contains its own input.
- Exit codes distinguish a usage error (2), a run that failed or could not proceed (1), and a run that hit its wall (3) — so a caller can tell a bankable result from a broken binary without parsing JSON.

## Test plan

`make ci` green: coverage gate with no new exception, complexity ledger 0, lint 0 issues. `qlty check lab/` clean. **All four lab packages at 100% line and function coverage** against the pitch's 94% target.

No test in the suite calls a model, touches the network, or spends anything. The spawn path is proven against real processes and a fake agent: a process that exits zero, one that exits non-zero, one killed on its wall, one whose grandchild must die with it, and the binary itself under SIGTERM (12 consecutive runs, no flake).

**The live run, which is what this pitch is actually for.** One real session, discourse at its pinned commit, sense arm, the two-step probe, against a scratch clone:

| | |
|---|---|
| outcome | completed, 424s of a 600s wall |
| turns / cost | 24 turns, $2.36 |
| answer | 52,000 characters |
| captured | 524KB of stream |
| Sense reached | `sense_search`, `sense_status`, `sense_blast`, `sense_graph`, alongside 19 Bash calls |

The test spec was mutation-checked rather than merely run. Every literal that carries a contract now dies when mutated individually: dropping `--permission-mode bypassPermissions` or `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1` from inside its slice, blanking any recorded field, flattening any of the three exit codes, `exitCodeKilled` to 0, hardcoding `TookSeconds`, moving the immutability guard later so it overwrites the prompt before refusing, or detaching the run from the signal context.

Reviewed by the council; test spec validated.