### PR TITLE
bench(lab): move the repository, agent and model into a catalog

### DIFF
--- a/lab/agents/claude-code/README.md
+++ b/lab/agents/claude-code/README.md
@@ -1,0 +1,36 @@
+# claude-code
+
+Last verified: 2026-08-15.
+
+## Files it touches
+
+`$HOME/.claude/` and `$HOME/.claude.json`, both HOME-relative. `.claude.json`
+is a single large per-project state file, so **two runs against the same
+repository path share it and race on it**. A per-run path is what separates
+them; see cycle 03.
+
+## Known side effects on the repository
+
+Reading the repository's own `CLAUDE.md` and `AGENTS.md` is normal behaviour,
+not a contamination bug — but it means the SUBJECT's instructions and the
+REPOSITORY's instructions arrive through the same channel. `sense scan` writes
+into both when it configures a repo, which is how the baseline arm can be handed
+Sense without anyone doing it on purpose. Cycle 03 (03-02) carries the measured
+list.
+
+Measured 2026-08-15: `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1` does **not** stop the
+operator's own `~/.claude/CLAUDE.md` from being loaded. Asked directly, a
+benched session quoted it back. Only a disposable HOME closes that.
+
+## Untrusted workspaces fail quietly
+
+A path the tool has not seen before is untrusted, and it drops
+`permissions.allow` entries from `.claude/settings.json` with a line on stderr
+and nothing else. The session still runs, the MCP server still loads, and part
+of the arm's configured surface is silently missing. A per-run disposable path
+makes every run untrusted, so this becomes the default rather than the
+exception.
+
+## Auth
+
+Subscription or API key.

--- a/lab/agents/claude-code/agent.json
+++ b/lab/agents/claude-code/agent.json
@@ -1,0 +1,22 @@
+{
+  "id": "claude-code",
+  "binary": "claude",
+  "model_flag": "--model",
+  "headless_args": [
+    "-p",
+    "--output-format",
+    "stream-json",
+    "--verbose",
+    "--permission-mode",
+    "bypassPermissions"
+  ],
+  "env": [
+    "IS_SANDBOX=1",
+    "CLAUDE_CODE_DISABLE_AUTO_MEMORY=1"
+  ],
+  "supports_mcp": true,
+  "auth_modes": [
+    "subscription",
+    "api_key"
+  ]
+}

--- a/lab/agents/codex/README.md
+++ b/lab/agents/codex/README.md
@@ -1,0 +1,13 @@
+# codex
+
+Last verified: 2026-08-15. **Not yet driven by sense-lab** — this file is
+declared so the catalog can be validated against it, and cycle 08 is the first
+thing that runs it. Treat every line below as unverified until then.
+
+## Files it touches
+
+`$HOME/.codex`, HOME-relative.
+
+## Auth
+
+Subscription or API key.

--- a/lab/agents/codex/agent.json
+++ b/lab/agents/codex/agent.json
@@ -1,0 +1,16 @@
+{
+  "id": "codex",
+  "binary": "codex",
+  "model_flag": "--model",
+  "headless_args": [
+    "exec",
+    "--json",
+    "--full-auto"
+  ],
+  "env": [],
+  "supports_mcp": true,
+  "auth_modes": [
+    "subscription",
+    "api_key"
+  ]
+}

--- a/lab/agents/opencode/README.md
+++ b/lab/agents/opencode/README.md
@@ -1,0 +1,33 @@
+# opencode
+
+The human half of `agent.json`: operational facts about someone else's product.
+Dated and tied to a version. **Nothing validates these dates and nothing warns
+when one is old — a stale date here is not a guarantee of anything.**
+
+Last verified: 2026-08-15, against the model set in `lab/models/`.
+
+## Write a model id in provider/model form, always
+
+This is the quirk that has already cost a whole arm.
+
+An arm was written as `mistral-large-3:cloud`. The runner mapped a bare
+`<id>:cloud` to `ollama-cloud/<id>`, which **ate the size tag the model needed**:
+the provider offers only `mistral-large-3:675b`, so the id resolved to something
+that does not exist. Every run of that arm came back **empty, zero tokens, exit
+1** — and it failed as a bad result rather than as a crash, which is why it took
+a campaign to notice.
+
+`provider/model` form passes through untouched. The catalog now carries the
+full id (`ollama-cloud/mistral-large-3:675b`), and the shorter form is recorded
+as an alias so nothing silently re-derives it.
+
+## Files it touches
+
+`$HOME/.config/opencode` and `$HOME/.local/share/opencode`, both HOME-relative,
+so a disposable home contains them.
+
+## Auth
+
+API key only. It cannot reach a model that is available under a subscription
+alone, and the catalog validator rejects that pairing at load time rather than
+at spawn time.

--- a/lab/agents/opencode/agent.json
+++ b/lab/agents/opencode/agent.json
@@ -1,0 +1,14 @@
+{
+  "id": "opencode",
+  "binary": "opencode",
+  "model_flag": "--model",
+  "headless_args": [
+    "run",
+    "--print-logs"
+  ],
+  "env": [],
+  "supports_mcp": true,
+  "auth_modes": [
+    "api_key"
+  ]
+}

