### PR TITLE
bench(lab): the rescore proof, with zero unexplained differences

### DIFF
--- a/lab/internal/cli/cli.go
+++ b/lab/internal/cli/cli.go
@@ -33,6 +33,7 @@ Commands:
   run       Run one scenario against one repository
   score     Score a recorded run against a scenario's gold
   validate  Audit a scenario's gold and report what would be quarantined
+  rescore   Recompute every recorded score and name the cause of each difference
   version   Print version
 `
 
@@ -91,6 +92,8 @@ func Run(args []string, stdout, stderr io.Writer) int {
 		return scoreRun(args[1:], stdout, stderr)
 	case "validate":
 		return validateGold(args[1:], stdout, stderr)
+	case "rescore":
+		return rescoreRuns(args[1:], stdout, stderr)
 	case "version":
 		_, _ = fmt.Fprintln(stdout, Version)
 		return exitOK

--- a/lab/internal/cli/rescorecmd.go
+++ b/lab/internal/cli/rescorecmd.go
@@ -1,0 +1,230 @@
+package cli
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/luuuc/sense/lab/internal/rescore"
+	"github.com/luuuc/sense/lab/internal/scenario"
+	"github.com/luuuc/sense/lab/internal/score"
+	"github.com/luuuc/sense/lab/internal/transcript"
+)
+
+// recordedScore is the part of the old scorer's output this reads.
+//
+// It carries per-group counts AND a per-row list, which is what makes the
+// comparison an accounting rather than a difference of two totals: without the
+// rows, "credited two more" and "credited two different ones" look the same.
+type recordedScore struct {
+	GoldRecall struct {
+		Groups map[string]struct {
+			Total int `json:"total"`
+			Cited int `json:"cited"`
+		} `json:"groups"`
+		Details []struct {
+			ID    string `json:"id"`
+			Cited bool   `json:"cited"`
+		} `json:"details"`
+	} `json:"gold_recall"`
+}
+
+type rescoreFlags struct {
+	results   string
+	scenarios string
+	preFix    string
+}
+
+func parseRescoreFlags(args []string, stderr io.Writer) (rescoreFlags, error) {
+	var f rescoreFlags
+	fs := flag.NewFlagSet("rescore", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.StringVar(&f.results, "results", "", "recorded results tree (required)")
+	fs.StringVar(&f.scenarios, "scenarios", "lab/scenarios", "directory of scenario sets")
+	fs.StringVar(&f.preFix, "pre-fix", "", "file listing the runs whose scores predate the symbol-oracle fix")
+	if err := fs.Parse(args); err != nil {
+		return f, err
+	}
+	if f.results == "" {
+		return f, fmt.Errorf("-results is required")
+	}
+	return f, nil
+}
+
+// rescoreRuns recomputes every recorded score and accounts for the differences.
+//
+// It is one command because cycle 06 reruns it whenever the scorer changes: a
+// proof that has to be reassembled by hand is a proof nobody reruns.
+func rescoreRuns(args []string, stdout, stderr io.Writer) int {
+	f, err := parseRescoreFlags(args, stderr)
+	if err != nil {
+		if err != flag.ErrHelp {
+			_, _ = fmt.Fprintf(stderr, "sense-lab rescore: %v\n", err)
+		}
+		return exitUsage
+	}
+
+	sets := loadScenarios(f.scenarios)
+	if len(sets) == 0 {
+		_, _ = fmt.Fprintf(stderr, "sense-lab rescore: no scenarios under %s\n", f.scenarios)
+		return exitError
+	}
+	preFix := readPreFix(f.preFix)
+
+	report, skipped := walkRecorded(f.results, sets, preFix)
+	if len(report.Rows) == 0 {
+		_, _ = fmt.Fprintf(stderr, "sense-lab rescore: nothing to compare under %s\n", f.results)
+		return exitError
+	}
+	_, _ = fmt.Fprint(stdout, report.String())
+	if skipped > 0 {
+		_, _ = fmt.Fprintf(stdout, "\n%d recorded runs were not comparable (no gold recall, or no readable capture)\n", skipped)
+	}
+	if len(report.Unexplained()) > 0 {
+		return exitBelowFloor
+	}
+	return exitOK
+}
+
+func loadScenarios(dir string) map[string]scenario.Set {
+	sets := map[string]scenario.Set{}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return sets
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if s, err := scenario.Load(filepath.Join(dir, e.Name()), e.Name()); err == nil {
+			sets[e.Name()] = s
+		}
+	}
+	return sets
+}
+
+// readPreFix reads the run keys whose recorded scores predate the fix.
+//
+// The list is written down BEFORE the comparison, from the artifacts' own
+// dates, so `scorer version` is a prediction that can be wrong rather than a
+// label assigned to whatever turns out to disagree.
+func readPreFix(path string) map[string]bool {
+	out := map[string]bool{}
+	if path == "" {
+		return out
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return out
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		if !strings.HasPrefix(line, "|") {
+			continue
+		}
+		cells := strings.Split(line, "|")
+		if len(cells) < 6 {
+			continue
+		}
+		repo, model, arm, run := trim(cells[2]), trim(cells[3]), trim(cells[4]), trim(cells[5])
+		// The header and the markdown separator are not runs.
+		if repo == "" || repo == "repo" || strings.HasPrefix(repo, "-") {
+			continue
+		}
+		out[strings.Join([]string{model, repo, arm, run}, "/")] = true
+	}
+	return out
+}
+
+func trim(s string) string { return strings.TrimSpace(s) }
+
+func walkRecorded(root string, sets map[string]scenario.Set, preFix map[string]bool) (rescore.Report, int) {
+	var report rescore.Report
+	skipped := 0
+
+	_ = filepath.Walk(root, func(p string, fi os.FileInfo, err error) error {
+		if err != nil || fi.IsDir() || fi.Name() != "scored.json" {
+			return nil
+		}
+		model, repo, arm, run, ok := runKey(p)
+		if !ok {
+			return nil
+		}
+		set, known := sets[repo]
+		if !known {
+			return nil
+		}
+		rows, ran := compareRun(p, set, model, repo, arm, run, preFix)
+		if !ran {
+			skipped++
+			return nil
+		}
+		report.Rows = append(report.Rows, rows...)
+		return nil
+	})
+	return report, skipped
+}
+
+// runKey pulls model, repo, arm and run out of a recorded run's path. The
+// directories under a results tree ARE the identity of a cell.
+func runKey(p string) (model, repo, arm, run string, ok bool) {
+	parts := strings.Split(filepath.ToSlash(p), "/results/")
+	if len(parts) < 2 {
+		return "", "", "", "", false
+	}
+	seg := strings.Split(parts[1], "/")
+	if len(seg) < 5 || (seg[2] != "sense" && seg[2] != "baseline") || strings.HasPrefix(seg[3], "_") {
+		return "", "", "", "", false
+	}
+	return seg[0], seg[3], seg[2], seg[4], true
+}
+
+func compareRun(p string, set scenario.Set, model, repo, arm, run string, preFix map[string]bool) ([]rescore.Row, bool) {
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return nil, false
+	}
+	var rec recordedScore
+	if json.Unmarshal(b, &rec) != nil || len(rec.GoldRecall.Groups) == 0 {
+		return nil, false
+	}
+	tr, err := transcript.ReadClaudeCode(filepath.Join(filepath.Dir(p), "transcript.json"))
+	if err != nil || strings.TrimSpace(tr.Answer()) == "" {
+		return nil, false
+	}
+	oldCited := map[string]bool{}
+	for _, d := range rec.GoldRecall.Details {
+		oldCited[d.ID] = d.Cited
+	}
+	cites := score.Scan(tr.Answer())
+	isPre := preFix[strings.Join([]string{model, repo, arm, run}, "/")]
+
+	var out []rescore.Row
+	for group, g := range rec.GoldRecall.Groups {
+		gold, err := set.Gold.Group(group)
+		// A group whose gold this cycle quarantined answers a different
+		// question now, and that is a named cause rather than a skipped row.
+		if err != nil || len(gold) == 0 {
+			out = append(out, rescore.Row{
+				Repo: repo, Model: model, Arm: arm, Run: run, Group: group,
+				Recorded: g.Cited, Total: g.Total, PreFix: isPre, Quarantined: true,
+			})
+			continue
+		}
+		gr := make([]score.Row, 0, len(gold))
+		for _, x := range gold {
+			gr = append(gr, score.Row{ID: x.ID, Cite: x.Cite()})
+		}
+		r := score.GroupCites(group, gr, cites, "", 0.5)
+		fileLevel, uncited := rescore.Split(cites, gr, oldCited)
+		out = append(out, rescore.Row{
+			Repo: repo, Model: model, Arm: arm, Run: run, Group: group,
+			Recorded: g.Cited, Now: r.Cited, Total: g.Total,
+			PreFix: isPre, FileLevel: fileLevel, Uncited: uncited,
+		})
+	}
+	return out, true
+}

--- a/lab/internal/cli/rescorecmd_test.go
+++ b/lab/internal/cli/rescorecmd_test.go
@@ -1,0 +1,347 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// recordedTree builds a results tree the way the old bench left one: a run
+// directory holding the capture it produced and the score it was given.
+func recordedTree(t *testing.T, scored, answer string) string {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, "results", "opus", "hash", "sense", "discourse", "run-1")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"type":"assistant","message":{"content":[{"type":"text","text":` + quote(answer) + `}]}}` + "\n" +
+		`{"type":"result","session_id":"s"}` + "\n"
+	for name, content := range map[string]string{
+		"scored.json":     scored,
+		"transcript.json": body,
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+func quote(s string) string {
+	return `"` + strings.ReplaceAll(strings.ReplaceAll(s, `\`, `\\`), `"`, `\"`) + `"`
+}
+
+// scenarioDir writes one scenario set into a directory laid out the way the
+// rescore command expects to find them.
+func scenarioDir(t *testing.T, name, scenario, gold, rubric string) string {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for suffix, content := range map[string]string{
+		".yaml":        scenario,
+		".gold.yaml":   gold,
+		".rubric.yaml": rubric,
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name+suffix), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+const discourseGold = `discriminator: dependents
+rows:
+  - id: d:one
+    group: dependents
+    relation: "app/models/category.rb:1083 the entry point"
+  - id: d:two
+    group: dependents
+    relation: "lib/tasks/search.rake:32 the reindex task"
+`
+
+// The old scorer credited both rows. The answer names the first file at the
+// wrong line and the second at the right one, so the new scorer credits one.
+const recordedBoth = `{"gold_recall":{"groups":{"dependents":{"total":2,"cited":2}},
+"details":[{"id":"d:one","cited":true},{"id":"d:two","cited":true}]}}`
+
+func TestRescoreNamesTheCauseOfEveryDifference(t *testing.T) {
+	results := recordedTree(t, recordedBoth,
+		"Found app/models/category.rb:40 and lib/tasks/search.rake:32.")
+	scenarios := scenarioDir(t, "discourse", scoredScenario, discourseGold, scoredRubric)
+
+	code, stdout, stderr := dispatch(t, "rescore", "-results", results, "-scenarios", scenarios)
+
+	if !strings.Contains(stdout, "the right file at a line gold does not name") {
+		t.Errorf("the cause was not named:\n%s\n%s", stdout, stderr)
+	}
+	if strings.Contains(stdout, "UNEXPLAINED") {
+		t.Errorf("a difference went unexplained:\n%s", stdout)
+	}
+	if code != exitOK {
+		t.Errorf("exit code = %d, want %d when everything is accounted for", code, exitOK)
+	}
+}
+
+// Zero unexplained is what closes the pitch, so a difference nothing accounts
+// for has to fail the command rather than print quietly.
+func TestRescoreFailsWhileAnythingIsUnexplained(t *testing.T) {
+	// The old scorer credited NEITHER row, and the answer cites one exactly, so
+	// the new score is HIGHER with no pre-fix list to explain it.
+	recorded := `{"gold_recall":{"groups":{"dependents":{"total":2,"cited":0}},"details":[]}}`
+	results := recordedTree(t, recorded, "Found app/models/category.rb:1083.")
+	scenarios := scenarioDir(t, "discourse", scoredScenario, discourseGold, scoredRubric)
+
+	code, stdout, _ := dispatch(t, "rescore", "-results", results, "-scenarios", scenarios)
+
+	if !strings.Contains(stdout, "UNEXPLAINED. The cycle stays open") {
+		t.Errorf("an unexplained difference was not surfaced:\n%s", stdout)
+	}
+	if code == exitOK {
+		t.Errorf("exit code = %d; an unexplained difference must not pass", code)
+	}
+}
+
+// And the same difference, with the pre-fix list saying this run predates the
+// symbol-oracle fix. Now it has a cause, and the command passes.
+func TestRescoreReadsThePreFixListWrittenBeforeTheComparison(t *testing.T) {
+	recorded := `{"gold_recall":{"groups":{"dependents":{"total":2,"cited":0}},"details":[]}}`
+	results := recordedTree(t, recorded, "Found app/models/category.rb:1083.")
+	scenarios := scenarioDir(t, "discourse", scoredScenario, discourseGold, scoredRubric)
+
+	list := filepath.Join(t.TempDir(), "pre-fix.md")
+	if err := os.WriteFile(list, []byte(
+		"| when | repo | model | arm | run | dated by |\n"+
+			"|---|---|---|---|---|---|\n"+
+			"| 2026-08-01 | discourse | opus | sense | run-1 | run_meta |\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code, stdout, _ := dispatch(t, "rescore",
+		"-results", results, "-scenarios", scenarios, "-pre-fix", list)
+
+	if !strings.Contains(stdout, "scorer version") {
+		t.Errorf("the pre-fix list was not read:\n%s", stdout)
+	}
+	if code != exitOK {
+		t.Errorf("exit code = %d, want %d", code, exitOK)
+	}
+}
+
+// A group whose gold this cycle quarantined answers a different question now.
+// It is a named cause, not a row quietly dropped from the comparison.
+func TestRescoreCallsAQuarantinedGroupAGoldChange(t *testing.T) {
+	unciteable := `discriminator: dependents
+rows:
+  - id: d:vague
+    group: dependents
+    relation: "somewhere in the search code"
+`
+	results := recordedTree(t, recordedBoth, "Found app/models/category.rb:1083.")
+	scenarios := scenarioDir(t, "discourse", scoredScenario, unciteable, scoredRubric)
+
+	_, stdout, _ := dispatch(t, "rescore", "-results", results, "-scenarios", scenarios)
+
+	if !strings.Contains(stdout, "gold change") {
+		t.Errorf("a quarantined group was not called a gold change:\n%s", stdout)
+	}
+}
+
+// A recorded run with no readable capture cannot be compared, and saying so is
+// the difference between "they all agreed" and "I could not look".
+func TestRescoreSaysHowManyRunsItCouldNotCompare(t *testing.T) {
+	results := recordedTree(t, recordedBoth, "Found app/models/category.rb:1083.")
+	scenarios := scenarioDir(t, "discourse", scoredScenario, discourseGold, scoredRubric)
+	// A second run whose capture is empty.
+	dir := filepath.Join(results, "results", "opus", "hash", "baseline", "discourse", "run-1")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, body := range map[string]string{"scored.json": recordedBoth, "transcript.json": ""} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	_, stdout, _ := dispatch(t, "rescore", "-results", results, "-scenarios", scenarios)
+
+	if !strings.Contains(stdout, "1 recorded runs were not comparable") {
+		t.Errorf("the uncomparable run was not reported:\n%s", stdout)
+	}
+}
+
+func TestRescoreRefusesWithoutTheThingsItNeeds(t *testing.T) {
+	scenarios := scenarioDir(t, "discourse", scoredScenario, discourseGold, scoredRubric)
+
+	t.Run("no results tree", func(t *testing.T) {
+		code, _, stderr := dispatch(t, "rescore")
+		if code != exitUsage || !strings.Contains(stderr, "-results is required") {
+			t.Errorf("code = %d, stderr = %q", code, stderr)
+		}
+	})
+	t.Run("a flag it does not have", func(t *testing.T) {
+		if code, _, _ := dispatch(t, "rescore", "-nope"); code != exitUsage {
+			t.Errorf("code = %d, want %d", code, exitUsage)
+		}
+	})
+	t.Run("no scenarios to score against", func(t *testing.T) {
+		code, _, stderr := dispatch(t, "rescore", "-results", t.TempDir(), "-scenarios", t.TempDir())
+		if code != exitError || !strings.Contains(stderr, "no scenarios") {
+			t.Errorf("code = %d, stderr = %q", code, stderr)
+		}
+	})
+	t.Run("nothing recorded to compare", func(t *testing.T) {
+		code, _, stderr := dispatch(t, "rescore", "-results", t.TempDir(), "-scenarios", scenarios)
+		if code != exitError || !strings.Contains(stderr, "nothing to compare") {
+			t.Errorf("code = %d, stderr = %q", code, stderr)
+		}
+	})
+	t.Run("a pre-fix list that is not there", func(t *testing.T) {
+		results := recordedTree(t, recordedBoth, "Found app/models/category.rb:40.")
+		// A missing list is not an error: it means nothing is known to predate
+		// the fix, which is the safe reading, and the run still gets accounted.
+		if code, _, _ := dispatch(t, "rescore", "-results", results,
+			"-scenarios", scenarios, "-pre-fix", filepath.Join(t.TempDir(), "nope.md")); code != exitOK {
+			t.Errorf("code = %d, want %d", code, exitOK)
+		}
+	})
+}
+
+// The paths and files this walks are produced by another program, so every
+// shape it can hand over has to be handled rather than assumed away.
+func TestRescoreSkipsWhatIsNotARecordedRun(t *testing.T) {
+	results := recordedTree(t, recordedBoth, "Found app/models/category.rb:40.")
+	scenarios := scenarioDir(t, "discourse", scoredScenario, discourseGold, scoredRubric)
+
+	base := filepath.Join(results, "results", "opus", "hash")
+	for _, tc := range []struct{ dir, scored, transcript string }{
+		// Not an arm we know, so not a run.
+		{filepath.Join(base, "sideways", "discourse", "run-1"), recordedBoth, "{}"},
+		// An arm and a repo we do not ship a scenario for.
+		{filepath.Join(base, "sense", "unknown-repo", "run-1"), recordedBoth, "{}"},
+		// A parked run, which the leading underscore marks.
+		{filepath.Join(base, "sense", "_pre-harness-fix-discourse", "run-1"), recordedBoth, "{}"},
+		// A score file that is not JSON.
+		{filepath.Join(base, "sense", "discourse", "run-2"), "not json at all", "{}"},
+		// A score file with no gold recall in it.
+		{filepath.Join(base, "sense", "discourse", "run-3"), `{"efficiency":0.5}`, "{}"},
+	} {
+		if err := os.MkdirAll(tc.dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for name, body := range map[string]string{"scored.json": tc.scored, "transcript.json": tc.transcript} {
+			if err := os.WriteFile(filepath.Join(tc.dir, name), []byte(body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	// A scored.json somewhere with no results segment above it at all.
+	stray := filepath.Join(results, "stray")
+	if err := os.MkdirAll(stray, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stray, "scored.json"), []byte(recordedBoth), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code, stdout, _ := dispatch(t, "rescore", "-results", results, "-scenarios", scenarios)
+
+	// The one real run is still compared, and nothing above turned into a row.
+	if !strings.Contains(stdout, "group-scores compared 1") {
+		t.Errorf("the walk picked up something that is not a recorded run:\n%s", stdout)
+	}
+	if code != exitOK {
+		t.Errorf("exit code = %d", code)
+	}
+}
+
+// A scenario directory holding something that is not a scenario is skipped
+// rather than failing the whole rescore.
+func TestRescoreSkipsWhatIsNotAScenario(t *testing.T) {
+	scenarios := scenarioDir(t, "discourse", scoredScenario, discourseGold, scoredRubric)
+	if err := os.WriteFile(filepath.Join(scenarios, "loose-file.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(scenarios, "not-a-scenario"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	results := recordedTree(t, recordedBoth, "Found app/models/category.rb:40.")
+
+	if code, _, stderr := dispatch(t, "rescore",
+		"-results", results, "-scenarios", scenarios); code != exitOK {
+		t.Errorf("exit code = %d: %s", code, stderr)
+	}
+}
+
+// A malformed pre-fix list must not be read as naming runs. A row it half-parses
+// would attach `scorer version` to a run nobody wrote down, which is exactly the
+// story-fitting the written list exists to prevent.
+func TestRescoreIgnoresRowsThatAreNotRunsInThePreFixList(t *testing.T) {
+	results := recordedTree(t, recordedBoth, "Found app/models/category.rb:40.")
+	scenarios := scenarioDir(t, "discourse", scoredScenario, discourseGold, scoredRubric)
+
+	list := filepath.Join(t.TempDir(), "pre-fix.md")
+	if err := os.WriteFile(list, []byte(
+		"Prose above the table, which is not a row.\n"+
+			"| when | repo | model | arm | run | dated by |\n"+
+			"|---|---|---|---|---|---|\n"+
+			"| short | row |\n"+
+			"|  |  |  |  |  |  |\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, stdout, _ := dispatch(t, "rescore",
+		"-results", results, "-scenarios", scenarios, "-pre-fix", list)
+
+	if strings.Contains(stdout, "scorer version") {
+		t.Errorf("a half-parsed row named a pre-fix run:\n%s", stdout)
+	}
+}
+
+// A scenarios path that is not a directory at all leaves nothing to score
+// against, and that is a refusal rather than an empty comparison reading clean.
+func TestRescoreRefusesAScenariosPathThatIsNotADirectory(t *testing.T) {
+	notADir := filepath.Join(t.TempDir(), "file.txt")
+	if err := os.WriteFile(notADir, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	results := recordedTree(t, recordedBoth, "Found app/models/category.rb:40.")
+
+	code, _, stderr := dispatch(t, "rescore", "-results", results, "-scenarios", notADir)
+
+	if code != exitError || !strings.Contains(stderr, "no scenarios") {
+		t.Errorf("code = %d, stderr = %q", code, stderr)
+	}
+}
+
+// A recorded score that cannot be read is not comparable, and must be counted
+// as such rather than crashing the walk or passing as agreement.
+func TestRescoreCountsAScoreItCannotRead(t *testing.T) {
+	results := recordedTree(t, recordedBoth, "Found app/models/category.rb:40.")
+	scenarios := scenarioDir(t, "discourse", scoredScenario, discourseGold, scoredRubric)
+
+	dir := filepath.Join(results, "results", "opus", "hash", "baseline", "discourse", "run-1")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	unreadable := filepath.Join(dir, "scored.json")
+	if err := os.WriteFile(unreadable, []byte(recordedBoth), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.ReadFile(unreadable); err == nil {
+		t.Skip("this user can read a mode-000 file, so the case is unreachable here")
+	}
+
+	code, stdout, _ := dispatch(t, "rescore", "-results", results, "-scenarios", scenarios)
+
+	if !strings.Contains(stdout, "1 recorded runs were not comparable") {
+		t.Errorf("the unreadable score was not counted:\n%s", stdout)
+	}
+	if code != exitOK {
+		t.Errorf("exit code = %d", code)
+	}
+}

--- a/lab/internal/rescore/rescore.go
+++ b/lab/internal/rescore/rescore.go
@@ -1,0 +1,295 @@
+// Package rescore recomputes every recorded score and accounts for the
+// differences.
+//
+// It answers the question the whole rewrite rests on: does the method survive
+// re-expression in Go? Not by reproducing the old numbers — the corpus was not
+// scored under one scorer, and reproducing every recorded number exactly would
+// mean reproducing a defect that was already fixed. Parity is a diagnostic, and
+// the output that closes the work is not "zero differences" but "zero
+// unexplained differences".
+package rescore
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/luuuc/sense/lab/internal/score"
+)
+
+// Cause is why one recomputed score differs from the one on disk.
+//
+// The set is CLOSED and was decided before the table was read, so nobody gets
+// to invent a category that makes a difference comfortable.
+type Cause string
+
+const (
+	// ScorerVersion means the recorded score predates a fix that is now
+	// standard. The symbol-oracle fix only ever ADDED credit, so a run under
+	// this cause must rescore HIGHER; one that rescores lower is a new defect
+	// wearing the wrong label, and Classify refuses to call it this.
+	ScorerVersion Cause = "scorer version"
+	// WrongLine means the old scorer gave a row to a citation naming the right
+	// file at a line gold does not name. It is an OLD DEFECT and a finding: the
+	// right file at the wrong line is a teammate sent to the wrong place, which
+	// is the thing this metric exists to measure.
+	WrongLine Cause = "old defect: the right file at a line gold does not name"
+	// NeverLocated means the old scorer gave a row to an answer that never
+	// located the file in any form. Also an old defect, and a starker one.
+	NeverLocated Cause = "old defect: a row the answer never located"
+	// GoldChange means rows were quarantined or corrected, so a different
+	// question is being answered. 02-05 hands over the affected runs in
+	// advance, so this cause is checked against a prediction.
+	GoldChange Cause = "gold change"
+	// NewDefect means the new scorer is wrong here. It BLOCKS the cycle.
+	NewDefect Cause = "new defect"
+	// Unexplained is not a cause. Anything here means the work continues.
+	Unexplained Cause = "unexplained"
+)
+
+// Row is one recomputed group-score set beside the one on disk.
+type Row struct {
+	Repo, Model, Arm, Run, Group string
+	Recorded, Now, Total         int
+	// PreFix says the recorded score predates the symbol-oracle fix, taken from
+	// the list written down before this comparison ran.
+	PreFix bool
+	// Quarantined says 02-05 removed rows from this group.
+	Quarantined bool
+	// FileLevel and Uncited split the rows the old scorer credited and the new
+	// one does not, by whether the answer located the file at all.
+	FileLevel, Uncited int
+}
+
+// Diff is the difference, positive when the new score is higher.
+func (r Row) Diff() int { return r.Now - r.Recorded }
+
+// Classify names the cause of one row's difference.
+//
+// The direction test comes FIRST, and it is what stops the comfortable label
+// being reached for: a pre-fix run that rescores LOWER cannot be a scorer
+// version difference, because that fix only ever added credit.
+func Classify(r Row) Cause {
+	switch {
+	case r.Diff() == 0:
+		return ""
+	case r.Quarantined:
+		return GoldChange
+	case r.Diff() > 0:
+		if r.PreFix {
+			return ScorerVersion
+		}
+		return Unexplained
+	case r.Uncited > r.FileLevel:
+		return NeverLocated
+	case r.FileLevel > 0:
+		return WrongLine
+	default:
+		return Unexplained
+	}
+}
+
+// Report is the whole comparison.
+type Report struct {
+	Rows []Row
+}
+
+// Distribution is how many group-scores differ, and by how much.
+//
+// It is read BEFORE the table: four differing rows is an afternoon of reading,
+// forty is a structural problem, and the shape says which before anyone starts
+// going row by row.
+func (rp Report) Distribution() map[int]int {
+	d := map[int]int{}
+	for _, r := range rp.Rows {
+		d[r.Diff()]++
+	}
+	return d
+}
+
+// Causes counts the rows under each cause.
+func (rp Report) Causes() map[Cause]int {
+	c := map[Cause]int{}
+	for _, r := range rp.Rows {
+		if cause := Classify(r); cause != "" {
+			c[cause]++
+		}
+	}
+	return c
+}
+
+// Unexplained is what keeps the cycle open. Zero of these closes the pitch;
+// anything else means the work continues.
+func (rp Report) Unexplained() []Row {
+	var out []Row
+	for _, r := range rp.Rows {
+		if Classify(r) == Unexplained {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// Differing counts the rows whose score moved.
+func (rp Report) Differing() int {
+	n := 0
+	for _, r := range rp.Rows {
+		if r.Diff() != 0 {
+			n++
+		}
+	}
+	return n
+}
+
+// CheckpointFired reports whether more than a third of the rows differ, which
+// is the structural signal to stop and look at the shape rather than work the
+// queue. It is scheduled in advance rather than reached at the moment of
+// fatigue, which is the whole point of having it.
+func (rp Report) CheckpointFired() bool {
+	return len(rp.Rows) > 0 && float64(rp.Differing()) > float64(len(rp.Rows))/3
+}
+
+// Split counts how the old scorer's extra credits break down for one group.
+//
+// The split IS the finding: a credit for the right file at the wrong line is a
+// different claim about the old instrument from a credit for a row the answer
+// never located.
+func Split(cites []score.Cite, gold []score.Row, oldCited map[string]bool) (fileLevel, uncited int) {
+	for _, g := range gold {
+		if !oldCited[g.ID] || g.Cite == "" {
+			continue
+		}
+		i := strings.LastIndex(g.Cite, ":")
+		if i <= 0 {
+			continue
+		}
+		path, line := g.Cite[:i], g.Cite[i+1:]
+		if anyMatches(cites, path, line) {
+			continue
+		}
+		if anyNames(cites, path) || mentionsBasename(cites, path) {
+			fileLevel++
+			continue
+		}
+		uncited++
+	}
+	return fileLevel, uncited
+}
+
+func anyMatches(cites []score.Cite, path, line string) bool {
+	for _, c := range cites {
+		if score.Matches(c, path, line) {
+			return true
+		}
+	}
+	return false
+}
+
+func anyNames(cites []score.Cite, path string) bool {
+	for _, c := range cites {
+		if score.NamesFile(c, path) {
+			return true
+		}
+	}
+	return false
+}
+
+// mentionsBasename catches a file the answer named by its bare basename.
+//
+// The matcher refuses a bare basename on purpose, because many files share a
+// name and crediting one would land on a gold line by coincidence. For
+// ACCOUNTING the question is different: did the old scorer credit a file the
+// answer had named in some form? It nearly always had — `OrganizationService.cs:36`
+// against gold at :835 — and filing that under "never located" would overstate
+// how badly the old instrument behaved.
+func mentionsBasename(cites []score.Cite, path string) bool {
+	base := basename(path)
+	for _, c := range cites {
+		where := c.Path
+		if where == "" {
+			where = c.Established
+		}
+		if where != "" && basename(where) == base {
+			return true
+		}
+	}
+	return false
+}
+
+func basename(p string) string { return p[strings.LastIndex(p, "/")+1:] }
+
+func sortedCauses(m map[Cause]int) []Cause {
+	out := make([]string, 0, len(m))
+	for c := range m {
+		out = append(out, string(c))
+	}
+	sort.Strings(out)
+	cs := make([]Cause, len(out))
+	for i, s := range out {
+		cs[i] = Cause(s)
+	}
+	return cs
+}
+
+// String renders the distribution, then the causes, then what is unexplained.
+func (rp Report) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "group-scores compared %d\n  identical %d\n  different %d\n",
+		len(rp.Rows), len(rp.Rows)-rp.Differing(), rp.Differing())
+	if rp.CheckpointFired() {
+		b.WriteString("\nCHECKPOINT: more than a third differ. Hold it before reading row by row.\n")
+	}
+
+	b.WriteString("\ndifference, in rows cited (new minus recorded):\n")
+	dist := rp.Distribution()
+	keys := make([]int, 0, len(dist))
+	for k := range dist {
+		keys = append(keys, k)
+	}
+	sort.Ints(keys)
+	for _, k := range keys {
+		fmt.Fprintf(&b, "  %+4d  %4d\n", k, dist[k])
+	}
+
+	b.WriteString("\ncause of every difference:\n")
+	causes := rp.Causes()
+	names := make([]string, 0, len(causes))
+	for c := range causes {
+		names = append(names, string(c))
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		fmt.Fprintf(&b, "  %4d  %s\n", causes[Cause(n)], n)
+	}
+	// Per repo as well as in total, because a cause that is concentrated in one
+	// repository is a different finding from one spread across all of them —
+	// and because `gold change` has to be checked against 02-05's handover
+	// list, which is a list of runs in one repository.
+	b.WriteString("\ncause by repo:\n")
+	byRepo := map[string]map[Cause]int{}
+	for _, r := range rp.Rows {
+		cause := Classify(r)
+		if cause == "" {
+			continue
+		}
+		if byRepo[r.Repo] == nil {
+			byRepo[r.Repo] = map[Cause]int{}
+		}
+		byRepo[r.Repo][cause]++
+	}
+	repos := make([]string, 0, len(byRepo))
+	for k := range byRepo {
+		repos = append(repos, k)
+	}
+	sort.Strings(repos)
+	for _, repo := range repos {
+		for _, n := range sortedCauses(byRepo[repo]) {
+			fmt.Fprintf(&b, "  %-18s %4d  %s\n", repo, byRepo[repo][n], n)
+		}
+	}
+
+	if n := len(rp.Unexplained()); n > 0 {
+		fmt.Fprintf(&b, "\n%d UNEXPLAINED. The cycle stays open.\n", n)
+	}
+	return b.String()
+}

--- a/lab/internal/rescore/rescore_test.go
+++ b/lab/internal/rescore/rescore_test.go
@@ -1,0 +1,223 @@
+package rescore
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/lab/internal/score"
+)
+
+// The classifier's whole job is to refuse the comfortable label.
+//
+// `scorer version` is the comfortable one: it says the old number was right for
+// its time and nothing is wrong now. The symbol-oracle fix only ever ADDED
+// credit, so it can only ever explain a rescore that went UP, and a pre-fix run
+// that rescores DOWN is a new defect wearing the wrong label.
+func TestAPreFixRunThatScoresLowerIsNotAScorerVersionDifference(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		row  Row
+		want Cause
+	}{
+		{
+			name: "pre-fix and higher, which the fix explains",
+			row:  Row{Recorded: 5, Now: 7, PreFix: true},
+			want: ScorerVersion,
+		},
+		{
+			name: "pre-fix and LOWER, which it cannot",
+			row:  Row{Recorded: 7, Now: 5, PreFix: true, FileLevel: 2},
+			want: WrongLine,
+		},
+		{
+			name: "higher, but not pre-fix, so nothing explains it",
+			row:  Row{Recorded: 5, Now: 7},
+			want: Unexplained,
+		},
+		{
+			name: "identical",
+			row:  Row{Recorded: 5, Now: 5},
+			want: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Classify(tc.row); got != tc.want {
+				t.Errorf("Classify = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The two old-defect classes are different claims about the old instrument, and
+// collapsing them would lose the starker one.
+func TestTheTwoOldDefectsAreToldApart(t *testing.T) {
+	fileLevel := Row{Recorded: 6, Now: 2, FileLevel: 4, Uncited: 0}
+	uncited := Row{Recorded: 6, Now: 2, FileLevel: 1, Uncited: 3}
+
+	if got := Classify(fileLevel); got != WrongLine {
+		t.Errorf("Classify = %q, want %q", got, WrongLine)
+	}
+	if got := Classify(uncited); got != NeverLocated {
+		t.Errorf("Classify = %q, want %q", got, NeverLocated)
+	}
+}
+
+// A quarantined group answers a different question now, and that is a named
+// cause rather than a difference to explain away. It outranks the rest, because
+// a group whose rows were removed cannot be compared on its numbers at all.
+func TestAQuarantinedGroupIsAGoldChange(t *testing.T) {
+	if got := Classify(Row{Recorded: 9, Now: 0, Quarantined: true, FileLevel: 9}); got != GoldChange {
+		t.Errorf("Classify = %q, want %q", got, GoldChange)
+	}
+}
+
+// A difference nothing accounts for is UNEXPLAINED, which is not a cause. It is
+// the state that keeps the cycle open, so it must be reachable — a classifier
+// that always finds a label has stopped being a check.
+func TestADifferenceWithNoAccountIsUnexplained(t *testing.T) {
+	r := Report{Rows: []Row{{Recorded: 4, Now: 1}}} // lower, but nothing credited extra
+
+	if got := Classify(r.Rows[0]); got != Unexplained {
+		t.Fatalf("Classify = %q, want %q", got, Unexplained)
+	}
+	if len(r.Unexplained()) != 1 {
+		t.Error("the report does not surface it")
+	}
+	if !strings.Contains(r.String(), "UNEXPLAINED. The cycle stays open") {
+		t.Errorf("the report does not say the cycle stays open:\n%s", r.String())
+	}
+}
+
+// The checkpoint is scheduled in advance rather than reached at the moment of
+// fatigue, which is the whole point of having one.
+func TestTheCheckpointFiresPastAThird(t *testing.T) {
+	same := Row{Recorded: 1, Now: 1}
+	diff := Row{Recorded: 2, Now: 1, FileLevel: 1}
+
+	for _, tc := range []struct {
+		name string
+		rows []Row
+		want bool
+	}{
+		{"nothing compared", nil, false},
+		{"none differ", []Row{same, same, same}, false},
+		{"exactly a third", []Row{diff, same, same}, false},
+		{"past a third", []Row{diff, diff, same}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rp := Report{Rows: tc.rows}
+			if got := rp.CheckpointFired(); got != tc.want {
+				t.Errorf("CheckpointFired = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// The distribution is read BEFORE the table: four differing rows is an
+// afternoon of reading and forty is a structural problem, and the shape says
+// which before anyone starts going row by row.
+func TestTheDistributionIsReportedBeforeTheCauses(t *testing.T) {
+	r := Report{Rows: []Row{
+		{Recorded: 5, Now: 5},
+		{Recorded: 5, Now: 4, FileLevel: 1},
+		{Recorded: 5, Now: 4, FileLevel: 1},
+	}}
+
+	d := r.Distribution()
+	if d[0] != 1 || d[-1] != 2 {
+		t.Errorf("Distribution = %v, want one identical and two at -1", d)
+	}
+	out := r.String()
+	if i, j := strings.Index(out, "difference, in rows cited"), strings.Index(out, "cause of every difference"); i < 0 || j < 0 || i > j {
+		t.Errorf("the causes are printed before the distribution:\n%s", out)
+	}
+}
+
+// Split is what makes the accounting an accounting rather than a subtraction of
+// two totals: it says WHICH rows the old scorer credited that the new one does
+// not, and why each one fails now.
+func TestSplitSaysWhyEachExtraCreditFailsNow(t *testing.T) {
+	gold := []score.Row{
+		{ID: "a", Cite: "app/models/category.rb:100"}, // cited at the wrong line
+		{ID: "b", Cite: "app/models/other.rb:12"},     // never located at all
+		{ID: "c", Cite: "app/models/third.rb:5"},      // still a hit
+		{ID: "d", Cite: "app/models/fourth.rb:9"},     // the old scorer did not credit it either
+	}
+	cites := score.Scan("app/models/category.rb:40 and app/models/third.rb:5")
+	oldCited := map[string]bool{"a": true, "b": true, "c": true}
+
+	fileLevel, uncited := Split(cites, gold, oldCited)
+
+	if fileLevel != 1 {
+		t.Errorf("fileLevel = %d, want 1 (the row cited at the wrong line)", fileLevel)
+	}
+	if uncited != 1 {
+		t.Errorf("uncited = %d, want 1 (the row never located)", uncited)
+	}
+}
+
+// A file named only by its bare basename was still NAMED. The matcher refuses
+// to score it, on purpose, but calling it "never located" in the accounting
+// would overstate how badly the old instrument behaved.
+func TestABareBasenameCountsAsLocatedForTheAccounting(t *testing.T) {
+	gold := []score.Row{{ID: "a", Cite: "src/Core/Services/OrganizationService.cs:835"}}
+	cites := score.Scan("see OrganizationService.cs:36 for the check")
+
+	fileLevel, uncited := Split(cites, gold, map[string]bool{"a": true})
+
+	if fileLevel != 1 || uncited != 0 {
+		t.Errorf("fileLevel=%d uncited=%d, want the basename counted as located", fileLevel, uncited)
+	}
+}
+
+// A symbol citation carries the file it continues in Established rather than in
+// Path, so the accounting has to look at both or it reads a located file as
+// never located.
+func TestTheAccountingSeesAFileASymbolCiteContinues(t *testing.T) {
+	gold := []score.Row{{ID: "a", Cite: "app/jobs/scheduled/reindex_search.rb:999"}}
+	// Built rather than scanned, because a scan that produces this cite also
+	// produces the path cite that established it, and the path would answer
+	// first — leaving the branch that reads Established untested.
+	// The established file is a DIFFERENT path with the same basename, so
+	// NamesFile refuses it (as it should — many files share a name) and the
+	// basename check is the only thing left to see it.
+	cites := []score.Cite{{
+		Symbol:      "Jobs::ReindexSearch#load_problem_category_ids",
+		Established: "app/jobs/regular/reindex_search.rb",
+		Line:        111,
+	}}
+
+	fileLevel, uncited := Split(cites, gold, map[string]bool{"a": true})
+
+	if fileLevel != 1 || uncited != 0 {
+		t.Errorf("fileLevel=%d uncited=%d, want the continued file counted as located", fileLevel, uncited)
+	}
+}
+
+// A gold row with no location is 02-05's problem, and must not be counted as
+// something the old scorer wrongly credited.
+func TestARowWithNoLocationIsNotCountedAsAnExtraCredit(t *testing.T) {
+	gold := []score.Row{{ID: "a", Cite: ""}, {ID: "b", Cite: "no-colon-here"}}
+
+	fileLevel, uncited := Split(nil, gold, map[string]bool{"a": true, "b": true})
+
+	if fileLevel != 0 || uncited != 0 {
+		t.Errorf("fileLevel=%d uncited=%d, want both zero", fileLevel, uncited)
+	}
+}
+
+// The per-repo breakdown is what makes `gold change` checkable against 02-05's
+// handover list, which is a list of runs in one repository.
+func TestTheReportBreaksTheCausesDownByRepo(t *testing.T) {
+	r := Report{Rows: []Row{
+		{Repo: "rails", Recorded: 9, Now: 0, Quarantined: true},
+		{Repo: "discourse", Recorded: 5, Now: 3, FileLevel: 2},
+	}}
+
+	out := r.String()
+	for _, want := range []string{"cause by repo", "rails", "gold change", "discourse"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("%q missing from:\n%s", want, out)
+		}
+	}
+}

--- a/lab/internal/score/cite.go
+++ b/lab/internal/score/cite.go
@@ -156,6 +156,7 @@ func (s *scanner) token(kind, t string) {
 	case "path":
 		body, line := splitLine(t)
 		s.lastPath = body
+		s.pinPrecedingSymbol(body, line)
 		s.out = append(s.out, Cite{Path: body, Line: line})
 	case "sym":
 		body, line := splitLine(t)
@@ -219,6 +220,37 @@ func (s *scanner) elidedPath(t string) {
 	if hasTail(s.lastPath, trimEllipsis(body)) {
 		s.out = append(s.out, Cite{Path: s.lastPath, Line: line})
 	}
+}
+
+// pinPrecedingSymbol gives a line to the symbol this path belongs to.
+//
+// The winning question in this bench asks the agent to "name the routine the
+// dependency is inside, give its file:line", and the answer to it is written as
+// one item in two tokens:
+//
+//	`SeedData::Categories#create_category`, `lib/seed_data/categories.rb:116`
+//
+// Read as two citations the routine is lost: the symbol carries no line, so it
+// can never match, and the path is held to the gold line. Measured against the
+// recorded corpus that cost 18 rows on one run alone, every one of them a case
+// where the arm named the right routine and pinned its definition line while
+// gold cites a use inside it.
+//
+// The pairing is CORROBORATED, exactly as an inherited file is: the symbol has
+// to name this path under Ruby's own rule. An unrelated constant next to an
+// unrelated path stays two citations, so this cannot merge things that merely
+// sit beside each other.
+func (s *scanner) pinPrecedingSymbol(path string, line int) {
+	i := len(s.out) - 1
+	if line == 0 || i < 0 {
+		return
+	}
+	prev := &s.out[i]
+	if prev.Symbol == "" || prev.Line != 0 || !symbolNamesPath(prev.Symbol, path) {
+		return
+	}
+	prev.Line = line
+	prev.Established = path
 }
 
 func (s *scanner) symbol(sym string, line int) {

--- a/lab/internal/score/fixture_test.go
+++ b/lab/internal/score/fixture_test.go
@@ -60,8 +60,23 @@ func fixture(t *testing.T) (rows []Row, answer string) {
 	return rows, answer
 }
 
-// The score, as the strict rule computes it.
-func TestTheRecordedRunScoresTwoOfTwelve(t *testing.T) {
+// The score, as the rule computes it.
+//
+// Cycle 00 recorded 2 of 12 and this is 4 of 12. The number moved because the
+// matcher had a defect, found by the rescore proof and fixed: the winning
+// question here asks the arm to "name the routine the dependency is inside,
+// give its file:line", and the answer to it is one item in two tokens —
+// `ImportScripts::Base#create_category` — `script/import_scripts/base.rb:465`.
+// Read as two citations the routine is lost, so the symbol carried no line and
+// could never match.
+//
+// Both rows added are hits by the gold rows' OWN words: d:import-scripts-base
+// says the location is "inside ImportScripts::Base#create_category" and the
+// answer named exactly that routine; d:bulk-import-merger says
+// "inside BulkImport::DiscourseMerger#category_exists" and so did the answer.
+// Each pins the routine's definition line where gold cites a use inside it,
+// which is the recorded ruling's case exactly.
+func TestTheRecordedRunScoresFourOfTwelve(t *testing.T) {
 	rows, answer := fixture(t)
 
 	got := Group("dependents", rows, text(answer), 0.50)
@@ -69,17 +84,23 @@ func TestTheRecordedRunScoresTwoOfTwelve(t *testing.T) {
 	if got.Total != 12 {
 		t.Fatalf("gold group has %d rows, want the 12 that were audited", got.Total)
 	}
-	if got.Cited != 2 {
-		t.Errorf("cited = %d, want 2 exact path:line hits", got.Cited)
+	if got.Cited != 4 {
+		t.Errorf("cited = %d, want 4", got.Cited)
 	}
 	if got.Verdict != BelowFloor {
 		t.Errorf("verdict = %q, want %q at recall %.2f against a 0.50 floor",
 			got.Verdict, BelowFloor, got.Recall)
 	}
 
-	// Named, not counted. A count that stayed at 2 while the identities changed
+	// Named, not counted. A count that stayed at 4 while the identities changed
 	// would mean the matcher had started crediting something else.
-	want := map[string]bool{"d:migrations-optimizer": true, "d:data-explorer-parameter": true}
+	want := map[string]bool{
+		"d:migrations-optimizer":    true,
+		"d:data-explorer-parameter": true,
+		// Added by the routine-attribution fix, and hits by gold's own prose.
+		"d:bulk-import-merger":  true,
+		"d:import-scripts-base": true,
+	}
 	for _, id := range got.Hits {
 		if !want[id] {
 			t.Errorf("credited %s, which the audit scored as a miss", id)
@@ -119,8 +140,8 @@ func TestTheRecordedRunReachedElevenFilesAndTwoLines(t *testing.T) {
 		t.Errorf("the agent reached %d of 12 gold files, want 11 — the audit found only "+
 			"lib/tasks/search.rake never named", reached)
 	}
-	if wrongLine != 9 {
-		t.Errorf("%d rows were the right file at the wrong line, want 9", wrongLine)
+	if wrongLine != 7 {
+		t.Errorf("%d rows were the right file at the wrong line, want 7", wrongLine)
 	}
 
 	// Asserted on the RENDERED report, because the line's only job is to stop
@@ -173,9 +194,14 @@ func TestTheRecordedRunMissesAreLinesTheGoldRowItselfNames(t *testing.T) {
 		gold     string // the call site gold records
 		agentHit string // the line the agent chose instead
 	}{
+		// SIX rows, where cycle 00 recorded eight. Two were recovered by the
+		// routine-attribution fix; the rest are still the right file at a line
+		// gold does not name, which is the gap the metric is measuring.
 		{"d:migrations-importer-categories", "migrations/lib/importer/steps/categories/categories.rb:124", "123"},
-		{"d:bulk-import-merger", "script/bulk_import/discourse_merger.rb:230", "226"},
-		{"d:import-scripts-base", "script/import_scripts/base.rb:467", "465"},
+		// d:bulk-import-merger and d:import-scripts-base used to be here and are
+		// now HITS. Both gold rows name the routine the location sits inside,
+		// the answer named that routine, and the routine-attribution fix reads
+		// the pairing. They are the two rows the rescore proof recovered.
 		{"d:templates-rake", "plugins/discourse-templates/lib/tasks/discourse-templates.rake:113", "100"},
 		{"d:slack-migration", "plugins/discourse-chat-integration/app/jobs/onceoff/migrate_from_slack_official.rb:52", "35"},
 		{"d:semantic-categorizer", "plugins/discourse-ai/lib/ai_helper/semantic_categorizer.rb:25", "13"},

--- a/lab/rescore/checkpoint.md
+++ b/lab/rescore/checkpoint.md
@@ -1,0 +1,102 @@
+# The checkpoint, held
+
+The count trigger fired: **253 of 430 group-scores differ (59%)**, well past the
+"about a third" that says stop and look at the shape rather than work the queue.
+
+The checkpoint is not an abort. Cycle 02 finishes. What follows is the three
+questions answered in writing, with the distribution that justifies each answer.
+
+## 1. Is it one cause or many?
+
+**One.** Of the rows the old scorer credited and the new one does not, the split is:
+
+| rows | share | what it is |
+|---|---|---|
+| 544 | 94% | the file is cited, at a line gold does not name |
+| 33 | 6% | a bare basename with a line, which the matcher refuses on purpose |
+| 1 | 0% | the file named with no line anywhere |
+
+The 6% is the same mechanism wearing a different coat. `"OrganizationService.cs:36"`
+against gold at `:835` is a citation to the right file at the wrong line, written
+short. Hand-read, all six sampled were that. So the class is one, at essentially
+100%: **the old scorer credited the right file at the wrong line.**
+
+That is not a difference to reconcile. It is the thing this metric exists to
+refuse — the right file at the wrong line is a teammate sent to the wrong place —
+and it is why the recomputed numbers are roughly half the recorded ones.
+
+So: a bug to name, not a queue to grind. The work continues.
+
+## 2. Is per-row still the right bar, or is per-class enough?
+
+**Per-class, and the classes were named before the table was read.** The closed
+set is in `rescore.Cause`, and every one of the 253 differences lands inside it:
+
+| rows | cause |
+|---|---|
+| 190 | old defect: the right file at a line gold does not name |
+| 61 | gold change |
+| 2 | old defect: a row the answer never located |
+| **0** | **unexplained** |
+
+Per-row on 253 rows sharing one mechanism would be an expensive way to write the
+same sentence 253 times. Per-class is not a lowered standard here, because
+nothing lands outside the classes and the classes were fixed in advance.
+
+The one row-level obligation was kept: the differences were hand-audited before
+the class was named, not after, and that audit is what found the new defect below.
+
+## 3. Does parity on the banked cells suffice?
+
+It did not have to be decided, because **zero rows are unexplained** — the pitch's
+closing condition — and the accounting covers all 430 comparable group-scores
+rather than a chosen subset. Narrowing to the 4 banked cells would have discarded
+the finding, since the file-level class is visible only across the corpus.
+
+## What the hand-audit found: one new defect, fixed
+
+A `new defect` blocks the cycle until fixed, and there was one.
+
+The winning question in this bench asks the arm to *name the routine the
+dependency is inside, give its file:line*. The answer to it is one item written in
+two tokens:
+
+```
+`ImportScripts::Base#create_category` — `script/import_scripts/base.rb:465`
+```
+
+The matcher read that as two citations. The symbol carried no line, so it could
+never match, and the path was held to the gold line. On one run alone that cost 18
+rows, every one a case where the arm named the right routine and pinned its
+definition line while gold cites a use inside it.
+
+Both rows checked by hand were hits **by the gold rows' own words**:
+`d:import-scripts-base` says the location is "inside
+`ImportScripts::Base#create_category`", and the answer named exactly that routine.
+
+Fixed, corroborated the same way an inherited file is — the symbol has to name
+that path under Ruby's own rule, so an unrelated constant beside an unrelated path
+stays two citations. Worth **+219 rows** across the corpus, and it moved the
+checked-in discourse figure from 2 of 12 to 4 of 12. That published number was
+wrong, and this is the correction.
+
+## The direction prediction, and what happened to it
+
+Written down before the comparison: the symbol-oracle fix only ever ADDED credit,
+so a pre-fix run must rescore **higher, never lower**.
+
+**No run rescored higher. Not one, out of 430.** So no difference could be labelled
+`scorer version`, and none was — the classifier tests direction first, precisely so
+the comfortable label cannot be reached for.
+
+That is the prediction failing in the honest direction. It was not wrong about the
+fix; it was wrong about which effect would dominate. Both effects are present in
+the 10 pre-fix runs, and the file-level one is much larger, so it buries the
+symbol-oracle gain underneath it. A prediction that can be wrong is worth
+something only if you say so when it is.
+
+## The gold-change prediction, and what happened to it
+
+02-05 handed over 33 rails runs as the runs its quarantine would move. Every one
+of the 61 `gold change` rows is rails, and rails carries no other cause. The
+prediction was met exactly.

--- a/lab/rescore/pre-fix-runs.md
+++ b/lab/rescore/pre-fix-runs.md
@@ -1,0 +1,40 @@
+# The pre-fix list
+
+Written down BEFORE the comparison, so `scorer version` is a prediction that can be
+wrong rather than a story fitted to the numbers afterwards.
+
+The symbol-oracle fix is commit `b90e7f2`, 2026-08-04 13:00:59 +0000:
+*bench(ruby-rails): count a class name plus a line as a citation*. It only ever ADDED
+credit, so a pre-fix run must rescore HIGHER, never lower. One that rescores lower is
+not a scorer-version difference; it is a new defect wearing the wrong label.
+
+Of 122 scored runs, **10 are pre-fix** and 112 follow it.
+
+| when | repo | model | arm | run | dated by |
+|---|---|---|---|---|---|
+| 2026-08-01 10:38:23 | rails | claude-opus-5 | baseline | run-1 | run_meta.timestamp |
+| 2026-08-01 10:41:49 | rails | claude-opus-5 | baseline | run-2 | run_meta.timestamp |
+| 2026-08-01 10:45:10 | rails | claude-opus-5 | sense | run-1 | run_meta.timestamp |
+| 2026-08-01 10:49:09 | rails | claude-opus-5 | sense | run-2 | run_meta.timestamp |
+| 2026-08-04 10:16:30 | rails | claude-opus-5 | sense | run-3 | run_meta.timestamp |
+| 2026-08-04 10:22:13 | rails | claude-opus-5 | baseline | run-3 | run_meta.timestamp |
+| 2026-08-04 11:13:57 | mastodon | claude-opus-5 | sense | run-1 | run_meta.timestamp |
+| 2026-08-04 11:21:24 | mastodon | claude-opus-5 | baseline | run-1 | run_meta.timestamp |
+| 2026-08-04 11:29:30 | mastodon | claude-opus-5 | sense | run-2 | run_meta.timestamp |
+| 2026-08-04 11:38:01 | mastodon | claude-opus-5 | baseline | run-2 | run_meta.timestamp |
+
+## How each run was dated
+
+The results tree is not in git, so the date is taken from the artifacts themselves:
+
+- `run_meta.json`'s own `timestamp` where it has one (42 runs).
+- otherwise the `sense_ref` it records, dated by git (47 runs). Every one of those
+  refs is 2026-08-06 or later, which is the cross-model re-run.
+- a baseline run with neither carries no clock of its own, because it uses no Sense
+  build; it takes the date of the sense run it was paired against in the same cell
+  (33 runs). The arms of a cell run together, so this is a fact about the cell
+  rather than an estimate.
+
+The boundary is not close. The last pre-fix run is 2026-08-04 11:38:01 and the first
+post-fix run is 2026-08-04 21:44:24, ten hours after the fix landed, so nothing sits
+near enough to the line for the dating method to decide it.


### PR DESCRIPTION
## Problem

Everything in cycle 02 is untested until it meets the corpus. The question it answers is the one the whole rewrite rests on: **does the method survive re-expression in Go?**

Not by reproducing the old numbers. The corpus was not scored under one scorer — the matcher defect was found, ruled and fixed while the old tree was live — so reproducing every recorded number exactly would mean reproducing a defect that was already fixed. Parity is a diagnostic. The output that closes this is not "zero differences", it is **zero unexplained differences**.

## Result

**430 group-scores compared, 177 identical, 253 different, 0 unexplained.**

| rows | cause |
|---|---|
| 190 | old defect: the right file at a line gold does not name |
| 61 | gold change |
| 2 | old defect: a row the answer never located |
| **0** | **unexplained** |

`sense-lab rescore` does the whole thing in one command, because cycle 06 reruns it whenever the scorer changes and a proof reassembled by hand is a proof nobody reruns.

## The prediction was written first, and it was wrong

The pre-fix list was established **before any comparison**, from the artifacts' own dates — `run_meta.json` timestamps, else the `sense_ref` git can date, else the paired arm in the same cell. All 122 runs dated, none ambiguous: the last pre-fix run is 10 hours before the first post-fix one. **10 runs are pre-fix.**

The prediction: the symbol-oracle fix (commit `b90e7f2`) only ever *added* credit, so a pre-fix run must rescore **higher, never lower**.

**Not one run of 430 rescored higher.** So no difference could carry the `scorer version` label, and none does — the classifier tests direction first, precisely so the comfortable label cannot be reached for. The prediction wasn't wrong about the fix; it was wrong about which effect dominates. Both are present in those 10 runs and the other is far larger.

## The checkpoint fired, and was held

59% differ, well past the one-third trigger. The three questions are answered in writing in `lab/rescore/checkpoint.md`. In short: **one cause, not many** — the old scorer gave a row to a citation naming the right file at a line gold does not name, which is exactly what this metric exists to refuse.

## One new defect, found by hand-audit and fixed

A `new defect` blocks the cycle. There was one, and it was in my matcher.

The winning question asks the arm to *name the routine the dependency is inside, give its file:line*, and the answer is one item in two tokens: `` `ImportScripts::Base#create_category` — `script/import_scripts/base.rb:465` ``. The matcher read it as two, so the symbol carried no line and could never match. That cost **18 rows on a single run**; the fix is worth **+219 across the corpus**.

Both rows I checked by hand are hits **by the gold rows' own prose** — `d:import-scripts-base` says the location is "inside `ImportScripts::Base#create_category`", and the answer named exactly that routine.

**It corrects a published number.** The checked-in discourse probe was recorded at 2 of 12 and is 4 of 12.

## 02-05's handover met exactly

02-05 predicted the runs its quarantine would move. Every one of the 61 `gold change` rows is rails, and rails carries no other cause.

## Test plan

- `make ci` green; **100% line and function coverage across every lab file**.
- The classifier is tested on the case that matters most: a pre-fix run that rescores *lower* must not be called a scorer-version difference.
- `unexplained` is reachable and fails the command, so a classifier that always finds a label would be caught.