### PR TITLE
bench(isolate): add the disposable run environment

### DIFF
--- a/lab/internal/cli/runcmd.go
+++ b/lab/internal/cli/runcmd.go
@@ -182,8 +182,12 @@ func runSession(ctx context.Context, args []string, stdout, stderr io.Writer) in
 		Name:  j.agent.Binary,
 		Args:  append(slices.Clone(j.agent.HeadlessArgs), j.agent.ModelFlag, j.model.ID),
 		Stdin: set.Scenario.Prompt(),
-		Env:   j.agent.Env,
-		Wall:  f.wall,
+		// The host's environment plus the agent's own, composed here rather
+		// than inside run.Session so the inheritance is a visible decision at
+		// the edge. It is still the wrong environment for a measured run, and
+		// 03-04 replaces this call site with a prepared isolate.Env.
+		Env:  append(os.Environ(), j.agent.Env...),
+		Wall: f.wall,
 	})
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "sense-lab run: %v\n", err)

--- a/lab/internal/isolate/env.go
+++ b/lab/internal/isolate/env.go
@@ -1,0 +1,150 @@
+package isolate
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// Arm is which side of a cell a run belongs to.
+//
+// It lives here, in the environment package, because the arms differ in exactly
+// one environmental fact: whether the Sense binary is reachable on PATH. Every
+// other difference between the two is repository state, and that is 03-02.
+type Arm string
+
+const (
+	// Sense is the arm that may reach Sense.
+	Sense Arm = "sense"
+	// Baseline is the arm that may not, by any channel.
+	Baseline Arm = "baseline"
+)
+
+// Entry is one environment variable a session is allowed to inherit from the
+// host, together with the reason it is allowed. The reason is not decoration:
+// an allowlist whose entries nobody can justify decays into a denylist one
+// convenience at a time.
+type Entry struct {
+	Name string
+	Why  string
+}
+
+// allowed is the environment allowlist, and it is an allowlist on purpose. A
+// denylist means every variable the host acquires later is a channel the arms
+// did not earn and nobody notices.
+//
+// PATH is deliberately absent. It is not a shared default but one entry with
+// two arm-specific values, and treating it as common is how the baseline arm
+// silently acquires a CLI fallback. PathFor builds it instead.
+//
+// HOME and the XDG variables are absent for a different reason: they are facts
+// about the disposable directory rather than about the host, so inheriting them
+// would defeat the whole package. Environ sets them.
+var allowed = []Entry{
+	{"TERM", "an agent CLI that cannot resolve a terminal writes control codes into the capture, which then reach the scorer as text"},
+	{"LANG", "collation and case folding differ without it, and a scenario's gold is matched by string"},
+	{"LC_ALL", "same as LANG, and it wins over LANG where both are set"},
+	{"ANTHROPIC_API_KEY", "the api_key auth mode; without it an api-key run reaches no model and produces an empty arm"},
+	{"ANTHROPIC_AUTH_TOKEN", "the api_key auth mode against a gateway that takes a bearer token rather than a key"},
+	{"CLAUDE_CODE_OAUTH_TOKEN", "the subscription auth mode; the disposable HOME carries no credential of its own"},
+	{"SSL_CERT_FILE", "a host with a custom CA store cannot reach the provider without it, and the failure reads as an empty arm"},
+	{"SSL_CERT_DIR", "same as SSL_CERT_FILE, for a store kept as a directory"},
+	{"HTTP_PROXY", "a host behind a proxy reaches nothing without it"},
+	{"HTTPS_PROXY", "same as HTTP_PROXY, and it is the one the provider is actually reached through"},
+	{"NO_PROXY", "a proxy without its exception list sends local traffic through the proxy"},
+	{"http_proxy", "the lowercase spelling; tooling is split on which it reads, and honouring only one is a proxy that works for half a session"},
+	{"https_proxy", "the lowercase spelling, as above"},
+	{"no_proxy", "the lowercase spelling, as above"},
+}
+
+// Layout is the directory tree of one run's environment.
+type Layout struct {
+	// Root is the run directory. Cleanup removes this and everything under it.
+	Root string
+	// Repo is where the worktree goes. Nothing creates it here: git refuses to
+	// add a worktree at a path that already exists, so 03-02 creates it.
+	Repo string
+	// Home is the disposable HOME, holding config, cache, data and state.
+	Home string
+	// Logs holds the session's capture.
+	Logs string
+	// Artifacts holds the transcript, the tool io capture and the run metadata.
+	Artifacts string
+}
+
+// LayoutFor computes the tree under a run root. It creates nothing.
+func LayoutFor(root string) Layout {
+	return Layout{
+		Root:      root,
+		Repo:      filepath.Join(root, "repo"),
+		Home:      filepath.Join(root, "home"),
+		Logs:      filepath.Join(root, "logs"),
+		Artifacts: filepath.Join(root, "artifacts"),
+	}
+}
+
+// homeSubdirs are the XDG directories inside the disposable HOME. The names are
+// the XDG defaults minus the dot, so a tool that ignores the variables and
+// hard-codes `~/.config` still lands inside the run directory.
+var homeSubdirs = []string{"config", "cache", "data", "state"}
+
+// dirs is everything Prepare creates, parents first.
+func (l Layout) dirs() []string {
+	d := []string{l.Root, l.Home, l.Logs, l.Artifacts}
+	for _, sub := range homeSubdirs {
+		d = append(d, filepath.Join(l.Home, sub))
+	}
+	return d
+}
+
+// PathFor builds an arm's PATH from the host's.
+//
+// The Sense arm gets the directory holding the Sense binary at the front. The
+// baseline arm gets the same PATH with that directory removed, and that removal
+// is the part a reasonable implementation misses: prepending for one arm leaves
+// the other with whatever the host already had, and on a machine where Sense is
+// installed that is a CLI fallback the baseline never earned.
+//
+// senseBinDir is therefore expected to hold the Sense binary and little else. A
+// directory shared with the agent tool would take the agent tool off the
+// baseline's PATH with it, which fails loudly rather than silently.
+func PathFor(arm Arm, hostPath, senseBinDir string) string {
+	sense := ""
+	if senseBinDir != "" {
+		sense = filepath.Clean(senseBinDir)
+	}
+	var keep []string
+	for _, dir := range filepath.SplitList(hostPath) {
+		if dir == "" || (sense != "" && filepath.Clean(dir) == sense) {
+			continue
+		}
+		keep = append(keep, dir)
+	}
+	if arm == Sense && sense != "" {
+		keep = append([]string{sense}, keep...)
+	}
+	return strings.Join(keep, string(filepath.ListSeparator))
+}
+
+// Environ builds the complete environment a session runs with: the disposable
+// directories, the arm's PATH, the allowlist as far as the host actually sets
+// it, and whatever the agent tool declares.
+//
+// lookup reads the host, so the decision is a pure function of its arguments and
+// a table test can state the whole of it. Production passes os.LookupEnv.
+func Environ(l Layout, path string, lookup func(string) (string, bool), agentEnv []string) []string {
+	env := []string{
+		"HOME=" + l.Home,
+		"PATH=" + path,
+	}
+	for _, sub := range homeSubdirs {
+		env = append(env, "XDG_"+strings.ToUpper(sub)+"_HOME="+filepath.Join(l.Home, sub))
+	}
+	for _, a := range allowed {
+		if v, ok := lookup(a.Name); ok {
+			env = append(env, a.Name+"="+v)
+		}
+	}
+	// The agent tool's overrides come last so a tool can correct a default it
+	// cannot live with. They are declared in agent.json and reviewed there.
+	return append(env, agentEnv...)
+}

