### PR TITLE
bench(lab): grounding, so a fabricated citation cannot score

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,6 +64,31 @@ linters:
         # server, because that is the channel the benched agent actually had.
         # Querying the index directly would measure a channel no agent has, and
         # nothing about that failure would be visible in a result.
+        # The lab's pure core. Scoring takes bytes and returns numbers, and it
+        # must keep doing so: the moment recall can fail because a checkout is
+        # missing, every number the instrument produces depends on the state of
+        # a disk. Grounding is the one piece needing a repository, and it lives
+        # in lab/internal/ground, at the edge.
+        #
+        # score and plan ONLY. transcript and scenario read files by design, so
+        # listing them here would describe an aspiration rather than a fact, and
+        # a rule that is already false where it points will not be believed when
+        # it matters. `os` is denied as well as `os/exec`, because the property
+        # is "does not touch a disk", and a rule that stopped only the shell
+        # would not hold it.
+        lab-pure:
+          files:
+            - "**/lab/internal/score/**"
+            - "**/lab/internal/plan/**"
+          deny:
+            - pkg: os
+              desc: "the lab's pure core must not read a disk; recall may not depend on the state of one"
+            - pkg: os/exec
+              desc: "the lab's pure core must not shell out; grounding lives in lab/internal/ground"
+            - pkg: net
+              desc: "the lab's pure core must not touch the network"
+            - pkg: syscall
+              desc: "the lab's pure core must not call syscalls directly"
         lab-boundary:
           files:
             - "**/lab/**"
@@ -86,6 +111,12 @@ linters:
       # claims it. Shrink this list as each package is brought into scope.
       - linters: [gocyclo, gocognit]
         path: (cmd/sense|internal/(benchmark|cli|freshen|hook|ignore|mcpio|summary))/
+      # depguard/lab-pure: the property is about the PRODUCTION core, which must
+      # not depend on the state of a disk. Its tests legitimately read checked-in
+      # fixtures, and forbidding that would only push the reads into a helper
+      # package and prove nothing.
+      - linters: [depguard]
+        path: lab/internal/(score|plan)/.*_test\.go
       # dupword: SQL NULL repetitions and embedded Ruby/test fixtures are fine
       - linters: [dupword]
         path: _test\.go

--- a/lab/LAWS.md
+++ b/lab/LAWS.md
@@ -50,7 +50,8 @@ NEVER KILLS · THE AUTHORING CYCLE IS UNATTENDED AND BOUNDED · AN OCCURRENCE-LI
 · "WHAT HOLDS THIS" NEEDS A RING, AND RUBY HAS NONE · AIM AT THE WINDOW, NOT AT THE OPPOSITE OF
 THE LAST FAILURE · A FREE ROW IS A GIFT TO THE BASELINE · ITERATE ON THE QUESTION, KEEP THE
 ANCHOR · TRY HARDER · THE LOOP CANNOT RECORD A LOSS · AXIS-DEAD IS NEVER REPO-DEAD · RUN FIRST,
-EXPLAIN AFTER · A FORM-DEPENDENT LENIENCY IS AN ARM-DEPENDENT LENIENCY
+EXPLAIN AFTER · A FORM-DEPENDENT LENIENCY IS AN ARM-DEPENDENT LENIENCY · AN UNGROUNDED RATE IS A
+FORM ARTIFACT UNTIL DECOMPOSED
 
 **Scenario and gold** — THE DISCRIMINATOR IS CITATION COST, NOT DISCOVERY · PUBLISHED GOLD LEAKS
 · A CORRECTNESS ORACLE MUST NOT BE SATISFIABLE BY THE ROUTE · A GOLD ROW MUST BE CITEABLE IN THE
@@ -127,6 +128,27 @@ biased both ways at once, and hunting one bias is how the other survives.
 **Mechanism.** doc. The range check that closes the symbol half needs a repository checkout and
 is 02-04. Until then `score.Result` prints the strict number beside the loose one and never a
 single figure.
+
+## AN UNGROUNDED RATE IS A FORM ARTIFACT UNTIL DECOMPOSED — doc, cycle 02
+
+The share of an arm's citations that fail to resolve is not its fabrication rate. Decompose it
+before quoting it: a path written without its directory does not resolve either, and it is a
+habit rather than an invention. Report the parts, per arm, per model.
+
+**Precedent.** Cycle 02 (02-04) grounded the 57 recorded discourse runs against the checkout at
+its pinned commit. The aggregate said sense 10.33% ungrounded against baseline 2.61%, which reads
+as one arm inventing four times as much.
+
+Decomposed it says the opposite. A real file cited past its end — the only shape that is
+unambiguously made up — occurs **3 times in each arm**. 70% of the remainder is a bare basename.
+And the whole gap is a single model-arm cell: 815 of the 823 sense failures are claude-opus-5,
+while the same arm is 0.35% on kimi and 0.00% on gpt-5.6.
+
+Quoted undecomposed, that aggregate would have published "sense fabricates four times as often"
+from a difference in how one model writes paths.
+
+**Mechanism.** doc. `ground.Report` keeps the failures as a list of locations rather than a rate,
+so the decomposition is always available and a bare rate has to be computed on purpose.
 
 ## RUN vs DECIDE — doc *(inherited)*
 

--- a/lab/internal/cli/scorecmd.go
+++ b/lab/internal/cli/scorecmd.go
@@ -2,12 +2,14 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 
+	"github.com/luuuc/sense/lab/internal/ground"
 	"github.com/luuuc/sense/lab/internal/run"
 	"github.com/luuuc/sense/lab/internal/scenario"
 	"github.com/luuuc/sense/lab/internal/score"
