### PR TITLE
bench(channels): derive the six channels and prove the baseline reaches none

### DIFF
--- a/lab/internal/channels/channels.go
+++ b/lab/internal/channels/channels.go
@@ -1,0 +1,200 @@
+// Package channels enumerates every route by which Sense reaches an agent, and
+// proves an arm has none of them.
+//
+// The whole measurement rests on one claim: the baseline arm cannot reach
+// Sense, and the sense arm can. If that claim is wrong in either direction,
+// every number in the corpus is wrong and nothing about it looks wrong.
+//
+// The repository routes are DERIVED, by running `sense setup` in a throwaway
+// project and reading back what it wrote. A written-down list is the failure
+// this package exists to prevent: a channel added to the product would leave
+// the bench's copy five entries long, every check would still pass, and the
+// baseline arm would have acquired a route nobody enumerated.
+package channels
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Kind says where a channel lives, which decides how it is checked.
+type Kind string
+
+const (
+	// Repository is a file `sense setup` writes into the project: the MCP
+	// registration, the routing guidance, the hook settings, the skills and the
+	// agents. A clean worktree closes these.
+	Repository Kind = "repository"
+	// Path is the Sense binary, reachable as a CLI fallback. The arm's PATH
+	// closes it.
+	Path Kind = "path"
+	// Home is persisted memory, outside the repository and keyed off the
+	// repository path. This is the one a reasonable implementation misses,
+	// because nothing in the repository or the prompt shows it. Only a
+	// disposable HOME closes it.
+	Home Kind = "home"
+)
+
+// Channel is one route, and the name is what a failing check reports. A check
+// that says "contamination detected" tells nobody which route leaked.
+type Channel struct {
+	Name string
+	Kind Kind
+	// Rel is the repository-relative path, for a Repository channel only.
+	Rel string
+}
+
+// setupTool is the agent tool whose channels are derived. Cycle 03 is Claude
+// Code only; naming it here rather than letting detection choose keeps the
+// derived list from depending on what happens to be installed on the machine
+// running the bench.
+const setupTool = "claude-code"
+
+// Derive runs `sense setup` in a throwaway project and reports the repository
+// channels it wrote, plus the two that no file on disk can reveal.
+//
+// workDir must not exist: Derive creates it, along with the throwaway project
+// and a throwaway HOME beside it, so the probe cannot touch the operator's
+// configuration on its way to telling us what the product writes.
+func Derive(ctx context.Context, senseBin, workDir string) ([]Channel, error) {
+	project := filepath.Join(workDir, "project")
+	home := filepath.Join(workDir, "home")
+	for _, dir := range []string{project, home} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, fmt.Errorf("derive channels: %w", err)
+		}
+	}
+
+	cmd := exec.CommandContext(ctx, senseBin, "setup", "--tools", setupTool)
+	cmd.Dir = project
+	cmd.Env = []string{"HOME=" + home, "PATH=" + os.Getenv("PATH")}
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("derive channels: sense setup: %w: %s", err, out)
+	}
+
+	tree, err := Tree(project)
+	if err != nil {
+		return nil, fmt.Errorf("derive channels: %w", err)
+	}
+	written := Sorted(tree)
+	if len(written) == 0 {
+		// A silent no-op would produce an empty channel list, and an empty list
+		// makes every absence check pass. That is the shape of a leak that
+		// reads as a clean bill of health.
+		return nil, errors.New("derive channels: sense setup wrote nothing; the derived list would be empty and every check would pass")
+	}
+
+	cs := make([]Channel, 0, len(written)+2)
+	for _, rel := range written {
+		cs = append(cs, Channel{Name: rel, Kind: Repository, Rel: rel})
+	}
+	return append(cs,
+		Channel{Name: "the sense binary on PATH", Kind: Path},
+		Channel{Name: "the persisted memory directory", Kind: Home},
+	), nil
+}
+
+// Arm is where one arm's channels would be if it had them.
+type Arm struct {
+	// Repo is the worktree the session runs against.
+	Repo string
+	// Home is the disposable HOME.
+	Home string
+	// PathValue is the PATH the session was given.
+	PathValue string
+	// SenseBinary is the binary name to look for on that PATH.
+	SenseBinary string
+}
+
+// Absent reports every channel the arm can still reach, by name. An empty
+// result is the only acceptable outcome for the baseline arm.
+//
+// Each channel is checked individually and reported by name, because "the
+// baseline arm is contaminated" does not say which route leaked, and the route
+// is the whole diagnosis.
+func Absent(cs []Channel, a Arm) []string {
+	var reached []string
+	for _, c := range cs {
+		if why := c.reachedBy(a); why != "" {
+			reached = append(reached, why)
+		}
+	}
+	return reached
+}
+
+// reachedBy reports how the arm reaches this channel, or "" if it cannot.
+func (c Channel) reachedBy(a Arm) string {
+	switch c.Kind {
+	case Repository:
+		if exists(filepath.Join(a.Repo, c.Rel)) {
+			return fmt.Sprintf("%s: %s is in the worktree", c.Name, c.Rel)
+		}
+	case Path:
+		if at := onPath(a.PathValue, a.SenseBinary); at != "" {
+			return fmt.Sprintf("%s: %s is executable at %s", c.Name, a.SenseBinary, at)
+		}
+	case Home:
+		if dir := MemoryDir(a.Home, a.Repo); exists(dir) {
+			return fmt.Sprintf("%s: %s exists", c.Name, dir)
+		}
+		// The exact directory name depends on how the agent tool flattens a
+		// repository path, which is observed rather than documented. The whole
+		// .claude tree is checked as well, so an exact match is not what the
+		// proof rests on.
+		if claude := filepath.Join(a.Home, ".claude"); exists(claude) {
+			return fmt.Sprintf("%s: %s exists in the disposable HOME", c.Name, claude)
+		}
+	}
+	return ""
+}
+
+// MemoryDir is where an agent tool persists memory for a repository: keyed off
+// the repository path, outside the repository, and read by every session that
+// runs against that path.
+//
+// The flattening rule — every character outside [A-Za-z0-9-] becomes a dash —
+// is taken from the directories the tool has actually produced, not from
+// documentation. Absent therefore also checks the whole .claude tree, so the
+// proof does not rest on this staying exact.
+func MemoryDir(home, repo string) string {
+	return filepath.Join(home, ".claude", "projects", flatten(repo), "memory")
+}
+
+func flatten(path string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-':
+			return r
+		default:
+			return '-'
+		}
+	}, path)
+}
+
+// onPath reports where name is executable on the given PATH, or "".
+func onPath(pathValue, name string) string {
+	if name == "" {
+		return ""
+	}
+	for _, dir := range filepath.SplitList(pathValue) {
+		if dir == "" {
+			continue
+		}
+		candidate := filepath.Join(dir, name)
+		info, err := os.Stat(candidate)
+		if err == nil && !info.IsDir() && info.Mode()&0o111 != 0 {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}

--- a/lab/internal/channels/channels_test.go
+++ b/lab/internal/channels/channels_test.go
@@ -1,0 +1,301 @@
+package channels_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/lab/internal/channels"
+)
+
+// fakeSense writes a stand-in for the product binary whose `setup` creates the
+// given repository-relative files in its working directory.
+//
+// The mechanism under test is "run setup and read back what it wrote", and a
+// stand-in states exactly what was written, so a failure is the derivation's
+// rather than the product's. The real binary is exercised separately, below.
+func fakeSense(t *testing.T, writes ...string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the stand-in is a shell script")
+	}
+	script := "#!/bin/sh\nset -e\n"
+	for _, rel := range writes {
+		script += "mkdir -p \"$(dirname " + rel + ")\"\n"
+		script += "echo configured > " + rel + "\n"
+	}
+	path := filepath.Join(t.TempDir(), "sense")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestDeriveReportsEveryFileSetupWroteIntoTheProject(t *testing.T) {
+	bin := fakeSense(t, ".mcp.json", "CLAUDE.md", ".claude/settings.json", ".claude/skills/sense-explore.md")
+
+	got, err := channels.Derive(context.Background(), bin, filepath.Join(t.TempDir(), "probe"))
+	if err != nil {
+		t.Fatalf("Derive: %v", err)
+	}
+
+	var repo []string
+	for _, c := range got {
+		if c.Kind == channels.Repository {
+			repo = append(repo, c.Rel)
+		}
+	}
+	want := []string{".claude/settings.json", ".claude/skills/sense-explore.md", ".mcp.json", "CLAUDE.md"}
+	if !slices.Equal(repo, want) {
+		t.Errorf("derived repository channels = %v, want %v", repo, want)
+	}
+}
+
+func TestDerivePicksUpAChannelNobodyWroteDown(t *testing.T) {
+	// The whole reason the list is derived: a channel added to the product must
+	// show up without an edit to the bench. A hard-coded list would still be
+	// four entries long here and every absence check would still pass.
+	bin := fakeSense(t, ".mcp.json", "CLAUDE.md", ".claude/settings.json", ".cursor/mcp.json")
+
+	got, err := channels.Derive(context.Background(), bin, filepath.Join(t.TempDir(), "probe"))
+	if err != nil {
+		t.Fatalf("Derive: %v", err)
+	}
+
+	if !slices.ContainsFunc(got, func(c channels.Channel) bool { return c.Rel == ".cursor/mcp.json" }) {
+		t.Errorf("derived channels %v do not include the newly written .cursor/mcp.json", got)
+	}
+}
+
+func TestDeriveAlsoNamesTheTwoChannelsNoFileCanReveal(t *testing.T) {
+	bin := fakeSense(t, ".mcp.json")
+
+	got, err := channels.Derive(context.Background(), bin, filepath.Join(t.TempDir(), "probe"))
+	if err != nil {
+		t.Fatalf("Derive: %v", err)
+	}
+
+	for _, kind := range []channels.Kind{channels.Path, channels.Home} {
+		if !slices.ContainsFunc(got, func(c channels.Channel) bool { return c.Kind == kind }) {
+			t.Errorf("derived channels do not name the %s channel; nothing setup writes would reveal it", kind)
+		}
+	}
+}
+
+func TestDeriveRefusesASetupThatWroteNothing(t *testing.T) {
+	// An empty derived list makes every absence check pass, which is the shape
+	// of a leak that reads as a clean bill of health.
+	bin := fakeSense(t)
+
+	_, err := channels.Derive(context.Background(), bin, filepath.Join(t.TempDir(), "probe"))
+
+	if err == nil {
+		t.Fatal("Derive accepted a setup that wrote nothing")
+	}
+	if !strings.Contains(err.Error(), "wrote nothing") {
+		t.Errorf("Derive error = %v, want it to name the empty result", err)
+	}
+}
+
+func TestDeriveReportsASetupThatFailed(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "not-a-binary")
+
+	if _, err := channels.Derive(context.Background(), bin, filepath.Join(t.TempDir(), "probe")); err == nil {
+		t.Fatal("Derive succeeded with no usable binary")
+	}
+}
+
+func TestDeriveCannotWriteIntoTheProbeItCannotCreate(t *testing.T) {
+	blocked := filepath.Join(t.TempDir(), "blocked")
+	if err := os.WriteFile(blocked, []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := channels.Derive(context.Background(), fakeSense(t, ".mcp.json"), filepath.Join(blocked, "work")); err == nil {
+		t.Fatal("Derive succeeded with an unusable work directory")
+	}
+}
+
+// The absence proof.
+
+func cleanArm(t *testing.T) channels.Arm {
+	t.Helper()
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "repo")
+	home := filepath.Join(dir, "home")
+	for _, d := range []string{repo, home} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return channels.Arm{Repo: repo, Home: home, PathValue: "/nonexistent/bin", SenseBinary: "sense"}
+}
+
+func TestTheBaselineArmReachesNothing(t *testing.T) {
+	cs := []channels.Channel{
+		{Name: "the MCP registration", Kind: channels.Repository, Rel: ".mcp.json"},
+		{Name: "the routing guidance", Kind: channels.Repository, Rel: "CLAUDE.md"},
+		{Name: "the sense binary on PATH", Kind: channels.Path},
+		{Name: "the persisted memory directory", Kind: channels.Home},
+	}
+
+	if reached := channels.Absent(cs, cleanArm(t)); len(reached) != 0 {
+		t.Errorf("a clean arm reaches %v", reached)
+	}
+}
+
+func TestARepositoryChannelIsReportedByName(t *testing.T) {
+	arm := cleanArm(t)
+	if err := os.WriteFile(filepath.Join(arm.Repo, ".mcp.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cs := []channels.Channel{
+		{Name: "the MCP registration", Kind: channels.Repository, Rel: ".mcp.json"},
+		{Name: "the routing guidance", Kind: channels.Repository, Rel: "CLAUDE.md"},
+	}
+
+	reached := channels.Absent(cs, arm)
+
+	if len(reached) != 1 {
+		t.Fatalf("Absent = %v, want exactly the MCP registration", reached)
+	}
+	// "contaminated" does not say which route leaked, and the route is the
+	// whole diagnosis.
+	if !strings.Contains(reached[0], "the MCP registration") {
+		t.Errorf("Absent reported %q, which does not name the channel", reached[0])
+	}
+}
+
+func TestTheSenseBinaryOnPathIsReported(t *testing.T) {
+	arm := cleanArm(t)
+	bin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bin, "sense"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	arm.PathValue = strings.Join([]string{"/nonexistent/bin", bin}, string(filepath.ListSeparator))
+
+	reached := channels.Absent([]channels.Channel{{Name: "the sense binary on PATH", Kind: channels.Path}}, arm)
+
+	if len(reached) != 1 {
+		t.Fatalf("Absent = %v, want the CLI fallback reported", reached)
+	}
+}
+
+func TestANonExecutableFileNamedSenseIsNotACliFallback(t *testing.T) {
+	arm := cleanArm(t)
+	bin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bin, "sense"), []byte("notes about sense"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	arm.PathValue = bin
+
+	if reached := channels.Absent([]channels.Channel{{Kind: channels.Path, Name: "path"}}, arm); len(reached) != 0 {
+		t.Errorf("Absent = %v; a file that cannot be executed is not a fallback", reached)
+	}
+}
+
+func TestAnEmptyPathElementIsNotSearched(t *testing.T) {
+	arm := cleanArm(t)
+	arm.PathValue = string(filepath.ListSeparator)
+
+	if reached := channels.Absent([]channels.Channel{{Kind: channels.Path, Name: "path"}}, arm); len(reached) != 0 {
+		t.Errorf("Absent = %v for an empty PATH", reached)
+	}
+}
+
+func TestNoBinaryNameMeansNoPathChannelToCheck(t *testing.T) {
+	arm := cleanArm(t)
+	arm.SenseBinary = ""
+
+	if reached := channels.Absent([]channels.Channel{{Kind: channels.Path, Name: "path"}}, arm); len(reached) != 0 {
+		t.Errorf("Absent = %v with no binary named", reached)
+	}
+}
+
+// The memory directory gets its own test because it is the one channel outside
+// the repository, and the one a reasonable implementation misses: nothing in
+// the worktree or the prompt would show it.
+
+func TestThePersistedMemoryDirectoryIsReportedEvenThoughItIsOutsideTheRepository(t *testing.T) {
+	arm := cleanArm(t)
+	memory := channels.MemoryDir(arm.Home, arm.Repo)
+	if err := os.MkdirAll(memory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(memory, "MEMORY.md"), []byte("- use sense_graph"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reached := channels.Absent([]channels.Channel{{Name: "the persisted memory directory", Kind: channels.Home}}, arm)
+
+	if len(reached) != 1 {
+		t.Fatalf("Absent = %v, want the memory directory reported", reached)
+	}
+	if !strings.Contains(reached[0], memory) {
+		t.Errorf("Absent reported %q, want it to name %s", reached[0], memory)
+	}
+}
+
+func TestAgentStateInTheDisposableHomeIsReportedEvenUnderAnotherKey(t *testing.T) {
+	// The directory name depends on how the agent tool flattens a repository
+	// path, which is observed rather than documented. If that ever changes, the
+	// exact key stops matching and the whole tree is what catches it.
+	arm := cleanArm(t)
+	if err := os.MkdirAll(filepath.Join(arm.Home, ".claude", "projects", "some-other-key"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	reached := channels.Absent([]channels.Channel{{Name: "the persisted memory directory", Kind: channels.Home}}, arm)
+
+	if len(reached) != 1 {
+		t.Fatalf("Absent = %v, want agent state in the disposable HOME reported", reached)
+	}
+}
+
+func TestTheMemoryDirectoryIsKeyedOffTheRepositoryPath(t *testing.T) {
+	// Two arms on different worktrees must not share a memory directory: that
+	// is the shared mutable host state the per-run worktree exists to separate.
+	sense := channels.MemoryDir("/home/bench", "/runs/r1/repo")
+	baseline := channels.MemoryDir("/home/bench", "/runs/r2/repo")
+
+	if sense == baseline {
+		t.Fatalf("both arms resolve to %s", sense)
+	}
+	if strings.ContainsAny(filepath.Base(filepath.Dir(sense)), "/._") {
+		t.Errorf("the directory key %q is not flattened", filepath.Base(filepath.Dir(sense)))
+	}
+}
+
+// The real product binary, when it is around. The stand-in above proves the
+// derivation; this proves the derivation is pointed at the right thing.
+
+func TestTheRealBinaryWritesTheRepositoryChannelsWeExpect(t *testing.T) {
+	bin, err := filepath.Abs(filepath.Join("..", "..", "..", "bin", "sense"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(bin); err != nil {
+		t.Skip("no built sense binary; make build")
+	}
+
+	got, err := channels.Derive(context.Background(), bin, filepath.Join(t.TempDir(), "probe"))
+	if err != nil {
+		t.Fatalf("Derive: %v", err)
+	}
+
+	// Not the whole list, which is the product's to change. These four are the
+	// routes the cycle names, and losing one silently would mean the baseline
+	// arm stopped being checked for it.
+	for _, rel := range []string{".mcp.json", "CLAUDE.md", ".claude/settings.json"} {
+		if !slices.ContainsFunc(got, func(c channels.Channel) bool { return c.Rel == rel }) {
+			t.Errorf("sense setup no longer writes %s; the derived channel list has changed", rel)
+		}
+	}
+	if !slices.ContainsFunc(got, func(c channels.Channel) bool { return strings.HasPrefix(c.Rel, ".claude/skills/") }) {
+		t.Error("sense setup no longer writes any skill file")
+	}
+}

--- a/lab/internal/channels/host.go
+++ b/lab/internal/channels/host.go
@@ -1,0 +1,167 @@
+package channels
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+)
+
+// HostWatch is the set of host paths a run must leave untouched: the host agent
+// config, the operator's own routing guidance, and the memory directory for the
+// repository under study.
+//
+// It is exactly the paths the channels name, and no more. A general sweep of
+// HOME is flaky the moment any other process on the machine writes something,
+// and a flaky check is a check somebody disables.
+func HostWatch(home, repo string) []string {
+	return []string{
+		filepath.Join(home, ".claude.json"),
+		filepath.Join(home, ".claude", "CLAUDE.md"),
+		filepath.Join(home, ".claude", "settings.json"),
+		MemoryDir(home, repo),
+	}
+}
+
+// absent is the digest of a path that is not there. It is a value rather than a
+// missing key, so a path that appears during a run is a change rather than a
+// silently ignored one.
+const absent = "absent"
+
+// Snapshot is the state of a set of paths at a moment, as path to digest.
+type Snapshot map[string]string
+
+// Take records the given paths. A path that does not exist is recorded as
+// absent rather than skipped: a run that CREATES the operator's memory
+// directory has contaminated the host just as surely as one that edits it.
+func Take(paths []string) (Snapshot, error) {
+	s := make(Snapshot, len(paths))
+	for _, path := range paths {
+		d, err := digest(path)
+		if err != nil {
+			return nil, fmt.Errorf("snapshot %s: %w", path, err)
+		}
+		s[path] = d
+	}
+	return s, nil
+}
+
+// Changed names every watched path whose state differs from the snapshot.
+//
+// A path that changed is a failed run and a bug. It is never something to tidy
+// up and continue past: the state that leaked out is also the state the next
+// run would have inherited.
+func (s Snapshot) Changed() ([]string, error) {
+	var changed []string
+	for path, was := range s {
+		now, err := digest(path)
+		if err != nil {
+			return nil, fmt.Errorf("re-read %s: %w", path, err)
+		}
+		if now == was {
+			continue
+		}
+		switch {
+		case was == absent:
+			changed = append(changed, fmt.Sprintf("%s was created by the run", path))
+		case now == absent:
+			changed = append(changed, fmt.Sprintf("%s was removed by the run", path))
+		default:
+			changed = append(changed, fmt.Sprintf("%s was modified by the run", path))
+		}
+	}
+	sort.Strings(changed)
+	return changed, nil
+}
+
+// digest is a content hash for a file, a content hash over the whole tree for a
+// directory, and the absent marker for a path that is not there.
+func digest(path string) (string, error) {
+	info, err := os.Lstat(path)
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return absent, nil
+	case err != nil:
+		return "", err
+	case info.IsDir():
+		return treeDigest(path)
+	default:
+		return fileDigest(path)
+	}
+}
+
+func fileDigest(path string) (string, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// treeDigest covers additions and removals as well as edits, because a run that
+// appended one memory file has left state the next run would inherit.
+func treeDigest(root string) (string, error) {
+	tree, err := Tree(root)
+	if err != nil {
+		return "", err
+	}
+	h := sha256.New()
+	for _, rel := range Sorted(tree) {
+		_, _ = io.WriteString(h, rel+"\x00"+tree[rel]+"\n")
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// Tree hashes every file below root, keyed by its path relative to root.
+// Directories with any of the given names are not descended into.
+//
+// It is the one walker in the lab: the channel derivation, the host
+// contamination digest and the record of what setup wrote are all "what files
+// are here and what is in them", and three spellings of that is three places
+// for a symlink or a permission to be handled differently.
+func Tree(root string, skip ...string) (map[string]string, error) {
+	tree := map[string]string{}
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if path != root && slices.Contains(skip, d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		h, err := fileDigest(path)
+		if err != nil {
+			return err
+		}
+		tree[rel] = h
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return tree, nil
+}
+
+// Sorted lists a tree's paths in a stable order, so anything derived from one
+// reads the same between runs.
+func Sorted(tree map[string]string) []string {
+	paths := make([]string, 0, len(tree))
+	for path := range tree {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths
+}

--- a/lab/internal/channels/host_test.go
+++ b/lab/internal/channels/host_test.go
@@ -1,0 +1,234 @@
+package channels_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/lab/internal/channels"
+)
+
+// hostHome is a stand-in for the operator's HOME, carrying the three pieces of
+// state a run must leave exactly as it found them.
+func hostHome(t *testing.T) (home, repo string) {
+	t.Helper()
+	home = t.TempDir()
+	repo = filepath.Join(t.TempDir(), "checkout")
+	write(t, filepath.Join(home, ".claude.json"), `{"projects":{}}`)
+	write(t, filepath.Join(home, ".claude", "CLAUDE.md"), "answer in under six lines")
+	write(t, filepath.Join(home, ".claude", "settings.json"), `{"hooks":{}}`)
+	write(t, filepath.Join(channels.MemoryDir(home, repo), "MEMORY.md"), "- a fact from a previous run")
+	return home, repo
+}
+
+func write(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func snapshot(t *testing.T, home, repo string) channels.Snapshot {
+	t.Helper()
+	s, err := channels.Take(channels.HostWatch(home, repo))
+	if err != nil {
+		t.Fatalf("Take: %v", err)
+	}
+	return s
+}
+
+func changed(t *testing.T, s channels.Snapshot) []string {
+	t.Helper()
+	c, err := s.Changed()
+	if err != nil {
+		t.Fatalf("Changed: %v", err)
+	}
+	return c
+}
+
+func TestAHostThatWasNotTouchedReportsNothing(t *testing.T) {
+	home, repo := hostHome(t)
+
+	if got := changed(t, snapshot(t, home, repo)); len(got) != 0 {
+		t.Errorf("an untouched host reports %v", got)
+	}
+}
+
+func TestAnEditedHostAgentConfigIsReported(t *testing.T) {
+	home, repo := hostHome(t)
+	before := snapshot(t, home, repo)
+
+	write(t, filepath.Join(home, ".claude.json"), `{"projects":{"/runs/r1/repo":{}}}`)
+
+	got := changed(t, before)
+	if len(got) != 1 || !strings.Contains(got[0], "modified") {
+		t.Fatalf("Changed = %v, want the host agent config reported as modified", got)
+	}
+}
+
+func TestAnEditedOperatorGuidanceFileIsReported(t *testing.T) {
+	// This is the seventh channel: the operator's own CLAUDE.md reaches both
+	// arms and suppresses answer length in both, which is what a richness floor
+	// and a recall count are measured on.
+	home, repo := hostHome(t)
+	before := snapshot(t, home, repo)
+
+	write(t, filepath.Join(home, ".claude", "CLAUDE.md"), "answer in under three lines")
+
+	if got := changed(t, before); len(got) != 1 {
+		t.Fatalf("Changed = %v, want the operator's guidance reported", got)
+	}
+}
+
+func TestAFileTheRunAddedToTheHostMemoryDirectoryIsReported(t *testing.T) {
+	// A directory digest must cover additions, not only edits: a run that
+	// appended a new memory file has left state the next run would inherit.
+	home, repo := hostHome(t)
+	before := snapshot(t, home, repo)
+
+	write(t, filepath.Join(channels.MemoryDir(home, repo), "learned.md"), "- a fact from this run")
+
+	got := changed(t, before)
+	if len(got) != 1 || !strings.Contains(got[0], "modified") {
+		t.Fatalf("Changed = %v, want the memory directory reported", got)
+	}
+}
+
+func TestAHostPathTheRunCreatedIsReported(t *testing.T) {
+	// Absent is a recorded state, not a skipped one. A run that CREATES the
+	// operator's memory directory has contaminated the host just as surely as
+	// one that edited it.
+	home := t.TempDir()
+	repo := filepath.Join(t.TempDir(), "checkout")
+	before := snapshot(t, home, repo)
+
+	write(t, filepath.Join(channels.MemoryDir(home, repo), "MEMORY.md"), "- written by the run")
+
+	got := changed(t, before)
+	if len(got) != 1 || !strings.Contains(got[0], "created") {
+		t.Fatalf("Changed = %v, want the created path reported", got)
+	}
+}
+
+func TestAHostPathTheRunRemovedIsReported(t *testing.T) {
+	home, repo := hostHome(t)
+	before := snapshot(t, home, repo)
+
+	if err := os.Remove(filepath.Join(home, ".claude.json")); err != nil {
+		t.Fatal(err)
+	}
+
+	got := changed(t, before)
+	if len(got) != 1 || !strings.Contains(got[0], "removed") {
+		t.Fatalf("Changed = %v, want the removed path reported", got)
+	}
+}
+
+func TestTheWatchListIsTheChannelPathsAndNoMore(t *testing.T) {
+	// Scoped on purpose. A general sweep of HOME is flaky the moment any other
+	// process on the machine writes something, and a flaky check is a check
+	// somebody disables.
+	home, repo := hostHome(t)
+
+	got := channels.HostWatch(home, repo)
+
+	want := []string{
+		filepath.Join(home, ".claude.json"),
+		filepath.Join(home, ".claude", "CLAUDE.md"),
+		filepath.Join(home, ".claude", "settings.json"),
+		channels.MemoryDir(home, repo),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("HostWatch = %v, want %v", got, want)
+	}
+	for i, path := range want {
+		if got[i] != path {
+			t.Errorf("HostWatch[%d] = %s, want %s", i, got[i], path)
+		}
+	}
+	// Unrelated host state a run may legitimately touch must not be watched.
+	if unrelated := filepath.Join(home, ".cache"); containsPath(got, unrelated) {
+		t.Errorf("HostWatch watches %s, which is outside the channels", unrelated)
+	}
+}
+
+func containsPath(paths []string, want string) bool {
+	for _, p := range paths {
+		if p == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestAPathThatCannotBeReadIsAnErrorRatherThanAPass(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores the permission that makes the read fail")
+	}
+	home := t.TempDir()
+	repo := filepath.Join(t.TempDir(), "checkout")
+	secret := filepath.Join(home, ".claude.json")
+	write(t, secret, "{}")
+	if err := os.Chmod(secret, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(secret, 0o600) })
+
+	// "I could not look" is not "nothing changed": reporting a pass here would
+	// clear a run on exactly the machines where something is already wrong.
+	if _, err := channels.Take(channels.HostWatch(home, repo)); err == nil {
+		t.Fatal("Take reported success on a path it could not read")
+	}
+}
+
+func TestAPathThatBecomesUnreadableDuringTheRunIsAnError(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores the permission that makes the read fail")
+	}
+	home, repo := hostHome(t)
+	before := snapshot(t, home, repo)
+
+	memory := channels.MemoryDir(home, repo)
+	if err := os.Chmod(memory, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(memory, 0o700) })
+
+	if _, err := before.Changed(); err == nil {
+		t.Fatal("Changed reported success on a path it could not re-read")
+	}
+}
+
+func TestAHomeThatIsNotADirectoryIsAnErrorRatherThanAnAllClear(t *testing.T) {
+	// Lstat fails with something other than "not there". Treating that as
+	// absent would report a clean host on a machine whose HOME is misconfigured,
+	// which is the one case where a clean bill of health is least deserved.
+	notADir := filepath.Join(t.TempDir(), "home")
+	write(t, notADir, "this is a file")
+
+	if _, err := channels.Take(channels.HostWatch(notADir, "/runs/r1/repo")); err == nil {
+		t.Fatal("Take reported success against a HOME that is not a directory")
+	}
+}
+
+func TestATreeSkipsTheDirectoriesItIsToldTo(t *testing.T) {
+	// .git and .sense are machinery rather than channels, and both are large
+	// enough to make hashing them the slowest step in a run.
+	root := t.TempDir()
+	write(t, filepath.Join(root, "app.go"), "package app")
+	write(t, filepath.Join(root, ".git", "HEAD"), "ref: refs/heads/main")
+	write(t, filepath.Join(root, ".sense", "index.db"), "binary")
+
+	tree, err := channels.Tree(root, ".git", ".sense")
+	if err != nil {
+		t.Fatalf("Tree: %v", err)
+	}
+
+	if got := channels.Sorted(tree); len(got) != 1 || got[0] != "app.go" {
+		t.Errorf("Tree = %v, want only app.go", got)
+	}
+}

--- a/lab/internal/isolate/isolate_test.go
+++ b/lab/internal/isolate/isolate_test.go
@@ -312,3 +312,52 @@ func readFile(t *testing.T, path string) string {
 	}
 	return string(b)
 }
+
+func TestTheSessionCannotSeeTheOperatorsOwnGuidanceFile(t *testing.T) {
+	// The seventh channel, and the one an environment variable does not close:
+	// the operator's ~/.claude/CLAUDE.md is loaded into every session, in both
+	// arms. A personal instruction of the "answer in under six lines" kind
+	// suppresses answer length in both, and answer length is what a richness
+	// floor and a recall count are measured on.
+	//
+	// The session is asked rather than told: it looks in its own HOME and says
+	// what it found. Setting CLAUDE_CODE_DISABLE_AUTO_MEMORY=1 was measured
+	// against a real spawn and does not close this; only a disposable HOME does.
+	hostHome := t.TempDir()
+	guidance := filepath.Join(hostHome, ".claude", "CLAUDE.md")
+	if err := os.MkdirAll(filepath.Dir(guidance), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(guidance, []byte("answer in under six lines"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	env, err := isolate.Prepare(isolate.Spec{
+		Root:     runRoot(t),
+		HostPath: os.Getenv("PATH"),
+		Lookup:   nothingSet,
+	})
+	if err != nil {
+		t.Fatalf("Prepare: %v", err)
+	}
+	out := filepath.Join(t.TempDir(), "out")
+
+	if _, err := run.Session(context.Background(), out, run.Spec{
+		Dir:  env.Root,
+		Name: "/bin/sh",
+		Args: []string{"-c", `cat "$HOME/.claude/CLAUDE.md" 2>/dev/null || echo NOTHING`},
+		Env:  env.Environ,
+		Wall: 30 * time.Second,
+	}); err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+
+	said := strings.TrimSpace(readFile(t, filepath.Join(out, "raw", "stdout")))
+	if said != "NOTHING" {
+		t.Errorf("the session read %q from its HOME; the operator's guidance reached it", said)
+	}
+	// And the guidance is still where the operator left it.
+	if _, err := os.Stat(guidance); err != nil {
+		t.Errorf("the operator's guidance was disturbed: %v", err)
+	}
+}

--- a/lab/internal/isolate/worktree.go
+++ b/lab/internal/isolate/worktree.go
@@ -1,0 +1,39 @@
+package isolate
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// AddWorktree checks the parent repository out at a commit, at dest.
+//
+// A worktree rather than a clone: it is cheap, it is pinned by construction,
+// and it cannot drift from the commit recorded in run-meta.json. Detached,
+// because a branch name would be a second thing that could move.
+//
+// Worktrees share the parent's object store. That is fine at one run at a time,
+// which the law requires anyway, but it means parallel runs contend and a
+// corrupted parent takes every worktree with it. Whoever adds concurrency meets
+// that constraint deliberately.
+func AddWorktree(ctx context.Context, parent, commit, dest string) error {
+	cmd := exec.CommandContext(ctx, "git", "-C", parent, "worktree", "add", "--detach", dest, commit)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("add worktree at %.12s: %w: %s", commit, err, out)
+	}
+	return nil
+}
+
+// RemoveWorktree removes the worktree and proves it is gone.
+//
+// The proof is the point, as it is for the rest of cleanup: git reporting
+// success says nothing was reported, and a worktree left behind is state the
+// next run inherits. --force because a session is expected to have dirtied the
+// tree, and a run that modified the repository must still clean up.
+func RemoveWorktree(ctx context.Context, parent, dest string) error {
+	cmd := exec.CommandContext(ctx, "git", "-C", parent, "worktree", "remove", "--force", dest)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("remove worktree %s: %w: %s", dest, err, out)
+	}
+	return gone(dest)
+}

--- a/lab/internal/isolate/worktree_test.go
+++ b/lab/internal/isolate/worktree_test.go
@@ -1,0 +1,155 @@
+package isolate_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/lab/internal/isolate"
+)
+
+// parentRepo is a two-commit repository, so a test can pin an older commit and
+// tell a pinned checkout from a checkout of the tip.
+func parentRepo(t *testing.T) (dir, first, second string) {
+	t.Helper()
+	dir = t.TempDir()
+	git := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=bench", "GIT_AUTHOR_EMAIL=bench@example.com",
+			"GIT_COMMITTER_NAME=bench", "GIT_COMMITTER_EMAIL=bench@example.com",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	git("init", "-q", "-b", "main")
+	if err := os.WriteFile(filepath.Join(dir, "app.go"), []byte("package app\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git("add", ".")
+	git("commit", "-q", "-m", "first")
+	first = git("rev-parse", "HEAD")
+
+	if err := os.WriteFile(filepath.Join(dir, "app.go"), []byte("package app\n\nfunc New() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git("commit", "-q", "-am", "second")
+	second = git("rev-parse", "HEAD")
+	return dir, first, second
+}
+
+func TestAWorktreeIsCheckedOutAtThePinnedCommitRatherThanTheTip(t *testing.T) {
+	parent, pinned, tip := parentRepo(t)
+	dest := filepath.Join(t.TempDir(), "repo")
+
+	if err := isolate.AddWorktree(context.Background(), parent, pinned, dest); err != nil {
+		t.Fatalf("AddWorktree: %v", err)
+	}
+
+	at := strings.TrimSpace(gitOut(t, dest, "rev-parse", "HEAD"))
+	if at != pinned {
+		t.Errorf("worktree is at %.12s, want the pinned %.12s", at, pinned)
+	}
+	if at == tip {
+		t.Error("the worktree drifted to the tip; the commit in run-meta.json would not be the commit that was read")
+	}
+	content := readFile(t, filepath.Join(dest, "app.go"))
+	if strings.Contains(content, "func New") {
+		t.Error("the worktree holds the later commit's content")
+	}
+}
+
+func TestAWorktreeIsDetachedSoNoBranchCanMoveUnderIt(t *testing.T) {
+	parent, pinned, _ := parentRepo(t)
+	dest := filepath.Join(t.TempDir(), "repo")
+	if err := isolate.AddWorktree(context.Background(), parent, pinned, dest); err != nil {
+		t.Fatalf("AddWorktree: %v", err)
+	}
+
+	// symbolic-ref fails on a detached HEAD, which is the state we want.
+	cmd := exec.Command("git", "-C", dest, "symbolic-ref", "-q", "HEAD")
+	if out, err := cmd.CombinedOutput(); err == nil {
+		t.Errorf("the worktree is on branch %s; a branch is a second thing that could move", strings.TrimSpace(string(out)))
+	}
+}
+
+func TestAWorktreeIsRemovedCompletely(t *testing.T) {
+	parent, pinned, _ := parentRepo(t)
+	dest := filepath.Join(t.TempDir(), "repo")
+	if err := isolate.AddWorktree(context.Background(), parent, pinned, dest); err != nil {
+		t.Fatalf("AddWorktree: %v", err)
+	}
+
+	if err := isolate.RemoveWorktree(context.Background(), parent, dest); err != nil {
+		t.Fatalf("RemoveWorktree: %v", err)
+	}
+
+	// Checked after cleanup, not assumed from a clean exit.
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Errorf("Stat(%s) = %v after removal, want the worktree gone", dest, err)
+	}
+	if list := gitOut(t, parent, "worktree", "list"); strings.Contains(list, dest) {
+		t.Errorf("the parent still lists %s:\n%s", dest, list)
+	}
+}
+
+func TestAWorktreeTheSessionDirtiedIsStillRemoved(t *testing.T) {
+	// A session is expected to have written to the repository. A run that
+	// modified the tree must still clean up, or the next run inherits it.
+	parent, pinned, _ := parentRepo(t)
+	dest := filepath.Join(t.TempDir(), "repo")
+	if err := isolate.AddWorktree(context.Background(), parent, pinned, dest); err != nil {
+		t.Fatalf("AddWorktree: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dest, "app.go"), []byte("package app // edited by the session\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dest, "scratch.txt"), []byte("notes"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := isolate.RemoveWorktree(context.Background(), parent, dest); err != nil {
+		t.Fatalf("RemoveWorktree: %v", err)
+	}
+	if _, err := os.Stat(dest); !os.IsNotExist(err) {
+		t.Errorf("Stat(%s) = %v, want a dirty worktree removed anyway", dest, err)
+	}
+}
+
+func TestAWorktreeAtACommitTheParentDoesNotHaveIsRefused(t *testing.T) {
+	parent, _, _ := parentRepo(t)
+	dest := filepath.Join(t.TempDir(), "repo")
+
+	err := isolate.AddWorktree(context.Background(), parent, "0000000000000000000000000000000000000000", dest)
+
+	if err == nil {
+		t.Fatal("AddWorktree succeeded at a commit the parent does not have")
+	}
+	if _, statErr := os.Stat(dest); !os.IsNotExist(statErr) {
+		t.Errorf("a failed AddWorktree left %s behind", dest)
+	}
+}
+
+func TestRemovingAWorktreeThatIsNotThereIsReported(t *testing.T) {
+	parent, _, _ := parentRepo(t)
+
+	if err := isolate.RemoveWorktree(context.Background(), parent, filepath.Join(t.TempDir(), "never-added")); err == nil {
+		t.Fatal("RemoveWorktree reported success on a worktree that was never added")
+	}
+}
+
+func gitOut(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	out, err := exec.Command("git", append([]string{"-C", dir}, args...)...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, out)
+	}
+	return string(out)
+}

--- a/lab/internal/run/run.go
+++ b/lab/internal/run/run.go
@@ -64,6 +64,9 @@ type Spec struct {
 	// Arm is which side of a cell this session is, recorded so a run can say so
 	// without anyone re-deriving it from a directory name.
 	Arm string
+	// SenseSetup is what the subject's setup wrote into the repository, as path
+	// to content hash. Empty for the baseline arm, which is the point.
+	SenseSetup map[string]string
 	// Wall is how long the process may take. It is part of run identity and is
 	// never raised to rescue a stalled arm.
 	Wall time.Duration
@@ -102,6 +105,15 @@ type Meta struct {
 	Arm  string `json:"arm,omitempty"`
 	Home string `json:"home,omitempty"`
 	Path string `json:"path,omitempty"`
+
+	// SenseSetup is what the subject's setup wrote into the repository, as path
+	// to content hash.
+	//
+	// A change to `sense setup` changes what the sense arm sees, which changes
+	// the measurement, and nothing about that is visible in a result months
+	// later. Recorded per run, two runs far apart are comparable on what was
+	// installed rather than on an assumption that it was the same.
+	SenseSetup map[string]string `json:"sense_setup,omitempty"`
 }
 
 // envValue reads one KEY=VALUE out of an environment slice. The last entry
@@ -178,6 +190,7 @@ func Session(ctx context.Context, dir string, s Spec) (Meta, error) {
 		Args:        s.Args,
 		StartedAt:   started.UTC().Format(time.RFC3339),
 		Arm:         s.Arm,
+		SenseSetup:  s.SenseSetup,
 		Home:        envValue(s.Env, "HOME"),
 		Path:        envValue(s.Env, "PATH"),
 	}

--- a/lab/internal/subject/subject.go
+++ b/lab/internal/subject/subject.go
@@ -1,0 +1,92 @@
+// Package subject prepares an arm's repository: what the code-intelligence
+// treatment installs, and nothing else.
+//
+// The two arms are deliberately asymmetric. The sense arm gets the product's
+// own setup surface, whatever that currently writes, because the arm must see
+// what a real user sees. The baseline arm gets nothing, and lab/internal/channels
+// proves it.
+package subject
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/luuuc/sense/lab/internal/channels"
+)
+
+// Sense prepares the sense arm's worktree: index it, then configure it, in that
+// order and both deliberately.
+//
+// The order matters more than it looks. `sense scan` runs setup itself whenever
+// the index directory is absent, and the client detector falls back to Claude
+// Code when nothing in the environment matches — so a headless scan of an
+// unindexed repository writes the routing channels as a side effect, and
+// nothing about it is visible afterwards. Creating the index directory first
+// makes that first-run branch false, so configuring the repository stays an
+// explicit act with a recorded result.
+//
+// It returns what setup wrote, as path to content hash. A change to
+// `sense setup` changes what the sense arm sees, which changes the measurement,
+// and nothing about that is visible in a result months later. Recorded per run,
+// two runs far apart are comparable on what was installed rather than on an
+// assumption that it was the same.
+func Sense(ctx context.Context, senseBin, repo string) (map[string]string, error) {
+	// The index lives at <repo>/.sense, where the MCP server the agent launches
+	// looks for it. Putting it anywhere else is a sense arm that is configured,
+	// reports no error, and reaches an empty index.
+	senseDir := filepath.Join(repo, ".sense")
+	if err := os.MkdirAll(senseDir, 0o755); err != nil {
+		return nil, fmt.Errorf("prepare index directory: %w", err)
+	}
+
+	// -dir, not a positional path: sense scan silently ignores positionals.
+	scan := exec.CommandContext(ctx, senseBin, "scan", "-dir", repo)
+	if out, err := scan.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("index the subject: %w: %s", err, out)
+	}
+
+	before, err := treeOf(repo)
+	if err != nil {
+		return nil, err
+	}
+
+	setup := exec.CommandContext(ctx, senseBin, "setup", "--tools", "claude-code")
+	setup.Dir = repo
+	if out, err := setup.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("configure the subject: %w: %s", err, out)
+	}
+
+	after, err := treeOf(repo)
+	if err != nil {
+		return nil, err
+	}
+	return added(before, after), nil
+}
+
+// added is what the second tree holds that the first did not, or holds
+// differently. Diffing rather than listing, so an index directory or a
+// .gitignore line the scan left behind is not reported as something setup
+// wrote.
+func added(before, after map[string]string) map[string]string {
+	wrote := map[string]string{}
+	for path, hash := range after {
+		if before[path] != hash {
+			wrote[path] = hash
+		}
+	}
+	return wrote
+}
+
+// treeOf hashes every file below root, keyed by its relative path. Anything
+// under .git or .sense is skipped: both are machinery rather than a channel,
+// and both are large enough to make this the slowest step in a run.
+func treeOf(root string) (map[string]string, error) {
+	tree, err := channels.Tree(root, ".git", ".sense")
+	if err != nil {
+		return nil, fmt.Errorf("read the subject tree: %w", err)
+	}
+	return tree, nil
+}

--- a/lab/internal/subject/subject_test.go
+++ b/lab/internal/subject/subject_test.go
@@ -1,0 +1,267 @@
+package subject_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/lab/internal/channels"
+	"github.com/luuuc/sense/lab/internal/subject"
+)
+
+// fakeSense stands in for the product binary, reproducing the one behaviour
+// this pitch turns on: `scan` configures the repository as a side effect
+// whenever the index directory is absent, exactly as the real first-run branch
+// does, and `setup` configures it deliberately.
+//
+// The stand-in is what makes the trap testable. Against the real binary a
+// missing pre-created index directory shows up as an extra .mcp.json nobody
+// looks at; here it shows up as a failing assertion.
+func fakeSense(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the stand-in is a shell script")
+	}
+	const script = `#!/bin/sh
+set -e
+configure() {
+  printf '{"mcpServers":{"sense":{}}}' > "$1/.mcp.json"
+  mkdir -p "$1/.claude/skills"
+  printf '{"hooks":{}}' > "$1/.claude/settings.json"
+  printf '# guidance\n' > "$1/CLAUDE.md"
+  printf '# explore\n' > "$1/.claude/skills/sense-explore.md"
+}
+case "$1" in
+scan)
+  repo="$3"
+  if [ ! -d "$repo/.sense" ]; then
+    # The first-run branch, and the trap: an unindexed repository is configured
+    # by the scan, writing EXACTLY what setup would have written.
+    configure "$repo"
+  fi
+  mkdir -p "$repo/.sense"
+  printf 'index' > "$repo/.sense/index.db"
+  printf '.sense/\n' >> "$repo/.gitignore"
+  ;;
+setup)
+  configure .
+  ;;
+esac
+`
+	path := filepath.Join(t.TempDir(), "sense")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// repoWithSource is a project with something to index and nothing else.
+func repoWithSource(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "app.go"), []byte("package app\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return repo
+}
+
+func prepare(t *testing.T) (repo string, wrote map[string]string) {
+	t.Helper()
+	repo = repoWithSource(t)
+	wrote, err := subject.Sense(context.Background(), fakeSense(t), repo)
+	if err != nil {
+		t.Fatalf("Sense: %v", err)
+	}
+	return repo, wrote
+}
+
+func TestIndexingTheSubjectDoesNotSilentlyConfigureIt(t *testing.T) {
+	// The trap: `sense scan` runs setup itself on a repository with no index,
+	// so the naive preparation configures the repository as a side effect and
+	// the record of what setup wrote comes back empty. Creating the index
+	// directory first is what makes configuring it an explicit act.
+	repo, wrote := prepare(t)
+
+	if _, ok := wrote[".mcp.json"]; !ok {
+		t.Errorf("the recorded setup %v does not include .mcp.json; the scan configured the repository before setup ran, and the record is now blind to it",
+			channels.Sorted(wrote))
+	}
+	if _, err := os.Stat(filepath.Join(repo, ".mcp.json")); err != nil {
+		t.Errorf(".mcp.json is not in the repository: %v", err)
+	}
+}
+
+func TestTheRecordNamesEveryFileSetupWroteWithItsHash(t *testing.T) {
+	// Recorded per run because a change to `sense setup` changes what the sense
+	// arm sees, and nothing about that is visible in a result months later.
+	_, wrote := prepare(t)
+
+	for _, rel := range []string{".mcp.json", "CLAUDE.md", ".claude/settings.json", ".claude/skills/sense-explore.md"} {
+		hash, ok := wrote[rel]
+		if !ok {
+			t.Errorf("the recorded setup %v does not include %s", channels.Sorted(wrote), rel)
+			continue
+		}
+		if len(hash) != 64 {
+			t.Errorf("%s is recorded as %q, which is not a content hash", rel, hash)
+		}
+	}
+}
+
+func TestTwoSetupsThatWroteDifferentContentAreDistinguishable(t *testing.T) {
+	// The whole point of hashing rather than listing: setup drift is a change in
+	// what the arm saw, and two runs far apart must be comparable on it.
+	_, first := prepare(t)
+	_, second := prepare(t)
+	if first[".mcp.json"] != second[".mcp.json"] {
+		t.Fatal("the same setup produced two different hashes")
+	}
+
+	repo := repoWithSource(t)
+	drifted := fakeSenseWriting(t, `printf '{"mcpServers":{"sense":{"args":["mcp","--new"]}}}' > .mcp.json`)
+	changed, err := subject.Sense(context.Background(), drifted, repo)
+	if err != nil {
+		t.Fatalf("Sense: %v", err)
+	}
+
+	if changed[".mcp.json"] == first[".mcp.json"] {
+		t.Error("a setup that wrote different content recorded the same hash")
+	}
+}
+
+func TestWhatTheScanLeftBehindIsNotReportedAsSetup(t *testing.T) {
+	// The scan appends a .gitignore line and builds an index. Neither is a
+	// channel, and reporting them as setup's work would make the record noise
+	// that nobody reads.
+	_, wrote := prepare(t)
+
+	if slices.ContainsFunc(channels.Sorted(wrote), func(rel string) bool {
+		return rel == ".gitignore" || strings.HasPrefix(rel, ".sense/")
+	}) {
+		t.Errorf("the recorded setup %v includes what the scan left behind", channels.Sorted(wrote))
+	}
+}
+
+func TestAFailedScanStopsBeforeAnythingIsConfigured(t *testing.T) {
+	repo := repoWithSource(t)
+	broken := fakeSenseFailing(t, "scan")
+
+	_, err := subject.Sense(context.Background(), broken, repo)
+
+	if err == nil {
+		t.Fatal("Sense succeeded with a scan that failed")
+	}
+	if !strings.Contains(err.Error(), "index the subject") {
+		t.Errorf("error = %v, want it to name the indexing step", err)
+	}
+}
+
+func TestAFailedSetupIsReportedRatherThanRecordedAsEmpty(t *testing.T) {
+	// An empty record and a failed setup look identical to whoever reads the run
+	// later, and one of them means the sense arm ran without Sense configured.
+	repo := repoWithSource(t)
+	broken := fakeSenseFailing(t, "setup")
+
+	_, err := subject.Sense(context.Background(), broken, repo)
+
+	if err == nil {
+		t.Fatal("Sense succeeded with a setup that failed")
+	}
+	if !strings.Contains(err.Error(), "configure the subject") {
+		t.Errorf("error = %v, want it to name the configuring step", err)
+	}
+}
+
+func TestAnUnusableIndexDirectoryIsRefused(t *testing.T) {
+	notARepo := filepath.Join(t.TempDir(), "repo")
+	if err := os.WriteFile(notARepo, []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := subject.Sense(context.Background(), fakeSense(t), notARepo); err == nil {
+		t.Fatal("Sense succeeded where the index directory cannot be created")
+	}
+}
+
+func TestTheIndexLandsWhereTheMcpServerLooksForIt(t *testing.T) {
+	// A sense arm whose index is elsewhere is configured, reports no error, and
+	// reaches an empty index: the worst possible failure, because it looks like
+	// a measurement.
+	repo, _ := prepare(t)
+
+	if _, err := os.Stat(filepath.Join(repo, ".sense")); err != nil {
+		t.Errorf("no index at <repo>/.sense: %v", err)
+	}
+}
+
+func TestAnUnreadableSubjectTreeIsReported(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores the permission that makes the read fail")
+	}
+	repo := repoWithSource(t)
+	locked := filepath.Join(repo, "vendor")
+	if err := os.MkdirAll(locked, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o700) })
+
+	if _, err := subject.Sense(context.Background(), fakeSense(t), repo); err == nil {
+		t.Fatal("Sense succeeded on a tree it could not read")
+	}
+}
+
+// The baseline arm gets none of this, and that is checked rather than assumed.
+
+func TestTheBaselineArmsRepositoryReachesNoChannelAfterPreparation(t *testing.T) {
+	derived, err := channels.Derive(context.Background(), fakeSenseWriting(t,
+		`printf '{}' > .mcp.json; mkdir -p .claude; printf '{}' > .claude/settings.json; printf '#\n' > CLAUDE.md`),
+		filepath.Join(t.TempDir(), "probe"))
+	if err != nil {
+		t.Fatalf("Derive: %v", err)
+	}
+
+	// Preparing the baseline arm is doing nothing to it, and this is what
+	// proves the nothing.
+	baseline := repoWithSource(t)
+	arm := channels.Arm{Repo: baseline, Home: t.TempDir(), PathValue: "/nonexistent/bin", SenseBinary: "sense"}
+
+	if reached := channels.Absent(derived, arm); len(reached) != 0 {
+		t.Errorf("the baseline arm reaches %v", reached)
+	}
+}
+
+// fakeSenseWriting is a stand-in whose `setup` runs the given shell and whose
+// `scan` does nothing.
+func fakeSenseWriting(t *testing.T, setup string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the stand-in is a shell script")
+	}
+	script := "#!/bin/sh\nset -e\ncase \"$1\" in\nsetup)\n" + setup + "\n;;\nesac\n"
+	path := filepath.Join(t.TempDir(), "sense")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// fakeSenseFailing is a stand-in that fails on one subcommand.
+func fakeSenseFailing(t *testing.T, failOn string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the stand-in is a shell script")
+	}
+	script := "#!/bin/sh\nif [ \"$1\" = \"" + failOn + "\" ]; then echo boom >&2; exit 1; fi\nexit 0\n"
+	path := filepath.Join(t.TempDir(), "sense")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}


### PR DESCRIPTION
## Problem

The whole measurement rests on one claim: **the baseline arm cannot reach Sense, and the sense arm can.** If that claim is wrong in either direction, every number in the corpus is wrong and nothing about it looks wrong.

Sense reaches an agent through six routes. Five live in the repository. The sixth — persisted memory at `$HOME/.claude/projects/<flattened-repo-path>/memory/` — does not, and it is the one a reasonable implementation misses.

## Summary

The routes are **derived**, the worktree is disposable, and preparing the sense arm no longer configures it by accident.

## Changes

**`lab/internal/channels`**

- `Derive` runs `sense setup` in a throwaway project with a throwaway `HOME` and reads back what it wrote. A written-down list is the failure this prevents: a route added to the product would leave the bench's copy five entries long, every check would pass, and the baseline arm would hold a route nobody enumerated. A setup that wrote nothing is refused, because an empty list makes every absence check pass.
- `Absent` checks each route individually and reports it **by name**. "Contaminated" does not say which route leaked, and the route is the whole diagnosis.
- The memory directory is checked at its exact key *and* the whole `.claude` tree, so the proof does not rest on a path-flattening rule that is observed rather than documented.
- `HostWatch` + `Take` + `Changed` snapshot exactly the paths the routes name, at run start, and report created / modified / removed afterwards. Scoped on purpose: a general sweep of `HOME` is flaky the moment any other process writes something, and a flaky check is a check somebody disables. A path that cannot be read is an error, not an all-clear.

**`lab/internal/isolate`**

- A disposable worktree, detached at the pinned commit so no branch can move under it, removed even when the session dirtied the tree, and proven gone after the fact.

**`lab/internal/subject`**

- Prepares the sense arm: create the index directory, index, then configure — in that order and all three deliberately. `sense scan` runs setup itself whenever the index directory is absent, so the naive preparation configures the repository as a side effect, writing exactly what setup would have written, and the record of what setup wrote comes back empty.
- The index lands at `<repo>/.sense`, where the MCP server the agent launches looks for it. Anywhere else is an arm that is configured, reports no error, and reaches an empty index.
- What setup wrote is recorded per run as path to content hash, and lands in `run-meta.json`. A change to `sense setup` changes what the sense arm sees; without the record, two runs months apart are comparable only on the assumption that it was the same.

## Test plan

- `make ci` green: build, tests, per-file coverage floor with no new exception, zero complexity suppressions, lint clean.
- New files at 96–100% line coverage.
- The first-run trap was checked by mutation: removing the pre-created index directory makes `TestIndexingTheSubjectDoesNotSilentlyConfigureIt` fail, and the stand-in binary reproduces the hazard faithfully by writing identical content from both paths.
- The seventh route — the operator's own `~/.claude/CLAUDE.md`, which suppresses answer length in *both* arms — is proven closed by asking a session what it can see in its own `HOME`, not by setting an environment variable and trusting it.
- Worktree behaviour is proven against a real two-commit repository: pinned rather than tip, detached, removed when dirty, refused at a commit the parent does not have.