### PR TITLE
bench(lab): the gold validator, and what it quarantines

### DIFF
--- a/lab/internal/cli/cli.go
+++ b/lab/internal/cli/cli.go
@@ -32,6 +32,7 @@ Commands:
   plan      Show what a campaign would run, and every rejection with its reason
   run       Run one scenario against one repository
   score     Score a recorded run against a scenario's gold
+  validate  Audit a scenario's gold and report what would be quarantined
   version   Print version
 `
 
@@ -88,6 +89,8 @@ func Run(args []string, stdout, stderr io.Writer) int {
 		return catalogCmd(args[1:], stdout, stderr)
 	case "score":
 		return scoreRun(args[1:], stdout, stderr)
+	case "validate":
+		return validateGold(args[1:], stdout, stderr)
 	case "version":
 		_, _ = fmt.Fprintln(stdout, Version)
 		return exitOK

--- a/lab/internal/cli/validatecmd.go
+++ b/lab/internal/cli/validatecmd.go
@@ -1,0 +1,137 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/luuuc/sense/lab/internal/goldcheck"
+	"github.com/luuuc/sense/lab/internal/ground"
+	"github.com/luuuc/sense/lab/internal/scenario"
+)
+
+type validateFlags struct {
+	scenario string
+	checkout string
+	commit   string
+	results  string
+}
+
+func parseValidateFlags(args []string, stderr io.Writer) (validateFlags, error) {
+	var f validateFlags
+	fs := flag.NewFlagSet("validate", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.StringVar(&f.scenario, "scenario", "", "path to the scenario file (required)")
+	fs.StringVar(&f.checkout, "checkout", "", "repository checkout to resolve gold against")
+	fs.StringVar(&f.commit, "commit", "", "commit the checkout is pinned at (required with -checkout)")
+	fs.StringVar(&f.results, "results", "", "recorded results tree, to list the runs a quarantine moves")
+	if err := fs.Parse(args); err != nil {
+		return f, err
+	}
+	if f.scenario == "" {
+		return f, fmt.Errorf("-scenario is required")
+	}
+	if f.checkout != "" && f.commit == "" {
+		return f, fmt.Errorf("-checkout needs -commit: resolving gold against an unpinned tree would " +
+			"check it against whatever happens to be checked out")
+	}
+	return f, nil
+}
+
+// validateGold audits a scenario's gold and reports what it found.
+//
+// It REPORTS. Quarantine and report; a validator that also edits gold is a
+// validator nobody can check, and fixing a row is a decision to take with the
+// scenario in front of you.
+func validateGold(args []string, stdout, stderr io.Writer) int {
+	f, err := parseValidateFlags(args, stderr)
+	if err != nil {
+		if err != flag.ErrHelp {
+			_, _ = fmt.Fprintf(stderr, "sense-lab validate: %v\n", err)
+		}
+		return exitUsage
+	}
+	set, err := scenario.LoadPath(f.scenario)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab validate: %v\n", err)
+		return exitError
+	}
+
+	var checkout *ground.Checkout
+	if f.checkout != "" {
+		if checkout, err = ground.Open(f.checkout, f.commit); err != nil {
+			_, _ = fmt.Fprintf(stderr, "sense-lab validate: resolving skipped: %v\n", err)
+			checkout = nil
+		}
+	}
+	// A nil *Checkout must go in as a nil INTERFACE, or the audit sees a
+	// non-nil interface holding a nil pointer and believes it can resolve.
+	report := goldcheck.Audit(set, resolverOrNil(checkout), grepperOrNil(checkout))
+	_, _ = fmt.Fprint(stdout, report.String())
+
+	if f.results != "" && len(report.Quarantined) > 0 {
+		printAffectedRuns(set, f.results, stdout, stderr)
+	}
+	if len(report.Quarantined) > 0 {
+		return exitBelowFloor
+	}
+	return exitOK
+}
+
+func resolverOrNil(c *ground.Checkout) goldcheck.Resolver {
+	if c == nil {
+		return nil
+	}
+	return c
+}
+
+func grepperOrNil(c *ground.Checkout) goldcheck.Grepper {
+	if c == nil {
+		return nil
+	}
+	return c
+}
+
+// printAffectedRuns lists the recorded runs whose scores a quarantine moves.
+//
+// Removing a row from a group changes that group's recall in every run that
+// scored against it. The rescore proof lists "gold change" as a cause of a
+// difference, and it should meet that cause as a prediction made HERE rather
+// than as a surprise found there.
+func printAffectedRuns(set scenario.Set, root string, stdout, stderr io.Writer) {
+	runs, err := scoredRuns(root, set.Scenario.Repo)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab validate: could not list recorded runs: %v\n", err)
+		return
+	}
+	_, _ = fmt.Fprintf(stdout, "\n  the quarantine moves the recorded score of %d runs:\n", len(runs))
+	for _, run := range runs {
+		_, _ = fmt.Fprintf(stdout, "    %s\n", run)
+	}
+}
+
+// scoredRuns finds the recorded runs for one repo that carry a score.
+func scoredRuns(root, repo string) ([]string, error) {
+	var out []string
+	err := filepath.Walk(root, func(path string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if fi.IsDir() || fi.Name() != "scored.json" {
+			return nil
+		}
+		if !strings.Contains(filepath.ToSlash(path), "/"+repo+"/") {
+			return nil
+		}
+		// Rel cannot fail here: path came from walking root, so it is under it.
+		rel, _ := filepath.Rel(root, filepath.Dir(path))
+		out = append(out, rel)
+		return nil
+	})
+	sort.Strings(out)
+	return out, err
+}

--- a/lab/internal/cli/validatecmd_test.go
+++ b/lab/internal/cli/validatecmd_test.go
@@ -1,0 +1,189 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The shipped rails scenario, which cannot be scored: not one of its 25 gold
+// rows carries a path:line. It is the reason this command exists, and it must
+// be visible from the command line rather than discovered by a paid run.
+func TestValidateQuarantinesTheShippedRailsGold(t *testing.T) {
+	code, stdout, _ := dispatch(t, "validate",
+		"-scenario", filepath.Join(repoRoot(t), "lab", "scenarios", "rails", "rails.yaml"))
+
+	if code != exitBelowFloor {
+		t.Errorf("exit code = %d, want %d for a scenario with quarantined rows", code, exitBelowFloor)
+	}
+	if !strings.Contains(stdout, "25 quarantined") {
+		t.Errorf("the rails gold was not quarantined:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "no path:line") {
+		t.Errorf("the quarantine carries no named reason:\n%s", stdout)
+	}
+}
+
+// A scenario whose gold is sound exits clean, or the command is just "always
+// complain" and nobody would read its output twice.
+func TestValidateAcceptsGoldThatIsSound(t *testing.T) {
+	code, stdout, stderr := dispatch(t, "validate",
+		"-scenario", filepath.Join(repoRoot(t), "lab", "scenarios", "discourse", "discourse.yaml"))
+
+	if code != exitOK {
+		t.Errorf("exit code = %d, want %d\n%s\n%s", code, exitOK, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "0 quarantined") {
+		t.Errorf("sound gold was quarantined:\n%s", stdout)
+	}
+}
+
+// Quarantining a row moves every recorded score taken against it, so this pitch
+// names which runs rather than leaving the rescore proof to discover it.
+func TestValidateListsTheRunsAQuarantineMoves(t *testing.T) {
+	results := t.TempDir()
+	for _, run := range []string{
+		"opus/hash/sense/rails/run-1",
+		"opus/hash/baseline/rails/run-1",
+		"opus/hash/sense/discourse/run-1", // a different repo, and not affected
+	} {
+		dir := filepath.Join(results, filepath.FromSlash(run))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "scored.json"), []byte(`{"recall":0.5}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	_, stdout, _ := dispatch(t, "validate",
+		"-scenario", filepath.Join(repoRoot(t), "lab", "scenarios", "rails", "rails.yaml"),
+		"-results", results)
+
+	if !strings.Contains(stdout, "moves the recorded score of 2 runs") {
+		t.Errorf("the handover list is wrong:\n%s", stdout)
+	}
+	for _, want := range []string{"sense/rails/run-1", "baseline/rails/run-1"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("the handover list is missing %s:\n%s", want, stdout)
+		}
+	}
+	if strings.Contains(stdout, "discourse") {
+		t.Errorf("a run of another repo is in the handover list:\n%s", stdout)
+	}
+}
+
+// -checkout without -commit resolves gold against whatever happens to be
+// checked out, which is how a scenario gets quarantined for being stale when it
+// is not.
+func TestValidateRefusesACheckoutWithoutACommit(t *testing.T) {
+	code, _, stderr := dispatch(t, "validate",
+		"-scenario", filepath.Join(repoRoot(t), "lab", "scenarios", "rails", "rails.yaml"),
+		"-checkout", t.TempDir())
+
+	if code != exitUsage {
+		t.Errorf("exit code = %d, want %d", code, exitUsage)
+	}
+	if !strings.Contains(stderr, "-checkout needs -commit") {
+		t.Errorf("the error does not say what is missing:\n%s", stderr)
+	}
+}
+
+// An unusable checkout downgrades the audit rather than failing it, and the
+// report says which checks did not run.
+func TestValidateWithAnUnusableCheckoutSaysWhatItSkipped(t *testing.T) {
+	_, stdout, stderr := dispatch(t, "validate",
+		"-scenario", filepath.Join(repoRoot(t), "lab", "scenarios", "discourse", "discourse.yaml"),
+		"-checkout", t.TempDir(), "-commit", "deadbeef")
+
+	if !strings.Contains(stderr, "resolving skipped") {
+		t.Errorf("nothing said resolving was skipped:\n%s", stderr)
+	}
+	if !strings.Contains(stdout, "NOT CHECKED") {
+		t.Errorf("a partial audit read as a complete one:\n%s", stdout)
+	}
+}
+
+func TestValidateNeedsAScenario(t *testing.T) {
+	code, _, stderr := dispatch(t, "validate")
+
+	if code != exitUsage {
+		t.Errorf("exit code = %d, want %d", code, exitUsage)
+	}
+	if !strings.Contains(stderr, "-scenario is required") {
+		t.Errorf("unhelpful error:\n%s", stderr)
+	}
+}
+
+func TestValidateReportsAScenarioItCannotLoad(t *testing.T) {
+	code, _, stderr := dispatch(t, "validate", "-scenario", filepath.Join(t.TempDir(), "nope.yaml"))
+
+	if code != exitError {
+		t.Errorf("exit code = %d, want %d", code, exitError)
+	}
+	if stderr == "" {
+		t.Error("nothing was reported")
+	}
+}
+
+// The whole audit against a real checkout, which is the only way the resolver
+// and the grepper are actually reached.
+func TestValidateAgainstARealCheckout(t *testing.T) {
+	dir, commit := repoWithGold(t)
+	// An anchor, so the covering-grep check runs too and nothing is skipped.
+	withAnchor := scoredScenario + "contract_symbol: Category\n"
+	set := scenarioSet(t, withAnchor, `discriminator: dependents
+rows:
+  - id: d:real
+    group: dependents
+    relation: "app/models/category.rb:1083 a line the checkout has"
+  - id: d:moved
+    group: dependents
+    relation: "lib/tasks/search.rake:4000 a line that moved"
+`, scoredRubric)
+
+	code, stdout, stderr := dispatch(t, "validate", "-scenario", set, "-checkout", dir, "-commit", commit)
+
+	if code != exitBelowFloor {
+		t.Errorf("exit code = %d, want %d\n%s\n%s", code, exitBelowFloor, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "does not resolve at the pinned commit") {
+		t.Errorf("the moved row was not caught:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "d:moved") {
+		t.Errorf("the report does not name the moved row:\n%s", stdout)
+	}
+	if strings.Contains(stdout, "d:real") {
+		t.Errorf("a row the checkout resolves was quarantined:\n%s", stdout)
+	}
+	// Both checks ran, so nothing should be named as skipped.
+	if strings.Contains(stdout, "NOT CHECKED") {
+		t.Errorf("a full audit reported checks it had not skipped:\n%s", stdout)
+	}
+}
+
+func TestValidateRejectsAFlagItDoesNotHave(t *testing.T) {
+	code, _, _ := dispatch(t, "validate", "-nope")
+
+	if code != exitUsage {
+		t.Errorf("exit code = %d, want %d", code, exitUsage)
+	}
+}
+
+// A results tree that is not there is worth a word, and must not be silently
+// read as "no runs are affected".
+func TestValidateSaysWhenItCannotListTheAffectedRuns(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "not-created")
+
+	_, stdout, stderr := dispatch(t, "validate",
+		"-scenario", filepath.Join(repoRoot(t), "lab", "scenarios", "rails", "rails.yaml"),
+		"-results", missing)
+
+	if !strings.Contains(stderr, "could not list recorded runs") {
+		t.Errorf("a missing results tree passed quietly:\n%s", stderr)
+	}
+	if strings.Contains(stdout, "moves the recorded score of 0 runs") {
+		t.Errorf("a missing tree was reported as no affected runs:\n%s", stdout)
+	}
+}

--- a/lab/internal/cli/validatecmd_test.go
+++ b/lab/internal/cli/validatecmd_test.go
@@ -27,6 +27,10 @@ func TestValidateQuarantinesTheShippedRailsGold(t *testing.T) {
 
 // A scenario whose gold is sound exits clean, or the command is just "always
 // complain" and nobody would read its output twice.
+//
+// This depends on the SHIPPED discourse gold staying sound. If it fails after
+// someone edits that scenario, the validator is probably right and the edit is
+// what to look at.
 func TestValidateAcceptsGoldThatIsSound(t *testing.T) {
 	code, stdout, stderr := dispatch(t, "validate",
 		"-scenario", filepath.Join(repoRoot(t), "lab", "scenarios", "discourse", "discourse.yaml"))

--- a/lab/internal/goldcheck/goldcheck.go
+++ b/lab/internal/goldcheck/goldcheck.go
@@ -1,0 +1,246 @@
+// Package goldcheck audits gold rows against the rails the laws already state.
+//
+// Gold is hand-audited, and that is why the numbers mean anything. It is also
+// where the expensive mistakes live, and the recorded ones do not look wrong
+// when you read the file:
+//
+//   - A row that can never score. A scenario asked for "the specs/fixtures that
+//     must be updated or added ... use file:line throughout", and its two gold
+//     rows named files with no line at all. They scored mentioned 2 of 2 in 8 of
+//     10 runs and cited 0 of 2 in 10 of 10, both arms, both models, for months.
+//     The arms did the work and named the files in the only natural form, since
+//     a line number is meaningless for a file that does not exist yet.
+//
+//   - A row that is free. A gold set whose eighteen rows were each a single
+//     `Setting.<key>` read scored 17 of 18 to a baseline in nine tool calls.
+//
+// Neither is caught by reading the file. Both are caught by a check that knows
+// the row's form, its group, and what a covering grep would print.
+//
+// The validator REPORTS. It never edits gold: a validator that also fixes what
+// it finds is a validator nobody can check.
+package goldcheck
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/luuuc/sense/lab/internal/scenario"
+)
+
+// Reason is why a row was quarantined, or flagged.
+//
+// Every finding carries one. "Quarantined with a named reason" is the whole
+// contract: a row dropped without one is indistinguishable from a row nobody
+// looked at.
+type Reason string
+
+const (
+	// NoLocation is the recorded spec-fixture failure. A row scored at
+	// path:line must carry a line a correct answer could actually write.
+	NoLocation Reason = "no path:line, so nothing an arm writes could ever match it"
+	// Unresolved is a row pointing somewhere that is not there at the pinned
+	// commit. A row pointing at a line that moved is not gold, it is history.
+	Unresolved Reason = "does not resolve at the pinned commit"
+	// DuplicateFile is two rows of one group in the same file, which weights
+	// the group toward whichever file has the most matches.
+	DuplicateFile Reason = "a second row of this group in the same file"
+	// DuplicateID is two rows sharing an id, which makes a hit ambiguous.
+	DuplicateID Reason = "another row already has this id"
+	// InCoveringGrep is a FLAG and never a quarantine.
+	//
+	// It says the row's exact location appears in a plain grep for the anchor.
+	// On its own that means very little, and the size of the grep is the whole
+	// story: on discourse, 19 of 23 rows lie inside a grep for `Category` that
+	// prints 4483 lines, and reading 4483 lines to find 23 is not free — it is
+	// the work the scenario is asking for. A row is only cheap to the baseline
+	// when the covering grep is small enough to read whole.
+	//
+	// So this reports the membership AND the size, and the human decides. The
+	// law is explicit that it ranks and never kills: run as a per-row census it
+	// once killed four shapes on a repository that banks +0.53.
+	InCoveringGrep Reason = "inside a covering grep for the anchor"
+)
+
+// Quarantines reports whether a reason removes the row rather than ranking it.
+func (r Reason) Quarantines() bool { return r != InCoveringGrep }
+
+// Finding is one thing wrong, or worth knowing, about one row.
+type Finding struct {
+	RowID  string
+	Group  string
+	Cite   string
+	Reason Reason
+	// Detail carries what the reason alone cannot: the grep's line count for a
+	// free row, the other row's id for a duplicate.
+	Detail string
+}
+
+func (f Finding) String() string {
+	s := fmt.Sprintf("%-34s %-12s", f.RowID, f.Group)
+	if f.Cite != "" {
+		s += " " + f.Cite
+	}
+	if f.Detail != "" {
+		s += " (" + f.Detail + ")"
+	}
+	return s
+}
+
+// Resolver says whether a location exists. It is an interface so this package
+// does not need a repository, and a scenario with no checkout is audited for
+// everything except resolution rather than not at all.
+type Resolver interface {
+	// Resolves reports whether path has that line. The second return is false
+	// when nothing could be checked.
+	Resolves(path string, line int) (ok, checked bool)
+}
+
+// Grepper says how many lines a covering grep prints, and whether a location is
+// among them. It is what makes "free" measurable rather than a judgement.
+type Grepper interface {
+	Covering(symbol string) (hits map[string]bool, total int, checked bool)
+}
+
+// Report is one scenario's gold, audited.
+type Report struct {
+	Scenario    string
+	Rows        int
+	Findings    []Finding
+	Quarantined []string // row ids, in gold file order
+	// Unchecked names the checks that could not run, so a clean report cannot
+	// be read as a complete one.
+	Unchecked []string
+}
+
+// Audit runs every check that can run, and names the ones that cannot.
+//
+// resolve and grep may both be nil: a scenario with no checkout is audited for
+// form and shape, and the report says what it could not look at. A validator
+// that refused to run without a repository would be a validator nobody runs.
+func Audit(set scenario.Set, resolve Resolver, grep Grepper) Report {
+	r := Report{Scenario: set.Name, Rows: len(set.Gold.Rows)}
+	seenID := map[string]string{}
+	seenFile := map[string]string{}
+	quarantined := map[string]bool{}
+
+	add := func(f Finding) {
+		r.Findings = append(r.Findings, f)
+		if f.Reason.Quarantines() && !quarantined[f.RowID] {
+			quarantined[f.RowID] = true
+			r.Quarantined = append(r.Quarantined, f.RowID)
+		}
+	}
+
+	for _, row := range set.Gold.Rows {
+		cite := row.Cite()
+		f := Finding{RowID: row.ID, Group: row.Group, Cite: cite}
+
+		if prev, ok := seenID[row.ID]; ok {
+			f.Reason, f.Detail = DuplicateID, "first seen in group "+prev
+			add(f)
+		}
+		seenID[row.ID] = row.Group
+
+		if cite == "" {
+			f.Reason = NoLocation
+			add(f)
+			continue
+		}
+		path, line := splitCite(cite)
+		key := row.Group + "\x00" + path
+		if prev, ok := seenFile[key]; ok {
+			f.Reason, f.Detail = DuplicateFile, "the first is "+prev
+			add(f)
+		} else {
+			seenFile[key] = row.ID
+		}
+
+		if resolve != nil {
+			if ok, checked := resolve.Resolves(path, line); checked && !ok {
+				f.Reason, f.Detail = Unresolved, ""
+				add(f)
+			}
+		}
+	}
+
+	if resolve == nil {
+		r.Unchecked = append(r.Unchecked, string(Unresolved))
+	}
+	r.Unchecked = append(r.Unchecked, freeRows(set, grep, add)...)
+	return r
+}
+
+// freeRows flags the rows whose location a covering grep for the anchor prints.
+//
+// It FLAGS, and the grep's size travels with every flag, because membership
+// alone is close to meaningless: a row inside a 4483-line grep is not free to
+// anybody. The law is explicit that this ranks and never kills.
+func freeRows(set scenario.Set, grep Grepper, add func(Finding)) []string {
+	symbol := set.Scenario.ContractSymbol
+	if grep == nil || symbol == "" {
+		return []string{string(InCoveringGrep)}
+	}
+	hits, total, checked := grep.Covering(symbol)
+	if !checked {
+		return []string{string(InCoveringGrep)}
+	}
+	for _, row := range set.Gold.Rows {
+		cite := row.Cite()
+		if cite == "" || !hits[cite] {
+			continue
+		}
+		add(Finding{
+			RowID: row.ID, Group: row.Group, Cite: cite, Reason: InCoveringGrep,
+			Detail: fmt.Sprintf("grep %q prints %d lines in all", symbol, total),
+		})
+	}
+	return nil
+}
+
+func splitCite(cite string) (path string, line int) {
+	i := strings.LastIndex(cite, ":")
+	if i <= 0 {
+		return cite, 0
+	}
+	n, err := strconv.Atoi(cite[i+1:])
+	if err != nil {
+		return cite, 0
+	}
+	return cite[:i], n
+}
+
+// String renders the report for a human, quarantines first.
+func (r Report) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s: %d gold rows, %d quarantined\n", r.Scenario, r.Rows, len(r.Quarantined))
+	byReason := map[Reason][]Finding{}
+	for _, f := range r.Findings {
+		byReason[f.Reason] = append(byReason[f.Reason], f)
+	}
+	reasons := make([]string, 0, len(byReason))
+	for reason := range byReason {
+		reasons = append(reasons, string(reason))
+	}
+	sort.Strings(reasons)
+	for _, reason := range reasons {
+		fs := byReason[Reason(reason)]
+		if !Reason(reason).Quarantines() {
+			// One line, not one per row: the detail is identical for every row
+			// and the size of the grep is the only part that carries meaning.
+			fmt.Fprintf(&b, "\n  flagged: %d of %d rows %s\n            %s\n",
+				len(fs), r.Rows, reason, fs[0].Detail)
+			continue
+		}
+		fmt.Fprintf(&b, "\n  QUARANTINED: %s (%d)\n", reason, len(fs))
+		for _, f := range fs {
+			fmt.Fprintf(&b, "    %s\n", f)
+		}
+	}
+	for _, u := range r.Unchecked {
+		fmt.Fprintf(&b, "\n  NOT CHECKED: %s\n", u)
+	}
+	return b.String()
+}

--- a/lab/internal/goldcheck/goldcheck.go
+++ b/lab/internal/goldcheck/goldcheck.go
@@ -200,16 +200,16 @@ func freeRows(set scenario.Set, grep Grepper, add func(Finding)) []string {
 	return nil
 }
 
+// splitCite separates a gold row's location.
+//
+// It cannot fail and has no error path, because a row's Cite is either empty or
+// matched by leadingCite, whose path part contains no colon and whose line part
+// is digits. Guarding against shapes neither side can produce would be three
+// branches nothing could ever take.
 func splitCite(cite string) (path string, line int) {
-	i := strings.LastIndex(cite, ":")
-	if i <= 0 {
-		return cite, 0
-	}
-	n, err := strconv.Atoi(cite[i+1:])
-	if err != nil {
-		return cite, 0
-	}
-	return cite[:i], n
+	path, num, _ := strings.Cut(cite, ":")
+	line, _ = strconv.Atoi(num)
+	return path, line
 }
 
 // String renders the report for a human, quarantines first.

--- a/lab/internal/goldcheck/goldcheck_test.go
+++ b/lab/internal/goldcheck/goldcheck_test.go
@@ -1,0 +1,340 @@
+package goldcheck
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/luuuc/sense/lab/internal/scenario"
+)
+
+// gold builds a Set from rows written inline, so each test reads as the shape
+// it is about rather than as a file somewhere else.
+func gold(t *testing.T, symbol string, rows ...scenario.GoldRow) scenario.Set {
+	t.Helper()
+	return scenario.Set{
+		Name:     "fixture",
+		Scenario: scenario.Scenario{Name: "fixture", ContractSymbol: symbol},
+		Gold:     scenario.Gold{Discriminator: "dependents", Rows: rows},
+	}
+}
+
+func row(id, group, relation string) scenario.GoldRow {
+	return scenario.GoldRow{ID: id, Group: group, Relation: relation}
+}
+
+func reasons(r Report) map[string]int {
+	out := map[string]int{}
+	for _, f := range r.Findings {
+		out[string(f.Reason)]++
+	}
+	return out
+}
+
+// THE recorded failure, against the gold that produced it.
+//
+// A scenario asked for specs and fixtures "using file:line throughout", and its
+// two gold rows named files with no line. They scored cited 0 of 2 in 10 of 10
+// runs for months, both arms, both models — and nothing about the file looks
+// wrong when you read it.
+func TestTheRecordedSpecFixtureRowsAreQuarantined(t *testing.T) {
+	b, err := os.ReadFile(filepath.Join("testdata", "spec-fixture.gold.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var g scenario.Gold
+	if err := yaml.Unmarshal(b, &g); err != nil {
+		t.Fatal(err)
+	}
+	set := scenario.Set{Name: "spec-fixture", Gold: g}
+
+	r := Audit(set, nil, nil)
+
+	want := []string{"spec:status", "spec:post-svc"}
+	if len(r.Quarantined) != len(want) {
+		t.Fatalf("quarantined %v, want exactly %v", r.Quarantined, want)
+	}
+	for i, id := range want {
+		if r.Quarantined[i] != id {
+			t.Errorf("quarantined[%d] = %q, want %q", i, r.Quarantined[i], id)
+		}
+	}
+	// And the row that IS citeable survives, or the check is just "reject
+	// everything" wearing a reason.
+	for _, id := range r.Quarantined {
+		if id == "d:real" {
+			t.Error("a row with a real location was quarantined")
+		}
+	}
+}
+
+func TestEveryQuarantineCarriesItsReason(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		set  scenario.Set
+		want Reason
+	}{
+		{
+			name: "a row with no location",
+			set:  gold(t, "", row("a", "dependents", "somewhere in the search code")),
+			want: NoLocation,
+		},
+		{
+			// One item per file, or a group is silently weighted toward
+			// whichever file happens to have the most matches in it.
+			name: "two rows of one group in the same file",
+			set: gold(t, "",
+				row("a", "dependents", "app/models/category.rb:12 the first"),
+				row("b", "dependents", "app/models/category.rb:99 the second")),
+			want: DuplicateFile,
+		},
+		{
+			name: "two rows sharing an id",
+			set: gold(t, "",
+				row("a", "dependents", "app/models/category.rb:12 the first"),
+				row("a", "contract", "app/models/other.rb:1 the second")),
+			want: DuplicateID,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := Audit(tc.set, nil, nil)
+			if len(r.Quarantined) == 0 {
+				t.Fatalf("nothing was quarantined:\n%s", r)
+			}
+			if got := reasons(r)[string(tc.want)]; got == 0 {
+				t.Errorf("no finding carried %q; got %v", tc.want, reasons(r))
+			}
+		})
+	}
+}
+
+// The same file in two DIFFERENT groups is fine: the rule is one item per file
+// per group, because that is where the weighting happens.
+func TestTheSameFileInTwoGroupsIsNotADuplicate(t *testing.T) {
+	set := gold(t, "",
+		row("c:anchor", "contract", "app/models/category.rb:1 the class itself"),
+		row("d:one", "dependents", "app/models/category.rb:1083 a dependent"))
+
+	if r := Audit(set, nil, nil); len(r.Quarantined) != 0 {
+		t.Errorf("quarantined %v across two groups:\n%s", r.Quarantined, r)
+	}
+}
+
+// stubResolver answers for exactly the locations it is given.
+type stubResolver map[string]bool
+
+func (s stubResolver) Resolves(path string, _ int) (ok, checked bool) {
+	return s[path], true
+}
+
+// A row pointing at a line that moved is not gold, it is history.
+func TestARowThatDoesNotResolveIsQuarantined(t *testing.T) {
+	set := gold(t, "",
+		row("a", "dependents", "app/models/category.rb:12 still there"),
+		row("b", "dependents", "app/models/moved.rb:40 not any more"))
+
+	r := Audit(set, stubResolver{"app/models/category.rb": true}, nil)
+
+	if len(r.Quarantined) != 1 || r.Quarantined[0] != "b" {
+		t.Errorf("quarantined %v, want just the row that moved", r.Quarantined)
+	}
+	if reasons(r)[string(Unresolved)] != 1 {
+		t.Errorf("the reason was not %q: %v", Unresolved, reasons(r))
+	}
+}
+
+// A validator that refused to run without a repository would be a validator
+// nobody runs. It audits what it can and NAMES what it could not, so a clean
+// report cannot be read as a complete one.
+func TestWithoutACheckoutItSaysWhatItCouldNotCheck(t *testing.T) {
+	set := gold(t, "Category", row("a", "dependents", "app/models/category.rb:12 fine"))
+
+	r := Audit(set, nil, nil)
+
+	if len(r.Quarantined) != 0 {
+		t.Errorf("quarantined %v with nothing to resolve against", r.Quarantined)
+	}
+	if len(r.Unchecked) != 2 {
+		t.Errorf("Unchecked = %v, want both resolution and the covering grep", r.Unchecked)
+	}
+	if got := r.String(); !strings.Contains(got, "NOT CHECKED") {
+		t.Errorf("a partial audit read as a complete one:\n%s", got)
+	}
+}
+
+type stubGrep struct {
+	hits  map[string]bool
+	total int
+}
+
+func (g stubGrep) Covering(string) (map[string]bool, int, bool) { return g.hits, g.total, true }
+
+// A free row RANKS and never kills. Run as a per-row census this check once
+// killed four shapes on a repository that banks +0.53, so it flags and the
+// human decides.
+func TestARowInsideTheCoveringGrepIsFlaggedAndNeverQuarantined(t *testing.T) {
+	set := gold(t, "Setting",
+		row("a", "dependents", "config/settings.rb:12 one Setting read"),
+		row("b", "dependents", "app/models/other.rb:4 not in the grep"))
+
+	r := Audit(set, nil, stubGrep{hits: map[string]bool{"config/settings.rb:12": true}, total: 18})
+
+	if len(r.Quarantined) != 0 {
+		t.Errorf("a free row was quarantined: %v", r.Quarantined)
+	}
+	if reasons(r)[string(InCoveringGrep)] != 1 {
+		t.Errorf("the free row was not flagged: %v", reasons(r))
+	}
+	// The size of the grep is the whole story: a row inside a 4483-line grep is
+	// not free to anybody, so the count travels with the flag.
+	if got := r.String(); !strings.Contains(got, "prints 18 lines") {
+		t.Errorf("the flag does not carry the grep's size:\n%s", got)
+	}
+}
+
+// The validator reports and never edits. A validator that also fixes what it
+// finds is a validator nobody can check.
+func TestAuditLeavesTheGoldAlone(t *testing.T) {
+	rows := []scenario.GoldRow{row("a", "dependents", "somewhere vague")}
+	set := gold(t, "", rows...)
+
+	Audit(set, nil, nil)
+
+	if rows[0].Relation != "somewhere vague" || rows[0].ID != "a" {
+		t.Errorf("the audit modified the row: %+v", rows[0])
+	}
+}
+
+// A finding reads as one line naming the row, where it points, and what is
+// wrong with it. It is the unit a human acts on, so it carries the location
+// rather than making them go and look it up.
+func TestAFindingReadsAsOneLine(t *testing.T) {
+	f := Finding{RowID: "d:one", Group: "dependents", Cite: "app/models/category.rb:12",
+		Reason: Unresolved, Detail: "moved in 2024"}
+
+	got := f.String()
+	for _, want := range []string{"d:one", "dependents", "app/models/category.rb:12", "moved in 2024"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("%q is missing from %q", want, got)
+		}
+	}
+	// A row with no location has none to print, and must not render an empty
+	// column that reads as a location of "".
+	bare := Finding{RowID: "a", Group: "specs", Reason: NoLocation}
+	if strings.Contains(bare.String(), "()") {
+		t.Errorf("an empty detail rendered as parentheses: %q", bare.String())
+	}
+}
+
+// Free rows RANK, everything else REMOVES. The distinction is the law, so it is
+// asserted on the type rather than left to each call site.
+func TestOnlyTheCoveringGrepFlagLeavesARowInPlace(t *testing.T) {
+	for _, r := range []Reason{NoLocation, Unresolved, DuplicateFile, DuplicateID} {
+		if !r.Quarantines() {
+			t.Errorf("%q does not quarantine", r)
+		}
+	}
+	if InCoveringGrep.Quarantines() {
+		t.Error("a free row was quarantined; the law says this ranks and never kills")
+	}
+}
+
+// A scenario naming no anchor has nothing to grep for, and the report says the
+// check did not run rather than reporting no free rows.
+func TestWithNoAnchorTheGrepCheckIsNamedAsSkipped(t *testing.T) {
+	set := gold(t, "", row("a", "dependents", "app/models/category.rb:12 fine"))
+
+	r := Audit(set, stubResolver{"app/models/category.rb": true}, stubGrep{})
+
+	if len(r.Unchecked) != 1 || r.Unchecked[0] != string(InCoveringGrep) {
+		t.Errorf("Unchecked = %v, want the covering grep named", r.Unchecked)
+	}
+}
+
+// A grepper that cannot answer is the same case as no grepper at all.
+type blindGrep struct{}
+
+func (blindGrep) Covering(string) (map[string]bool, int, bool) { return nil, 0, false }
+
+func TestAGrepperThatCannotAnswerIsNamedAsSkipped(t *testing.T) {
+	set := gold(t, "Category", row("a", "dependents", "app/models/category.rb:12 fine"))
+
+	r := Audit(set, nil, blindGrep{})
+
+	found := false
+	for _, u := range r.Unchecked {
+		if u == string(InCoveringGrep) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Unchecked = %v, want the covering grep named", r.Unchecked)
+	}
+}
+
+// A row with no location cannot be in a covering grep, and must not be counted
+// as one on the strength of an empty string matching an empty key.
+func TestARowWithNoLocationIsNotCountedAsFree(t *testing.T) {
+	set := gold(t, "Category", row("a", "specs", "models/status_spec.rb"))
+
+	r := Audit(set, nil, stubGrep{hits: map[string]bool{"": true}, total: 3})
+
+	if reasons(r)[string(InCoveringGrep)] != 0 {
+		t.Errorf("a row with no location was flagged as free: %v", reasons(r))
+	}
+}
+
+// A resolver that cannot answer for a row leaves it alone rather than
+// quarantining it for a question nobody could ask.
+type mutedResolver struct{}
+
+func (mutedResolver) Resolves(string, int) (bool, bool) { return false, false }
+
+func TestAResolverThatCannotAnswerQuarantinesNothing(t *testing.T) {
+	set := gold(t, "", row("a", "dependents", "app/models/category.rb:12 fine"))
+
+	if r := Audit(set, mutedResolver{}, nil); len(r.Quarantined) != 0 {
+		t.Errorf("quarantined %v on an answer nobody gave", r.Quarantined)
+	}
+}
+
+// A gold row whose location has no parseable line still has a path, and the
+// resolver is asked about the path rather than being handed a line of zero
+// that every checkout would refuse.
+func TestACiteWithNoParseableLineStillNamesItsPath(t *testing.T) {
+	if path, line := splitCite("app/models/category.rb"); path != "app/models/category.rb" || line != 0 {
+		t.Errorf("splitCite = (%q, %d)", path, line)
+	}
+	if path, line := splitCite("app/models/category.rb:notanumber"); line != 0 || path != "app/models/category.rb:notanumber" {
+		t.Errorf("splitCite = (%q, %d)", path, line)
+	}
+}
+
+// The report a human reads. Quarantines are listed row by row because each one
+// is a decision someone has to take with the scenario in front of them, and a
+// count alone does not tell them which rows to open.
+func TestTheReportListsEveryQuarantinedRow(t *testing.T) {
+	set := gold(t, "",
+		row("spec:status", "specs", "models/status_spec.rb"),
+		row("spec:post-svc", "specs", "services/post_status_service_spec.rb"),
+		row("d:fine", "dependents", "app/models/status.rb:12 a real one"))
+
+	got := Audit(set, nil, nil).String()
+
+	for _, want := range []string{
+		"3 gold rows, 2 quarantined",
+		"QUARANTINED: no path:line",
+		"spec:status",
+		"spec:post-svc",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("%q is missing from the report:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "d:fine") {
+		t.Errorf("a sound row appears in the report:\n%s", got)
+	}
+}

--- a/lab/internal/goldcheck/goldcheck_test.go
+++ b/lab/internal/goldcheck/goldcheck_test.go
@@ -49,9 +49,38 @@ func TestTheRecordedSpecFixtureRowsAreQuarantined(t *testing.T) {
 	if err := yaml.Unmarshal(b, &g); err != nil {
 		t.Fatal(err)
 	}
+	// Pinned to the recorded scenario, not merely to two ids. Without this the
+	// test passes against any two lineless rows carrying those names, and the
+	// nineteen lines of history in the fixture are a comment with a
+	// test-shaped decoration attached.
+	if len(g.Rows) != 3 {
+		t.Fatalf("the fixture has %d rows, want 3 including the citeable control", len(g.Rows))
+	}
+	for _, want := range []struct{ id, group, relation string }{
+		{"d:real", "dependents", "app/models/status.rb:12 a dependent with a real location"},
+		{"spec:status", "specs", "models/status_spec.rb"},
+		{"spec:post-svc", "specs", "services/post_status_service_spec.rb"},
+	} {
+		var found bool
+		for _, r := range g.Rows {
+			if r.ID == want.id {
+				found = true
+				if r.Group != want.group || r.Relation != want.relation {
+					t.Errorf("%s = (%q, %q), want (%q, %q)", want.id, r.Group, r.Relation, want.group, want.relation)
+				}
+			}
+		}
+		if !found {
+			t.Errorf("the fixture no longer has the row %q", want.id)
+		}
+	}
 	set := scenario.Set{Name: "spec-fixture", Gold: g}
 
 	r := Audit(set, nil, nil)
+
+	if r.Rows != 3 {
+		t.Errorf("audited %d rows, want 3", r.Rows)
+	}
 
 	want := []string{"spec:status", "spec:post-svc"}
 	if len(r.Quarantined) != len(want) {
@@ -180,7 +209,9 @@ func TestARowInsideTheCoveringGrepIsFlaggedAndNeverQuarantined(t *testing.T) {
 		row("a", "dependents", "config/settings.rb:12 one Setting read"),
 		row("b", "dependents", "app/models/other.rb:4 not in the grep"))
 
-	r := Audit(set, nil, stubGrep{hits: map[string]bool{"config/settings.rb:12": true}, total: 18})
+	// A distinctive count, so a validator that fabricates the number rather
+	// than reporting the grepper's is not green.
+	r := Audit(set, nil, stubGrep{hits: map[string]bool{"config/settings.rb:12": true}, total: 4483})
 
 	if len(r.Quarantined) != 0 {
 		t.Errorf("a free row was quarantined: %v", r.Quarantined)
@@ -190,21 +221,36 @@ func TestARowInsideTheCoveringGrepIsFlaggedAndNeverQuarantined(t *testing.T) {
 	}
 	// The size of the grep is the whole story: a row inside a 4483-line grep is
 	// not free to anybody, so the count travels with the flag.
-	if got := r.String(); !strings.Contains(got, "prints 18 lines") {
-		t.Errorf("the flag does not carry the grep's size:\n%s", got)
+	if got := r.String(); !strings.Contains(got, "prints 4483 lines") {
+		t.Errorf("the flag does not carry the grep's own size:\n%s", got)
+	}
+	// And the size never turns the flag into a quarantine, however large. A row
+	// inside a 4483-line grep is not free to anybody, but that is a judgement
+	// for a human and never a rejection here.
+	if len(r.Quarantined) != 0 {
+		t.Errorf("a large covering grep quarantined %v", r.Quarantined)
 	}
 }
 
-// The validator reports and never edits. A validator that also fixes what it
-// finds is a validator nobody can check.
-func TestAuditLeavesTheGoldAlone(t *testing.T) {
-	rows := []scenario.GoldRow{row("a", "dependents", "somewhere vague")}
-	set := gold(t, "", rows...)
+// A row with no location has exactly ONE thing wrong with it.
+//
+// Checking it for duplicate files and for resolution invents reasons that are
+// false: splitCite("") gives an empty path, every such row collides with every
+// other in seenFile, and the empty path then goes to a real checkout. The
+// report would tell a human that two rows in two different files are the same
+// file and that both moved at the pinned commit. Neither is true, and every
+// other test in this file agrees with it, because they all assert that a reason
+// is PRESENT and none asserts that a reason is absent.
+func TestARowWithNoLocationCollectsNoOtherReason(t *testing.T) {
+	set := gold(t, "",
+		row("spec:a", "specs", "models/status_spec.rb"),
+		row("spec:b", "specs", "services/post_status_service_spec.rb"))
 
-	Audit(set, nil, nil)
+	r := Audit(set, stubResolver{}, nil)
 
-	if rows[0].Relation != "somewhere vague" || rows[0].ID != "a" {
-		t.Errorf("the audit modified the row: %+v", rows[0])
+	got := reasons(r)
+	if len(got) != 1 || got[string(NoLocation)] != 2 {
+		t.Errorf("reasons = %v, want only NoLocation twice", got)
 	}
 }
 
@@ -298,18 +344,6 @@ func TestAResolverThatCannotAnswerQuarantinesNothing(t *testing.T) {
 
 	if r := Audit(set, mutedResolver{}, nil); len(r.Quarantined) != 0 {
 		t.Errorf("quarantined %v on an answer nobody gave", r.Quarantined)
-	}
-}
-
-// A gold row whose location has no parseable line still has a path, and the
-// resolver is asked about the path rather than being handed a line of zero
-// that every checkout would refuse.
-func TestACiteWithNoParseableLineStillNamesItsPath(t *testing.T) {
-	if path, line := splitCite("app/models/category.rb"); path != "app/models/category.rb" || line != 0 {
-		t.Errorf("splitCite = (%q, %d)", path, line)
-	}
-	if path, line := splitCite("app/models/category.rb:notanumber"); line != 0 || path != "app/models/category.rb:notanumber" {
-		t.Errorf("splitCite = (%q, %d)", path, line)
 	}
 }
 

--- a/lab/internal/goldcheck/testdata/spec-fixture.gold.yaml
+++ b/lab/internal/goldcheck/testdata/spec-fixture.gold.yaml
@@ -1,0 +1,19 @@
+# The RECORDED failure, copied from the mastodon banked-status-control scenario.
+#
+# Its step asked for "the specs/fixtures that must be updated or added to cover
+# the behavior. Use file:line throughout", and these two rows name a file with
+# no line. They scored mentioned 2 of 2 in 8 of 10 runs and cited 0 of 2 in 10
+# of 10, both arms, both models, for months: the arms did the work and named the
+# files in the only natural form, because a line number is meaningless for a
+# file that does not exist yet.
+discriminator: dependents
+rows:
+  - id: d:real
+    group: dependents
+    relation: "app/models/status.rb:12 a dependent with a real location"
+  - id: spec:status
+    group: specs
+    relation: "models/status_spec.rb"
+  - id: spec:post-svc
+    group: specs
+    relation: "services/post_status_service_spec.rb"

--- a/lab/internal/ground/ground.go
+++ b/lab/internal/ground/ground.go
@@ -245,3 +245,52 @@ func (r Report) String() string {
 	return fmt.Sprintf("grounding   %d of %d cited locations do not resolve at the pinned commit\n",
 		len(r.Ungrounded), r.Checked)
 }
+
+// Resolves reports whether path has that line at the pinned commit. It is the
+// gold validator's Resolver: a row pointing at a line that moved is not gold,
+// it is history, and that is the same question grounding already answers.
+func (c *Checkout) Resolves(path string, line int) (ok, checked bool) {
+	if c == nil {
+		return false, false
+	}
+	n, exists := c.lineCount(path)
+	return exists && line <= n && line > 0, true
+}
+
+// Covering returns the locations a plain grep for the anchor prints, and how
+// many lines that is.
+//
+// This is what the baseline gets for free. A gold row inside this output floors
+// the baseline and shrinks the achievable margin before either arm runs, which
+// is worth knowing and is never worth killing a scenario over — run as a
+// per-row census it once killed four shapes on a repository that banks +0.53.
+func (c *Checkout) Covering(symbol string) (hits map[string]bool, total int, checked bool) {
+	if c == nil || symbol == "" {
+		return nil, 0, false
+	}
+	out, err := c.git(c.dir, "grep", "-n", "--fixed-strings", symbol, c.commit)
+	if err != nil {
+		// git grep exits 1 on no match, which is a real answer rather than a
+		// failure: nothing is free if the anchor appears nowhere.
+		return map[string]bool{}, 0, true
+	}
+	hits = map[string]bool{}
+	for _, line := range strings.Split(strings.TrimRight(string(out), "\n"), "\n") {
+		// <commit>:<path>:<line>:<text>
+		rest, ok := strings.CutPrefix(line, c.commit+":")
+		if !ok {
+			continue
+		}
+		path, after, ok := strings.Cut(rest, ":")
+		if !ok {
+			continue
+		}
+		num, _, _ := strings.Cut(after, ":")
+		if _, err := strconv.Atoi(num); err != nil {
+			continue
+		}
+		hits[path+":"+num] = true
+		total++
+	}
+	return hits, total, true
+}

--- a/lab/internal/ground/ground_test.go
+++ b/lab/internal/ground/ground_test.go
@@ -16,6 +16,7 @@ import (
 type fakeGit struct {
 	commit string
 	files  map[string]string
+	grep   []string // "path:line" entries a covering grep would print
 	calls  int
 }
 
@@ -29,6 +30,16 @@ func (f *fakeGit) run(_ string, args ...string) ([]byte, error) {
 			return nil, nil
 		}
 		return nil, errors.New("not a commit")
+	case "grep":
+		// <commit>:<path>:<line>:<text>, which is what `git grep -n <rev>` emits.
+		if len(f.grep) == 0 {
+			return nil, errors.New("no matches")
+		}
+		var b strings.Builder
+		for _, hit := range f.grep {
+			b.WriteString(f.commit + ":" + hit + ":the line\n")
+		}
+		return []byte(b.String()), nil
 	case "show":
 		_, path, _ := strings.Cut(args[1], ":")
 		if body, ok := f.files[path]; ok {
@@ -397,4 +408,97 @@ func TestItReadsThePinnedCommitAndNotTheCurrentOne(t *testing.T) {
 		t.Error("a line that only exists at HEAD resolved against the pinned commit")
 	}
 
+}
+
+// Resolves is the gold validator's view of the same question grounding already
+// answers: is this location there at the pinned commit?
+func TestResolvesAnswersForTheValidator(t *testing.T) {
+	c, _ := repo(t)
+
+	for _, tc := range []struct {
+		name       string
+		path       string
+		line       int
+		ok, checkd bool
+	}{
+		{"a real line", "app/models/category.rb", 3, true, true},
+		{"past the end", "app/models/category.rb", 4, false, true},
+		{"line zero is not a line", "app/models/category.rb", 0, false, true},
+		{"a file that is not there", "app/models/nope.rb", 1, false, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, checked := c.Resolves(tc.path, tc.line)
+			if ok != tc.ok || checked != tc.checkd {
+				t.Errorf("Resolves = (%v, %v), want (%v, %v)", ok, checked, tc.ok, tc.checkd)
+			}
+		})
+	}
+
+	var absent *Checkout
+	if _, checked := absent.Resolves("app/models/category.rb", 1); checked {
+		t.Error("a nil checkout claimed to have checked something")
+	}
+}
+
+// Covering is what the baseline gets for free, and the SIZE is the whole story:
+// a row inside a 4483-line grep is not free to anybody.
+func TestCoveringReportsTheGrepAndItsSize(t *testing.T) {
+	g := &fakeGit{
+		commit: "abc123",
+		grep:   []string{"app/models/category.rb:12", "app/models/other.rb:4"},
+	}
+	c, err := open("/repo", "abc123", g.run)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hits, total, checked := c.Covering("Category")
+	if !checked {
+		t.Fatal("Covering reported it could not check")
+	}
+	if total != 2 {
+		t.Errorf("total = %d, want 2", total)
+	}
+	if !hits["app/models/category.rb:12"] || hits["app/models/nowhere.rb:1"] {
+		t.Errorf("hits = %v", hits)
+	}
+
+	t.Run("an anchor that appears nowhere is a real answer", func(t *testing.T) {
+		empty := &fakeGit{commit: "abc123"}
+		c, _ := open("/repo", "abc123", empty.run)
+		hits, total, checked := c.Covering("Nowhere")
+		if !checked || total != 0 || len(hits) != 0 {
+			t.Errorf("got (%v, %d, %v), want an empty but checked answer", hits, total, checked)
+		}
+	})
+
+	t.Run("nothing to grep for", func(t *testing.T) {
+		if _, _, checked := c.Covering(""); checked {
+			t.Error("Covering claimed to check an empty anchor")
+		}
+		var absent *Checkout
+		if _, _, checked := absent.Covering("Category"); checked {
+			t.Error("a nil checkout claimed to have grepped")
+		}
+	})
+}
+
+// git grep output that is not the shape this expects is skipped rather than
+// half-parsed into a location nobody cited.
+func TestCoveringIgnoresLinesThatAreNotHits(t *testing.T) {
+	g := &fakeGit{commit: "abc123"}
+	c, _ := open("/repo", "abc123", func(dir string, args ...string) ([]byte, error) {
+		if args[0] == "grep" {
+			return []byte("abc123:app/models/category.rb:12:real\n" +
+				"some binary file matches\n" +
+				"abc123:app/models/x.rb:notanumber:nope\n" +
+				"abc123:justapath\n"), nil
+		}
+		return g.run(dir, args...)
+	})
+
+	hits, total, _ := c.Covering("Category")
+	if total != 1 || !hits["app/models/category.rb:12"] {
+		t.Errorf("got %v (total %d), want only the well-formed hit", hits, total)
+	}
 }

--- a/lab/internal/scenario/scenario.go
+++ b/lab/internal/scenario/scenario.go
@@ -16,10 +16,15 @@ import (
 
 // Scenario is the subset of a scenario file the skeleton uses.
 type Scenario struct {
-	Name        string `yaml:"name"`
-	Repo        string `yaml:"repo"`
-	Description string `yaml:"description"`
-	Steps       []Step `yaml:"steps"`
+	Name string `yaml:"name"`
+	Repo string `yaml:"repo"`
+	// ContractSymbol is the anchor the session is about. The gold validator
+	// needs it: what a covering grep for the anchor prints is what the baseline
+	// gets for free, and a row inside that output shrinks the achievable margin
+	// before either arm runs.
+	ContractSymbol string `yaml:"contract_symbol"`
+	Description    string `yaml:"description"`
+	Steps          []Step `yaml:"steps"`
 }
 
 // GoldRow is one thing a good answer has to find. The corpus keeps the row's


### PR DESCRIPTION
## Problem

Gold is hand-audited, and that is why the numbers mean anything. It is also where the expensive mistakes live, and neither recorded one looks wrong when you read the file:

- **A row that can never score.** A scenario asked for the specs and fixtures that must be updated or added, *using file:line throughout*, and its two gold rows named files with **no line at all**. They scored mentioned 2 of 2 in 8 of 10 runs and cited **0 of 2 in 10 of 10** — both arms, both models, for months. The arms did the work and named the files in the only natural form, because a line number is meaningless for a file that does not exist yet.
- **A row that is free.** Eighteen rows each a single `Setting.<key>` read scored 17 of 18 to a baseline in nine tool calls.

154 hand-audited rows are about to become the regression corpus. Whatever is wrong in them becomes wrong in every future comparison.

## Summary

`sense-lab validate` audits gold against the rails the laws already state. Every quarantine carries a named reason: no `path:line`, does not resolve at the pinned commit, a second row of the same group in the same file, a duplicate id.

It **reports and never edits** — a validator that also fixes what it finds is a validator nobody can check.

## What it found on the shipped corpus

All 154 rows validated: **129 pass, 25 quarantined** — every `rails` row, none of which carries a `path:line`, so nothing an arm could write would ever match one. The command also names the **33 recorded runs** whose scores that quarantine moves, which 02-06 meets as a prediction rather than as a surprise.

## The free-row flag nearly became the trap it exists to catch

The first version flagged 19 of 23 discourse rows as free. But the covering grep for `Category` prints **4483 lines** — reading 4483 lines to find 23 is not free, it is the work the scenario is asking for. Membership alone means very little, so the flag carries the grep's size and stays a flag. The law is explicit that this ranks and never kills: run as a per-row census it once killed four shapes on a repository that banks +0.53.

## Fixes found by council review

The tests enforced that a quarantine carries a reason, and never that the reason was **true**. Losing one `continue` was green, and produced a report stating that two rows in two different files were the same file and that both had moved. Every assertion checked a reason was present; none checked one was absent.

The recorded fixture was also unpinned — deleting its citeable control row, or rewriting both spec rows to unrelated text, left the suite green.

## Test plan

- `make ci` green; **100% line and function coverage across every lab file**.
- Mutation-checked: 15 of 18 died on the first pass; all four survivors (the missing `continue`, the two fixture rewrites, and a fabricated grep count) now die.

## Note on scope

The corpus *crossing* landed in 02-02, not here — this pitch adds validation on arrival. Since the files are content-hashed, re-running the crossing is already a no-op, which is the idempotence the pitch asked for.