### PR TITLE
bench(session): capture the MCP traffic and run one arm end to end

### DIFF
--- a/lab/internal/cli/cli.go
+++ b/lab/internal/cli/cli.go
@@ -86,6 +86,11 @@ func Run(args []string, stdout, stderr io.Writer) int {
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		defer stop()
 		return runSession(ctx, args[1:], stdout, stderr)
+	case "tee":
+		// Deliberately absent from the usage text. It is what a run's
+		// .mcp.json points at instead of the Sense server, not a verb a person
+		// types.
+		return teeServer(args[1:], os.Stdin, stdout, stderr)
 	case "catalog":
 		return catalogCmd(args[1:], stdout, stderr)
 	case "score":

--- a/lab/internal/cli/teecmd.go
+++ b/lab/internal/cli/teecmd.go
@@ -1,0 +1,176 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"syscall"
+
+	"github.com/luuuc/sense/lab/internal/tee"
+)
+
+// `sense-lab tee` is not a verb anybody types. It is the command a run's
+// `.mcp.json` points at instead of the Sense server, so that the traffic
+// between the agent and Sense passes through something that can record it. It
+// is left out of the usage text for that reason: a person invoking it by hand
+// has misunderstood what it is for.
+
+// captureFile is written beside the log so a later reader can tell a complete
+// capture from a degraded one without inferring it from a file size.
+const captureFile = "capture.json"
+
+// teeFlags is the parsed form of `sense-lab tee`: where to log, and the server
+// command after a bare --.
+type teeFlags struct {
+	log    string
+	server []string
+}
+
+func parseTeeFlags(args []string, stderr io.Writer) (teeFlags, error) {
+	var f teeFlags
+	// The server command is everything after the first bare --, taken out
+	// before flag parsing so the server's own flags are never read as ours.
+	for i, arg := range args {
+		if arg == "--" {
+			f.server = args[i+1:]
+			args = args[:i]
+			break
+		}
+	}
+	fs := flag.NewFlagSet("tee", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.StringVar(&f.log, "log", "", "JSONL capture file; empty means no interposition at all")
+	if err := fs.Parse(args); err != nil {
+		return f, err
+	}
+	if len(f.server) == 0 {
+		return f, errors.New("the server command is required after `--`")
+	}
+	return f, nil
+}
+
+// teeServer sits between an MCP client and the server it would have spawned,
+// passing every byte through unchanged and recording each frame.
+func teeServer(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	f, err := parseTeeFlags(args, stderr)
+	if err != nil {
+		if err != flag.ErrHelp {
+			_, _ = fmt.Fprintf(stderr, "sense-lab tee: %v\n", err)
+		}
+		return exitUsage
+	}
+
+	// No log configured means no interposition at all: the process is replaced
+	// by the server, so there is nothing between the client and Sense, not even
+	// a copy loop. Fail-open in its strongest form.
+	if f.log == "" {
+		return execServer(f.server, stderr)
+	}
+
+	sink, closeLog := openLog(f.log, stderr)
+	defer closeLog()
+
+	return relay(f, sink, stdin, stdout, stderr)
+}
+
+// execServer replaces this process with the server. It returns only if that
+// could not be done.
+func execServer(server []string, stderr io.Writer) int {
+	path, err := exec.LookPath(server[0])
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab tee: %v\n", err)
+		return exitError
+	}
+	err = syscall.Exec(path, server, os.Environ())
+	_, _ = fmt.Fprintf(stderr, "sense-lab tee: exec %s: %v\n", path, err)
+	return exitError
+}
+
+// openLog opens the capture file, or reports that capture is off and carries on
+// with a sink that records nothing. Capture is telemetry, never a run
+// dependency: a session must not fail because its instrument could not.
+func openLog(path string, stderr io.Writer) (tee.Sink, func()) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab tee: capture disabled (%v)\n", err)
+		return nil, func() {}
+	}
+	// #nosec G304 -- the path is the runner's own capture file, not user input.
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab tee: capture disabled (%v)\n", err)
+		writeCaptureStatus(path, tee.Status{Reason: err.Error()})
+		return nil, func() {}
+	}
+
+	log := tee.NewLog(f, nil)
+	// Written before a frame arrives, so a session killed at its wall still
+	// leaves a file saying capture was running rather than nothing at all.
+	writeCaptureStatus(path, tee.Status{Capturing: true})
+	return log, func() {
+		status := log.Close()
+		_ = f.Close()
+		writeCaptureStatus(path, status)
+	}
+}
+
+// writeCaptureStatus records what capture managed, beside the log. It is
+// best-effort by design: a capture that cannot describe itself must still not
+// take the session down with it.
+func writeCaptureStatus(logPath string, status tee.Status) {
+	b, _ := json.MarshalIndent(status, "", "  ")
+	_ = os.WriteFile(filepath.Join(filepath.Dir(logPath), captureFile), append(b, '\n'), 0o644)
+}
+
+// relay spawns the server and copies in both directions until it closes its
+// output.
+func relay(f teeFlags, sink tee.Sink, stdin io.Reader, stdout, stderr io.Writer) int {
+	// #nosec G204 -- the command is the run's own MCP registration.
+	cmd := exec.Command(f.server[0], f.server[1:]...)
+	cmd.Stderr = stderr
+	toServer, err := cmd.StdinPipe()
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab tee: %v\n", err)
+		return exitError
+	}
+	fromServer, err := cmd.StdoutPipe()
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab tee: %v\n", err)
+		return exitError
+	}
+	if err := cmd.Start(); err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab tee: start %s: %v\n", f.server[0], err)
+		return exitError
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// The client's end closing is how a session ends, so the server is told
+		// by closing its input rather than by a signal.
+		_ = tee.Pump(toServer, stdin, tee.ClientToServer, sink)
+		_ = toServer.Close()
+	}()
+
+	// The server closing its output is the end of the session, so this one is
+	// waited on rather than left to a goroutine.
+	_ = tee.Pump(stdout, fromServer, tee.ServerToClient, sink)
+	err = cmd.Wait()
+	wg.Wait()
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab tee: %v\n", err)
+		return exitError
+	}
+	return exitOK
+}