@@ -32,6 +34,8 @@ type scoreFlags struct {
 	run      string
 	group    string
 	floor    float64
+	checkout string
+	commit   string
 }
 
 func parseScoreFlags(args []string, stderr io.Writer) (scoreFlags, error) {
@@ -42,6 +46,8 @@ func parseScoreFlags(args []string, stderr io.Writer) (scoreFlags, error) {
 	fs.StringVar(&f.run, "run", "", "path to the run directory to score (required)")
 	fs.StringVar(&f.group, "group", "", "gold group to score, or \"all\" (default: the scenario's discriminator)")
 	fs.Float64Var(&f.floor, "floor", defaultFloor, "recall at or above which the run passes")
+	fs.StringVar(&f.checkout, "checkout", "", "repository checkout to verify citations against")
+	fs.StringVar(&f.commit, "commit", "", "commit the checkout is pinned at (required with -checkout)")
 	if err := fs.Parse(args); err != nil {
 		return f, err
 	}
@@ -52,6 +58,13 @@ func parseScoreFlags(args []string, stderr io.Writer) (scoreFlags, error) {
 		if required.value == "" {
 			return f, fmt.Errorf("%s is required", required.name)
 		}
+	}
+	// A missing checkout is a deferral. A checkout given WITHOUT its commit is
+	// a typo, and downgrading it to unverified would exit 0 on a stderr line
+	// the operator may well be piping away.
+	if f.checkout != "" && f.commit == "" {
+		return f, errors.New("-checkout needs -commit: grounding against an unpinned tree would " +
+			"check citations against whatever happens to be checked out")
 	}
 	return f, nil
 }
@@ -83,7 +96,7 @@ func scoreRun(args []string, stdout, stderr io.Writer) int {
 	_, _ = fmt.Fprintf(stdout, "repo       %s\nscenario   %s\n", set.Scenario.Repo, set.Scenario.Name)
 
 	if f.group == allGroups {
-		return scoreEveryGroup(set, src, f.floor, stdout, stderr)
+		return scoreEveryGroup(set, src, f, stdout, stderr)
 	}
 
 	group := f.group
@@ -102,7 +115,8 @@ func scoreRun(args []string, stdout, stderr io.Writer) int {
 
 	// The transcript goes in, not its text, so the provisional mark travels
 	// with the number rather than depending on this caller to copy it.
-	result := score.Group(group, rows, src, f.floor)
+	result := score.GroupCites(group, rows, score.Scan(src.Answer()), src.ProvisionalWhy(), f.floor)
+	result.Grounding = groundReport(src.Answer(), f, rows, stderr).String()
 	_, _ = fmt.Fprint(stdout, result)
 
 	// A provisional number is not a verdict either way, so it never reports as
@@ -178,15 +192,18 @@ func goldRows(set scenario.Set, group string) ([]score.Row, error) {
 // one group and a margin spread across all of them are different results, and
 // reporting only the discriminator cannot tell them apart. The exit code is the
 // discriminator's, because that is still the number the floor applies to.
-func scoreEveryGroup(set scenario.Set, src score.Source, floor float64, stdout, stderr io.Writer) int {
+func scoreEveryGroup(set scenario.Set, src score.Source, f scoreFlags, stdout, stderr io.Writer) int {
 	code := exitError
+	cites := score.Scan(src.Answer())
+	report := groundReport(src.Answer(), f, allRows(set), stderr)
 	for _, group := range set.Gold.Groups() {
 		rows, err := goldRows(set, group)
 		if err != nil {
 			_, _ = fmt.Fprintf(stderr, "sense-lab score: %v\n", err)
 			return exitError
 		}
-		result := score.Group(group, rows, src, floor)
+		result := score.GroupCites(group, rows, cites, src.ProvisionalWhy(), f.floor)
+		result.Grounding = report.String()
 		_, _ = fmt.Fprint(stdout, result)
 		if group != set.Gold.Discriminator {
 			continue
@@ -201,4 +218,54 @@ func scoreEveryGroup(set scenario.Set, src score.Source, floor float64, stdout, 
 		}
 	}
 	return code
+}
+
+// groundReport verifies the answer's citations against a checkout when one is
+// given.
+//
+// No checkout is not an error. It downgrades the result to unverified and says
+// so: a scorer that refused to score without a git checkout would make the
+// whole pure layer depend on the state of a disk, and three of the four benched
+// repositories are not cloned on this machine today.
+//
+// A checkout that is the WRONG one is different, and it is the dangerous case:
+// a commit that exists in another repository passes every existence check and
+// then resolves nothing, so every citation reads as fabricated and the report
+// says verified. The gold rows are the detector — they have known locations at
+// the pinned commit — and grounding refuses rather than publishing that.
+func groundReport(answer string, f scoreFlags, rows []score.Row, stderr io.Writer) ground.Report {
+	if f.checkout == "" {
+		return ground.Check(nil, nil)
+	}
+	c, err := ground.Open(f.checkout, f.commit)
+	if err == nil {
+		err = ground.CheckGold(locations(rows), c)
+	}
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab score: grounding skipped: %v\n", err)
+		return ground.Check(nil, nil)
+	}
+	return ground.Check(score.Scan(answer), c)
+}
+
+func locations(rows []score.Row) []string {
+	out := make([]string, 0, len(rows))
+	for _, r := range rows {
+		if r.Cite != "" {
+			out = append(out, r.Cite)
+		}
+	}
+	return out
+}
+
+// allRows is every gold row in the set, used to verify the checkout when all
+// groups are scored at once.
+func allRows(set scenario.Set) []score.Row {
+	var out []score.Row
+	for _, g := range set.Gold.Rows {
+		if c := g.Cite(); c != "" {
+			out = append(out, score.Row{ID: g.ID, Cite: c})
+		}
+	}
+	return out
 }

--- a/lab/internal/cli/scorecmd_test.go
+++ b/lab/internal/cli/scorecmd_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -456,4 +457,149 @@ func TestScoringEveryGroupStaysProvisionalWhenTheCaptureIsTruncated(t *testing.T
 	if code != exitProvisional {
 		t.Errorf("exit code = %d, want %d\n%s", code, exitProvisional, stdout)
 	}
+}
+
+// Scoring without a checkout is a valid result that says grounding was not
+// verified. A scorer that refused to score without one would make the whole
+// pure layer depend on the state of a disk — and three of the four benched
+// repositories are not cloned on this machine today.
+func TestScoringWithoutACheckoutIsValidAndSaysSo(t *testing.T) {
+	run := recordedRun(t, "Found app/models/category.rb:1083 and lib/tasks/search.rake:32.")
+
+	code, stdout, _ := dispatch(t, "score", "-scenario", scoredFile(t), "-run", run)
+
+	if code != exitOK {
+		t.Errorf("exit code = %d, want %d: a missing checkout is not a failure", code, exitOK)
+	}
+	if !strings.Contains(stdout, "NOT VERIFIED") {
+		t.Errorf("the report does not say its citations were unverified:\n%s", stdout)
+	}
+}
+
+// A checkout that cannot be opened is worth a word on stderr, because the
+// operator asked for verification and did not get it — but it still scores.
+func TestAnUnusableCheckoutSaysSoAndStillScores(t *testing.T) {
+	run := recordedRun(t, "Found app/models/category.rb:1083 and lib/tasks/search.rake:32.")
+
+	code, stdout, stderr := dispatch(t, "score", "-scenario", scoredFile(t), "-run", run,
+		"-checkout", t.TempDir(), "-commit", "deadbeef")
+
+	if code != exitOK {
+		t.Errorf("exit code = %d, want %d", code, exitOK)
+	}
+	if !strings.Contains(stderr, "grounding skipped") {
+		t.Errorf("nothing on stderr said grounding was skipped:\n%s", stderr)
+	}
+	if !strings.Contains(stdout, "NOT VERIFIED") {
+		t.Errorf("the report claimed more than it checked:\n%s", stdout)
+	}
+}
+
+// The whole grounding path end to end, against a real checkout.
+//
+// It asserts the REPORT, not the score, because grounding does not change a
+// score: it returns a report and nothing else. An earlier version of this test
+// was named for the score and claimed "the number is smaller for it", which was
+// never true — its fabricated citation matched no gold row, so pruning it could
+// not have moved anything. A test whose name promises more than it checks is
+// worse than no test, because it is where you look and stop looking.
+func TestAFabricatedCitationIsReportedAgainstARealCheckout(t *testing.T) {
+	dir, commit := repoWithGold(t)
+	// The answer cites the gold line, and also a line that file does not have.
+	run := recordedRun(t, "Found app/models/category.rb:1083 and app/models/category.rb:999999.")
+
+	code, stdout, stderr := dispatch(t, "score", "-scenario", scoredFile(t), "-run", run,
+		"-checkout", dir, "-commit", commit)
+
+	if !strings.Contains(stdout, "1 of 2 cited locations do not resolve") {
+		t.Errorf("the fabricated citation was not reported:\n%s\n%s", stdout, stderr)
+	}
+	if strings.Contains(stdout, "NOT VERIFIED") {
+		t.Errorf("a run WITH a usable checkout reported as unverified:\n%s\n%s", stdout, stderr)
+	}
+	if code != exitBelowFloor && code != exitOK {
+		t.Errorf("exit code = %d", code)
+	}
+}
+
+// A checkout that cannot resolve the gold is the WRONG checkout, and that is
+// the dangerous case: a commit that exists in another repository passes every
+// existence check, resolves nothing, and would report as verified.
+func TestACheckoutThatCannotResolveTheGoldIsRefused(t *testing.T) {
+	dir, commit := repoMissingGold(t)
+	run := recordedRun(t, "Found app/models/category.rb:1083.")
+
+	// The scored scenario's gold also names lib/tasks/search.rake, which this
+	// repository does not have.
+	_, stdout, stderr := dispatch(t, "score", "-scenario", scoredFile(t), "-run", run,
+		"-checkout", dir, "-commit", commit)
+
+	if !strings.Contains(stderr, "wrong checkout or the scenario is stale") {
+		t.Errorf("a checkout that cannot resolve the gold was accepted:\n%s", stderr)
+	}
+	if !strings.Contains(stdout, "NOT VERIFIED") {
+		t.Errorf("the report claimed verification it did not have:\n%s", stdout)
+	}
+}
+
+// -checkout without -commit is a typo, not a deferral. Downgrading it to
+// unverified would exit 0 on a stderr line an operator may be piping away.
+func TestACheckoutWithoutACommitIsAUsageError(t *testing.T) {
+	run := recordedRun(t, "Found app/models/category.rb:1083.")
+
+	code, _, stderr := dispatch(t, "score", "-scenario", scoredFile(t), "-run", run,
+		"-checkout", t.TempDir())
+
+	if code != exitUsage {
+		t.Errorf("exit code = %d, want %d", code, exitUsage)
+	}
+	if !strings.Contains(stderr, "-checkout needs -commit") {
+		t.Errorf("the error does not say what is missing:\n%s", stderr)
+	}
+}
+
+// repoWithGold builds a checkout holding every file the scored fixture's gold
+// names, long enough to contain each gold line and no longer.
+func repoWithGold(t *testing.T) (dir, commit string) {
+	t.Helper()
+	return buildRepo(t, map[string]string{
+		"app/models/category.rb": strings.Repeat("line\n", 1100),
+		"lib/tasks/search.rake":  strings.Repeat("line\n", 40),
+	})
+}
+
+// repoMissingGold holds one of the two gold files, so grounding can tell that
+// this is not the repository the scenario was written against.
+func repoMissingGold(t *testing.T) (dir, commit string) {
+	t.Helper()
+	return buildRepo(t, map[string]string{
+		"app/models/category.rb": strings.Repeat("line\n", 1100),
+	})
+}
+
+func buildRepo(t *testing.T, files map[string]string) (dir, commit string) {
+	t.Helper()
+	dir = t.TempDir()
+	for path, body := range files {
+		full := filepath.Join(dir, filepath.FromSlash(path))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, args := range [][]string{
+		{"init", "-q"}, {"config", "user.email", "t@example.com"}, {"config", "user.name", "t"},
+		{"add", "-A"}, {"commit", "-qm", "fixture"},
+	} {
+		if out, err := exec.Command("git", append([]string{"-C", dir}, args...)...).CombinedOutput(); err != nil {
+			t.Skipf("git is unavailable here: %v: %s", err, out)
+		}
+	}
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir, strings.TrimSpace(string(out))
 }

--- a/lab/internal/ground/ground.go
+++ b/lab/internal/ground/ground.go
@@ -1,0 +1,247 @@
+// Package ground checks that a citation points at somewhere that exists.
+//
+// An arm can cite a file and a line that are not there. Unverified, a
+// fabricated citation scores exactly like a correct one, so the metric rewards
+// confident invention.
+//
+// This is the ONLY part of scoring that needs a repository on disk, and it is
+// its own package for that reason. Recall must not become dependent on the
+// state of a disk: a missing checkout downgrades a result to unverified, and
+// never fails it.
+//
+// # What it found on the corpus
+//
+// Run over the 57 recorded discourse runs, against the checkout at its pinned
+// commit: 11,369 located citations, 912 of which do not resolve. By arm that
+// reads as sense 10.33% and baseline 2.61%, which invites the conclusion that
+// one arm invents four times as much. It does not survive being checked.
+//
+// Decomposed, outright invention is negligible and SYMMETRIC: a real file cited
+// past its end happens 3 times in each arm. 70% of the rest is a path written
+// without its directory (`category.rb:1090` for `app/models/category.rb`),
+// which is a citation form rather than a falsehood. And the gap is one cell:
+// 815 of the 823 sense failures are claude-opus-5, while the same arm on kimi
+// is 0.35% and on gpt-5.6 is 0.00%.
+//
+// So the headline rate measures how often an arm writes a short path, not how
+// often it makes something up. Two things follow. The number is reported per
+// run and never aggregated across arms without that decomposition, and the 579
+// bare basenames are a standing opportunity: a checkout can say whether a
+// basename is unique at that commit, which would turn a guess into a fact. That
+// is a later pitch, not this one.
+package ground
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/luuuc/sense/lab/internal/score"
+)
+
+// Checkout is a repository at one commit. A nil *Checkout is the "cannot check"
+// case and is valid input everywhere in this package.
+type Checkout struct {
+	dir    string
+	commit string
+	git    runner
+	lines  map[string]int // -1 means the file is not there at this commit
+}
+
+// runner is how this package reaches git, so a test can drive every outcome
+// without a repository. The real one is gitCommand.
+type runner func(dir string, args ...string) ([]byte, error)
+
+// gitTimeout bounds one git call.
+//
+// Nothing here is networked, and Stdin is nil so the child cannot read a
+// prompt, but git can still reach /dev/tty through an askpass helper and a
+// directory on a dead network mount blocks in the kernel with no way out.
+// Without a deadline that is a wedged bench rather than a slow one.
+const gitTimeout = 30 * time.Second
+
+func gitCommand(dir string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), gitTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...)
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(errBuf.String()))
+	}
+	return out, nil
+}
+
+// Open prepares a checkout for grounding, verifying that the pinned commit is
+// actually there.
+//
+// A checkout at the wrong commit is worse than none: it would report a citation
+// as fabricated because a file moved between revisions, which is a claim about
+// the arm made from a fact about the disk.
+func Open(dir, commit string) (*Checkout, error) {
+	return open(dir, commit, gitCommand)
+}
+
+func open(dir, commit string, git runner) (*Checkout, error) {
+	if dir == "" || commit == "" {
+		return nil, fmt.Errorf("grounding needs a directory and a commit, got %q and %q", dir, commit)
+	}
+	if _, err := git(dir, "cat-file", "-e", commit+"^{commit}"); err != nil {
+		return nil, fmt.Errorf("the pinned commit is not in %s: %w", dir, err)
+	}
+	return &Checkout{dir: dir, commit: commit, git: git, lines: map[string]int{}}, nil
+}
+
+// lineCount returns how many lines path has at the pinned commit, and false
+// when the file is not there.
+func (c *Checkout) lineCount(path string) (int, bool) {
+	if n, ok := c.lines[path]; ok {
+		return n, n >= 0
+	}
+	out, err := c.git(c.dir, "show", c.commit+":"+path)
+	if err != nil {
+		c.lines[path] = -1
+		return 0, false
+	}
+	n := bytes.Count(out, []byte{'\n'})
+	// A last line with no trailing newline is still a line.
+	if len(out) > 0 && !bytes.HasSuffix(out, []byte{'\n'}) {
+		n++
+	}
+	c.lines[path] = n
+	return n, true
+}
+
+// Report is what grounding found, and it is reported separately from recall
+// rather than folded into it. "Wrong" and "absent" are different findings about
+// an arm, and collapsing them loses the more interesting one: an arm that
+// fabricates is failing differently from an arm that stays silent.
+type Report struct {
+	// Why says why nothing was checked, and empty means it was checked.
+	//
+	// "cannot check" is a first-class outcome, not an error. A score computed
+	// without a checkout is valid and says grounding was not verified. What is
+	// forbidden is silently treating unverified as verified.
+	Why string
+	// Checked is how many distinct locations were looked up.
+	Checked int
+	// Ungrounded lists the locations that are not there AS WRITTEN, in the
+	// order cited.
+	//
+	// Not all of these are inventions. A path an arm wrote without its
+	// directory — `category.rb:1090` for `app/models/category.rb` — does not
+	// resolve either, and on the discourse fixture all three ungrounded
+	// citations are that rather than fabrication. They are excluded from recall
+	// regardless, because a citation that cannot be resolved cannot be checked,
+	// and the strict path rule already refuses a bare basename.
+	Ungrounded []string
+}
+
+// Verified reports whether grounding actually ran.
+func (r Report) Verified() bool { return r.Why == "" }
+
+// Check reports which of an answer's citations name somewhere that exists.
+//
+// It returns a report and NOTHING ELSE. An earlier version also returned the
+// surviving citations, for the scorer to use in place of the full set, and that
+// was wrong in a way worth writing down.
+//
+// It bought nothing. A citation is credited under the path rule only by
+// carrying a gold row's exact path and line, and gold rows are hand-audited real
+// locations, so anything scoring that way names a place that exists. The one
+// rule that could credit an invention is the symbol rule, which does not compare
+// the line — and that is precisely the citation this package cannot check,
+// because it has no path.
+//
+// And it cost real hits. samePath deliberately credits a citation carrying MORE
+// leading directories than gold, which is how an arm writing an absolute path is
+// scored; `git show commit:/Users/.../app/x.rb` cannot resolve that, so the
+// citation was dropped and the hit with it. There are 127 such citations in the
+// recorded corpus, in both arms. That is form-dependent STRICTNESS, the mirror
+// of the leniency this cycle already has a law about.
+//
+// So grounding moves the report and never the number, and recall is
+// disk-independent by construction rather than by argument.
+func Check(cites []score.Cite, c *Checkout) Report {
+	if c == nil {
+		return Report{Why: "no checkout available, so no citation was verified to exist"}
+	}
+	var r Report
+	seen := map[string]bool{}
+
+	for _, cite := range cites {
+		path := cite.Path
+		if path == "" {
+			path = cite.Established
+		}
+		// A symbol with no file behind it names no path to resolve, and a
+		// citation with no line names no location. Neither is counted as
+		// fabricated: unresolvable is not the same as invented.
+		if path == "" || cite.Line == 0 {
+			continue
+		}
+		where := path + ":" + strconv.Itoa(cite.Line)
+		if seen[where] {
+			continue
+		}
+		seen[where] = true
+		r.Checked++
+		if n, ok := c.lineCount(path); !ok || cite.Line > n {
+			r.Ungrounded = append(r.Ungrounded, where)
+		}
+	}
+	return r
+}
+
+// CheckGold resolves the gold rows themselves, and is how a checkout proves it
+// is the RIGHT checkout.
+//
+// A commit that exists in the wrong repository passes cat-file and then resolves
+// nothing, so every citation reads as fabricated while the report says verified:
+// a confident, wrong, verified-looking number. Gold rows have known locations at
+// the pinned commit, so if they do not resolve, the pair is wrong and grounding
+// refuses rather than publishing that.
+//
+// A gold row that stops resolving on the RIGHT checkout is a stale scenario — a
+// row pointing at a line that moved is not gold, it is history — and that is a
+// loud failure of the instrument rather than a quiet subtraction from an arm.
+func CheckGold(locations []string, c *Checkout) error {
+	if c == nil {
+		return nil
+	}
+	var bad []string
+	for _, loc := range locations {
+		i := strings.LastIndex(loc, ":")
+		if i <= 0 {
+			continue
+		}
+		line, err := strconv.Atoi(loc[i+1:])
+		if err != nil {
+			continue
+		}
+		if n, ok := c.lineCount(loc[:i]); !ok || line > n {
+			bad = append(bad, loc)
+		}
+	}
+	if len(bad) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%d of %d gold locations do not resolve at %s in %s, so this is the wrong "+
+		"checkout or the scenario is stale: %s", len(bad), len(locations), c.commit, c.dir, strings.Join(bad, ", "))
+}
+
+func (r Report) String() string {
+	if !r.Verified() {
+		return "grounding   NOT VERIFIED: " + r.Why + "\n"
+	}
+	if r.Checked == 0 {
+		return "grounding   nothing to check: no citation named both a file and a line\n"
+	}
+	return fmt.Sprintf("grounding   %d of %d cited locations do not resolve at the pinned commit\n",
+		len(r.Ungrounded), r.Checked)
+}

