### PR TITLE
bench(lab): plan a campaign and refuse what cannot run

### DIFF
--- a/lab/campaigns/csharp-aspnet/README.md
+++ b/lab/campaigns/csharp-aspnet/README.md
@@ -1,0 +1,33 @@
+# csharp-aspnet
+
+The arm set as of `547f1bf` (*bench(arms): name the mistral arm in
+provider/model form, template included*), **over the one repository that
+campaign had reached**, expressed as config.
+
+Two different as-ofs, on purpose, and worth saying plainly: the arms are frozen
+at the commit, the repository list is frozen at what had actually run.
+`repos.txt` at that commit names four repositories; the campaign had reached
+one.
+
+Frozen at that commit on purpose. A mid-flight campaign as a moving target
+turns the plan into a bookkeeping exercise, and the point of this file is to
+show that the config plans to the cells the campaign actually had.
+
+At that commit the campaign had reached **one repository**, bitwarden-server,
+and had banked the headline arm there: baseline and sense on `claude-opus-5`.
+The four confirmation arms were declared and had not run.
+
+## The judge is not an arm
+
+`claude-opus-4-7` grades the rubric axes. It produces no cell and it is a
+service the scoring layer calls, so it is a pinned field of the campaign rather
+than a line in the arm list. It only lived in the arm list before because that
+file existed, and leaving it there would mean every consumer skipping it by
+convention, forever.
+
+## Adding an arm
+
+One line here, and a model file if the model is new. Nothing else — no dispatch
+to edit, no prefix matching to extend. That is the whole point of the catalog,
+and it is the thing that failed when an arm's id was rewritten by a runner into
+something that did not exist.

--- a/lab/campaigns/csharp-aspnet/campaign.json
+++ b/lab/campaigns/csharp-aspnet/campaign.json
@@ -1,0 +1,38 @@
+{
+  "key": "csharp-aspnet",
+  "judge": "claude-opus-4-7",
+  "subjects": [
+    "untreated",
+    "sense-main"
+  ],
+  "repos": [
+    "bitwarden-server"
+  ],
+  "arms": [
+    {
+      "role": "headline",
+      "model": "claude-opus-5",
+      "runs": 2
+    },
+    {
+      "role": "confirmation",
+      "model": "gpt-5.6-sol",
+      "runs": 2
+    },
+    {
+      "role": "confirmation",
+      "model": "kimi-for-coding/k3",
+      "runs": 2
+    },
+    {
+      "role": "confirmation",
+      "model": "glm-5.2:cloud",
+      "runs": 2
+    },
+    {
+      "role": "confirmation",
+      "model": "ollama-cloud/mistral-large-3:675b",
+      "runs": 2
+    }
+  ]
+}