--- a/lab/internal/cli/teecmd_test.go
+++ b/lab/internal/cli/teecmd_test.go
@@ -1,0 +1,244 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// echoServer stands in for `sense mcp`: it reads newline-delimited frames and
+// answers each one, so a test can watch traffic in both directions.
+func echoServer(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the stand-in is a shell script")
+	}
+	const script = `#!/bin/sh
+while IFS= read -r line; do
+  printf '{"jsonrpc":"2.0","id":1,"result":{"echo":%s}}\n' "$(printf '%s' "$line" | wc -c | tr -d ' ')"
+done
+`
+	path := filepath.Join(t.TempDir(), "server")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func runTee(t *testing.T, args []string, stdin string) (code int, stdout, stderr string) {
+	t.Helper()
+	var out, errOut bytes.Buffer
+	code = teeServer(args, strings.NewReader(stdin), &out, &errOut)
+	return code, out.String(), errOut.String()
+}
+
+func TestTheSessionSeesTheServersAnswersThroughTheShim(t *testing.T) {
+	log := filepath.Join(t.TempDir(), "artifacts", "sense-io.jsonl")
+
+	code, stdout, stderr := runTee(t,
+		[]string{"-log", log, "--", echoServer(t)},
+		"{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\"}\n")
+
+	if code != exitOK {
+		t.Fatalf("tee exited %d: %s", code, stderr)
+	}
+	if !strings.Contains(stdout, `"echo"`) {
+		t.Errorf("the client received %q, want the server's answer", stdout)
+	}
+	captured := readCapture(t, log)
+	if len(captured) != 2 {
+		t.Fatalf("captured %d frames, want the request and the response", len(captured))
+	}
+	if captured[0]["dir"] != "c2s" || captured[1]["dir"] != "s2c" {
+		t.Errorf("captured directions %v and %v", captured[0]["dir"], captured[1]["dir"])
+	}
+}
+
+func TestTheCaptureSaysWhetherItIsComplete(t *testing.T) {
+	log := filepath.Join(t.TempDir(), "artifacts", "sense-io.jsonl")
+
+	if code, _, stderr := runTee(t, []string{"-log", log, "--", echoServer(t)}, "{\"id\":1}\n"); code != exitOK {
+		t.Fatalf("tee exited %d: %s", code, stderr)
+	}
+
+	var status struct {
+		Capturing bool `json:"capturing"`
+		Frames    int  `json:"frames"`
+		Dropped   int  `json:"dropped"`
+	}
+	b, err := os.ReadFile(filepath.Join(filepath.Dir(log), "capture.json"))
+	if err != nil {
+		t.Fatalf("no capture status beside the log: %v", err)
+	}
+	if err := json.Unmarshal(b, &status); err != nil {
+		t.Fatalf("capture status is not JSON: %v", err)
+	}
+	if !status.Capturing || status.Frames != 2 || status.Dropped != 0 {
+		t.Errorf("capture status = %+v, want a complete capture of two frames", status)
+	}
+}
+
+func TestALogThatCannotBeOpenedDoesNotStopTheSession(t *testing.T) {
+	// Capture is telemetry, never a run dependency. A session that dies because
+	// its instrument could not write is a self-inflicted burned cell.
+	blocked := filepath.Join(t.TempDir(), "blocked")
+	if err := os.WriteFile(blocked, []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code, stdout, stderr := runTee(t,
+		[]string{"-log", filepath.Join(blocked, "sense-io.jsonl"), "--", echoServer(t)},
+		"{\"id\":1}\n")
+
+	if code != exitOK {
+		t.Fatalf("tee exited %d although only capture failed: %s", code, stderr)
+	}
+	if !strings.Contains(stdout, `"echo"`) {
+		t.Errorf("the client received %q; the session was cut off by its own capture", stdout)
+	}
+	if !strings.Contains(stderr, "capture disabled") {
+		t.Errorf("stderr = %q, want it to say capture was disabled", stderr)
+	}
+}
+
+func TestAnUnwritableLogFileDisablesCaptureAndSaysWhy(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores the permission that makes the open fail")
+	}
+	dir := t.TempDir()
+	log := filepath.Join(dir, "sense-io.jsonl")
+	if err := os.WriteFile(log, nil, 0o400); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(log, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(log, 0o600) })
+
+	code, stdout, _ := runTee(t, []string{"-log", log, "--", echoServer(t)}, "{\"id\":1}\n")
+
+	if code != exitOK {
+		t.Fatalf("tee exited %d although only capture failed", code)
+	}
+	if !strings.Contains(stdout, `"echo"`) {
+		t.Error("the session lost its answers when capture failed")
+	}
+	// The run must be able to tell "capture failed" from "Sense was never
+	// called", and the two are the same empty file otherwise.
+	b, err := os.ReadFile(filepath.Join(dir, "capture.json"))
+	if err != nil {
+		t.Fatalf("no capture status was written: %v", err)
+	}
+	if !strings.Contains(string(b), `"capturing": false`) {
+		t.Errorf("capture status = %s, want it to report capture off", b)
+	}
+}
+
+func TestNoLogMeansNoInterpositionAtAll(t *testing.T) {
+	// The strongest form of fail-open: the process is replaced by the server,
+	// so there is not even a copy loop between the client and Sense. Proven by
+	// the process image changing, since a shim that merely forwarded would
+	// still be this process.
+	if runtime.GOOS == "windows" {
+		t.Skip("exec replacement is a POSIX behaviour")
+	}
+	code, _, stderr := runTee(t, []string{"--", filepath.Join(t.TempDir(), "no-such-server")}, "")
+
+	// The lookup fails, which is the only way this path can return at all.
+	if code != exitError {
+		t.Fatalf("tee exited %d, want the exec failure reported", code)
+	}
+	if !strings.Contains(stderr, "no-such-server") {
+		t.Errorf("stderr = %q, want it to name the server it could not become", stderr)
+	}
+}
+
+func TestAServerThatCannotBeBecomeIsReported(t *testing.T) {
+	// With no log there is nothing between the client and Sense: this process
+	// is replaced by the server. The only way that path can return is when the
+	// replacement itself fails, and it must say so rather than exiting quietly
+	// and leaving the agent with a server that never spoke.
+	if runtime.GOOS == "windows" {
+		t.Skip("exec replacement is a POSIX behaviour")
+	}
+	// Executable, so it is found, but not something the kernel can run: a file
+	// with no interpreter line. Anything the kernel COULD run would replace
+	// this test process.
+	notRunnable := filepath.Join(t.TempDir(), "server")
+	if err := os.WriteFile(notRunnable, []byte("\x00\x01not an executable"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	code, _, stderr := runTee(t, []string{"--", notRunnable}, "")
+
+	if code != exitError {
+		t.Fatalf("tee exited %d, want the failed replacement reported", code)
+	}
+	if !strings.Contains(stderr, "exec") {
+		t.Errorf("stderr = %q, want it to name the replacement that failed", stderr)
+	}
+}
+
+func TestAServerCommandIsRequired(t *testing.T) {
+	if code, _, _ := runTee(t, []string{"-log", "/tmp/x.jsonl"}, ""); code != exitUsage {
+		t.Errorf("tee exited %d with no server command, want a usage error", code)
+	}
+	if code, _, _ := runTee(t, []string{"-log", "/tmp/x.jsonl", "--"}, ""); code != exitUsage {
+		t.Errorf("tee exited %d with an empty server command, want a usage error", code)
+	}
+}
+
+func TestAnUnknownFlagIsAUsageError(t *testing.T) {
+	if code, _, _ := runTee(t, []string{"-nonsense", "--", "true"}, ""); code != exitUsage {
+		t.Errorf("tee exited %d on an unknown flag, want a usage error", code)
+	}
+}
+
+func TestTheServersExitStatusIsPassedOn(t *testing.T) {
+	failing := filepath.Join(t.TempDir(), "server")
+	if err := os.WriteFile(failing, []byte("#!/bin/sh\nexit 3\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	code, _, _ := runTee(t, []string{"-log", filepath.Join(t.TempDir(), "io.jsonl"), "--", failing}, "")
+
+	if code != 3 {
+		t.Errorf("tee exited %d, want the server's own 3", code)
+	}
+}
+
+func TestAServerThatCannotBeStartedIsReported(t *testing.T) {
+	code, _, stderr := runTee(t,
+		[]string{"-log", filepath.Join(t.TempDir(), "io.jsonl"), "--", filepath.Join(t.TempDir(), "missing")}, "")
+
+	if code != exitError {
+		t.Errorf("tee exited %d, want an error", code)
+	}
+	if stderr == "" {
+		t.Error("tee failed to start the server without saying so")
+	}
+}
+
+func readCapture(t *testing.T, path string) []map[string]any {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read capture: %v", err)
+	}
+	var entries []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(string(b)), "\n") {
+		if line == "" {
+			continue
+		}
+		var e map[string]any
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("capture line %q is not JSON: %v", line, err)
+		}
+		entries = append(entries, e)
+	}
+	return entries
+}

--- a/lab/internal/session/session.go
+++ b/lab/internal/session/session.go
@@ -1,0 +1,204 @@
+// Package session runs one arm end to end: a disposable environment, a worktree
+// at the pinned commit, the subject prepared, the agent tool spawned under a
+// wall, and everything it said captured.
+//
+// It captures and it does not interpret. Cycle 02 owns the canonical
+// transcript and reads raw/; nothing here normalises anything.
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/luuuc/sense/lab/internal/isolate"
+	"github.com/luuuc/sense/lab/internal/run"
+	"github.com/luuuc/sense/lab/internal/subject"
+	"github.com/luuuc/sense/lab/internal/tee"
+)
+
+// Spec is one arm to run.
+type Spec struct {
+	// Root is the run directory to create. It must not already exist.
+	Root string
+	// Arm decides both the PATH and whether the subject is configured at all.
+	Arm isolate.Arm
+	// Parent is the repository the worktree is taken from, and Commit is where
+	// it is pinned.
+	Parent string
+	Commit string
+	// Prompt is what the agent is asked, on stdin.
+	Prompt string
+	// Command and Args spawn the agent tool.
+	Command string
+	Args    []string
+	// AgentEnv is what the agent tool declares in agent.json, as KEY=VALUE.
+	AgentEnv []string
+	// SenseBin is the Sense binary, and LabBin is this binary, which the
+	// capture shim is invoked through.
+	SenseBin string
+	LabBin   string
+	// HostPath is the PATH both arms derive from.
+	HostPath string
+	// Wall is how long the session may take, and Grace how long it gets to stop
+	// on its own afterwards.
+	Wall  time.Duration
+	Grace time.Duration
+}
+
+// Result is where the run landed and what it did.
+type Result struct {
+	Env  isolate.Env
+	Meta run.Meta
+}
+
+// senseBinDir is the directory holding the Sense binary, and "" when there is
+// no binary. Passing filepath.Dir("") would hand both arms "." as the directory
+// to add and remove, which is the working directory: the repository under study.
+func senseBinDir(bin string) string {
+	if bin == "" {
+		return ""
+	}
+	return filepath.Dir(bin)
+}
+
+// captureLog is the MCP capture, relative to the run's artifacts directory.
+const captureLog = "sense-io.jsonl"
+
+// Run prepares the environment and the repository, spawns the agent, and leaves
+// the run directory behind. Cleaning it up is the caller's, because a run that
+// is about to be diagnosed must survive the process that made it.
+func Run(ctx context.Context, s Spec) (Result, error) {
+	env, err := isolate.Prepare(isolate.Spec{
+		Root:        s.Root,
+		Arm:         s.Arm,
+		SenseBinDir: senseBinDir(s.SenseBin),
+		HostPath:    s.HostPath,
+		AgentEnv:    s.AgentEnv,
+	})
+	if err != nil {
+		return Result{}, err
+	}
+
+	if err := isolate.AddWorktree(ctx, s.Parent, s.Commit, env.Repo); err != nil {
+		return Result{}, err
+	}
+
+	wrote, err := prepareArm(ctx, s, env)
+	if err != nil {
+		return Result{}, err
+	}
+
+	m, err := run.Session(ctx, filepath.Join(env.Root, "session"), run.Spec{
+		Dir:        env.Repo,
+		Name:       s.Command,
+		Args:       s.Args,
+		Stdin:      s.Prompt,
+		Env:        env.Environ,
+		Arm:        string(s.Arm),
+		SenseSetup: wrote,
+		Wall:       s.Wall,
+		Grace:      s.Grace,
+	})
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{Env: env, Meta: m}, nil
+}
+
+// prepareArm configures the repository for the sense arm and does nothing at
+// all for the baseline arm. The asymmetry is the measurement.
+func prepareArm(ctx context.Context, s Spec, env isolate.Env) (map[string]string, error) {
+	if s.Arm != isolate.Sense {
+		return nil, nil
+	}
+	wrote, err := subject.Sense(ctx, s.SenseBin, env.Repo)
+	if err != nil {
+		return nil, err
+	}
+	if err := wrapMCP(env.Repo, s.LabBin, filepath.Join(env.Artifacts, captureLog)); err != nil {
+		return nil, err
+	}
+	return wrote, nil
+}
+
+// wrapMCP points the registered Sense server at the capture shim, keeping the
+// command the product wrote as the shim's argument.
+//
+// The registration is the product's, written by `sense setup` and recorded as
+// such: the bench does not hand-roll it, because the moment it does it is
+// measuring a configuration no user has. What changes is only where the server
+// is spawned from, and the server spawned is still exactly the one the product
+// named.
+func wrapMCP(repo, labBin, logPath string) error {
+	path := filepath.Join(repo, ".mcp.json")
+	b, err := os.ReadFile(path) // #nosec G304 -- the run's own worktree
+	if err != nil {
+		return fmt.Errorf("read the MCP registration: %w", err)
+	}
+	// Edited as a generic document rather than through the struct above, so
+	// every key the product wrote survives untouched. A round trip through a
+	// type the bench declares would silently drop whatever the bench does not
+	// know about yet.
+	var raw map[string]any
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return fmt.Errorf("read the MCP registration: %w", err)
+	}
+	servers, _ := raw["mcpServers"].(map[string]any)
+	entry, ok := servers["sense"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("%s registers no sense server; the sense arm would run without Sense", path)
+	}
+	command, _ := entry["command"].(string)
+	if command == "" {
+		return fmt.Errorf("%s registers a sense server with no command", path)
+	}
+	args := []string{"tee", "-log", logPath, "--", command}
+	if declared, ok := entry["args"].([]any); ok {
+		for _, a := range declared {
+			args = append(args, fmt.Sprint(a))
+		}
+	}
+	entry["command"] = labBin
+	entry["args"] = args
+
+	// Re-marshalling a document that was just unmarshalled into `any` cannot
+	// fail, so there is no error branch to write here.
+	out, _ := json.MarshalIndent(raw, "", "  ")
+	if err := os.WriteFile(path, append(out, '\n'), 0o644); err != nil {
+		return fmt.Errorf("rewrite the MCP registration: %w", err)
+	}
+	return nil
+}
+
+// Capture reports what the run's MCP capture managed, and whether there is one
+// at all.
+//
+// The baseline arm has no MCP server to capture, so it has no capture file. Its
+// absence is the signal rather than an error: an empty file would be
+// indistinguishable from a capture that failed.
+func Capture(env isolate.Env) (status tee.Status, present bool, err error) {
+	b, readErr := os.ReadFile(filepath.Join(env.Artifacts, "capture.json"))
+	if readErr != nil {
+		return tee.Status{}, false, nil
+	}
+	if err := json.Unmarshal(b, &status); err != nil {
+		return tee.Status{}, true, fmt.Errorf("read the capture status: %w", err)
+	}
+	return status, true, nil
+}
+
+// Cleanup removes the worktree and then the whole environment, and proves both
+// are gone.
+func Cleanup(ctx context.Context, parent string, env isolate.Env) error {
+	if err := isolate.RemoveWorktree(ctx, parent, env.Repo); err != nil {
+		return err
+	}
+	return isolate.Cleanup(env)
+}
+
+// LogPath is where a run's MCP capture lives.
+func LogPath(env isolate.Env) string { return filepath.Join(env.Artifacts, captureLog) }