--- a/lab/internal/ground/ground_test.go
+++ b/lab/internal/ground/ground_test.go
@@ -1,0 +1,400 @@
+package ground
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/lab/internal/score"
+)
+
+// fakeGit is a repository described as a map, so every outcome below is
+// reachable without a checkout on disk. The real runner is one exec.Command.
+type fakeGit struct {
+	commit string
+	files  map[string]string
+	calls  int
+}
+
+func (f *fakeGit) run(_ string, args ...string) ([]byte, error) {
+	f.calls++
+	switch args[0] {
+	case "cat-file":
+		// EXACT. An earlier version accepted any commit that extended its own,
+		// which is more permissive than git and hid the difference.
+		if args[2] == f.commit+"^{commit}" {
+			return nil, nil
+		}
+		return nil, errors.New("not a commit")
+	case "show":
+		_, path, _ := strings.Cut(args[1], ":")
+		if body, ok := f.files[path]; ok {
+			return []byte(body), nil
+		}
+		return nil, errors.New("path does not exist")
+	}
+	return nil, errors.New("unexpected git call")
+}
+
+func repo(t *testing.T) (*Checkout, *fakeGit) {
+	t.Helper()
+	g := &fakeGit{commit: "abc123", files: map[string]string{
+		"app/models/category.rb": "one\ntwo\nthree\n",
+		"app/no_trailing.rb":     "one\ntwo",
+	}}
+	c, err := open("/repo", "abc123", g.run)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	return c, g
+}
+
+// The whole point of the package: unverified, a fabricated citation scores
+// exactly like a correct one, so the metric rewards confident invention.
+func TestAFabricatedCitationIsReportedAndExcluded(t *testing.T) {
+	c, _ := repo(t)
+	cites := []score.Cite{
+		{Path: "app/models/category.rb", Line: 2},
+		{Path: "app/models/invented.rb", Line: 1},
+	}
+
+	r := Check(cites, c)
+
+	if len(r.Ungrounded) != 1 || r.Ungrounded[0] != "app/models/invented.rb:1" {
+		t.Errorf("ungrounded = %v, want the invented file", r.Ungrounded)
+	}
+	if r.Checked != 2 {
+		t.Errorf("checked %d locations, want 2", r.Checked)
+	}
+}
+
+// A real file and a line past its end. This is the half a file-existence check
+// would miss, and it is the commoner shape: the file is real, the line is not.
+func TestARealFileAtALineItDoesNotHaveDoesNotResolve(t *testing.T) {
+	c, _ := repo(t)
+
+	for _, tc := range []struct {
+		name string
+		line int
+		want bool
+	}{
+		{"the last line", 3, true},
+		{"one past the end", 4, false},
+		{"far past the end", 999999, false},
+		{"the first line", 1, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := Check([]score.Cite{{Path: "app/models/category.rb", Line: tc.line}}, c)
+			if got := len(r.Ungrounded) == 0; got != tc.want {
+				t.Errorf("resolves = %v, want %v (ungrounded %v)", got, tc.want, r.Ungrounded)
+			}
+		})
+	}
+}
+
+// A last line with no trailing newline is still a line, and counting newlines
+// alone would report the real last line of such a file as fabricated.
+func TestTheLastLineCountsWhenTheFileHasNoTrailingNewline(t *testing.T) {
+	c, _ := repo(t)
+
+	r := Check([]score.Cite{{Path: "app/no_trailing.rb", Line: 2}}, c)
+	if len(r.Ungrounded) != 0 {
+		t.Errorf("the real last line was reported as not resolving: %v", r.Ungrounded)
+	}
+}
+
+// "cannot check" is a first-class outcome, not an error. A score computed
+// without a checkout is valid and says grounding was not verified; what is
+// forbidden is silently treating unverified as verified.
+func TestWithNoCheckoutNothingIsDroppedAndNothingIsClaimed(t *testing.T) {
+	cites := []score.Cite{
+		{Path: "app/models/invented.rb", Line: 1},
+		{Path: "app/models/category.rb", Line: 2},
+	}
+
+	r := Check(cites, nil)
+
+	if r.Checked != 0 {
+		t.Errorf("checked %d locations with no checkout", r.Checked)
+	}
+	if r.Verified() {
+		t.Error("a report with no checkout behind it claimed to be verified")
+	}
+	if !strings.Contains(r.String(), "NOT VERIFIED") {
+		t.Errorf("the rendered report does not say it verified nothing:\n%s", r.String())
+	}
+}
+
+// A checkout at the wrong commit is worse than none: it reports a citation as
+// fabricated because a file moved between revisions, which is a claim about the
+// arm made from a fact about the disk.
+func TestACheckoutWithoutThePinnedCommitIsRefused(t *testing.T) {
+	g := &fakeGit{commit: "abc123"}
+
+	if _, err := open("/repo", "deadbeef", g.run); err == nil {
+		t.Error("a checkout that does not have the pinned commit was accepted")
+	}
+	// A prefix of the pinned commit is not the pinned commit here: the fake is
+	// exact so that it cannot be laxer than git and hide a bug.
+	if _, err := open("/repo", "abc", g.run); err == nil {
+		t.Error("a prefix of the pinned commit was accepted by the fake")
+	}
+	for _, tc := range [][2]string{{"", "abc123"}, {"/repo", ""}} {
+		if _, err := open(tc[0], tc[1], g.run); err == nil {
+			t.Errorf("open(%q, %q) was accepted", tc[0], tc[1])
+		}
+	}
+}
+
+// A citation with no line, or a bare symbol with no file behind it, names no
+// location to resolve. It is carried through rather than counted as fabricated,
+// because this package cannot tell where a bare constant lives.
+func TestWhatCannotBeResolvedIsCarriedRatherThanCondemned(t *testing.T) {
+	c, _ := repo(t)
+	cites := []score.Cite{
+		{Path: "app/models/category.rb"},                                // named, no line
+		{Symbol: "Admin::ActionLogsController#index", Line: 7},          // no file behind it
+		{Established: "app/models/category.rb", Symbol: "X#y", Line: 2}, // a file it continues
+	}
+
+	r := Check(cites, c)
+
+	if len(r.Ungrounded) != 0 {
+		t.Errorf("unresolvable was reported as fabricated: %v", r.Ungrounded)
+	}
+	if r.Checked != 1 {
+		t.Errorf("checked %d locations, want only the one that names a file and a line", r.Checked)
+	}
+}
+
+// The same location cited twenty times is one lookup. Grounding shells out per
+// distinct file, and a long answer names the same file constantly.
+func TestTheSameFileIsLookedUpOnce(t *testing.T) {
+	c, g := repo(t)
+	before := g.calls
+
+	var cites []score.Cite
+	for i := 1; i <= 3; i++ {
+		for j := 0; j < 5; j++ {
+			cites = append(cites, score.Cite{Path: "app/models/category.rb", Line: i})
+		}
+	}
+	if r := Check(cites, c); r.Checked != 3 {
+		t.Errorf("checked %d distinct locations, want 3", r.Checked)
+	}
+	if got := g.calls - before; got != 1 {
+		t.Errorf("%d git calls for one file, want 1", got)
+	}
+}
+
+// The real git seam, against a real repository.
+//
+// Every test above drives a fake runner, which proves the logic and proves
+// nothing about the one line that actually shells out. A repository built here
+// is small, hermetic and disposable, and it is the only thing that can catch a
+// wrong argument to git.
+func newRepo(t *testing.T) (dir, commit string) {
+	t.Helper()
+	dir = t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "app", "models"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "app", "models", "category.rb"),
+		[]byte("one\ntwo\nthree\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"config", "user.email", "t@example.com"},
+		{"config", "user.name", "t"},
+		{"add", "-A"},
+		{"commit", "-qm", "fixture"},
+	} {
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Skipf("git is unavailable here: %v: %s", err, out)
+		}
+	}
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir, strings.TrimSpace(string(out))
+}
+
+func TestAgainstARealRepository(t *testing.T) {
+	dir, commit := newRepo(t)
+
+	c, err := Open(dir, commit)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	r := Check([]score.Cite{
+		{Path: "app/models/category.rb", Line: 3},
+		{Path: "app/models/category.rb", Line: 4},
+		{Path: "app/models/nowhere.rb", Line: 1},
+	}, c)
+
+	if len(r.Ungrounded) != 2 {
+		t.Errorf("ungrounded = %v, want the past-the-end line and the absent file", r.Ungrounded)
+	}
+	if !r.Verified() {
+		t.Error("a report from a real checkout says it verified nothing")
+	}
+	if got := r.String(); !strings.Contains(got, "2 of 3 cited locations do not resolve") {
+		t.Errorf("rendered as %q", got)
+	}
+}
+
+func TestOpeningSomethingThatIsNotARepository(t *testing.T) {
+	if _, err := Open(t.TempDir(), "deadbeef"); err == nil {
+		t.Error("an empty directory was accepted as a checkout")
+	}
+}
+
+// The property that makes grounding safe, stated as strongly as it can be.
+//
+// Grounding does not return citations at all, so it CANNOT change a score. An
+// earlier version returned a filtered set for the scorer to use, which looked
+// stricter and was not: the only rule that can credit an invention is the symbol
+// rule, which has no path for this package to check, while samePath deliberately
+// credits a citation carrying more leading directories than gold — an absolute
+// path, of which the corpus holds 127 — and `git show commit:/Users/...` cannot
+// resolve one. So the filter removed true positives and no fabrications.
+//
+// This test is the guard on that: the matches a gold row has before grounding
+// are the matches it has after, whatever grounding thinks of them.
+func TestGroundingCannotChangeWhatMatches(t *testing.T) {
+	c, _ := repo(t)
+	const goldPath, goldLine = "app/models/category.rb", "2"
+
+	cites := []score.Cite{
+		{Path: goldPath, Line: 2},
+		{Path: "/Users/someone/checkouts/" + goldPath, Line: 2}, // absolute; samePath credits it, git cannot resolve it
+		{Path: goldPath, Line: 4000},
+		{Path: "app/models/invented.rb", Line: 2},
+	}
+
+	before := countMatches(cites, goldPath, goldLine)
+	r := Check(cites, c)
+	after := countMatches(cites, goldPath, goldLine)
+
+	if len(r.Ungrounded) < 2 {
+		t.Fatalf("premise gone: only %v failed to resolve", r.Ungrounded)
+	}
+	if before != after || before != 2 {
+		t.Errorf("matches went from %d to %d, want 2 both times", before, after)
+	}
+}
+
+func countMatches(cites []score.Cite, goldPath, goldLine string) int {
+	n := 0
+	for _, c := range cites {
+		if score.Matches(c, goldPath, goldLine) {
+			n++
+		}
+	}
+	return n
+}
+
+// The wrong checkout is the dangerous case: a commit that exists in another
+// repository passes every existence check, resolves nothing, and the report
+// says verified. The gold rows are the detector.
+func TestAValidCommitInTheWrongRepositoryIsRefused(t *testing.T) {
+	c, _ := repo(t)
+
+	if err := CheckGold([]string{"app/models/category.rb:2"}, c); err != nil {
+		t.Fatalf("the right checkout was refused: %v", err)
+	}
+
+	err := CheckGold([]string{"app/models/category.rb:2", "src/Core/Billing/Plan.cs:40"}, c)
+	if err == nil {
+		t.Fatal("a checkout that cannot resolve the gold was accepted")
+	}
+	if !strings.Contains(err.Error(), "Plan.cs:40") {
+		t.Errorf("the error does not name what failed: %v", err)
+	}
+	// And a stale gold row on the RIGHT checkout fails the same way, loudly,
+	// rather than quietly subtracting from an arm.
+	if err := CheckGold([]string{"app/models/category.rb:9999"}, c); err == nil {
+		t.Error("a gold row pointing past the end of a real file was accepted")
+	}
+	if err := CheckGold([]string{"app/models/category.rb:2"}, nil); err != nil {
+		t.Errorf("with no checkout there is nothing to refuse: %v", err)
+	}
+	// A gold row carrying no location is 02-05's problem, not grounding's: it
+	// is skipped rather than reported as a checkout that cannot resolve it,
+	// because condemning the checkout for it would point at the wrong thing.
+	for _, unlocatable := range []string{
+		"the ActiveRecord::Relation object itself", // colons, but no line after one
+		"app/models/category.rb:not-a-number",      // a colon, and not a number
+		"a gold row that is pure prose",            // no colon at all
+	} {
+		if err := CheckGold([]string{unlocatable}, c); err != nil {
+			t.Errorf("CheckGold(%q) blamed the checkout for a row that names no location: %v",
+				unlocatable, err)
+		}
+	}
+}
+
+// Nothing checkable is not a clean bill of health.
+func TestAReportWithNothingToCheckSaysSo(t *testing.T) {
+	c, _ := repo(t)
+	r := Check([]score.Cite{{Symbol: "Category#find", Line: 3}}, c)
+
+	if got := r.String(); !strings.Contains(got, "nothing to check") {
+		t.Errorf("rendered as %q, which reads as a pass", got)
+	}
+}
+
+// The peel, which only a real repository can express. `commit^{commit}` is what
+// makes a tree or a tag resolve to the commit it belongs to, or fail. Without
+// it a tree SHA passes as a commit and every path afterwards resolves against
+// something that is not a revision.
+func TestATreeIsNotACommit(t *testing.T) {
+	dir, commit := newRepo(t)
+	out, err := exec.Command("git", "-C", dir, "rev-parse", commit+"^{tree}").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tree := strings.TrimSpace(string(out))
+
+	if tree == commit {
+		t.Fatal("premise gone: the tree and the commit are the same object")
+	}
+	if _, err := Open(dir, tree); err == nil {
+		t.Error("a tree SHA was accepted as the pinned commit")
+	}
+}
+
+// The package's central promise: it reads the PINNED commit, not whatever is
+// checked out. A one-commit fixture cannot tell the two apart, so this one has
+// two and the file grows between them.
+func TestItReadsThePinnedCommitAndNotTheCurrentOne(t *testing.T) {
+	dir, first := newRepo(t)
+
+	if err := os.WriteFile(filepath.Join(dir, "app", "models", "category.rb"),
+		[]byte("one\ntwo\nthree\nfour\nfive\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{{"add", "-A"}, {"commit", "-qm", "grew"}} {
+		if out, err := exec.Command("git", append([]string{"-C", dir}, args...)...).CombinedOutput(); err != nil {
+			t.Fatalf("%v: %s", err, out)
+		}
+	}
+
+	// Line 5 exists at HEAD and does not exist at the pinned commit.
+	c, err := Open(dir, first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := Check([]score.Cite{{Path: "app/models/category.rb", Line: 5}}, c)
+	if len(r.Ungrounded) != 1 {
+		t.Error("a line that only exists at HEAD resolved against the pinned commit")
+	}
+
+}

--- a/lab/internal/score/score.go
+++ b/lab/internal/score/score.go
@@ -26,6 +26,11 @@ type Row struct {
 
 // Result is one gold group scored against one transcript.
 type Result struct {
+	// Grounding is what checking the citations against the repository found,
+	// rendered. It is empty when nothing checked them, and empty RENDERS as not
+	// verified — a number that does not say whether its citations were checked
+	// reads as though they were.
+	Grounding string
 	// Why says what makes this number provisional, and empty means it is not.
 	// It travels from the transcript because a score that does not carry the
 	// mark is exactly the failure the mark exists to prevent: a truncated
@@ -158,8 +163,16 @@ func (r Result) Provisional() bool { return r.Why != "" }
 // a path boundary of the gold cite. That is a suffix rule on the PATH only; the
 // line still has to be exactly right.
 func Group(name string, rows []Row, tr Source, floor float64) Result {
-	cites := Scan(tr.Answer())
-	r := Result{Group: name, Total: len(rows), Floor: floor, Why: tr.ProvisionalWhy()}
+	return GroupCites(name, rows, Scan(tr.Answer()), tr.ProvisionalWhy(), floor)
+}
+
+// GroupCites scores an already-scanned set of citations.
+//
+// It exists so grounding can remove the citations that do not exist before the
+// number is taken, without this package needing a repository on disk. Group is
+// the same function with the scan done for you.
+func GroupCites(name string, rows []Row, cites []Cite, why string, floor float64) Result {
+	r := Result{Group: name, Total: len(rows), Floor: floor, Why: why}
 
 	for _, row := range rows {
 		p, _, ok := split(row.Cite)
@@ -313,6 +326,14 @@ func (r Result) String() string {
 	fmt.Fprintf(&b, "recall     %.2f\n", r.Recall)
 	fmt.Fprintf(&b, "floor      %.2f\n", r.Floor)
 	fmt.Fprintf(&b, "verdict    %s\n", r.Verdict)
+	// Deny by default. An empty Grounding is a number nobody checked, and
+	// printing nothing would make it visually identical to a verified one minus
+	// a line no reader has been trained to miss.
+	if r.Grounding == "" {
+		b.WriteString("grounding   NOT VERIFIED: nothing checked these citations\n")
+	} else {
+		b.WriteString(r.Grounding)
+	}
 	if len(r.Misses) > 0 {
 		fmt.Fprintf(&b, "missed     %s\n", strings.Join(r.Misses, ", "))
 	}

--- a/lab/internal/score/score_test.go
+++ b/lab/internal/score/score_test.go
@@ -302,3 +302,26 @@ func TestAProvisionalResultSaysSoBeforeItSaysAnythingElse(t *testing.T) {
 		t.Errorf("report dropped the number:\n%s", out)
 	}
 }
+
+// Grounding is DENY BY DEFAULT on the report.
+//
+// A Result nobody grounded used to print nothing at all, which made it visually
+// identical to a verified one minus a line no reader has been trained to miss.
+// Absence of evidence has to render as absence of evidence: this is the one
+// property the grounding work exists to protect, and leaving it to caller
+// discipline is how it gets lost.
+func TestAnUngroundedResultSaysSoWithoutBeingTold(t *testing.T) {
+	rows := []Row{{ID: "d:one", Cite: "app/models/category.rb:12"}}
+	r := Group("dependents", rows, text("app/models/category.rb:12"), 0.50)
+
+	if !strings.Contains(r.String(), "NOT VERIFIED") {
+		t.Errorf("a number nobody checked printed as though it had been:\n%s", r.String())
+	}
+
+	r.Grounding = "grounding   1 of 4 cited locations do not resolve at the pinned commit\n"
+	if got := r.String(); !strings.Contains(got, "1 of 4 cited locations") {
+		t.Errorf("the grounding line did not reach the report:\n%s", got)
+	} else if strings.Contains(got, "NOT VERIFIED") {
+		t.Errorf("a grounded result also claimed to be unverified:\n%s", got)
+	}
+}


### PR DESCRIPTION
## Problem

An arm can cite a file and a line that do not exist. Unverified, a fabricated citation scores exactly like a correct one, so the metric rewards confident invention.

## Summary

Every cited `file:line` is resolved against the repository at its pinned commit, with three outcomes: **resolves**, **does not resolve**, **cannot check**. Grounding lives in its own package because it is the only part of scoring that needs a repository, and a new depguard rule keeps `os`, `os/exec`, `net` and `syscall` out of the lab's pure core so recall structurally cannot come to depend on a disk.

## It reports, and it does not subtract

The pitch says ungrounded citations are "excluded from recall". Building it that way and then measuring showed the exclusion buys nothing and costs real hits:

- A citation is credited under the path rule only by carrying a gold row's exact path **and line**. Gold rows are hand-audited real locations, so anything scoring that way names a place that exists.
- The one rule that could credit an invention is the symbol rule, which does not compare the line — and that is exactly the citation with no path for grounding to check.
- Meanwhile `samePath` deliberately credits a citation carrying *more* leading directories than gold. `git show <commit>:/Users/…/app/x.rb` cannot resolve one, so the filter dropped the hit. **127 such citations sit in the recorded corpus, in both arms.**

That was form-dependent *strictness*, the mirror of the leniency this cycle already has a law about. Grounding now returns a report and nothing else, and recall is disk-independent by construction rather than by argument.

## Deny by default

A result nobody grounded prints `NOT VERIFIED`, not nothing. Printing nothing made an unverified number visually identical to a verified one minus a line no reader has been trained to miss — allow-by-default on the exact property this exists to protect.

A checkout also has to prove it is the *right* one, by resolving the gold. A commit that exists in another repository passes every existence check, resolves nothing, and would publish a confident wrong number as verified.

## What it found on the corpus

Across the 57 recorded discourse runs: sense 10.33% of citations ungrounded against baseline 2.61% — which invites "one arm invents four times as much". Decomposed, it says nothing of the sort:

- A real file cited past its end, the only unambiguous fabrication: **3 in each arm**.
- 70% of the rest is a path written without its directory, a citation form rather than a falsehood.
- 815 of the 823 sense failures are a single model.

Recorded as a law: an ungrounded rate is a form artifact until decomposed.

## Test plan

- `make ci` green; **100% line and function coverage across every lab file**.
- Mutation-checked: of twelve mutations, eleven died; the survivor was the exclusion path itself, which is why it is gone.
- The real git seam is tested against real temporary repositories, including a tree SHA (which pins the `^{commit}` peel) and a two-commit fixture (which pins that the *pinned* commit is read, not `HEAD`).