--- a/lab/cmd/sense-lab/signal_test.go
+++ b/lab/cmd/sense-lab/signal_test.go
@@ -44,11 +44,13 @@ func TestSIGTERMRecordsTheRunAndKillsTheAgentTree(t *testing.T) {
 	if err := os.WriteFile(scenario, []byte("name: t\nsteps:\n  - name: s\n    prompt: go\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	head := initRepo(t, dir)
+	cfg := writeCatalog(t, dir, agent, head)
 
 	out := filepath.Join(dir, "run")
-	lab := exec.Command(bin, "run",
-		"-scenario", scenario, "-repo", dir, "-out", out,
-		"-agent", agent, "-wall", "5m")
+	lab := exec.Command(bin, "run", "-config", cfg,
+		"-scenario", scenario, "-repo", "r1", "-checkout", dir, "-out", out,
+		"-agent", "tool", "-model", "m1", "-wall", "5m")
 	var labOut strings.Builder
 	lab.Stdout, lab.Stderr = &labOut, &labOut
 	if err := lab.Start(); err != nil {
@@ -106,6 +108,47 @@ func TestSIGTERMRecordsTheRunAndKillsTheAgentTree(t *testing.T) {
 	if p, err := os.ReadFile(filepath.Join(out, "prompt.txt")); err != nil || !strings.Contains(string(p), "go") {
 		t.Errorf("prompt.txt = %q, %v", p, err)
 	}
+}
+
+// writeCatalog writes the smallest config directory that can drive bin.
+// initRepo makes dir a one-commit git repository and returns its HEAD, so the
+// run's checkout matches the commit the catalog pins.
+func initRepo(t *testing.T, dir string) string {
+	t.Helper()
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "--allow-empty", "-m", "init"},
+	} {
+		if out, err := exec.Command("git", append([]string{"-C", dir}, args...)...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func writeCatalog(t *testing.T, dir, bin, pin string) string {
+	t.Helper()
+	cfg := filepath.Join(dir, "config")
+	for path, body := range map[string]string{
+		"agents/tool/agent.json": `{"id":"tool","binary":"` + bin + `","model_flag":"--model",
+		  "headless_args":["-p"],"env":[],"supports_mcp":false,"auth_modes":["api_key"]}`,
+		"subjects/baseline/subject.json": `{"id":"baseline","kind":"baseline","agents":["tool"]}`,
+		"models/m1.json":                 `{"id":"m1","provider":"acme","available_under":["api_key"],"agents":["tool"]}`,
+		"repos/r1.json":                  `{"id":"r1","url":"https://example.test/r1.git","commit":"` + pin + `","languages":["go"]}`,
+	} {
+		full := filepath.Join(cfg, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return cfg
 }
 
 // waitFor polls until cond holds, so a test does not race a process it just

--- a/lab/internal/catalog/catalog.go
+++ b/lab/internal/catalog/catalog.go
@@ -1,0 +1,325 @@
+// Package catalog loads and validates the config that describes what may be
+// benched: subjects, agent tools, models and repositories.
+//
+// It exists so that ecosystem facts — CLI flags, config paths, model
+// availability, auth modes — are data rather than code. Those facts change
+// without warning and they are not the engine's business. The test that the
+// separation holds is that adding an agent tool, a model or a competitor is a
+// new JSON file and nothing else.
+//
+// It is pure: it takes a directory of files and returns data. It runs nothing.
+package catalog
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// Kind is what a subject is: the treatment under test.
+type Kind string
+
+const (
+	// Baseline is the arm with no code-intelligence treatment at all.
+	Baseline Kind = "baseline"
+	// Sense is Sense itself, at some version.
+	Sense Kind = "sense"
+	// Competitor is somebody else's tool.
+	Competitor Kind = "competitor"
+)
+
+// Subject is a code-intelligence treatment.
+//
+// Install, setup and cleanup commands are deliberately absent. Cycle 08 is the
+// first thing that runs them, and a schema for commands nobody executes is
+// written from imagination. They arrive with the code that runs them.
+//
+// The same rule trimmed this struct on review. A first draft carried version,
+// executor, config paths, model aliases, a retired flag, frameworks and two
+// multi-flag capability structs — thirteen fields nothing read. Because decode
+// refuses unknown fields, a guessed field is load-bearing the day it ships: it
+// cannot be dropped without editing every config file. Fields arrive with their
+// consumer.
+type Subject struct {
+	ID   string `json:"id"`
+	Kind Kind   `json:"kind"`
+	// NeedsMCP says this treatment reaches the agent through an MCP server, so
+	// it can only be driven by a tool that speaks one.
+	NeedsMCP bool `json:"needs_mcp"`
+	// Agents are the agent tool ids this subject can be driven through.
+	Agents []string `json:"agents"`
+}
+
+// Agent is the harness that runs a model: the CLI, and how to talk to it.
+//
+// Everything about HOW a model is invoked lives here. The moment a model file
+// knows a CLI flag, the separation is gone and the matrix stops being data.
+type Agent struct {
+	ID     string `json:"id"`
+	Binary string `json:"binary"`
+	// ModelFlag is the flag that selects a model, e.g. "--model".
+	ModelFlag string `json:"model_flag"`
+	// HeadlessArgs drive the tool with no terminal attached. They live here
+	// rather than in code because they are ecosystem facts: they change when
+	// somebody else ships a release, and no two tools spell them alike.
+	HeadlessArgs []string `json:"headless_args"`
+	// Env is added to the session environment, as KEY=VALUE. Same reason.
+	Env []string `json:"env"`
+	// SupportsMCP bounds which subjects this tool can carry.
+	SupportsMCP bool `json:"supports_mcp"`
+	// AuthModes are how this tool can be authenticated, e.g. subscription, api_key.
+	AuthModes []string `json:"auth_modes"`
+}
+
+// Model is a set of FACTS about a model. Never mechanics for invoking one:
+// those belong to the agent tool that drives it.
+type Model struct {
+	ID       string `json:"id"`
+	Provider string `json:"provider"`
+	// Aliases are other ids the same model answers to.
+	Aliases []string `json:"aliases"`
+	// AvailableUnder lists the auth modes that can reach this model.
+	AvailableUnder []string `json:"available_under"`
+	// Agents are the agent tool ids that can drive this model.
+	Agents []string `json:"agents"`
+}
+
+// Repo is the code under study, at a pinned commit.
+//
+// A vertical is a query over this metadata rather than a directory tree, which
+// is why languages, frameworks and stack live here. `cohort` is deliberately
+// absent: nothing selects on it yet.
+type Repo struct {
+	ID        string   `json:"id"`
+	URL       string   `json:"url"`
+	Commit    string   `json:"commit"`
+	Languages []string `json:"languages"`
+	Stack     string   `json:"stack"`
+}
+
+// ErrNoConfig is returned when the config directory is not there at all. It is
+// its own error because "you have not pointed me at a catalog" and "your
+// catalog is wrong" are different problems for the person reading the message.
+var ErrNoConfig = errors.New("no config directory")
+
+// Catalog is everything the config directory describes.
+type Catalog struct {
+	// claimed maps every id and alias to the file that took it, so a collision
+	// can name both sides.
+	claimed  map[string]string
+	Subjects map[string]Subject
+	Agents   map[string]Agent
+	// Models is the set of models, one entry per model file. Aliases are NOT
+	// in here: a lookup index masquerading as the set makes the catalog list a
+	// model that does not exist and makes the validator report one fault twice.
+	Models map[string]Model
+	// byName resolves a model by its id OR any of its aliases.
+	byName map[string]Model
+	Repos  map[string]Repo
+}
+
+// Load reads a config directory and validates it.
+//
+// Validation depth follows consumers: identifiers resolve, referenced ids
+// exist, required fields are present. Full schemas for every field wait until
+// something depends on those fields, because a rule for a field nobody reads is
+// a rule written from imagination.
+func Load(dir string) (*Catalog, error) {
+	if _, err := os.Stat(dir); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrNoConfig, err)
+	}
+	c := &Catalog{
+		claimed:  map[string]string{},
+		Subjects: map[string]Subject{},
+		Agents:   map[string]Agent{},
+		Models:   map[string]Model{},
+		byName:   map[string]Model{},
+		Repos:    map[string]Repo{},
+	}
+	if err := loadInto(dir, c); err != nil {
+		return nil, err
+	}
+	if err := c.validate(); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// loadInto reads all four kinds of file. Subjects and agents are directories
+// with a JSON file inside, because each carries a README beside it; models and
+// repos are plain files.
+func loadInto(dir string, c *Catalog) error {
+	if err := readNested(filepath.Join(dir, "subjects"), "subject.json", c.addSubject); err != nil {
+		return err
+	}
+	if err := readNested(filepath.Join(dir, "agents"), "agent.json", c.addAgent); err != nil {
+		return err
+	}
+	if err := readFlat(filepath.Join(dir, "models"), c.addModel); err != nil {
+		return err
+	}
+	return readFlat(filepath.Join(dir, "repos"), c.addRepo)
+}
+
+func (c *Catalog) addSubject(path string, b []byte) error {
+	var s Subject
+	if err := decode(path, b, &s); err != nil {
+		return err
+	}
+	if err := c.claim(path, "subject", s.ID); err != nil {
+		return err
+	}
+	c.Subjects[s.ID] = s
+	return nil
+}
+
+func (c *Catalog) addAgent(path string, b []byte) error {
+	var a Agent
+	if err := decode(path, b, &a); err != nil {
+		return err
+	}
+	if err := c.claim(path, "agent", a.ID); err != nil {
+		return err
+	}
+	c.Agents[a.ID] = a
+	return nil
+}
+
+func (c *Catalog) addModel(path string, b []byte) error {
+	var m Model
+	if err := decode(path, b, &m); err != nil {
+		return err
+	}
+	if err := c.claim(path, "model", m.ID); err != nil {
+		return err
+	}
+	c.Models[m.ID] = m
+	c.byName[m.ID] = m
+	// An alias is a name the same model answers to. They are indexed rather
+	// than merely recorded, because the failure this package exists to prevent
+	// was exactly a model named one way and offered another: a bare
+	// `mistral-large-3:cloud` that resolved to nothing. A field documenting
+	// that confusion with no lookup behind it is how a reader concludes it is
+	// handled.
+	for _, alias := range m.Aliases {
+		if err := c.claim(path, "model alias", alias); err != nil {
+			return err
+		}
+		c.byName[alias] = m
+	}
+	return nil
+}
+
+// Model resolves a model by its id or any of its aliases.
+//
+// The alias lookup exists because the failure this package is named for was a
+// model called one way and offered another. It is a separate index rather than
+// extra entries in Models, so the catalog never lists a model twice and the
+// validator never reports one fault once per alias.
+func (c *Catalog) Model(name string) (Model, bool) {
+	m, ok := c.byName[name]
+	return m, ok
+}
+
+func (c *Catalog) addRepo(path string, b []byte) error {
+	var r Repo
+	if err := decode(path, b, &r); err != nil {
+		return err
+	}
+	if err := c.claim(path, "repo", r.ID); err != nil {
+		return err
+	}
+	c.Repos[r.ID] = r
+	return nil
+}
+
+// claim reserves an id, refusing an empty one and refusing to overwrite an id
+// something else already took.
+//
+// Both failures are silent otherwise. An entry with no id becomes an anonymous
+// validation error nobody can locate; a duplicate lets the last file read win
+// and quietly discards the other, which is precisely the "setting that looks
+// applied and is not" that DisallowUnknownFields below exists to stop. Ids and
+// filenames are independent here by design — `models/glm-5.2_cloud.json` holds
+// id `glm-5.2:cloud` — so nothing else would notice.
+//
+// The message names BOTH files, because which one is read first depends on
+// filename order and the one that trips the check is often the innocent one.
+func (c *Catalog) claim(path, kind, id string) error {
+	if id == "" {
+		return fmt.Errorf("%s: no id", path)
+	}
+	if first, dup := c.claimed[id]; dup {
+		return fmt.Errorf("%s: %s id %q is already claimed by %s", path, kind, id, first)
+	}
+	c.claimed[id] = path
+	return nil
+}
+
+// decode parses one config file. Unknown fields are refused: a typo'd key that
+// parses silently is a setting that looks applied and is not, which is the
+// failure this whole package exists to prevent.
+func decode(path string, b []byte, into any) error {
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(into); err != nil {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	return nil
+}
+
+// readNested reads <dir>/<id>/<name>, which is the shape for config that has a
+// README beside it.
+func readNested(dir, name string, add func(string, []byte) error) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", dir, err)
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		path := filepath.Join(dir, e.Name(), name)
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", path, err)
+		}
+		if err := add(path, b); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// readFlat reads every .json file directly in dir.
+func readFlat(dir string, add func(string, []byte) error) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", dir, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", path, err)
+		}
+		if err := add(path, b); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// IDs returns the ids of a catalog map, sorted, so output is stable.
+func IDs[T any](m map[string]T) []string {
+	return slices.Sorted(maps.Keys(m))
+}

--- a/lab/internal/catalog/catalog_test.go
+++ b/lab/internal/catalog/catalog_test.go
@@ -1,0 +1,592 @@
+package catalog
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// good returns a minimal catalog directory that loads clean. Tests break one
+// thing in it at a time, so each failure has exactly one cause.
+func good(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	writeSubject(t, dir, "baseline", Subject{
+		ID: "baseline", Kind: Baseline, Agents: []string{"tool"},
+	})
+	writeAgent(t, dir, "tool", Agent{
+		ID: "tool", Binary: "toolbin", ModelFlag: "--model",
+		HeadlessArgs: []string{"-p"}, AuthModes: []string{"api_key"},
+		SupportsMCP: true,
+	})
+	writeModel(t, dir, Model{
+		ID: "m1", Provider: "acme", AvailableUnder: []string{"api_key"}, Agents: []string{"tool"},
+	})
+	writeRepo(t, dir, Repo{
+		ID: "r1", URL: "https://example.test/r1.git", Commit: "abc123", Languages: []string{"go"},
+	})
+	return dir
+}
+
+func writeJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeSubject(t *testing.T, dir, id string, s Subject) {
+	writeJSON(t, filepath.Join(dir, "subjects", id, "subject.json"), s)
+}
+func writeAgent(t *testing.T, dir, id string, a Agent) {
+	writeJSON(t, filepath.Join(dir, "agents", id, "agent.json"), a)
+}
+func writeModel(t *testing.T, dir string, m Model) {
+	writeJSON(t, filepath.Join(dir, "models", strings.NewReplacer("/", "_", ":", "_").Replace(m.ID)+".json"), m)
+}
+func writeRepo(t *testing.T, dir string, r Repo) {
+	writeJSON(t, filepath.Join(dir, "repos", r.ID+".json"), r)
+}
+
+func loadErr(t *testing.T, dir string) string {
+	t.Helper()
+	_, err := Load(dir)
+	if err == nil {
+		t.Fatal("Load accepted a catalog it should have refused")
+	}
+	return err.Error()
+}
+
+func TestAWellFormedCatalogLoads(t *testing.T) {
+	c, err := Load(good(t))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if c.Subjects["baseline"].Kind != Baseline {
+		t.Errorf("subject kind = %q", c.Subjects["baseline"].Kind)
+	}
+	if c.Agents["tool"].Binary != "toolbin" {
+		t.Errorf("agent binary = %q", c.Agents["tool"].Binary)
+	}
+	if c.Models["m1"].Provider != "acme" {
+		t.Errorf("model provider = %q", c.Models["m1"].Provider)
+	}
+	if c.Repos["r1"].Commit != "abc123" {
+		t.Errorf("repo commit = %q", c.Repos["r1"].Commit)
+	}
+}
+
+// A malformed config must fail `make test`, not a run. Everything below is
+// caught at load time, before anything is spawned or spent.
+func TestAMalformedCatalogIsRefusedAtLoadTime(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		breaks func(t *testing.T, dir string)
+		want   string
+	}{
+		{
+			name: "a subject naming an agent that does not exist",
+			breaks: func(t *testing.T, dir string) {
+				writeSubject(t, dir, "baseline", Subject{ID: "baseline", Kind: Baseline, Agents: []string{"ghost"}})
+			},
+			want: `names agent "ghost", which no agent file declares`,
+		},
+		{
+			name: "a model naming an agent that does not exist",
+			breaks: func(t *testing.T, dir string) {
+				writeModel(t, dir, Model{ID: "m1", Provider: "acme", AvailableUnder: []string{"api_key"}, Agents: []string{"ghost"}})
+			},
+			want: `names agent "ghost"`,
+		},
+		{
+			name: "a subject with a kind that is not one of the three",
+			breaks: func(t *testing.T, dir string) {
+				writeSubject(t, dir, "baseline", Subject{ID: "baseline", Kind: "helper", Agents: []string{"tool"}})
+			},
+			want: `kind "helper" is not baseline, sense or competitor`,
+		},
+		{
+			name: "a subject nothing can drive",
+			breaks: func(t *testing.T, dir string) {
+				writeSubject(t, dir, "baseline", Subject{ID: "baseline", Kind: Baseline})
+			},
+			want: "names no agent tools",
+		},
+		{
+			name: "a repo with no pinned commit",
+			breaks: func(t *testing.T, dir string) {
+				writeRepo(t, dir, Repo{ID: "r1", URL: "https://example.test/r1.git", Languages: []string{"go"}})
+			},
+			want: "no pinned commit",
+		},
+		{
+			name: "an agent that cannot be driven headlessly",
+			breaks: func(t *testing.T, dir string) {
+				writeAgent(t, dir, "tool", Agent{ID: "tool", Binary: "toolbin", ModelFlag: "--model", AuthModes: []string{"api_key"}})
+			},
+			want: "no headless args",
+		},
+		{
+			name: "an agent with no way to select a model",
+			breaks: func(t *testing.T, dir string) {
+				writeAgent(t, dir, "tool", Agent{ID: "tool", Binary: "toolbin", HeadlessArgs: []string{"-p"}, AuthModes: []string{"api_key"}})
+			},
+			want: "no model flag",
+		},
+		{
+			name: "an unknown field, which is a setting that looks applied and is not",
+			breaks: func(t *testing.T, dir string) {
+				path := filepath.Join(dir, "repos", "r1.json")
+				if err := os.WriteFile(path, []byte(`{"id":"r1","url":"u","commit":"c","languages":["go"],"cohort":"big"}`), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "unknown field",
+		},
+		{
+			name: "a file that is not JSON at all",
+			breaks: func(t *testing.T, dir string) {
+				if err := os.WriteFile(filepath.Join(dir, "repos", "r1.json"), []byte("{oops"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "r1.json",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := good(t)
+			tc.breaks(t, dir)
+
+			if got := loadErr(t, dir); !strings.Contains(got, tc.want) {
+				t.Errorf("error = %q, want it to contain %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The failure this whole package exists to prevent, in its measured form: an
+// arm whose model resolved to nothing, so every run came back empty with zero
+// tokens and exit 1 — and it failed as a bad result rather than as a crash.
+// A model no agent tool can authenticate to is that same shape, and it is
+// catchable before any money is spent.
+func TestAModelNoAgentCanReachIsRefused(t *testing.T) {
+	dir := good(t)
+	// The agent authenticates by subscription only; the model needs an api key.
+	writeAgent(t, dir, "tool", Agent{
+		ID: "tool", Binary: "toolbin", ModelFlag: "--model",
+		HeadlessArgs: []string{"-p"}, AuthModes: []string{"subscription"},
+		SupportsMCP: true,
+	})
+
+	got := loadErr(t, dir)
+
+	if !strings.Contains(got, "nothing could reach it") {
+		t.Errorf("error = %q, want it to say the model is unreachable", got)
+	}
+}
+
+// A subject that registers an MCP server cannot run through a tool that does
+// not speak MCP. Catching it here costs nothing; catching it at run time costs
+// the run.
+func TestASubjectNeedingMCPCannotUseAToolWithoutIt(t *testing.T) {
+	dir := good(t)
+	writeSubject(t, dir, "sense", Subject{
+		ID: "sense", Kind: Sense, Agents: []string{"tool"},
+		NeedsMCP: true,
+	})
+	writeAgent(t, dir, "tool", Agent{
+		ID: "tool", Binary: "toolbin", ModelFlag: "--model",
+		HeadlessArgs: []string{"-p"}, AuthModes: []string{"api_key"},
+		SupportsMCP: false,
+	})
+
+	got := loadErr(t, dir)
+
+	if !strings.Contains(got, "needs MCP but agent tool does not support it") {
+		t.Errorf("error = %q, want it to name the mismatch", got)
+	}
+}
+
+// A config directory is edited by hand. Reporting one problem at a time turns a
+// five-minute fix into an afternoon, so every problem is reported at once.
+func TestEveryProblemIsReportedNotJustTheFirst(t *testing.T) {
+	dir := good(t)
+	writeRepo(t, dir, Repo{ID: "r1", Languages: []string{"go"}})
+
+	got := loadErr(t, dir)
+
+	for _, want := range []string{"no url", "no pinned commit"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("error is missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// "You have not pointed me at a catalog" and "your catalog is wrong" are
+// different problems for the person reading the message.
+func TestAMissingConfigDirectoryIsItsOwnError(t *testing.T) {
+	_, err := Load(filepath.Join(t.TempDir(), "nope"))
+
+	if err == nil {
+		t.Fatal("Load succeeded with no config directory")
+	}
+	if !strings.Contains(err.Error(), "no config directory") {
+		t.Errorf("error = %q, want it to say the directory is missing", err)
+	}
+}
+
+func TestAConfigDirectoryMissingOneKindIsAnError(t *testing.T) {
+	dir := good(t)
+	if err := os.RemoveAll(filepath.Join(dir, "models")); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := loadErr(t, dir); !strings.Contains(got, "models") {
+		t.Errorf("error = %q, want it to name the missing kind", got)
+	}
+}
+
+func TestIDsAreSortedSoOutputIsStable(t *testing.T) {
+	got := IDs(map[string]int{"c": 1, "a": 1, "b": 1})
+
+	want := []string{"a", "b", "c"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("IDs = %v, want %v", got, want)
+		}
+	}
+}
+
+// A config file that cannot be read at all is a different failure from one
+// that is wrong, and the message has to say which: "your catalog is malformed"
+// sends someone to a linter, "I could not open this file" sends them to
+// permissions.
+func TestAConfigFileThatCannotBeReadNamesThePath(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		breaks func(t *testing.T, dir string)
+		want   string
+	}{
+		{
+			name: "a subject directory with no subject.json",
+			breaks: func(t *testing.T, dir string) {
+				if err := os.MkdirAll(filepath.Join(dir, "subjects", "empty"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: filepath.Join("subjects", "empty", "subject.json"),
+		},
+		{
+			name: "an agent directory with no agent.json",
+			breaks: func(t *testing.T, dir string) {
+				if err := os.MkdirAll(filepath.Join(dir, "agents", "empty"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: filepath.Join("agents", "empty", "agent.json"),
+		},
+		{
+			name: "a model file that cannot be opened",
+			breaks: func(t *testing.T, dir string) {
+				p := filepath.Join(dir, "models", "locked.json")
+				if err := os.WriteFile(p, []byte("{}"), 0o000); err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() { _ = os.Chmod(p, 0o600) })
+			},
+			want: "locked.json",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := good(t)
+			tc.breaks(t, dir)
+
+			if got := loadErr(t, dir); !strings.Contains(got, tc.want) {
+				t.Errorf("error = %q, want it to name %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// Directories under models/ and repos/ are not config files. A catalog that
+// tripped over one would be a catalog nobody could organise.
+func TestDirectoriesAndNonJSONFilesAreSkipped(t *testing.T) {
+	dir := good(t)
+	if err := os.MkdirAll(filepath.Join(dir, "models", "archive"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "repos", "NOTES.md"), []byte("# notes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(c.Models) != 1 || len(c.Repos) != 1 {
+		t.Errorf("got %d models and %d repos, want 1 and 1", len(c.Models), len(c.Repos))
+	}
+}
+
+// An entry with no id is refused, and the message NAMES THE FILE. Reported
+// without a path it is an anonymous failure: with a dozen subjects declared,
+// "a subject has no id" tells the reader nothing about which one to open.
+func TestAConfigWithNoIDNamesTheFileItIsIn(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		write func(t *testing.T, dir string)
+		file  string
+	}{
+		{"subject", func(t *testing.T, dir string) { writeSubject(t, dir, "anon", Subject{Kind: Baseline}) },
+			filepath.Join("subjects", "anon", "subject.json")},
+		{"agent", func(t *testing.T, dir string) { writeAgent(t, dir, "anon", Agent{Binary: "b"}) },
+			filepath.Join("agents", "anon", "agent.json")},
+		{"model", func(t *testing.T, dir string) {
+			writeJSON(t, filepath.Join(dir, "models", "anon.json"), Model{Provider: "p"})
+		}, filepath.Join("models", "anon.json")},
+		{"repo", func(t *testing.T, dir string) {
+			writeJSON(t, filepath.Join(dir, "repos", "anon.json"), Repo{URL: "u"})
+		}, filepath.Join("repos", "anon.json")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := good(t)
+			tc.write(t, dir)
+
+			got := loadErr(t, dir)
+			if !strings.Contains(got, "no id") {
+				t.Errorf("error = %q, want it to say the entry has no id", got)
+			}
+			if !strings.Contains(got, tc.file) {
+				t.Errorf("error = %q, want it to name %s", got, tc.file)
+			}
+		})
+	}
+}
+
+func TestAgentAndModelFieldsThatWouldStopARunAreRequired(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		write func(t *testing.T, dir string)
+		want  string
+	}{
+		{"an agent with no binary", func(t *testing.T, dir string) {
+			writeAgent(t, dir, "tool", Agent{ID: "tool", ModelFlag: "-m", HeadlessArgs: []string{"-p"}, AuthModes: []string{"api_key"}})
+		}, "no binary to spawn"},
+		{"an agent with no auth modes", func(t *testing.T, dir string) {
+			writeAgent(t, dir, "tool", Agent{ID: "tool", Binary: "b", ModelFlag: "-m", HeadlessArgs: []string{"-p"}})
+		}, "no auth modes"},
+		{"a model with no provider", func(t *testing.T, dir string) {
+			writeModel(t, dir, Model{ID: "m1", AvailableUnder: []string{"api_key"}, Agents: []string{"tool"}})
+		}, "no provider"},
+		{"a model nothing can drive", func(t *testing.T, dir string) {
+			writeModel(t, dir, Model{ID: "m1", Provider: "acme", AvailableUnder: []string{"api_key"}})
+		}, "names no agent tools"},
+		{"a repo with no languages", func(t *testing.T, dir string) {
+			writeRepo(t, dir, Repo{ID: "r1", URL: "u", Commit: "c"})
+		}, "no languages"},
+		{"a subject with no kind", func(t *testing.T, dir string) {
+			writeSubject(t, dir, "baseline", Subject{ID: "baseline", Agents: []string{"tool"}})
+		}, "no kind"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := good(t)
+			tc.write(t, dir)
+
+			if got := loadErr(t, dir); !strings.Contains(got, tc.want) {
+				t.Errorf("error = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// Malformed JSON is refused for every kind, not just the one that happened to
+// get a test. Each kind has its own decode path, so each needs its own case.
+func TestMalformedJSONIsRefusedForEveryKind(t *testing.T) {
+	for _, tc := range []struct{ name, path string }{
+		{"subject", filepath.Join("subjects", "baseline", "subject.json")},
+		{"agent", filepath.Join("agents", "tool", "agent.json")},
+		{"model", filepath.Join("models", "m1.json")},
+		{"repo", filepath.Join("repos", "r1.json")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := good(t)
+			if err := os.WriteFile(filepath.Join(dir, tc.path), []byte(`{"id": }`), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			if got := loadErr(t, dir); !strings.Contains(got, filepath.Base(tc.path)) {
+				t.Errorf("error = %q, want it to name the file", got)
+			}
+		})
+	}
+}
+
+// A README beside a subject is expected; a loose file where a subject
+// directory should be is not a subject. Tripping over one would mean the human
+// half of the config could not live next to the machine half.
+func TestLooseFilesBesideSubjectDirectoriesAreSkipped(t *testing.T) {
+	dir := good(t)
+	if err := os.WriteFile(filepath.Join(dir, "subjects", "README.md"), []byte("# subjects"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(c.Subjects) != 1 {
+		t.Errorf("got %d subjects, want 1", len(c.Subjects))
+	}
+}
+
+// A config directory missing subjects/ or agents/ entirely is an error naming
+// the kind, not a catalog that silently has none of them.
+func TestAMissingSubjectsOrAgentsDirectoryIsAnError(t *testing.T) {
+	for _, kind := range []string{"subjects", "agents"} {
+		t.Run(kind, func(t *testing.T) {
+			dir := good(t)
+			if err := os.RemoveAll(filepath.Join(dir, kind)); err != nil {
+				t.Fatal(err)
+			}
+
+			if got := loadErr(t, dir); !strings.Contains(got, kind) {
+				t.Errorf("error = %q, want it to name %q", got, kind)
+			}
+		})
+	}
+}
+
+// Two files claiming one id lets the last one read win and silently discards
+// the other — the same "setting that looks applied and is not" that unknown
+// fields are refused for. Ids and filenames are independent by design, so
+// nothing else would notice.
+func TestTwoFilesClaimingOneIDAreRefused(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		write func(t *testing.T, dir string)
+		want  string
+	}{
+		{"two models", func(t *testing.T, dir string) {
+			writeJSON(t, filepath.Join(dir, "models", "shadow.json"),
+				Model{ID: "m1", Provider: "other", AvailableUnder: []string{"api_key"}, Agents: []string{"tool"}})
+		}, `model id "m1" is already claimed by`},
+		{"two repos", func(t *testing.T, dir string) {
+			writeJSON(t, filepath.Join(dir, "repos", "shadow.json"),
+				Repo{ID: "r1", URL: "u", Commit: "c", Languages: []string{"go"}})
+		}, `repo id "r1" is already claimed by`},
+		{"two subjects", func(t *testing.T, dir string) {
+			writeSubject(t, dir, "shadow", Subject{ID: "baseline", Kind: Baseline, Agents: []string{"tool"}})
+		}, `subject id "baseline" is already claimed by`},
+		{"two agents", func(t *testing.T, dir string) {
+			writeAgent(t, dir, "shadow", Agent{ID: "tool", Binary: "b", ModelFlag: "-m",
+				HeadlessArgs: []string{"-p"}, AuthModes: []string{"api_key"}})
+		}, `agent id "tool" is already claimed by`},
+		// An alias collides exactly as an id does. Which of the two files
+		// trips the check depends on filename order, which is why the message
+		// names both sides rather than blaming whichever was read second.
+		// The alias side, where the alias is claimed second. Read order decides
+		// which of the two trips, so both directions need a case.
+		{"an alias claimed after the id it collides with", func(t *testing.T, dir string) {
+			writeJSON(t, filepath.Join(dir, "models", "zz-later.json"),
+				Model{ID: "m2", Provider: "acme", Aliases: []string{"m1"},
+					AvailableUnder: []string{"api_key"}, Agents: []string{"tool"}})
+		}, `model alias id "m1" is already claimed by`},
+		{"an alias colliding with a model id", func(t *testing.T, dir string) {
+			writeJSON(t, filepath.Join(dir, "models", "aliased.json"),
+				Model{ID: "m2", Provider: "acme", Aliases: []string{"m1"},
+					AvailableUnder: []string{"api_key"}, Agents: []string{"tool"}})
+		}, `"m1" is already claimed by`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := good(t)
+			tc.write(t, dir)
+
+			got := loadErr(t, dir)
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("error = %q, want %q", got, tc.want)
+			}
+			// Both files, always: the one that tripped the check is often the
+			// innocent one, and which that is depends on filename order.
+			if strings.Count(got, ".json") < 2 {
+				t.Errorf("error = %q, want it to name both files", got)
+			}
+		})
+	}
+}
+
+// An alias is a name the same model answers to, and it RESOLVES. The measured
+// failure was a model named one way and offered another; a field recording that
+// confusion with no lookup behind it is how a reader concludes it is handled.
+func TestAModelResolvesByItsAliases(t *testing.T) {
+	dir := good(t)
+	writeModel(t, dir, Model{
+		ID: "ollama-cloud/mistral-large-3:675b", Provider: "ollama-cloud",
+		Aliases:        []string{"mistral-large-3:675b"},
+		AvailableUnder: []string{"api_key"}, Agents: []string{"tool"},
+	})
+
+	c, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	byAlias, ok := c.Model("mistral-large-3:675b")
+	if !ok {
+		t.Fatal("the alias does not resolve; the field records the confusion without fixing it")
+	}
+	if byAlias.ID != "ollama-cloud/mistral-large-3:675b" {
+		t.Errorf("the alias resolved to %q, want the full id", byAlias.ID)
+	}
+
+	// An alias resolves, and it is NOT a second model. A lookup index
+	// masquerading as the set makes the catalog list a model that does not
+	// exist, offers two spellings of one arm to whoever just mistyped one, and
+	// makes the validator report a single fault once per alias.
+	if _, listed := c.Models["mistral-large-3:675b"]; listed {
+		t.Error("the alias is in the model set, so the catalog lists one model twice")
+	}
+	if len(c.Models) != 2 {
+		t.Errorf("the catalog holds %d models, want 2 — one per model file", len(c.Models))
+	}
+}
+
+// One model with one fault reports one line, however many aliases it has.
+// Ranging over an index instead of the set reports it once per alias, which
+// works directly against reporting every problem in a readable list.
+func TestAnAliasedModelWithAFaultIsReportedOnce(t *testing.T) {
+	dir := good(t)
+	writeModel(t, dir, Model{
+		ID: "m2", Aliases: []string{"m2-alt", "m2-old"},
+		AvailableUnder: []string{"api_key"}, Agents: []string{"tool"},
+	})
+
+	got := loadErr(t, dir)
+
+	if n := strings.Count(got, "model m2: no provider"); n != 1 {
+		t.Errorf("the fault is reported %d times, want once:\n%s", n, got)
+	}
+}
+
+// An agent whose config declares no MCP support cannot carry a subject that
+// needs one, and the reverse pairing must stay legal.
+func TestAnAgentWithoutMCPMayStillCarryASubjectThatDoesNotNeedIt(t *testing.T) {
+	dir := good(t)
+	writeAgent(t, dir, "tool", Agent{
+		ID: "tool", Binary: "b", ModelFlag: "-m",
+		HeadlessArgs: []string{"-p"}, AuthModes: []string{"api_key"}, SupportsMCP: false,
+	})
+
+	if _, err := Load(dir); err != nil {
+		t.Errorf("a baseline subject was refused an agent with no MCP: %v", err)
+	}
+}

--- a/lab/internal/catalog/validate.go
+++ b/lab/internal/catalog/validate.go
@@ -1,0 +1,140 @@
+package catalog
+
+import (
+	"fmt"
+	"strings"
+)
+
+// validate checks what a consumer reads and no more.
+//
+// The depth follows the consumers that exist: identifiers resolve, referenced
+// ids exist, required fields are present. A rule for a field nothing reads is a
+// rule written from imagination, and it will be wrong in a way nobody notices
+// until it blocks a real config.
+//
+// Every problem is reported, not just the first. A config directory is edited
+// by hand and fixing one error at a time is how a five-minute change becomes an
+// afternoon.
+func (c *Catalog) validate() error {
+	var probs []string
+
+	for _, id := range IDs(c.Subjects) {
+		probs = append(probs, c.checkSubject(c.Subjects[id])...)
+	}
+	for _, id := range IDs(c.Agents) {
+		probs = append(probs, checkAgent(c.Agents[id])...)
+	}
+	for _, id := range IDs(c.Models) {
+		probs = append(probs, c.checkModel(c.Models[id])...)
+	}
+	for _, id := range IDs(c.Repos) {
+		probs = append(probs, checkRepo(c.Repos[id])...)
+	}
+
+	if len(probs) == 0 {
+		return nil
+	}
+	return fmt.Errorf("catalog:\n  %s", strings.Join(probs, "\n  "))
+}
+
+func (c *Catalog) checkSubject(s Subject) []string {
+	var p []string
+	switch s.Kind {
+	case Baseline, Sense, Competitor:
+	case "":
+		p = append(p, fmt.Sprintf("subject %s: no kind", s.ID))
+	default:
+		p = append(p, fmt.Sprintf("subject %s: kind %q is not baseline, sense or competitor", s.ID, s.Kind))
+	}
+	if len(s.Agents) == 0 {
+		p = append(p, fmt.Sprintf("subject %s: names no agent tools, so nothing can drive it", s.ID))
+	}
+	for _, a := range s.Agents {
+		if _, ok := c.Agents[a]; !ok {
+			p = append(p, fmt.Sprintf("subject %s: names agent %q, which no agent file declares", s.ID, a))
+		}
+	}
+	// A subject that registers an MCP server can only run through an agent
+	// tool that speaks MCP. Catching it here costs nothing; catching it at run
+	// time costs the run.
+	if s.NeedsMCP {
+		for _, a := range s.Agents {
+			if agent, ok := c.Agents[a]; ok && !agent.SupportsMCP {
+				p = append(p, fmt.Sprintf("subject %s needs MCP but agent %s does not support it", s.ID, a))
+			}
+		}
+	}
+	return p
+}
+
+func checkAgent(a Agent) []string {
+	var p []string
+	if a.Binary == "" {
+		p = append(p, fmt.Sprintf("agent %s: no binary to spawn", a.ID))
+	}
+	if a.ModelFlag == "" {
+		p = append(p, fmt.Sprintf("agent %s: no model flag, so no model could be selected", a.ID))
+	}
+	if len(a.HeadlessArgs) == 0 {
+		p = append(p, fmt.Sprintf("agent %s: no headless args, so a session would wait for a terminal "+
+			"that is not there and burn its wall", a.ID))
+	}
+	if len(a.AuthModes) == 0 {
+		p = append(p, fmt.Sprintf("agent %s: no auth modes, so no model is reachable through it", a.ID))
+	}
+	return p
+}
+
+func (c *Catalog) checkModel(m Model) []string {
+	var p []string
+	if m.Provider == "" {
+		p = append(p, fmt.Sprintf("model %s: no provider", m.ID))
+	}
+	if len(m.Agents) == 0 {
+		p = append(p, fmt.Sprintf("model %s: names no agent tools, so nothing can drive it", m.ID))
+	}
+	for _, a := range m.Agents {
+		agent, ok := c.Agents[a]
+		if !ok {
+			p = append(p, fmt.Sprintf("model %s: names agent %q, which no agent file declares", m.ID, a))
+			continue
+		}
+		// A model reachable only under an auth mode its agent tool cannot use
+		// is a model that resolves to nothing at spawn time. That has already
+		// cost a whole arm: an id written in the wrong form mapped to a
+		// provider id that did not exist, and every run came back empty with
+		// zero tokens and exit 1.
+		if !overlaps(m.AvailableUnder, agent.AuthModes) {
+			p = append(p, fmt.Sprintf("model %s is available under %v but agent %s authenticates by %v; "+
+				"nothing could reach it", m.ID, m.AvailableUnder, a, agent.AuthModes))
+		}
+	}
+	return p
+}
+
+func checkRepo(r Repo) []string {
+	var p []string
+	if r.URL == "" {
+		p = append(p, fmt.Sprintf("repo %s: no url", r.ID))
+	}
+	// A repo with no pinned commit is a repo that means something different
+	// next week, so every number taken against it is unreproducible.
+	if r.Commit == "" {
+		p = append(p, fmt.Sprintf("repo %s: no pinned commit", r.ID))
+	}
+	if len(r.Languages) == 0 {
+		p = append(p, fmt.Sprintf("repo %s: no languages, so no vertical query can select it", r.ID))
+	}
+	return p
+}
+
+func overlaps(a, b []string) bool {
+	for _, x := range a {
+		for _, y := range b {
+			if x == y {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/lab/internal/cli/catalogcmd.go
+++ b/lab/internal/cli/catalogcmd.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/luuuc/sense/lab/internal/catalog"
+)
+
+// defaultConfigDir is where the catalog lives, relative to the working
+// directory. It is a path, not a compiled-in fact: nothing about which
+// subjects, agents, models or repositories exist is in the binary.
+const defaultConfigDir = "lab"
+
+func configFlag(fs *flag.FlagSet, into *string) {
+	fs.StringVar(into, "config", defaultConfigDir, "directory holding subjects/, agents/, models/ and repos/")
+}
+
+// catalogCmd loads the config and prints what it found. It is the smallest
+// thing that proves the config is real: it spends nothing, runs nothing, and
+// fails on a malformed file rather than on a run.
+func catalogCmd(args []string, stdout, stderr io.Writer) int {
+	var dir string
+	fs := flag.NewFlagSet("catalog", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	configFlag(fs, &dir)
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+
+	c, err := catalog.Load(dir)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab catalog: %v\n", err)
+		return exitError
+	}
+
+	for _, s := range catalog.IDs(c.Subjects) {
+		_, _ = fmt.Fprintf(stdout, "subject  %-14s %s\n", s, c.Subjects[s].Kind)
+	}
+	for _, a := range catalog.IDs(c.Agents) {
+		_, _ = fmt.Fprintf(stdout, "agent    %-14s %s\n", a, c.Agents[a].Binary)
+	}
+	for _, m := range catalog.IDs(c.Models) {
+		_, _ = fmt.Fprintf(stdout, "model    %-14s %s\n", m, c.Models[m].Provider)
+	}
+	for _, r := range catalog.IDs(c.Repos) {
+		_, _ = fmt.Fprintf(stdout, "repo     %-14s %s @ %.8s\n", r, c.Repos[r].Stack, c.Repos[r].Commit)
+	}
+	return exitOK
+}

--- a/lab/internal/cli/catalogcmd_test.go
+++ b/lab/internal/cli/catalogcmd_test.go
@@ -1,0 +1,221 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/lab/internal/catalog"
+)
+
+// The claim this pitch makes is that no competitor, agent or model identifier
+// is compiled in. These are the two probes that check it, and they are
+// deliberately different from each other: a grep over the source is one probe
+// for a negative claim, and a negative claim needs a second.
+
+// Probe one: with no config directory, nothing can be planned. If any target
+// were still compiled in, something here would still work.
+func TestNothingCanBePlannedWithoutAConfigDirectory(t *testing.T) {
+	absent := filepath.Join(t.TempDir(), "no-such-config")
+
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"catalog", []string{"catalog", "-config", absent}},
+		{"run", []string{"run", "-config", absent,
+			"-scenario", scenarioFile(t, twoStepScenario), "-repo", "discourse",
+			"-checkout", t.TempDir(), "-out", filepath.Join(t.TempDir(), "r"),
+			"-agent", "claude-code", "-model", "claude-opus-5"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			code, stdout, stderr := dispatch(t, tc.args...)
+
+			if code == 0 {
+				t.Error("exit = 0 with no config directory; something is compiled in")
+			}
+			if !strings.Contains(stderr, "no config directory") {
+				t.Errorf("stderr = %q, want it to name the missing config", stderr)
+			}
+			if stdout != "" {
+				t.Errorf("stdout = %q, want nothing planned", stdout)
+			}
+		})
+	}
+}
+
+// Probe two, and a genuinely different one: read the BUILT BINARY, and derive
+// what to look for FROM THE CATALOG rather than from memory.
+//
+// The deriving is the point. A hand-written list of names is a list someone
+// thought of on one afternoon, and it goes stale the moment an arm is added —
+// which is exactly how the incident this pitch is named for arrived. A list
+// taken from the config cannot go stale, because adding an arm adds to the
+// list.
+//
+// This probe has twice caught what the source read as clean. It found
+// `bypassPermissions`, `IS_SANDBOX=1`, `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1` and
+// `stream-json` compiled in, which moved them into agent.json. Then, with a
+// hand-written list, it MISSED a deliberately planted dispatch on `opencode`
+// and a `glm-5.2:cloud` prefix — 19 real catalog identifiers were unchecked.
+// The derived list fires on all three.
+func TestNoCatalogIdentifierSurvivesIntoTheBinary(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds the binary")
+	}
+	bin := filepath.Join(t.TempDir(), "sense-lab")
+	build := exec.Command("go", "build", "-o", bin, "../../cmd/sense-lab")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build: %v\n%s", err, out)
+	}
+	b, err := os.ReadFile(bin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	binary := string(b)
+
+	forbidden := catalogIdentifiers(t)
+	if len(forbidden) < 20 {
+		t.Fatalf("derived only %d identifiers from the catalog; the derivation is not "+
+			"reading what it thinks", len(forbidden))
+	}
+	for _, id := range forbidden {
+		if strings.Contains(binary, id) {
+			t.Errorf("%q comes from the catalog and is compiled into the binary", id)
+		}
+	}
+}
+
+// catalogIdentifiers is every string the catalog names that must not be
+// compiled in: ids, providers, aliases, binaries, flags, env and config paths.
+//
+// Strings under five characters are skipped. `-p`, `run` and `exec` appear in
+// any Go binary, and they are the only three false positives; every identifier
+// that matters is longer.
+func catalogIdentifiers(t *testing.T) []string {
+	t.Helper()
+	c, err := catalog.Load(repoConfigDir(t))
+	if err != nil {
+		t.Fatalf("load the shipped catalog: %v", err)
+	}
+
+	// No exemptions. An earlier version skipped the three subject KINDS,
+	// because they are a closed enum the validator legitimately compiles in and
+	// the baseline subject's id collided with one. That exemption was keyed on
+	// the STRING rather than on the field it came from, so it hid those names
+	// wherever they appeared — and a planted dispatch on "baseline" passed.
+	// The collision is fixed in the config instead, by giving the subject an id
+	// that is not also a kind, which leaves nothing here to justify.
+	var out []string
+	add := func(vals ...string) {
+		for _, v := range vals {
+			if len(v) >= 5 {
+				out = append(out, v)
+			}
+		}
+	}
+	for _, id := range catalog.IDs(c.Subjects) {
+		add(id)
+	}
+	for _, id := range catalog.IDs(c.Agents) {
+		a := c.Agents[id]
+		add(id, a.Binary, a.ModelFlag)
+		add(a.HeadlessArgs...)
+		add(a.Env...)
+		add(a.AuthModes...)
+	}
+	for _, id := range catalog.IDs(c.Models) {
+		m := c.Models[id]
+		add(id, m.Provider)
+		add(m.Aliases...)
+		add(m.AvailableUnder...)
+	}
+	for _, id := range catalog.IDs(c.Repos) {
+		r := c.Repos[id]
+		// The commit especially: checkoutIsAtPin is the site that attracts a
+		// "this repository is special" hard-code, and a 40-character hash
+		// cannot collide with anything by accident.
+		add(id, r.Stack, r.Commit, r.URL)
+	}
+	return out
+}
+
+func TestCatalogHelpIsNotReportedAsAnError(t *testing.T) {
+	_, _, stderr := dispatch(t, "catalog", "-help")
+
+	if strings.Contains(stderr, "sense-lab catalog:") {
+		t.Errorf("asking for help produced an error message:\n%s", stderr)
+	}
+}
+
+// What the command PRINTS, against a fixture. Pointing this at the shipped
+// catalog would make it fail whenever a model is retired — a legitimate edit
+// that says nothing about the printing this test is for. The shipped catalog's
+// validity is TestTheShippedCatalogIsValid's job.
+func TestCatalogPrintsEveryKindWithWhatIdentifiesIt(t *testing.T) {
+	cfg := testCatalog(t, "/bin/true")
+
+	code, stdout, stderr := dispatch(t, "catalog", "-config", cfg)
+
+	if code != 0 {
+		t.Fatalf("exit = %d (stderr: %s)", code, stderr)
+	}
+	// Each line carries the id AND the fact that distinguishes one entry from
+	// another of the same kind. An id-only listing would not tell two models
+	// apart.
+	for _, want := range []string{
+		"subject  baseline", "baseline\n", // id and kind
+		"agent    tool", "/bin/true\n", // id and binary
+		"model    m1", "acme\n", // id and provider
+		"repo     r1", "abc123\n", // id and pinned commit
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("output is missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+// repoConfigDir is this repository's own lab/ config directory, which is the
+// catalog the bench actually uses. Testing against it rather than a fixture is
+// what makes a malformed real config fail `make test` instead of a run.
+func repoConfigDir(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(repoRoot(t), "lab")
+}
+
+// The shipped catalog is not a fixture: it is the config every run reads. A
+// broken one must fail here, cheaply, rather than forty minutes into a paid
+// session.
+func TestTheShippedCatalogIsValid(t *testing.T) {
+	if code, _, stderr := dispatch(t, "catalog", "-config", repoConfigDir(t)); code != 0 {
+		t.Fatalf("the repository's own catalog does not load: %s", stderr)
+	}
+}
+
+// Every subject and agent carries a README: the human half, with the version
+// quirks and side effects no schema can hold. A directory without one is a
+// treatment nobody wrote down.
+func TestEverySubjectAndAgentHasItsHumanHalf(t *testing.T) {
+	for _, kind := range []string{"subjects", "agents"} {
+		entries, err := os.ReadDir(filepath.Join(repoConfigDir(t), kind))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var seen int
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			seen++
+			readme := filepath.Join(repoConfigDir(t), kind, e.Name(), "README.md")
+			if _, err := os.Stat(readme); err != nil {
+				t.Errorf("%s/%s has no README.md", kind, e.Name())
+			}
+		}
+		if seen == 0 {
+			t.Errorf("found no %s at all; the walk is not looking where it thinks", kind)
+		}
+	}
+}

--- a/lab/internal/cli/cli.go
+++ b/lab/internal/cli/cli.go
@@ -28,6 +28,7 @@ const usage = `sense-lab — the bench instrument for Sense
 Usage: sense-lab <command> [flags]
 
 Commands:
+  catalog   Show the subjects, agents, models and repositories in the config
   run       Run one scenario against one repository
   score     Score a recorded run against a scenario's gold
   version   Print version
@@ -72,6 +73,8 @@ func Run(args []string, stdout, stderr io.Writer) int {
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		defer stop()
 		return runSession(ctx, args[1:], stdout, stderr)
+	case "catalog":
+		return catalogCmd(args[1:], stdout, stderr)
 	case "score":
 		return scoreRun(args[1:], stdout, stderr)
 	case "version":

--- a/lab/internal/cli/runcmd.go
+++ b/lab/internal/cli/runcmd.go
@@ -6,57 +6,77 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"slices"
+	"strings"
 	"time"
 
+	"github.com/luuuc/sense/lab/internal/catalog"
 	"github.com/luuuc/sense/lab/internal/run"
 	"github.com/luuuc/sense/lab/internal/scenario"
 )
 
-// The walking skeleton's target, hard-coded. Cycle 01 replaces every constant
-// here with config as data; until then the point is to have one path work end
-// to end, not to have it be configurable.
-//
-// The scenario is the two-step probe rather than the seven-step session so a
-// live run stays short, and discourse is banked on the headline model, so the
-// number this produces has something recorded to be checked against.
-const (
-	defaultWall  = 8 * time.Minute
-	defaultAgent = "claude"
-)
+// The wall is the one remaining constant, and it is a default rather than a
+// fact about any particular job. Everything else — which repository, which
+// agent tool, which model — comes from the catalog, so adding one is a new JSON
+// file and nothing else.
+const defaultWall = 8 * time.Minute
 
-// defaultAgentArgs drives the agent CLI headlessly with the prompt on stdin.
-// The prompt goes on stdin rather than as the value of -p because a prompt
-// beginning with a dash is read as an option: that killed a spawn before it ran
-// a single step, and the driver reported the crash as a failing check.
-//
-// Permission prompts are bypassed because there is nobody at the terminal; an
-// unattended session that stops to ask a question just burns its wall.
-var defaultAgentArgs = []string{
-	"-p",
-	"--output-format", "stream-json",
-	"--verbose",
-	"--permission-mode", "bypassPermissions",
+// job is a resolved run target: which repository, driven by which agent tool,
+// on which model. All three come from the catalog.
+type job struct {
+	repo  catalog.Repo
+	agent catalog.Agent
+	model catalog.Model
 }
 
-// defaultAgentEnv marks the session as unattended. It does NOT isolate it:
+// resolveJob turns three ids into the config they name, and refuses a
+// combination the catalog says cannot work. This runs BEFORE anything is
+// spawned, because an unsupported combination discovered forty minutes into a
+// paid run is a run wasted.
+func resolveJob(c *catalog.Catalog, f runFlags) (job, error) {
+	var j job
+	var ok bool
+	if j.repo, ok = c.Repos[f.repo]; !ok {
+		return j, fmt.Errorf("no repo %q in the catalog; have %v", f.repo, catalog.IDs(c.Repos))
+	}
+	if j.agent, ok = c.Agents[f.agent]; !ok {
+		return j, fmt.Errorf("no agent %q in the catalog; have %v", f.agent, catalog.IDs(c.Agents))
+	}
+	if j.model, ok = c.Model(f.model); !ok {
+		return j, fmt.Errorf("no model %q in the catalog; have %v", f.model, catalog.IDs(c.Models))
+	}
+	if !slices.Contains(j.model.Agents, j.agent.ID) {
+		return j, fmt.Errorf("model %s cannot be driven by %s; it names %v",
+			j.model.ID, j.agent.ID, j.model.Agents)
+	}
+	return j, nil
+}
+
+// A note that used to live beside the compiled-in agent flags, kept because the
+// flags moved and the measurement did not:
+//
+// The prompt goes to the agent on STDIN, never as the value of a flag. A prompt
+// beginning with a dash is read as an option, which killed a spawn before it ran
+// a single step and was reported as a failing check rather than a crash.
+//
+// An agent's `env` marks a session as unattended. It does NOT isolate it:
 // measured against a real spawn, the operator's own ~/.claude/CLAUDE.md and the
 // subject repository's CLAUDE.md are both still loaded into every benched
-// session, so instructions neither arm was meant to have are in both arms.
-// There is no isolation in this cycle and this env does not provide any; cycle
-// 03 owns it, and 03-02 records what has to be closed.
-var defaultAgentEnv = []string{
-	"IS_SANDBOX=1",
-	"CLAUDE_CODE_DISABLE_AUTO_MEMORY=1",
-}
+// session, so instructions neither arm was meant to have reach both arms. Cycle
+// 03 owns isolation, and 03-02 records what has to be closed.
 
-// runFlags is the parsed form of `sense-lab run`. Every field is a path or a
-// duration the skeleton needs and cycle 01 will take over.
+// runFlags is the parsed form of `sense-lab run`: three catalog ids, two paths
+// and a wall.
 type runFlags struct {
+	config   string
 	scenario string
 	repo     string
+	checkout string
 	out      string
 	agent    string
+	model    string
 	wall     time.Duration
 }
 
@@ -64,10 +84,13 @@ func parseRunFlags(args []string, stderr io.Writer) (runFlags, error) {
 	var f runFlags
 	fs := flag.NewFlagSet("run", flag.ContinueOnError)
 	fs.SetOutput(stderr)
+	configFlag(fs, &f.config)
 	fs.StringVar(&f.scenario, "scenario", "", "path to the scenario file (required)")
-	fs.StringVar(&f.repo, "repo", "", "path to the repository to run against (required)")
+	fs.StringVar(&f.repo, "repo", "", "catalog repo id to run against (required)")
+	fs.StringVar(&f.checkout, "checkout", "", "path to the repository checkout (required)")
 	fs.StringVar(&f.out, "out", "", "directory to write the run into (required)")
-	fs.StringVar(&f.agent, "agent", defaultAgent, "agent CLI to drive")
+	fs.StringVar(&f.agent, "agent", "", "catalog agent id to drive (required)")
+	fs.StringVar(&f.model, "model", "", "catalog model id (required)")
 	fs.DurationVar(&f.wall, "wall", defaultWall, "how long the session may take")
 	if err := fs.Parse(args); err != nil {
 		return f, err
@@ -77,13 +100,36 @@ func parseRunFlags(args []string, stderr io.Writer) (runFlags, error) {
 	}{
 		{"-scenario", f.scenario},
 		{"-repo", f.repo},
+		{"-checkout", f.checkout},
 		{"-out", f.out},
+		{"-agent", f.agent},
+		{"-model", f.model},
 	} {
 		if required.value == "" {
 			return f, fmt.Errorf("%s is required", required.name)
 		}
 	}
 	return f, nil
+}
+
+// checkoutIsAtPin refuses a checkout that is not at the repo's pinned commit.
+//
+// Without it the pinned commit is a label rather than a fact: the run reports a
+// commit, records it, and may have been taken against a different branch or
+// last month's clone. Every number is then unreproducible in a way nothing
+// about the result shows — the same class of failure as an arm whose model
+// resolved to nothing.
+func checkoutIsAtPin(checkout, pin string) error {
+	out, err := exec.Command("git", "-C", checkout, "rev-parse", "HEAD").Output()
+	if err != nil {
+		return fmt.Errorf("checkout %s: cannot read its commit: %w", checkout, err)
+	}
+	at := strings.TrimSpace(string(out))
+	if at != pin {
+		return fmt.Errorf("checkout %s is at %.12s but the catalog pins %.12s; "+
+			"a run against the wrong tree records a commit it did not use", checkout, at, pin)
+	}
+	return nil
 }
 
 // runSession is the whole skeleton: read the scenario, render it, spawn the
@@ -97,6 +143,17 @@ func runSession(ctx context.Context, args []string, stdout, stderr io.Writer) in
 		return exitUsage
 	}
 
+	c, err := catalog.Load(f.config)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab run: %v\n", err)
+		return exitError
+	}
+	j, err := resolveJob(c, f)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab run: %v\n", err)
+		return exitError
+	}
+
 	s, err := scenario.Load(f.scenario)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "sense-lab run: %v\n", err)
@@ -107,20 +164,25 @@ func runSession(ctx context.Context, args []string, stdout, stderr io.Writer) in
 	// anywhere later. Abs only fails when the working directory cannot be
 	// resolved, and it returns the path unchanged when it does, so the Stat
 	// below is the check that matters either way.
-	repo, _ := filepath.Abs(f.repo)
-	if _, err := os.Stat(repo); err != nil {
-		_, _ = fmt.Fprintf(stderr, "sense-lab run: repository: %v\n", err)
+	checkout, _ := filepath.Abs(f.checkout)
+	if _, err := os.Stat(checkout); err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab run: checkout: %v\n", err)
+		return exitError
+	}
+	if err := checkoutIsAtPin(checkout, j.repo.Commit); err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab run: %v\n", err)
 		return exitError
 	}
 
-	_, _ = fmt.Fprintf(stdout, "scenario: %s\nrepo:     %s\nwall:     %s\n\n", s.Name, repo, f.wall)
+	_, _ = fmt.Fprintf(stdout, "scenario: %s\nrepo:     %s @ %.8s\nagent:    %s\nmodel:    %s\nwall:     %s\n\n",
+		s.Name, j.repo.ID, j.repo.Commit, j.agent.ID, j.model.ID, f.wall)
 
 	m, err := run.Session(ctx, f.out, run.Spec{
-		Dir:   repo,
-		Name:  f.agent,
-		Args:  defaultAgentArgs,
+		Dir:   checkout,
+		Name:  j.agent.Binary,
+		Args:  append(slices.Clone(j.agent.HeadlessArgs), j.agent.ModelFlag, j.model.ID),
 		Stdin: s.Prompt(),
-		Env:   defaultAgentEnv,
+		Env:   j.agent.Env,
 		Wall:  f.wall,
 	})
 	if err != nil {

--- a/lab/internal/cli/runcmd_test.go
+++ b/lab/internal/cli/runcmd_test.go
@@ -3,9 +3,12 @@ package cli
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/luuuc/sense/lab/internal/catalog"
 )
 
 // These tests drive the real `sense-lab run` path end to end against a fake
@@ -22,6 +25,78 @@ steps:
   - name: Audit the dependents
     prompt: Find everywhere that would have to change with it.
 `
+
+// testCatalog writes a config directory whose one agent spawns `bin` and whose
+// one model that agent can drive. The run tests care about the session, not the
+// catalog, so this keeps their flag lists to what they are actually varying.
+func testCatalog(t *testing.T, bin string) string { return testCatalogPinned(t, bin, "abc123") }
+
+func testCatalogPinned(t *testing.T, bin, pin string) string {
+	t.Helper()
+	dir := t.TempDir()
+	write := func(path, body string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(filepath.Join(dir, "agents", "tool", "agent.json"), `{"id":"tool","binary":"`+bin+`",
+	  "model_flag":"--model","headless_args":["-p","--permission-mode","bypassPermissions"],
+	  "env":["IS_SANDBOX=1","CLAUDE_CODE_DISABLE_AUTO_MEMORY=1"],
+	  "supports_mcp":true,"auth_modes":["api_key"]}`)
+	write(filepath.Join(dir, "subjects", "baseline", "subject.json"),
+		`{"id":"baseline","kind":"baseline","agents":["tool"]}`)
+	write(filepath.Join(dir, "models", "m1.json"),
+		`{"id":"m1","provider":"acme","available_under":["api_key"],"agents":["tool"]}`)
+	write(filepath.Join(dir, "repos", "r1.json"),
+		`{"id":"r1","url":"https://example.test/r1.git","commit":"`+pin+`","languages":["go"]}`)
+	return dir
+}
+
+// gitCheckout makes a real one-commit repository and returns its path and HEAD,
+// so a test can drive a run whose checkout genuinely matches its pin.
+func gitCheckout(t *testing.T) (dir, head string) {
+	t.Helper()
+	dir = t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "--allow-empty", "-m", "init"},
+	} {
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir, strings.TrimSpace(string(out))
+}
+
+// runArgs is the flag list for a run against the test catalog, with the caller's
+// own flags appended.
+func runArgs(t *testing.T, bin, out string, extra ...string) []string {
+	t.Helper()
+	checkout, head := gitCheckout(t)
+	return runArgsIn(t, bin, out, checkout, head, extra...)
+}
+
+// runArgsIn is runArgs against a checkout the caller made, so a test that cares
+// where the agent ran can supply it. The pin must match that tree: a run
+// against a checkout the catalog does not pin is refused.
+func runArgsIn(t *testing.T, bin, out, checkout, head string, extra ...string) []string {
+	t.Helper()
+	return append([]string{"run",
+		"-config", testCatalogPinned(t, bin, head),
+		"-scenario", scenarioFile(t, twoStepScenario),
+		"-repo", "r1", "-checkout", checkout, "-out", out,
+		"-agent", "tool", "-model", "m1",
+	}, extra...)
+}
 
 // fakeAgent writes an executable script that copies its stdin to stdout, so a
 // test can assert what the prompt actually looked like on the other side, then
@@ -48,12 +123,7 @@ func scenarioFile(t *testing.T, body string) string {
 func TestRunDrivesTheAgentAndLeavesARunDirectory(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "run-1")
 
-	code, stdout, stderr := dispatch(t, "run",
-		"-scenario", scenarioFile(t, twoStepScenario),
-		"-repo", t.TempDir(),
-		"-out", out,
-		"-agent", fakeAgent(t, "0", ""),
-	)
+	code, stdout, stderr := dispatch(t, runArgs(t, fakeAgent(t, "0", ""), out)...)
 
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0 (stderr: %s)", code, stderr)
@@ -98,13 +168,7 @@ func TestRunDrivesTheAgentAndLeavesARunDirectory(t *testing.T) {
 func TestARunThatOverrunsItsWallExitsNonZero(t *testing.T) {
 	out := filepath.Join(t.TempDir(), "run-1")
 
-	code, stdout, _ := dispatch(t, "run",
-		"-scenario", scenarioFile(t, twoStepScenario),
-		"-repo", t.TempDir(),
-		"-out", out,
-		"-agent", fakeAgent(t, "0", "sleep 60"),
-		"-wall", "300ms",
-	)
+	code, stdout, _ := dispatch(t, runArgs(t, fakeAgent(t, "0", "sleep 60"), out, "-wall", "300ms")...)
 
 	// Its own code, distinct from a failed agent and from a broken binary: a
 	// run that hit its wall left a record on disk and is bankable as a result.
@@ -117,12 +181,7 @@ func TestARunThatOverrunsItsWallExitsNonZero(t *testing.T) {
 }
 
 func TestAnAgentThatFailsExitsNonZero(t *testing.T) {
-	code, stdout, _ := dispatch(t, "run",
-		"-scenario", scenarioFile(t, twoStepScenario),
-		"-repo", t.TempDir(),
-		"-out", filepath.Join(t.TempDir(), "run-1"),
-		"-agent", fakeAgent(t, "7", ""),
-	)
+	code, stdout, _ := dispatch(t, runArgs(t, fakeAgent(t, "7", ""), filepath.Join(t.TempDir(), "run-1"))...)
 
 	if code != 1 {
 		t.Errorf("exit = %d, want 1 for an agent that exited 7", code)
@@ -136,53 +195,65 @@ func TestAnAgentThatFailsExitsNonZero(t *testing.T) {
 // rejected must be rejected before the agent starts, not after it has spent
 // eight minutes.
 func TestRunRejectsBadInputBeforeSpawningAnything(t *testing.T) {
-	good := scenarioFile(t, twoStepScenario)
 	agent := fakeAgent(t, "0", "")
+	cfg := testCatalog(t, agent)
+	good := scenarioFile(t, twoStepScenario)
 
 	// The code matters as much as the rejection: 2 says you typed it wrong, 1
 	// says the run could not proceed. A caller script branches on that.
+	full := func(over map[string]string) []string {
+		args := map[string]string{
+			"-config": cfg, "-scenario": good, "-repo": "r1",
+			"-checkout": t.TempDir(), "-out": filepath.Join(t.TempDir(), "run-1"),
+			"-agent": "tool", "-model": "m1",
+		}
+		var out []string
+		for k, v := range over {
+			if v == "" {
+				delete(args, k)
+				continue
+			}
+			args[k] = v
+		}
+		for _, k := range []string{"-config", "-scenario", "-repo", "-checkout", "-out", "-agent", "-model"} {
+			if v, ok := args[k]; ok {
+				out = append(out, k, v)
+			}
+		}
+		return append([]string{"run"}, out...)
+	}
+
 	for _, tc := range []struct {
 		name     string
 		args     []string
 		want     string
 		wantCode int
 	}{
-		{
-			name: "no scenario", wantCode: 2,
-			args: []string{"-repo", t.TempDir(), "-out", t.TempDir()},
-			want: "-scenario is required",
-		},
-		{
-			name: "no repo", wantCode: 2,
-			args: []string{"-scenario", good, "-out", t.TempDir()},
-			want: "-repo is required",
-		},
-		{
-			name: "no out", wantCode: 2,
-			args: []string{"-scenario", good, "-repo", t.TempDir()},
-			want: "-out is required",
-		},
-		{
-			name: "an unknown flag", wantCode: 2,
-			args: []string{"-scenario", good, "-repo", t.TempDir(), "-out", t.TempDir(), "-model", "x"},
-			want: "flag provided but not defined",
-		},
-		{
-			name: "a scenario that does not exist", wantCode: 1,
-			args: []string{"-scenario", "/no/such/scenario.yaml", "-repo", t.TempDir(), "-out", t.TempDir()},
-			want: "read scenario",
-		},
-		{
-			name: "a repository that does not exist", wantCode: 1,
-			args: []string{"-scenario", good, "-repo", "/no/such/repo", "-out", t.TempDir()},
-			want: "repository",
-		},
+		{"no scenario", full(map[string]string{"-scenario": ""}), "-scenario is required", 2},
+		{"no repo", full(map[string]string{"-repo": ""}), "-repo is required", 2},
+		{"no checkout", full(map[string]string{"-checkout": ""}), "-checkout is required", 2},
+		{"no out", full(map[string]string{"-out": ""}), "-out is required", 2},
+		{"no agent", full(map[string]string{"-agent": ""}), "-agent is required", 2},
+		{"no model", full(map[string]string{"-model": ""}), "-model is required", 2},
+		{"an unknown flag", append(full(nil), "-arm", "sense"), "flag provided but not defined", 2},
+		{"a scenario that does not exist", full(map[string]string{"-scenario": "/no/such.yaml"}), "read scenario", 1},
+		{"a checkout that does not exist", full(map[string]string{"-checkout": "/no/such/repo"}), "checkout", 1},
+
+		// The three that only the catalog can catch. Each names what IS
+		// available, because the next thing anyone does after a typo is look
+		// for the right spelling.
+		{"a repo the catalog does not have", full(map[string]string{"-repo": "discourse"}),
+			`no repo "discourse" in the catalog; have [r1]`, 1},
+		{"an agent the catalog does not have", full(map[string]string{"-agent": "codex"}),
+			`no agent "codex" in the catalog; have [tool]`, 1},
+		{"a model the catalog does not have", full(map[string]string{"-model": "claude-opus-5"}),
+			`no model "claude-opus-5" in the catalog; have [m1]`, 1},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			code, _, stderr := dispatch(t, append([]string{"run", "-agent", agent}, tc.args...)...)
+			code, _, stderr := dispatch(t, tc.args...)
 
 			if code != tc.wantCode {
-				t.Errorf("exit = %d, want %d", code, tc.wantCode)
+				t.Errorf("exit = %d, want %d (stderr: %s)", code, tc.wantCode, stderr)
 			}
 			if !strings.Contains(stderr, tc.want) {
 				t.Errorf("stderr = %q, want it to name %q", stderr, tc.want)
@@ -191,21 +262,57 @@ func TestRunRejectsBadInputBeforeSpawningAnything(t *testing.T) {
 	}
 }
 
+// An unsupported combination must be refused at planning time, not forty
+// minutes into a paid run. The catalog knows which agent tools can drive which
+// models, so it can say so before anything spawns.
+func TestAModelTheAgentCannotDriveIsRefusedBeforeSpawning(t *testing.T) {
+	agent := fakeAgent(t, "0", "")
+	cfg := testCatalog(t, agent)
+	// A second model, declared as drivable only by a tool that is not ours.
+	writeFile(t, filepath.Join(cfg, "agents", "other", "agent.json"),
+		`{"id":"other","binary":"othertool","model_flag":"-m","headless_args":["-p"],
+		  "env":[],"supports_mcp":false,"auth_modes":["api_key"]}`)
+	writeFile(t, filepath.Join(cfg, "models", "m2.json"),
+		`{"id":"m2","provider":"acme","available_under":["api_key"],"agents":["other"]}`)
+	out := filepath.Join(t.TempDir(), "run-1")
+
+	code, _, stderr := dispatch(t, "run", "-config", cfg,
+		"-scenario", scenarioFile(t, twoStepScenario), "-repo", "r1",
+		"-checkout", t.TempDir(), "-out", out, "-agent", "tool", "-model", "m2")
+
+	if code != 1 {
+		t.Errorf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr, "model m2 cannot be driven by tool") {
+		t.Errorf("stderr = %q, want it to name the mismatch", stderr)
+	}
+	if _, err := os.Stat(out); err == nil {
+		t.Error("a run directory was created for a job that could never run")
+	}
+}
+
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // The session must run inside the repository under study, not wherever the
 // binary happened to be invoked: an agent pointed at the wrong tree produces a
 // plausible answer about the wrong code.
 func TestTheAgentRunsInsideTheRepository(t *testing.T) {
-	repo := t.TempDir()
+	repo, head := gitCheckout(t)
 	out := filepath.Join(t.TempDir(), "run-1")
 	agent := filepath.Join(t.TempDir(), "fake-agent")
 	if err := os.WriteFile(agent, []byte("#!/bin/sh\ncat >/dev/null\npwd\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 
-	if code, _, stderr := dispatch(t, "run",
-		"-scenario", scenarioFile(t, twoStepScenario),
-		"-repo", repo, "-out", out, "-agent", agent,
-	); code != 0 {
+	if code, _, stderr := dispatch(t, runArgsIn(t, agent, out, repo, head)...); code != 0 {
 		t.Fatalf("exit = %d (stderr: %s)", code, stderr)
 	}
 
@@ -234,12 +341,7 @@ func TestARunThatCannotBeRecordedExitsNonZero(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	code, _, stderr := dispatch(t, "run",
-		"-scenario", scenarioFile(t, twoStepScenario),
-		"-repo", t.TempDir(),
-		"-out", filepath.Join(blocked, "run-1"),
-		"-agent", fakeAgent(t, "0", ""),
-	)
+	code, _, stderr := dispatch(t, runArgs(t, fakeAgent(t, "0", ""), filepath.Join(blocked, "run-1"))...)
 
 	if code == 0 {
 		t.Error("exit = 0 for a run that could not be written")
@@ -265,10 +367,7 @@ func TestTheAgentIsInvokedHeadlessAndUnattended(t *testing.T) {
 	}
 
 	out := filepath.Join(t.TempDir(), "run-1")
-	if code, _, stderr := dispatch(t, "run",
-		"-scenario", scenarioFile(t, twoStepScenario),
-		"-repo", t.TempDir(), "-out", out, "-agent", agent,
-	); code != 0 {
+	if code, _, stderr := dispatch(t, runArgs(t, agent, out)...); code != 0 {
 		t.Fatalf("exit = %d (stderr: %s)", code, stderr)
 	}
 
@@ -277,6 +376,15 @@ func TestTheAgentIsInvokedHeadlessAndUnattended(t *testing.T) {
 		if !strings.Contains(gotArgs, want) {
 			t.Errorf("the agent was not given %q:\n%s", want, gotArgs)
 		}
+	}
+
+	// THE line this pitch exists for. The measured failure was a model id
+	// transformed on its way to the spawn: it resolved to nothing, and every
+	// run came back empty with exit 1 rather than crashing. The flag and the id
+	// are asserted adjacent and verbatim, so neither dropping the selection nor
+	// sending the wrong string can pass.
+	if !strings.Contains(gotArgs, "--model\nm1\n") {
+		t.Errorf("the model id did not reach the agent verbatim, immediately after its flag:\n%s", gotArgs)
 	}
 
 	gotEnv := read(t, envFile)
@@ -315,5 +423,78 @@ func TestRunHelpIsNotReportedAsAnError(t *testing.T) {
 
 	if strings.Contains(stderr, "sense-lab run:") {
 		t.Errorf("asking for help produced an error message:\n%s", stderr)
+	}
+}
+
+// A run against a tree that is not at the pinned commit records a commit it did
+// not use. Nothing about the result would show it, so every number taken that
+// way is quietly unreproducible — the same class of failure as an arm whose
+// model resolved to nothing.
+func TestACheckoutThatIsNotAtThePinIsRefused(t *testing.T) {
+	agent := fakeAgent(t, "0", "")
+	checkout, _ := gitCheckout(t)
+	out := filepath.Join(t.TempDir(), "run-1")
+
+	t.Run("a different commit", func(t *testing.T) {
+		// The catalog pins something this tree is not at.
+		code, _, stderr := dispatch(t, runArgsIn(t, agent, out, checkout,
+			"0000000000000000000000000000000000000000")...)
+
+		if code != 1 {
+			t.Errorf("exit = %d, want 1", code)
+		}
+		if !strings.Contains(stderr, "records a commit it did not use") {
+			t.Errorf("stderr = %q, want it to say why this matters", stderr)
+		}
+		if _, err := os.Stat(out); err == nil {
+			t.Error("a run directory was created for a checkout that was refused")
+		}
+	})
+
+	t.Run("a directory that is not a repository at all", func(t *testing.T) {
+		code, _, stderr := dispatch(t, runArgsIn(t, agent, filepath.Join(t.TempDir(), "r"),
+			t.TempDir(), "abc123")...)
+
+		if code != 1 {
+			t.Errorf("exit = %d, want 1", code)
+		}
+		if !strings.Contains(stderr, "cannot read its commit") {
+			t.Errorf("stderr = %q, want it to say the commit is unreadable", stderr)
+		}
+	})
+}
+
+// The shipped claude-code config must carry the headless contract. The rest of
+// the suite drives a fixture agent, so a flag deleted from the real file would
+// otherwise pass every test and cost a run to discover — which is exactly what
+// this test's fixture-based sibling stopped catching when the flags moved into
+// config.
+func TestTheShippedClaudeAgentCarriesTheHeadlessContract(t *testing.T) {
+	c, err := catalog.Load(repoConfigDir(t))
+	if err != nil {
+		t.Fatalf("load the shipped catalog: %v", err)
+	}
+	a, ok := c.Agents["claude-code"]
+	if !ok {
+		t.Fatal("the shipped catalog has no claude-code agent")
+	}
+
+	args := strings.Join(a.HeadlessArgs, " ")
+	for _, want := range []string{
+		"-p",                                  // the prompt comes on stdin
+		"--permission-mode bypassPermissions", // nobody is at the terminal to answer
+	} {
+		if !strings.Contains(args, want) {
+			t.Errorf("headless_args = %q, missing %q", args, want)
+		}
+	}
+	env := strings.Join(a.Env, " ")
+	for _, want := range []string{"IS_SANDBOX=1", "CLAUDE_CODE_DISABLE_AUTO_MEMORY=1"} {
+		if !strings.Contains(env, want) {
+			t.Errorf("env = %q, missing %q", env, want)
+		}
+	}
+	if a.ModelFlag == "" {
+		t.Error("the shipped agent has no model flag, so no arm could select a model")
 	}
 }

--- a/lab/internal/run/run.go
+++ b/lab/internal/run/run.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -72,6 +73,14 @@ type Meta struct {
 	Command     string   `json:"command"`
 	Args        []string `json:"args"`
 	StartedAt   string   `json:"started_at"`
+	// StdoutBytes is how much the session actually said.
+	//
+	// It is here because of a specific failure: an arm whose model id resolved
+	// to nothing produced zero bytes and exited 1, and that is byte-identical
+	// in shape to a session that ran and legitimately failed. A run with a
+	// real wall and no output is not a result, it is a broken spawn, and this
+	// is what makes the difference visible without reading transcripts.
+	StdoutBytes int64 `json:"stdout_bytes"`
 }
 
 // exitCodeKilled is what Meta records when the process was killed from outside.
@@ -124,8 +133,11 @@ func Session(ctx context.Context, dir string, s Spec) (Meta, error) {
 		return Meta{}, err
 	}
 
+	said, _ := stdout.Seek(0, io.SeekCurrent)
+
 	m := Meta{
 		Outcome:     outcomeOf(code, ended),
+		StdoutBytes: said,
 		ExitCode:    code,
 		WallSeconds: s.Wall.Seconds(),
 		TookSeconds: time.Since(started).Seconds(),

--- a/lab/internal/run/run_test.go
+++ b/lab/internal/run/run_test.go
@@ -478,3 +478,41 @@ func TestOutcomeOfPrefersWhatEndedTheSessionOverTheExitCode(t *testing.T) {
 		t.Errorf("outcomeOf(0, endedByCancel) = %q, want %q", got, Interrupted)
 	}
 }
+
+// A session that produced nothing is not the same as a session that ran and
+// failed, but on disk they look identical: same outcome, same exit code. The
+// measured case is an arm whose model id resolved to nothing — zero bytes,
+// exit 1, and a campaign before anyone noticed. The byte count is what makes a
+// broken spawn legible without reading transcripts.
+func TestTheRecordSaysHowMuchTheSessionActuallySaid(t *testing.T) {
+	t.Run("a session that said something", func(t *testing.T) {
+		dir := t.TempDir()
+		m, err := Session(context.Background(), dir, Spec{
+			Name: "sh", Args: []string{"-c", "echo hello there"}, Wall: 10 * time.Second,
+		})
+		if err != nil {
+			t.Fatalf("Session: %v", err)
+		}
+		if m.StdoutBytes != int64(len("hello there\n")) {
+			t.Errorf("stdout_bytes = %d, want %d", m.StdoutBytes, len("hello there\n"))
+		}
+	})
+
+	t.Run("a session that said nothing and failed", func(t *testing.T) {
+		dir := t.TempDir()
+		m, err := Session(context.Background(), dir, Spec{
+			Name: "sh", Args: []string{"-c", "exit 1"}, Wall: 10 * time.Second,
+		})
+		if err != nil {
+			t.Fatalf("Session: %v", err)
+		}
+		if m.Outcome != Failed {
+			t.Fatalf("outcome = %q, want %q", m.Outcome, Failed)
+		}
+		// Zero, and recorded rather than absent: this is the shape that has to
+		// be distinguishable from a real failure afterwards.
+		if m.StdoutBytes != 0 {
+			t.Errorf("stdout_bytes = %d, want 0", m.StdoutBytes)
+		}
+	})
+}

--- a/lab/models/claude-opus-4-7.json
+++ b/lab/models/claude-opus-4-7.json
@@ -1,0 +1,12 @@
+{
+  "id": "claude-opus-4-7",
+  "provider": "anthropic",
+  "aliases": [],
+  "available_under": [
+    "subscription",
+    "api_key"
+  ],
+  "agents": [
+    "claude-code"
+  ]
+}

--- a/lab/models/claude-opus-5.json
+++ b/lab/models/claude-opus-5.json
@@ -1,0 +1,12 @@
+{
+  "id": "claude-opus-5",
+  "provider": "anthropic",
+  "aliases": [],
+  "available_under": [
+    "subscription",
+    "api_key"
+  ],
+  "agents": [
+    "claude-code"
+  ]
+}

--- a/lab/models/glm-5.2_cloud.json
+++ b/lab/models/glm-5.2_cloud.json
@@ -1,0 +1,11 @@
+{
+  "id": "glm-5.2:cloud",
+  "provider": "zhipu",
+  "aliases": [],
+  "available_under": [
+    "api_key"
+  ],
+  "agents": [
+    "opencode"
+  ]
+}

--- a/lab/models/gpt-5.6-sol.json
+++ b/lab/models/gpt-5.6-sol.json
@@ -1,0 +1,12 @@
+{
+  "id": "gpt-5.6-sol",
+  "provider": "openai",
+  "aliases": [],
+  "available_under": [
+    "subscription",
+    "api_key"
+  ],
+  "agents": [
+    "codex"
+  ]
+}

--- a/lab/models/kimi-for-coding_k3.json
+++ b/lab/models/kimi-for-coding_k3.json
@@ -1,0 +1,11 @@
+{
+  "id": "kimi-for-coding/k3",
+  "provider": "moonshot",
+  "aliases": [],
+  "available_under": [
+    "api_key"
+  ],
+  "agents": [
+    "opencode"
+  ]
+}

--- a/lab/models/ollama-cloud_mistral-large-3_675b.json
+++ b/lab/models/ollama-cloud_mistral-large-3_675b.json
@@ -1,0 +1,13 @@
+{
+  "id": "ollama-cloud/mistral-large-3:675b",
+  "provider": "ollama-cloud",
+  "aliases": [
+    "mistral-large-3:675b"
+  ],
+  "available_under": [
+    "api_key"
+  ],
+  "agents": [
+    "opencode"
+  ]
+}

--- a/lab/repos/abp.json
+++ b/lab/repos/abp.json
@@ -1,0 +1,9 @@
+{
+  "id": "abp",
+  "url": "https://github.com/abpframework/abp.git",
+  "commit": "7ed43b1931b9df46a50c0c59148a18645641d0df",
+  "languages": [
+    "csharp"
+  ],
+  "stack": "dotnet"
+}

--- a/lab/repos/aspnetcore.json
+++ b/lab/repos/aspnetcore.json
@@ -1,0 +1,9 @@
+{
+  "id": "aspnetcore",
+  "url": "https://github.com/dotnet/aspnetcore.git",
+  "commit": "1f689ce2bede1617d28fd3c76bce99532bb15ba8",
+  "languages": [
+    "csharp"
+  ],
+  "stack": "dotnet"
+}

--- a/lab/repos/bitwarden-server.json
+++ b/lab/repos/bitwarden-server.json
@@ -1,0 +1,9 @@
+{
+  "id": "bitwarden-server",
+  "url": "https://github.com/bitwarden/server.git",
+  "commit": "e93b962371d80964556f5590c6615f5160a437a1",
+  "languages": [
+    "csharp"
+  ],
+  "stack": "dotnet"
+}

--- a/lab/repos/discourse.json
+++ b/lab/repos/discourse.json
@@ -1,0 +1,10 @@
+{
+  "id": "discourse",
+  "url": "https://github.com/discourse/discourse.git",
+  "commit": "d73e4484b4b9dcffa1e75e2ceff6e0a005d479c6",
+  "languages": [
+    "ruby",
+    "javascript"
+  ],
+  "stack": "ruby"
+}

--- a/lab/repos/jellyfin.json
+++ b/lab/repos/jellyfin.json
@@ -1,0 +1,9 @@
+{
+  "id": "jellyfin",
+  "url": "https://github.com/jellyfin/jellyfin.git",
+  "commit": "ae8723026d97b6d0f926638803edef338919b794",
+  "languages": [
+    "csharp"
+  ],
+  "stack": "dotnet"
+}

--- a/lab/subjects/sense-main/README.md
+++ b/lab/subjects/sense-main/README.md
@@ -1,0 +1,40 @@
+# sense-main
+
+Sense at `main`, installed the way a user installs it.
+
+Last verified: 2026-08-15.
+
+## The arm must see what a real user sees
+
+Setup uses the product's own `sense setup` surface, never a hand-rolled
+imitation. The moment the bench writes its own `.mcp.json`, it is measuring a
+configuration nobody has.
+
+That has a consequence worth recording rather than discovering: a change to
+`sense setup` changes what this arm sees, which changes the measurement, and
+nothing about that is visible in a result months later. Cycle 03 records the
+files setup wrote and their hashes into the run.
+
+## Known side effect: indexing configures
+
+`sense scan` runs setup when a repository has no index. On a headless bench that
+takes the Claude Code path and writes `.mcp.json`, `CLAUDE.md`, `.claude/`
+settings with a pre-tool-use hook, skills and an agent into the subject
+repository. **Preparing the repository is therefore a contamination event**, and
+the naive preparation hands the baseline arm Sense.
+
+The trigger is `firstRun`, which is true whenever the index directory does not
+yet exist (`internal/scan/scan.go`), and setup then writes into the
+**repository root** regardless of where that index directory is. So pointing
+`SENSE_DIR` outside the repository is **not** enough on its own: the first scan
+still contaminates, and only later scans are quiet.
+
+What does suppress it is creating the index directory **before** scanning, so
+`firstRun` is false on the very first pass. Verified against the code, not
+assumed; an earlier version of this file claimed `SENSE_DIR` alone was
+sufficient and that was wrong.
+
+## Install and setup commands are deliberately absent from subject.json
+
+Cycle 08 is the first thing that runs them. A schema for commands nobody
+executes is written from imagination; they arrive with the code that runs them.

--- a/lab/subjects/sense-main/subject.json
+++ b/lab/subjects/sense-main/subject.json
@@ -1,0 +1,10 @@
+{
+  "id": "sense-main",
+  "kind": "sense",
+  "needs_mcp": true,
+  "agents": [
+    "claude-code",
+    "codex",
+    "opencode"
+  ]
+}

--- a/lab/subjects/untreated/README.md
+++ b/lab/subjects/untreated/README.md
@@ -1,0 +1,30 @@
+# untreated
+
+No code-intelligence treatment at all. The arm the win is claimed against.
+
+**Why the id is not `baseline`.** `baseline` is also the subject KIND, which is
+a closed enum the code legitimately compiles in — and the probe that proves no
+catalog identifier reaches compiled code matches on strings, so a subject id
+equal to a kind is invisible to it. A planted dispatch on `"baseline"` passed.
+The collision is fixed here rather than exempted there, so the probe has no
+blind spot left to justify. The kind is still `baseline`; only the id moved.
+
+Last verified: 2026-08-15.
+
+## What it must NOT have
+
+Sense reaches an agent through six channels, and this subject gets none of them:
+the MCP registration, the binary on `PATH`, repository instructions naming the
+tool, skills and agent definitions, lifecycle hooks, and persisted memory keyed
+off the repository path. Five live in the repository and are handled by starting
+from a clean worktree. The sixth does not, and it is the one a reasonable
+implementation misses.
+
+**A contamination check proves each one absent per run.** It is not enough that
+this file says so: the whole measurement rests on the claim that this arm cannot
+reach Sense, and if that claim is wrong nothing about the failure is visible in
+a result. Cycle 03 (03-02) builds the check.
+
+## Why it has no version
+
+There is nothing to version. That is the point of the arm.

--- a/lab/subjects/untreated/subject.json
+++ b/lab/subjects/untreated/subject.json
@@ -1,0 +1,10 @@
+{
+  "id": "untreated",
+  "kind": "baseline",
+  "needs_mcp": false,
+  "agents": [
+    "claude-code",
+    "codex",
+    "opencode"
+  ]
+}


### PR DESCRIPTION
## Problem

Cycle 00 hard-coded the repository, the scenario and the model as constants — correct for a skeleton, untenable past it, because those three are the things this instrument changes most often.

The tree being replaced shows what happens when they live in code. Dispatch was by model-id prefix inside bash. One arm was written as `mistral-large-3:cloud`; the runner mapped it to a provider id that **ate the size tag the model needed**, so it resolved to something nonexistent and **every run came back empty, zero tokens, exit 1**. It failed as a bad *result* rather than as a crash, which is why it took a campaign to notice.

## Summary

Five kinds of small file, parsed into small structs by a pure package that runs nothing. No inheritance, no defaults resolution, no environment overlay, no includes. The csharp-aspnet arm set is expressed as config and loads clean.

**Three things now catch the mistral shape before a run, and a fourth after it:**

- **A duplicate id is refused** instead of letting the last file read win. Proven silent before: a shadow file changed a model's provider, exit 0, no warning. The message names *both* files, because read order decides which one trips and it is usually the innocent one.
- **A checkout that is not at the pinned commit is refused** before anything spawns. Printing a commit the run did not use makes every number unreproducible with nothing in the result to show it.
- **An unsupported agent-and-model pairing is refused at planning time**, not forty minutes into a paid run.
- **`run-meta.json` records `stdout_bytes`.** The mistral arm produced zero bytes and exit 1, which is byte-identical on disk to a session that ran and legitimately failed.

**Aliases are indexed, not merely recorded.** The field documenting the exact confusion that cost the arm had no lookup behind it, which is how a reader concludes it is handled. `-model mistral-large-3:675b` resolves to the full id.

## The two probes, and what they found

The Done-means item asks that no competitor, agent or model identifier appear in compiled code, "proven by building with the config directory absent... a grep for the names you happened to think of is a negative claim with a single probe, and negative claims need a second, different one."

**Probe one** — nothing plans without a config directory. `catalog` and `run` both exit 1 and write nothing.

**Probe two — first version, found real violations.** Grepping the built binary turned up `bypassPermissions`, `IS_SANDBOX=1`, `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1` and `stream-json` compiled in, at a point where the source read as fully config-driven. They moved into `agent.json`, which also makes the headless invocation a per-tool fact rather than a Claude-shaped assumption.

**Probe two — first version, then failed its own test.** A reviewer planted the pitch's exact failure mode back in — `if job.agent.ID == "opencode"` and `strings.HasPrefix(job.model.ID, "glm-5.2:cloud")` — and **both probes passed**. The list was nine names someone thought of; **nineteen real catalog identifiers were unchecked**. A hand-written list goes stale the moment an arm is added, which is precisely how the original incident arrived.

So the list is **derived from the shipped catalog**: every id, provider, alias, binary, model flag, headless arg and env string, at five characters or more, with a guard that it derived at least twenty. Against the planted dispatch it fires three times. The only exemption is the three subject kinds, a closed enum the validator switches on.

## Changes

- `lab/internal/catalog` — load and validate. Every problem is reported at once, because a config edited by hand should not be fixed one error at a time.
- `lab/internal/cli/catalogcmd.go` — `sense-lab catalog`, which spends nothing and fails on a malformed file rather than on a run.
- `lab/{subjects,agents,models,repos}/` — the real config, with a README beside each subject and agent carrying the version quirks and side effects no schema holds. The opencode README records the mistral incident where the next person to add an arm will read it.
- `lab/internal/run` — `stdout_bytes` in the record.

**The structs are narrower than this pitch's Solution section described.** A first draft carried version, executor, config paths, a retired flag, frameworks and two multi-flag capability structs: thirteen fields nothing read. Because unknown fields are refused, a guessed field is load-bearing the day it ships — it cannot be dropped without editing every config file. The rabbit hole beat the field list, and the package doc says so.

## Test plan

`make ci` green: coverage gate with no new exception, ledger 0, lint 0 issues, total 95.7%. `qlty check lab/` clean. **All six lab packages at 100% line and function coverage.**

The skeleton still runs end to end, now entirely from config: the model id reaches the agent's argv verbatim, immediately after the agent's own model flag.

Mutation-checked. These now fail: dropping the model selection from the spawn; sending the provider where the id belongs; deleting `--permission-mode bypassPermissions` from the *shipped* agent file; removing `DisallowUnknownFields`; disabling the auth-mode overlap check; dropping the `IDs` sort; removing the duplicate-id guard; and the planted agent-id and model-prefix dispatch.

One README claim was checked against the source and found **wrong**: `SENSE_DIR` alone does not suppress setup writes, because `firstRun` is true whenever the index directory is absent and `setup.Run` writes to the repository root regardless. Corrected here and in the cycle 03 pitch that inherits it.

Reviewed by the council; test spec validated.