### PR TITLE
bench(run): escalate the kill, record the wall's start, prevent the half-pair

### DIFF
--- a/lab/internal/cell/cell.go
+++ b/lab/internal/cell/cell.go
@@ -1,0 +1,156 @@
+// Package cell runs the two arms of one job under a single supervising process
+// and records whether they can be paired.
+//
+// It exists to prevent one failure rather than to detect it. Killing a session
+// between the two arms of a cell does not merely cost time: the finished arm is
+// burned, because it can never be paired, and the money spent on it is gone.
+// The old loop had a function that caught a half-pair after the fact. Catching
+// it is not preventing it.
+package cell
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+
+	"github.com/luuuc/sense/lab/internal/run"
+)
+
+// Arm is one side of a cell: a name and the session to run.
+type Arm struct {
+	Name string
+	Spec run.Spec
+}
+
+// Record is the cell's own metadata, written whether or not the cell finished.
+type Record struct {
+	// Arms maps an arm's name to its run directory, for the arms that ran.
+	Arms map[string]string `json:"arms"`
+	// Complete says whether every arm reached a terminal state. Only a complete
+	// cell can be paired.
+	Complete bool `json:"complete"`
+	// Burned names the arms that finished and can never be paired, because the
+	// cell was interrupted before its other side ran. Named rather than
+	// counted: the point is that a later pass can recognise the specific run
+	// and refuse it, not that it knows one exists.
+	Burned []string `json:"burned,omitempty"`
+	// Unusable names the arms with no result to pair: interrupted part way, or
+	// never started at all.
+	Unusable []string `json:"unusable,omitempty"`
+}
+
+// recordFile is the cell's self-describing record, beside the arms it holds.
+const recordFile = "cell-meta.json"
+
+// Run launches every arm in order, under this process, and writes the cell
+// record. Both arms are launched by the same supervising process, so there is
+// no detached shell to be reaped and no launch to confirm afterwards.
+//
+// An interruption after the first arm does not raise an error: it produces a
+// record that names the burned run, which is what a later pairing attempt needs
+// in order to refuse it.
+func Run(ctx context.Context, dir string, arms []Arm) (Record, error) {
+	if len(arms) == 0 {
+		return Record{}, errors.New("a cell with no arms")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return Record{}, fmt.Errorf("prepare cell directory: %w", err)
+	}
+
+	rec := Record{Arms: map[string]string{}, Complete: true}
+	for i, arm := range arms {
+		// Checked before the spawn as well as after: an interrupt that arrives
+		// while the previous arm was being recorded must not start another
+		// session that is certain to be killed. That is a second arm's worth of
+		// spend on a cell that can never be paired.
+		if ctx.Err() != nil {
+			return incomplete(dir, rec, arms[i:])
+		}
+		at := filepath.Join(dir, arm.Name)
+
+		m, err := run.Session(ctx, at, arm.Spec)
+		if err != nil {
+			return Record{}, fmt.Errorf("cell arm %s: %w", arm.Name, err)
+		}
+		if m.Outcome == run.Interrupted {
+			// The arm that was cut has no result to pair. The arms before it
+			// finished and are burned.
+			return incomplete(dir, rec, arms[i:])
+		}
+		rec.Arms[arm.Name] = at
+	}
+	return rec, write(dir, rec)
+}
+
+// incomplete records a cell that was stopped part way. Every arm already in the
+// record finished and is burned; every arm from the interruption onwards has no
+// result to pair, whether it was cut or never started.
+func incomplete(dir string, rec Record, remaining []Arm) (Record, error) {
+	rec.Complete = false
+	for name := range rec.Arms {
+		rec.Burned = append(rec.Burned, name)
+	}
+	slices.Sort(rec.Burned)
+	for _, arm := range remaining {
+		rec.Unusable = append(rec.Unusable, arm.Name)
+	}
+	return rec, write(dir, rec)
+}
+
+// Pair reports the arms of a complete cell, ready to be compared.
+//
+// It refuses an incomplete one by name. The baseline's budget derives from its
+// paired sense wall, so a burned arm has no partner it could ever be measured
+// against, and pairing it with a later run would compare two things that were
+// never a cell.
+func Pair(dir string) (map[string]run.Meta, error) {
+	rec, err := ReadRecord(dir)
+	if err != nil {
+		return nil, err
+	}
+	if !rec.Complete {
+		return nil, fmt.Errorf("cell %s is incomplete: %v has no result, and %v can never be paired",
+			dir, rec.Unusable, rec.Burned)
+	}
+	metas := make(map[string]run.Meta, len(rec.Arms))
+	for name, at := range rec.Arms {
+		m, err := run.Read(at)
+		if err != nil {
+			return nil, fmt.Errorf("cell %s: arm %s: %w", dir, name, err)
+		}
+		metas[name] = m
+	}
+	return metas, nil
+}
+
+// ReadRecord reports the cell recorded in dir. A directory with no record is a
+// cell that was stopped by something that could not write one, which is the
+// same rule a run directory follows: invalid on discovery, never resumed.
+func ReadRecord(dir string) (Record, error) {
+	b, err := os.ReadFile(filepath.Join(dir, recordFile))
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return Record{}, fmt.Errorf("cell %s: %w", dir, run.ErrNoTerminalState)
+	case err != nil:
+		return Record{}, fmt.Errorf("read cell %s: %w", dir, err)
+	}
+	var rec Record
+	if err := json.Unmarshal(b, &rec); err != nil {
+		return Record{}, fmt.Errorf("cell %s: unreadable record: %w", dir, err)
+	}
+	return rec, nil
+}
+
+func write(dir string, rec Record) error {
+	// Record is a fixed struct of strings and bools, so encoding cannot fail.
+	b, _ := json.MarshalIndent(rec, "", "  ")
+	if err := os.WriteFile(filepath.Join(dir, recordFile), append(b, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write cell record: %w", err)
+	}
+	return nil
+}

--- a/lab/internal/cell/cell_test.go
+++ b/lab/internal/cell/cell_test.go
@@ -1,0 +1,255 @@
+package cell_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/lab/internal/cell"
+	"github.com/luuuc/sense/lab/internal/run"
+)
+
+// arms is a cell of two sessions, each running the script it is given.
+func arms(senseScript, baselineScript string) []cell.Arm {
+	spec := func(name, script string) run.Spec {
+		return run.Spec{
+			Name: "/bin/sh", Args: []string{"-c", script}, Arm: name,
+			Wall: 30 * time.Second, Grace: 100 * time.Millisecond,
+		}
+	}
+	return []cell.Arm{
+		{Name: "sense", Spec: spec("sense", senseScript)},
+		{Name: "baseline", Spec: spec("baseline", baselineScript)},
+	}
+}
+
+// bothFinish is the ordinary cell: two sessions that end on their own.
+func bothFinish() []cell.Arm { return arms("echo sense answer", "echo baseline answer") }
+
+// cutAfterTheFirstArm is the failure this package exists to prevent: the sense
+// arm finishes and is paid for, and the interruption lands while the baseline
+// arm is still running.
+func cutAfterTheFirstArm() []cell.Arm { return arms("echo sense answer", "sleep 30") }
+
+func TestBothArmsRunUnderOneSupervisorAndTheCellIsComplete(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "cell")
+
+	rec, err := cell.Run(context.Background(), dir, bothFinish())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if !rec.Complete {
+		t.Fatalf("cell is incomplete: %+v", rec)
+	}
+	if len(rec.Burned) != 0 {
+		t.Errorf("a complete cell burned %v", rec.Burned)
+	}
+	for _, arm := range []string{"sense", "baseline"} {
+		if _, err := run.Read(rec.Arms[arm]); err != nil {
+			t.Errorf("arm %s: %v", arm, err)
+		}
+	}
+}
+
+func TestAnInterruptionBetweenTheArmsNamesTheBurnedRun(t *testing.T) {
+	// The failure this package exists to prevent. The finished arm can never be
+	// paired, because the baseline's budget derives from its paired sense wall,
+	// and money was spent on it. Naming it is what lets a later pass refuse it
+	// rather than quietly pair it with something else.
+	dir := filepath.Join(t.TempDir(), "cell")
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		cancel()
+	}()
+
+	rec, err := cell.Run(ctx, dir, cutAfterTheFirstArm())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if rec.Complete {
+		t.Fatal("an interrupted cell reported itself complete")
+	}
+	if !slices.Contains(rec.Unusable, "baseline") {
+		t.Errorf("Unusable = %v, want the baseline arm named as having no result", rec.Unusable)
+	}
+	if !slices.Contains(rec.Burned, "sense") {
+		t.Errorf("Burned = %v, want the sense arm named", rec.Burned)
+	}
+}
+
+func TestAnInterruptedCellRefusesToBePaired(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "cell")
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		cancel()
+	}()
+	if _, err := cell.Run(ctx, dir, cutAfterTheFirstArm()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	_, err := cell.Pair(dir)
+
+	if err == nil {
+		t.Fatal("Pair accepted an incomplete cell; the burned arm would be measured against a run it was never a cell with")
+	}
+	if !strings.Contains(err.Error(), "sense") {
+		t.Errorf("Pair error = %v, want it to name the burned arm", err)
+	}
+}
+
+func TestACompleteCellPairsItsArms(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "cell")
+	if _, err := cell.Run(context.Background(), dir, bothFinish()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	metas, err := cell.Pair(dir)
+	if err != nil {
+		t.Fatalf("Pair: %v", err)
+	}
+
+	if len(metas) != 2 {
+		t.Fatalf("Pair returned %d arms, want 2", len(metas))
+	}
+	if metas["sense"].Arm != "sense" || metas["baseline"].Arm != "baseline" {
+		t.Errorf("Pair returned %+v", metas)
+	}
+}
+
+func TestAnAlreadyCancelledCellStartsNothing(t *testing.T) {
+	// An interrupt that arrives while the previous arm is being recorded must
+	// not start another session that is certain to be killed: that is a second
+	// arm's worth of spend for a cell that can never be paired.
+	dir := filepath.Join(t.TempDir(), "cell")
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	rec, err := cell.Run(ctx, dir, bothFinish())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if rec.Complete {
+		t.Fatal("a cancelled cell reported itself complete")
+	}
+	if len(rec.Burned) != 0 {
+		t.Errorf("Burned = %v; nothing had run, so nothing was burned", rec.Burned)
+	}
+	if !slices.Contains(rec.Unusable, "sense") || !slices.Contains(rec.Unusable, "baseline") {
+		t.Errorf("Unusable = %v, want both arms", rec.Unusable)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "sense")); !os.IsNotExist(err) {
+		t.Errorf("a session directory was created for an arm that never ran: %v", err)
+	}
+}
+
+func TestACellWithNoRecordIsInvalidOnDiscovery(t *testing.T) {
+	// A reboot leaves a cell directory with no record. Resuming it would pair
+	// runs whose conditions nobody can reconstruct.
+	dir := t.TempDir()
+
+	if _, err := cell.Pair(dir); err == nil {
+		t.Fatal("Pair accepted a cell directory with no record")
+	}
+}
+
+func TestAnUnreadableCellRecordIsReported(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "cell-meta.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := cell.ReadRecord(dir); err == nil {
+		t.Fatal("ReadRecord accepted an unreadable record")
+	}
+}
+
+func TestACompleteCellWhoseArmLostItsRecordIsRefused(t *testing.T) {
+	// The cell says complete and the arm on disk does not agree. Trusting the
+	// cell record alone would pair a run that never reached a terminal state.
+	dir := filepath.Join(t.TempDir(), "cell")
+	if _, err := cell.Run(context.Background(), dir, bothFinish()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if err := os.Remove(filepath.Join(dir, "sense", "run-meta.json")); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := cell.Pair(dir); err == nil {
+		t.Fatal("Pair accepted a cell whose arm has no terminal state")
+	}
+}
+
+func TestACellWithNoArmsIsRefused(t *testing.T) {
+	if _, err := cell.Run(context.Background(), t.TempDir(), nil); err == nil {
+		t.Fatal("Run accepted a cell with no arms")
+	}
+}
+
+func TestACellDirectoryThatCannotBeCreatedIsReported(t *testing.T) {
+	blocked := filepath.Join(t.TempDir(), "blocked")
+	if err := os.WriteFile(blocked, []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := cell.Run(context.Background(), filepath.Join(blocked, "cell"), bothFinish()); err == nil {
+		t.Fatal("Run succeeded with an unusable cell directory")
+	}
+}
+
+func TestAnArmThatCannotBeRecordedStopsTheCell(t *testing.T) {
+	// A cell directory that already holds a recorded run for one arm. Runs are
+	// immutable, so this must fail loudly rather than write over paid-for work.
+	dir := filepath.Join(t.TempDir(), "cell")
+	if _, err := cell.Run(context.Background(), dir, bothFinish()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if _, err := cell.Run(context.Background(), dir, bothFinish()); err == nil {
+		t.Fatal("Run wrote over a cell that already holds recorded runs")
+	}
+}
+
+func TestACellRecordThatCannotBeWrittenIsReported(t *testing.T) {
+	// Without the record there is nothing on disk saying which arm was burned,
+	// and a later pass would pair it with whatever ran next.
+	dir := filepath.Join(t.TempDir(), "cell")
+	// A directory where the record file belongs: the arms run and finish, and
+	// only the record fails.
+	if err := os.MkdirAll(filepath.Join(dir, "cell-meta.json"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := cell.Run(context.Background(), dir, bothFinish())
+
+	if err == nil {
+		t.Fatal("Run reported success although the cell record could not be written")
+	}
+}
+
+func TestACellRecordThatCannotBeReadIsReported(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores the permission that makes the read fail")
+	}
+	dir := t.TempDir()
+	record := filepath.Join(dir, "cell-meta.json")
+	if err := os.WriteFile(record, []byte(`{"complete":true}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(record, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(record, 0o600) })
+
+	if _, err := cell.ReadRecord(dir); err == nil {
+		t.Fatal("ReadRecord reported success on a record it could not read")
+	}
+}

--- a/lab/internal/run/proc_unix.go
+++ b/lab/internal/run/proc_unix.go
@@ -5,6 +5,7 @@ package run
 import (
 	"os/exec"
 	"syscall"
+	"time"
 )
 
 // setProcessGroup puts the child in its own process group so the whole tree can
@@ -17,12 +18,35 @@ func setProcessGroup(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 }
 
-// killGroup signals the child's whole process group. It runs as cmd.Cancel,
-// which os/exec invokes only after the process has started, so cmd.Process is
-// set and the negative pid is certainly this session's group rather than one
-// the OS has recycled.
-func killGroup(cmd *exec.Cmd) error {
+// killPoll is how often the group is checked during its grace period. Short
+// enough that a session which stops promptly is not held for the whole grace.
+const killPoll = 20 * time.Millisecond
+
+// stopGroup asks the child's whole process group to stop, gives it the grace
+// period, and then kills it.
+//
+// The escalation is not politeness. An agent CLI traps its first signal and
+// spends seconds flushing: a supervisor that sends one signal and moves on
+// truncates a flush that was about to complete, and a supervisor that sends
+// only SIGKILL never lets it start. Ten seconds of graceful cleanup is normal
+// behaviour for the thing being measured.
+//
+// It runs as cmd.Cancel, which os/exec invokes only after the process has
+// started, so cmd.Process is set and the negative pid is certainly this
+// session's group rather than one the OS has recycled.
+func stopGroup(cmd *exec.Cmd, grace time.Duration) error {
+	pgid := -cmd.Process.Pid
 	// A group that has already gone is the normal race, not a failure.
-	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	_ = syscall.Kill(pgid, syscall.SIGTERM)
+
+	deadline := time.Now().Add(grace)
+	for time.Now().Before(deadline) {
+		// Signal 0 asks whether the group is still there without touching it.
+		if err := syscall.Kill(pgid, 0); err != nil {
+			return nil
+		}
+		time.Sleep(killPoll)
+	}
+	_ = syscall.Kill(pgid, syscall.SIGKILL)
 	return nil
 }

--- a/lab/internal/run/read.go
+++ b/lab/internal/run/read.go
@@ -1,0 +1,39 @@
+package run
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// ErrNoTerminalState marks a run directory that was started and never finished.
+var ErrNoTerminalState = errors.New("no terminal state: the run was interrupted by something that could not record it")
+
+// Read reports the run recorded in dir.
+//
+// A directory with no run-meta.json holds a run that started and never reached
+// a terminal state. Signals cover an interrupt; nothing covers a reboot or a
+// power loss, so the gap is closed by a rule instead: such a directory is
+// invalid on discovery and is never resumed. Resuming one would silently pair a
+// run whose conditions nobody can reconstruct, and nothing about the resulting
+// number would show it.
+func Read(dir string) (Meta, error) {
+	b, err := os.ReadFile(filepath.Join(dir, metaFile))
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return Meta{}, fmt.Errorf("run %s: %w", dir, ErrNoTerminalState)
+	case err != nil:
+		return Meta{}, fmt.Errorf("read run %s: %w", dir, err)
+	}
+	var m Meta
+	if err := json.Unmarshal(b, &m); err != nil {
+		return Meta{}, fmt.Errorf("run %s: unreadable metadata: %w", dir, err)
+	}
+	if m.Outcome == "" {
+		return Meta{}, fmt.Errorf("run %s: %w", dir, ErrNoTerminalState)
+	}
+	return m, nil
+}

--- a/lab/internal/run/run.go
+++ b/lab/internal/run/run.go
@@ -68,8 +68,12 @@ type Spec struct {
 	// to content hash. Empty for the baseline arm, which is the point.
 	SenseSetup map[string]string
 	// Wall is how long the process may take. It is part of run identity and is
-	// never raised to rescue a stalled arm.
+	// never raised to rescue a stalled arm: a wall that can be lifted at the
+	// moment of frustration is not a measurement.
 	Wall time.Duration
+	// Grace is how long a session gets to stop on its own after being asked,
+	// before it is killed. Zero means defaultGrace.
+	Grace time.Duration
 }
 
 // Meta is the self-describing record left in every run directory. It is what a
@@ -77,13 +81,22 @@ type Spec struct {
 // time actually taken: a run at 481 seconds against a 480 second wall reads
 // very differently from one that finished in 30.
 type Meta struct {
-	Outcome     Outcome  `json:"outcome"`
-	ExitCode    int      `json:"exit_code"`
-	WallSeconds float64  `json:"wall_seconds"`
-	TookSeconds float64  `json:"took_seconds"`
-	Command     string   `json:"command"`
-	Args        []string `json:"args"`
-	StartedAt   string   `json:"started_at"`
+	Outcome     Outcome `json:"outcome"`
+	ExitCode    int     `json:"exit_code"`
+	WallSeconds float64 `json:"wall_seconds"`
+	// WallStartsAt is the point the wall is counted from, recorded because it is
+	// a property of the measurement rather than of the code.
+	//
+	// The sense arm pays for MCP server startup, which is slow to first output.
+	// A wall counted from first streamed event would charge that to the sense
+	// arm alone, and the two arms would have different effective budgets while
+	// appearing to share one. It is spawn, for both arms, and it is written down
+	// so a later reader does not have to take that on trust.
+	WallStartsAt string   `json:"wall_starts_at"`
+	TookSeconds  float64  `json:"took_seconds"`
+	Command      string   `json:"command"`
+	Args         []string `json:"args"`
+	StartedAt    string   `json:"started_at"`
 	// StdoutBytes is how much the session actually said.
 	//
 	// It is here because of a specific failure: an arm whose model id resolved
@@ -128,10 +141,25 @@ func envValue(env []string, key string) string {
 	return value
 }
 
+// defaultGrace is how long a session gets to stop on its own. An agent CLI
+// traps its first signal and spends seconds flushing, and ten seconds of
+// graceful cleanup is normal behaviour for the thing being measured.
+const defaultGrace = 10 * time.Second
+
+func (s Spec) grace() time.Duration {
+	if s.Grace <= 0 {
+		return defaultGrace
+	}
+	return s.Grace
+}
+
 // exitCodeKilled is what Meta records when the process was killed from outside.
 // Its real code is meaningless once we sent the signal, and 124 is what
 // timeout(1) uses.
 const exitCodeKilled = 124
+
+// wallStartsAtSpawn is the one wall start point, for both arms.
+const wallStartsAtSpawn = "spawn"
 
 // metaFile is the run's self-describing record. Its presence marks a directory
 // as holding a run that already happened.
@@ -181,18 +209,19 @@ func Session(ctx context.Context, dir string, s Spec) (Meta, error) {
 	said, _ := stdout.Seek(0, io.SeekCurrent)
 
 	m := Meta{
-		Outcome:     outcomeOf(code, ended),
-		StdoutBytes: said,
-		ExitCode:    code,
-		WallSeconds: s.Wall.Seconds(),
-		TookSeconds: time.Since(started).Seconds(),
-		Command:     s.Name,
-		Args:        s.Args,
-		StartedAt:   started.UTC().Format(time.RFC3339),
-		Arm:         s.Arm,
-		SenseSetup:  s.SenseSetup,
-		Home:        envValue(s.Env, "HOME"),
-		Path:        envValue(s.Env, "PATH"),
+		Outcome:      outcomeOf(code, ended),
+		StdoutBytes:  said,
+		ExitCode:     code,
+		WallSeconds:  s.Wall.Seconds(),
+		WallStartsAt: wallStartsAtSpawn,
+		TookSeconds:  time.Since(started).Seconds(),
+		Command:      s.Name,
+		Args:         s.Args,
+		StartedAt:    started.UTC().Format(time.RFC3339),
+		Arm:          s.Arm,
+		SenseSetup:   s.SenseSetup,
+		Home:         envValue(s.Env, "HOME"),
+		Path:         envValue(s.Env, "PATH"),
 	}
 	if err := writeMeta(dir, m); err != nil {
 		return Meta{}, err
@@ -274,7 +303,7 @@ func spawn(ctx context.Context, s Spec, stdout, stderr *os.File) (code int, ende
 	// and Cancel fires on the parent's cancellation as well as the wall, so an
 	// interrupted campaign does not leave agents running and spending.
 	setProcessGroup(cmd)
-	cmd.Cancel = func() error { return killGroup(cmd) }
+	cmd.Cancel = func() error { return stopGroup(cmd, s.grace()) }
 
 	runErr := cmd.Run()
 

--- a/lab/internal/run/supervision_test.go
+++ b/lab/internal/run/supervision_test.go
@@ -1,0 +1,360 @@
+package run_test
+
+import (
+	"context"
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/lab/internal/run"
+)
+
+// out is a fresh run directory. Session refuses to write over a recorded run,
+// so every session in a test needs its own.
+func out(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "run")
+}
+
+func TestASleeperIsKilledAtItsWallAndTheRunSaysSo(t *testing.T) {
+	dir := out(t)
+
+	m, err := run.Session(context.Background(), dir, run.Spec{
+		Name:  "/bin/sh",
+		Args:  []string{"-c", `echo the answer so far; sleep 30`},
+		Wall:  300 * time.Millisecond,
+		Grace: 100 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+
+	// A run that exceeds its budget is a result, not an error. The wall is
+	// never raised to rescue it.
+	if m.Outcome != run.CannotFinishAtBudget {
+		t.Errorf("outcome = %s, want %s", m.Outcome, run.CannotFinishAtBudget)
+	}
+	// The partial answer is evidence about where the arm spent its budget. One
+	// recorded run spent 269 of 480 seconds writing a final message that was cut
+	// mid-sentence, and that is only visible because the output was kept.
+	if said := readFile(t, filepath.Join(dir, "raw", "stdout")); !strings.Contains(said, "the answer so far") {
+		t.Errorf("stdout = %q, want the output captured up to the kill", said)
+	}
+	if m.StdoutBytes == 0 {
+		t.Error("run-meta reports no output although the session spoke before its wall")
+	}
+}
+
+func TestTheWallStartPointIsRecordedAndIsTheSameForBothArms(t *testing.T) {
+	// The sense arm pays for MCP server startup. A wall counted from first
+	// streamed event would charge that to one arm only, and the arms would have
+	// different effective budgets while appearing to share one.
+	metas := map[string]run.Meta{}
+	for _, arm := range []string{"sense", "baseline"} {
+		m, err := run.Session(context.Background(), out(t), run.Spec{
+			Name: "/bin/sh", Args: []string{"-c", "true"}, Arm: arm, Wall: 10 * time.Second,
+		})
+		if err != nil {
+			t.Fatalf("Session(%s): %v", arm, err)
+		}
+		metas[arm] = m
+	}
+
+	if metas["sense"].WallStartsAt == "" {
+		t.Fatal("run-meta does not record where the wall is counted from")
+	}
+	if metas["sense"].WallStartsAt != metas["baseline"].WallStartsAt {
+		t.Errorf("the arms count their walls from %q and %q", metas["sense"].WallStartsAt, metas["baseline"].WallStartsAt)
+	}
+}
+
+func TestAChildIsAskedToStopBeforeItIsKilled(t *testing.T) {
+	// Ten seconds of graceful cleanup is normal behaviour for an agent CLI. A
+	// supervisor that sends only SIGKILL never lets the flush start, and the
+	// output it was about to write is lost.
+	dir := out(t)
+
+	// Catches the signal, says so, and leaves on its own. If the supervisor
+	// went straight to SIGKILL, nothing would be said.
+	script := `trap 'echo flushed on request; exit 0' TERM
+	while :; do sleep 0.05; done`
+	m, err := run.Session(context.Background(), dir, run.Spec{
+		Name:  "/bin/sh",
+		Args:  []string{"-c", script},
+		Wall:  300 * time.Millisecond,
+		Grace: 2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+
+	if m.Outcome != run.CannotFinishAtBudget {
+		t.Errorf("outcome = %s, want %s", m.Outcome, run.CannotFinishAtBudget)
+	}
+	if said := readFile(t, filepath.Join(dir, "raw", "stdout")); !strings.Contains(said, "flushed on request") {
+		t.Errorf("stdout = %q; the session was never asked to stop, it was killed", said)
+	}
+}
+
+func TestAChildThatIgnoresTheRequestIsKilledAnyway(t *testing.T) {
+	// The other half of the escalation. A supervisor that asks and then waits
+	// forever has turned the wall into a suggestion.
+	dir := out(t)
+	pidFile := filepath.Join(t.TempDir(), "pid")
+
+	script := `trap '' TERM
+	echo $$ > ` + pidFile + `
+	while :; do sleep 0.05; done`
+	m, err := run.Session(context.Background(), dir, run.Spec{
+		Name:  "/bin/sh",
+		Args:  []string{"-c", script},
+		Wall:  300 * time.Millisecond,
+		Grace: 200 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+
+	if m.Outcome != run.CannotFinishAtBudget {
+		t.Errorf("outcome = %s, want %s", m.Outcome, run.CannotFinishAtBudget)
+	}
+	if m.TookSeconds > 5 {
+		t.Errorf("the session took %.1fs; an ignored request must not hold the wall open", m.TookSeconds)
+	}
+	assertGone(t, pidFile)
+}
+
+func TestKillingTheSessionLeavesNoOrphanBehind(t *testing.T) {
+	// Checked by looking for the orphan, not by watching a terminal. An agent
+	// CLI spawns children of its own, and killing only the direct child leaves
+	// them alive holding the capture files and still spending.
+	dir := out(t)
+	pidFile := filepath.Join(t.TempDir(), "grandchild-pid")
+
+	// A child that spawns its own child and then exits, so the survivor is not
+	// the process the supervisor is waiting on.
+	script := `sh -c 'echo $$ > ` + pidFile + `; sleep 30' &
+	sleep 30`
+	if _, err := run.Session(context.Background(), dir, run.Spec{
+		Name:  "/bin/sh",
+		Args:  []string{"-c", script},
+		Wall:  400 * time.Millisecond,
+		Grace: 200 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+
+	assertGone(t, pidFile)
+}
+
+func TestAnInterruptedSessionIsNotABudgetFailure(t *testing.T) {
+	// An operator pressing Ctrl-C says nothing about whether the session could
+	// have finished, and a row that conflates the two reads as a stalled arm.
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+	}()
+
+	m, err := run.Session(ctx, out(t), run.Spec{
+		Name:  "/bin/sh",
+		Args:  []string{"-c", "sleep 30"},
+		Wall:  30 * time.Second,
+		Grace: 100 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+
+	if m.Outcome != run.Interrupted {
+		t.Errorf("outcome = %s, want %s", m.Outcome, run.Interrupted)
+	}
+}
+
+func TestARunWithNoTerminalStateIsInvalidOnDiscovery(t *testing.T) {
+	// Signals cover an interrupt. Nothing covers a reboot or a power loss, so
+	// the gap is closed by a rule: such a directory is never resumed, because
+	// resuming it would silently pair a run whose conditions nobody can
+	// reconstruct.
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "raw"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "raw", "stdout"), []byte("half an answer"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := run.Read(dir)
+
+	if err == nil {
+		t.Fatal("Read accepted a run directory with no terminal state")
+	}
+	if !strings.Contains(err.Error(), "no terminal state") {
+		t.Errorf("Read error = %v, want it to name the missing terminal state", err)
+	}
+}
+
+func TestARecordWithoutAnOutcomeIsAlsoInvalid(t *testing.T) {
+	// A metadata file that exists but records nothing terminal is the same
+	// failure wearing a more convincing costume.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "run-meta.json"), []byte(`{"exit_code":0}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := run.Read(dir); err == nil {
+		t.Fatal("Read accepted metadata with no outcome")
+	}
+}
+
+func TestUnreadableRecordsAreReportedRatherThanTreatedAsAbsent(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "run-meta.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := run.Read(dir); err == nil {
+		t.Fatal("Read accepted unreadable metadata")
+	}
+}
+
+func TestARecordThatCannotBeReadIsNotTreatedAsAbsent(t *testing.T) {
+	// "I could not read it" and "there is nothing there" lead to opposite
+	// actions: one is a broken machine, the other is a run that never finished.
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "run-meta.json"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := run.Read(dir)
+
+	if err == nil {
+		t.Fatal("Read reported success on metadata it could not read")
+	}
+	if strings.Contains(err.Error(), "no terminal state") {
+		t.Errorf("Read error = %v, which reports an unreadable record as a run that never finished", err)
+	}
+}
+
+func TestARecordedRunReadsBackAsItWasWritten(t *testing.T) {
+	dir := out(t)
+	wrote, err := run.Session(context.Background(), dir, run.Spec{
+		Name: "/bin/sh", Args: []string{"-c", "echo hello"}, Arm: "sense", Wall: 10 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+
+	read, err := run.Read(dir)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	if read.Outcome != wrote.Outcome || read.Arm != wrote.Arm || read.StdoutBytes != wrote.StdoutBytes {
+		t.Errorf("read back %+v, want %+v", read, wrote)
+	}
+}
+
+// assertGone waits briefly for the recorded process to disappear and fails if
+// it is still alive. Briefly, because the kill and this check race by design.
+func assertGone(t *testing.T, pidFile string) {
+	t.Helper()
+	pid := readPID(t, pidFile)
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if syscall.Kill(pid, 0) != nil {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	_ = syscall.Kill(pid, syscall.SIGKILL)
+	t.Fatalf("process %d survived the session that spawned it", pid)
+}
+
+func readPID(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		b, err := os.ReadFile(path)
+		if err == nil && len(strings.TrimSpace(string(b))) > 0 {
+			pid, err := strconv.Atoi(strings.TrimSpace(string(b)))
+			if err != nil {
+				t.Fatalf("pid file holds %q", b)
+			}
+			return pid
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("the session never recorded a pid at %s", path)
+	return 0
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+// The supervision rules the old shell driver worked around are meant to be
+// gone, not merely unused.
+
+func TestNoShellDetachmentTrickSurvivesInTheLabTree(t *testing.T) {
+	// A Go binary supervising its own children is most of the argument for the
+	// rewrite at this layer. screen, nohup, disown and setsid are the symptoms
+	// of not owning them, and one of them already cost a 312-second run to a
+	// launcher that looked detached and was not.
+	//
+	// The tree is walked rather than grepped through git, so a file that is not
+	// yet committed is covered too. Test files are skipped: this one names the
+	// tricks in order to forbid them.
+	root, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tricks := []string{"screen -dmS", "nohup", "disown", "setsid"}
+
+	err = filepath.WalkDir(filepath.Join(root, "lab"), func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return err
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for _, trick := range tricks {
+			if strings.Contains(string(b), trick) {
+				t.Errorf("%q appears in %s; the binary owns its children", trick, path)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk the lab tree: %v", err)
+	}
+}
+
+func TestTheRecordedMetadataIsReadableJSON(t *testing.T) {
+	dir := out(t)
+	if _, err := run.Session(context.Background(), dir, run.Spec{
+		Name: "/bin/sh", Args: []string{"-c", "true"}, Wall: 10 * time.Second,
+	}); err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(readFile(t, filepath.Join(dir, "run-meta.json"))), &raw); err != nil {
+		t.Fatalf("run-meta is not readable JSON: %v", err)
+	}
+	if _, ok := raw["wall_starts_at"]; !ok {
+		t.Error("run-meta does not carry wall_starts_at")
+	}
+}


### PR DESCRIPTION
## Problem

Two supervision failures here have already been paid for in real money.

**The reaped launcher.** A 312-second run was lost because the process that launched it was owned by an agent harness and died with it. The workaround was `screen -dmS` or nohup and disown, followed by a `ps` to confirm the launch actually happened.

**The half-pair.** Killing a session between the two arms of a cell does not merely cost time. The finished arm is *burned*: it can never be paired, because the baseline's budget derives from its paired sense wall. The old loop had a function that **caught** a half-pair after the fact. Catching it is not preventing it.

And the watchdog is a measurement instrument, not an error path. Two recorded runs hit 481 seconds against a 480-second wall with both answers cut mid-sentence. That is a result.

## Summary

A Go binary supervising its own children turns all of this into ordinary process management, which is most of the argument for the rewrite at this layer.

## Changes

- **Kill escalation.** The process group is asked to stop, given a grace period, and only then killed. An agent CLI traps its first signal and spends seconds flushing: a supervisor that sends only SIGKILL never lets the flush start, and one that asks and then waits forever has turned the wall into a suggestion. Both halves are tested, and the graceful half was mutation-checked — replacing SIGTERM with SIGKILL fails it.
- **The wall's start point is recorded.** `run-meta.json` carries `wall_starts_at`. The sense arm pays for MCP server startup, so counting from first streamed event would charge that to one arm alone and the two arms would have different effective budgets while appearing to share one. It is spawn, for both arms, written down rather than taken on trust.
- **`lab/internal/cell`** launches every arm under one supervising process and writes `cell-meta.json`. An interruption after the first arm names the **burned** arm and the arms with no usable result, and `Pair` refuses an incomplete cell by name. An already-cancelled cell starts nothing, so an interrupt does not buy a second arm that is certain to be killed.
- **A run directory with no terminal state is invalid on discovery** and is never resumed. Signals cover an interrupt; nothing covers a reboot or a power loss, so the gap is closed by a rule. An unreadable record is reported as unreadable, not as a run that never finished — the two lead to opposite actions.
- **No shell detachment trick survives.** A test walks the lab tree (not `git grep`, so uncommitted files count) and fails on `screen -dmS`, `nohup`, `disown` or `setsid`. It was checked against a planted violation.

## Test plan

- `make ci` green: build, tests, per-file coverage floor with no new exception, zero complexity suppressions, lint clean.
- New files at 100% line coverage; `run.go` at 98.5%.
- Everything is hermetic: a sleeper, a child that catches its signal and says so, a child that ignores it, a grandchild that outlives its parent, and a hand-made run directory. No model, no network, no spend.
- Orphans are checked by looking for the surviving process, not by watching a terminal.