--- a/lab/internal/session/session_test.go
+++ b/lab/internal/session/session_test.go
@@ -1,0 +1,573 @@
+package session_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/lab/internal/isolate"
+	"github.com/luuuc/sense/lab/internal/run"
+	"github.com/luuuc/sense/lab/internal/session"
+)
+
+// parentRepo is a one-commit repository to take a worktree from.
+func parentRepo(t *testing.T) (dir, commit string) {
+	t.Helper()
+	dir = t.TempDir()
+	git := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=bench", "GIT_AUTHOR_EMAIL=bench@example.com",
+			"GIT_COMMITTER_NAME=bench", "GIT_COMMITTER_EMAIL=bench@example.com")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	git("init", "-q", "-b", "main")
+	if err := os.WriteFile(filepath.Join(dir, "app.go"), []byte("package app\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git("add", ".")
+	git("commit", "-q", "-m", "first")
+	return dir, git("rev-parse", "HEAD")
+}
+
+// fakeSense stands in for the product binary: `scan` builds an index and
+// `setup` writes the registration a real setup would.
+func fakeSense(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the stand-in is a shell script")
+	}
+	const script = `#!/bin/sh
+set -e
+case "$1" in
+scan)  mkdir -p "$3/.sense"; printf 'index' > "$3/.sense/index.db" ;;
+setup)
+  printf '{"mcpServers":{"sense":{"command":"sense","args":["mcp"],"type":"stdio"}}}' > .mcp.json
+  printf '# guidance\n' > CLAUDE.md
+  ;;
+esac
+`
+	path := filepath.Join(t.TempDir(), "sense")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// agent is a stand-in for the agent CLI: it says something and stops.
+func agent(t *testing.T, says string) (name string, args []string) {
+	t.Helper()
+	return "/bin/sh", []string{"-c", "cat > /dev/null; echo " + says}
+}
+
+func spec(t *testing.T, arm isolate.Arm) session.Spec {
+	t.Helper()
+	parent, commit := parentRepo(t)
+	name, args := agent(t, "answered")
+	return session.Spec{
+		Root:     filepath.Join(t.TempDir(), "run"),
+		Arm:      arm,
+		Parent:   parent,
+		Commit:   commit,
+		Prompt:   "list the dependents of Category",
+		Command:  name,
+		Args:     args,
+		SenseBin: fakeSense(t),
+		LabBin:   "/opt/sense-lab",
+		HostPath: os.Getenv("PATH"),
+		Wall:     30 * time.Second,
+		Grace:    200 * time.Millisecond,
+	}
+}
+
+func TestASenseArmLeavesTheRunTreeItsResultWillBeReadFrom(t *testing.T) {
+	s := spec(t, isolate.Sense)
+
+	res, err := session.Run(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if res.Meta.Outcome != run.Completed {
+		t.Fatalf("outcome = %s", res.Meta.Outcome)
+	}
+	// raw/ is what cycle 02's canonical transcript reads. Nothing here
+	// normalises it.
+	for _, path := range []string{
+		filepath.Join(res.Env.Root, "session", "raw", "stdout"),
+		filepath.Join(res.Env.Root, "session", "run-meta.json"),
+		filepath.Join(res.Env.Repo, "app.go"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("%s: %v", path, err)
+		}
+	}
+	if said := readFile(t, filepath.Join(res.Env.Root, "session", "raw", "stdout")); !strings.Contains(said, "answered") {
+		t.Errorf("stdout = %q", said)
+	}
+}
+
+func TestTheWorktreeIsAtThePinnedCommitAndTheSessionRunsInIt(t *testing.T) {
+	s := spec(t, isolate.Baseline)
+
+	res, err := session.Run(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	at := strings.TrimSpace(gitOut(t, res.Env.Repo, "rev-parse", "HEAD"))
+	if at != s.Commit {
+		t.Errorf("the session ran against %.12s, want the pinned %.12s", at, s.Commit)
+	}
+}
+
+func TestTheSenseArmsMcpRegistrationPointsAtTheCapture(t *testing.T) {
+	res, err := session.Run(context.Background(), spec(t, isolate.Sense))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	entry := mcpEntry(t, filepath.Join(res.Env.Repo, ".mcp.json"))
+	if entry["command"] != "/opt/sense-lab" {
+		t.Errorf("the registration spawns %v, want the capture shim", entry["command"])
+	}
+	args := strings.Join(strs(entry["args"]), " ")
+	if !strings.Contains(args, session.LogPath(res.Env)) {
+		t.Errorf("the registration logs to %q, want %q", args, session.LogPath(res.Env))
+	}
+	// The server actually spawned is still the one the product named. The bench
+	// does not hand-roll a registration, because then it measures a
+	// configuration no user has.
+	if !strings.HasSuffix(args, "-- sense mcp") {
+		t.Errorf("the registration ends %q, want the product's own command", args)
+	}
+}
+
+func TestARegistrationKeyTheBenchDoesNotKnowAboutSurvives(t *testing.T) {
+	// The registration is rewritten as a generic document. A round trip through
+	// a type the bench declares would drop whatever `sense setup` adds next,
+	// and the sense arm would quietly lose part of its configured surface.
+	res, err := session.Run(context.Background(), spec(t, isolate.Sense))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if entry := mcpEntry(t, filepath.Join(res.Env.Repo, ".mcp.json")); entry["type"] != "stdio" {
+		t.Errorf("the registration lost its type key: %v", entry)
+	}
+}
+
+func TestTheBaselineArmsRepositoryIsNeverConfigured(t *testing.T) {
+	res, err := session.Run(context.Background(), spec(t, isolate.Baseline))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	for _, rel := range []string{".mcp.json", "CLAUDE.md", ".sense"} {
+		if _, err := os.Stat(filepath.Join(res.Env.Repo, rel)); !os.IsNotExist(err) {
+			t.Errorf("the baseline arm's worktree holds %s", rel)
+		}
+	}
+	if len(res.Meta.SenseSetup) != 0 {
+		t.Errorf("the baseline arm recorded a setup: %v", res.Meta.SenseSetup)
+	}
+}
+
+func TestABaselineArmWithNoSenseBinaryLeavesThePathAlone(t *testing.T) {
+	// There is no Sense binary to keep off the baseline's PATH, and the empty
+	// name must not be read as the working directory: that is the repository
+	// under study, and putting it on PATH would let a scenario's own files be
+	// executed.
+	s := spec(t, isolate.Baseline)
+	s.SenseBin = ""
+
+	res, err := session.Run(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	for _, dir := range filepath.SplitList(res.Meta.Path) {
+		if dir == "." || dir == "" {
+			t.Errorf("the session's PATH is %q, which searches the repository under study", res.Meta.Path)
+		}
+	}
+	if res.Meta.Path == "" {
+		t.Error("the session was given no PATH at all")
+	}
+}
+
+func TestTheBaselineArmHasNoCaptureAtAll(t *testing.T) {
+	// It has no MCP server to capture. An empty sense-io.jsonl would be
+	// indistinguishable from a capture failure; its absence is the signal.
+	res, err := session.Run(context.Background(), spec(t, isolate.Baseline))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if _, err := os.Stat(session.LogPath(res.Env)); !os.IsNotExist(err) {
+		t.Errorf("the baseline arm left a capture file: %v", err)
+	}
+	if _, present, err := session.Capture(res.Env); err != nil || present {
+		t.Errorf("Capture reported present=%v err=%v for the baseline arm", present, err)
+	}
+}
+
+func TestAKilledSessionStillLeavesWhatItSaidBeforeTheKill(t *testing.T) {
+	s := spec(t, isolate.Baseline)
+	s.Args = []string{"-c", "echo the answer so far; sleep 30"}
+	s.Wall = 400 * time.Millisecond
+
+	res, err := session.Run(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if res.Meta.Outcome != run.CannotFinishAtBudget {
+		t.Errorf("outcome = %s, want %s", res.Meta.Outcome, run.CannotFinishAtBudget)
+	}
+	said := readFile(t, filepath.Join(res.Env.Root, "session", "raw", "stdout"))
+	if !strings.Contains(said, "the answer so far") {
+		t.Errorf("stdout = %q, want everything captured up to the kill", said)
+	}
+}
+
+func TestTheCaptureStatusIsReadBackWhenThereIsOne(t *testing.T) {
+	res, err := session.Run(context.Background(), spec(t, isolate.Sense))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// The stand-in agent never launches the MCP server, so the shim never runs.
+	// Written by hand here, because what is under test is reading it back.
+	writeJSON(t, filepath.Join(res.Env.Artifacts, "capture.json"),
+		map[string]any{"capturing": true, "frames": 12, "dropped": 0})
+
+	status, present, err := session.Capture(res.Env)
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	if !present || !status.Complete() || status.Frames != 12 {
+		t.Errorf("Capture = %+v present=%v, want a complete capture of 12 frames", status, present)
+	}
+}
+
+func TestADroppedFrameMakesTheCaptureIncomplete(t *testing.T) {
+	// A partial file that nothing marks as partial reads as "Sense was barely
+	// called", which is a finding about the product rather than about the disk.
+	res, err := session.Run(context.Background(), spec(t, isolate.Sense))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	writeJSON(t, filepath.Join(res.Env.Artifacts, "capture.json"),
+		map[string]any{"capturing": true, "frames": 12, "dropped": 4})
+
+	status, _, err := session.Capture(res.Env)
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	if status.Complete() {
+		t.Errorf("Capture = %+v reports a complete record although frames were dropped", status)
+	}
+}
+
+func TestAnUnreadableCaptureStatusIsReported(t *testing.T) {
+	res, err := session.Run(context.Background(), spec(t, isolate.Sense))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(res.Env.Artifacts, "capture.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := session.Capture(res.Env); err == nil {
+		t.Fatal("Capture accepted an unreadable status")
+	}
+}
+
+func TestASenseArmWithNoRegistrationIsRefusedRatherThanRunBlind(t *testing.T) {
+	// A sense arm that ran without Sense configured is the worst possible
+	// result: it looks like a measurement and it is not one.
+	s := spec(t, isolate.Sense)
+	s.SenseBin = fakeSenseWriting(t, `printf '{"mcpServers":{}}' > .mcp.json`)
+
+	_, err := session.Run(context.Background(), s)
+
+	if err == nil {
+		t.Fatal("Run accepted a sense arm with no Sense server registered")
+	}
+	if !strings.Contains(err.Error(), "no sense server") {
+		t.Errorf("error = %v, want it to name the missing registration", err)
+	}
+}
+
+func TestARegistrationWithNoCommandIsRefused(t *testing.T) {
+	s := spec(t, isolate.Sense)
+	s.SenseBin = fakeSenseWriting(t, `printf '{"mcpServers":{"sense":{}}}' > .mcp.json`)
+
+	if _, err := session.Run(context.Background(), s); err == nil {
+		t.Fatal("Run accepted a registration with no command")
+	}
+}
+
+func TestAnUnreadableRegistrationIsReported(t *testing.T) {
+	s := spec(t, isolate.Sense)
+	s.SenseBin = fakeSenseWriting(t, `printf 'not json' > .mcp.json`)
+
+	if _, err := session.Run(context.Background(), s); err == nil {
+		t.Fatal("Run accepted an unreadable registration")
+	}
+}
+
+func TestAMissingRegistrationIsReported(t *testing.T) {
+	s := spec(t, isolate.Sense)
+	s.SenseBin = fakeSenseWriting(t, `printf '# guidance\n' > CLAUDE.md`)
+
+	if _, err := session.Run(context.Background(), s); err == nil {
+		t.Fatal("Run accepted a sense arm with no registration file at all")
+	}
+}
+
+func TestARunRootThatAlreadyExistsIsRefused(t *testing.T) {
+	s := spec(t, isolate.Baseline)
+	s.Root = t.TempDir()
+
+	if _, err := session.Run(context.Background(), s); err == nil {
+		t.Fatal("Run reused an existing run directory")
+	}
+}
+
+func TestACommitTheParentDoesNotHaveIsRefused(t *testing.T) {
+	s := spec(t, isolate.Baseline)
+	s.Commit = "0000000000000000000000000000000000000000"
+
+	if _, err := session.Run(context.Background(), s); err == nil {
+		t.Fatal("Run accepted a commit the parent does not have")
+	}
+}
+
+func TestAFailingSubjectPreparationStopsBeforeTheAgentSpawns(t *testing.T) {
+	s := spec(t, isolate.Sense)
+	s.SenseBin = filepath.Join(t.TempDir(), "not-a-binary")
+
+	if _, err := session.Run(context.Background(), s); err == nil {
+		t.Fatal("Run spawned the agent although the subject could not be prepared")
+	}
+}
+
+func TestAnAgentThatCannotBeSpawnedIsReported(t *testing.T) {
+	s := spec(t, isolate.Baseline)
+	s.Command = filepath.Join(t.TempDir(), "no-such-agent")
+	s.Args = nil
+
+	if _, err := session.Run(context.Background(), s); err == nil {
+		t.Fatal("Run reported success although the agent could not be spawned")
+	}
+}
+
+func TestCleanupRemovesTheWorktreeAndTheEnvironment(t *testing.T) {
+	s := spec(t, isolate.Baseline)
+	res, err := session.Run(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if err := session.Cleanup(context.Background(), s.Parent, res.Env); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+
+	if _, err := os.Stat(res.Env.Root); !os.IsNotExist(err) {
+		t.Errorf("Stat(%s) = %v after cleanup", res.Env.Root, err)
+	}
+	if list := gitOut(t, s.Parent, "worktree", "list"); strings.Contains(list, res.Env.Repo) {
+		t.Errorf("the parent still lists the worktree:\n%s", list)
+	}
+}
+
+func TestCleanupReportsAWorktreeItCouldNotRemove(t *testing.T) {
+	s := spec(t, isolate.Baseline)
+	res, err := session.Run(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if err := session.Cleanup(context.Background(), s.Parent, res.Env); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+
+	if err := session.Cleanup(context.Background(), s.Parent, res.Env); err == nil {
+		t.Fatal("Cleanup reported success on a worktree that is not there")
+	}
+}
+
+// fakeSenseWriting is a stand-in whose setup runs the given shell.
+func fakeSenseWriting(t *testing.T, setup string) string {
+	t.Helper()
+	script := "#!/bin/sh\nset -e\ncase \"$1\" in\nscan) mkdir -p \"$3/.sense\" ;;\nsetup)\n" + setup + "\n;;\nesac\n"
+	path := filepath.Join(t.TempDir(), "sense")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func mcpEntry(t *testing.T, path string) map[string]any {
+	t.Helper()
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(readFile(t, path)), &doc); err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	servers, _ := doc["mcpServers"].(map[string]any)
+	entry, ok := servers["sense"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s registers no sense server", path)
+	}
+	return entry
+}
+
+func strs(v any) []string {
+	list, _ := v.([]any)
+	out := make([]string, 0, len(list))
+	for _, item := range list {
+		s, _ := item.(string)
+		out = append(out, s)
+	}
+	return out
+}
+
+func writeJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+func gitOut(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	out, err := exec.Command("git", append([]string{"-C", dir}, args...)...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, out)
+	}
+	return string(out)
+}
+
+// The whole chain, end to end: the registration the product wrote, rewritten to
+// pass through the shim, spawning the server it named, with every frame landing
+// in the run's capture file.
+
+func TestTheRegistrationTheAgentWouldUseProducesTheCapture(t *testing.T) {
+	labBin := buildLabBinary(t)
+	s := spec(t, isolate.Sense)
+	s.LabBin = labBin
+	// A stand-in Sense whose `mcp` answers frames, so there is something real
+	// on the far side of the shim.
+	s.SenseBin = fakeSenseServing(t)
+
+	res, err := session.Run(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Invoked exactly as the registration says, which is what the agent CLI
+	// would do. Nothing here reconstructs the command.
+	entry := mcpEntry(t, filepath.Join(res.Env.Repo, ".mcp.json"))
+	cmd := exec.Command(entry["command"].(string), strs(entry["args"])...)
+	cmd.Stdin = strings.NewReader("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\"}\n")
+	var spoke strings.Builder
+	cmd.Stdout = &spoke
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("the registered server: %v", err)
+	}
+
+	if !strings.Contains(spoke.String(), `"result"`) {
+		t.Errorf("the client received %q, want the server's answer through the shim", spoke.String())
+	}
+	captured := readCaptured(t, session.LogPath(res.Env))
+	if len(captured) != 2 {
+		t.Fatalf("captured %d frames from %s, want the request and the response", len(captured), session.LogPath(res.Env))
+	}
+	if captured[0]["dir"] != "c2s" || captured[1]["dir"] != "s2c" {
+		t.Errorf("captured directions %v and %v", captured[0]["dir"], captured[1]["dir"])
+	}
+
+	status, present, err := session.Capture(res.Env)
+	if err != nil || !present {
+		t.Fatalf("Capture present=%v err=%v", present, err)
+	}
+	if !status.Complete() {
+		t.Errorf("capture status = %+v, want a complete record", status)
+	}
+}
+
+// buildLabBinary builds this binary so a test can invoke it the way a run's
+// registration does.
+func buildLabBinary(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "sense-lab")
+	build := exec.Command("go", "build", "-o", bin, "github.com/luuuc/sense/lab/cmd/sense-lab")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build sense-lab: %v: %s", err, out)
+	}
+	return bin
+}
+
+// fakeSenseServing is a stand-in Sense whose `mcp` answers newline-delimited
+// frames, so the shim has a real server to sit in front of.
+func fakeSenseServing(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "sense")
+	script := `#!/bin/sh
+set -e
+case "$1" in
+scan) mkdir -p "$3/.sense"; printf 'index' > "$3/.sense/index.db" ;;
+setup) printf '{"mcpServers":{"sense":{"command":"` + bin + `","args":["mcp"],"type":"stdio"}}}' > .mcp.json ;;
+mcp)
+  while IFS= read -r line; do
+    printf '{"jsonrpc":"2.0","id":1,"result":{"symbols":[]}}\n'
+  done
+  ;;
+esac
+`
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return bin
+}
+
+func readCaptured(t *testing.T, path string) []map[string]any {
+	t.Helper()
+	var entries []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(readFile(t, path)), "\n") {
+		if line == "" {
+			continue
+		}
+		var e map[string]any
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("capture line %q is not JSON: %v", line, err)
+		}
+		entries = append(entries, e)
+	}
+	return entries
+}

--- a/lab/internal/tee/tee.go
+++ b/lab/internal/tee/tee.go
@@ -1,0 +1,229 @@
+// Package tee is the bench's transparent capture of the MCP traffic between an
+// agent and the Sense server.
+//
+// It exists because the agent tool's own output says what the agent said, not
+// what Sense told it. Without the other half, a losing sense arm is
+// unattributable: Sense returned nothing, returned the wrong thing, returned
+// the right thing and the agent ignored it, or was never called. Four findings,
+// four different fixes, and three of them are product findings.
+//
+// # Why this is a process
+//
+// The pitch left it open whether the capture could live inside the binary that
+// owns the session. It cannot. The agent CLI spawns the MCP server itself, from
+// the `.mcp.json` registration in the repository, so the pipe carrying that
+// traffic exists between two of its own processes and the supervisor never
+// holds either end. The only place to stand is where the registration points,
+// which means a command the registration names. The cost is one process in the
+// tree, started once per session and idle between frames.
+//
+// # The contract
+//
+// Two properties, inherited deliberately from the shim this replaces:
+//
+//   - byte-transparent: what reaches the client is exactly what the server
+//     wrote. A frame that fails to parse is forwarded verbatim and logged raw.
+//     The shim never gates or repairs traffic.
+//   - fail-open: capture is telemetry, never a run dependency. A log that
+//     cannot be opened or written disables logging and the session continues. A
+//     run killed by its own telemetry is a self-inflicted burned cell.
+//
+// And one the shim did not have: capture never blocks the session. A failed
+// write is loud; a blocked write is silent and applies backpressure to a
+// session running against a wall, so the instrument alters what it measures.
+// When the sink cannot keep up, frames are dropped and counted.
+package tee
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"io"
+	"sync/atomic"
+	"time"
+)
+
+// Direction is which way a frame was travelling.
+const (
+	// ClientToServer is the agent asking Sense something.
+	ClientToServer = "c2s"
+	// ServerToClient is Sense answering.
+	ServerToClient = "s2c"
+)
+
+// entry is one line of the capture log. The shape is the one the corpus already
+// holds, so recorded runs and new ones read the same.
+type entry struct {
+	TS  string          `json:"ts"`
+	Dir string          `json:"dir"`
+	Msg json.RawMessage `json:"msg"`
+}
+
+// Sink takes a copy of every frame. It must never block: Pump calls it on the
+// path the session's own traffic travels. A nil Sink means no capture, which is
+// what a session with no log configured gets.
+type Sink interface {
+	Record(dir string, frame []byte)
+}
+
+// Pump forwards src to dst frame by frame, handing a copy of each to the sink.
+//
+// MCP stdio framing is newline-delimited JSON, so a frame is a line. It is read
+// with an unbounded reader rather than a scanner: a tool result carrying a large
+// answer is exactly the frame whose value shows up months later, and a scanner
+// would quietly truncate it at its buffer size.
+//
+// The bytes written to dst are the bytes read from src, including the newline.
+// Nothing is re-encoded, so a frame the shim cannot parse still arrives intact.
+func Pump(dst io.Writer, src io.Reader, dir string, sink Sink) error {
+	r := bufio.NewReader(src)
+	for {
+		line, err := r.ReadBytes('\n')
+		if len(line) > 0 {
+			if _, werr := dst.Write(line); werr != nil {
+				return werr
+			}
+			if sink != nil {
+				sink.Record(dir, line)
+			}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+// Status is what capture managed to do, so a run can say whether its record is
+// complete rather than leaving a reader to guess from a file size.
+type Status struct {
+	// Capturing is false once logging has been given up on.
+	Capturing bool `json:"capturing"`
+	// Frames is how many were written.
+	Frames int `json:"frames"`
+	// Dropped is how many were discarded because the sink could not keep up.
+	// Non-zero means the capture is incomplete and says so.
+	Dropped int `json:"dropped"`
+	// Reason is why capture stopped, when it did.
+	Reason string `json:"reason,omitempty"`
+}
+
+// Complete reports whether the capture is a full record of the session.
+func (s Status) Complete() bool { return s.Capturing && s.Dropped == 0 && s.Reason == "" }
+
+// queue is how many frames may be waiting to be written. Deep enough that a
+// burst of tool results does not reach the drop path on an ordinary disk,
+// shallow enough that a wedged writer is noticed within one session.
+const queue = 1024
+
+// Log is a Sink that writes frames to an io.Writer from its own goroutine.
+//
+// The goroutine is the whole point. The session's traffic is handed to a
+// channel and the caller returns immediately, so a slow or wedged writer costs
+// dropped frames rather than a stalled session running against a wall.
+type Log struct {
+	frames  chan entry
+	done    chan struct{}
+	now     func() time.Time
+	written int
+	// dropped is touched by every pump goroutine, so it is atomic. written and
+	// stopped belong to the writer goroutine and are read only after it has
+	// finished.
+	dropped atomic.Int64
+	stopped string
+	// state is read by Status after Close, so it is only ever touched by the
+	// writer goroutine before then.
+	w io.Writer
+}
+
+// NewLog starts a log writing to w. now supplies the timestamp; nil means the
+// wall clock. Close stops it and reports what it managed.
+func NewLog(w io.Writer, now func() time.Time) *Log {
+	if now == nil {
+		now = time.Now
+	}
+	l := &Log{
+		frames: make(chan entry, queue),
+		done:   make(chan struct{}),
+		now:    now,
+		w:      w,
+	}
+	go l.write()
+	return l
+}
+
+// Record hands a frame to the writer, or drops it. It never blocks, and it
+// never returns an error: there is nothing a session could usefully do about a
+// capture problem, and the one thing it must not do is stop.
+func (l *Log) Record(dir string, frame []byte) {
+	e := entry{
+		TS:  l.now().UTC().Format(time.RFC3339Nano),
+		Dir: dir,
+		Msg: message(frame),
+	}
+	if e.Msg == nil {
+		return
+	}
+	select {
+	case l.frames <- e:
+	default:
+		l.dropped.Add(1)
+	}
+}
+
+// message turns a raw frame into the JSON the log records: the frame itself
+// when it parses, and a marked copy of the text when it does not. A blank line
+// is framing, not a frame, and is not recorded.
+func message(frame []byte) json.RawMessage {
+	text := trimEOL(frame)
+	if len(text) == 0 {
+		return nil
+	}
+	if json.Valid(text) {
+		return json.RawMessage(text)
+	}
+	// The shim never repairs traffic. It records what went past, marked as
+	// something that was not JSON, and forwards the bytes untouched.
+	//
+	// Marshalling a string cannot fail: invalid UTF-8 is replaced rather than
+	// rejected, so there is no error branch to write here.
+	quoted, _ := json.Marshal(string(text))
+	return json.RawMessage(`{"_unparsed":` + string(quoted) + `}`)
+}
+
+func trimEOL(b []byte) []byte {
+	for len(b) > 0 && (b[len(b)-1] == '\n' || b[len(b)-1] == '\r') {
+		b = b[:len(b)-1]
+	}
+	return b
+}
+
+func (l *Log) write() {
+	defer close(l.done)
+	enc := json.NewEncoder(l.w)
+	for e := range l.frames {
+		if l.stopped != "" {
+			continue // drain, so Record never blocks after a write failure
+		}
+		if err := enc.Encode(e); err != nil {
+			// Capture is telemetry. Give up on it and let the session run.
+			l.stopped = err.Error()
+			continue
+		}
+		l.written++
+	}
+}
+
+// Close stops the writer and reports what capture managed.
+func (l *Log) Close() Status {
+	close(l.frames)
+	<-l.done
+	return Status{
+		Capturing: l.stopped == "",
+		Frames:    l.written,
+		Dropped:   int(l.dropped.Load()),
+		Reason:    l.stopped,
+	}
+}

--- a/lab/internal/tee/tee_test.go
+++ b/lab/internal/tee/tee_test.go
@@ -1,0 +1,325 @@
+package tee_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/lab/internal/tee"
+)
+
+// frozen is a clock that never moves, so a recorded frame is compared on what
+// it carries rather than on when the test ran.
+func frozen() func() time.Time {
+	at := time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)
+	return func() time.Time { return at }
+}
+
+// captured runs the frames through a log and returns what was written.
+func captured(t *testing.T, dir string, frames ...string) []map[string]any {
+	t.Helper()
+	var out bytes.Buffer
+	log := tee.NewLog(&out, frozen())
+	for _, f := range frames {
+		log.Record(dir, []byte(f))
+	}
+	if status := log.Close(); !status.Complete() {
+		t.Fatalf("capture did not complete: %+v", status)
+	}
+	return decode(t, out.String())
+}
+
+func decode(t *testing.T, jsonl string) []map[string]any {
+	t.Helper()
+	var entries []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(jsonl), "\n") {
+		if line == "" {
+			continue
+		}
+		var e map[string]any
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("capture line %q is not JSON: %v", line, err)
+		}
+		entries = append(entries, e)
+	}
+	return entries
+}
+
+func TestWhatReachesTheClientIsExactlyWhatTheServerWrote(t *testing.T) {
+	// Byte-transparency is the contract. A shim that re-encodes is a shim that
+	// can change an answer, and nothing about the run would show it.
+	said := "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"text\":\"a\\u00e9b\"}}\n" +
+		"{ \"jsonrpc\" : \"2.0\" , \"id\" : 2 }\n"
+	var toClient bytes.Buffer
+
+	if err := tee.Pump(&toClient, strings.NewReader(said), tee.ServerToClient, nil); err != nil {
+		t.Fatalf("Pump: %v", err)
+	}
+
+	if toClient.String() != said {
+		t.Errorf("the client received:\n%q\nthe server wrote:\n%q", toClient.String(), said)
+	}
+}
+
+func TestAFrameThatIsNotJSONStillReachesTheClientAndIsLoggedRaw(t *testing.T) {
+	// The shim never gates or repairs traffic. A server that printed a warning
+	// onto its output stream has broken the protocol, and hiding that from the
+	// client would turn a diagnosable failure into a mystery.
+	broken := "sense: warning, index is stale\n"
+	var toClient bytes.Buffer
+	var out bytes.Buffer
+	log := tee.NewLog(&out, frozen())
+
+	if err := tee.Pump(&toClient, strings.NewReader(broken), tee.ServerToClient, log); err != nil {
+		t.Fatalf("Pump: %v", err)
+	}
+	log.Close()
+
+	if toClient.String() != broken {
+		t.Errorf("the client received %q, want %q", toClient.String(), broken)
+	}
+	entries := decode(t, out.String())
+	if len(entries) != 1 {
+		t.Fatalf("logged %d entries, want 1", len(entries))
+	}
+	msg, ok := entries[0]["msg"].(map[string]any)
+	if !ok || msg["_unparsed"] != "sense: warning, index is stale" {
+		t.Errorf("logged %v, want the unparsed text recorded verbatim", entries[0]["msg"])
+	}
+}
+
+func TestBothDirectionsAreRecordedAndTold(t *testing.T) {
+	// Without the direction, a losing arm cannot be attributed: "Sense returned
+	// nothing" and "the agent never asked" are the same file.
+	asked := captured(t, tee.ClientToServer, `{"method":"tools/call"}`)
+	answered := captured(t, tee.ServerToClient, `{"result":{}}`)
+
+	if asked[0]["dir"] != "c2s" {
+		t.Errorf("a request was recorded as %v", asked[0]["dir"])
+	}
+	if answered[0]["dir"] != "s2c" {
+		t.Errorf("a response was recorded as %v", answered[0]["dir"])
+	}
+}
+
+func TestALargeResponseIsRecordedWholeRatherThanTruncated(t *testing.T) {
+	// A scanner's default buffer is 64KB, and a tool result carrying a real
+	// answer is exactly the frame whose value shows up months later. The whole
+	// point of the file is the question nobody anticipated.
+	body := strings.Repeat("x", 512*1024)
+	frame := `{"jsonrpc":"2.0","id":1,"result":{"content":"` + body + `"}}`
+	var toClient bytes.Buffer
+	var out bytes.Buffer
+	log := tee.NewLog(&out, frozen())
+
+	if err := tee.Pump(&toClient, strings.NewReader(frame+"\n"), tee.ServerToClient, log); err != nil {
+		t.Fatalf("Pump: %v", err)
+	}
+	log.Close()
+
+	if toClient.Len() != len(frame)+1 {
+		t.Errorf("the client received %d bytes, want %d", toClient.Len(), len(frame)+1)
+	}
+	entries := decode(t, out.String())
+	if len(entries) != 1 {
+		t.Fatalf("logged %d entries, want 1", len(entries))
+	}
+	msg, _ := entries[0]["msg"].(map[string]any)
+	result, _ := msg["result"].(map[string]any)
+	if content, _ := result["content"].(string); len(content) != len(body) {
+		t.Errorf("the recorded response holds %d bytes of content, want %d", len(content), len(body))
+	}
+}
+
+func TestAFrameWithNoTrailingNewlineIsStillForwardedAndRecorded(t *testing.T) {
+	// A server killed mid-write leaves a frame with no terminator. Dropping it
+	// would lose the last thing Sense said before the session ended, which is
+	// the most interesting frame in the file.
+	last := `{"jsonrpc":"2.0","id":9}`
+	var toClient bytes.Buffer
+	var out bytes.Buffer
+	log := tee.NewLog(&out, frozen())
+
+	if err := tee.Pump(&toClient, strings.NewReader(last), tee.ServerToClient, log); err != nil {
+		t.Fatalf("Pump: %v", err)
+	}
+	log.Close()
+
+	if toClient.String() != last {
+		t.Errorf("the client received %q, want %q", toClient.String(), last)
+	}
+	if entries := decode(t, out.String()); len(entries) != 1 {
+		t.Errorf("logged %d entries, want the final frame recorded", len(entries))
+	}
+}
+
+func TestBlankLinesAreFramingRatherThanFrames(t *testing.T) {
+	var out bytes.Buffer
+	log := tee.NewLog(&out, frozen())
+	var toClient bytes.Buffer
+
+	if err := tee.Pump(&toClient, strings.NewReader("\n\n"), tee.ServerToClient, log); err != nil {
+		t.Fatalf("Pump: %v", err)
+	}
+	log.Close()
+
+	if toClient.String() != "\n\n" {
+		t.Errorf("the client received %q; framing must pass through too", toClient.String())
+	}
+	if out.Len() != 0 {
+		t.Errorf("logged %q, want nothing", out.String())
+	}
+}
+
+func TestCaptureNeverBlocksTheSession(t *testing.T) {
+	// A failed write is loud; a blocked write is silent and applies backpressure
+	// to a session running against a wall, so the instrument alters what it
+	// measures. Capture degrades instead.
+	log := tee.NewLog(newGated(), frozen())
+	frame := []byte(`{"jsonrpc":"2.0","id":1}`)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 20000; i++ {
+			log.Record(tee.ServerToClient, frame)
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the session was blocked by its own capture")
+	}
+}
+
+func TestAWedgedWriterIsReportedAsAnIncompleteCapture(t *testing.T) {
+	// Degrading silently would be worse than blocking: a partial file that
+	// nothing marks as partial reads as "Sense was never called".
+	stuck := newGated()
+	log := tee.NewLog(stuck, frozen())
+	for i := 0; i < 20000; i++ {
+		log.Record(tee.ServerToClient, []byte(`{"jsonrpc":"2.0","id":1}`))
+	}
+	stuck.release()
+
+	status := log.Close()
+
+	if status.Dropped == 0 {
+		t.Fatal("a writer far slower than the session dropped nothing; capture was applying backpressure")
+	}
+	if status.Complete() {
+		t.Errorf("status %+v reports a complete capture although frames were dropped", status)
+	}
+}
+
+func TestALogThatCannotBeWrittenGivesUpRatherThanFailingTheSession(t *testing.T) {
+	// Capture is telemetry, never a run dependency. A run killed by its own
+	// telemetry is a self-inflicted burned cell.
+	log := tee.NewLog(failing{}, frozen())
+
+	log.Record(tee.ServerToClient, []byte(`{"id":1}`))
+	log.Record(tee.ServerToClient, []byte(`{"id":2}`))
+	status := log.Close()
+
+	if status.Capturing {
+		t.Error("the log still reports itself as capturing after a write failure")
+	}
+	if status.Reason == "" {
+		t.Error("the log gave up without saying why")
+	}
+	if status.Complete() {
+		t.Error("a capture that failed reports itself complete")
+	}
+}
+
+func TestPumpReportsAClientItCanNoLongerWriteTo(t *testing.T) {
+	// The forwarding path is not telemetry. If the client's end is gone, the
+	// session is over and saying so is how the shim exits.
+	err := tee.Pump(failing{}, strings.NewReader("{\"id\":1}\n"), tee.ServerToClient, nil)
+
+	if err == nil {
+		t.Fatal("Pump reported success although the client could not be written to")
+	}
+}
+
+func TestPumpReportsAServerItCanNoLongerReadFrom(t *testing.T) {
+	err := tee.Pump(io.Discard, brokenReader{}, tee.ServerToClient, nil)
+
+	if err == nil {
+		t.Fatal("Pump reported success although the stream failed")
+	}
+}
+
+func TestWithNoSinkTheTrafficStillPassesThrough(t *testing.T) {
+	// No log configured is the fail-open case in its strongest form, and
+	// forwarding must not depend on capture being on.
+	said := "{\"id\":1}\n"
+	var toClient bytes.Buffer
+
+	if err := tee.Pump(&toClient, strings.NewReader(said), tee.ServerToClient, nil); err != nil {
+		t.Fatalf("Pump: %v", err)
+	}
+	if toClient.String() != said {
+		t.Errorf("the client received %q, want %q", toClient.String(), said)
+	}
+}
+
+func TestALogWithNoClockUsesTheWallClock(t *testing.T) {
+	var out bytes.Buffer
+	log := tee.NewLog(&out, nil)
+
+	log.Record(tee.ServerToClient, []byte(`{"id":1}`))
+	log.Close()
+
+	entries := decode(t, out.String())
+	ts, _ := entries[0]["ts"].(string)
+	at, err := time.Parse(time.RFC3339Nano, ts)
+	if err != nil {
+		t.Fatalf("recorded ts %q is not a timestamp: %v", ts, err)
+	}
+	if time.Since(at) > time.Minute {
+		t.Errorf("recorded ts = %v, want roughly now", at)
+	}
+}
+
+func TestARecordedFrameCarriesWhenItWentPast(t *testing.T) {
+	entries := captured(t, tee.ServerToClient, `{"id":1}`)
+
+	if ts, _ := entries[0]["ts"].(string); !strings.HasPrefix(ts, "2026-08-16T12:00:00") {
+		t.Errorf("recorded ts = %v, want the frame's own time", entries[0]["ts"])
+	}
+}
+
+// gated is a disk that has stopped answering: every write blocks until the test
+// lets it go. It stands in for a wedged filesystem without a sleep, so the
+// backpressure question is answered by the shape of the code rather than by a
+// timing guess.
+type gated struct {
+	open chan struct{}
+	once sync.Once
+}
+
+func newGated() *gated { return &gated{open: make(chan struct{})} }
+
+func (g *gated) Write(p []byte) (int, error) {
+	<-g.open
+	return len(p), nil
+}
+
+func (g *gated) release() { g.once.Do(func() { close(g.open) }) }
+
+// failing is a writer whose every write fails.
+type failing struct{}
+
+func (failing) Write([]byte) (int, error) { return 0, errors.New("no space left on device") }
+
+// brokenReader is a stream that fails rather than ending.
+type brokenReader struct{}
+
+func (brokenReader) Read([]byte) (int, error) { return 0, errors.New("connection reset") }