--- a/lab/internal/isolate/env_test.go
+++ b/lab/internal/isolate/env_test.go
@@ -1,0 +1,228 @@
+package isolate
+
+import (
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// noHost is a host that sets nothing, so a test states its own inheritance
+// rather than inheriting whatever the machine running it happens to carry.
+func noHost(string) (string, bool) { return "", false }
+
+// hostWith is a host that sets exactly the given variables.
+func hostWith(kv map[string]string) func(string) (string, bool) {
+	return func(name string) (string, bool) {
+		v, ok := kv[name]
+		return v, ok
+	}
+}
+
+// envMap turns a KEY=VALUE slice into a map, honouring the last-wins rule exec
+// applies to duplicates.
+func envMap(t *testing.T, env []string) map[string]string {
+	t.Helper()
+	m := make(map[string]string, len(env))
+	for _, kv := range env {
+		name, value, ok := strings.Cut(kv, "=")
+		if !ok {
+			t.Fatalf("environment entry %q is not KEY=VALUE", kv)
+		}
+		m[name] = value
+	}
+	return m
+}
+
+func joinPath(dirs ...string) string {
+	return strings.Join(dirs, string(filepath.ListSeparator))
+}
+
+func TestSessionSeesTheDisposableHomeAndXDGDirectories(t *testing.T) {
+	l := LayoutFor("/runs/r1")
+
+	got := envMap(t, Environ(l, "/usr/bin", noHost, nil))
+
+	want := map[string]string{
+		"HOME":            "/runs/r1/home",
+		"XDG_CONFIG_HOME": "/runs/r1/home/config",
+		"XDG_CACHE_HOME":  "/runs/r1/home/cache",
+		"XDG_DATA_HOME":   "/runs/r1/home/data",
+		"XDG_STATE_HOME":  "/runs/r1/home/state",
+	}
+	for name, value := range want {
+		if got[name] != value {
+			t.Errorf("%s = %q, want %q", name, got[name], value)
+		}
+	}
+}
+
+func TestHostVariablesOutsideTheAllowlistDoNotReachTheSession(t *testing.T) {
+	// A denylist would let every one of these through, and the memory directory
+	// is the one that has already cost a measurement.
+	host := hostWith(map[string]string{
+		"TERM": "xterm",
+		"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+		"AWS_SECRET_ACCESS_KEY":                    "leaked",
+		"GITHUB_TOKEN":                             "leaked",
+		"EDITOR":                                   "vim",
+	})
+
+	got := envMap(t, Environ(LayoutFor("/runs/r1"), "/usr/bin", host, nil))
+
+	if got["TERM"] != "xterm" {
+		t.Errorf("TERM = %q, want the allowlisted host value", got["TERM"])
+	}
+	for _, name := range []string{"AWS_SECRET_ACCESS_KEY", "GITHUB_TOKEN", "EDITOR", "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"} {
+		if _, ok := got[name]; ok {
+			t.Errorf("%s reached the session; it is not on the allowlist", name)
+		}
+	}
+}
+
+func TestAnAllowlistedVariableTheHostDoesNotSetIsNotInvented(t *testing.T) {
+	got := envMap(t, Environ(LayoutFor("/runs/r1"), "/usr/bin", noHost, nil))
+
+	// An empty ANTHROPIC_API_KEY is not the same as an absent one: a tool that
+	// checks for presence would take the empty string as api-key auth and fail
+	// to reach a model at all.
+	if _, ok := got["ANTHROPIC_API_KEY"]; ok {
+		t.Error("ANTHROPIC_API_KEY was set although the host does not set it")
+	}
+}
+
+func TestEveryAllowlistEntryRecordsWhyItIsThere(t *testing.T) {
+	for _, e := range allowed {
+		if e.Name == "" {
+			t.Error("an allowlist entry has no name")
+		}
+		if e.Why == "" {
+			t.Errorf("allowlist entry %s records no reason", e.Name)
+		}
+	}
+}
+
+func TestPathIsNotInheritedFromTheHostAllowlist(t *testing.T) {
+	// PATH is an arm-specific value, so it must not be reachable as an ordinary
+	// allowlist entry: an entry would give both arms the host's PATH and the
+	// baseline arm a CLI fallback with it.
+	if slices.ContainsFunc(allowed, func(e Entry) bool { return e.Name == "PATH" }) {
+		t.Fatal("PATH is on the environment allowlist; it must be built per arm by PathFor")
+	}
+
+	host := hostWith(map[string]string{"PATH": "/host/bin"})
+	got := envMap(t, Environ(LayoutFor("/runs/r1"), "/arm/bin", host, nil))
+	if got["PATH"] != "/arm/bin" {
+		t.Errorf("PATH = %q, want the arm's value /arm/bin", got["PATH"])
+	}
+}
+
+func TestTheAgentToolsOwnEnvironmentWinsOverADefault(t *testing.T) {
+	agentEnv := []string{"IS_SANDBOX=1", "TERM=dumb"}
+	host := hostWith(map[string]string{"TERM": "xterm"})
+
+	got := envMap(t, Environ(LayoutFor("/runs/r1"), "/usr/bin", host, agentEnv))
+
+	if got["IS_SANDBOX"] != "1" {
+		t.Errorf("IS_SANDBOX = %q, want the agent tool's 1", got["IS_SANDBOX"])
+	}
+	if got["TERM"] != "dumb" {
+		t.Errorf("TERM = %q, want the agent tool's dumb to win over the host's xterm", got["TERM"])
+	}
+}
+
+func TestTheSenseArmGetsTheSenseBinaryFirstOnPath(t *testing.T) {
+	got := PathFor(Sense, joinPath("/usr/bin", "/bin"), "/lab/bin")
+
+	if want := joinPath("/lab/bin", "/usr/bin", "/bin"); got != want {
+		t.Errorf("PathFor(sense) = %q, want %q", got, want)
+	}
+}
+
+func TestTheBaselineArmLosesTheSenseDirectoryTheHostAlreadyHad(t *testing.T) {
+	// The failure this exists to catch: prepending for the Sense arm only, on a
+	// machine where the Sense binary's directory is already on the host PATH.
+	// The baseline arm then keeps a CLI fallback it never earned.
+	host := joinPath("/usr/bin", "/lab/bin", "/bin")
+
+	got := PathFor(Baseline, host, "/lab/bin")
+
+	if strings.Contains(got, "/lab/bin") {
+		t.Fatalf("PathFor(baseline) = %q, which still reaches the Sense binary", got)
+	}
+	if want := joinPath("/usr/bin", "/bin"); got != want {
+		t.Errorf("PathFor(baseline) = %q, want %q", got, want)
+	}
+}
+
+func TestTheSenseDirectoryIsNotListedTwiceForTheSenseArm(t *testing.T) {
+	got := PathFor(Sense, joinPath("/usr/bin", "/lab/bin/"), "/lab/bin")
+
+	if want := joinPath("/lab/bin", "/usr/bin"); got != want {
+		t.Errorf("PathFor(sense) = %q, want %q; an unclean spelling of the same directory should match", got, want)
+	}
+}
+
+func TestAnEmptyPathElementIsDroppedRatherThanMeaningTheWorkingDirectory(t *testing.T) {
+	// An empty element means "the current directory" to execvp, which in a run
+	// is the repository under study. A scenario that writes an executable named
+	// after a tool would then be running it.
+	got := PathFor(Baseline, joinPath("/usr/bin", "", "/bin"), "")
+
+	if want := joinPath("/usr/bin", "/bin"); got != want {
+		t.Errorf("PathFor = %q, want %q", got, want)
+	}
+}
+
+func TestWithNoSenseDirectoryBothArmsGetTheSamePath(t *testing.T) {
+	host := joinPath("/usr/bin", "/bin")
+
+	if got := PathFor(Sense, host, ""); got != host {
+		t.Errorf("PathFor(sense) = %q, want %q", got, host)
+	}
+	if got := PathFor(Baseline, host, ""); got != host {
+		t.Errorf("PathFor(baseline) = %q, want %q", got, host)
+	}
+}
+
+func TestTheCleanupProofFailsWhileAnythingRemains(t *testing.T) {
+	// The proof exists because os.RemoveAll returning nil says nothing was
+	// reported, not that nothing remains.
+	dir := t.TempDir()
+
+	if err := gone(dir); err == nil {
+		t.Fatal("the cleanup proof passed on a directory that still exists")
+	}
+	if err := gone(filepath.Join(dir, "never-created")); err != nil {
+		t.Errorf("the cleanup proof failed on an absent path: %v", err)
+	}
+}
+
+func TestTheCleanupProofFailsWhenItCannotTell(t *testing.T) {
+	// A path that cannot be statted at all. "I could not look" is not "it is
+	// gone", and reporting success here would let a contaminated environment
+	// through on exactly the machines where something is already wrong.
+	long := strings.Repeat("x", 1<<12)
+
+	if err := gone(filepath.Join(long, long, "root")); err == nil {
+		t.Fatal("the cleanup proof passed on a path it could not check")
+	}
+}
+
+func TestTheLayoutNamesTheWholeRunTree(t *testing.T) {
+	l := LayoutFor("/runs/r1")
+
+	for name, got := range map[string]string{
+		"Repo":      l.Repo,
+		"Home":      l.Home,
+		"Logs":      l.Logs,
+		"Artifacts": l.Artifacts,
+	} {
+		if !strings.HasPrefix(got, "/runs/r1/") {
+			t.Errorf("%s = %q, which is outside the run root", name, got)
+		}
+	}
+	if l.Root != "/runs/r1" {
+		t.Errorf("Root = %q, want /runs/r1", l.Root)
+	}
+}

--- a/lab/internal/isolate/isolate.go
+++ b/lab/internal/isolate/isolate.go
@@ -1,0 +1,118 @@
+// Package isolate builds the disposable environment one run happens inside, and
+// destroys it afterwards.
+//
+// It exists because of a specific measurement failure: the walking skeleton ran
+// an agent against the host's HOME, so anything the host carried between runs —
+// a persisted memory directory keyed off the repository path, a warm cache, an
+// agent config — reached both arms of every cell, and nothing in the repository
+// or the prompt would show it.
+//
+// This is isolated-home, written as a concrete type. The Executor interface is
+// cycle 08's, extracted once the container exists and both shapes are visible;
+// an interface with one implementation is indirection rather than abstraction.
+package isolate
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// Spec is one environment to prepare.
+type Spec struct {
+	// Root is the run directory to create. It must not already exist.
+	Root string
+	// Arm decides the PATH, and nothing else here.
+	Arm Arm
+	// SenseBinDir holds the Sense binary. The Sense arm gets it at the front of
+	// PATH and the baseline arm gets it removed.
+	SenseBinDir string
+	// HostPath is the PATH both arms derive from, usually the host's.
+	HostPath string
+	// AgentEnv is what the agent tool declares in agent.json, as KEY=VALUE.
+	AgentEnv []string
+	// Lookup reads the host environment. nil means os.LookupEnv.
+	Lookup func(string) (string, bool)
+}
+
+// Env is a prepared environment: where it is, and what a session run inside it
+// sees.
+type Env struct {
+	Layout
+	// Arm is recorded so a run can say which side of the cell it was.
+	Arm Arm
+	// Environ is the session's complete environment, as KEY=VALUE. It is
+	// complete rather than additive: a measured run inherits nothing it was not
+	// given.
+	Environ []string
+}
+
+// Prepare creates the run directory tree and computes the environment a session
+// inside it runs with. It spawns nothing.
+//
+// It refuses a root that already exists. A run's environment is created fresh
+// or not at all, because reusing one is the contamination this package exists
+// to prevent, arriving through the front door.
+func Prepare(s Spec) (Env, error) {
+	if s.Root == "" {
+		return Env{}, errors.New("prepare: no run root given")
+	}
+	// Abs only fails when the working directory cannot be resolved, and it
+	// returns the path unchanged when it does; the Stat below is the check that
+	// matters either way. The absolute form is what gets recorded, so a run
+	// directory is readable from anywhere later.
+	root, _ := filepath.Abs(s.Root)
+	if _, err := os.Stat(root); err == nil {
+		return Env{}, fmt.Errorf("%s already exists; a run's environment is created fresh, never reused", root)
+	}
+
+	l := LayoutFor(root)
+	for _, dir := range l.dirs() {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return Env{}, fmt.Errorf("prepare run environment: %w", err)
+		}
+	}
+
+	lookup := s.Lookup
+	if lookup == nil {
+		lookup = os.LookupEnv
+	}
+	return Env{
+		Layout:  l,
+		Arm:     s.Arm,
+		Environ: Environ(l, PathFor(s.Arm, s.HostPath, s.SenseBinDir), lookup, s.AgentEnv),
+	}, nil
+}
+
+// Cleanup removes the whole environment and proves it is gone.
+//
+// The proof is the point. RemoveAll returning nil says nothing was reported,
+// not that nothing remains, and a run that leaves state behind contaminates the
+// next one — which is the failure that would then be attributed to the model.
+func Cleanup(e Env) error {
+	if e.Root == "" {
+		return errors.New("cleanup: no run root")
+	}
+	if err := os.RemoveAll(e.Root); err != nil {
+		return fmt.Errorf("remove run environment %s: %w", e.Root, err)
+	}
+	return gone(e.Root)
+}
+
+// gone is the proof half of Cleanup: it reports an error unless the path is
+// really absent. It is separate from the removal so the check can be stated on
+// its own, which is the only thing that distinguishes it from trusting
+// RemoveAll's return value.
+func gone(path string) error {
+	_, err := os.Stat(path)
+	switch {
+	case err == nil:
+		return fmt.Errorf("run environment %s still exists after cleanup", path)
+	case errors.Is(err, fs.ErrNotExist):
+		return nil
+	default:
+		return fmt.Errorf("verify cleanup of %s: %w", path, err)
+	}
+}

