### PR TITLE
bench(lab): re-author the law file into lab/LAWS.md

### DIFF
--- a/lab/LAWS.md
+++ b/lab/LAWS.md
@@ -1,0 +1,857 @@
+# LAWS
+
+The standing laws of this bench. They bind every phase, and every session that touches
+sense-lab, including the operator session driving it by hand, which no driver injects a plan into
+and which is therefore the one that reads them by choice. They are not re-argued at runtime.
+
+**A summary of this file is not this file.** A paraphrase kept somewhere closer to hand will omit
+the law you are about to break. Measured 2026-08-11: an operator session closed a
+repo on a grep screen, forecast a cell from pooled per-row rates, and recommended authoring for
+token-darkness, having read a ten-law digest that contained none of the seven laws those three
+moves break. Read this file before any verdict, close, swap, kill, pay call, or ledger entry.
+
+**55 laws: 46 inherited, 9 new with sense-lab.** 44 inherited from the retired bench's law file,
+2 from its instructions file. Each is marked at its heading. The count is stated because a count
+that reads complete and is not is the same failure as the digest.
+
+## How to read a law
+
+Every law is `## NAME — mechanism (cycle)`, so the heading alone says whether anything will stop
+you. Under it: the statement in full, then two labelled blocks and no others.
+
+- **Precedent** — the measurement, the burned cell or the wrong call that produced the law.
+  `none recorded` where there is none. That absence is stated rather than left blank, because an
+  invisible gap is indistinguishable from a law nobody bothered to source.
+- **Mechanism** — the same tag as the heading, spelled out.
+
+| Mechanism | What it means |
+|---|---|
+| **gate** | code that exits non-zero on the condition. Every gate names the cycle that builds it. A gate that only builds a report string is not a gate. |
+| **shape** | the data model or the type system makes the violation unrepresentable |
+| **doc** | binds a human or an agent, with nothing behind it. The honest label for what cannot be mechanized, never the default. |
+
+**The mechanism column is not yet enforced.** A test that parses this file and fails when a
+`gate`-tagged law names no cycle is the only thing standing between it and the digest it
+replaces. It is named for **cycle 01** (01-02) and does not exist today.
+
+## The five killers live elsewhere
+
+Confound, per-unit, arithmetic, negative space, n. They bind the person reading a result rather
+than the binary, and they are in sense-lab's instructions file, not here. **QUOTE IT OR YOU HAVE
+NOT VERIFIED IT** leans directly on the rule attached to them: *a confirming check is not
+evidence, it is the absence of a test*, and the killer runs before the finding is stated.
+
+## The laws, by name
+
+**What may be concluded** — RUN vs DECIDE · QUOTE IT OR YOU HAVE NOT VERIFIED IT · NO PREDICTORS
+BEFORE A SCENARIO EXISTS · A METRIC WITH A FREE PARAMETER IS SWEPT, NEVER EVALUATED · WE SCORE
+THE HEADLINE MODEL FORWARD · THE FIRST MEASUREMENT IS A REAL BASELINE ARM · PRECISION RANKS, IT
+NEVER KILLS · THE AUTHORING CYCLE IS UNATTENDED AND BOUNDED · AN OCCURRENCE-LIST QUESTION CAN WIN
+· "WHAT HOLDS THIS" NEEDS A RING, AND RUBY HAS NONE · AIM AT THE WINDOW, NOT AT THE OPPOSITE OF
+THE LAST FAILURE · A FREE ROW IS A GIFT TO THE BASELINE · ITERATE ON THE QUESTION, KEEP THE
+ANCHOR · TRY HARDER · THE LOOP CANNOT RECORD A LOSS · AXIS-DEAD IS NEVER REPO-DEAD · RUN FIRST,
+EXPLAIN AFTER
+
+**Scenario and gold** — THE DISCRIMINATOR IS CITATION COST, NOT DISCOVERY · PUBLISHED GOLD LEAKS
+· A CORRECTNESS ORACLE MUST NOT BE SATISFIABLE BY THE ROUTE · A GOLD ROW MUST BE CITEABLE IN THE
+FORM THE ASK DEMANDS · A GOLD ROW SHOULD COST A READ · THE ASK NAMES THE MECHANISM, NEVER THE
+INVENTORY · GOLD RAILS, ALL OF THEM, EVERY SCENARIO · TOKEN-DARKNESS IS NOT THE MECHANISM · NO
+GREP SCREEN IS A GATE, IN ANY FORM · MEMORIZATION IS A GOLD-TIME CONSTRAINT · A COMPETITOR
+COMPARISON IS REPORTED NO MORE FAVOURABLY · NO ORACLE, IN EITHER SENSE OF THE WORD · THE CONTROL
+BOUND IS RETIRED
+
+**Spending** — THE MINI-BENCH COMES FIRST · THE VALIDATION RUN IS UNSCORED · IF THE BASELINE
+ASSEMBLES THE SET, DO NOT PAY · THE BAR IS +0.50 ON A GOLD GROUP · EVERY ARM GETS 2 RUNS PER CELL
+· CANNOT-FINISH-AT-BUDGET IS A RESULT · ONE SENSE RETRY, NEVER A LOOP · COSTING MORE IS A PRODUCT
+FINDING · SPEND IS QUERYABLE BY CELL, CAMPAIGN AND MODEL
+
+**The instrument** — MCP IS THE ONLY SURFACE · STOPPER · THE SIMULATED ADVERSARY PROBE IS RETIRED
+· ONE REPO AT A TIME, TO A VERDICT · A PHASE IS SELF-CONTAINED · WHAT A PER-REPO PHASE DOES NOT
+OWN · A CONFIRMED WIN IS HANDED OFF, NOT HELD · NO HUMAN GATE IN THE PER-REPO PHASES · INSTRUMENTS
+CARRY, DOCS DO NOT
+
+**The code around the bench** — NO NEW MODULE DEPENDENCY WITHOUT AN EXPLICIT DECISION · THE
+`lab/` COVERAGE EXCEPTION LIST STARTS EMPTY AND STAYS EMPTY · THE EXCLUDED LIVE SUITE MUST COVER
+NOTHING EXCLUSIVELY · IF A SCRIPT READS IT, IT IS DATA · DETECTION IS POST-RUN OR IT DOES NOT
+EXIST · A SCRIPT IS NOT A RULE UNTIL YOU PROVE IT RUNS AND IT GATES · NEVER CHANGE A SCRIPT
+ANOTHER CYCLE'S PLANS USE
+
+Which laws bind which decision: a **verdict** or a **kill** is *What may be concluded*; a **pay
+call** is *Spending*; a **close** or a **swap** is *What may be concluded* plus *The instrument*;
+authoring or correcting gold is *Scenario and gold*.
+
+---
+
+# What may be concluded
+
+## RUN vs DECIDE — doc *(inherited)*
+
+A RUN step (index, gates, stamping, rendering, the ledger check, the phase order) is followed
+exactly: no substitute, no hand-rolling what a script does; if it looks wrong, say so and stop.
+A DECIDE step (anchor, gold, the pay call, routing) is judgment, and every factual claim leaving
+it is quoted command output or is labelled an assumption.
+
+**Precedent:** none recorded.
+
+**Mechanism:** doc.
+
+## QUOTE IT OR YOU HAVE NOT VERIFIED IT — doc *(inherited)*
+
+Before stating a finding, quote the output that shows it. Negative claims — cannot, no, never,
+dead, nonexistent, not reached — need a second, DIFFERENT probe before they are stated at all.
+
+**Precedent:** none in the source; the law was carried statement-only. *Added by sense-lab, cycle
+00 (00-03):* a hand audit of a scored transcript agreed with the matcher and was still wrong,
+because it asked the matcher's own question rather than the one that would kill it. One level
+down, a check that cleared the matcher by varying the citation *separator* missed that the agent
+elides the *path* — 160 elided citations, 254 visible locations resolving to 319, a 26% blind
+spot, and a conclusion retracted.
+
+**Mechanism:** doc.
+
+## NO PREDICTORS BEFORE A SCENARIO EXISTS — gate, cycle 01 *(inherited)*
+
+A win is crafted, never detected by a script beforehand. A killer runs against a scenario that
+exists and may kill it; a predictor guesses before one does and is banned.
+
+**Precedent:** none recorded here; see THE FIRST MEASUREMENT IS A REAL BASELINE ARM, which
+carries the list of substitutes that were measured wrong.
+
+**Mechanism:** gate — the planner refuses a job whose scenario has no committed content hash.
+Built in **cycle 01** (01-03, plan and compatibility).
+
+## A METRIC WITH A FREE PARAMETER IS SWEPT, NEVER EVALUATED — gate + doc, cycle 04 *(inherited)*
+
+Report the whole curve, not the chosen point.
+
+**Precedent:** a fixed per-miss cost was measured at 1/3, reported and recommended before the
+sweep was run. The sweep showed `delta = cost * 1.8` on that cell — monotone, no optimum, 0.0625
+giving +0.112 and 1.0 giving +0.800 — and 1/3 sat at the edge of a window derived FROM the cell
+it was meant to judge. If turning the knob one way always makes us look better, it is a dial and
+not a measurement. A blend whose delta is a convex combination of its terms is safe by
+construction: it lands BETWEEN them and cannot manufacture a win neither supports.
+
+**Mechanism:** gate over DECLARED parameters — the report emits the curve; a single-point report
+exits non-zero. Built in **cycle 04** (04-03). Plus doc for the harder half: the precedent was an
+*undeclared* knob, and no gate catches a parameter nobody registered as free.
+
+## WE SCORE THE HEADLINE MODEL FORWARD — shape + gate, cycle 01 and 04 *(inherited)*
+
+(ruling, 2026-08-04) A number banked on a RETIRED model is historical and does NOT constrain a
+scoring change. Killers still bind on every cell benched on the headline model.
+
+**Sense-lab's reading, not in the source: this law bounds what constrains a scoring change. It
+does not retire evidence.** Read in a it looks like "numbers on old models do not count", which would void the mastodon +0.53,
+the 67.4 against 48.4, and the +0.72 — all measured on retired models, all load-bearing
+precedents in this file. Those stand.
+
+**Precedent:** the killer "it must hold on the banked cell" was treating a record on a retired
+model as a live constraint.
+
+**Mechanism:** shape — the model id is part of run identity (**cycle 01**, 01-02). Plus gate — a
+banked cell on a retired model flags (**cycle 04**, 04-04).
+
+## THE FIRST MEASUREMENT IS A REAL BASELINE ARM — gate + doc, cycle 04 *(inherited)*
+
+Nothing kills a draft before a two-arm run has answered its question at a real wall. A hand
+estimate of a baseline is not evidence about a baseline.
+
+**Precedent:** every cheaper substitute this bench has built — the token-cover battery, the
+import screen, the scored adversary probe, the hand-run read-cost census — was measured wrong,
+and each one killed a repo that a benched scenario then won.
+
+**Mechanism:** gate — no verdict without a two-arm cell (**cycle 04**, 04-04). Plus doc, and the
+doc half is the one that has been violated: a draft killed by hand estimate never reaches a
+verdict record, so the gate never fires on it.
+
+## PRECISION RANKS, IT NEVER KILLS — shape + doc, cycle 04 *(inherited)*
+
+Dependents divided by grep hits is the one profile figure that has separated wins from ties
+across three verticals. Use it to order candidates. It orders; the run decides.
+
+**Precedent:** 0.078 preceded a +1.00 cell, 0.78 was a deliberate control tie, and a cell near
+0.94 handed its baseline 17 of 18 rows in one grep.
+
+**Mechanism:** shape — ranking outputs cannot reach a kill path in code (**cycle 04**, 04-04).
+Plus doc for the operator, who is not reached by any type system and is who broke it on
+2026-08-11.
+
+## THE AUTHORING CYCLE IS UNATTENDED AND BOUNDED — gate, cycle 05 *(inherited)*
+
+A routed lever re-enters authoring immediately, up to six cycles on one repo, then parks. Your
+artifact is not a report filed for later: the next authoring agent reads it within the minute and
+it is the only thing that agent has to improve on. A verdict with no named rows and no route is a
+wasted cycle.
+
+**Precedent:** none recorded.
+
+**Mechanism:** gate — a cycle counter with a ceiling. Built in **cycle 05** (05-01).
+
+## AN OCCURRENCE-LIST QUESTION CAN WIN, AND THE SESSION IS PART OF WHY — doc *(inherited)*
+
+"Find every place that depends on X" is not a disqualifying shape.
+
+**Precedent:** it is the shape of the banked mastodon cell — baseline 7 of 23, sense 19 of 23,
++0.53. A law saying otherwise was written on 2026-08-03 from five failures and retracted the same
+day against that cell. What differs is the SESSION: the banked ask sits at step 4 of 7, so both
+arms arrive with wall and context already spent, while the five failures asked it cold at step 2
+of 2 and the plain arm scored 0.81, 0.16, 0.09, 1.00, 1.00. **Budget pressure is a candidate
+cause, under test, not yet established** — this is the one law in the file that is a hypothesis,
+and it either graduates or reverts.
+
+**Mechanism:** doc.
+
+## "WHAT HOLDS THIS" NEEDS A RING, AND RUBY HAS NONE — doc *(inherited)*
+
+A kind that cannot fire in the stack is not an option, it is an unanswerable question.
+
+**Precedent:** the strongest measured kind is +0.58 to +1.00 on four Go cells, but it needs a
+non-empty retention ring. A retention-ring sweep measured ZERO rings on both Ruby repos swept
+(2026-08-03, top twelve anchors each, mastodon and the banked rails winner). *That instrument
+lives in the retired tree; the measurement is historical and cannot be re-run until the sweep is
+rebuilt.*
+
+**Mechanism:** doc, plus a per-stack fact pack. The fact belongs in the catalog as a per-stack
+row rather than in this file — **cycle 01** (01-02) — because a dated measurement with no owner
+goes stale and is then believed.
+
+## AIM AT THE WINDOW, NOT AT THE OPPOSITE OF THE LAST FAILURE — doc *(inherited)*
+
+Both conditions at once: the plain arm at or below 0.50 AND ours at least 0.50 above. Correcting
+only the last cycle's complaint lands on the far side and burns a cycle proving it. Read every
+previous cycle, not the latest one.
+
+**Precedent:** none recorded.
+
+**Mechanism:** doc.
+
+## A FREE ROW IS A GIFT TO THE BASELINE, AND THE RANKING NAMES THEM — shape + gate, cycle 02 and 04 *(inherited)*
+
+Citation rate per gold row across every run sorts gold into three classes: rows the baseline
+never cites and sense always does (the discriminator), rows every run cites (free, and they put a
+floor under the baseline no wording can lift), and rows nobody ever cites (hard, or unreachable
+if the blast payload does not carry them).
+
+**Precedent:** measured on mastodon at n=5: ten of twenty-three rows free, two unreachable across
+two models, one row discriminating. Scope the ranking to the HEADLINE model — mixing generations
+reorders the middle — and do not re-gold below ~5 runs per arm: a row that looked like a perfect
+discriminator at n=2 was 4/5 at n=5. *The ranking was computed by an inverse-frequency script in
+the retired tree; no cycle currently rebuilds it.*
+
+**Mechanism:** shape — gold group typing (**cycle 02**, 02-02). Plus gate — the ceiling is
+computed before spend (**cycle 04**, 04-04).
+
+## ITERATE ON THE QUESTION, KEEP THE ANCHOR — gate, cycle 05 *(inherited)*
+
+A sub-floor cell is a question that the baseline's route answered, not a dead contract.
+Re-scouting a new contract discards the only measured thing the loop owns.
+
+**Precedent:** measured both ways — a tied `serialize_payload` axis became a winning teardown
+audit on the same repo, and a dead dispatch axis became a winning retention audit on the SAME
+TYPE.
+
+**Mechanism:** gate — the re-author path preserves the anchor. Built in **cycle 05** (05-02).
+
+## TRY HARDER — doc *(inherited)*
+
+The default stance is "there is an unfound win axis here; prove otherwise", starting at proposal
+time. No phase offers a tie, a boundary framing or ballast; it deepens the contract hunt and
+widens the pool first.
+
+**Precedent:** none recorded.
+
+**Mechanism:** doc. Its operative half becomes shape for free if the verdict enum in **cycle 04**
+has no tie value, which THE LOOP CANNOT RECORD A LOSS already requires.
+
+## THE LOOP CANNOT RECORD A LOSS — shape, cycle 04 *(inherited)*
+
+It wins, parks, or hands up a swap with the numbers attached. A sub-floor verdict is a routed
+lever.
+
+**Precedent:** none recorded.
+
+**Mechanism:** shape — the verdict enum has no loss state. Built in **cycle 04** (04-04).
+
+## AXIS-DEAD IS NEVER REPO-DEAD — doc *(inherited)*
+
+A screen bounds the axis it measured and nothing else, and an adversary probe graded at MENTION
+level is not a kill — re-grade it at `path:line` first.
+
+**Precedent:** none recorded.
+
+**Mechanism:** doc.
+
+## RUN FIRST, EXPLAIN AFTER — gate, cycle 04 *(inherited)*
+
+A kill or a hold reasoned without a run is not a verdict. A session ends with a run artifact or
+it parks; protocol writing is overhead, never the deliverable.
+
+**Precedent:** none recorded.
+
+**Mechanism:** gate — a verdict requires run rows. Built in **cycle 04** (04-04).
+
+---
+
+# Scenario and gold
+
+## THE DISCRIMINATOR IS CITATION COST, NOT DISCOVERY — shape + doc, cycle 02 *(inherited)*
+
+The metric is cited recall at `path:line`. A baseline greps a filename cheaply; what it cannot
+afford is opening sixteen files to pin sixteen lines. Curate gold from the scattered periphery,
+keep the contract centre as non-scoring anchors, demand `path:line`, and never judge a shape by
+whether grep finds the file.
+
+**Precedent:** none recorded here; TOKEN-DARKNESS and NO GREP SCREEN carry the measurements.
+
+**Mechanism:** shape — an explicit discriminator field records the judgment (**cycle 02**,
+02-02). Plus doc: a field records a decision, it does not make the wrong decision
+unrepresentable.
+
+## PUBLISHED GOLD LEAKS, SO A HELD-OUT SET IS PERMANENT — gate, cycle 02 *(new)*
+
+Gold that has been published is gold a future model may have read. A held-out set is not a phase
+of the project; it is a permanent property of the corpus.
+
+**Precedent:** none recorded. New with sense-lab.
+
+**Mechanism:** gate — a leakage check, backed by `published` and `held_out` on the scenario row.
+Built in **cycle 02** (02-05). The fields record; the check enforces.
+
+## A CORRECTNESS ORACLE MUST NOT BE SATISFIABLE BY THE ROUTE — doc *(inherited)*
+
+Scoring a citation as on-target when the audited token appears on the pinned line is a
+restatement of "did you find this by grepping for that token", and it scores the grepper 100%
+where the structural arm scores 0% on rows where BOTH are right.
+
+**Precedent:** measured **67.4% baseline against 48.4% sense over 10 transcripts**, with the
+difference being `def attached_to_preview_card` (sense) against `Status.joins(...)` (baseline)
+one line below it. If citation correctness is ever scored, the oracle is a RANGE — does the pin
+fall inside the symbol carrying the dependency — never a text match, and its circularity must be
+answered before it runs.
+
+**Mechanism:** doc, plus a route-satisfiability check at authoring. **No cycle owns that check
+today.**
+
+## A GOLD ROW MUST BE CITEABLE IN THE FORM THE ASK DEMANDS — gate, cycle 02 *(inherited)*
+
+The headline scores `path:line`, so a row for an artifact the ask says to ADD has no line to cite
+and can never score. Before golding a row, say out loud what the ask asks for it and what a
+correct answer looks like: if a line number would be meaningless in that sentence, the row is
+mention-only or it does not belong in gold. A never-cited row is NOT automatically hard or
+unreachable — check the ask's wording before checking the blast payload.
+
+**Precedent:** measured on the banked Status control. Its step 7 asks for "the specs/fixtures
+that must be updated or added", and `spec:status` / `spec:post-svc` scored **mentioned 2/2 in 8
+of 10 runs, cited 0/2 in 10 of 10**, both arms, both models, since June. The arms did the work
+and named the files in the only natural form (`spec/models/status_spec.rb`, no line).
+
+**Second precedent, sense-lab cycle 00 (00-03):** the same failure has a second shape — the ask
+and the gold can name DIFFERENT LINES of the same routine. On the discourse two-step probe, step
+2 asks for the routine's `file:line` while every `dependents` gold row records the call site; the
+agent cited the routine's definition, which each row's own prose names, and scored 2 of 12 where
+the same answer reads 9 of 12 under the other convention. Citeable in the form the ask demands
+includes citeable at the LINE the ask demands.
+
+**Mechanism:** gate — the gold validator. Built in **cycle 02** (02-05).
+
+## A GOLD ROW SHOULD COST A READ, AND THE RUN IS WHAT CHARGES IT — doc + report, cycle 02 *(inherited)*
+
+`grep -rn` prints `path:line`, so a row whose dependency IS the token occurrence can be free.
+Prefer rows that must be opened. But this is a hand estimate of a baseline, it is not a
+measurement of one. It is an authoring preference: **it may not kill a draft, and it never
+belongs in a phase that runs before the two-arm bench.**
+
+**Precedent:** a gold set whose eighteen rows were each a single `Setting.<key>` read scored 17
+of 18 to a baseline in nine tool calls and 157 seconds. And run as a per-row census, this
+preference killed four shapes on a repo that banks +0.53.
+
+**Mechanism:** doc, plus a report — free-row detection is **reported, never vetoed**, and a
+report is deliberately not a gate here. Built in **cycle 02** (02-05).
+
+## THE ASK NAMES THE MECHANISM, NEVER THE INVENTORY — doc *(inherited)*
+
+Describing HOW a dependent hides is the task; listing WHERE dependents live is the answer.
+
+**Precedent:** "a shared concern, an association, a service that derives something from the model
+rather than naming the class plainly" is a mechanism. "Validation rules, background workers and
+schedulers, response headers, the data-retention policy, the onboarding follow list,
+service-discovery documents, static assets served from a stored value, and the historical data
+migrations" is an inventory: nine categories that between them name almost every gold row's job,
+and the baseline transcript shows it working down them. **The neutrality gate reads TOKENS** —
+paths, symbols, counts, tool names — so a semantic inventory passes it clean. *(Sense-lab note:
+the neutrality gate is the mechanical check that a prompt hands neither arm a route.)* This one is caught by hand or not at all.
+
+**Mechanism:** doc. The hand is currently the author's own, which is the weakness; the phase
+graph in **cycle 05** (05-01) can require the ask be read by an agent other than the one that
+wrote it.
+
+## GOLD RAILS, ALL OF THEM, EVERY SCENARIO — gate, cycle 02 *(inherited)*
+
+One item per FILE; every blast-sourced row appears in the output the agent is SHOWN over MCP;
+every chain is hand-audited at its construction site; per-dependency credits are hand-audited,
+never taken from a script tally; gold is the scattered periphery, selected for CITATION COST and
+never for token-darkness.
+
+**Precedent:** none recorded.
+
+**Mechanism:** gate — the gold validator: one item per file, every row resolves at the pinned
+commit. Built in **cycle 02** (02-05).
+
+## TOKEN-DARKNESS IS NOT THE MECHANISM — doc *(inherited)*
+
+A dependent whose line writes the anchor token is still gold.
+
+**Precedent:** a banked cell scored `dependents` **+0.72 (baseline 2.5 of 16, n=2)** on a gold
+set where **16 of 16 files carry the token** and one `grep -rl` returns all of them, while a cell
+curated FOR darkness put the baseline at 10 of 16 and died on its ceiling. Darkness was one
+mechanism on one repo; it was read as the law and it inverts the result.
+
+**Mechanism:** doc.
+
+## NO GREP SCREEN IS A GATE, IN ANY FORM — shape + doc, cycle 04 *(inherited)*
+
+Not a token cover, not an importer dump, not a per-row coverage census, not a darkness scan.
+Every one of them answers "a covering grep exists", and the metric is "the agent runs it to
+closure at `path:line` inside its wall" — a different question that only a run answers. Record
+what a grep prints in the yaml header; never let it decide.
+
+**Precedent:** **the import screen in its old home rejected four of four banked wins.** Two
+verticals disagree on the mechanism outright: a Rails cell banks +0.53 with 16 of 16 gold files
+carrying the anchor token, and a Go cell banks +1.00 on dependents that never name the type at
+all.
+
+**Mechanism:** shape — no screen output has a path to a kill decision in code (**cycle 04**,
+04-04). Plus doc, and the doc half is the one that broke: on 2026-08-11 an operator closed a repo
+on a grep screen, and no type system reaches an operator.
+
+## MEMORIZATION IS A GOLD-TIME CONSTRAINT, NEVER AN ADMISSION VERDICT — shape, cycle 02 *(inherited)*
+
+A famous repo is not disqualified; a memorized gold row is. Every target is churn-dated after the
+model snapshot or is a line-level structural fact the model cannot recite.
+
+**Precedent:** none recorded.
+
+**Mechanism:** shape — the memorization probe writes to gold notes, and admission has no field it
+can write to. Built in **cycle 02** (02-05).
+
+## A COMPETITOR COMPARISON IS REPORTED NO MORE FAVOURABLY THAN A SENSE ONE — shape, cycle 08 *(new)*
+
+Same axes, same floors, same spread rule. Ties and losses are reported.
+
+**Precedent:** none recorded. New with sense-lab, and it is the law in this file with the least
+holding it up and the most incentive to break: no scar, and its mechanism sits eight cycles away.
+
+**Mechanism:** shape, and it must be built as one rather than waited for — **one report function
+taking an arm identifier**, so a competitor arm structurally cannot acquire its own renderer.
+Declared in **cycle 04** (04-03) when the report is first written, consumed in **cycle 08**
+(08-05).
+
+## NO ORACLE, IN EITHER SENSE OF THE WORD — shape, cycle 06 *(new)*
+
+Nothing asks Sense a question the gold already answers and calls the result a health check.
+Product gaps come from a post-run transcript miner, never from an oracle.
+
+**Precedent:** measured on a live campaign, such a check reported 100% green on the exact repo
+where the paid runs showed four discriminator-group misses, a nondeterministic return and an
+empty one.
+
+**Mechanism:** shape — the miner takes recorded artifacts only, so it cannot answer before a run
+(**cycle 06**). See also the retired-concepts gate named under INSTRUMENTS CARRY: absence is not
+a shape until something checks for it.
+
+## THE CONTROL BOUND IS RETIRED. DO NOT REBUILD IT — doc *(inherited)*
+
+`delta = sense - control` with recall capped at 1.00 is true arithmetic that never once prevented
+a spend.
+
+**Precedent:** the arithmetic is sound and it never once prevented a spend. That is the whole
+case against it.
+
+**Mechanism:** doc, and the concept is absent from the schema. Absence is not enforced by
+anything today; see INSTRUMENTS CARRY.
+
+---
+
+# Spending
+
+## THE MINI-BENCH COMES FIRST, BOTH ARMS, ONCE — gate, cycle 04 *(inherited)*
+
+The two-step probe scenario is run before any seven-step session is written, at a real wall,
+unscored. It passes only when the baseline holds at or below 0.50 of `dependents` AND sense beats
+it by at least +0.50.
+
+**Precedent:** a banked +1.00 cell was authored in full only after its mini run measured baseline
+0 of 5 against sense 5 of 5.
+
+**Mechanism:** gate — the pay path requires a mini-bench cell. Built in **cycle 04** (04-04).
+
+## THE VALIDATION RUN IS UNSCORED, BOTH ARMS, ONCE — gate, cycle 04 *(inherited)*
+
+At the cell's real wall, before anything paid. A hand-grep is not a run. A baseline-only
+validation tells you the scenario is hard, not that Sense reaches.
+
+**Precedent:** none recorded.
+
+**Mechanism:** gate — the pay path requires a validation cell at the real wall. Built in **cycle
+04** (04-04).
+
+## IF THE BASELINE ASSEMBLES THE SET, DO NOT PAY — gate, cycle 04 *(inherited)*
+
+That holds regardless of how good the scenario looks.
+
+**Precedent:** none recorded.
+
+**Mechanism:** gate — the pay gate, non-zero exit. Built in **cycle 04** (04-04).
+
+## THE BAR IS +0.50 ON A GOLD GROUP, AND RECALL CAPS AT 1.00 — gate, cycle 01 *(inherited)*
+
+So a group whose baseline already sits at B can never deliver more than `1.00 - B`. Discriminating
+is not the same as clearing the bar — check the arithmetic against the floor, not against zero.
+
+**Precedent:** a baseline holding 0.625 makes +0.50 unreachable before the pair runs. *From the
+arithmetic killer in the retired instructions file:* 10 of 20 paid cells were dead before they
+ran.
+
+**Mechanism:** gate — the arithmetic ceiling is checked at plan time. Built in **cycle 01**
+(01-03).
+
+## EVERY ARM GETS 2 RUNS PER CELL — gate, cycle 04 *(inherited)*
+
+A third when the two disagree too much. A cell benched x1 is a sample: it may not close a
+question, settle a win or a loss, or enter an article.
+
+**Precedent:** none recorded.
+
+**Mechanism:** gate — a single-run cell is open and unpublishable. Built in **cycle 04** (04-04).
+
+## CANNOT-FINISH-AT-BUDGET IS A RESULT — shape, cycle 00 *(inherited)*
+
+Never raise the watchdog to rescue a stalled arm. A failed exam is not an invalid exam — stop and
+read the transcripts.
+
+**Precedent:** none in the source. *Sense-lab cycle 00 (00-02) added one:* two runs were killed
+at 481 seconds against a 480 second wall, with the answer cut mid-sentence, and the honest record
+of that is what makes the wall resistible.
+
+**Mechanism:** shape — it is a verdict value, and the wall is part of run identity. Shipped in
+**cycle 00** (00-02).
+
+## ONE SENSE RETRY, NEVER A LOOP, AND THE REPLACED RUN IS PARKED, NEVER SCORED — gate, cycle 05 *(inherited)*
+
+The sense arm runs first and its wall IS the baseline's budget (`paired sense wall x 1.2`), so a
+watchdogged sense run is a *censored* wall — it says "at least the ceiling", not what the work
+took — and nothing honest can be derived from it. That, and only that, is why the retry exists:
+to recover an uncensored wall, never to buy Sense a second draw at scoring.
+
+Two consequences bind. *(The source says two and then states three; see Questioned, not changed.)*
+
+**The retry is sense-only.** A baseline that runs out of `sense_wall x 1.2` is the measurement,
+not a malfunction — it is the win condition itself, and 12 such runs are where the campaign's
+second cycle result actually lives. *(The source says "cycle 2"; renumbered here only to avoid
+collision with sense-lab's build cycles.)* Never "fix" a timed-out baseline by re-running it.
+
+**The replaced run is parked**, renamed from `run-N` to `failed-run-N` rather than scored.
+Scoring both the run you declared unfit and its replacement is a double count: it put 3 sense runs
+against a 2-run baseline in two of that campaign's cells, with the superseded 0.0 still in the
+mean.
+
+**The cap is load-bearing.** Because the replaced run is parked, raising the retry cap above one
+would let Sense re-roll until it got a clean run and quietly delete every failure on the way —
+the exact bias this loop exists to avoid. One retry: a second failure STANDS as the result and is
+scored. Do not raise it. If a cell needs three attempts, that is the finding.
+
+**Precedent:** carried in the three consequences above — 12 timed-out baseline runs that are the
+measurement rather than a malfunction, and two cells that ran 3 sense runs against a 2-run
+baseline with a superseded 0.0 still in the mean.
+
+**Mechanism:** gate — a retry counter; the replaced run is parked, never scored. Built in **cycle
+05** (05-01).
+
+## COSTING MORE IS A PRODUCT FINDING, NOT A STOPPER — shape, cycle 04 *(inherited)*
+
+A cell that wins its discriminator at a cost premium says the arm is not reaching at parity,
+which is a lever, not a halt. The cost axis is priced tokens — every billed token in input-token
+equivalents — never the uncached remainder.
+
+**Precedent:** none recorded.
+
+**Mechanism:** shape — cost cannot reach the verdict. Built in **cycle 04** (04-04).
+
+## SPEND IS QUERYABLE BY CELL, CAMPAIGN AND MODEL — shape, cycle 04 *(new)*
+
+Total spend is answerable from the store by cell, by campaign and by model. A spend ceiling is
+enforced from the store, never from a counter in memory.
+
+**Precedent:** none recorded. Promoted from an enforcement-map row rather than inherited as a
+law; the in-memory-counter clause is new with sense-lab.
+
+**Mechanism:** shape — the store. Built in **cycle 04** (04-04).
+
+---
+
+# The instrument
+
+## MCP IS THE ONLY SURFACE — gate, cycle 00 and 03 *(inherited)*
+
+Every check that queries Sense goes through the MCP server, never the CLI. The CLI diverges by
+design — different defaults, caps and budget — so a CLI call measures a surface no arm touches.
+
+**Precedent:** none recorded.
+
+**Mechanism:** gate, in two halves, and the second is the one that bites. depguard forbids
+`lab/**` importing `sense/internal/**`, with a test that fires on the violation — shipped in
+**cycle 00** (00-01). But depguard does not stop `exec.Command("sense", "graph", ...)`, and this
+project shells out as a matter of habit. The real check is the tee: every Sense query appears in
+`sense-io.jsonl`, and a run whose queries do not all appear there used a surface no arm touched.
+Built in **cycle 03** (03-05).
+
+## STOPPER — doc, and it should be a gate in cycle 01 *(inherited)*
+
+A bug in anything whose output becomes a number that decides something halts the line: no new
+cells, no verdicts, no swaps, no kills, until the human rules. Continue without a ruling only on
+a re-score diff proving zero impact. A mitigation is not a resolution.
+
+**Precedent:** none recorded.
+
+**Mechanism:** doc today, and it is describing a gate. It wants a `stopper` flag on the campaign
+row that the planner refuses to plan against — the same row ONE REPO AT A TIME already reads, so
+it should be built with it in **cycle 01** (01-03).
+
+## THE SIMULATED ADVERSARY PROBE IS RETIRED — gate, cycle 01 *(inherited)*
+
+**Precedent:** it never estimated the benched arm in either direction. On the parked cell it
+reached 4 of 16 where the arm reached 10; on the banked cell it reached at most 7 of 16 where the
+arm reached 2.5, and a leaked run reached 15 of 16 over that same arm. No correction factor fits
+points that disagree by 2.5x one way and 0.36x the other. The mini-bench measures the same thing
+with a real baseline at a real wall and costs about the same. Do not rebuild it.
+
+**Mechanism:** absence, which is not a shape until something checks for it. The gate is the
+retired-concepts check named under INSTRUMENTS CARRY — **cycle 01** (01-02).
+
+## ONE REPO AT A TIME, TO A VERDICT — gate, cycle 01 *(inherited)*
+
+No second repo's scenario is authored while the first is mid-diagnosis. A parked repo resumes
+from state, it never restarts.
+
+**Precedent:** none recorded.
+
+**Mechanism:** gate — the planner refuses a second repo mid-verdict, against the campaigns row.
+Built in **cycle 01** (01-03).
+
+## A PHASE IS SELF-CONTAINED — shape, cycle 05 *(inherited)*
+
+Its input is a file on disk and its output is a file plus a verdict, never a conversation carried
+forward. If a phase needs something the previous one did not write down, that is a defect in the
+previous phase.
+
+**Precedent:** none recorded.
+
+**Mechanism:** shape — the declared phase graph. Each phase names its input artifact, output
+artifact, verdict enum and transitions. Built in **cycle 05** (05-01).
+
+## WHAT A PER-REPO PHASE DOES NOT OWN — doc *(inherited)*
+
+The slate belongs to bootstrap. Product fixes are parked, never made mid-vertical. The agent
+survey is read in aggregate, never per run. Cross-model confirmation is downstream.
+
+**Precedent:** none recorded.
+
+**Mechanism:** doc.
+
+## A CONFIRMED WIN IS HANDED OFF, NOT HELD — gate, cycle 07 *(inherited)*
+
+"Downstream" above bounds what a per-repo phase may JUDGE, never what it may START: on
+`WIN CONFIRMED` the board phase invokes the next stage and stops there, and that stage owns its
+gate, its spend, its **two agent verdicts** and its publish check from that point on.
+
+Two consequences are deliberate. The hand-off runs only behind the five mechanical
+win-confirmation checks — the checks a win-confirmation agent runs before a win may be banked;
+the checklist that printed "confirm by hand" in their place was a gate only while someone was
+reading, and the loop advanced whether or not anyone ticked it. And it moves the vertical into a
+regime that CAN record a loss, with no human in between, which is the point: what is measured is
+published, and the boards a human never got around to starting were never evidence of anything.
+
+**Precedent:** the retired driver's own words for the regime change — "Cycle 1 cannot record a
+loss; this one can, and must".
+
+**Mechanism:** gate — the win path writes to the board and stops. Built in **cycle 07** (07-02).
+
+## NO HUMAN GATE IN THE PER-REPO PHASES — shape, cycle 03 *(inherited)*
+
+They author, spend, diagnose and swap on their own; what replaced each removed gate is mechanical
+and named in the plan that runs it.
+
+**Precedent:** none recorded.
+
+**Mechanism:** shape — no interactive prompt in the run path. Built in **cycle 03** (03-04).
+
+## INSTRUMENTS CARRY, DOCS DO NOT — gate, cycle 01 *(inherited)*
+
+A check that must survive the vertical is a gate or a shape, never a paragraph in a page.
+
+**Precedent:** this file's own history. A line believed to be law lived inside a function that
+rendered a sentence, and nothing enforced it.
+
+**Mechanism:** gate, and it does not exist yet. Two checks make this file carry itself, both
+**cycle 01** (01-02):
+
+- a test that parses this file and exits non-zero when a `gate`-tagged law names no cycle
+- a test asserting the names in *Retired. Do not rebuild* stay absent from `lab/**`, which is
+  what turns "absent from the codebase" from a hope into a shape
+
+---
+
+# The code around the bench
+
+## NO NEW MODULE DEPENDENCY WITHOUT AN EXPLICIT DECISION — doc, wants a gate in cycle 01 *(new)*
+
+sense-lab stays pure Go, cgo-free, and cross-compiles to a single static binary exactly as Sense
+does. Everything it needs is already present or in the standard library, and containers are
+reached by shelling out rather than by a client library.
+
+One `go.mod`, one `go.sum`, one dependabot target — so every dependency sense-lab acquires lands
+in the *product's* supply chain. This rule is the entire justification for rejecting a second
+module.
+
+**Precedent:** none recorded. New with sense-lab.
+
+**Mechanism:** doc today, and it is the one load-bearing rule in this file with nothing behind
+it. The gate it wants: a test asserting `go.mod`'s direct-require block matches a checked-in
+list. Named for **cycle 01** (01-02).
+
+## THE `lab/` COVERAGE EXCEPTION LIST STARTS EMPTY AND STAYS EMPTY — gate, cycle 00 *(new)*
+
+Not a small list. Empty. A lab file that cannot reach the floor is telling you decision logic
+leaked into the effectful layer, and the fix is to move the logic, never to add a line to the
+list.
+
+**Precedent:** none recorded. New with sense-lab.
+
+**Mechanism:** gate — `scripts/coveragegate` is deny-by-default, so a new lab package holds the
+floor with no allow-list edit. Shipped in **cycle 00** (00-01).
+
+## THE EXCLUDED LIVE SUITE MUST COVER NOTHING EXCLUSIVELY — gate, cycle 00 *(new)*
+
+If files are covered only by tests CI does not run, the floor lands hardest on precisely the thin
+effectful layer, which inverts the incentive. Real process work stays in the default suite
+because it is hermetic. Only tests needing an authenticated agent CLI or a model are excluded.
+
+The consequence: an agent-tool adapter splits into a pure part that builds the argument list and
+environment from config, and a generic spawn. If a file exists that only a live test can cover,
+the layering is wrong.
+
+**Precedent:** none recorded. New with sense-lab.
+
+**Mechanism:** gate — the coverage floor, since a file covered only by excluded tests fails it.
+Shipped in **cycle 00** (00-01).
+
+## IF A SCRIPT READS IT, IT IS DATA. IF ONLY A HUMAN READS IT, IT IS PROSE — doc *(new)*
+
+Data goes in the store. Prose stays markdown. Nothing lives in both places.
+
+**Precedent:** none recorded. New with sense-lab.
+
+**Mechanism:** doc.
+
+## DETECTION IS POST-RUN OR IT DOES NOT EXIST — shape, cycle 06 *(new)*
+
+A check that can answer before a run can be consulted before spending, and then it is a screen.
+Every screen this project built was measured wrong. The miner reads transcripts and
+`sense-io.jsonl` from runs that already happened; there is no pre-run detector.
+
+**Precedent:** see NO GREP SCREEN IS A GATE and NO ORACLE, which carry the measurements.
+
+**Mechanism:** shape — the miner takes recorded artifacts and nothing else. Built in **cycle 06**.
+
+## A SCRIPT IS NOT A RULE UNTIL YOU PROVE IT RUNS AND IT GATES — gate + doc, cycle 00 *(inherited)*
+
+Before citing a script as a constraint, or opening it to edit, establish both. **Used** has three
+states, not two: *invoked* (a driver, plan or agent names its path), *imported* (a live module
+imports it), or *cold*. Import probes are UNANCHORED — a module can import another from inside a
+function, where a `^(import|from)` probe misses it. **Enforces** is separate: a live script that
+only builds a report string constrains nothing; the test is whether it exits non-zero on the
+condition.
+
+**Precedent:** "RUNS=2 binds the headline arm only" was quoted as a law from two scripts in the
+retired tree — one cold, one live but with the line inside a function that rendered a sentence.
+Nothing enforced it.
+
+**Mechanism:** gate — in Go an unused package is a build or lint failure, which kills the *cold*
+case outright. Shipped in **cycle 00** (00-01). Plus doc for the rest: coverage proves a gate was
+executed, never that its exit code was asserted, so "enforces" still has to be established by
+reading the test.
+
+## NEVER CHANGE A SCRIPT ANOTHER CYCLE'S PLANS USE — shape, cycle 02 *(inherited)*
+
+Verifying such a change costs a full cycle — hours and paid sessions — and it fails silently, as
+a slightly different score rather than a crash. A new cycle reads artifacts off disk and writes
+its OWN code. Every shared instrument already writes its output down — the scored result, the
+Sense io capture, the banked cells — so reaching into an older cycle's code is never necessary.
+The pattern is a read-only pass over transcripts that already exist: no spend, no shared code.
+
+**The carve-out is WRITE-ONLY HUMAN SURFACES.** A status page decides nothing, no loop reads it,
+and no measurement can move because of it, so a second cycle extends it rather than building a
+second page nobody thinks to open. **The rule protects what feeds a decision, not what feeds a
+reader.**
+
+**Precedent:** none recorded beyond the cost.
+
+**Mechanism:** shape — the scorer version and the rubric hash are part of run identity, so a
+change makes new cells instead of quietly repricing old ones. Built in **cycle 02** (02-06).
+
+---
+
+# Retired. Do not rebuild
+
+A retired idea with no recorded reason is an idea someone rebuilds in eight months believing it
+is new. **The evidence for each lives in the law named beside it; it is not repeated here, so
+there is one owner per number.**
+
+| Retired | Why | Evidence |
+|---|---|---|
+| The control bound | True arithmetic that never once prevented a spend | THE CONTROL BOUND IS RETIRED |
+| The simulated adversary probe | Never estimated the benched arm in either direction, and the disagreements admit no correction factor | THE SIMULATED ADVERSARY PROBE IS RETIRED |
+| Grep screens as gates (token cover, importer dump, per-row coverage census, darkness scan) | They answer "a covering grep exists", not "the agent runs it to closure inside its wall" | NO GREP SCREEN IS A GATE, IN ANY FORM |
+| The correctness oracle, text-match form | Scores the route rather than the answer | A CORRECTNESS ORACLE MUST NOT BE SATISFIABLE BY THE ROUTE |
+| The resolution oracle | Asking Sense what the gold already answers, and calling it a health check | NO ORACLE, IN EITHER SENSE OF THE WORD |
+
+**This table is not enforced.** The gate that would make it real — a test asserting these names
+stay absent from `lab/**` — is named under INSTRUMENTS CARRY for cycle 01.
+
+---
+
+# Questioned, not changed
+
+Laws copied here unchanged that something about looks wrong. A note, never an edit: changing a
+rule and its home in one pass means nobody can tell which change did what.
+
+- **ONE SENSE RETRY** *(2026-08-15)* — the source says "Two consequences bind" and then states
+  three. The wording is preserved as-is rather than corrected, because correcting a source error
+  while re-homing it is exactly the edit this section exists to prevent. Whoever revisits it
+  should make it three.
+- **A GOLD ROW MUST BE CITEABLE IN THE FORM THE ASK DEMANDS** *(2026-08-15)* — stated about the
+  *form* (path:line versus mention). Cycle 00 measured a second failure of the same kind about
+  the *line* (call site versus routine definition), which the wording does not obviously cover.
+  Whether that is the same law or a second one is open.
+- **A FREE ROW IS A GIFT TO THE BASELINE** *(2026-08-15)* — sits one line from A GOLD ROW SHOULD
+  COST A READ, whose whole point is that the same measurement may not kill a draft, yet the two
+  carry different enforcement strengths. Worth checking they are not read as one.
+- **PRECISION RANKS, IT NEVER KILLS** *(2026-08-15)* — three data points across three verticals
+  (0.078, 0.78, ~0.94). The `n` killer applies to the law itself, not only to findings under it.
+- **AN OCCURRENCE-LIST QUESTION CAN WIN** *(2026-08-15)* — states its own causal claim as "under
+  test, not yet established". It is the only law here that admits it is a hypothesis. It needs a
+  cycle by which it graduates or reverts; without one it becomes a law by attrition.
+- **Three inherited laws gained a sense-lab precedent** *(2026-08-15)* — QUOTE IT, A GOLD ROW MUST
+  BE CITEABLE and CANNOT-FINISH-AT-BUDGET. Each is labelled where it appears. Only the second was
+  sanctioned in advance; the other two were added because cycle 00 measured them, and they are
+  recorded here so the expansion is visible rather than assumed.
+- **Ten mechanism tags differ from the enforcement map** *(2026-08-15)* — mostly because the map
+  overclaimed (an absence called a shape, a table called a mechanism). But three change
+  enforcement STRENGTH rather than honesty: A GOLD ROW SHOULD COST A READ moved off the gate
+  column, A METRIC WITH A FREE PARAMETER narrowed to declared parameters, and A COMPETITOR
+  COMPARISON was promoted from doc to shape. Where the two files disagree the law file wins; the
+  map is stale until someone reconciles it.
+- **The instruments four laws depend on are in the retired tree** *(2026-08-15)* — the
+  inverse-frequency ranking (A FREE ROW), the retention-ring sweep ("WHAT HOLDS THIS"), and the
+  two scripts behind A SCRIPT IS NOT A RULE. Their measurements are recorded here and marked
+  historical, but nothing rebuilds them, so those measurements cannot be refreshed or challenged.


### PR DESCRIPTION
## Problem

The authority for every judgment in this build lived in `improvement-loop/plans/cycle-1-craft-the-scenario/laws.md` — inside the tree being frozen. That is the exact dependency the clean room exists to remove, and it is the one dependency no depguard rule can catch.

The carryover doc does not solve it. It is an **index**: laws by title with an enforcement mechanism attached, deliberately not restating them, because a summary of the laws is not the laws. This project has measured what working from a digest costs. One operator session, reading a ten-law digest, closed a repo on a grep screen, forecast a cell from per-row rates pooled across thirteen different asks, and recommended authoring for token-darkness. Three moves, three laws banned them, none of the three was in the digest.

## Summary

`lab/LAWS.md` carries **55 laws in full: 46 inherited, 9 new with sense-lab.** There is no path from it back into `improvement-loop/` — verified, zero references.

Each law arrives with its statement, the **precedent** that produced it, and the **mechanism** that enforces it. Where there is no precedent the file says `none recorded` rather than leaving a blank, because an invisible gap reads the same as a law nobody bothered to source.

**The mechanism is on the heading**, not buried at the foot of the entry: `## NO GREP SCREEN IS A GATE, IN ANY FORM — shape + doc, cycle 04`. This file is meant to be opened under time pressure before every verdict, close, swap, kill, pay call and ledger entry, and a reader who stops early should still learn whether anything will actually stop them. Every `gate` names the cycle that builds it.

Several tags were made honest along the way. "Absent from the codebase" is not a shape until something checks for it. A type system does not reach the operator who closed a repo on a grep screen — that half is `doc`, and it is the half that has been violated. A report that flags is not a gate. `depguard` does not stop `exec.Command("sense", ...)`, so MCP IS THE ONLY SURFACE names the tee as its real check. The file also names the two gates that would make it carry itself — a parser that fails when a `gate`-tagged law names no cycle, and a check that the retired concepts stay absent — neither of which exists yet.

## Laws were copied, not improved

Where a law looks wrong it gets a line in `Questioned, not changed` and no edit. That includes a source which says "Two consequences bind" and then states three: the wording is preserved and the discrepancy noted, because correcting a source error while re-homing it is precisely the change nobody could later attribute.

## Fidelity was audited, and the audit found real defects

Not spot-checked and assumed. Every law was compared against its source, and the audit returned nine discrepancies, all now fixed:

- **A carve-out was dropped**, which made a law forbid what its source explicitly permits: NEVER CHANGE A SCRIPT ANOTHER CYCLE'S PLANS USE lost "the carve-out is WRITE-ONLY HUMAN SURFACES ... the rule protects what feeds a decision, not what feeds a reader."
- **A law was retitled while being copied** — the same one — which is the rabbit hole the pitch names explicitly. Restored to its source title.
- **A count was silently generalised**, "its two agent verdicts" to "its verdicts".
- **A scope was widened**, "a check that must survive the vertical" to "a check that must survive".
- **Three additions were presented as inherited law** and are now labelled as new or sourced.
- Dropped detail restored where it is what makes a law actionable — the unanchored-import mechanism, the parking rename, the regime-change quote.

Twelve measurements were then checked word for word against the source, including the three the pitch names: 67.4% baseline against 48.4% sense over 10 transcripts; the import screen rejecting four of four banked wins; +0.72 at baseline 2.5 of 16 with 16 of 16 files carrying the token.

## Changes

- `lab/LAWS.md` — the authority.
- `.doc/sense-lab/05-laws-carryover.md` — stops being the authority and says so at the top; it is the enforcement map. Its instrument-section miscount is corrected and its law titles now match the law file verbatim, so lookup between the two works.

## Test plan

This pitch adds no Go files, so the coverage bar and the test review do not apply; the count check and the council review are its gates. That exception is stated rather than left implicit.

- `make ci` green, unaffected.
- **Count, section by section:** 17 / 13 / 9 / 9 / 7 = 55. Inherited 46 (44 from the law file, 2 from the instructions file), new 9. Mechanically verified.
- **Every law has a mechanism, and every `gate` names its cycle** — mechanically verified.
- **Every law has a precedent block** — mechanically verified.
- **No reference to `improvement-loop/` anywhere in the file** — mechanically verified.
- Doc 05's titles match the law file verbatim — mechanically verified.

Reviewed by the council.