### PR DESCRIPTION
## Problem

The agent tool's own output says what the agent said. **It does not say what Sense told it.** Without that, a losing sense arm is unattributable: Sense returned nothing, returned the wrong thing, returned the right thing and the agent ignored it, or was never called. Four different findings with four different fixes, and three of them are product findings.

## The open question, answered first

The pitch left it open whether the capture could be an in-process reader rather than a separate process. **It cannot.** The agent CLI spawns the MCP server itself, from the `.mcp.json` registration in the repository, so the pipe carrying that traffic exists between two of its own processes and the supervisor never holds either end. The only place to stand is where the registration points, which means a command the registration names. The cost is one process in the tree, started once per session and idle between frames.

## Changes

**`lab/internal/tee` + a hidden `sense-lab tee` subcommand**

- **Byte-transparent.** What reaches the client is exactly what the server wrote, newline included. A frame that fails to parse is forwarded verbatim and logged as unparsed text. The shim never gates or repairs traffic. Frames are read with an unbounded reader, not a scanner: a 512KB tool result is exactly the frame whose value shows up months later, and a scanner would truncate it at 64KB.
- **Fail-open.** No log configured means the process is *replaced* by the server, so there is not even a copy loop in the way. A log that cannot be opened, or fails mid-session, disables capture and the session continues. A run killed by its own telemetry is a self-inflicted burned cell.
- **Capture never blocks.** Frames go to a buffered channel drained by its own goroutine. A failed write is loud; a blocked write is silent and applies backpressure to a session running against a wall, so the instrument would alter what it measures. A wedged disk costs dropped frames instead — and the drop is counted.
- **A partial capture says so.** `capture.json` sits beside the log with frames written, frames dropped, and why capture stopped. A truncated file that nothing marks as truncated reads as "Sense was barely called", which is a finding about the product rather than about the disk.