--- a/lab/internal/isolate/isolate_test.go
+++ b/lab/internal/isolate/isolate_test.go
@@ -1,0 +1,314 @@
+package isolate_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/lab/internal/isolate"
+	"github.com/luuuc/sense/lab/internal/run"
+)
+
+// runRoot is a path under a fresh temp directory that does not yet exist,
+// because Prepare refuses a root that does.
+func runRoot(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "run-1")
+}
+
+func TestPrepareCreatesTheRunTree(t *testing.T) {
+	env, err := isolate.Prepare(isolate.Spec{Root: runRoot(t), Arm: isolate.Sense, Lookup: nothingSet})
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	for _, dir := range []string{
+		env.Home,
+		filepath.Join(env.Home, "config"),
+		filepath.Join(env.Home, "cache"),
+		filepath.Join(env.Home, "data"),
+		filepath.Join(env.Home, "state"),
+		env.Logs,
+		env.Artifacts,
+	} {
+		info, err := os.Stat(dir)
+		if err != nil {
+			t.Errorf("%s: %v", dir, err)
+			continue
+		}
+		if !info.IsDir() {
+			t.Errorf("%s is not a directory", dir)
+		}
+	}
+}
+
+func TestPrepareLeavesTheWorktreePathForGitToCreate(t *testing.T) {
+	// git worktree add refuses a path that already exists, so creating repo/
+	// here would break 03-02 in a way only a live git call would show.
+	env, err := isolate.Prepare(isolate.Spec{Root: runRoot(t), Lookup: nothingSet})
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	if _, err := os.Stat(env.Repo); !os.IsNotExist(err) {
+		t.Errorf("Stat(%s) = %v, want the path not to exist yet", env.Repo, err)
+	}
+}
+
+func TestPrepareWithNoLookupReadsTheRealHost(t *testing.T) {
+	t.Setenv("TERM", "xterm-from-the-host")
+
+	env, err := isolate.Prepare(isolate.Spec{Root: runRoot(t)})
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+
+	if !slices.Contains(env.Environ, "TERM=xterm-from-the-host") {
+		t.Errorf("environment %v does not carry the host's TERM; the default lookup is not reading the process environment", env.Environ)
+	}
+}
+
+func TestPrepareRefusesAnEnvironmentThatAlreadyExists(t *testing.T) {
+	root := t.TempDir() // exists, and may hold a recorded run
+
+	_, err := isolate.Prepare(isolate.Spec{Root: root, Lookup: nothingSet})
+
+	if err == nil {
+		t.Fatal("Prepare reused an existing directory; a run's environment is created fresh or not at all")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("Prepare error = %v, want it to say the root already exists", err)
+	}
+}
+
+func TestPrepareWithoutARootIsRefused(t *testing.T) {
+	if _, err := isolate.Prepare(isolate.Spec{}); err == nil {
+		t.Fatal("Prepare accepted an empty root")
+	}
+}
+
+func TestPrepareFailsWhenTheRunTreeCannotBeCreated(t *testing.T) {
+	// A file where the run root should be. MkdirAll then cannot proceed, and
+	// the failure must be reported rather than leaving a half-built tree that
+	// a session would run inside.
+	parent := t.TempDir()
+	blocked := filepath.Join(parent, "blocked")
+	if err := os.WriteFile(blocked, []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := isolate.Prepare(isolate.Spec{Root: filepath.Join(blocked, "run-1"), Lookup: nothingSet})
+
+	if err == nil {
+		t.Fatal("Prepare succeeded with an unusable run root")
+	}
+}
+
+func TestCleanupRemovesTheWholeEnvironment(t *testing.T) {
+	env, err := isolate.Prepare(isolate.Spec{Root: runRoot(t), Lookup: nothingSet})
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	// State a run would leave behind: a cache the next run must not inherit.
+	if err := os.WriteFile(filepath.Join(env.Home, "cache", "warm"), []byte("state"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := isolate.Cleanup(env); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+
+	if _, err := os.Stat(env.Root); !os.IsNotExist(err) {
+		t.Errorf("Stat(%s) = %v after cleanup, want the tree to be gone", env.Root, err)
+	}
+}
+
+func TestCleanupReportsAnEnvironmentItCouldNotRemove(t *testing.T) {
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		t.Skip("relies on POSIX directory permissions")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores the permission that makes removal fail")
+	}
+	env, err := isolate.Prepare(isolate.Spec{Root: runRoot(t), Lookup: nothingSet})
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	// A directory whose parent denies write cannot be removed. Cleanup must say
+	// so: a run that silently left its home behind contaminates the next one,
+	// and the failure would then be read as the model's.
+	if err := os.Chmod(env.Home, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(env.Home, 0o700) })
+	if err := os.WriteFile(filepath.Join(env.Logs, "kept"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(env.Root, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(env.Root, 0o700) })
+
+	if err := isolate.Cleanup(env); err == nil {
+		t.Fatal("Cleanup reported success on an environment it could not remove")
+	}
+}
+
+func TestCleanupWithoutARootIsRefused(t *testing.T) {
+	if err := isolate.Cleanup(isolate.Env{}); err == nil {
+		t.Fatal("Cleanup accepted an environment with no root; that is one os.RemoveAll away from a very bad day")
+	}
+}
+
+// The process-level proof. Everything above states what the environment is;
+// these run a command inside it and read what the process actually saw.
+
+func TestTheProcessWritesIntoTheDisposableHomeAndXDGDirectories(t *testing.T) {
+	env, err := isolate.Prepare(isolate.Spec{
+		Root:     runRoot(t),
+		Arm:      isolate.Sense,
+		HostPath: os.Getenv("PATH"),
+		Lookup:   nothingSet,
+	})
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	out := filepath.Join(t.TempDir(), "out")
+
+	// Written by the process, from the variables the process was given. If HOME
+	// or any XDG variable still pointed at the host, the files would land there.
+	script := `set -e
+	echo home > "$HOME/wrote-home"
+	echo config > "$XDG_CONFIG_HOME/wrote-config"
+	echo cache > "$XDG_CACHE_HOME/wrote-cache"
+	echo data > "$XDG_DATA_HOME/wrote-data"
+	echo state > "$XDG_STATE_HOME/wrote-state"`
+	m, err := run.Session(context.Background(), out, run.Spec{
+		Dir:  env.Root,
+		Name: "/bin/sh",
+		Args: []string{"-c", script},
+		Env:  env.Environ,
+		Arm:  string(env.Arm),
+		Wall: 30 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+	if m.Outcome != run.Completed {
+		stderr, _ := os.ReadFile(filepath.Join(out, "raw", "stderr"))
+		t.Fatalf("outcome = %s, want completed; stderr: %s", m.Outcome, stderr)
+	}
+
+	for _, path := range []string{
+		filepath.Join(env.Home, "wrote-home"),
+		filepath.Join(env.Home, "config", "wrote-config"),
+		filepath.Join(env.Home, "cache", "wrote-cache"),
+		filepath.Join(env.Home, "data", "wrote-data"),
+		filepath.Join(env.Home, "state", "wrote-state"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("%s: %v", path, err)
+		}
+	}
+}
+
+func TestTheProcessDoesNotSeeTheHostsHome(t *testing.T) {
+	env, err := isolate.Prepare(isolate.Spec{
+		Root:     runRoot(t),
+		HostPath: os.Getenv("PATH"),
+		Lookup:   nothingSet,
+	})
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	out := filepath.Join(t.TempDir(), "out")
+
+	if _, err := run.Session(context.Background(), out, run.Spec{
+		Dir:  env.Root,
+		Name: "/bin/sh",
+		Args: []string{"-c", `printenv HOME`},
+		Env:  env.Environ,
+		Wall: 30 * time.Second,
+	}); err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+
+	said := strings.TrimSpace(readFile(t, filepath.Join(out, "raw", "stdout")))
+	if said != env.Home {
+		t.Errorf("the process saw HOME=%q, want the disposable %q", said, env.Home)
+	}
+	if host, ok := os.LookupEnv("HOME"); ok && said == host {
+		t.Errorf("the process saw the host's HOME %q", host)
+	}
+}
+
+func TestBothArmsRecordTheirPathAndOnlyOneReachesSense(t *testing.T) {
+	senseBin := t.TempDir()
+	hostPath := strings.Join([]string{senseBin, "/usr/bin", "/bin"}, string(filepath.ListSeparator))
+
+	paths := map[isolate.Arm]string{}
+	for _, arm := range []isolate.Arm{isolate.Sense, isolate.Baseline} {
+		env, err := isolate.Prepare(isolate.Spec{
+			Root:        filepath.Join(t.TempDir(), "run-"+string(arm)),
+			Arm:         arm,
+			SenseBinDir: senseBin,
+			HostPath:    hostPath,
+			Lookup:      nothingSet,
+		})
+		if err != nil {
+			t.Fatalf("Prepare(%s): %v", arm, err)
+		}
+		out := filepath.Join(t.TempDir(), "out-"+string(arm))
+		if _, err := run.Session(context.Background(), out, run.Spec{
+			Dir:  env.Root,
+			Name: "/bin/sh",
+			Args: []string{"-c", "true"},
+			Env:  env.Environ,
+			Arm:  string(arm),
+			Wall: 30 * time.Second,
+		}); err != nil {
+			t.Fatalf("Session(%s): %v", arm, err)
+		}
+
+		var meta run.Meta
+		if err := json.Unmarshal([]byte(readFile(t, filepath.Join(out, "run-meta.json"))), &meta); err != nil {
+			t.Fatalf("read run-meta for %s: %v", arm, err)
+		}
+		if meta.Arm != string(arm) {
+			t.Errorf("run-meta arm = %q, want %q", meta.Arm, arm)
+		}
+		if meta.Home != env.Home {
+			t.Errorf("run-meta home = %q, want %q", meta.Home, env.Home)
+		}
+		if meta.Path == "" {
+			t.Fatalf("run-meta for %s records no PATH; the arm difference is then invisible on disk", arm)
+		}
+		paths[arm] = meta.Path
+	}
+
+	if !strings.Contains(paths[isolate.Sense], senseBin) {
+		t.Errorf("the sense arm's recorded PATH %q does not reach the Sense binary", paths[isolate.Sense])
+	}
+	if strings.Contains(paths[isolate.Baseline], senseBin) {
+		t.Errorf("the baseline arm's recorded PATH %q reaches the Sense binary", paths[isolate.Baseline])
+	}
+}
+
+// nothingSet is a host that sets no allowlisted variable, so these tests do not
+// depend on the environment of the machine running them.
+func nothingSet(string) (string, bool) { return "", false }
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}

--- a/lab/internal/run/run.go
+++ b/lab/internal/run/run.go
@@ -52,10 +52,18 @@ type Spec struct {
 	// their prompt this way; a prompt beginning with a dash is read as an
 	// option when passed as an argument, which has already killed a spawn.
 	Stdin string
-	// Env is added to the parent environment, as KEY=VALUE. There is no
-	// isolation this cycle: the session inherits the host environment and this
-	// only adds to it. Cycle 03 replaces the whole of that.
+	// Env is the session's complete environment, as KEY=VALUE. It is complete
+	// rather than additive: a measured run is handed a scrubbed environment by
+	// lab/internal/isolate and inherits nothing it was not given. A caller that
+	// genuinely wants the host's environment composes it at the call site,
+	// where the decision is visible.
+	//
+	// A nil Env leaves the session with the parent's environment, which is only
+	// ever right for a test.
 	Env []string
+	// Arm is which side of a cell this session is, recorded so a run can say so
+	// without anyone re-deriving it from a directory name.
+	Arm string
 	// Wall is how long the process may take. It is part of run identity and is
 	// never raised to rescue a stalled arm.
 	Wall time.Duration
@@ -81,6 +89,31 @@ type Meta struct {
 	// real wall and no output is not a result, it is a broken spawn, and this
 	// is what makes the difference visible without reading transcripts.
 	StdoutBytes int64 `json:"stdout_bytes"`
+
+	// Arm, Home and Path record the isolation the session actually ran under.
+	//
+	// Path is here because it is one of the six channels Sense reaches an agent
+	// through, and it is the one that differs by arm. Recording it is what makes
+	// "the baseline arm could not reach the Sense binary" a fact on disk rather
+	// than a claim about what the code intended. Home is recorded beside it so
+	// a run says which disposable HOME it saw.
+	//
+	// Nothing else from the environment is recorded: it carries credentials.
+	Arm  string `json:"arm,omitempty"`
+	Home string `json:"home,omitempty"`
+	Path string `json:"path,omitempty"`
+}
+
+// envValue reads one KEY=VALUE out of an environment slice. The last entry
+// wins, which is what exec does with a duplicate.
+func envValue(env []string, key string) string {
+	value := ""
+	for _, kv := range env {
+		if name, v, ok := strings.Cut(kv, "="); ok && name == key {
+			value = v
+		}
+	}
+	return value
 }
 
 // exitCodeKilled is what Meta records when the process was killed from outside.
@@ -144,6 +177,9 @@ func Session(ctx context.Context, dir string, s Spec) (Meta, error) {
 		Command:     s.Name,
 		Args:        s.Args,
 		StartedAt:   started.UTC().Format(time.RFC3339),
+		Arm:         s.Arm,
+		Home:        envValue(s.Env, "HOME"),
+		Path:        envValue(s.Env, "PATH"),
 	}
 	if err := writeMeta(dir, m); err != nil {
 		return Meta{}, err
@@ -213,9 +249,7 @@ func spawn(ctx context.Context, s Spec, stdout, stderr *os.File) (code int, ende
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	cmd.Stdin = strings.NewReader(s.Stdin)
-	if len(s.Env) > 0 {
-		cmd.Env = append(os.Environ(), s.Env...)
-	}
+	cmd.Env = s.Env
 
 	// Kill the whole process group, not just the child. An agent CLI spawns its
 	// own children, and killing only the parent leaves them holding the pipe:


### PR DESCRIPTION
## Problem

The walking skeleton runs an agent against the host's `HOME`, the host's agent config and the host's environment. Anything the host carries between runs is a channel the arms did not earn, and none of it is visible in the repository or the prompt.

The concrete case: the runner resolves a memory directory at `$HOME/.claude/projects/<flattened-git-root>/memory/`, keyed off the repository path. It persists across runs, outside the repository, and both arms of every cell read it.

## Summary

A disposable environment per run, written as a concrete type. The executor interface is not here; it gets extracted once a second implementation exists and both shapes are visible.

## Changes

- `lab/internal/isolate` prepares `<run-root>/{home/{config,cache,data,state},logs,artifacts}` with `HOME` and the four XDG variables pointed inside it. `repo/` is deliberately left uncreated, because git refuses to add a worktree at a path that already exists.
- The environment is an **allowlist**, not a denylist, and every entry records why it is there. A denylist means every variable the host acquires later is a leak nobody notices.
- `PATH` is not a shared default. It is one entry with two arm-specific values: the Sense arm gets the Sense binary's directory at the front, and the baseline arm gets it **removed** — including when the host `PATH` already carried it, which is the case a prepend-only implementation misses.
- Cleanup removes the whole tree and then proves it is gone. `RemoveAll` returning nil says nothing was reported, not that nothing remains.
- `run.Spec.Env` is now the session's complete environment rather than an addition to the host's, so inheritance is a visible decision at the call site.
- `run-meta.json` records the arm, the disposable `HOME` and the `PATH`. Nothing else from the environment is recorded, because it carries credentials.

## Test plan

- `make ci` green: build, tests, per-file coverage floor with no new exception, zero complexity suppressions, lint clean.
- `lab/internal/isolate` at 100% line and function coverage.
- Process-level proofs rather than assertions about intent: a session writes into `$HOME` and each XDG directory and the files are found inside the run directory; a session prints `HOME` and it is the disposable one, not the host's; both arms run and their recorded `PATH` values are read back out of `run-meta.json`, with only the Sense arm's reaching the Sense binary.
- Cleanup is proven by a check after the fact, and reports an environment it could not remove.