--- a/lab/cmd/sense-lab/signal_test.go
+++ b/lab/cmd/sense-lab/signal_test.go
@@ -136,9 +136,10 @@ func writeCatalog(t *testing.T, dir, bin, pin string) string {
 	for path, body := range map[string]string{
 		"agents/tool/agent.json": `{"id":"tool","binary":"` + bin + `","model_flag":"--model",
 		  "headless_args":["-p"],"env":[],"supports_mcp":false,"auth_modes":["api_key"]}`,
-		"subjects/baseline/subject.json": `{"id":"baseline","kind":"baseline","agents":["tool"]}`,
-		"models/m1.json":                 `{"id":"m1","provider":"acme","available_under":["api_key"],"agents":["tool"]}`,
-		"repos/r1.json":                  `{"id":"r1","url":"https://example.test/r1.git","commit":"` + pin + `","languages":["go"]}`,
+		"subjects/untreated/subject.json": `{"id":"untreated","kind":"baseline","executor":"isolated-home","agents":["tool"]}`,
+		"executors/isolated-home.json":    `{"id":"isolated-home","preserves_auth":["api_key"],"isolates_global_config":true}`,
+		"models/m1.json":                  `{"id":"m1","provider":"acme","available_under":["api_key"],"agents":["tool"]}`,
+		"repos/r1.json":                   `{"id":"r1","url":"https://example.test/r1.git","commit":"` + pin + `","languages":["go"]}`,
 	} {
 		full := filepath.Join(cfg, path)
 		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {

--- a/lab/executors/README.md
+++ b/lab/executors/README.md
@@ -1,0 +1,51 @@
+# executors
+
+Where and how a run happens. Two facts about each one are read before anything
+spawns, and both come from the design docs rather than from imagination.
+
+**Neither executor exists yet.** Cycle 03 builds isolated-home; cycle 08 builds
+the container. They are declared here because the planner must be able to refuse
+an impossible combination before either exists — a job that cannot authenticate
+is a burned arm, and its partner goes with it.
+
+That means these are the one place in the catalog that describes code rather
+than an ecosystem fact, and they are the one place most likely to be wrong. Both
+files carry their source.
+
+## isolated-home
+
+`preserves_auth: ["subscription", "api_key"]`
+
+- *subscription* is verbatim from `02-architecture.md`: isolated-home "keeps the
+  host subscription usable".
+- *api_key* comes from `03-01`, which sets the environment allowlist: "Start
+  from empty, add what the agent tool genuinely needs (`PATH`, `TERM`,
+  **credentials the tool requires**)".
+
+The second one was questioned on review, because `02-architecture.md` mentions
+only the subscription and describes the environment as scrubbed. It is recorded
+here because it decides real money: four of the five arms in the frozen
+csharp-aspnet campaign reach their model by API key, and dropping it would
+reject arms that genuinely ran. **If cycle 03's allowlist turns out not to pass
+credentials, this line is wrong in the expensive direction — a false accept —
+and it is the first thing to check.**
+
+`isolates_global_config: true` is verbatim: "Strong config isolation".
+
+## container
+
+`preserves_auth: []` is verbatim from `02-architecture.md`: "Credentials stay on
+the host; the container never receives them."
+
+`isolates_global_config: true` is inferred from the same lines: the container is
+the escalation "for a subject that mutates global state in ways the disposable
+home cannot contain."
+
+The container is declared without being referenced by any subject, because it is
+the only executor that makes the auth question answer NO, and a rule with no
+case that exercises it is a rule nobody can check.
+
+## local
+
+Deleted. It appears in the architecture doc's list, nothing references it, and
+the judgment phases that would are cycle 05. It arrives with them.

--- a/lab/executors/container.json
+++ b/lab/executors/container.json
@@ -1,0 +1,5 @@
+{
+  "id": "container",
+  "preserves_auth": [],
+  "isolates_global_config": true
+}

--- a/lab/executors/isolated-home.json
+++ b/lab/executors/isolated-home.json
@@ -1,0 +1,8 @@
+{
+  "id": "isolated-home",
+  "preserves_auth": [
+    "subscription",
+    "api_key"
+  ],
+  "isolates_global_config": true
+}

--- a/lab/internal/catalog/catalog.go
+++ b/lab/internal/catalog/catalog.go
@@ -52,6 +52,11 @@ type Subject struct {
 	// NeedsMCP says this treatment reaches the agent through an MCP server, so
 	// it can only be driven by a tool that speaks one.
 	NeedsMCP bool `json:"needs_mcp"`
+	// NeedsIsolatedConfig says this treatment writes agent configuration, so it
+	// may only run somewhere that configuration cannot escape onto the host.
+	NeedsIsolatedConfig bool `json:"needs_isolated_config"`
+	// Executor is where this subject runs.
+	Executor string `json:"executor"`
 	// Agents are the agent tool ids this subject can be driven through.
 	Agents []string `json:"agents"`
 }
@@ -90,6 +95,30 @@ type Model struct {
 	Agents []string `json:"agents"`
 }
 
+// Executor is where and how a run happens. Two facts about it matter before
+// anything spawns, and both are load-bearing:
+//
+//   - which auth modes survive into the session. A container that never
+//     receives credentials cannot reach a model that needs them, and that is a
+//     planning-time fact rather than a run-time surprise
+//   - whether it isolates global config, which is what a subject that writes
+//     agent configuration depends on
+//
+// Cycle 03 implements isolated-home and cycle 08 the container. Declaring them
+// as data now is what lets the planner refuse an impossible combination before
+// either exists.
+// Nothing validates an executor beyond its id, which is claimed at decode time.
+// An executor preserving no auth mode at all is legal and deliberate: the
+// container never receives credentials.
+type Executor struct {
+	ID string `json:"id"`
+	// PreservesAuth lists the auth modes that reach a session run this way.
+	PreservesAuth []string `json:"preserves_auth"`
+	// IsolatesGlobalConfig says the session gets its own agent configuration
+	// rather than the host's.
+	IsolatesGlobalConfig bool `json:"isolates_global_config"`
+}
+
 // Repo is the code under study, at a pinned commit.
 //
 // A vertical is a query over this metadata rather than a directory tree, which
@@ -120,8 +149,9 @@ type Catalog struct {
 	// model that does not exist and makes the validator report one fault twice.
 	Models map[string]Model
 	// byName resolves a model by its id OR any of its aliases.
-	byName map[string]Model
-	Repos  map[string]Repo
+	byName    map[string]Model
+	Repos     map[string]Repo
+	Executors map[string]Executor
 }
 
 // Load reads a config directory and validates it.
@@ -135,12 +165,13 @@ func Load(dir string) (*Catalog, error) {
 		return nil, fmt.Errorf("%w: %w", ErrNoConfig, err)
 	}
 	c := &Catalog{
-		claimed:  map[string]string{},
-		Subjects: map[string]Subject{},
-		Agents:   map[string]Agent{},
-		Models:   map[string]Model{},
-		byName:   map[string]Model{},
-		Repos:    map[string]Repo{},
+		claimed:   map[string]string{},
+		Subjects:  map[string]Subject{},
+		Agents:    map[string]Agent{},
+		Models:    map[string]Model{},
+		byName:    map[string]Model{},
+		Repos:     map[string]Repo{},
+		Executors: map[string]Executor{},
 	}
 	if err := loadInto(dir, c); err != nil {
 		return nil, err
@@ -164,7 +195,10 @@ func loadInto(dir string, c *Catalog) error {
 	if err := readFlat(filepath.Join(dir, "models"), c.addModel); err != nil {
 		return err
 	}
-	return readFlat(filepath.Join(dir, "repos"), c.addRepo)
+	if err := readFlat(filepath.Join(dir, "repos"), c.addRepo); err != nil {
+		return err
+	}
+	return readFlat(filepath.Join(dir, "executors"), c.addExecutor)
 }
 
 func (c *Catalog) addSubject(path string, b []byte) error {
@@ -222,8 +256,15 @@ func (c *Catalog) addModel(path string, b []byte) error {
 // model called one way and offered another. It is a separate index rather than
 // extra entries in Models, so the catalog never lists a model twice and the
 // validator never reports one fault once per alias.
+// It consults the set as well as the index, so a Catalog built as a literal —
+// which every caller outside this package does in its tests — resolves ids even
+// though it has no alias index. A method that silently finds nothing on a
+// hand-built value is a trap.
 func (c *Catalog) Model(name string) (Model, bool) {
-	m, ok := c.byName[name]
+	if m, ok := c.byName[name]; ok {
+		return m, true
+	}
+	m, ok := c.Models[name]
 	return m, ok
 }
 
@@ -236,6 +277,18 @@ func (c *Catalog) addRepo(path string, b []byte) error {
 		return err
 	}
 	c.Repos[r.ID] = r
+	return nil
+}
+
+func (c *Catalog) addExecutor(path string, b []byte) error {
+	var e Executor
+	if err := decode(path, b, &e); err != nil {
+		return err
+	}
+	if err := c.claim(path, "executor", e.ID); err != nil {
+		return err
+	}
+	c.Executors[e.ID] = e
 	return nil
 }
 

--- a/lab/internal/catalog/catalog_test.go
+++ b/lab/internal/catalog/catalog_test.go
@@ -13,9 +13,11 @@ import (
 func good(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
-	writeSubject(t, dir, "baseline", Subject{
-		ID: "baseline", Kind: Baseline, Agents: []string{"tool"},
+	writeSubject(t, dir, "untreated", Subject{
+		ID: "untreated", Kind: Baseline, Executor: "isolated-home", Agents: []string{"tool"},
 	})
+	writeExecutor(t, dir, Executor{ID: "isolated-home",
+		PreservesAuth: []string{"api_key"}, IsolatesGlobalConfig: true})
 	writeAgent(t, dir, "tool", Agent{
 		ID: "tool", Binary: "toolbin", ModelFlag: "--model",
 		HeadlessArgs: []string{"-p"}, AuthModes: []string{"api_key"},
@@ -56,6 +58,9 @@ func writeModel(t *testing.T, dir string, m Model) {
 func writeRepo(t *testing.T, dir string, r Repo) {
 	writeJSON(t, filepath.Join(dir, "repos", r.ID+".json"), r)
 }
+func writeExecutor(t *testing.T, dir string, e Executor) {
+	writeJSON(t, filepath.Join(dir, "executors", e.ID+".json"), e)
+}
 
 func loadErr(t *testing.T, dir string) string {
 	t.Helper()
@@ -72,8 +77,8 @@ func TestAWellFormedCatalogLoads(t *testing.T) {
 		t.Fatalf("Load: %v", err)
 	}
 
-	if c.Subjects["baseline"].Kind != Baseline {
-		t.Errorf("subject kind = %q", c.Subjects["baseline"].Kind)
+	if c.Subjects["untreated"].Kind != Baseline {
+		t.Errorf("subject kind = %q", c.Subjects["untreated"].Kind)
 	}
 	if c.Agents["tool"].Binary != "toolbin" {
 		t.Errorf("agent binary = %q", c.Agents["tool"].Binary)
@@ -97,7 +102,7 @@ func TestAMalformedCatalogIsRefusedAtLoadTime(t *testing.T) {
 		{
 			name: "a subject naming an agent that does not exist",
 			breaks: func(t *testing.T, dir string) {
-				writeSubject(t, dir, "baseline", Subject{ID: "baseline", Kind: Baseline, Agents: []string{"ghost"}})
+				writeSubject(t, dir, "untreated", Subject{ID: "untreated", Kind: Baseline, Executor: "isolated-home", Agents: []string{"ghost"}})
 			},
 			want: `names agent "ghost", which no agent file declares`,
 		},
@@ -111,14 +116,14 @@ func TestAMalformedCatalogIsRefusedAtLoadTime(t *testing.T) {
 		{
 			name: "a subject with a kind that is not one of the three",
 			breaks: func(t *testing.T, dir string) {
-				writeSubject(t, dir, "baseline", Subject{ID: "baseline", Kind: "helper", Agents: []string{"tool"}})
+				writeSubject(t, dir, "untreated", Subject{ID: "untreated", Kind: "helper", Executor: "isolated-home", Agents: []string{"tool"}})
 			},
 			want: `kind "helper" is not baseline, sense or competitor`,
 		},
 		{
 			name: "a subject nothing can drive",
 			breaks: func(t *testing.T, dir string) {
-				writeSubject(t, dir, "baseline", Subject{ID: "baseline", Kind: Baseline})
+				writeSubject(t, dir, "untreated", Subject{ID: "untreated", Kind: Baseline, Executor: "isolated-home"})
 			},
 			want: "names no agent tools",
 		},
@@ -201,7 +206,7 @@ func TestAModelNoAgentCanReachIsRefused(t *testing.T) {
 func TestASubjectNeedingMCPCannotUseAToolWithoutIt(t *testing.T) {
 	dir := good(t)
 	writeSubject(t, dir, "sense", Subject{
-		ID: "sense", Kind: Sense, Agents: []string{"tool"},
+		ID: "sense", Kind: Sense, Executor: "isolated-home", Agents: []string{"tool"},
 		NeedsMCP: true,
 	})
 	writeAgent(t, dir, "tool", Agent{
@@ -395,7 +400,7 @@ func TestAgentAndModelFieldsThatWouldStopARunAreRequired(t *testing.T) {
 			writeRepo(t, dir, Repo{ID: "r1", URL: "u", Commit: "c"})
 		}, "no languages"},
 		{"a subject with no kind", func(t *testing.T, dir string) {
-			writeSubject(t, dir, "baseline", Subject{ID: "baseline", Agents: []string{"tool"}})
+			writeSubject(t, dir, "untreated", Subject{ID: "untreated", Executor: "isolated-home", Agents: []string{"tool"}})
 		}, "no kind"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -413,7 +418,7 @@ func TestAgentAndModelFieldsThatWouldStopARunAreRequired(t *testing.T) {
 // get a test. Each kind has its own decode path, so each needs its own case.
 func TestMalformedJSONIsRefusedForEveryKind(t *testing.T) {
 	for _, tc := range []struct{ name, path string }{
-		{"subject", filepath.Join("subjects", "baseline", "subject.json")},
+		{"subject", filepath.Join("subjects", "untreated", "subject.json")},
 		{"agent", filepath.Join("agents", "tool", "agent.json")},
 		{"model", filepath.Join("models", "m1.json")},
 		{"repo", filepath.Join("repos", "r1.json")},
@@ -485,8 +490,8 @@ func TestTwoFilesClaimingOneIDAreRefused(t *testing.T) {
 				Repo{ID: "r1", URL: "u", Commit: "c", Languages: []string{"go"}})
 		}, `repo id "r1" is already claimed by`},
 		{"two subjects", func(t *testing.T, dir string) {
-			writeSubject(t, dir, "shadow", Subject{ID: "baseline", Kind: Baseline, Agents: []string{"tool"}})
-		}, `subject id "baseline" is already claimed by`},
+			writeSubject(t, dir, "shadow", Subject{ID: "untreated", Kind: Baseline, Executor: "isolated-home", Agents: []string{"tool"}})
+		}, `subject id "untreated" is already claimed by`},
 		{"two agents", func(t *testing.T, dir string) {
 			writeAgent(t, dir, "shadow", Agent{ID: "tool", Binary: "b", ModelFlag: "-m",
 				HeadlessArgs: []string{"-p"}, AuthModes: []string{"api_key"}})
@@ -588,5 +593,80 @@ func TestAnAgentWithoutMCPMayStillCarryASubjectThatDoesNotNeedIt(t *testing.T) {
 
 	if _, err := Load(dir); err != nil {
 		t.Errorf("a baseline subject was refused an agent with no MCP: %v", err)
+	}
+}
+
+// A subject with no executor has nowhere to run, and one naming an executor
+// that does not exist is a typo that would otherwise surface as a job with an
+// empty executor field.
+func TestASubjectWithoutAValidExecutorIsRefused(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		write func(t *testing.T, dir string)
+		want  string
+	}{
+		{"no executor at all", func(t *testing.T, dir string) {
+			writeSubject(t, dir, "untreated", Subject{ID: "untreated", Kind: Baseline, Agents: []string{"tool"}})
+		}, "names no executor, so there is nowhere to run it"},
+		{"an executor no file declares", func(t *testing.T, dir string) {
+			writeSubject(t, dir, "untreated", Subject{ID: "untreated", Kind: Baseline,
+				Executor: "ghost", Agents: []string{"tool"}})
+		}, `names executor "ghost"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := good(t)
+			tc.write(t, dir)
+
+			if got := loadErr(t, dir); !strings.Contains(got, tc.want) {
+				t.Errorf("error = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// Executors are config like everything else: malformed, duplicated or
+// unreadable ones are caught at load.
+func TestExecutorFilesAreValidatedLikeTheRest(t *testing.T) {
+	t.Run("malformed", func(t *testing.T) {
+		dir := good(t)
+		if err := os.WriteFile(filepath.Join(dir, "executors", "isolated-home.json"),
+			[]byte(`{"id": }`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if got := loadErr(t, dir); !strings.Contains(got, "isolated-home.json") {
+			t.Errorf("error = %q", got)
+		}
+	})
+
+	t.Run("duplicate", func(t *testing.T) {
+		dir := good(t)
+		writeJSON(t, filepath.Join(dir, "executors", "shadow.json"),
+			Executor{ID: "isolated-home", PreservesAuth: []string{"api_key"}})
+		if got := loadErr(t, dir); !strings.Contains(got, `executor id "isolated-home" is already claimed by`) {
+			t.Errorf("error = %q", got)
+		}
+	})
+
+	t.Run("an executor that preserves nothing is legal", func(t *testing.T) {
+		// The container deliberately never receives credentials.
+		dir := good(t)
+		writeExecutor(t, dir, Executor{ID: "container", IsolatesGlobalConfig: true})
+		if _, err := Load(dir); err != nil {
+			t.Errorf("a credential-free executor was refused: %v", err)
+		}
+	})
+}
+
+// Model resolves against a Catalog built as a literal, which is what every
+// caller outside this package does in its own tests. A method that silently
+// finds nothing on a hand-built value is a trap.
+func TestModelResolvesOnACatalogBuiltAsALiteral(t *testing.T) {
+	c := &Catalog{Models: map[string]Model{"m1": {ID: "m1"}}}
+
+	if _, ok := c.Model("m1"); !ok {
+		t.Error("a model in the set does not resolve without the alias index")
+	}
+	if _, ok := c.Model("nope"); ok {
+		t.Error("a model that does not exist resolved")
 	}
 }

--- a/lab/internal/catalog/validate.go
+++ b/lab/internal/catalog/validate.go
@@ -49,6 +49,11 @@ func (c *Catalog) checkSubject(s Subject) []string {
 	if len(s.Agents) == 0 {
 		p = append(p, fmt.Sprintf("subject %s: names no agent tools, so nothing can drive it", s.ID))
 	}
+	if s.Executor == "" {
+		p = append(p, fmt.Sprintf("subject %s: names no executor, so there is nowhere to run it", s.ID))
+	} else if _, ok := c.Executors[s.Executor]; !ok {
+		p = append(p, fmt.Sprintf("subject %s: names executor %q, which no executor file declares", s.ID, s.Executor))
+	}
 	for _, a := range s.Agents {
 		if _, ok := c.Agents[a]; !ok {
 			p = append(p, fmt.Sprintf("subject %s: names agent %q, which no agent file declares", s.ID, a))

--- a/lab/internal/cli/catalogcmd.go
+++ b/lab/internal/cli/catalogcmd.go
@@ -14,7 +14,7 @@ import (
 const defaultConfigDir = "lab"
 
 func configFlag(fs *flag.FlagSet, into *string) {
-	fs.StringVar(into, "config", defaultConfigDir, "directory holding subjects/, agents/, models/ and repos/")
+	fs.StringVar(into, "config", defaultConfigDir, "directory holding subjects/, agents/, models/, repos/ and executors/")
 }
 
 // catalogCmd loads the config and prints what it found. It is the smallest
@@ -46,6 +46,9 @@ func catalogCmd(args []string, stdout, stderr io.Writer) int {
 	}
 	for _, r := range catalog.IDs(c.Repos) {
 		_, _ = fmt.Fprintf(stdout, "repo     %-14s %s @ %.8s\n", r, c.Repos[r].Stack, c.Repos[r].Commit)
+	}
+	for _, e := range catalog.IDs(c.Executors) {
+		_, _ = fmt.Fprintf(stdout, "executor %-14s preserves %v\n", e, c.Executors[e].PreservesAuth)
 	}
 	return exitOK
 }

--- a/lab/internal/cli/catalogcmd_test.go
+++ b/lab/internal/cli/catalogcmd_test.go
@@ -166,7 +166,7 @@ func TestCatalogPrintsEveryKindWithWhatIdentifiesIt(t *testing.T) {
 	// another of the same kind. An id-only listing would not tell two models
 	// apart.
 	for _, want := range []string{
-		"subject  baseline", "baseline\n", // id and kind
+		"subject  untreated", "baseline\n", // id and kind
 		"agent    tool", "/bin/true\n", // id and binary
 		"model    m1", "acme\n", // id and provider
 		"repo     r1", "abc123\n", // id and pinned commit

--- a/lab/internal/cli/cli.go
+++ b/lab/internal/cli/cli.go
@@ -28,7 +28,8 @@ const usage = `sense-lab — the bench instrument for Sense
 Usage: sense-lab <command> [flags]
 
 Commands:
-  catalog   Show the subjects, agents, models and repositories in the config
+  catalog   Show the subjects, agents, models, repositories and executors in the config
+  plan      Show what a campaign would run, and every rejection with its reason
   run       Run one scenario against one repository
   score     Score a recorded run against a scenario's gold
   version   Print version
@@ -52,6 +53,10 @@ const (
 	// and came up short is a result, and a caller must be able to tell it from
 	// a typo'd path or an unreadable transcript.
 	exitBelowFloor = 4
+	// exitIncomplete: the campaign is well-formed and part of its matrix cannot
+	// run. A caller must not proceed on a partial matrix, but "your config is
+	// broken" and "three arms cannot run" are opposite actions.
+	exitIncomplete = 5
 )
 
 // Run dispatches args to a subcommand and returns the process exit code.
@@ -63,6 +68,8 @@ func Run(args []string, stdout, stderr io.Writer) int {
 		return exitUsage
 	}
 	switch args[0] {
+	case "plan":
+		return planCmd(args[1:], stdout, stderr)
 	case "run":
 		// A run must die with the binary. Without this the cancel path the
 		// runner carefully distinguishes can never fire in production:

--- a/lab/internal/cli/plancmd.go
+++ b/lab/internal/cli/plancmd.go
@@ -1,0 +1,96 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/luuuc/sense/lab/internal/catalog"
+	"github.com/luuuc/sense/lab/internal/plan"
+)
+
+// planCmd prints what a campaign would run and every rejection with its reason.
+//
+// Printing is for humans. Later cycles call the planner as a library and take
+// the job list as values; nothing anywhere parses this table.
+func planCmd(args []string, stdout, stderr io.Writer) int {
+	var dir, key string
+	fs := flag.NewFlagSet("plan", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	configFlag(fs, &dir)
+	fs.StringVar(&key, "campaign", "", "campaign key under campaigns/ (required)")
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if key == "" {
+		_, _ = fmt.Fprintln(stderr, "sense-lab plan: -campaign is required")
+		return exitUsage
+	}
+
+	c, err := catalog.Load(dir)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab plan: %v\n", err)
+		return exitError
+	}
+	camp, err := loadCampaign(dir, key)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab plan: %v\n", err)
+		return exitError
+	}
+	res, err := plan.Expand(c, camp)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab plan: %v\n", err)
+		return exitError
+	}
+
+	printPlan(stdout, camp, res)
+
+	// A plan that rejects something is not a failure — the whole point is to
+	// find it here rather than in a session — but it exits non-zero so an
+	// unattended caller cannot proceed as though the matrix were whole.
+	if len(res.Rejected) > 0 {
+		return exitIncomplete
+	}
+	return exitOK
+}
+
+func printPlan(w io.Writer, camp plan.Campaign, res plan.Result) {
+	_, _ = fmt.Fprintf(w, "campaign %s\njudge    %s (pinned, not an arm)\n\n", camp.Key, camp.Judge)
+
+	_, _ = fmt.Fprintf(w, "WILL RUN: %d cells, %d sessions\n", res.Cells(), res.Runs())
+	for _, j := range res.Jobs {
+		_, _ = fmt.Fprintf(w, "  %-12s %s\n", j.Role, j)
+	}
+	if len(res.Rejected) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintf(w, "\nWILL NOT RUN: %d\n", len(res.Rejected))
+	for _, r := range res.Rejected {
+		_, _ = fmt.Fprintf(w, "  %s\n", r)
+	}
+}
+
+// loadCampaign reads campaigns/<key>/campaign.json. Unknown fields are refused
+// for the same reason the catalog refuses them: a typo'd key that parses
+// silently is a setting that looks applied and is not.
+func loadCampaign(dir, key string) (plan.Campaign, error) {
+	path := filepath.Join(dir, "campaigns", key, "campaign.json")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return plan.Campaign{}, fmt.Errorf("read campaign: %w", err)
+	}
+	var camp plan.Campaign
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&camp); err != nil {
+		return plan.Campaign{}, fmt.Errorf("%s: %w", path, err)
+	}
+	if camp.Key != key {
+		return plan.Campaign{}, fmt.Errorf("%s declares key %q but lives under %q", path, camp.Key, key)
+	}
+	return camp, nil
+}

--- a/lab/internal/cli/plancmd_test.go
+++ b/lab/internal/cli/plancmd_test.go
@@ -1,0 +1,430 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// planCatalog is a config directory with two executors, so a test can vary
+// where a subject runs and watch resolution answer differently.
+func planCatalog(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	for path, body := range map[string]string{
+		"agents/tool/agent.json": `{"id":"tool","binary":"b","model_flag":"--model",
+		  "headless_args":["-p"],"env":[],"supports_mcp":true,"auth_modes":["api_key"]}`,
+		"subjects/untreated/subject.json": `{"id":"untreated","kind":"baseline","needs_mcp":false,
+		  "needs_isolated_config":false,"executor":"isolated-home","agents":["tool"]}`,
+		"subjects/sense/subject.json": `{"id":"sense","kind":"sense","needs_mcp":true,
+		  "needs_isolated_config":true,"executor":"isolated-home","agents":["tool"]}`,
+		"models/m1.json":    `{"id":"m1","provider":"acme","aliases":[],"available_under":["api_key"],"agents":["tool"]}`,
+		"models/judge.json": `{"id":"judge","provider":"acme","aliases":[],"available_under":["api_key"],"agents":["tool"]}`,
+		"repos/r1.json":     `{"id":"r1","url":"u","commit":"abc","languages":["go"],"stack":"go"}`,
+		"executors/isolated-home.json": `{"id":"isolated-home","preserves_auth":["api_key"],
+		  "isolates_global_config":true}`,
+		"executors/local.json": `{"id":"local","preserves_auth":["api_key"],"isolates_global_config":false}`,
+		"campaigns/c/campaign.json": `{"key":"c","judge":"judge","subjects":["untreated","sense"],
+		  "repos":["r1"],"arms":[{"role":"headline","model":"m1","runs":2}]}`,
+	} {
+		full := filepath.Join(dir, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func TestPlanPrintsWhatWouldRun(t *testing.T) {
+	code, stdout, stderr := dispatch(t, "plan", "-config", planCatalog(t), "-campaign", "c")
+
+	if code != 0 {
+		t.Fatalf("exit = %d (stderr: %s)", code, stderr)
+	}
+	for _, want := range []string{
+		"campaign c",
+		"judge    judge (pinned, not an arm)",
+		"WILL RUN: 1 cells, 4 sessions", // one repo, one arm, two subjects
+		"headline     r1 / untreated / tool / m1 / isolated-home / api_key x2",
+		"headline     r1 / sense / tool / m1 / isolated-home / api_key x2",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("output is missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+// A rejection without a reason is a mystery someone routes around by guessing,
+// so the reason is printed with the job it belongs to, and the command exits
+// non-zero so an unattended caller cannot proceed as though the matrix were
+// whole.
+func TestPlanPrintsEveryRejectionWithItsReason(t *testing.T) {
+	dir := planCatalog(t)
+	// The sense subject writes agent config; local does not isolate it.
+	if err := os.WriteFile(filepath.Join(dir, "subjects", "sense", "subject.json"),
+		[]byte(`{"id":"sense","kind":"sense","needs_mcp":true,"needs_isolated_config":true,
+		  "executor":"local","agents":["tool"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code, stdout, _ := dispatch(t, "plan", "-config", dir, "-campaign", "c")
+
+	// Its own code: a caller must not proceed on a partial matrix, but "your
+	// config is broken" and "part of your matrix cannot run" are opposite
+	// actions and both used to exit 1.
+	if code != 5 {
+		t.Errorf("exit = %d, want 5 for a plan with a hole in it", code)
+	}
+	// BOTH sides go: a cell that lost a subject is a half-pair, and planning
+	// the survivor guarantees a burned arm.
+	for _, want := range []string{
+		"WILL RUN: 0 cells",
+		"WILL NOT RUN: 2",
+		"r1 / sense / tool / m1 / local",
+		"would leak onto the host and into the next run",
+		"its cell is incomplete, so running this would burn it",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("output is missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+// A job the catalog says cannot work must never reach a spawn. This is the
+// half-pair hazard: a combination that was never going to run burns the arm
+// that did.
+//
+// The break used here is one a VALID catalog permits — a model driven only by a
+// tool no subject supports. A model nothing can authenticate to would be
+// rejected earlier, when the catalog loads, which is a different and better
+// failure: see TestSomeRejectionsCannotBeReachedThroughAValidCatalog.
+func TestADeliberatelyBrokenCombinationPlansNothingForThatArm(t *testing.T) {
+	dir := planCatalog(t)
+	write := func(path, body string) {
+		t.Helper()
+		full := filepath.Join(dir, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A second tool that exists and is reachable, but that no subject supports.
+	write("agents/lonely/agent.json", `{"id":"lonely","binary":"l","model_flag":"-m",
+	  "headless_args":["-p"],"env":[],"supports_mcp":true,"auth_modes":["api_key"]}`)
+	write("models/m1.json", `{"id":"m1","provider":"acme","aliases":[],
+	  "available_under":["api_key"],"agents":["lonely"]}`)
+
+	code, stdout, _ := dispatch(t, "plan", "-config", dir, "-campaign", "c")
+
+	if code == 0 {
+		t.Error("exit = 0 for a campaign nothing in which can run")
+	}
+	if !strings.Contains(stdout, "WILL RUN: 0 cells") {
+		t.Errorf("something was planned anyway:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "cannot be driven by lonely") {
+		t.Errorf("output does not say why:\n%s", stdout)
+	}
+}
+
+// ONE of the resolution questions cannot fire through a catalog that loads:
+// "is this model reachable through this tool", which the catalog answers first
+// and refuses the whole config over. That is the better failure — an internally
+// inconsistent catalog is a mistake, not a job that happens not to fit.
+//
+// It is recorded here so nobody later reads that branch as dead code and
+// deletes it: without it, the executor question's message degenerates to
+// "needs one of []". It is a guard behind an invariant the catalog owns, and it
+// is tested directly against an in-memory catalog in the plan package.
+//
+// The executor question IS reachable — a subject may name the container, which
+// preserves nothing — and TestPlanPrintsEveryRejectionWithItsReason exercises
+// the isolation question. An earlier version of this comment claimed two
+// questions were unreachable and demonstrated one.
+func TestOneRejectionCannotBeReachedThroughAValidCatalog(t *testing.T) {
+	dir := planCatalog(t)
+	if err := os.WriteFile(filepath.Join(dir, "models", "m1.json"),
+		[]byte(`{"id":"m1","provider":"acme","aliases":[],"available_under":["subscription"],"agents":["tool"]}`),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code, stdout, stderr := dispatch(t, "plan", "-config", dir, "-campaign", "c")
+
+	if code == 0 {
+		t.Error("a model nothing can authenticate to was accepted")
+	}
+	if !strings.Contains(stderr, "nothing could reach it") {
+		t.Errorf("stderr = %q, want the catalog to refuse it at load", stderr)
+	}
+	if stdout != "" {
+		t.Errorf("a plan was printed for a config that does not load:\n%s", stdout)
+	}
+}
+
+// Adding an arm is one line in the campaign and one model file. Nothing else:
+// no dispatch to edit, no prefix matching to extend. That is the whole point of
+// the catalog, and it is what failed when a runner rewrote an arm's id into
+// something that did not exist.
+func TestAddingAnArmIsOneFileAndOneLine(t *testing.T) {
+	dir := planCatalog(t)
+	before := planned(t, dir)
+
+	if err := os.WriteFile(filepath.Join(dir, "models", "m2.json"),
+		[]byte(`{"id":"m2","provider":"acme","aliases":[],"available_under":["api_key"],"agents":["tool"]}`),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "campaigns", "c", "campaign.json"),
+		[]byte(`{"key":"c","judge":"judge","subjects":["untreated","sense"],"repos":["r1"],
+		  "arms":[{"role":"headline","model":"m1","runs":2},{"role":"confirmation","model":"m2","runs":2}]}`),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	after := planned(t, dir)
+
+	if !strings.Contains(after, "m2") {
+		t.Errorf("the new arm does not appear in the plan:\n%s", after)
+	}
+	if strings.Contains(before, "m2") {
+		t.Error("the arm was in the plan before it was added")
+	}
+	if !strings.Contains(after, "WILL RUN: 2 cells, 8 sessions") {
+		t.Errorf("the new arm did not add a cell:\n%s", after)
+	}
+}
+
+// The "one file" claim is narrower than it reads, and the narrow part is worth
+// pinning: an arm on a tool no subject lists needs an edit to every subject
+// too. That is correct behaviour — a subject decides what can drive it — but
+// somebody reading "adding an arm is one new file" should not be surprised by
+// it.
+func TestAnArmOnANewToolAlsoNeedsEverySubjectToAllowThatTool(t *testing.T) {
+	dir := planCatalog(t)
+	write := func(path, body string) {
+		t.Helper()
+		full := filepath.Join(dir, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("agents/newtool/agent.json", `{"id":"newtool","binary":"n","model_flag":"-m",
+	  "headless_args":["-p"],"env":[],"supports_mcp":true,"auth_modes":["api_key"]}`)
+	write("models/m2.json", `{"id":"m2","provider":"acme","aliases":[],
+	  "available_under":["api_key"],"agents":["newtool"]}`)
+	write("campaigns/c/campaign.json", `{"key":"c","judge":"judge","subjects":["untreated","sense"],
+	  "repos":["r1"],"arms":[{"role":"headline","model":"m1","runs":2},
+	  {"role":"confirmation","model":"m2","runs":2}]}`)
+
+	code, stdout, _ := dispatch(t, "plan", "-config", dir, "-campaign", "c")
+
+	if code != 5 {
+		t.Errorf("exit = %d, want 5", code)
+	}
+	if !strings.Contains(stdout, "cannot be driven by newtool; it supports [tool]") {
+		t.Errorf("the plan does not say what else needs editing:\n%s", stdout)
+	}
+	// And the existing arm is untouched.
+	if !strings.Contains(stdout, "WILL RUN: 1 cells") {
+		t.Errorf("the new arm took the existing one with it:\n%s", stdout)
+	}
+}
+
+func planned(t *testing.T, dir string) string {
+	t.Helper()
+	code, stdout, stderr := dispatch(t, "plan", "-config", dir, "-campaign", "c")
+	if code != 0 {
+		t.Fatalf("plan exit = %d (stderr: %s)", code, stderr)
+	}
+	return stdout
+}
+
+func TestPlanRejectsWhatItCannotRead(t *testing.T) {
+	dir := planCatalog(t)
+
+	for _, tc := range []struct {
+		name     string
+		args     []string
+		want     string
+		wantCode int
+	}{
+		{"no campaign named", []string{"-config", dir}, "-campaign is required", 2},
+		{"an unknown flag", []string{"-config", dir, "-campaign", "c", "-arm", "x"},
+			"flag provided but not defined", 2},
+		{"a campaign that does not exist", []string{"-config", dir, "-campaign", "nope"},
+			"read campaign", 1},
+		{"no config directory", []string{"-config", filepath.Join(t.TempDir(), "gone"), "-campaign", "c"},
+			"no config directory", 1},
+		{"a campaign that is malformed rather than unsatisfiable", []string{
+			"-config", malformedCampaign(t), "-campaign", "c"},
+			"has 2 headline arms", 1},
+		{"a campaign naming a subject twice", []string{
+			"-config", duplicateSubject(t), "-campaign", "c"},
+			`names subject "untreated" twice; a duplicated arm is not a pair`, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			code, _, stderr := dispatch(t, append([]string{"plan"}, tc.args...)...)
+
+			if code != tc.wantCode {
+				t.Errorf("exit = %d, want %d", code, tc.wantCode)
+			}
+			if !strings.Contains(stderr, tc.want) {
+				t.Errorf("stderr = %q, want %q", stderr, tc.want)
+			}
+		})
+	}
+}
+
+// A campaign file whose key disagrees with its directory is ambiguous about
+// which campaign it is, and every later artifact is keyed on one of the two.
+// malformedCampaign is a config directory whose campaign cannot be read as a
+// campaign at all. That is a different answer from a campaign whose jobs cannot
+// run: one sends you to fix the campaign file, the other to fix the catalog.
+func malformedCampaign(t *testing.T) string {
+	t.Helper()
+	dir := planCatalog(t)
+	if err := os.WriteFile(filepath.Join(dir, "campaigns", "c", "campaign.json"),
+		[]byte(`{"key":"c","judge":"judge","subjects":["untreated"],"repos":["r1"],
+		  "arms":[{"role":"headline","model":"m1","runs":2},{"role":"headline","model":"judge","runs":2}]}`),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// A list naming the same subject twice is the hazard in disguise: two untreated
+// arms and no sense arm looks complete to anything counting jobs.
+func duplicateSubject(t *testing.T) string {
+	t.Helper()
+	dir := planCatalog(t)
+	if err := os.WriteFile(filepath.Join(dir, "campaigns", "c", "campaign.json"),
+		[]byte(`{"key":"c","judge":"judge","subjects":["untreated","untreated"],"repos":["r1"],
+		  "arms":[{"role":"headline","model":"m1","runs":2}]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestACampaignKeyMustMatchItsDirectory(t *testing.T) {
+	dir := planCatalog(t)
+	if err := os.WriteFile(filepath.Join(dir, "campaigns", "c", "campaign.json"),
+		[]byte(`{"key":"other","judge":"judge","subjects":["untreated"],"repos":["r1"],
+		  "arms":[{"role":"headline","model":"m1","runs":2}]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code, _, stderr := dispatch(t, "plan", "-config", dir, "-campaign", "c")
+
+	if code == 0 {
+		t.Error("a mismatched campaign key was accepted")
+	}
+	if !strings.Contains(stderr, `declares key "other" but lives under "c"`) {
+		t.Errorf("stderr = %q", stderr)
+	}
+}
+
+// A typo'd key in a campaign file is a setting that looks applied and is not,
+// for the same reason it is in the catalog.
+func TestAnUnknownFieldInACampaignIsRefused(t *testing.T) {
+	dir := planCatalog(t)
+	if err := os.WriteFile(filepath.Join(dir, "campaigns", "c", "campaign.json"),
+		[]byte(`{"key":"c","judge":"judge","subjects":["untreated"],"repos":["r1"],"wall":"8m",
+		  "arms":[{"role":"headline","model":"m1","runs":2}]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code, _, stderr := dispatch(t, "plan", "-config", dir, "-campaign", "c")
+
+	if code == 0 || !strings.Contains(stderr, "unknown field") {
+		t.Errorf("exit = %d, stderr = %q", code, stderr)
+	}
+}
+
+// The shipped campaign is the reference this pitch is checked against: the
+// csharp-aspnet arm set as of a named commit, planning to the cells that
+// campaign had. A broken one must fail here rather than in a session.
+func TestTheShippedCampaignPlansTheCellsItHad(t *testing.T) {
+	code, stdout, stderr := dispatch(t, "plan", "-config", repoConfigDir(t), "-campaign", "csharp-aspnet")
+
+	if code != 0 {
+		t.Fatalf("the shipped campaign does not plan: %s", stderr)
+	}
+	// One repository and five arms is five CELLS; two subjects makes each one a
+	// pair, so twenty sessions. A cell is the unit that is paired, budgeted and
+	// banked, and counting jobs as cells doubles every board.
+	if !strings.Contains(stdout, "WILL RUN: 5 cells, 20 sessions") {
+		t.Errorf("plan is not the frozen arm set:\n%s", stdout)
+	}
+	// The headline cell is the one that banked: both arms, on the headline
+	// model, against the repository the campaign had reached.
+	for _, want := range []string{
+		"headline     bitwarden-server / untreated / claude-code / claude-opus-5 / isolated-home / subscription x2",
+		"headline     bitwarden-server / sense-main / claude-code / claude-opus-5 / isolated-home / subscription x2",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("the banked cell is not planned:\n%s", stdout)
+		}
+	}
+	// The arm whose id cost a campaign to debug, in the form that works.
+	if !strings.Contains(stdout, "ollama-cloud/mistral-large-3:675b") {
+		t.Errorf("the mistral arm is missing:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "WILL NOT RUN") {
+		t.Errorf("the frozen arm set rejects something:\n%s", stdout)
+	}
+}
+
+func TestPlanHelpIsNotReportedAsAnError(t *testing.T) {
+	_, _, stderr := dispatch(t, "plan", "-help")
+
+	if strings.Contains(stderr, "sense-lab plan:") {
+		t.Errorf("asking for help produced an error message:\n%s", stderr)
+	}
+}
+
+// `plan` and `run` must agree on what a model NAME is. `run` resolves through
+// the alias index; if `plan` looked only at the id map it would report "no
+// model file declares it" for a name that a model file does declare — a false
+// statement aimed at exactly the person who just wrote the id in the other
+// form, which is the confusion that cost an arm in the first place.
+func TestACampaignMayNameAModelByItsAlias(t *testing.T) {
+	dir := planCatalog(t)
+	write := func(path, body string) {
+		t.Helper()
+		full := filepath.Join(dir, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("models/long.json", `{"id":"provider/long-model:675b","provider":"acme",
+	  "aliases":["long-model:675b"],"available_under":["api_key"],"agents":["tool"]}`)
+	// The campaign names the SHORT form.
+	write("campaigns/c/campaign.json", `{"key":"c","judge":"judge","subjects":["untreated","sense"],
+	  "repos":["r1"],"arms":[{"role":"headline","model":"long-model:675b","runs":2}]}`)
+
+	code, stdout, stderr := dispatch(t, "plan", "-config", dir, "-campaign", "c")
+
+	if code != 0 {
+		t.Fatalf("a campaign naming a model by its alias did not plan: %s", stderr)
+	}
+	// And the plan shows the canonical id, so one plan names one form.
+	if !strings.Contains(stdout, "provider/long-model:675b") {
+		t.Errorf("the plan does not name the canonical id:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "/ long-model:675b /") {
+		t.Errorf("the plan names the alias as though it were the model:\n%s", stdout)
+	}
+}

--- a/lab/internal/cli/runcmd_test.go
+++ b/lab/internal/cli/runcmd_test.go
@@ -47,8 +47,10 @@ func testCatalogPinned(t *testing.T, bin, pin string) string {
 	  "model_flag":"--model","headless_args":["-p","--permission-mode","bypassPermissions"],
 	  "env":["IS_SANDBOX=1","CLAUDE_CODE_DISABLE_AUTO_MEMORY=1"],
 	  "supports_mcp":true,"auth_modes":["api_key"]}`)
-	write(filepath.Join(dir, "subjects", "baseline", "subject.json"),
-		`{"id":"baseline","kind":"baseline","agents":["tool"]}`)
+	write(filepath.Join(dir, "subjects", "untreated", "subject.json"),
+		`{"id":"untreated","kind":"baseline","executor":"isolated-home","agents":["tool"]}`)
+	write(filepath.Join(dir, "executors", "isolated-home.json"),
+		`{"id":"isolated-home","preserves_auth":["api_key"],"isolates_global_config":true}`)
 	write(filepath.Join(dir, "models", "m1.json"),
 		`{"id":"m1","provider":"acme","available_under":["api_key"],"agents":["tool"]}`)
 	write(filepath.Join(dir, "repos", "r1.json"),

--- a/lab/internal/plan/plan.go
+++ b/lab/internal/plan/plan.go
@@ -1,0 +1,324 @@
+// Package plan expands a campaign into the jobs it implies and answers, for
+// each one, whether it can run at all.
+//
+// It exists so that an impossible combination is found before anything is
+// spent, rather than forty minutes into a session, or worse at the end of a
+// cell whose other arm already completed and can now never be paired. Two
+// recorded failures have this shape: an arm whose model id resolved to nothing
+// and returned empty at zero tokens, and a half-pair whose finished arm was
+// burned because its partner was never going to run.
+//
+// It is pure: config in, a list of jobs and a list of named rejections out. No
+// network, no spawn, nothing on disk beyond the config it was handed.
+package plan
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/luuuc/sense/lab/internal/catalog"
+)
+
+// Role is what an arm is for.
+type Role string
+
+const (
+	// Headline is the arm a win is claimed on. Exactly one per campaign.
+	Headline Role = "headline"
+	// Confirmation is a cross-model check that the win is not an artifact of
+	// one model.
+	Confirmation Role = "confirmation"
+)
+
+// Arm is one model the campaign benches, and how many times per cell.
+type Arm struct {
+	Role  Role   `json:"role"`
+	Model string `json:"model"`
+	Runs  int    `json:"runs"`
+	// Agent names the tool to drive the model with. It may be empty when the
+	// model names exactly one, which is the normal case.
+	Agent string `json:"agent"`
+}
+
+// Campaign is one measurement programme: which arms, over which repositories,
+// with which subjects.
+type Campaign struct {
+	Key string `json:"key"`
+	// Judge grades the rubric axes. It is NOT an arm: it produces no cell and
+	// it is a service the scoring layer calls. It lives here as a pinned field
+	// because a judge that moves with the arm makes every board incomparable,
+	// and because leaving it in the arm list would mean every consumer skipping
+	// it by convention, forever.
+	Judge    string   `json:"judge"`
+	Subjects []string `json:"subjects"`
+	Repos    []string `json:"repos"`
+	Arms     []Arm    `json:"arms"`
+}
+
+// Job is one cell's worth of work: one scenario's repository, one subject, one
+// agent tool, one model, one executor, run N times.
+type Job struct {
+	// cell groups the jobs that must run together: one repository and one arm,
+	// across every subject. It is keyed on the arm's POSITION rather than on
+	// resolved fields, because a job rejected before its agent was chosen would
+	// otherwise key differently from its own partner.
+	cell     string
+	Repo     string
+	Subject  string
+	Agent    string
+	Model    string
+	Executor string
+	// Auth is the mode chosen to reach this model, not merely one that could
+	// work. Cycle 03's executor provisions it rather than guessing.
+	Auth string
+	Role Role
+	Runs int
+}
+
+func (j Job) String() string {
+	return fmt.Sprintf("%s / %s / %s / %s / %s / %s x%d",
+		j.Repo, j.Subject, j.Agent, j.Model, j.Executor, j.Auth, j.Runs)
+}
+
+// Rejection is a job that cannot run, and why. The reason is always one of the
+// resolution questions: a rejection without a reason is a mystery someone will
+// route around by guessing.
+type Rejection struct {
+	Job    Job
+	Reason string
+}
+
+func (r Rejection) String() string { return r.Job.String() + "\n    " + r.Reason }
+
+// Result is what a campaign plans to.
+type Result struct {
+	Jobs     []Job
+	Rejected []Rejection
+}
+
+// Cells is how many cells the plan runs: a cell is one repository and one arm
+// across every subject, which is the unit that is paired, budgeted and banked.
+// It is NOT the number of jobs — a two-subject campaign runs two jobs per cell.
+func (r Result) Cells() int {
+	seen := map[string]bool{}
+	for _, j := range r.Jobs {
+		seen[j.cell] = true
+	}
+	return len(seen)
+}
+func (r Result) Runs() int {
+	var n int
+	for _, j := range r.Jobs {
+		n += j.Runs
+	}
+	return n
+}
+
+// Expand turns a campaign into every job it implies and resolves each one.
+//
+// Order is repo, then subject, then arm, so the output reads the way a campaign
+// is run: one repository at a time, both arms of a cell adjacent.
+func Expand(c *catalog.Catalog, camp Campaign) (Result, error) {
+	if err := camp.validate(c); err != nil {
+		return Result{}, err
+	}
+
+	// One ordered pass, decided afterwards, so the output reads in the order the
+	// campaign is run rather than grouped by outcome.
+	var walked []Rejection
+	for _, repo := range camp.Repos {
+		for _, subject := range camp.Subjects {
+			for i, arm := range camp.Arms {
+				j, reason := resolve(c, repo, subject, arm)
+				j.cell = fmt.Sprintf("%s#%d", repo, i)
+				walked = append(walked, Rejection{Job: j, Reason: reason})
+			}
+		}
+	}
+	return decide(walked, camp.Subjects), nil
+}
+
+// decide splits a walked matrix into what runs and what does not, rejecting the
+// survivors of any cell that lost a subject.
+//
+// That last part is the hazard the whole pitch is named for, and without it the
+// planner CREATES it rather than preventing it: if one subject of a cell
+// resolves and the other does not, planning only the survivor guarantees a
+// burned arm. The finished side can never be paired, and the baseline's budget
+// derives from its partner's wall, so there is nothing to derive it from.
+//
+// Rejecting the survivor is the right direction. A run that never happens costs
+// nothing; a run that happens and cannot be paired costs its whole spend and
+// yields no result.
+func decide(walked []Rejection, subjects []string) Result {
+	// The SET of subjects present per cell, not how many jobs there are. A
+	// count is a proxy that a duplicated subject satisfies without a partner
+	// ever existing: two untreated arms and no sense arm counts as two.
+	planned := map[string]map[string]bool{}
+	// Why each incomplete cell is incomplete, so a survivor's rejection names
+	// the reason its partner failed rather than merely reporting that one did.
+	lost := map[string]string{}
+	for _, w := range walked {
+		if w.Reason != "" {
+			if _, ok := lost[w.Job.cell]; !ok {
+				lost[w.Job.cell] = w.Job.Subject + ": " + w.Reason
+			}
+			continue
+		}
+		if planned[w.Job.cell] == nil {
+			planned[w.Job.cell] = map[string]bool{}
+		}
+		planned[w.Job.cell][w.Job.Subject] = true
+	}
+
+	var res Result
+	for _, w := range walked {
+		switch {
+		case w.Reason != "":
+			res.Rejected = append(res.Rejected, w)
+		case len(subjects) > 1 && !complete(planned[w.Job.cell], subjects):
+			why, ok := lost[w.Job.cell]
+			if !ok {
+				// Nothing in this cell was rejected, so it is short a subject
+				// for a reason the campaign chose: one listed twice, or one
+				// missing.
+				why = "the campaign does not name every subject for this cell"
+			}
+			res.Rejected = append(res.Rejected, Rejection{Job: w.Job,
+				Reason: fmt.Sprintf("its cell is incomplete, so running this would burn it: %s", why)})
+		default:
+			res.Jobs = append(res.Jobs, w.Job)
+		}
+	}
+	return res
+}
+
+func complete(present map[string]bool, subjects []string) bool {
+	for _, s := range subjects {
+		if !present[s] {
+			return false
+		}
+	}
+	return true
+}
+
+// validate refuses a campaign that is malformed rather than merely
+// unsatisfiable. A campaign naming a subject the catalog does not have is a
+// typo; a campaign whose model no tool can drive is a rejection with a reason,
+// and those are different answers.
+func (camp Campaign) validate(c *catalog.Catalog) error {
+	if err := camp.validateArms(); err != nil {
+		return err
+	}
+	if err := camp.validateNothingIsNamedTwice(); err != nil {
+		return err
+	}
+	return camp.validateReferences(c)
+}
+
+// validateArms checks the arm set can be read as one: exactly one arm to claim
+// a win on, and no arm that never runs.
+//
+// EVERY ARM GETS 2 RUNS PER CELL is a spending law and belongs to the gates,
+// not here. What this refuses is a campaign nobody could interpret.
+func (camp Campaign) validateArms() error {
+	var heads int
+	for _, a := range camp.Arms {
+		switch a.Role {
+		case Headline:
+			heads++
+		case Confirmation:
+		default:
+			return fmt.Errorf("arm %s: role %q is not headline or confirmation", a.Model, a.Role)
+		}
+		if a.Runs < 1 {
+			return fmt.Errorf("arm %s: %d runs; an arm that never runs is not an arm", a.Model, a.Runs)
+		}
+	}
+	if heads != 1 {
+		return fmt.Errorf("campaign %s has %d headline arms; exactly one arm is the one a win is claimed on",
+			camp.Key, heads)
+	}
+	return nil
+}
+
+// validateReferences checks every id the campaign names exists.
+//
+// A campaign naming a subject the catalog does not have is a TYPO; a campaign
+// whose model no tool can drive is a rejection with a reason. Confusing the two
+// sends someone to fix the wrong file.
+// validateNothingIsNamedTwice refuses a list that repeats itself.
+//
+// This is the half-pair hazard in disguise, and it is why the check exists:
+// two untreated arms and no sense arm looks like a complete cell to anything
+// counting jobs, and the pair guard would pass it.
+func (camp Campaign) validateNothingIsNamedTwice() error {
+	if len(camp.Subjects) == 0 || len(camp.Repos) == 0 || len(camp.Arms) == 0 {
+		return fmt.Errorf("campaign %s plans nothing: %d subjects, %d repos, %d arms",
+			camp.Key, len(camp.Subjects), len(camp.Repos), len(camp.Arms))
+	}
+	for _, dup := range []struct {
+		kind string
+		ids  []string
+	}{
+		{"subject", camp.Subjects},
+		{"repo", camp.Repos},
+	} {
+		if id := firstRepeat(dup.ids); id != "" {
+			return fmt.Errorf("campaign %s names %s %q twice; a duplicated arm is not a pair",
+				camp.Key, dup.kind, id)
+		}
+	}
+	var armKeys []string
+	for _, a := range camp.Arms {
+		armKeys = append(armKeys, a.Model+"/"+a.Agent)
+	}
+	if key := firstRepeat(armKeys); key != "" {
+		return fmt.Errorf("campaign %s names model %q twice; running one arm twice is not two arms",
+			camp.Key, strings.SplitN(key, "/", 2)[0])
+	}
+	return nil
+}
+
+func firstRepeat(ids []string) string {
+	seen := map[string]bool{}
+	for _, id := range ids {
+		if seen[id] {
+			return id
+		}
+		seen[id] = true
+	}
+	return ""
+}
+
+func (camp Campaign) validateReferences(c *catalog.Catalog) error {
+
+	if camp.Judge == "" {
+		return fmt.Errorf("campaign %s pins no judge; a judge that moves with the arm makes every board incomparable",
+			camp.Key)
+	}
+	if _, ok := c.Model(camp.Judge); !ok {
+		return fmt.Errorf("campaign %s pins judge %q, which no model file declares", camp.Key, camp.Judge)
+	}
+	for _, s := range camp.Subjects {
+		if !has(c.Subjects, s) {
+			return fmt.Errorf("campaign %s names subject %q, which no subject file declares", camp.Key, s)
+		}
+	}
+	for _, r := range camp.Repos {
+		if !has(c.Repos, r) {
+			return fmt.Errorf("campaign %s names repo %q, which no repo file declares", camp.Key, r)
+		}
+	}
+	for _, a := range camp.Arms {
+		if _, ok := c.Model(a.Model); !ok {
+			return fmt.Errorf("campaign %s names model %q, which no model file declares", camp.Key, a.Model)
+		}
+	}
+	return nil
+}
+
+func has[T any](m map[string]T, id string) bool {
+	_, ok := m[id]
+	return ok
+}

--- a/lab/internal/plan/plan_test.go
+++ b/lab/internal/plan/plan_test.go
@@ -1,0 +1,590 @@
+package plan
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/lab/internal/catalog"
+)
+
+// cat builds a catalog in memory. This package answers questions ABOUT config,
+// so the tests vary config directly; reading it off disk is the catalog
+// package's job and is tested there.
+func cat() *catalog.Catalog {
+	return &catalog.Catalog{
+		Subjects: map[string]catalog.Subject{
+			"untreated": {ID: "untreated", Kind: catalog.Baseline,
+				Executor: "isolated-home", Agents: []string{"tool"}},
+			"sense": {ID: "sense", Kind: catalog.Sense, NeedsMCP: true, NeedsIsolatedConfig: true,
+				Executor: "isolated-home", Agents: []string{"tool"}},
+		},
+		Agents: map[string]catalog.Agent{
+			"tool":  {ID: "tool", Binary: "b", SupportsMCP: true, AuthModes: []string{"api_key"}},
+			"other": {ID: "other", Binary: "o", AuthModes: []string{"subscription"}},
+		},
+		Models: map[string]catalog.Model{
+			"m1":    {ID: "m1", Provider: "acme", AvailableUnder: []string{"api_key"}, Agents: []string{"tool"}},
+			"judge": {ID: "judge", Provider: "acme", AvailableUnder: []string{"api_key"}, Agents: []string{"tool"}},
+		},
+		Repos: map[string]catalog.Repo{"r1": {ID: "r1"}, "r2": {ID: "r2"}},
+		Executors: map[string]catalog.Executor{
+			"isolated-home": {ID: "isolated-home",
+				PreservesAuth: []string{"subscription", "api_key"}, IsolatesGlobalConfig: true},
+			"local":     {ID: "local", PreservesAuth: []string{"subscription", "api_key"}},
+			"container": {ID: "container", IsolatesGlobalConfig: true},
+		},
+	}
+}
+
+func campaign() Campaign {
+	return Campaign{
+		Key: "c", Judge: "judge",
+		Subjects: []string{"untreated", "sense"},
+		Repos:    []string{"r1"},
+		Arms:     []Arm{{Role: Headline, Model: "m1", Runs: 2}},
+	}
+}
+
+func expand(t *testing.T, c *catalog.Catalog, camp Campaign) Result {
+	t.Helper()
+	res, err := Expand(c, camp)
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+	return res
+}
+
+// Expansion is a matrix and it must produce BOTH arms of every cell. A plan
+// missing one side is a guaranteed half-pair: the finished arm can never be
+// paired, and the baseline's budget derives from its partner's wall.
+func TestEveryRepoSubjectAndArmBecomesAJob(t *testing.T) {
+	camp := campaign()
+	camp.Repos = []string{"r1", "r2"}
+	camp.Arms = append(camp.Arms, Arm{Role: Confirmation, Model: "judge", Runs: 3})
+
+	res := expand(t, cat(), camp)
+
+	// A cell is one repository and one arm across every subject, so this is
+	// 2 repos x 2 arms — NOT the number of jobs, which is twice that.
+	if res.Cells() != 4 {
+		t.Fatalf("planned %d cells, want 4:\n%v", res.Cells(), res.Jobs)
+	}
+	if len(res.Jobs) != 8 {
+		t.Errorf("planned %d jobs, want 8", len(res.Jobs))
+	}
+	if res.Runs() != 4*(2+3) { // per-arm run counts, not a flat multiplier
+		t.Errorf("planned %d sessions, want %d", res.Runs(), 4*(2+3))
+	}
+	if len(res.Rejected) != 0 {
+		t.Errorf("rejected %v", res.Rejected)
+	}
+}
+
+// One repository at a time, both arms of a cell adjacent: the output reads in
+// the order a campaign is run in.
+func TestJobsComeOutInTheOrderACampaignIsRun(t *testing.T) {
+	camp := campaign()
+	camp.Repos = []string{"r1", "r2"}
+
+	res := expand(t, cat(), camp)
+
+	var got []string
+	for _, j := range res.Jobs {
+		got = append(got, j.Repo+"/"+j.Subject)
+	}
+	want := "r1/untreated r1/sense r2/untreated r2/sense"
+	if strings.Join(got, " ") != want {
+		t.Errorf("order = %v, want %s", got, want)
+	}
+}
+
+// The five resolution questions, one rejection each. Every reason names what is
+// wrong AND what would be right, because a rejection someone cannot act on is
+// one they route around by guessing.
+func TestEachResolutionQuestionRejectsWithItsOwnReason(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		change func(c *catalog.Catalog, camp *Campaign)
+		want   string
+	}{
+		{
+			name: "one: the subject cannot be driven by that agent tool",
+			change: func(c *catalog.Catalog, _ *Campaign) {
+				s := c.Subjects["untreated"]
+				s.Agents = []string{"other"}
+				c.Subjects["untreated"] = s
+			},
+			want: "subject untreated cannot be driven by tool; it supports [other]",
+		},
+		{
+			// Question two is answered by pickAgent: the arm names a tool the
+			// model does not list.
+			name: "two: the agent tool cannot drive that model",
+			change: func(_ *catalog.Catalog, camp *Campaign) {
+				camp.Arms[0].Agent = "other" // m1 names only "tool"
+			},
+			want: `the arm names agent "other", but model m1 can be driven by [tool]`,
+		},
+		{
+			name: "three: nothing can authenticate to that model through that tool",
+			change: func(c *catalog.Catalog, _ *Campaign) {
+				m := c.Models["m1"]
+				m.AvailableUnder = []string{"subscription"}
+				c.Models["m1"] = m
+			},
+			want: "nothing could reach it",
+		},
+		{
+			name: "four: the executor does not preserve the auth that would reach it",
+			change: func(c *catalog.Catalog, _ *Campaign) {
+				for id, s := range c.Subjects {
+					s.Executor = "container"
+					c.Subjects[id] = s
+				}
+			},
+			want: "executor container preserves []",
+		},
+		{
+			name: "five: the executor does not isolate config the subject writes",
+			change: func(c *catalog.Catalog, _ *Campaign) {
+				s := c.Subjects["sense"]
+				s.Executor = "local"
+				c.Subjects["sense"] = s
+			},
+			want: "would leak onto the host and into the next run",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c, camp := cat(), campaign()
+			tc.change(c, &camp)
+
+			res := expand(t, c, camp)
+
+			if len(res.Rejected) == 0 {
+				t.Fatalf("nothing was rejected; planned %v", res.Jobs)
+			}
+			var found bool
+			for _, r := range res.Rejected {
+				if strings.Contains(r.Reason, tc.want) {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("no rejection said %q; got:\n%v", tc.want, res.Rejected)
+			}
+		})
+	}
+}
+
+// A rejected job is not silently dropped: it comes back with the job it was,
+// so a reader can see what would have run.
+func TestARejectionCarriesTheJobItWas(t *testing.T) {
+	c, camp := cat(), campaign()
+	s := c.Subjects["sense"]
+	s.Executor = "local"
+	c.Subjects["sense"] = s
+
+	res := expand(t, c, camp)
+
+	var r Rejection
+	for _, got := range res.Rejected {
+		if got.Job.Subject == "sense" {
+			r = got
+		}
+	}
+	if r.Job.Repo != "r1" || r.Job.Model != "m1" || r.Job.Executor != "local" {
+		t.Errorf("the rejection lost the job: %+v", r.Job)
+	}
+	if !strings.Contains(r.Reason, "would leak onto the host") {
+		t.Errorf("the rejection lost its reason: %q", r.Reason)
+	}
+}
+
+// A model several tools can drive is ambiguous, and picking one arbitrarily is
+// how an arm ends up measured on a surface nobody intended.
+func TestAModelSeveralToolsCanDriveNeedsTheArmToSayWhich(t *testing.T) {
+	c, camp := cat(), campaign()
+	m := c.Models["m1"]
+	m.Agents = []string{"tool", "other"}
+	c.Models["m1"] = m
+
+	res := expand(t, c, camp)
+
+	if len(res.Rejected) == 0 {
+		t.Fatal("an ambiguous model was resolved anyway")
+	}
+	if !strings.Contains(res.Rejected[0].Reason, "does not say which") {
+		t.Errorf("reason = %q, want it to name the ambiguity", res.Rejected[0].Reason)
+	}
+
+	// Naming the tool resolves it.
+	camp.Arms[0].Agent = "tool"
+	if res := expand(t, c, camp); res.Cells() != 1 || len(res.Jobs) != 2 {
+		t.Errorf("naming the agent left %d cells / %d jobs, want 1 and 2:\n%v",
+			res.Cells(), len(res.Jobs), res.Rejected)
+	}
+}
+
+func TestAnArmNamingAToolItsModelDoesNotSupportIsRejected(t *testing.T) {
+	c, camp := cat(), campaign()
+	camp.Arms[0].Agent = "other" // m1 names only "tool"
+
+	res := expand(t, c, camp)
+
+	if len(res.Rejected) == 0 {
+		t.Fatal("the arm's agent was not checked against its model")
+	}
+	if !strings.Contains(res.Rejected[0].Reason, `the arm names agent "other"`) {
+		t.Errorf("reason = %q", res.Rejected[0].Reason)
+	}
+}
+
+// A malformed campaign is a different answer from an unsatisfiable one. Naming
+// a subject the catalog does not have is a typo; a model no tool can drive is a
+// rejection with a reason. Confusing the two sends someone to fix the wrong
+// file.
+func TestAMalformedCampaignIsAnErrorNotARejection(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		change func(camp *Campaign)
+		want   string
+	}{
+		{"no headline arm", func(c *Campaign) { c.Arms[0].Role = Confirmation },
+			"has 0 headline arms"},
+		{"two headline arms", func(c *Campaign) {
+			c.Arms = append(c.Arms, Arm{Role: Headline, Model: "judge", Runs: 2})
+		}, "has 2 headline arms"},
+		{"a role that is neither", func(c *Campaign) { c.Arms[0].Role = "control" },
+			`role "control" is not headline or confirmation`},
+		{"an arm that never runs", func(c *Campaign) { c.Arms[0].Runs = 0 },
+			"an arm that never runs is not an arm"},
+		{"no judge", func(c *Campaign) { c.Judge = "" },
+			"makes every board incomparable"},
+		{"a judge no model file declares", func(c *Campaign) { c.Judge = "ghost" },
+			`pins judge "ghost"`},
+		{"a subject no file declares", func(c *Campaign) { c.Subjects = []string{"ghost"} },
+			`names subject "ghost"`},
+		{"a repo no file declares", func(c *Campaign) { c.Repos = []string{"ghost"} },
+			`names repo "ghost"`},
+		{"a model no file declares", func(c *Campaign) { c.Arms[0].Model = "ghost" },
+			`names model "ghost"`},
+		{"nothing to run", func(c *Campaign) { c.Repos = nil },
+			"plans nothing"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			camp := campaign()
+			tc.change(&camp)
+
+			_, err := Expand(cat(), camp)
+
+			if err == nil {
+				t.Fatal("a malformed campaign was expanded")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// The judge is not an arm. It produces no cell, and a plan that ran it as one
+// would spend on a session that scores nothing.
+func TestTheJudgeIsNotPlannedAsAnArm(t *testing.T) {
+	res := expand(t, cat(), campaign())
+
+	for _, j := range res.Jobs {
+		if j.Model == "judge" {
+			t.Errorf("the judge was planned as a job: %s", j)
+		}
+	}
+}
+
+func TestAJobAndARejectionReadAsThemselves(t *testing.T) {
+	j := Job{Repo: "r1", Subject: "sense", Agent: "tool", Model: "m1",
+		Executor: "local", Auth: "api_key", Runs: 2}
+
+	// The auth mode is on the line because it was chosen, not merely possible.
+	for _, want := range []string{"r1", "sense", "tool", "m1", "local", "api_key", "x2"} {
+		if !strings.Contains(j.String(), want) {
+			t.Errorf("job = %q, missing %q", j.String(), want)
+		}
+	}
+	if got := (Rejection{Job: j, Reason: "because"}).String(); !strings.Contains(got, "because") {
+		t.Errorf("rejection = %q, want it to carry the reason", got)
+	}
+}
+
+// An arm may name a tool the model lists, and still be unreachable through it.
+// Support and reachability are different questions and both have to be asked.
+func TestAToolTheModelListsMayStillBeUnableToReachIt(t *testing.T) {
+	c, camp := cat(), campaign()
+	// The subject supports both tools, so question one passes and question two
+	// is the one that has to fire.
+	for id, s := range c.Subjects {
+		s.Agents = []string{"tool", "other"}
+		c.Subjects[id] = s
+	}
+	m := c.Models["m1"]
+	m.Agents = []string{"tool", "other"}
+	c.Models["m1"] = m
+	camp.Arms[0].Agent = "other"
+
+	res := expand(t, c, camp)
+
+	// "other" authenticates by subscription; m1 is api_key only, so the pair
+	// cannot authenticate and question three answers.
+	if len(res.Rejected) == 0 {
+		t.Fatal("an unreachable pairing was planned")
+	}
+	if !strings.Contains(res.Rejected[0].Reason, "nothing could reach it") {
+		t.Errorf("reason = %q", res.Rejected[0].Reason)
+	}
+}
+
+// A model naming no agent tool at all cannot be driven by anything, and the
+// arm cannot rescue it by naming one.
+func TestAModelNamingNoAgentToolIsRejected(t *testing.T) {
+	c, camp := cat(), campaign()
+	m := c.Models["m1"]
+	m.Agents = nil
+	c.Models["m1"] = m
+
+	res := expand(t, c, camp)
+
+	if len(res.Rejected) == 0 {
+		t.Fatal("a model nothing can drive was planned")
+	}
+	if !strings.Contains(res.Rejected[0].Reason, "names no agent tool, so nothing can drive it") {
+		t.Errorf("reason = %q", res.Rejected[0].Reason)
+	}
+}
+
+// THE hazard this pitch is named for, and the one the planner created before
+// this was written. A cell is a PAIR of jobs. If one subject resolves and the
+// other does not, planning only the survivor guarantees a burned arm: the
+// finished side can never be paired, and the baseline's budget derives from its
+// partner's wall, so there is nothing to derive it from.
+func TestASurvivingArmOfAnIncompleteCellIsRejectedToo(t *testing.T) {
+	c, camp := cat(), campaign()
+	// The sense subject cannot run where it is pointed; untreated still can.
+	s := c.Subjects["sense"]
+	s.Executor = "local"
+	c.Subjects["sense"] = s
+
+	res := expand(t, c, camp)
+
+	if len(res.Jobs) != 0 {
+		t.Fatalf("planned %d jobs; a half-pair was planned:\n%v", len(res.Jobs), res.Jobs)
+	}
+	if len(res.Rejected) != 2 {
+		t.Fatalf("rejected %d, want both sides", len(res.Rejected))
+	}
+
+	// The survivor's rejection names WHY its partner failed, not merely that it
+	// did: a reader should not have to correlate two entries by hand.
+	var survivor string
+	for _, r := range res.Rejected {
+		if r.Job.Subject == "untreated" {
+			survivor = r.Reason
+		}
+	}
+	if !strings.Contains(survivor, "its cell is incomplete, so running this would burn it") {
+		t.Errorf("the survivor's reason = %q", survivor)
+	}
+	if !strings.Contains(survivor, "sense: subject sense writes agent configuration") {
+		t.Errorf("the survivor's reason does not carry its partner's: %q", survivor)
+	}
+}
+
+// Only the cell that lost a subject is dropped. One broken arm must not take
+// the rest of the campaign with it.
+func TestAnIncompleteCellDoesNotTakeTheWholeCampaignWithIt(t *testing.T) {
+	c, camp := cat(), campaign()
+	camp.Repos = []string{"r1", "r2"}
+	camp.Arms = append(camp.Arms, Arm{Role: Confirmation, Model: "judge", Runs: 2})
+	// Break exactly one job: the sense subject on the confirmation model.
+	m := c.Models["judge"]
+	m.Agents = []string{"tool", "other"}
+	c.Models["judge"] = m
+
+	res := expand(t, c, camp)
+
+	// The judge-model arm is ambiguous for BOTH subjects, so its cells go. The
+	// m1 arm is untouched: one cell per repository, two jobs each.
+	if res.Cells() != 2 {
+		t.Fatalf("planned %d cells, want the 2 m1 cells to survive:\n%v", res.Cells(), res.Jobs)
+	}
+	if len(res.Jobs) != 4 {
+		t.Errorf("planned %d jobs, want 4 — a cell is a pair", len(res.Jobs))
+	}
+	for _, j := range res.Jobs {
+		if j.Model != "m1" {
+			t.Errorf("planned %s, which should have gone with its cell", j)
+		}
+	}
+}
+
+// A campaign with one subject has no pair to complete, and dropping its jobs
+// would be the planner inventing a rule the campaign did not ask for. Whether
+// one subject is enough to conclude anything is a spending law, and it belongs
+// to the gates.
+func TestASingleSubjectCampaignIsNotTreatedAsHalfOfSomething(t *testing.T) {
+	c, camp := cat(), campaign()
+	camp.Subjects = []string{"untreated"}
+
+	res := expand(t, c, camp)
+
+	if res.Cells() != 1 || len(res.Jobs) != 1 {
+		t.Errorf("planned %d cells / %d jobs, want 1 and 1", res.Cells(), len(res.Jobs))
+	}
+	if len(res.Rejected) != 0 {
+		t.Errorf("rejected %v", res.Rejected)
+	}
+}
+
+// A cell short a subject with nothing rejected in it is not a resolution
+// failure, it is a campaign that listed something twice. An earlier version
+// reported it with a blank reason, which breaks this package's own rule that a
+// rejection someone cannot act on is one they route around by guessing.
+func TestACellShortASubjectForNoResolutionReasonStillSaysWhy(t *testing.T) {
+	// decide is exercised directly: a campaign like this is refused at
+	// validation now, and the branch is the last line of defence if it ever
+	// is not.
+	walked := []Rejection{
+		{Job: Job{cell: "r1#0", Repo: "r1", Subject: "untreated", Model: "m1"}},
+	}
+
+	res := decide(walked, []string{"untreated", "sense"})
+
+	if len(res.Jobs) != 0 {
+		t.Fatalf("planned %d jobs from a cell with one side", len(res.Jobs))
+	}
+	if len(res.Rejected) != 1 {
+		t.Fatalf("rejected %d, want 1", len(res.Rejected))
+	}
+	if !strings.Contains(res.Rejected[0].Reason, "does not name every subject for this cell") {
+		t.Errorf("reason = %q, want it to say why rather than trail off", res.Rejected[0].Reason)
+	}
+}
+
+// A campaign that lists the same thing twice looks complete to anything
+// counting: two untreated arms and no sense arm is two jobs in one cell.
+func TestACampaignNamingSomethingTwiceIsRefused(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		change func(camp *Campaign)
+		want   string
+	}{
+		{"a subject twice", func(c *Campaign) { c.Subjects = []string{"untreated", "untreated"} },
+			`names subject "untreated" twice; a duplicated arm is not a pair`},
+		{"a repo twice", func(c *Campaign) { c.Repos = []string{"r1", "r1"} },
+			`names repo "r1" twice`},
+		{"an arm twice", func(c *Campaign) {
+			c.Arms = append(c.Arms, Arm{Role: Confirmation, Model: "m1", Runs: 2})
+		}, `names model "m1" twice; running one arm twice is not two arms`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			camp := campaign()
+			tc.change(&camp)
+
+			_, err := Expand(cat(), camp)
+
+			if err == nil {
+				t.Fatal("a campaign naming something twice was expanded")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// The planned job names the model's canonical id, so one plan shows one form
+// of a name. Whether an ALIAS resolves is an integration property — a Catalog
+// literal has no alias index — and it is tested against a real config directory
+// in TestACampaignMayNameAModelByItsAlias.
+func TestAPlannedJobNamesTheCanonicalModelID(t *testing.T) {
+	c, camp := cat(), campaign()
+	c.Models["full/m1:v2"] = catalog.Model{ID: "full/m1:v2", Provider: "acme",
+		AvailableUnder: []string{"api_key"}, Agents: []string{"tool"}}
+	camp.Arms[0].Model = "full/m1:v2"
+
+	res := expand(t, c, camp)
+
+	for _, j := range res.Jobs {
+		if j.Model != "full/m1:v2" {
+			t.Errorf("job names model %q, want the canonical id", j.Model)
+		}
+	}
+}
+
+// Role says which arm a win is claimed on, so it has to survive expansion. A
+// plan that labelled every job headline would look right and mean something
+// else entirely.
+func TestEachJobKeepsItsArmsRole(t *testing.T) {
+	camp := campaign()
+	camp.Arms = append(camp.Arms, Arm{Role: Confirmation, Model: "judge", Runs: 2})
+
+	res := expand(t, cat(), camp)
+
+	got := map[Role]int{}
+	for _, j := range res.Jobs {
+		got[j.Role]++
+	}
+	// Two subjects on each of the two arms.
+	if got[Headline] != 2 || got[Confirmation] != 2 {
+		t.Errorf("roles = %v, want 2 headline and 2 confirmation", got)
+	}
+}
+
+// The auth mode is CHOSEN, not merely confirmed to exist. A model available two
+// ways, on an executor that preserves one of them, must resolve to that one —
+// otherwise cycle 03's executor has to guess, and a session that guesses wrong
+// dies empty at zero tokens.
+func TestTheJobCarriesTheAuthModeThatWasChosen(t *testing.T) {
+	c, camp := cat(), campaign()
+	m := c.Models["m1"]
+	m.AvailableUnder = []string{"subscription", "api_key"}
+	c.Models["m1"] = m
+	a := c.Agents["tool"]
+	a.AuthModes = []string{"subscription", "api_key"}
+	c.Agents["tool"] = a
+	// The executor preserves only one of the two.
+	e := c.Executors["isolated-home"]
+	e.PreservesAuth = []string{"api_key"}
+	c.Executors["isolated-home"] = e
+
+	res := expand(t, c, camp)
+
+	if len(res.Jobs) == 0 {
+		t.Fatalf("nothing planned: %v", res.Rejected)
+	}
+	for _, j := range res.Jobs {
+		if j.Auth != "api_key" {
+			t.Errorf("job chose auth %q, want the one the executor preserves", j.Auth)
+		}
+	}
+}
+
+// Deterministic: the model's own order decides, so a plan does not change
+// between runs of the same config.
+func TestTheChosenAuthModeIsDeterministic(t *testing.T) {
+	c, camp := cat(), campaign()
+	for _, mode := range [][]string{{"subscription", "api_key"}, {"api_key", "subscription"}} {
+		m := c.Models["m1"]
+		m.AvailableUnder = mode
+		c.Models["m1"] = m
+		a := c.Agents["tool"]
+		a.AuthModes = []string{"subscription", "api_key"}
+		c.Agents["tool"] = a
+
+		res := expand(t, c, camp)
+
+		if len(res.Jobs) == 0 {
+			t.Fatalf("nothing planned for %v: %v", mode, res.Rejected)
+		}
+		if res.Jobs[0].Auth != mode[0] {
+			t.Errorf("with the model offering %v the plan chose %q, want the first", mode, res.Jobs[0].Auth)
+		}
+	}
+}

--- a/lab/internal/plan/resolve.go
+++ b/lab/internal/plan/resolve.go
@@ -1,0 +1,138 @@
+package plan
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/luuuc/sense/lab/internal/catalog"
+)
+
+// resolve answers whether one job can run, and returns the reason when it
+// cannot. It is five explicit questions with five explicit answers.
+//
+// It is deliberately not clever. A score for "how well supported" a
+// combination is would be a screen wearing a suit: it would let a job through
+// on a number rather than on a fact, and every screen this project built was
+// measured wrong.
+func resolve(c *catalog.Catalog, repo, subjectID string, arm Arm) (Job, string) {
+	subject := c.Subjects[subjectID]
+	// Through the alias index, so `plan` and `run` agree on what a model name
+	// is. Looking in the id map alone reports "no model file declares it" for
+	// an alias that `run` accepts, which is a false statement aimed at exactly
+	// the person who just wrote a model id in the other form.
+	model, _ := c.Model(arm.Model)
+
+	j := Job{
+		Repo: repo, Subject: subjectID, Model: model.ID,
+		Executor: subject.Executor, Role: arm.Role, Runs: arm.Runs,
+	}
+
+	agentID, reason := pickAgent(arm, model)
+	if reason != "" {
+		return j, reason
+	}
+	j.Agent = agentID
+	agent := c.Agents[agentID]
+	executor := c.Executors[subject.Executor]
+
+	if reason := subjectSupportsAgent(subject, agentID); reason != "" {
+		return j, reason
+	}
+	// Questions three and four together, because separating them would leave
+	// the auth mode unchosen: a model available two ways passes an executor
+	// that preserves only one of them, and if the machine has neither the
+	// session dies empty at zero tokens — the very failure this refuses.
+	auth, reason := pickAuth(model, agent, executor)
+	if reason != "" {
+		return j, reason
+	}
+	j.Auth = auth
+	if reason := executorSatisfiesIsolation(executor, subject); reason != "" {
+		return j, reason
+	}
+	return j, ""
+}
+
+// pickAgent chooses the tool to drive the model, and IS resolution question
+// two: does this agent tool support this model. Normally a model names exactly
+// one and the arm says nothing; when a model names several, the arm has to
+// choose, because picking one arbitrarily is how an arm ends up measured on a
+// surface nobody intended.
+//
+// A separate "can this agent drive this model" check after it would be dead
+// code: every path out of here already comes from the model's own agent list.
+func pickAgent(arm Arm, model catalog.Model) (string, string) {
+	if arm.Agent != "" {
+		if !slices.Contains(model.Agents, arm.Agent) {
+			return "", fmt.Sprintf("the arm names agent %q, but model %s can be driven by %v",
+				arm.Agent, model.ID, model.Agents)
+		}
+		return arm.Agent, ""
+	}
+	switch len(model.Agents) {
+	case 1:
+		return model.Agents[0], ""
+	case 0:
+		return "", fmt.Sprintf("model %s names no agent tool, so nothing can drive it", model.ID)
+	default:
+		return "", fmt.Sprintf("model %s can be driven by %v and the arm does not say which",
+			model.ID, model.Agents)
+	}
+}
+
+// Question one: does this subject support this agent tool?
+func subjectSupportsAgent(s catalog.Subject, agentID string) string {
+	if slices.Contains(s.Agents, agentID) {
+		return ""
+	}
+	return fmt.Sprintf("subject %s cannot be driven by %s; it supports %v", s.ID, agentID, s.Agents)
+}
+
+// pickAuth answers questions three and four together and CHOOSES the mode,
+// rather than merely confirming that some mode could work.
+//
+// Choosing is the point. A model available under two modes, an agent that
+// accepts both and an executor that preserves one of them is runnable — but
+// only one way, and nothing downstream would know which. Cycle 03's executor is
+// handed the answer instead of guessing, and the rejection message can name
+// what was tried.
+//
+// The order is the model's own, so the choice is deterministic and a plan does
+// not change between runs.
+func pickAuth(m catalog.Model, a catalog.Agent, e catalog.Executor) (string, string) {
+	var reachable []string
+	for _, auth := range m.AvailableUnder {
+		if slices.Contains(a.AuthModes, auth) {
+			reachable = append(reachable, auth)
+		}
+	}
+	// Question three: is this model reachable at all through this tool? A model
+	// available only under a mode its tool cannot use resolves to nothing at
+	// spawn time, which is how an arm returns empty rather than crashing.
+	if len(reachable) == 0 {
+		return "", fmt.Sprintf("model %s is available under %v but agent %s authenticates by %v; "+
+			"nothing could reach it", m.ID, m.AvailableUnder, a.ID, a.AuthModes)
+	}
+	// Question four: does the executor preserve one of them? A container that
+	// never receives credentials cannot reach a model that needs them.
+	for _, auth := range reachable {
+		if slices.Contains(e.PreservesAuth, auth) {
+			return auth, ""
+		}
+	}
+	return "", fmt.Sprintf("executor %s preserves %v, but reaching model %s through %s needs one of %v",
+		e.ID, e.PreservesAuth, m.ID, a.ID, reachable)
+}
+
+// Question five: are the subject's isolation requirements met by the executor?
+//
+// A subject that writes agent configuration must not run where that
+// configuration escapes onto the host: the next run would inherit it, and
+// nothing in either result would show it.
+func executorSatisfiesIsolation(e catalog.Executor, s catalog.Subject) string {
+	if !s.NeedsIsolatedConfig || e.IsolatesGlobalConfig {
+		return ""
+	}
+	return fmt.Sprintf("subject %s writes agent configuration but executor %s does not isolate it, "+
+		"so it would leak onto the host and into the next run", s.ID, e.ID)
+}

--- a/lab/subjects/sense-main/subject.json
+++ b/lab/subjects/sense-main/subject.json
@@ -2,6 +2,8 @@
   "id": "sense-main",
   "kind": "sense",
   "needs_mcp": true,
+  "needs_isolated_config": true,
+  "executor": "isolated-home",
   "agents": [
     "claude-code",
     "codex",

--- a/lab/subjects/untreated/subject.json
+++ b/lab/subjects/untreated/subject.json
@@ -2,6 +2,8 @@
   "id": "untreated",
   "kind": "baseline",
   "needs_mcp": false,
+  "needs_isolated_config": false,
+  "executor": "isolated-home",
   "agents": [
     "claude-code",
     "codex",


### PR DESCRIPTION
## Problem

An arm set is a matrix, and nothing expanded one or checked it before spending against it. An unsupported combination was discovered by running it: forty minutes into a session, or worse at the end of a cell whose other arm already completed and can now never be paired.

Two recorded failure shapes:
- **a model that cannot be reached the way the arm assumes.** Every run of one arm returned empty at zero tokens because an id resolved to nothing. Nothing checked first.
- **a half-pair.** The finished arm of a cell is burned when its partner never runs, because the baseline's budget derives from its paired sense wall.

## Summary

`sense-lab plan` expands a campaign into concrete jobs and answers, per job, whether it can run — printing every rejection with its reason, because a rejection without one is a mystery someone routes around by guessing. It is pure: config in, jobs and named rejections out.

## The half-pair, which the first version created

Resolution answers per **job**. A cell is a **pair** of jobs — the same repository and arm across every subject. With one side rejected and the other not, the first version printed the survivor under `WILL RUN`. That is the hazard, planned.

Survivors of an incomplete cell are rejected too, carrying the reason their partner failed rather than merely reporting that one did. Rejecting is the right direction: a run that never happens costs nothing, a run that happens and cannot be paired costs its whole spend and yields no result.

**The guard then had two holes of its own, both a copy-paste away.** It compared a *count* of jobs per cell, which a duplicated subject satisfies without a partner ever existing — `subjects: ["untreated","untreated"]` planned two identical baselines, no sense arm, exit 0. It compares the set now, and a campaign naming any subject, repo or arm twice is refused. And a cell short a subject with nothing rejected in it printed a reason that trailed off after the colon.

## What else building it found

**`Cells()` counted jobs.** The frozen campaign read `10 cells` for what is 5 cells of 2 jobs each. A cell is the unit that is paired, budgeted and banked, so counting jobs as cells doubles every board.

**Nothing was choosing the auth mode.** Questions three and four separately only confirmed that *some* mode could work: a model available two ways passed an executor preserving one of them, and a machine with neither would produce a session that died empty at zero tokens — the very failure being refused, walked straight through the check. They are one question now; the chosen mode is on the job, deterministic in the model's own order, so cycle 03's executor provisions it rather than guessing.

**`plan` and `run` disagreed about what a model name is.** `run` resolved aliases and `plan` did not, so a campaign naming a model by its alias was told "no model file declares it" — false, and aimed at exactly the person who had just written the id in the other form.

**Two of the five questions could not fire as written.** One was already answered by the agent choice and was merged rather than kept as a branch that cannot fire. One cannot fire through a catalog that loads, because the catalog refuses the config first; it is kept as the guard behind that invariant, and a test records why so nobody reads it as dead code.

## Changes

- `lab/internal/plan` — expansion, the resolution questions, and the pair guard.
- `lab/internal/cli/plancmd.go` — `sense-lab plan`. A plan with a hole exits **5**, its own code: "your config is broken" and "part of your matrix cannot run" are opposite actions and both used to exit 1.
- `lab/executors/` — a fifth config kind, because two questions are about where a job runs. Neither executor exists yet; the README cites the doc line behind every field, and flags the one that could cost money if cycle 03's environment allowlist turns out not to pass credentials.
- `lab/campaigns/csharp-aspnet/` — the arm set frozen at `547f1bf`, over the one repository that campaign had reached. Two different as-ofs, said plainly in the README.

## Test plan

`make ci` green: coverage gate with no new exception, ledger 0, lint 0 issues, total 95.7%. `qlty check lab/` clean. **All seven lab packages at 100% line and function coverage.**

The frozen arm set plans to 5 cells and 20 sessions with nothing rejected, and the banked cell — both arms, headline model, bitwarden-server — is in it.

Mutation-checked. These all now fail: `Role` forced to headline; the alias lookup replaced by the id map (caught at the CLI level, where a real config has an alias index); each of the three duplicate-name guards disabled; the auth choice returning the first *reachable* mode rather than the first *preserved* one; deleting the pair guard; the cell key's repository component; `Cells`; `Runs`; and every resolution question.

One claim in the pitch is narrower than it reads and is now pinned as such: "adding a sixth arm is one new file" holds for a model on a tool a subject already lists. An arm on a *new* tool also needs every subject's agent list edited.

Reviewed by the council; test spec validated.