**`lab/internal/session`**

- Runs one arm end to end: disposable environment, worktree at the pinned commit, subject prepared, agent spawned under the wall, everything captured to `raw/`, `sense-io.jsonl` and `run-meta.json`. Nothing is normalised — the canonical transcript reads `raw/` and is cycle 02's.
- The registration is the product's own. The bench does not hand-roll one, because then it measures a configuration no user has. It is edited as a generic JSON document rather than through a declared type, so a key `sense setup` adds next survives untouched, and only the command it is spawned from changes.
- A sense arm whose registration has no Sense server is **refused**, rather than run blind. An arm that ran without Sense configured looks like a measurement and is not one.
- The baseline arm's worktree is never configured, and it produces **no capture file at all**. An empty one would be indistinguishable from a capture failure; its absence is the signal.

## Test plan

- `make ci` green: build, tests, per-file coverage floor with no new exception, zero complexity suppressions, lint clean.
- `tee.go` 100%, `session.go` 98.2%, `teecmd.go` 92.1%. The residual in `teecmd.go` is the `StdinPipe`/`StdoutPipe` error returns, which cannot fail on a command that has not been started but are mandated by the API; no test was written to move that number.
- The whole chain is proven end to end and hermetically: a session runs, and the registration it left behind is then invoked **exactly as written** — nothing reconstructs the command — spawning a stand-in server through the shim, with both frames landing in the run's capture file and the status reporting a complete record.
- Byte-transparency, the unparsed frame, the 512KB response, the final frame with no newline, the wedged writer, the failing writer and the unwritable log each have their own test.