### PR TITLE
bench(probe): run both arms and prove they differ in one thing only

### DIFF
--- a/lab/internal/cell/cell.go
+++ b/lab/internal/cell/cell.go
@@ -21,10 +21,15 @@ import (
 	"github.com/luuuc/sense/lab/internal/run"
 )
 
-// Arm is one side of a cell: a name and the session to run.
+// Arm is one side of a cell: a name, and what running it does.
+//
+// The work is a function rather than a session spec because supervision is all
+// this package knows about. What an arm has to do to produce a run — prepare an
+// environment, take a worktree, configure a subject — belongs to whoever is
+// running the cell.
 type Arm struct {
 	Name string
-	Spec run.Spec
+	Run  func(ctx context.Context, dir string) (run.Meta, error)
 }
 
 // Record is the cell's own metadata, written whether or not the cell finished.
@@ -73,7 +78,14 @@ func Run(ctx context.Context, dir string, arms []Arm) (Record, error) {
 		}
 		at := filepath.Join(dir, arm.Name)
 
-		m, err := run.Session(ctx, at, arm.Spec)
+		m, err := arm.Run(ctx, at)
+		if ctx.Err() != nil {
+			// The arm was cut short. It failed BECAUSE the cell was stopped,
+			// so it is an interruption to be recorded rather than an error to
+			// be reported: without the record nothing on disk names the arms
+			// that finished, and a later pass would pair one of them.
+			return incomplete(dir, rec, arms[i:])
+		}
 		if err != nil {
 			return Record{}, fmt.Errorf("cell arm %s: %w", arm.Name, err)
 		}

--- a/lab/internal/cell/cell_test.go
+++ b/lab/internal/cell/cell_test.go
@@ -15,15 +15,17 @@ import (
 
 // arms is a cell of two sessions, each running the script it is given.
 func arms(senseScript, baselineScript string) []cell.Arm {
-	spec := func(name, script string) run.Spec {
-		return run.Spec{
-			Name: "/bin/sh", Args: []string{"-c", script}, Arm: name,
-			Wall: 30 * time.Second, Grace: 100 * time.Millisecond,
+	session := func(name, script string) func(context.Context, string) (run.Meta, error) {
+		return func(ctx context.Context, dir string) (run.Meta, error) {
+			return run.Session(ctx, dir, run.Spec{
+				Name: "/bin/sh", Args: []string{"-c", script}, Arm: name,
+				Wall: 30 * time.Second, Grace: 100 * time.Millisecond,
+			})
 		}
 	}
 	return []cell.Arm{
-		{Name: "sense", Spec: spec("sense", senseScript)},
-		{Name: "baseline", Spec: spec("baseline", baselineScript)},
+		{Name: "sense", Run: session("sense", senseScript)},
+		{Name: "baseline", Run: session("baseline", baselineScript)},
 	}
 }
 

--- a/lab/internal/channels/tools.go
+++ b/lab/internal/channels/tools.go
@@ -1,0 +1,148 @@
+package channels
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// handshake is the smallest exchange that gets a tool list out of an MCP
+// server: initialise, say so, ask. It is written out rather than built with a
+// client library because this is the only MCP conversation the bench ever has,
+// and the lab may reach Sense only through this channel.
+const handshake = `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"sense-lab","version":"1"}}}
+{"jsonrpc":"2.0","method":"notifications/initialized"}
+{"jsonrpc":"2.0","id":2,"method":"tools/list"}
+`
+
+// ToolNames asks the Sense MCP server what it offers, in an indexed repository.
+//
+// Derived rather than written down, for the same reason the repository channels
+// are: a tool added to the product would leave the bench's list short, the
+// baseline arm's transcript would be searched for the old names, and a run in
+// which the baseline reached Sense through the new one would pass every check.
+//
+// The server needs an index to start, so repo must be a prepared sense arm's
+// worktree. That is where a real server runs, which is the point.
+func ToolNames(ctx context.Context, senseBin, repo string) ([]string, error) {
+	cmd := exec.CommandContext(ctx, senseBin, "mcp")
+	cmd.Dir = repo
+	cmd.Stdin = strings.NewReader(handshake)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("ask the sense server for its tools: %w", err)
+	}
+
+	names, err := toolsInReply(out)
+	if err != nil {
+		return nil, err
+	}
+	if len(names) == 0 {
+		// An empty list makes every transcript check pass, which is the shape
+		// of a leak that reads as a clean bill of health.
+		return nil, errors.New("the sense server offered no tools; a transcript check against an empty list proves nothing")
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// toolsInReply pulls the tool names out of the server's answers.
+func toolsInReply(out []byte) ([]string, error) {
+	var reply struct {
+		ID     int `json:"id"`
+		Result struct {
+			Tools []struct {
+				Name string `json:"name"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	r := bufio.NewReader(strings.NewReader(string(out)))
+	for {
+		line, err := r.ReadBytes('\n')
+		if len(line) > 0 {
+			reply.Result.Tools = nil
+			if json.Unmarshal(line, &reply) == nil && reply.ID == 2 {
+				names := make([]string, 0, len(reply.Result.Tools))
+				for _, t := range reply.Result.Tools {
+					names = append(names, t.Name)
+				}
+				return names, nil
+			}
+		}
+		if err != nil {
+			return nil, errors.New("the sense server never answered the tool list")
+		}
+	}
+}
+
+// mcpPrefix is how an agent tool names an MCP tool in its own transcript. It is
+// matched as well as the bare names, because a transcript that says
+// `mcp__sense__sense_graph` and one that says `sense_graph` are the same event.
+const mcpPrefix = "mcp__sense"
+
+// UsedBy reports every sign that a transcript used Sense, by name.
+//
+// Configuration checks say what was set up. This says what was used, and it is
+// the one that would reveal a channel nobody thought to enumerate: an arm that
+// found the binary some other way leaves no configuration trace at all.
+//
+// An empty result for the baseline arm is necessary and not sufficient. An arm
+// that did not use Sense in one run may still have been able to, which is why
+// the channels are checked directly as well.
+func UsedBy(transcript []byte, toolNames []string, binary string) []string {
+	text := string(transcript)
+	var used []string
+	if strings.Contains(text, mcpPrefix) {
+		used = append(used, "the transcript names an MCP tool from the sense server")
+	}
+	for _, name := range toolNames {
+		if strings.Contains(text, name) {
+			used = append(used, "the transcript names the tool "+name)
+		}
+	}
+	if ranBinary(text, binary) {
+		used = append(used, "the transcript invokes the "+binary+" binary")
+	}
+	return used
+}
+
+// commandValue finds the shell commands an agent tool recorded running. The
+// transcript is searched for those rather than for the binary's name anywhere,
+// because a repository under study may legitimately contain the word and a bare
+// substring search would report every run against such a codebase.
+var commandValue = regexp.MustCompile(`"command"\s*:\s*("(?:[^"\\]|\\.)*")`)
+
+// shellOperator is where one command ends and the next begins.
+var shellOperator = regexp.MustCompile(`[|;&()\n]+`)
+
+// ranBinary reports whether any recorded command ran the binary.
+//
+// It is checked at every command position rather than only the first, because
+// `git log | sense search ...` runs it just as surely as `sense search ...`. The
+// subcommand is deliberately not part of the test: a list of subcommands here
+// would be exactly the written-down list this package exists to avoid.
+func ranBinary(text, binary string) bool {
+	if binary == "" {
+		return false
+	}
+	for _, match := range commandValue.FindAllStringSubmatch(text, -1) {
+		var command string
+		if json.Unmarshal([]byte(match[1]), &command) != nil {
+			continue
+		}
+		for _, part := range shellOperator.Split(command, -1) {
+			fields := strings.Fields(part)
+			if len(fields) > 0 && path.Base(fields[0]) == binary {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/lab/internal/channels/tools_test.go
+++ b/lab/internal/channels/tools_test.go
@@ -1,0 +1,199 @@
+package channels_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/lab/internal/channels"
+)
+
+// senseServing stands in for `sense mcp`: it answers the handshake with the
+// tools it is given.
+func senseServing(t *testing.T, tools string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the stand-in is a shell script")
+	}
+	script := `#!/bin/sh
+while IFS= read -r line; do
+  case "$line" in
+    *'"tools/list"'*) printf '{"jsonrpc":"2.0","id":2,"result":{"tools":[` + tools + `]}}\n' ;;
+  esac
+done
+`
+	path := filepath.Join(t.TempDir(), "sense")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestTheToolNamesComeFromTheServerRatherThanFromAList(t *testing.T) {
+	// Derived for the same reason the repository routes are: a tool added to
+	// the product would leave a written-down list short, the baseline arm's
+	// transcript would be searched for the old names, and a run in which the
+	// baseline reached Sense through the new one would pass every check.
+	bin := senseServing(t, `{"name":"sense_graph"},{"name":"sense_blast"},{"name":"sense_newthing"}`)
+
+	got, err := channels.ToolNames(context.Background(), bin, t.TempDir())
+	if err != nil {
+		t.Fatalf("ToolNames: %v", err)
+	}
+
+	if !slices.Equal(got, []string{"sense_blast", "sense_graph", "sense_newthing"}) {
+		t.Errorf("ToolNames = %v", got)
+	}
+}
+
+func TestAServerThatOffersNoToolsIsRefused(t *testing.T) {
+	// An empty list makes every transcript check pass, which is the shape of a
+	// leak that reads as a clean bill of health.
+	_, err := channels.ToolNames(context.Background(), senseServing(t, ""), t.TempDir())
+
+	if err == nil {
+		t.Fatal("ToolNames accepted an empty tool list")
+	}
+	if !strings.Contains(err.Error(), "no tools") {
+		t.Errorf("error = %v, want it to name the empty list", err)
+	}
+}
+
+func TestAServerThatNeverAnswersIsRefused(t *testing.T) {
+	silent := filepath.Join(t.TempDir(), "sense")
+	if err := os.WriteFile(silent, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := channels.ToolNames(context.Background(), silent, t.TempDir()); err == nil {
+		t.Fatal("ToolNames accepted a server that never answered")
+	}
+}
+
+func TestAServerThatCannotStartIsReported(t *testing.T) {
+	if _, err := channels.ToolNames(context.Background(), filepath.Join(t.TempDir(), "missing"), t.TempDir()); err == nil {
+		t.Fatal("ToolNames accepted a server that could not start")
+	}
+}
+
+func TestNoiseBeforeTheToolListDoesNotHideIt(t *testing.T) {
+	// A server that logged a line onto its output stream before answering.
+	bin := filepath.Join(t.TempDir(), "sense")
+	script := `#!/bin/sh
+printf 'starting up\n'
+printf '{"jsonrpc":"2.0","id":1,"result":{}}\n'
+while IFS= read -r line; do
+  case "$line" in
+    *'"tools/list"'*) printf '{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"sense_graph"}]}}\n' ;;
+  esac
+done
+`
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := channels.ToolNames(context.Background(), bin, t.TempDir())
+	if err != nil {
+		t.Fatalf("ToolNames: %v", err)
+	}
+	if !slices.Equal(got, []string{"sense_graph"}) {
+		t.Errorf("ToolNames = %v", got)
+	}
+}
+
+// What the transcript says was used.
+
+const tools = "sense_graph,sense_blast"
+
+func used(transcript string) []string {
+	return channels.UsedBy([]byte(transcript), strings.Split(tools, ","), "sense")
+}
+
+func TestATranscriptThatCalledAnMcpToolIsReported(t *testing.T) {
+	got := used(`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"mcp__sense__sense_graph"}]}}`)
+
+	if len(got) == 0 {
+		t.Fatal("a transcript naming an MCP tool was reported clean")
+	}
+}
+
+func TestATranscriptThatRanTheBinaryIsReported(t *testing.T) {
+	// The check that catches what configuration checks cannot: an arm that
+	// found the binary some other way leaves no configuration trace at all.
+	got := used(`{"name":"Bash","input":{"command":"sense graph -symbol Category"}}`)
+
+	if len(got) != 1 || !strings.Contains(got[0], "invokes") {
+		t.Fatalf("UsedBy = %v, want the invocation reported", got)
+	}
+}
+
+func TestTheBinaryIsCaughtAtAnyCommandPosition(t *testing.T) {
+	// `git log | sense search x` runs it just as surely as `sense search x`.
+	for _, command := range []string{
+		"sense search Category",
+		"git log | sense search Category",
+		"cd app && sense graph -symbol Category",
+		"(sense status)",
+		"/usr/local/bin/sense mcp",
+	} {
+		if got := used(`{"input":{"command":"` + command + `"}}`); len(got) == 0 {
+			t.Errorf("%q was reported clean", command)
+		}
+	}
+}
+
+func TestARepositoryThatMerelyMentionsSenseIsNotAnInvocation(t *testing.T) {
+	// A bare substring search would report every run against a codebase whose
+	// prose uses the word, and a check that cries wolf is a check somebody
+	// stops reading.
+	for _, command := range []string{
+		"grep -rn 'makes sense' .",
+		"cat docs/sense-of-scale.md",
+		"echo this does not make sense",
+	} {
+		if got := used(`{"input":{"command":"` + command + `"}}`); len(got) != 0 {
+			t.Errorf("%q was reported as an invocation: %v", command, got)
+		}
+	}
+}
+
+func TestACleanBaselineTranscriptReportsNothing(t *testing.T) {
+	got := used(`{"type":"assistant","message":{"content":[
+		{"type":"tool_use","name":"Grep"},
+		{"type":"tool_use","name":"Bash","input":{"command":"grep -rn Category app/"}}]}}
+		{"type":"result","result":"Category is referenced in three files"}`)
+
+	if len(got) != 0 {
+		t.Errorf("a clean baseline transcript reported %v", got)
+	}
+}
+
+func TestAToolNameOnItsOwnIsEnough(t *testing.T) {
+	// An agent tool that records the bare name rather than the prefixed one is
+	// recording the same event.
+	if got := used(`{"tool":"sense_blast","args":{}}`); len(got) == 0 {
+		t.Fatal("a transcript naming sense_blast was reported clean")
+	}
+}
+
+func TestWithNoBinaryNamedNoInvocationIsLookedFor(t *testing.T) {
+	got := channels.UsedBy([]byte(`{"input":{"command":"sense graph"}}`), nil, "")
+
+	if len(got) != 0 {
+		t.Errorf("UsedBy = %v with no binary named", got)
+	}
+}
+
+func TestACommandThatIsNotAStringIsSkipped(t *testing.T) {
+	// A transcript is another program's output, so it must be read defensively:
+	// one malformed record must not stop the check that follows it.
+	got := used(`{"input":{"command":"\uDEAD"}}{"input":{"command":"sense graph"}}`)
+
+	if len(got) == 0 {
+		t.Fatal("a malformed record hid the invocation that followed it")
+	}
+}

--- a/lab/internal/cli/cli.go
+++ b/lab/internal/cli/cli.go
@@ -86,6 +86,11 @@ func Run(args []string, stdout, stderr io.Writer) int {
 		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 		defer stop()
 		return runSession(ctx, args[1:], stdout, stderr)
+	case "tee":
+		// Deliberately absent from the usage text. It is what a run's
+		// .mcp.json points at instead of the Sense server, not a verb a person
+		// types.
+		return teeServer(args[1:], os.Stdin, stdout, stderr)
 	case "catalog":
 		return catalogCmd(args[1:], stdout, stderr)
 	case "score":

--- a/lab/internal/cli/teecmd.go
+++ b/lab/internal/cli/teecmd.go
@@ -1,0 +1,176 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"syscall"
+
+	"github.com/luuuc/sense/lab/internal/tee"
+)
+
+// `sense-lab tee` is not a verb anybody types. It is the command a run's
+// `.mcp.json` points at instead of the Sense server, so that the traffic
+// between the agent and Sense passes through something that can record it. It
+// is left out of the usage text for that reason: a person invoking it by hand
+// has misunderstood what it is for.
+
+// captureFile is written beside the log so a later reader can tell a complete
+// capture from a degraded one without inferring it from a file size.
+const captureFile = "capture.json"
+
+// teeFlags is the parsed form of `sense-lab tee`: where to log, and the server
+// command after a bare --.
+type teeFlags struct {
+	log    string
+	server []string
+}
+
+func parseTeeFlags(args []string, stderr io.Writer) (teeFlags, error) {
+	var f teeFlags
+	// The server command is everything after the first bare --, taken out
+	// before flag parsing so the server's own flags are never read as ours.
+	for i, arg := range args {
+		if arg == "--" {
+			f.server = args[i+1:]
+			args = args[:i]
+			break
+		}
+	}
+	fs := flag.NewFlagSet("tee", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.StringVar(&f.log, "log", "", "JSONL capture file; empty means no interposition at all")
+	if err := fs.Parse(args); err != nil {
+		return f, err
+	}
+	if len(f.server) == 0 {
+		return f, errors.New("the server command is required after `--`")
+	}
+	return f, nil
+}
+
+// teeServer sits between an MCP client and the server it would have spawned,
+// passing every byte through unchanged and recording each frame.
+func teeServer(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	f, err := parseTeeFlags(args, stderr)
+	if err != nil {
+		if err != flag.ErrHelp {
+			_, _ = fmt.Fprintf(stderr, "sense-lab tee: %v\n", err)
+		}
+		return exitUsage
+	}
+
+	// No log configured means no interposition at all: the process is replaced
+	// by the server, so there is nothing between the client and Sense, not even
+	// a copy loop. Fail-open in its strongest form.
+	if f.log == "" {
+		return execServer(f.server, stderr)
+	}
+
+	sink, closeLog := openLog(f.log, stderr)
+	defer closeLog()
+
+	return relay(f, sink, stdin, stdout, stderr)
+}
+
+// execServer replaces this process with the server. It returns only if that
+// could not be done.
+func execServer(server []string, stderr io.Writer) int {
+	path, err := exec.LookPath(server[0])
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab tee: %v\n", err)
+		return exitError
+	}
+	err = syscall.Exec(path, server, os.Environ())
+	_, _ = fmt.Fprintf(stderr, "sense-lab tee: exec %s: %v\n", path, err)
+	return exitError
+}
+
+// openLog opens the capture file, or reports that capture is off and carries on
+// with a sink that records nothing. Capture is telemetry, never a run
+// dependency: a session must not fail because its instrument could not.
+func openLog(path string, stderr io.Writer) (tee.Sink, func()) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab tee: capture disabled (%v)\n", err)
+		return nil, func() {}
+	}
+	// #nosec G304 -- the path is the runner's own capture file, not user input.
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab tee: capture disabled (%v)\n", err)
+		writeCaptureStatus(path, tee.Status{Reason: err.Error()})
+		return nil, func() {}
+	}
+
+	log := tee.NewLog(f, nil)
+	// Written before a frame arrives, so a session killed at its wall still
+	// leaves a file saying capture was running rather than nothing at all.
+	writeCaptureStatus(path, tee.Status{Capturing: true})
+	return log, func() {
+		status := log.Close()
+		_ = f.Close()
+		writeCaptureStatus(path, status)
+	}
+}
+
+// writeCaptureStatus records what capture managed, beside the log. It is
+// best-effort by design: a capture that cannot describe itself must still not
+// take the session down with it.
+func writeCaptureStatus(logPath string, status tee.Status) {
+	b, _ := json.MarshalIndent(status, "", "  ")
+	_ = os.WriteFile(filepath.Join(filepath.Dir(logPath), captureFile), append(b, '\n'), 0o644)
+}
+
+// relay spawns the server and copies in both directions until it closes its
+// output.
+func relay(f teeFlags, sink tee.Sink, stdin io.Reader, stdout, stderr io.Writer) int {
+	// #nosec G204 -- the command is the run's own MCP registration.
+	cmd := exec.Command(f.server[0], f.server[1:]...)
+	cmd.Stderr = stderr
+	toServer, err := cmd.StdinPipe()
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab tee: %v\n", err)
+		return exitError
+	}
+	fromServer, err := cmd.StdoutPipe()
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab tee: %v\n", err)
+		return exitError
+	}
+	if err := cmd.Start(); err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab tee: start %s: %v\n", f.server[0], err)
+		return exitError
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// The client's end closing is how a session ends, so the server is told
+		// by closing its input rather than by a signal.
+		_ = tee.Pump(toServer, stdin, tee.ClientToServer, sink)
+		_ = toServer.Close()
+	}()
+
+	// The server closing its output is the end of the session, so this one is
+	// waited on rather than left to a goroutine.
+	_ = tee.Pump(stdout, fromServer, tee.ServerToClient, sink)
+	err = cmd.Wait()
+	wg.Wait()
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab tee: %v\n", err)
+		return exitError
+	}
+	return exitOK
+}

--- a/lab/internal/cli/teecmd_test.go
+++ b/lab/internal/cli/teecmd_test.go
@@ -1,0 +1,244 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// echoServer stands in for `sense mcp`: it reads newline-delimited frames and
+// answers each one, so a test can watch traffic in both directions.
+func echoServer(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the stand-in is a shell script")
+	}
+	const script = `#!/bin/sh
+while IFS= read -r line; do
+  printf '{"jsonrpc":"2.0","id":1,"result":{"echo":%s}}\n' "$(printf '%s' "$line" | wc -c | tr -d ' ')"
+done
+`
+	path := filepath.Join(t.TempDir(), "server")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func runTee(t *testing.T, args []string, stdin string) (code int, stdout, stderr string) {
+	t.Helper()
+	var out, errOut bytes.Buffer
+	code = teeServer(args, strings.NewReader(stdin), &out, &errOut)
+	return code, out.String(), errOut.String()
+}
+
+func TestTheSessionSeesTheServersAnswersThroughTheShim(t *testing.T) {
+	log := filepath.Join(t.TempDir(), "artifacts", "sense-io.jsonl")
+
+	code, stdout, stderr := runTee(t,
+		[]string{"-log", log, "--", echoServer(t)},
+		"{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\"}\n")
+
+	if code != exitOK {
+		t.Fatalf("tee exited %d: %s", code, stderr)
+	}
+	if !strings.Contains(stdout, `"echo"`) {
+		t.Errorf("the client received %q, want the server's answer", stdout)
+	}
+	captured := readCapture(t, log)
+	if len(captured) != 2 {
+		t.Fatalf("captured %d frames, want the request and the response", len(captured))
+	}
+	if captured[0]["dir"] != "c2s" || captured[1]["dir"] != "s2c" {
+		t.Errorf("captured directions %v and %v", captured[0]["dir"], captured[1]["dir"])
+	}
+}
+
+func TestTheCaptureSaysWhetherItIsComplete(t *testing.T) {
+	log := filepath.Join(t.TempDir(), "artifacts", "sense-io.jsonl")
+
+	if code, _, stderr := runTee(t, []string{"-log", log, "--", echoServer(t)}, "{\"id\":1}\n"); code != exitOK {
+		t.Fatalf("tee exited %d: %s", code, stderr)
+	}
+
+	var status struct {
+		Capturing bool `json:"capturing"`
+		Frames    int  `json:"frames"`
+		Dropped   int  `json:"dropped"`
+	}
+	b, err := os.ReadFile(filepath.Join(filepath.Dir(log), "capture.json"))
+	if err != nil {
+		t.Fatalf("no capture status beside the log: %v", err)
+	}
+	if err := json.Unmarshal(b, &status); err != nil {
+		t.Fatalf("capture status is not JSON: %v", err)
+	}
+	if !status.Capturing || status.Frames != 2 || status.Dropped != 0 {
+		t.Errorf("capture status = %+v, want a complete capture of two frames", status)
+	}
+}
+
+func TestALogThatCannotBeOpenedDoesNotStopTheSession(t *testing.T) {
+	// Capture is telemetry, never a run dependency. A session that dies because
+	// its instrument could not write is a self-inflicted burned cell.
+	blocked := filepath.Join(t.TempDir(), "blocked")
+	if err := os.WriteFile(blocked, []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code, stdout, stderr := runTee(t,
+		[]string{"-log", filepath.Join(blocked, "sense-io.jsonl"), "--", echoServer(t)},
+		"{\"id\":1}\n")
+
+	if code != exitOK {
+		t.Fatalf("tee exited %d although only capture failed: %s", code, stderr)
+	}
+	if !strings.Contains(stdout, `"echo"`) {
+		t.Errorf("the client received %q; the session was cut off by its own capture", stdout)
+	}
+	if !strings.Contains(stderr, "capture disabled") {
+		t.Errorf("stderr = %q, want it to say capture was disabled", stderr)
+	}
+}
+
+func TestAnUnwritableLogFileDisablesCaptureAndSaysWhy(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores the permission that makes the open fail")
+	}
+	dir := t.TempDir()
+	log := filepath.Join(dir, "sense-io.jsonl")
+	if err := os.WriteFile(log, nil, 0o400); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(log, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(log, 0o600) })
+
+	code, stdout, _ := runTee(t, []string{"-log", log, "--", echoServer(t)}, "{\"id\":1}\n")
+
+	if code != exitOK {
+		t.Fatalf("tee exited %d although only capture failed", code)
+	}
+	if !strings.Contains(stdout, `"echo"`) {
+		t.Error("the session lost its answers when capture failed")
+	}
+	// The run must be able to tell "capture failed" from "Sense was never
+	// called", and the two are the same empty file otherwise.
+	b, err := os.ReadFile(filepath.Join(dir, "capture.json"))
+	if err != nil {
+		t.Fatalf("no capture status was written: %v", err)
+	}
+	if !strings.Contains(string(b), `"capturing": false`) {
+		t.Errorf("capture status = %s, want it to report capture off", b)
+	}
+}
+
+func TestNoLogMeansNoInterpositionAtAll(t *testing.T) {
+	// The strongest form of fail-open: the process is replaced by the server,
+	// so there is not even a copy loop between the client and Sense. Proven by
+	// the process image changing, since a shim that merely forwarded would
+	// still be this process.
+	if runtime.GOOS == "windows" {
+		t.Skip("exec replacement is a POSIX behaviour")
+	}
+	code, _, stderr := runTee(t, []string{"--", filepath.Join(t.TempDir(), "no-such-server")}, "")
+
+	// The lookup fails, which is the only way this path can return at all.
+	if code != exitError {
+		t.Fatalf("tee exited %d, want the exec failure reported", code)
+	}
+	if !strings.Contains(stderr, "no-such-server") {
+		t.Errorf("stderr = %q, want it to name the server it could not become", stderr)
+	}
+}
+
+func TestAServerThatCannotBeBecomeIsReported(t *testing.T) {
+	// With no log there is nothing between the client and Sense: this process
+	// is replaced by the server. The only way that path can return is when the
+	// replacement itself fails, and it must say so rather than exiting quietly
+	// and leaving the agent with a server that never spoke.
+	if runtime.GOOS == "windows" {
+		t.Skip("exec replacement is a POSIX behaviour")
+	}
+	// Executable, so it is found, but not something the kernel can run: a file
+	// with no interpreter line. Anything the kernel COULD run would replace
+	// this test process.
+	notRunnable := filepath.Join(t.TempDir(), "server")
+	if err := os.WriteFile(notRunnable, []byte("\x00\x01not an executable"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	code, _, stderr := runTee(t, []string{"--", notRunnable}, "")
+
+	if code != exitError {
+		t.Fatalf("tee exited %d, want the failed replacement reported", code)
+	}
+	if !strings.Contains(stderr, "exec") {
+		t.Errorf("stderr = %q, want it to name the replacement that failed", stderr)
+	}
+}
+
+func TestAServerCommandIsRequired(t *testing.T) {
+	if code, _, _ := runTee(t, []string{"-log", "/tmp/x.jsonl"}, ""); code != exitUsage {
+		t.Errorf("tee exited %d with no server command, want a usage error", code)
+	}
+	if code, _, _ := runTee(t, []string{"-log", "/tmp/x.jsonl", "--"}, ""); code != exitUsage {
+		t.Errorf("tee exited %d with an empty server command, want a usage error", code)
+	}
+}
+
+func TestAnUnknownFlagIsAUsageError(t *testing.T) {
+	if code, _, _ := runTee(t, []string{"-nonsense", "--", "true"}, ""); code != exitUsage {
+		t.Errorf("tee exited %d on an unknown flag, want a usage error", code)
+	}
+}
+
+func TestTheServersExitStatusIsPassedOn(t *testing.T) {
+	failing := filepath.Join(t.TempDir(), "server")
+	if err := os.WriteFile(failing, []byte("#!/bin/sh\nexit 3\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	code, _, _ := runTee(t, []string{"-log", filepath.Join(t.TempDir(), "io.jsonl"), "--", failing}, "")
+
+	if code != 3 {
+		t.Errorf("tee exited %d, want the server's own 3", code)
+	}
+}
+
+func TestAServerThatCannotBeStartedIsReported(t *testing.T) {
+	code, _, stderr := runTee(t,
+		[]string{"-log", filepath.Join(t.TempDir(), "io.jsonl"), "--", filepath.Join(t.TempDir(), "missing")}, "")
+
+	if code != exitError {
+		t.Errorf("tee exited %d, want an error", code)
+	}
+	if stderr == "" {
+		t.Error("tee failed to start the server without saying so")
+	}
+}
+
+func readCapture(t *testing.T, path string) []map[string]any {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read capture: %v", err)
+	}
+	var entries []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(string(b)), "\n") {
+		if line == "" {
+			continue
+		}
+		var e map[string]any
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("capture line %q is not JSON: %v", line, err)
+		}
+		entries = append(entries, e)
+	}
+	return entries
+}

--- a/lab/internal/isolate/env.go
+++ b/lab/internal/isolate/env.go
@@ -34,7 +34,7 @@ type Entry struct {
 //
 // PATH is deliberately absent. It is not a shared default but one entry with
 // two arm-specific values, and treating it as common is how the baseline arm
-// silently acquires a CLI fallback. PathFor builds it instead.
+// silently acquires a CLI fallback. ShadowBin builds it instead.
 //
 // HOME and the XDG variables are absent for a different reason: they are facts
 // about the disposable directory rather than about the host, so inheriting them
@@ -94,35 +94,6 @@ func (l Layout) dirs() []string {
 		d = append(d, filepath.Join(l.Home, sub))
 	}
 	return d
-}
-
-// PathFor builds an arm's PATH from the host's.
-//
-// The Sense arm gets the directory holding the Sense binary at the front. The
-// baseline arm gets the same PATH with that directory removed, and that removal
-// is the part a reasonable implementation misses: prepending for one arm leaves
-// the other with whatever the host already had, and on a machine where Sense is
-// installed that is a CLI fallback the baseline never earned.
-//
-// senseBinDir is therefore expected to hold the Sense binary and little else. A
-// directory shared with the agent tool would take the agent tool off the
-// baseline's PATH with it, which fails loudly rather than silently.
-func PathFor(arm Arm, hostPath, senseBinDir string) string {
-	sense := ""
-	if senseBinDir != "" {
-		sense = filepath.Clean(senseBinDir)
-	}
-	var keep []string
-	for _, dir := range filepath.SplitList(hostPath) {
-		if dir == "" || (sense != "" && filepath.Clean(dir) == sense) {
-			continue
-		}
-		keep = append(keep, dir)
-	}
-	if arm == Sense && sense != "" {
-		keep = append([]string{sense}, keep...)
-	}
-	return strings.Join(keep, string(filepath.ListSeparator))
 }
 
 // Environ builds the complete environment a session runs with: the disposable

--- a/lab/internal/isolate/env_test.go
+++ b/lab/internal/isolate/env_test.go
@@ -34,10 +34,6 @@ func envMap(t *testing.T, env []string) map[string]string {
 	return m
 }
 
-func joinPath(dirs ...string) string {
-	return strings.Join(dirs, string(filepath.ListSeparator))
-}
-
 func TestSessionSeesTheDisposableHomeAndXDGDirectories(t *testing.T) {
 	l := LayoutFor("/runs/r1")
 
@@ -107,7 +103,7 @@ func TestPathIsNotInheritedFromTheHostAllowlist(t *testing.T) {
 	// allowlist entry: an entry would give both arms the host's PATH and the
 	// baseline arm a CLI fallback with it.
 	if slices.ContainsFunc(allowed, func(e Entry) bool { return e.Name == "PATH" }) {
-		t.Fatal("PATH is on the environment allowlist; it must be built per arm by PathFor")
+		t.Fatal("PATH is on the environment allowlist; it must be built per arm by ShadowBin")
 	}
 
 	host := hostWith(map[string]string{"PATH": "/host/bin"})
@@ -128,60 +124,6 @@ func TestTheAgentToolsOwnEnvironmentWinsOverADefault(t *testing.T) {
 	}
 	if got["TERM"] != "dumb" {
 		t.Errorf("TERM = %q, want the agent tool's dumb to win over the host's xterm", got["TERM"])
-	}
-}
-
-func TestTheSenseArmGetsTheSenseBinaryFirstOnPath(t *testing.T) {
-	got := PathFor(Sense, joinPath("/usr/bin", "/bin"), "/lab/bin")
-
-	if want := joinPath("/lab/bin", "/usr/bin", "/bin"); got != want {
-		t.Errorf("PathFor(sense) = %q, want %q", got, want)
-	}
-}
-
-func TestTheBaselineArmLosesTheSenseDirectoryTheHostAlreadyHad(t *testing.T) {
-	// The failure this exists to catch: prepending for the Sense arm only, on a
-	// machine where the Sense binary's directory is already on the host PATH.
-	// The baseline arm then keeps a CLI fallback it never earned.
-	host := joinPath("/usr/bin", "/lab/bin", "/bin")
-
-	got := PathFor(Baseline, host, "/lab/bin")
-
-	if strings.Contains(got, "/lab/bin") {
-		t.Fatalf("PathFor(baseline) = %q, which still reaches the Sense binary", got)
-	}
-	if want := joinPath("/usr/bin", "/bin"); got != want {
-		t.Errorf("PathFor(baseline) = %q, want %q", got, want)
-	}
-}
-
-func TestTheSenseDirectoryIsNotListedTwiceForTheSenseArm(t *testing.T) {
-	got := PathFor(Sense, joinPath("/usr/bin", "/lab/bin/"), "/lab/bin")
-
-	if want := joinPath("/lab/bin", "/usr/bin"); got != want {
-		t.Errorf("PathFor(sense) = %q, want %q; an unclean spelling of the same directory should match", got, want)
-	}
-}
-
-func TestAnEmptyPathElementIsDroppedRatherThanMeaningTheWorkingDirectory(t *testing.T) {
-	// An empty element means "the current directory" to execvp, which in a run
-	// is the repository under study. A scenario that writes an executable named
-	// after a tool would then be running it.
-	got := PathFor(Baseline, joinPath("/usr/bin", "", "/bin"), "")
-
-	if want := joinPath("/usr/bin", "/bin"); got != want {
-		t.Errorf("PathFor = %q, want %q", got, want)
-	}
-}
-
-func TestWithNoSenseDirectoryBothArmsGetTheSamePath(t *testing.T) {
-	host := joinPath("/usr/bin", "/bin")
-
-	if got := PathFor(Sense, host, ""); got != host {
-		t.Errorf("PathFor(sense) = %q, want %q", got, host)
-	}
-	if got := PathFor(Baseline, host, ""); got != host {
-		t.Errorf("PathFor(baseline) = %q, want %q", got, host)
 	}
 }
 

--- a/lab/internal/isolate/isolate.go
+++ b/lab/internal/isolate/isolate.go
@@ -26,9 +26,9 @@ type Spec struct {
 	Root string
 	// Arm decides the PATH, and nothing else here.
 	Arm Arm
-	// SenseBinDir holds the Sense binary. The Sense arm gets it at the front of
-	// PATH and the baseline arm gets it removed.
-	SenseBinDir string
+	// SenseBin is the Sense binary under test. The sense arm reaches it and the
+	// baseline arm reaches no binary of that name at all.
+	SenseBin string
 	// HostPath is the PATH both arms derive from, usually the host's.
 	HostPath string
 	// AgentEnv is what the agent tool declares in agent.json, as KEY=VALUE.
@@ -75,6 +75,14 @@ func Prepare(s Spec) (Env, error) {
 		}
 	}
 
+	// The arm's PATH is one directory of symlinks rather than the host's own
+	// list, because "the baseline arm cannot reach Sense" has to hold against a
+	// machine where Sense is installed the way a user installs it.
+	bin, err := ShadowBin(filepath.Join(root, "bin"), s.HostPath, s.SenseBin, s.Arm)
+	if err != nil {
+		return Env{}, err
+	}
+
 	lookup := s.Lookup
 	if lookup == nil {
 		lookup = os.LookupEnv
@@ -82,7 +90,7 @@ func Prepare(s Spec) (Env, error) {
 	return Env{
 		Layout:  l,
 		Arm:     s.Arm,
-		Environ: Environ(l, PathFor(s.Arm, s.HostPath, s.SenseBinDir), lookup, s.AgentEnv),
+		Environ: Environ(l, bin, lookup, s.AgentEnv),
 	}, nil
 }
 

--- a/lab/internal/isolate/isolate_test.go
+++ b/lab/internal/isolate/isolate_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -249,17 +250,25 @@ func TestTheProcessDoesNotSeeTheHostsHome(t *testing.T) {
 }
 
 func TestBothArmsRecordTheirPathAndOnlyOneReachesSense(t *testing.T) {
-	senseBin := t.TempDir()
-	hostPath := strings.Join([]string{senseBin, "/usr/bin", "/bin"}, string(filepath.ListSeparator))
+	// The host is a machine where Sense is already installed the way a user
+	// installs it, in a directory holding other tools too. Removing that
+	// directory would take the other tools with it, and leaving it hands the
+	// baseline arm a CLI fallback it never earned.
+	hostBin := t.TempDir()
+	writeExecutable(t, filepath.Join(hostBin, "sense"), "#!/bin/sh\necho host sense\n")
+	writeExecutable(t, filepath.Join(hostBin, "git"), "#!/bin/sh\necho git\n")
+	senseBin := filepath.Join(t.TempDir(), "sense")
+	writeExecutable(t, senseBin, "#!/bin/sh\necho the build under test\n")
+	hostPath := strings.Join([]string{hostBin, "/usr/bin", "/bin"}, string(filepath.ListSeparator))
 
 	paths := map[isolate.Arm]string{}
 	for _, arm := range []isolate.Arm{isolate.Sense, isolate.Baseline} {
 		env, err := isolate.Prepare(isolate.Spec{
-			Root:        filepath.Join(t.TempDir(), "run-"+string(arm)),
-			Arm:         arm,
-			SenseBinDir: senseBin,
-			HostPath:    hostPath,
-			Lookup:      nothingSet,
+			Root:     filepath.Join(t.TempDir(), "run-"+string(arm)),
+			Arm:      arm,
+			SenseBin: senseBin,
+			HostPath: hostPath,
+			Lookup:   nothingSet,
 		})
 		if err != nil {
 			t.Fatalf("Prepare(%s): %v", arm, err)
@@ -292,11 +301,56 @@ func TestBothArmsRecordTheirPathAndOnlyOneReachesSense(t *testing.T) {
 		paths[arm] = meta.Path
 	}
 
-	if !strings.Contains(paths[isolate.Sense], senseBin) {
-		t.Errorf("the sense arm's recorded PATH %q does not reach the Sense binary", paths[isolate.Sense])
+	if !reaches(t, paths[isolate.Sense], "sense") {
+		t.Errorf("the sense arm's PATH %q does not reach a sense binary", paths[isolate.Sense])
 	}
-	if strings.Contains(paths[isolate.Baseline], senseBin) {
-		t.Errorf("the baseline arm's recorded PATH %q reaches the Sense binary", paths[isolate.Baseline])
+	if reaches(t, paths[isolate.Baseline], "sense") {
+		t.Errorf("the baseline arm's PATH %q reaches a sense binary", paths[isolate.Baseline])
+	}
+	// And the tools that shared the directory with it are still there, for both
+	// arms. Dropping the directory would have taken them along.
+	for arm, path := range paths {
+		if !reaches(t, path, "git") {
+			t.Errorf("the %s arm lost git along with the sense binary: %q", arm, path)
+		}
+	}
+	if got := senseVersionOn(t, paths[isolate.Sense]); !strings.Contains(got, "the build under test") {
+		t.Errorf("the sense arm reached %q, want the build under test rather than the host's install", got)
+	}
+}
+
+// reaches reports whether the named binary is executable on the given PATH.
+func reaches(t *testing.T, pathValue, name string) bool {
+	t.Helper()
+	for _, dir := range filepath.SplitList(pathValue) {
+		info, err := os.Stat(filepath.Join(dir, name))
+		if err == nil && !info.IsDir() && info.Mode()&0o111 != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// senseVersionOn runs whatever `sense` the PATH resolves to.
+func senseVersionOn(t *testing.T, pathValue string) string {
+	t.Helper()
+	for _, dir := range filepath.SplitList(pathValue) {
+		candidate := filepath.Join(dir, "sense")
+		if _, err := os.Stat(candidate); err == nil {
+			out, err := exec.Command(candidate).CombinedOutput()
+			if err != nil {
+				t.Fatalf("run %s: %v", candidate, err)
+			}
+			return string(out)
+		}
+	}
+	return ""
+}
+
+func writeExecutable(t *testing.T, path, script string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/lab/internal/isolate/shadow.go
+++ b/lab/internal/isolate/shadow.go
@@ -1,0 +1,91 @@
+package isolate
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// ShadowBin builds the one directory an arm's PATH points at: a symlink to
+// every executable the host PATH offers, minus any binary named like Sense,
+// plus the Sense binary itself for the sense arm.
+//
+// # Why a farm rather than a filtered PATH
+//
+// Removing the directory that holds the Sense binary is not enough, and the
+// channel proof caught it: on a machine where Sense is installed the way a user
+// installs it, the baseline arm still found `sense` on the host's own PATH,
+// through a directory the bench never configured. Dropping that directory
+// instead would take every other tool in it with it.
+//
+// So both arms get a farm, and they differ in exactly one link. That is also
+// what makes the arms comparable: a baseline with a farm and a sense arm with
+// the raw host PATH would differ in the shape of PATH as well as in Sense.
+//
+// First entry wins, so the host's own precedence survives.
+func ShadowBin(dir, hostPath, senseBin string, arm Arm) (string, error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("prepare the arm's bin directory: %w", err)
+	}
+
+	deny := ""
+	if senseBin != "" {
+		deny = filepath.Base(senseBin)
+	}
+	linked := map[string]bool{}
+	for _, from := range filepath.SplitList(hostPath) {
+		if from == "" {
+			continue
+		}
+		if err := linkExecutables(dir, from, deny, linked); err != nil {
+			return "", err
+		}
+	}
+
+	// The Sense binary goes in last and deliberately, so the sense arm reaches
+	// the build under test rather than whatever the host happens to have
+	// installed.
+	if arm == Sense && senseBin != "" {
+		target := filepath.Join(dir, deny)
+		_ = os.Remove(target)
+		if err := os.Symlink(senseBin, target); err != nil {
+			return "", fmt.Errorf("link the sense binary: %w", err)
+		}
+	}
+	return dir, nil
+}
+
+// linkExecutables links everything runnable in one host directory, skipping
+// names already linked and the denied one.
+func linkExecutables(into, from, deny string, linked map[string]bool) error {
+	entries, err := os.ReadDir(from)
+	if err != nil {
+		// A PATH entry that is not there is normal on any real machine, and a
+		// run must not fail because of one.
+		return nil //nolint:nilerr // an unreadable PATH entry is not a run failure
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if linked[name] || name == deny || !runnable(from, e) {
+			continue
+		}
+		if err := os.Symlink(filepath.Join(from, name), filepath.Join(into, name)); err != nil {
+			return fmt.Errorf("link %s: %w", name, err)
+		}
+		linked[name] = true
+	}
+	return nil
+}
+
+// runnable reports whether an entry can be executed. A directory cannot, and a
+// file with no execute bit is data.
+func runnable(dir string, e fs.DirEntry) bool {
+	info, err := os.Stat(filepath.Join(dir, e.Name()))
+	if err != nil {
+		// A dangling symlink on the host PATH. Skipping it is what the shell
+		// does too.
+		return false
+	}
+	return !info.IsDir() && info.Mode()&0o111 != 0
+}

--- a/lab/internal/isolate/shadow_test.go
+++ b/lab/internal/isolate/shadow_test.go
@@ -1,0 +1,229 @@
+package isolate_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/lab/internal/isolate"
+)
+
+// hostBin is a directory on the host PATH holding the given executables.
+func hostBin(t *testing.T, names ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, name := range names {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("#!/bin/sh\necho "+name+"\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func hostPath(dirs ...string) string {
+	return strings.Join(dirs, string(filepath.ListSeparator))
+}
+
+// runs the named command out of a bin directory and returns what it said.
+func runs(t *testing.T, bin, name string) (string, bool) {
+	t.Helper()
+	path := filepath.Join(bin, name)
+	if _, err := os.Stat(path); err != nil {
+		return "", false
+	}
+	out, err := exec.Command(path).CombinedOutput()
+	if err != nil {
+		t.Fatalf("run %s: %v", path, err)
+	}
+	return strings.TrimSpace(string(out)), true
+}
+
+func TestTheBaselineArmCannotReachASenseTheHostAlreadyHad(t *testing.T) {
+	// The failure the channel proof caught. Removing the directory that holds
+	// the Sense binary is not enough: on a machine where Sense is installed the
+	// way a user installs it, the baseline arm still finds it through a
+	// directory the bench never configured.
+	installed := hostBin(t, "sense", "git", "rg")
+	senseBin := filepath.Join(hostBin(t, "sense"), "sense")
+
+	bin, err := isolate.ShadowBin(filepath.Join(t.TempDir(), "bin"), hostPath(installed), senseBin, isolate.Baseline)
+	if err != nil {
+		t.Fatalf("ShadowBin: %v", err)
+	}
+
+	if _, ok := runs(t, bin, "sense"); ok {
+		t.Error("the baseline arm reaches a sense binary")
+	}
+	// And dropping the directory would have taken these with it.
+	for _, name := range []string{"git", "rg"} {
+		if _, ok := runs(t, bin, name); !ok {
+			t.Errorf("the baseline arm lost %s along with the sense binary", name)
+		}
+	}
+}
+
+func TestTheSenseArmReachesTheBuildUnderTestRatherThanTheHostsInstall(t *testing.T) {
+	// A run against whatever happens to be installed measures a binary nobody
+	// chose, and nothing in the result would say which one it was.
+	installed := hostBin(t, "sense", "git")
+	underTest := t.TempDir()
+	if err := os.WriteFile(filepath.Join(underTest, "sense"), []byte("#!/bin/sh\necho the build under test\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	bin, err := isolate.ShadowBin(filepath.Join(t.TempDir(), "bin"), hostPath(installed),
+		filepath.Join(underTest, "sense"), isolate.Sense)
+	if err != nil {
+		t.Fatalf("ShadowBin: %v", err)
+	}
+
+	said, ok := runs(t, bin, "sense")
+	if !ok {
+		t.Fatal("the sense arm cannot reach a sense binary at all")
+	}
+	if said != "the build under test" {
+		t.Errorf("the sense arm reached %q, want the build under test", said)
+	}
+}
+
+func TestBothArmsGetTheSameToolsApartFromSense(t *testing.T) {
+	// If the arms differed in the shape of PATH as well as in Sense, they would
+	// differ in two things and the measurement would be of neither.
+	installed := hostBin(t, "sense", "git", "rg", "jq")
+	senseBin := filepath.Join(t.TempDir(), "sense")
+	if err := os.WriteFile(senseBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var got [2][]string
+	for i, arm := range []isolate.Arm{isolate.Sense, isolate.Baseline} {
+		bin, err := isolate.ShadowBin(filepath.Join(t.TempDir(), "bin"), hostPath(installed), senseBin, arm)
+		if err != nil {
+			t.Fatalf("ShadowBin(%s): %v", arm, err)
+		}
+		entries, err := os.ReadDir(bin)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, e := range entries {
+			if e.Name() != "sense" {
+				got[i] = append(got[i], e.Name())
+			}
+		}
+	}
+
+	if strings.Join(got[0], ",") != strings.Join(got[1], ",") {
+		t.Errorf("the sense arm has %v and the baseline has %v", got[0], got[1])
+	}
+	if len(got[0]) != 3 {
+		t.Errorf("the arms have %v, want git, jq and rg", got[0])
+	}
+}
+
+func TestTheHostsOwnPrecedenceSurvives(t *testing.T) {
+	// A machine with two versions of a tool on PATH resolves the first. An arm
+	// that resolved the second would be running something the operator does not
+	// run.
+	first := hostBin(t)
+	second := hostBin(t)
+	if err := os.WriteFile(filepath.Join(first, "rg"), []byte("#!/bin/sh\necho the first rg\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(second, "rg"), []byte("#!/bin/sh\necho the second rg\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	bin, err := isolate.ShadowBin(filepath.Join(t.TempDir(), "bin"), hostPath(first, second), "", isolate.Baseline)
+	if err != nil {
+		t.Fatalf("ShadowBin: %v", err)
+	}
+
+	if said, _ := runs(t, bin, "rg"); said != "the first rg" {
+		t.Errorf("rg resolved to %q, want the first on the host PATH", said)
+	}
+}
+
+func TestWhatCannotBeRunIsNotLinked(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "subdir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(dir, "gone"), filepath.Join(dir, "dangling")); err != nil {
+		t.Fatal(err)
+	}
+
+	bin, err := isolate.ShadowBin(filepath.Join(t.TempDir(), "bin"), hostPath(dir), "", isolate.Baseline)
+	if err != nil {
+		t.Fatalf("ShadowBin: %v", err)
+	}
+
+	entries, err := os.ReadDir(bin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("linked %v, want nothing runnable", entries)
+	}
+}
+
+func TestAPathEntryThatIsNotThereIsNotAFailure(t *testing.T) {
+	// Every real machine has one. A run must not fail because of it.
+	present := hostBin(t, "git")
+
+	bin, err := isolate.ShadowBin(filepath.Join(t.TempDir(), "bin"),
+		hostPath("/no/such/directory", present, ""), "", isolate.Baseline)
+	if err != nil {
+		t.Fatalf("ShadowBin: %v", err)
+	}
+
+	if _, ok := runs(t, bin, "git"); !ok {
+		t.Error("a missing PATH entry took the rest of the PATH with it")
+	}
+}
+
+func TestABinDirectoryThatCannotBeCreatedIsReported(t *testing.T) {
+	blocked := filepath.Join(t.TempDir(), "blocked")
+	if err := os.WriteFile(blocked, []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := isolate.ShadowBin(filepath.Join(blocked, "bin"), "", "", isolate.Baseline); err == nil {
+		t.Fatal("ShadowBin succeeded with an unusable directory")
+	}
+}
+
+func TestALinkThatCannotBeMadeIsReported(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores the permission that makes the link fail")
+	}
+	into := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(into, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(into, 0o700) })
+
+	if _, err := isolate.ShadowBin(into, hostPath(hostBin(t, "git")), "", isolate.Baseline); err == nil {
+		t.Fatal("ShadowBin reported success although it could link nothing")
+	}
+}
+
+func TestTheSenseLinkIsReportedWhenItCannotBeMade(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores the permission that makes the link fail")
+	}
+	into := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(into, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(into, 0o700) })
+
+	// Nothing on the host PATH, so the only link attempted is the Sense one.
+	if _, err := isolate.ShadowBin(into, "", filepath.Join(t.TempDir(), "sense"), isolate.Sense); err == nil {
+		t.Fatal("ShadowBin reported success although the sense arm has no sense binary")
+	}
+}

--- a/lab/internal/probe/probe.go
+++ b/lab/internal/probe/probe.go
@@ -1,0 +1,327 @@
+// Package probe runs both arms of one job and proves they differed in exactly
+// one thing.
+//
+// A one-arm run measures nothing. The number that matters is a difference,
+// sense minus baseline, and the difference is only meaningful if the two arms
+// were the same agent, on the same repository, at the same commit, under the
+// same budget, differing in Sense access and nothing else.
+//
+// That claim is what the whole corpus rests on, so it is checked with an output
+// rather than believed because the setup code looks right.
+package probe
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/luuuc/sense/lab/internal/cell"
+	"github.com/luuuc/sense/lab/internal/channels"
+	"github.com/luuuc/sense/lab/internal/isolate"
+	"github.com/luuuc/sense/lab/internal/run"
+	"github.com/luuuc/sense/lab/internal/session"
+)
+
+// Spec is one job: the same everything, run twice.
+type Spec struct {
+	// Root is the cell directory to create, holding one run per arm.
+	Root string
+	// Parent is the repository each worktree is taken from, at Commit.
+	Parent string
+	Commit string
+	// Prompt is what both arms are asked. It is one field, not two, because
+	// there is no version of this where the arms are asked different things:
+	// an asymmetry is fixed in the environment, never in the question.
+	Prompt string
+	// Command and Args spawn the agent tool, and AgentEnv is what it declares.
+	Command  string
+	Args     []string
+	AgentEnv []string
+	// SenseBin is the Sense binary and LabBin is this one.
+	SenseBin string
+	LabBin   string
+	// HostPath is the PATH both arms derive from.
+	HostPath string
+	// Wall is the sense arm's budget. The baseline's is derived from it.
+	Wall  time.Duration
+	Grace time.Duration
+}
+
+// Arms, named once so a directory name and a check read the same.
+const (
+	senseArm    = "sense"
+	baselineArm = "baseline"
+)
+
+// BaselineWall is the baseline arm's budget, derived from the sense arm's.
+//
+// It is a function rather than an assignment because the relationship is easy
+// to get backwards, and getting it backwards is not visible in a result. The
+// two walls are not independently chosen: the baseline's derives from the sense
+// arm it is paired with, which is also why a burned sense arm can never be
+// paired with a later baseline.
+func BaselineWall(senseWall time.Duration) time.Duration { return senseWall }
+
+// Report is what the pair proved.
+type Report struct {
+	// Sense and Baseline are the two arms' environments and metadata.
+	Sense    session.Result
+	Baseline session.Result
+	// SenseMissing names the routes the sense arm was supposed to have and does
+	// not. Empty is the only acceptable value: an arm configured for Sense that
+	// is missing one is a weakened treatment, and nothing in a score shows it.
+	SenseMissing []string
+	// BaselineReached names the routes the baseline arm could still use. Empty
+	// is the only acceptable value.
+	BaselineReached []string
+	// MemoryReached names persisted state either arm could read. It is
+	// contamination rather than treatment, so it must be empty for BOTH arms:
+	// the sense arm reading a memory directory is measuring a previous run.
+	MemoryReached []string
+	// BaselineUsed names every sign the baseline's transcript used Sense.
+	// Empty is the only acceptable value.
+	BaselineUsed []string
+	// SenseUsed names every sign the sense arm's transcript used Sense. Empty
+	// here is a different failure: an arm that had Sense and never touched it.
+	SenseUsed []string
+	// Frames is how many MCP frames the sense arm's capture holds.
+	Frames int
+	// BaselineCaptured says whether the baseline arm left a capture file. It
+	// should not have one at all: an empty file would be indistinguishable
+	// from a capture failure, and its absence is the signal.
+	BaselineCaptured bool
+	// Differences names every way the two arms differ other than Sense access.
+	// Empty is the only acceptable value.
+	Differences []string
+}
+
+// Sound reports whether the pair is a measurement.
+func (r Report) Sound() bool {
+	return len(r.SenseMissing) == 0 &&
+		len(r.MemoryReached) == 0 &&
+		len(r.BaselineReached) == 0 &&
+		len(r.BaselineUsed) == 0 &&
+		!r.BaselineCaptured &&
+		len(r.Differences) == 0 &&
+		len(r.SenseUsed) > 0 &&
+		r.Frames > 0
+}
+
+// Run runs both arms in sequence and checks the claim the corpus rests on.
+//
+// The arms run under this process, in order, so an interruption between them
+// cannot produce a half-pair: lab/internal/cell owns that, and this is the
+// caller that needs it.
+func Run(ctx context.Context, s Spec) (Report, error) {
+	var sense, baseline session.Result
+	arms := []cell.Arm{
+		{Name: senseArm, Run: s.armRunner(isolate.Sense, s.Wall, &sense)},
+		{Name: baselineArm, Run: s.armRunner(isolate.Baseline, BaselineWall(s.Wall), &baseline)},
+	}
+
+	rec, err := cell.Run(ctx, s.Root, arms)
+	if err != nil {
+		return Report{}, err
+	}
+	if !rec.Complete {
+		// The finished arm is paid for and can never be paired, because the
+		// baseline's budget derives from the sense arm it ran with. The cell
+		// record names it so a later pass refuses it rather than quietly
+		// pairing it with something else.
+		return Report{}, fmt.Errorf("the cell is incomplete: %v has no result, and %v can never be paired",
+			rec.Unusable, rec.Burned)
+	}
+
+	return s.check(ctx, sense, baseline)
+}
+
+// armRunner is one side of the pair, as the supervisor sees it: a function that
+// produces a run in the directory it is handed, and leaves its result where the
+// checks can read it.
+func (s Spec) armRunner(arm isolate.Arm, wall time.Duration, into *session.Result) func(context.Context, string) (run.Meta, error) {
+	return func(ctx context.Context, dir string) (run.Meta, error) {
+		res, err := session.Run(ctx, s.arm(dir, arm, wall))
+		if err != nil {
+			return run.Meta{}, err
+		}
+		*into = res
+		return res.Meta, nil
+	}
+}
+
+// arm builds one side of the pair. Everything except the arm and its wall is
+// shared by construction rather than by two call sites that must be kept the
+// same: an asymmetry between the arms is the one failure that invalidates every
+// number without being visible in any of them.
+func (s Spec) arm(root string, arm isolate.Arm, wall time.Duration) session.Spec {
+	return session.Spec{
+		Root:     root,
+		Arm:      arm,
+		Parent:   s.Parent,
+		Commit:   s.Commit,
+		Prompt:   s.Prompt,
+		Command:  s.Command,
+		Args:     s.Args,
+		AgentEnv: s.AgentEnv,
+		SenseBin: s.SenseBin,
+		LabBin:   s.LabBin,
+		HostPath: s.HostPath,
+		Wall:     wall,
+		Grace:    s.Grace,
+	}
+}
+
+// check runs every proof against the pair that just ran.
+func (s Spec) check(ctx context.Context, sense, baseline session.Result) (Report, error) {
+	r := Report{Sense: sense, Baseline: baseline}
+
+	derived, err := channels.Derive(ctx, s.SenseBin, filepath.Join(s.Root, "channel-probe"))
+	if err != nil {
+		return Report{}, err
+	}
+	tools, err := channels.ToolNames(ctx, s.SenseBin, sense.Env.Repo)
+	if err != nil {
+		return Report{}, err
+	}
+	binary := filepath.Base(s.SenseBin)
+
+	// The routes split in two. The repository files and the binary on PATH are
+	// the treatment: the sense arm must have every one and the baseline none.
+	// Persisted memory is not a treatment at all — it is state carried between
+	// runs — so it must be absent from both, and an arm that has it is
+	// measuring a previous session rather than this one.
+	treatment, contamination := split(derived)
+	senseWorld, baselineWorld := armWorld(sense, binary), armWorld(baseline, binary)
+
+	r.SenseMissing = missing(treatment, channels.Absent(treatment, senseWorld))
+	r.BaselineReached = channels.Absent(treatment, baselineWorld)
+	r.MemoryReached = append(
+		channels.Absent(contamination, senseWorld),
+		channels.Absent(contamination, baselineWorld)...)
+
+	senseSaid, err := transcript(sense)
+	if err != nil {
+		return Report{}, err
+	}
+	baselineSaid, err := transcript(baseline)
+	if err != nil {
+		return Report{}, err
+	}
+	r.SenseUsed = channels.UsedBy(senseSaid, tools, binary)
+	r.BaselineUsed = channels.UsedBy(baselineSaid, tools, binary)
+
+	frames, err := countFrames(session.LogPath(sense.Env))
+	if err != nil {
+		return Report{}, err
+	}
+	r.Frames = frames
+	_, r.BaselineCaptured, err = session.Capture(baseline.Env)
+	if err != nil {
+		return Report{}, err
+	}
+	if _, err := os.Stat(session.LogPath(baseline.Env)); err == nil {
+		r.BaselineCaptured = true
+	}
+
+	r.Differences = Differences(sense.Meta, baseline.Meta)
+	return r, nil
+}
+
+// split separates the routes that are the treatment from the one that is
+// contamination.
+func split(all []channels.Channel) (treatment, contamination []channels.Channel) {
+	for _, c := range all {
+		if c.Kind == channels.Home {
+			contamination = append(contamination, c)
+			continue
+		}
+		treatment = append(treatment, c)
+	}
+	return treatment, contamination
+}
+
+// missing names the routes that were not reached, given the ones that were.
+func missing(all []channels.Channel, reached []string) []string {
+	var absent []string
+	for _, c := range all {
+		found := false
+		for _, r := range reached {
+			if strings.HasPrefix(r, c.Name+":") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			absent = append(absent, c.Name)
+		}
+	}
+	return absent
+}
+
+// armWorld is where one arm's channels would be if it had them.
+func armWorld(res session.Result, binary string) channels.Arm {
+	return channels.Arm{
+		Repo:        res.Env.Repo,
+		Home:        res.Env.Home,
+		PathValue:   res.Meta.Path,
+		SenseBinary: binary,
+	}
+}
+
+// Differences names every way the two arms differ other than Sense access.
+//
+// Read off what was recorded rather than off what was configured: the two are
+// the same only when nothing went wrong, and the case worth catching is the one
+// where something did.
+func Differences(sense, baseline run.Meta) []string {
+	var found []string
+	compare := func(what, a, b string) {
+		if a != b {
+			found = append(found, fmt.Sprintf("%s: the sense arm had %q and the baseline had %q", what, a, b))
+		}
+	}
+	compare("the agent tool", sense.Command, baseline.Command)
+	compare("the arguments", fmt.Sprint(sense.Args), fmt.Sprint(baseline.Args))
+	compare("where the wall starts", sense.WallStartsAt, baseline.WallStartsAt)
+	if sense.WallSeconds != baseline.WallSeconds {
+		found = append(found, fmt.Sprintf("the budget: the sense arm had %.0fs and the baseline had %.0fs, "+
+			"but the baseline's derives from the sense arm's", sense.WallSeconds, baseline.WallSeconds))
+	}
+	return found
+}
+
+// transcript is what an arm actually said, unnormalised. The canonical form is
+// cycle 02's and is built from the same bytes.
+func transcript(res session.Result) ([]byte, error) {
+	path := filepath.Join(res.Env.Root, "session", "raw", "stdout")
+	b, err := os.ReadFile(path) // #nosec G304 -- the run's own capture
+	if err != nil {
+		return nil, fmt.Errorf("read the %s arm's transcript: %w", res.Meta.Arm, err)
+	}
+	return b, nil
+}
+
+// countFrames is how much the sense arm's capture holds. Zero on a sense arm is
+// a finding: either Sense was never reached or the capture never worked, and
+// the run cannot tell those apart on its own.
+func countFrames(path string) (int, error) {
+	b, err := os.ReadFile(path) // #nosec G304 -- the run's own capture
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read the capture: %w", err)
+	}
+	n := 0
+	for _, line := range bytes.Split(b, []byte("\n")) {
+		if len(bytes.TrimSpace(line)) > 0 {
+			n++
+		}
+	}
+	return n, nil
+}

--- a/lab/internal/probe/probe_test.go
+++ b/lab/internal/probe/probe_test.go
@@ -1,0 +1,523 @@
+package probe_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/lab/internal/probe"
+	"github.com/luuuc/sense/lab/internal/run"
+)
+
+// parentRepo is the repository under study: one commit, something to index.
+func parentRepo(t *testing.T) (dir, commit string) {
+	t.Helper()
+	dir = t.TempDir()
+	git := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=bench", "GIT_AUTHOR_EMAIL=bench@example.com",
+			"GIT_COMMITTER_NAME=bench", "GIT_COMMITTER_EMAIL=bench@example.com")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	git("init", "-q", "-b", "main")
+	if err := os.WriteFile(filepath.Join(dir, "app.go"), []byte("package app\n\nfunc New() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git("add", ".")
+	git("commit", "-q", "-m", "first")
+	return dir, git("rev-parse", "HEAD")
+}
+
+// fakeSense stands in for the product: it indexes, configures, and answers an
+// MCP tool list. The tool names are read off it rather than written down, so a
+// stand-in that offered different tools would change what the checks look for.
+func fakeSense(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the stand-in is a shell script")
+	}
+	bin := filepath.Join(t.TempDir(), "sense")
+	script := `#!/bin/sh
+set -e
+case "$1" in
+scan) mkdir -p "$3/.sense"; printf 'index' > "$3/.sense/index.db" ;;
+setup)
+  printf '{"mcpServers":{"sense":{"command":"` + bin + `","args":["mcp"]}}}' > .mcp.json
+  printf '# guidance\n' > CLAUDE.md
+  mkdir -p .claude/skills
+  printf '{"hooks":{}}' > .claude/settings.json
+  printf '# explore\n' > .claude/skills/sense-explore.md
+  ;;
+mcp)
+  while IFS= read -r line; do
+    case "$line" in
+      *'"tools/list"'*) printf '{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"sense_graph"},{"name":"sense_blast"}]}}\n' ;;
+      *'"id"'*) printf '{"jsonrpc":"2.0","id":1,"result":{"symbols":[]}}\n' ;;
+    esac
+  done
+  ;;
+esac
+`
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return bin
+}
+
+// labBinary builds this binary so the capture shim can be spawned the way a
+// run's registration spawns it.
+func labBinary(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "sense-lab")
+	if out, err := exec.Command("go", "build", "-o", bin, "github.com/luuuc/sense/lab/cmd/sense-lab").CombinedOutput(); err != nil {
+		t.Fatalf("build sense-lab: %v: %s", err, out)
+	}
+	return bin
+}
+
+// agentThatUsesSense stands in for an agent CLI that reaches the MCP server,
+// records the call in its own output the way Claude Code does, and answers.
+const agentThatUsesSense = `cat > /dev/null
+if [ -f .mcp.json ]; then
+  flat=$(tr -d ' \n' < .mcp.json)
+  server=$(printf '%s' "$flat" | sed 's/.*"command":"\([^"]*\)".*/\1/')
+  args=$(printf '%s' "$flat" | sed 's/.*"args":\[\([^]]*\)\].*/\1/' | tr -d '"' | tr ',' ' ')
+  printf '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"sense_graph"}}\n' | $server $args > /dev/null
+  printf '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"mcp__sense__sense_graph"}]}}\n'
+fi
+printf '{"type":"result","result":"Category has three dependents"}\n'
+`
+
+// agentThatCannotUseSense is the same agent with nothing to reach.
+const agentThatCannotUseSense = `cat > /dev/null
+printf '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Grep"},{"type":"tool_use","name":"Bash","input":{"command":"grep -rn Category ."}}]}}\n'
+printf '{"type":"result","result":"Category is referenced in three files"}\n'
+`
+
+func spec(t *testing.T) probe.Spec {
+	t.Helper()
+	parent, commit := parentRepo(t)
+	return probe.Spec{
+		Root:     filepath.Join(t.TempDir(), "cell"),
+		Parent:   parent,
+		Commit:   commit,
+		Prompt:   "what depends on Category?",
+		Command:  "/bin/sh",
+		Args:     []string{"-c", agentThatUsesSense + agentThatCannotUseSense},
+		SenseBin: fakeSense(t),
+		LabBin:   labBinary(t),
+		HostPath: os.Getenv("PATH"),
+		Wall:     60 * time.Second,
+		Grace:    200 * time.Millisecond,
+	}
+}
+
+func TestBothArmsRunAndTheDifferenceIsOnlySenseAccess(t *testing.T) {
+	s := spec(t)
+
+	report, err := probe.Run(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if report.Sense.Meta.Outcome != run.Completed || report.Baseline.Meta.Outcome != run.Completed {
+		t.Fatalf("outcomes: sense %s, baseline %s", report.Sense.Meta.Outcome, report.Baseline.Meta.Outcome)
+	}
+	if !report.Sound() {
+		t.Fatalf("the pair is not a measurement: %+v", report)
+	}
+	if len(report.Differences) != 0 {
+		t.Errorf("the arms differ in %v", report.Differences)
+	}
+}
+
+func TestTheSenseArmHasEveryRouteItWasSupposedToHave(t *testing.T) {
+	// A sense arm missing one route is a weakened treatment, and nothing in a
+	// score would show it.
+	report, err := probe.Run(context.Background(), spec(t))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(report.SenseMissing) != 0 {
+		t.Errorf("the sense arm is missing %v", report.SenseMissing)
+	}
+	if report.Frames == 0 {
+		t.Error("the sense arm's capture is empty; either Sense was never reached or capture never worked")
+	}
+	if len(report.SenseUsed) == 0 {
+		t.Error("the sense arm's transcript shows no Sense tool call")
+	}
+}
+
+func TestTheBaselineArmReachesNoRouteAndUsesNone(t *testing.T) {
+	// The claim the whole corpus rests on. Configuration says what was set up;
+	// the transcript says what was used; neither alone is the claim.
+	report, err := probe.Run(context.Background(), spec(t))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(report.BaselineReached) != 0 {
+		t.Errorf("the baseline arm reaches %v", report.BaselineReached)
+	}
+	if len(report.BaselineUsed) != 0 {
+		t.Errorf("the baseline arm's transcript shows %v", report.BaselineUsed)
+	}
+	if report.BaselineCaptured {
+		t.Error("the baseline arm left a capture file; it has no MCP server, so its absence is the signal")
+	}
+}
+
+func TestNeitherArmCanReadPersistedMemory(t *testing.T) {
+	// Persisted memory is not a treatment. A sense arm that reads a memory
+	// directory is measuring a previous session, which is worse than an
+	// asymmetry because it moves both arms in the same direction.
+	report, err := probe.Run(context.Background(), spec(t))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(report.MemoryReached) != 0 {
+		t.Errorf("persisted memory was reachable: %v", report.MemoryReached)
+	}
+}
+
+func TestABaselineThatReachedSenseIsCaught(t *testing.T) {
+	// The check that catches what configuration checks cannot: an arm that
+	// found the binary some other way. There is no configuration trace at all,
+	// and only the transcript shows it.
+	s := spec(t)
+	s.Args = []string{"-c", `cat > /dev/null
+printf '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"sense graph -symbol Category"}}]}}\n'
+` + agentThatUsesSense}
+
+	report, err := probe.Run(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(report.BaselineUsed) == 0 {
+		t.Fatal("a baseline arm that invoked the sense binary was reported clean")
+	}
+	if report.Sound() {
+		t.Error("the pair reports itself sound although the baseline arm reached Sense")
+	}
+}
+
+func TestABaselineThatNamedASenseToolIsCaught(t *testing.T) {
+	s := spec(t)
+	s.Args = []string{"-c", `cat > /dev/null
+printf '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"mcp__sense__sense_graph"}]}}\n'
+` + agentThatUsesSense}
+
+	report, err := probe.Run(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(report.BaselineUsed) == 0 {
+		t.Fatal("a baseline arm that called a Sense tool was reported clean")
+	}
+}
+
+func TestABaselineWorktreeCarryingARouteIsCaught(t *testing.T) {
+	// The other half. A transcript that happens not to use Sense in one run
+	// says nothing about whether the arm could have.
+	s := spec(t)
+	// A parent repository that already carries the registration, so the
+	// baseline arm's worktree inherits it.
+	if err := os.WriteFile(filepath.Join(s.Parent, ".mcp.json"), []byte(`{"mcpServers":{"sense":{}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	commitAll(t, s.Parent)
+	s.Commit = head(t, s.Parent)
+
+	report, err := probe.Run(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(report.BaselineReached) == 0 {
+		t.Fatal("a baseline worktree carrying the MCP registration was reported clean")
+	}
+	if report.Sound() {
+		t.Error("the pair reports itself sound although the baseline arm carried a route")
+	}
+}
+
+func TestTheTwoArmsShareTheirBudgetRelationship(t *testing.T) {
+	// The baseline's wall is not independently chosen. Getting the relationship
+	// backwards is not visible in a result, which is why it is a function with
+	// a name rather than an assignment at two call sites.
+	if got := probe.BaselineWall(480 * time.Second); got != 480*time.Second {
+		t.Errorf("BaselineWall(480s) = %s, want the sense arm's own wall", got)
+	}
+
+	report, err := probe.Run(context.Background(), spec(t))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Read off what was recorded, not off what was configured: the two are the
+	// same only when nothing went wrong.
+	if report.Sense.Meta.WallSeconds != report.Baseline.Meta.WallSeconds {
+		t.Errorf("the arms ran at %.0fs and %.0fs", report.Sense.Meta.WallSeconds, report.Baseline.Meta.WallSeconds)
+	}
+	if report.Sense.Meta.Command != report.Baseline.Meta.Command {
+		t.Errorf("the arms ran %q and %q", report.Sense.Meta.Command, report.Baseline.Meta.Command)
+	}
+}
+
+func TestArmsThatDifferInAnythingElseAreNamed(t *testing.T) {
+	same := run.Meta{Command: "claude", Args: []string{"-p"}, WallSeconds: 480, WallStartsAt: "spawn"}
+
+	if got := probe.Differences(same, same); len(got) != 0 {
+		t.Errorf("two identical arms differ in %v", got)
+	}
+
+	for _, tc := range []struct {
+		what     string
+		baseline run.Meta
+	}{
+		{"a different agent tool", run.Meta{Command: "codex", Args: []string{"-p"}, WallSeconds: 480, WallStartsAt: "spawn"}},
+		{"different arguments", run.Meta{Command: "claude", Args: []string{"-p", "--verbose"}, WallSeconds: 480, WallStartsAt: "spawn"}},
+		{"a halved budget", run.Meta{Command: "claude", Args: []string{"-p"}, WallSeconds: 240, WallStartsAt: "spawn"}},
+		{"a different wall start", run.Meta{Command: "claude", Args: []string{"-p"}, WallSeconds: 480, WallStartsAt: "first event"}},
+	} {
+		got := probe.Differences(same, tc.baseline)
+		if len(got) == 0 {
+			t.Errorf("%s went unreported", tc.what)
+		}
+	}
+}
+
+func TestAnInterruptionAfterTheFirstArmRefusesToPair(t *testing.T) {
+	// The half-pair. The finished arm is paid for and can never be paired,
+	// because the baseline's budget derives from the sense arm it ran with.
+	s := spec(t)
+	// The sense arm answers and stops; the baseline arm is still running when
+	// the interruption lands, which is the moment that burns a paid-for arm.
+	s.Args = []string{"-c", `cat > /dev/null
+if [ -f .mcp.json ]; then echo answered; else sleep 30; fi`}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(4 * time.Second)
+		cancel()
+	}()
+
+	_, err := probe.Run(ctx, s)
+
+	if err == nil {
+		t.Fatal("Run returned a report from an interrupted cell")
+	}
+	if !strings.Contains(err.Error(), "sense") {
+		t.Errorf("error = %v, want it to name the burned arm", err)
+	}
+	// The record is on disk, so a later pass refuses the burned run rather than
+	// quietly pairing it with something else.
+	if _, statErr := os.Stat(filepath.Join(s.Root, "cell-meta.json")); statErr != nil {
+		t.Errorf("no cell record was written: %v", statErr)
+	}
+}
+
+func TestASenseArmThatCannotBePreparedStopsTheCell(t *testing.T) {
+	s := spec(t)
+	s.SenseBin = filepath.Join(t.TempDir(), "not-a-binary")
+
+	if _, err := probe.Run(context.Background(), s); err == nil {
+		t.Fatal("Run reported success although the sense arm could not be prepared")
+	}
+}
+
+func TestAServerThatOffersNoToolsIsRefused(t *testing.T) {
+	// An empty tool list makes every transcript check pass, which is the shape
+	// of a leak that reads as a clean bill of health.
+	s := spec(t)
+	s.SenseBin = senseWithNoTools(t)
+
+	_, err := probe.Run(context.Background(), s)
+
+	if err == nil {
+		t.Fatal("Run accepted a server that offered no tools")
+	}
+	if !strings.Contains(err.Error(), "no tools") {
+		t.Errorf("error = %v, want it to name the empty tool list", err)
+	}
+}
+
+func TestAServerThatNeverAnswersTheToolListIsRefused(t *testing.T) {
+	s := spec(t)
+	s.SenseBin = senseThatIgnoresTheHandshake(t)
+
+	if _, err := probe.Run(context.Background(), s); err == nil {
+		t.Fatal("Run accepted a server that never answered the tool list")
+	}
+}
+
+// senseWithNoTools answers the handshake with an empty tool list.
+func senseWithNoTools(t *testing.T) string {
+	return senseServing(t, `printf '{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}\n'`)
+}
+
+// senseThatIgnoresTheHandshake answers nothing at all.
+func senseThatIgnoresTheHandshake(t *testing.T) string {
+	return senseServing(t, `:`)
+}
+
+func senseServing(t *testing.T, reply string) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "sense")
+	script := `#!/bin/sh
+set -e
+case "$1" in
+scan) mkdir -p "$3/.sense"; printf 'index' > "$3/.sense/index.db" ;;
+setup) printf '{"mcpServers":{"sense":{"command":"` + bin + `","args":["mcp"]}}}' > .mcp.json ;;
+mcp) ` + reply + ` ;;
+esac
+`
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return bin
+}
+
+func commitAll(t *testing.T, dir string) {
+	t.Helper()
+	for _, args := range [][]string{{"add", "."}, {"commit", "-q", "-m", "carry the registration"}} {
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=bench", "GIT_AUTHOR_EMAIL=bench@example.com",
+			"GIT_COMMITTER_NAME=bench", "GIT_COMMITTER_EMAIL=bench@example.com")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+}
+
+func head(t *testing.T, dir string) string {
+	t.Helper()
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func TestASenseArmThatNeverTouchedSenseIsNotAMeasurement(t *testing.T) {
+	// An arm that had Sense and never used it is a different failure from one
+	// that could not reach it, and a score cannot tell them apart. Zero frames
+	// on a sense arm means either Sense was never reached or capture never
+	// worked, and the run says so rather than reporting a number.
+	s := spec(t)
+	s.Args = []string{"-c", agentThatCannotUseSense}
+
+	report, err := probe.Run(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if report.Frames != 0 {
+		t.Fatalf("Frames = %d, want none from an agent that never called Sense", report.Frames)
+	}
+	if len(report.SenseUsed) != 0 {
+		t.Errorf("SenseUsed = %v", report.SenseUsed)
+	}
+	if report.Sound() {
+		t.Error("the pair reports itself sound although the sense arm never touched Sense")
+	}
+}
+
+func TestARouteTheSenseArmDoesNotHaveIsNamed(t *testing.T) {
+	// The product gained a route between the arm being prepared and the routes
+	// being derived. That is the shape of a sense arm running with a weakened
+	// treatment, and nothing in a score would show it.
+	s := spec(t)
+	s.SenseBin = senseThatGainsARoute(t)
+
+	report, err := probe.Run(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(report.SenseMissing) == 0 {
+		t.Fatal("a sense arm missing a route was reported complete")
+	}
+	if report.Sound() {
+		t.Error("the pair reports itself sound although the sense arm is missing a route")
+	}
+}
+
+func TestASetupThatWritesNothingAtDerivationTimeIsRefused(t *testing.T) {
+	// An empty derived list makes every absence check pass, which is the shape
+	// of a leak that reads as a clean bill of health.
+	s := spec(t)
+	s.SenseBin = senseThatStopsConfiguring(t)
+
+	if _, err := probe.Run(context.Background(), s); err == nil {
+		t.Fatal("Run accepted a derivation that found no routes")
+	}
+}
+
+// senseThatGainsARoute writes one more file the second time it configures a
+// project, which is when the routes are derived.
+func senseThatGainsARoute(t *testing.T) string {
+	return senseCounting(t, `printf '{}' > .cursor-route.json`, "")
+}
+
+// senseThatStopsConfiguring writes nothing the second time.
+func senseThatStopsConfiguring(t *testing.T) string {
+	return senseCounting(t, "", "skip")
+}
+
+// senseCounting is a stand-in whose setup behaves differently on its second
+// call: the first is the sense arm's, the second is the derivation's.
+func senseCounting(t *testing.T, extra, mode string) string {
+	t.Helper()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "sense")
+	base := `printf '{"mcpServers":{"sense":{"command":"` + bin + `","args":["mcp"]}}}' > .mcp.json
+  printf '# guidance\n' > CLAUDE.md`
+	second := base + "\n  " + extra
+	if mode == "skip" {
+		second = ":"
+	}
+	script := `#!/bin/sh
+set -e
+count=` + filepath.Join(dir, "calls") + `
+case "$1" in
+scan) mkdir -p "$3/.sense"; printf 'index' > "$3/.sense/index.db" ;;
+setup)
+  printf 'x' >> "$count"
+  if [ "$(wc -c < "$count" | tr -d ' ')" -eq 1 ]; then
+    ` + base + `
+  else
+    ` + second + `
+  fi
+  ;;
+mcp)
+  while IFS= read -r line; do
+    case "$line" in
+      *'"tools/list"'*) printf '{"jsonrpc":"2.0","id":2,"result":{"tools":[{"name":"sense_graph"}]}}\n' ;;
+      *'"id"'*) printf '{"jsonrpc":"2.0","id":1,"result":{}}\n' ;;
+    esac
+  done
+  ;;
+esac
+`
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return bin
+}

--- a/lab/internal/session/session.go
+++ b/lab/internal/session/session.go
@@ -55,16 +55,6 @@ type Result struct {
 	Meta run.Meta
 }
 
-// senseBinDir is the directory holding the Sense binary, and "" when there is
-// no binary. Passing filepath.Dir("") would hand both arms "." as the directory
-// to add and remove, which is the working directory: the repository under study.
-func senseBinDir(bin string) string {
-	if bin == "" {
-		return ""
-	}
-	return filepath.Dir(bin)
-}
-
 // captureLog is the MCP capture, relative to the run's artifacts directory.
 const captureLog = "sense-io.jsonl"
 
@@ -73,11 +63,11 @@ const captureLog = "sense-io.jsonl"
 // is about to be diagnosed must survive the process that made it.
 func Run(ctx context.Context, s Spec) (Result, error) {
 	env, err := isolate.Prepare(isolate.Spec{
-		Root:        s.Root,
-		Arm:         s.Arm,
-		SenseBinDir: senseBinDir(s.SenseBin),
-		HostPath:    s.HostPath,
-		AgentEnv:    s.AgentEnv,
+		Root:     s.Root,
+		Arm:      s.Arm,
+		SenseBin: s.SenseBin,
+		HostPath: s.HostPath,
+		AgentEnv: s.AgentEnv,
 	})
 	if err != nil {
 		return Result{}, err

--- a/lab/internal/session/session.go
+++ b/lab/internal/session/session.go
@@ -1,0 +1,204 @@
+// Package session runs one arm end to end: a disposable environment, a worktree
+// at the pinned commit, the subject prepared, the agent tool spawned under a
+// wall, and everything it said captured.
+//
+// It captures and it does not interpret. Cycle 02 owns the canonical
+// transcript and reads raw/; nothing here normalises anything.
+package session
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/luuuc/sense/lab/internal/isolate"
+	"github.com/luuuc/sense/lab/internal/run"
+	"github.com/luuuc/sense/lab/internal/subject"
+	"github.com/luuuc/sense/lab/internal/tee"
+)
+
+// Spec is one arm to run.
+type Spec struct {
+	// Root is the run directory to create. It must not already exist.
+	Root string
+	// Arm decides both the PATH and whether the subject is configured at all.
+	Arm isolate.Arm
+	// Parent is the repository the worktree is taken from, and Commit is where
+	// it is pinned.
+	Parent string
+	Commit string
+	// Prompt is what the agent is asked, on stdin.
+	Prompt string
+	// Command and Args spawn the agent tool.
+	Command string
+	Args    []string
+	// AgentEnv is what the agent tool declares in agent.json, as KEY=VALUE.
+	AgentEnv []string
+	// SenseBin is the Sense binary, and LabBin is this binary, which the
+	// capture shim is invoked through.
+	SenseBin string
+	LabBin   string
+	// HostPath is the PATH both arms derive from.
+	HostPath string
+	// Wall is how long the session may take, and Grace how long it gets to stop
+	// on its own afterwards.
+	Wall  time.Duration
+	Grace time.Duration
+}
+
+// Result is where the run landed and what it did.
+type Result struct {
+	Env  isolate.Env
+	Meta run.Meta
+}
+
+// senseBinDir is the directory holding the Sense binary, and "" when there is
+// no binary. Passing filepath.Dir("") would hand both arms "." as the directory
+// to add and remove, which is the working directory: the repository under study.
+func senseBinDir(bin string) string {
+	if bin == "" {
+		return ""
+	}
+	return filepath.Dir(bin)
+}
+
+// captureLog is the MCP capture, relative to the run's artifacts directory.
+const captureLog = "sense-io.jsonl"
+
+// Run prepares the environment and the repository, spawns the agent, and leaves
+// the run directory behind. Cleaning it up is the caller's, because a run that
+// is about to be diagnosed must survive the process that made it.
+func Run(ctx context.Context, s Spec) (Result, error) {
+	env, err := isolate.Prepare(isolate.Spec{
+		Root:        s.Root,
+		Arm:         s.Arm,
+		SenseBinDir: senseBinDir(s.SenseBin),
+		HostPath:    s.HostPath,
+		AgentEnv:    s.AgentEnv,
+	})
+	if err != nil {
+		return Result{}, err
+	}
+
+	if err := isolate.AddWorktree(ctx, s.Parent, s.Commit, env.Repo); err != nil {
+		return Result{}, err
+	}
+
+	wrote, err := prepareArm(ctx, s, env)
+	if err != nil {
+		return Result{}, err
+	}
+
+	m, err := run.Session(ctx, filepath.Join(env.Root, "session"), run.Spec{
+		Dir:        env.Repo,
+		Name:       s.Command,
+		Args:       s.Args,
+		Stdin:      s.Prompt,
+		Env:        env.Environ,
+		Arm:        string(s.Arm),
+		SenseSetup: wrote,
+		Wall:       s.Wall,
+		Grace:      s.Grace,
+	})
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{Env: env, Meta: m}, nil
+}
+
+// prepareArm configures the repository for the sense arm and does nothing at
+// all for the baseline arm. The asymmetry is the measurement.
+func prepareArm(ctx context.Context, s Spec, env isolate.Env) (map[string]string, error) {
+	if s.Arm != isolate.Sense {
+		return nil, nil
+	}
+	wrote, err := subject.Sense(ctx, s.SenseBin, env.Repo)
+	if err != nil {
+		return nil, err
+	}
+	if err := wrapMCP(env.Repo, s.LabBin, filepath.Join(env.Artifacts, captureLog)); err != nil {
+		return nil, err
+	}
+	return wrote, nil
+}
+
+// wrapMCP points the registered Sense server at the capture shim, keeping the
+// command the product wrote as the shim's argument.
+//
+// The registration is the product's, written by `sense setup` and recorded as
+// such: the bench does not hand-roll it, because the moment it does it is
+// measuring a configuration no user has. What changes is only where the server
+// is spawned from, and the server spawned is still exactly the one the product
+// named.
+func wrapMCP(repo, labBin, logPath string) error {
+	path := filepath.Join(repo, ".mcp.json")
+	b, err := os.ReadFile(path) // #nosec G304 -- the run's own worktree
+	if err != nil {
+		return fmt.Errorf("read the MCP registration: %w", err)
+	}
+	// Edited as a generic document rather than through the struct above, so
+	// every key the product wrote survives untouched. A round trip through a
+	// type the bench declares would silently drop whatever the bench does not
+	// know about yet.
+	var raw map[string]any
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return fmt.Errorf("read the MCP registration: %w", err)
+	}
+	servers, _ := raw["mcpServers"].(map[string]any)
+	entry, ok := servers["sense"].(map[string]any)
+	if !ok {
+		return fmt.Errorf("%s registers no sense server; the sense arm would run without Sense", path)
+	}
+	command, _ := entry["command"].(string)
+	if command == "" {
+		return fmt.Errorf("%s registers a sense server with no command", path)
+	}
+	args := []string{"tee", "-log", logPath, "--", command}
+	if declared, ok := entry["args"].([]any); ok {
+		for _, a := range declared {
+			args = append(args, fmt.Sprint(a))
+		}
+	}
+	entry["command"] = labBin
+	entry["args"] = args
+
+	// Re-marshalling a document that was just unmarshalled into `any` cannot
+	// fail, so there is no error branch to write here.
+	out, _ := json.MarshalIndent(raw, "", "  ")
+	if err := os.WriteFile(path, append(out, '\n'), 0o644); err != nil {
+		return fmt.Errorf("rewrite the MCP registration: %w", err)
+	}
+	return nil
+}
+
+// Capture reports what the run's MCP capture managed, and whether there is one
+// at all.
+//
+// The baseline arm has no MCP server to capture, so it has no capture file. Its
+// absence is the signal rather than an error: an empty file would be
+// indistinguishable from a capture that failed.
+func Capture(env isolate.Env) (status tee.Status, present bool, err error) {
+	b, readErr := os.ReadFile(filepath.Join(env.Artifacts, "capture.json"))
+	if readErr != nil {
+		return tee.Status{}, false, nil
+	}
+	if err := json.Unmarshal(b, &status); err != nil {
+		return tee.Status{}, true, fmt.Errorf("read the capture status: %w", err)
+	}
+	return status, true, nil
+}
+
+// Cleanup removes the worktree and then the whole environment, and proves both
+// are gone.
+func Cleanup(ctx context.Context, parent string, env isolate.Env) error {
+	if err := isolate.RemoveWorktree(ctx, parent, env.Repo); err != nil {
+		return err
+	}
+	return isolate.Cleanup(env)
+}
+
+// LogPath is where a run's MCP capture lives.
+func LogPath(env isolate.Env) string { return filepath.Join(env.Artifacts, captureLog) }

--- a/lab/internal/session/session_test.go
+++ b/lab/internal/session/session_test.go
@@ -1,0 +1,573 @@
+package session_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/lab/internal/isolate"
+	"github.com/luuuc/sense/lab/internal/run"
+	"github.com/luuuc/sense/lab/internal/session"
+)
+
+// parentRepo is a one-commit repository to take a worktree from.
+func parentRepo(t *testing.T) (dir, commit string) {
+	t.Helper()
+	dir = t.TempDir()
+	git := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=bench", "GIT_AUTHOR_EMAIL=bench@example.com",
+			"GIT_COMMITTER_NAME=bench", "GIT_COMMITTER_EMAIL=bench@example.com")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	git("init", "-q", "-b", "main")
+	if err := os.WriteFile(filepath.Join(dir, "app.go"), []byte("package app\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git("add", ".")
+	git("commit", "-q", "-m", "first")
+	return dir, git("rev-parse", "HEAD")
+}
+
+// fakeSense stands in for the product binary: `scan` builds an index and
+// `setup` writes the registration a real setup would.
+func fakeSense(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the stand-in is a shell script")
+	}
+	const script = `#!/bin/sh
+set -e
+case "$1" in
+scan)  mkdir -p "$3/.sense"; printf 'index' > "$3/.sense/index.db" ;;
+setup)
+  printf '{"mcpServers":{"sense":{"command":"sense","args":["mcp"],"type":"stdio"}}}' > .mcp.json
+  printf '# guidance\n' > CLAUDE.md
+  ;;
+esac
+`
+	path := filepath.Join(t.TempDir(), "sense")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// agent is a stand-in for the agent CLI: it says something and stops.
+func agent(t *testing.T, says string) (name string, args []string) {
+	t.Helper()
+	return "/bin/sh", []string{"-c", "cat > /dev/null; echo " + says}
+}
+
+func spec(t *testing.T, arm isolate.Arm) session.Spec {
+	t.Helper()
+	parent, commit := parentRepo(t)
+	name, args := agent(t, "answered")
+	return session.Spec{
+		Root:     filepath.Join(t.TempDir(), "run"),
+		Arm:      arm,
+		Parent:   parent,
+		Commit:   commit,
+		Prompt:   "list the dependents of Category",
+		Command:  name,
+		Args:     args,
+		SenseBin: fakeSense(t),
+		LabBin:   "/opt/sense-lab",
+		HostPath: os.Getenv("PATH"),
+		Wall:     30 * time.Second,
+		Grace:    200 * time.Millisecond,
+	}
+}
+
+func TestASenseArmLeavesTheRunTreeItsResultWillBeReadFrom(t *testing.T) {
+	s := spec(t, isolate.Sense)
+
+	res, err := session.Run(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if res.Meta.Outcome != run.Completed {
+		t.Fatalf("outcome = %s", res.Meta.Outcome)
+	}
+	// raw/ is what cycle 02's canonical transcript reads. Nothing here
+	// normalises it.
+	for _, path := range []string{
+		filepath.Join(res.Env.Root, "session", "raw", "stdout"),
+		filepath.Join(res.Env.Root, "session", "run-meta.json"),
+		filepath.Join(res.Env.Repo, "app.go"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("%s: %v", path, err)
+		}
+	}
+	if said := readFile(t, filepath.Join(res.Env.Root, "session", "raw", "stdout")); !strings.Contains(said, "answered") {
+		t.Errorf("stdout = %q", said)
+	}
+}
+
+func TestTheWorktreeIsAtThePinnedCommitAndTheSessionRunsInIt(t *testing.T) {
+	s := spec(t, isolate.Baseline)
+
+	res, err := session.Run(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	at := strings.TrimSpace(gitOut(t, res.Env.Repo, "rev-parse", "HEAD"))
+	if at != s.Commit {
+		t.Errorf("the session ran against %.12s, want the pinned %.12s", at, s.Commit)
+	}
+}
+
+func TestTheSenseArmsMcpRegistrationPointsAtTheCapture(t *testing.T) {
+	res, err := session.Run(context.Background(), spec(t, isolate.Sense))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	entry := mcpEntry(t, filepath.Join(res.Env.Repo, ".mcp.json"))
+	if entry["command"] != "/opt/sense-lab" {
+		t.Errorf("the registration spawns %v, want the capture shim", entry["command"])
+	}
+	args := strings.Join(strs(entry["args"]), " ")
+	if !strings.Contains(args, session.LogPath(res.Env)) {
+		t.Errorf("the registration logs to %q, want %q", args, session.LogPath(res.Env))
+	}
+	// The server actually spawned is still the one the product named. The bench
+	// does not hand-roll a registration, because then it measures a
+	// configuration no user has.
+	if !strings.HasSuffix(args, "-- sense mcp") {
+		t.Errorf("the registration ends %q, want the product's own command", args)
+	}
+}
+
+func TestARegistrationKeyTheBenchDoesNotKnowAboutSurvives(t *testing.T) {
+	// The registration is rewritten as a generic document. A round trip through
+	// a type the bench declares would drop whatever `sense setup` adds next,
+	// and the sense arm would quietly lose part of its configured surface.
+	res, err := session.Run(context.Background(), spec(t, isolate.Sense))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if entry := mcpEntry(t, filepath.Join(res.Env.Repo, ".mcp.json")); entry["type"] != "stdio" {
+		t.Errorf("the registration lost its type key: %v", entry)
+	}
+}
+
+func TestTheBaselineArmsRepositoryIsNeverConfigured(t *testing.T) {
+	res, err := session.Run(context.Background(), spec(t, isolate.Baseline))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	for _, rel := range []string{".mcp.json", "CLAUDE.md", ".sense"} {
+		if _, err := os.Stat(filepath.Join(res.Env.Repo, rel)); !os.IsNotExist(err) {
+			t.Errorf("the baseline arm's worktree holds %s", rel)
+		}
+	}
+	if len(res.Meta.SenseSetup) != 0 {
+		t.Errorf("the baseline arm recorded a setup: %v", res.Meta.SenseSetup)
+	}
+}
+
+func TestABaselineArmWithNoSenseBinaryLeavesThePathAlone(t *testing.T) {
+	// There is no Sense binary to keep off the baseline's PATH, and the empty
+	// name must not be read as the working directory: that is the repository
+	// under study, and putting it on PATH would let a scenario's own files be
+	// executed.
+	s := spec(t, isolate.Baseline)
+	s.SenseBin = ""
+
+	res, err := session.Run(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	for _, dir := range filepath.SplitList(res.Meta.Path) {
+		if dir == "." || dir == "" {
+			t.Errorf("the session's PATH is %q, which searches the repository under study", res.Meta.Path)
+		}
+	}
+	if res.Meta.Path == "" {
+		t.Error("the session was given no PATH at all")
+	}
+}
+
+func TestTheBaselineArmHasNoCaptureAtAll(t *testing.T) {
+	// It has no MCP server to capture. An empty sense-io.jsonl would be
+	// indistinguishable from a capture failure; its absence is the signal.
+	res, err := session.Run(context.Background(), spec(t, isolate.Baseline))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if _, err := os.Stat(session.LogPath(res.Env)); !os.IsNotExist(err) {
+		t.Errorf("the baseline arm left a capture file: %v", err)
+	}
+	if _, present, err := session.Capture(res.Env); err != nil || present {
+		t.Errorf("Capture reported present=%v err=%v for the baseline arm", present, err)
+	}
+}
+
+func TestAKilledSessionStillLeavesWhatItSaidBeforeTheKill(t *testing.T) {
+	s := spec(t, isolate.Baseline)
+	s.Args = []string{"-c", "echo the answer so far; sleep 30"}
+	s.Wall = 400 * time.Millisecond
+
+	res, err := session.Run(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if res.Meta.Outcome != run.CannotFinishAtBudget {
+		t.Errorf("outcome = %s, want %s", res.Meta.Outcome, run.CannotFinishAtBudget)
+	}
+	said := readFile(t, filepath.Join(res.Env.Root, "session", "raw", "stdout"))
+	if !strings.Contains(said, "the answer so far") {
+		t.Errorf("stdout = %q, want everything captured up to the kill", said)
+	}
+}
+
+func TestTheCaptureStatusIsReadBackWhenThereIsOne(t *testing.T) {
+	res, err := session.Run(context.Background(), spec(t, isolate.Sense))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// The stand-in agent never launches the MCP server, so the shim never runs.
+	// Written by hand here, because what is under test is reading it back.
+	writeJSON(t, filepath.Join(res.Env.Artifacts, "capture.json"),
+		map[string]any{"capturing": true, "frames": 12, "dropped": 0})
+
+	status, present, err := session.Capture(res.Env)
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	if !present || !status.Complete() || status.Frames != 12 {
+		t.Errorf("Capture = %+v present=%v, want a complete capture of 12 frames", status, present)
+	}
+}
+
+func TestADroppedFrameMakesTheCaptureIncomplete(t *testing.T) {
+	// A partial file that nothing marks as partial reads as "Sense was barely
+	// called", which is a finding about the product rather than about the disk.
+	res, err := session.Run(context.Background(), spec(t, isolate.Sense))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	writeJSON(t, filepath.Join(res.Env.Artifacts, "capture.json"),
+		map[string]any{"capturing": true, "frames": 12, "dropped": 4})
+
+	status, _, err := session.Capture(res.Env)
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	if status.Complete() {
+		t.Errorf("Capture = %+v reports a complete record although frames were dropped", status)
+	}
+}
+
+func TestAnUnreadableCaptureStatusIsReported(t *testing.T) {
+	res, err := session.Run(context.Background(), spec(t, isolate.Sense))
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(res.Env.Artifacts, "capture.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := session.Capture(res.Env); err == nil {
+		t.Fatal("Capture accepted an unreadable status")
+	}
+}
+
+func TestASenseArmWithNoRegistrationIsRefusedRatherThanRunBlind(t *testing.T) {
+	// A sense arm that ran without Sense configured is the worst possible
+	// result: it looks like a measurement and it is not one.
+	s := spec(t, isolate.Sense)
+	s.SenseBin = fakeSenseWriting(t, `printf '{"mcpServers":{}}' > .mcp.json`)
+
+	_, err := session.Run(context.Background(), s)
+
+	if err == nil {
+		t.Fatal("Run accepted a sense arm with no Sense server registered")
+	}
+	if !strings.Contains(err.Error(), "no sense server") {
+		t.Errorf("error = %v, want it to name the missing registration", err)
+	}
+}
+
+func TestARegistrationWithNoCommandIsRefused(t *testing.T) {
+	s := spec(t, isolate.Sense)
+	s.SenseBin = fakeSenseWriting(t, `printf '{"mcpServers":{"sense":{}}}' > .mcp.json`)
+
+	if _, err := session.Run(context.Background(), s); err == nil {
+		t.Fatal("Run accepted a registration with no command")
+	}
+}
+
+func TestAnUnreadableRegistrationIsReported(t *testing.T) {
+	s := spec(t, isolate.Sense)
+	s.SenseBin = fakeSenseWriting(t, `printf 'not json' > .mcp.json`)
+
+	if _, err := session.Run(context.Background(), s); err == nil {
+		t.Fatal("Run accepted an unreadable registration")
+	}
+}
+
+func TestAMissingRegistrationIsReported(t *testing.T) {
+	s := spec(t, isolate.Sense)
+	s.SenseBin = fakeSenseWriting(t, `printf '# guidance\n' > CLAUDE.md`)
+
+	if _, err := session.Run(context.Background(), s); err == nil {
+		t.Fatal("Run accepted a sense arm with no registration file at all")
+	}
+}
+
+func TestARunRootThatAlreadyExistsIsRefused(t *testing.T) {
+	s := spec(t, isolate.Baseline)
+	s.Root = t.TempDir()
+
+	if _, err := session.Run(context.Background(), s); err == nil {
+		t.Fatal("Run reused an existing run directory")
+	}
+}
+
+func TestACommitTheParentDoesNotHaveIsRefused(t *testing.T) {
+	s := spec(t, isolate.Baseline)
+	s.Commit = "0000000000000000000000000000000000000000"
+
+	if _, err := session.Run(context.Background(), s); err == nil {
+		t.Fatal("Run accepted a commit the parent does not have")
+	}
+}
+
+func TestAFailingSubjectPreparationStopsBeforeTheAgentSpawns(t *testing.T) {
+	s := spec(t, isolate.Sense)
+	s.SenseBin = filepath.Join(t.TempDir(), "not-a-binary")
+
+	if _, err := session.Run(context.Background(), s); err == nil {
+		t.Fatal("Run spawned the agent although the subject could not be prepared")
+	}
+}
+
+func TestAnAgentThatCannotBeSpawnedIsReported(t *testing.T) {
+	s := spec(t, isolate.Baseline)
+	s.Command = filepath.Join(t.TempDir(), "no-such-agent")
+	s.Args = nil
+
+	if _, err := session.Run(context.Background(), s); err == nil {
+		t.Fatal("Run reported success although the agent could not be spawned")
+	}
+}
+
+func TestCleanupRemovesTheWorktreeAndTheEnvironment(t *testing.T) {
+	s := spec(t, isolate.Baseline)
+	res, err := session.Run(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if err := session.Cleanup(context.Background(), s.Parent, res.Env); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+
+	if _, err := os.Stat(res.Env.Root); !os.IsNotExist(err) {
+		t.Errorf("Stat(%s) = %v after cleanup", res.Env.Root, err)
+	}
+	if list := gitOut(t, s.Parent, "worktree", "list"); strings.Contains(list, res.Env.Repo) {
+		t.Errorf("the parent still lists the worktree:\n%s", list)
+	}
+}
+
+func TestCleanupReportsAWorktreeItCouldNotRemove(t *testing.T) {
+	s := spec(t, isolate.Baseline)
+	res, err := session.Run(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if err := session.Cleanup(context.Background(), s.Parent, res.Env); err != nil {
+		t.Fatalf("Cleanup: %v", err)
+	}
+
+	if err := session.Cleanup(context.Background(), s.Parent, res.Env); err == nil {
+		t.Fatal("Cleanup reported success on a worktree that is not there")
+	}
+}
+
+// fakeSenseWriting is a stand-in whose setup runs the given shell.
+func fakeSenseWriting(t *testing.T, setup string) string {
+	t.Helper()
+	script := "#!/bin/sh\nset -e\ncase \"$1\" in\nscan) mkdir -p \"$3/.sense\" ;;\nsetup)\n" + setup + "\n;;\nesac\n"
+	path := filepath.Join(t.TempDir(), "sense")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func mcpEntry(t *testing.T, path string) map[string]any {
+	t.Helper()
+	var doc map[string]any
+	if err := json.Unmarshal([]byte(readFile(t, path)), &doc); err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	servers, _ := doc["mcpServers"].(map[string]any)
+	entry, ok := servers["sense"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s registers no sense server", path)
+	}
+	return entry
+}
+
+func strs(v any) []string {
+	list, _ := v.([]any)
+	out := make([]string, 0, len(list))
+	for _, item := range list {
+		s, _ := item.(string)
+		out = append(out, s)
+	}
+	return out
+}
+
+func writeJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}
+
+func gitOut(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	out, err := exec.Command("git", append([]string{"-C", dir}, args...)...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, out)
+	}
+	return string(out)
+}
+
+// The whole chain, end to end: the registration the product wrote, rewritten to
+// pass through the shim, spawning the server it named, with every frame landing
+// in the run's capture file.
+
+func TestTheRegistrationTheAgentWouldUseProducesTheCapture(t *testing.T) {
+	labBin := buildLabBinary(t)
+	s := spec(t, isolate.Sense)
+	s.LabBin = labBin
+	// A stand-in Sense whose `mcp` answers frames, so there is something real
+	// on the far side of the shim.
+	s.SenseBin = fakeSenseServing(t)
+
+	res, err := session.Run(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Invoked exactly as the registration says, which is what the agent CLI
+	// would do. Nothing here reconstructs the command.
+	entry := mcpEntry(t, filepath.Join(res.Env.Repo, ".mcp.json"))
+	cmd := exec.Command(entry["command"].(string), strs(entry["args"])...)
+	cmd.Stdin = strings.NewReader("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\"}\n")
+	var spoke strings.Builder
+	cmd.Stdout = &spoke
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("the registered server: %v", err)
+	}
+
+	if !strings.Contains(spoke.String(), `"result"`) {
+		t.Errorf("the client received %q, want the server's answer through the shim", spoke.String())
+	}
+	captured := readCaptured(t, session.LogPath(res.Env))
+	if len(captured) != 2 {
+		t.Fatalf("captured %d frames from %s, want the request and the response", len(captured), session.LogPath(res.Env))
+	}
+	if captured[0]["dir"] != "c2s" || captured[1]["dir"] != "s2c" {
+		t.Errorf("captured directions %v and %v", captured[0]["dir"], captured[1]["dir"])
+	}
+
+	status, present, err := session.Capture(res.Env)
+	if err != nil || !present {
+		t.Fatalf("Capture present=%v err=%v", present, err)
+	}
+	if !status.Complete() {
+		t.Errorf("capture status = %+v, want a complete record", status)
+	}
+}
+
+// buildLabBinary builds this binary so a test can invoke it the way a run's
+// registration does.
+func buildLabBinary(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "sense-lab")
+	build := exec.Command("go", "build", "-o", bin, "github.com/luuuc/sense/lab/cmd/sense-lab")
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build sense-lab: %v: %s", err, out)
+	}
+	return bin
+}
+
+// fakeSenseServing is a stand-in Sense whose `mcp` answers newline-delimited
+// frames, so the shim has a real server to sit in front of.
+func fakeSenseServing(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "sense")
+	script := `#!/bin/sh
+set -e
+case "$1" in
+scan) mkdir -p "$3/.sense"; printf 'index' > "$3/.sense/index.db" ;;
+setup) printf '{"mcpServers":{"sense":{"command":"` + bin + `","args":["mcp"],"type":"stdio"}}}' > .mcp.json ;;
+mcp)
+  while IFS= read -r line; do
+    printf '{"jsonrpc":"2.0","id":1,"result":{"symbols":[]}}\n'
+  done
+  ;;
+esac
+`
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return bin
+}
+
+func readCaptured(t *testing.T, path string) []map[string]any {
+	t.Helper()
+	var entries []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(readFile(t, path)), "\n") {
+		if line == "" {
+			continue
+		}
+		var e map[string]any
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("capture line %q is not JSON: %v", line, err)
+		}
+		entries = append(entries, e)
+	}
+	return entries
+}

--- a/lab/internal/tee/tee.go
+++ b/lab/internal/tee/tee.go
@@ -1,0 +1,229 @@
+// Package tee is the bench's transparent capture of the MCP traffic between an
+// agent and the Sense server.
+//
+// It exists because the agent tool's own output says what the agent said, not
+// what Sense told it. Without the other half, a losing sense arm is
+// unattributable: Sense returned nothing, returned the wrong thing, returned
+// the right thing and the agent ignored it, or was never called. Four findings,
+// four different fixes, and three of them are product findings.
+//
+// # Why this is a process
+//
+// The pitch left it open whether the capture could live inside the binary that
+// owns the session. It cannot. The agent CLI spawns the MCP server itself, from
+// the `.mcp.json` registration in the repository, so the pipe carrying that
+// traffic exists between two of its own processes and the supervisor never
+// holds either end. The only place to stand is where the registration points,
+// which means a command the registration names. The cost is one process in the
+// tree, started once per session and idle between frames.
+//
+// # The contract
+//
+// Two properties, inherited deliberately from the shim this replaces:
+//
+//   - byte-transparent: what reaches the client is exactly what the server
+//     wrote. A frame that fails to parse is forwarded verbatim and logged raw.
+//     The shim never gates or repairs traffic.
+//   - fail-open: capture is telemetry, never a run dependency. A log that
+//     cannot be opened or written disables logging and the session continues. A
+//     run killed by its own telemetry is a self-inflicted burned cell.
+//
+// And one the shim did not have: capture never blocks the session. A failed
+// write is loud; a blocked write is silent and applies backpressure to a
+// session running against a wall, so the instrument alters what it measures.
+// When the sink cannot keep up, frames are dropped and counted.
+package tee
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"io"
+	"sync/atomic"
+	"time"
+)
+
+// Direction is which way a frame was travelling.
+const (
+	// ClientToServer is the agent asking Sense something.
+	ClientToServer = "c2s"
+	// ServerToClient is Sense answering.
+	ServerToClient = "s2c"
+)
+
+// entry is one line of the capture log. The shape is the one the corpus already
+// holds, so recorded runs and new ones read the same.
+type entry struct {
+	TS  string          `json:"ts"`
+	Dir string          `json:"dir"`
+	Msg json.RawMessage `json:"msg"`
+}
+
+// Sink takes a copy of every frame. It must never block: Pump calls it on the
+// path the session's own traffic travels. A nil Sink means no capture, which is
+// what a session with no log configured gets.
+type Sink interface {
+	Record(dir string, frame []byte)
+}
+
+// Pump forwards src to dst frame by frame, handing a copy of each to the sink.
+//
+// MCP stdio framing is newline-delimited JSON, so a frame is a line. It is read
+// with an unbounded reader rather than a scanner: a tool result carrying a large
+// answer is exactly the frame whose value shows up months later, and a scanner
+// would quietly truncate it at its buffer size.
+//
+// The bytes written to dst are the bytes read from src, including the newline.
+// Nothing is re-encoded, so a frame the shim cannot parse still arrives intact.
+func Pump(dst io.Writer, src io.Reader, dir string, sink Sink) error {
+	r := bufio.NewReader(src)
+	for {
+		line, err := r.ReadBytes('\n')
+		if len(line) > 0 {
+			if _, werr := dst.Write(line); werr != nil {
+				return werr
+			}
+			if sink != nil {
+				sink.Record(dir, line)
+			}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+	}
+}
+
+// Status is what capture managed to do, so a run can say whether its record is
+// complete rather than leaving a reader to guess from a file size.
+type Status struct {
+	// Capturing is false once logging has been given up on.
+	Capturing bool `json:"capturing"`
+	// Frames is how many were written.
+	Frames int `json:"frames"`
+	// Dropped is how many were discarded because the sink could not keep up.
+	// Non-zero means the capture is incomplete and says so.
+	Dropped int `json:"dropped"`
+	// Reason is why capture stopped, when it did.
+	Reason string `json:"reason,omitempty"`
+}
+
+// Complete reports whether the capture is a full record of the session.
+func (s Status) Complete() bool { return s.Capturing && s.Dropped == 0 && s.Reason == "" }
+
+// queue is how many frames may be waiting to be written. Deep enough that a
+// burst of tool results does not reach the drop path on an ordinary disk,
+// shallow enough that a wedged writer is noticed within one session.
+const queue = 1024
+
+// Log is a Sink that writes frames to an io.Writer from its own goroutine.
+//
+// The goroutine is the whole point. The session's traffic is handed to a
+// channel and the caller returns immediately, so a slow or wedged writer costs
+// dropped frames rather than a stalled session running against a wall.
+type Log struct {
+	frames  chan entry
+	done    chan struct{}
+	now     func() time.Time
+	written int
+	// dropped is touched by every pump goroutine, so it is atomic. written and
+	// stopped belong to the writer goroutine and are read only after it has
+	// finished.
+	dropped atomic.Int64
+	stopped string
+	// state is read by Status after Close, so it is only ever touched by the
+	// writer goroutine before then.
+	w io.Writer
+}
+
+// NewLog starts a log writing to w. now supplies the timestamp; nil means the
+// wall clock. Close stops it and reports what it managed.
+func NewLog(w io.Writer, now func() time.Time) *Log {
+	if now == nil {
+		now = time.Now
+	}
+	l := &Log{
+		frames: make(chan entry, queue),
+		done:   make(chan struct{}),
+		now:    now,
+		w:      w,
+	}
+	go l.write()
+	return l
+}
+
+// Record hands a frame to the writer, or drops it. It never blocks, and it
+// never returns an error: there is nothing a session could usefully do about a
+// capture problem, and the one thing it must not do is stop.
+func (l *Log) Record(dir string, frame []byte) {
+	e := entry{
+		TS:  l.now().UTC().Format(time.RFC3339Nano),
+		Dir: dir,
+		Msg: message(frame),
+	}
+	if e.Msg == nil {
+		return
+	}
+	select {
+	case l.frames <- e:
+	default:
+		l.dropped.Add(1)
+	}
+}
+
+// message turns a raw frame into the JSON the log records: the frame itself
+// when it parses, and a marked copy of the text when it does not. A blank line
+// is framing, not a frame, and is not recorded.
+func message(frame []byte) json.RawMessage {
+	text := trimEOL(frame)
+	if len(text) == 0 {
+		return nil
+	}
+	if json.Valid(text) {
+		return json.RawMessage(text)
+	}
+	// The shim never repairs traffic. It records what went past, marked as
+	// something that was not JSON, and forwards the bytes untouched.
+	//
+	// Marshalling a string cannot fail: invalid UTF-8 is replaced rather than
+	// rejected, so there is no error branch to write here.
+	quoted, _ := json.Marshal(string(text))
+	return json.RawMessage(`{"_unparsed":` + string(quoted) + `}`)
+}
+
+func trimEOL(b []byte) []byte {
+	for len(b) > 0 && (b[len(b)-1] == '\n' || b[len(b)-1] == '\r') {
+		b = b[:len(b)-1]
+	}
+	return b
+}
+
+func (l *Log) write() {
+	defer close(l.done)
+	enc := json.NewEncoder(l.w)
+	for e := range l.frames {
+		if l.stopped != "" {
+			continue // drain, so Record never blocks after a write failure
+		}
+		if err := enc.Encode(e); err != nil {
+			// Capture is telemetry. Give up on it and let the session run.
+			l.stopped = err.Error()
+			continue
+		}
+		l.written++
+	}
+}
+
+// Close stops the writer and reports what capture managed.
+func (l *Log) Close() Status {
+	close(l.frames)
+	<-l.done
+	return Status{
+		Capturing: l.stopped == "",
+		Frames:    l.written,
+		Dropped:   int(l.dropped.Load()),
+		Reason:    l.stopped,
+	}
+}

--- a/lab/internal/tee/tee_test.go
+++ b/lab/internal/tee/tee_test.go
@@ -1,0 +1,325 @@
+package tee_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/lab/internal/tee"
+)
+
+// frozen is a clock that never moves, so a recorded frame is compared on what
+// it carries rather than on when the test ran.
+func frozen() func() time.Time {
+	at := time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)
+	return func() time.Time { return at }
+}
+
+// captured runs the frames through a log and returns what was written.
+func captured(t *testing.T, dir string, frames ...string) []map[string]any {
+	t.Helper()
+	var out bytes.Buffer
+	log := tee.NewLog(&out, frozen())
+	for _, f := range frames {
+		log.Record(dir, []byte(f))
+	}
+	if status := log.Close(); !status.Complete() {
+		t.Fatalf("capture did not complete: %+v", status)
+	}
+	return decode(t, out.String())
+}
+
+func decode(t *testing.T, jsonl string) []map[string]any {
+	t.Helper()
+	var entries []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(jsonl), "\n") {
+		if line == "" {
+			continue
+		}
+		var e map[string]any
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("capture line %q is not JSON: %v", line, err)
+		}
+		entries = append(entries, e)
+	}
+	return entries
+}
+
+func TestWhatReachesTheClientIsExactlyWhatTheServerWrote(t *testing.T) {
+	// Byte-transparency is the contract. A shim that re-encodes is a shim that
+	// can change an answer, and nothing about the run would show it.
+	said := "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"text\":\"a\\u00e9b\"}}\n" +
+		"{ \"jsonrpc\" : \"2.0\" , \"id\" : 2 }\n"
+	var toClient bytes.Buffer
+
+	if err := tee.Pump(&toClient, strings.NewReader(said), tee.ServerToClient, nil); err != nil {
+		t.Fatalf("Pump: %v", err)
+	}
+
+	if toClient.String() != said {
+		t.Errorf("the client received:\n%q\nthe server wrote:\n%q", toClient.String(), said)
+	}
+}
+
+func TestAFrameThatIsNotJSONStillReachesTheClientAndIsLoggedRaw(t *testing.T) {
+	// The shim never gates or repairs traffic. A server that printed a warning
+	// onto its output stream has broken the protocol, and hiding that from the
+	// client would turn a diagnosable failure into a mystery.
+	broken := "sense: warning, index is stale\n"
+	var toClient bytes.Buffer
+	var out bytes.Buffer
+	log := tee.NewLog(&out, frozen())
+
+	if err := tee.Pump(&toClient, strings.NewReader(broken), tee.ServerToClient, log); err != nil {
+		t.Fatalf("Pump: %v", err)
+	}
+	log.Close()
+
+	if toClient.String() != broken {
+		t.Errorf("the client received %q, want %q", toClient.String(), broken)
+	}
+	entries := decode(t, out.String())
+	if len(entries) != 1 {
+		t.Fatalf("logged %d entries, want 1", len(entries))
+	}
+	msg, ok := entries[0]["msg"].(map[string]any)
+	if !ok || msg["_unparsed"] != "sense: warning, index is stale" {
+		t.Errorf("logged %v, want the unparsed text recorded verbatim", entries[0]["msg"])
+	}
+}
+
+func TestBothDirectionsAreRecordedAndTold(t *testing.T) {
+	// Without the direction, a losing arm cannot be attributed: "Sense returned
+	// nothing" and "the agent never asked" are the same file.
+	asked := captured(t, tee.ClientToServer, `{"method":"tools/call"}`)
+	answered := captured(t, tee.ServerToClient, `{"result":{}}`)
+
+	if asked[0]["dir"] != "c2s" {
+		t.Errorf("a request was recorded as %v", asked[0]["dir"])
+	}
+	if answered[0]["dir"] != "s2c" {
+		t.Errorf("a response was recorded as %v", answered[0]["dir"])
+	}
+}
+
+func TestALargeResponseIsRecordedWholeRatherThanTruncated(t *testing.T) {
+	// A scanner's default buffer is 64KB, and a tool result carrying a real
+	// answer is exactly the frame whose value shows up months later. The whole
+	// point of the file is the question nobody anticipated.
+	body := strings.Repeat("x", 512*1024)
+	frame := `{"jsonrpc":"2.0","id":1,"result":{"content":"` + body + `"}}`
+	var toClient bytes.Buffer
+	var out bytes.Buffer
+	log := tee.NewLog(&out, frozen())
+
+	if err := tee.Pump(&toClient, strings.NewReader(frame+"\n"), tee.ServerToClient, log); err != nil {
+		t.Fatalf("Pump: %v", err)
+	}
+	log.Close()
+
+	if toClient.Len() != len(frame)+1 {
+		t.Errorf("the client received %d bytes, want %d", toClient.Len(), len(frame)+1)
+	}
+	entries := decode(t, out.String())
+	if len(entries) != 1 {
+		t.Fatalf("logged %d entries, want 1", len(entries))
+	}
+	msg, _ := entries[0]["msg"].(map[string]any)
+	result, _ := msg["result"].(map[string]any)
+	if content, _ := result["content"].(string); len(content) != len(body) {
+		t.Errorf("the recorded response holds %d bytes of content, want %d", len(content), len(body))
+	}
+}
+
+func TestAFrameWithNoTrailingNewlineIsStillForwardedAndRecorded(t *testing.T) {
+	// A server killed mid-write leaves a frame with no terminator. Dropping it
+	// would lose the last thing Sense said before the session ended, which is
+	// the most interesting frame in the file.
+	last := `{"jsonrpc":"2.0","id":9}`
+	var toClient bytes.Buffer
+	var out bytes.Buffer
+	log := tee.NewLog(&out, frozen())
+
+	if err := tee.Pump(&toClient, strings.NewReader(last), tee.ServerToClient, log); err != nil {
+		t.Fatalf("Pump: %v", err)
+	}
+	log.Close()
+
+	if toClient.String() != last {
+		t.Errorf("the client received %q, want %q", toClient.String(), last)
+	}
+	if entries := decode(t, out.String()); len(entries) != 1 {
+		t.Errorf("logged %d entries, want the final frame recorded", len(entries))
+	}
+}
+
+func TestBlankLinesAreFramingRatherThanFrames(t *testing.T) {
+	var out bytes.Buffer
+	log := tee.NewLog(&out, frozen())
+	var toClient bytes.Buffer
+
+	if err := tee.Pump(&toClient, strings.NewReader("\n\n"), tee.ServerToClient, log); err != nil {
+		t.Fatalf("Pump: %v", err)
+	}
+	log.Close()
+
+	if toClient.String() != "\n\n" {
+		t.Errorf("the client received %q; framing must pass through too", toClient.String())
+	}
+	if out.Len() != 0 {
+		t.Errorf("logged %q, want nothing", out.String())
+	}
+}
+
+func TestCaptureNeverBlocksTheSession(t *testing.T) {
+	// A failed write is loud; a blocked write is silent and applies backpressure
+	// to a session running against a wall, so the instrument alters what it
+	// measures. Capture degrades instead.
+	log := tee.NewLog(newGated(), frozen())
+	frame := []byte(`{"jsonrpc":"2.0","id":1}`)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 20000; i++ {
+			log.Record(tee.ServerToClient, frame)
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the session was blocked by its own capture")
+	}
+}
+
+func TestAWedgedWriterIsReportedAsAnIncompleteCapture(t *testing.T) {
+	// Degrading silently would be worse than blocking: a partial file that
+	// nothing marks as partial reads as "Sense was never called".
+	stuck := newGated()
+	log := tee.NewLog(stuck, frozen())
+	for i := 0; i < 20000; i++ {
+		log.Record(tee.ServerToClient, []byte(`{"jsonrpc":"2.0","id":1}`))
+	}
+	stuck.release()
+
+	status := log.Close()
+
+	if status.Dropped == 0 {
+		t.Fatal("a writer far slower than the session dropped nothing; capture was applying backpressure")
+	}
+	if status.Complete() {
+		t.Errorf("status %+v reports a complete capture although frames were dropped", status)
+	}
+}
+
+func TestALogThatCannotBeWrittenGivesUpRatherThanFailingTheSession(t *testing.T) {
+	// Capture is telemetry, never a run dependency. A run killed by its own
+	// telemetry is a self-inflicted burned cell.
+	log := tee.NewLog(failing{}, frozen())
+
+	log.Record(tee.ServerToClient, []byte(`{"id":1}`))
+	log.Record(tee.ServerToClient, []byte(`{"id":2}`))
+	status := log.Close()
+
+	if status.Capturing {
+		t.Error("the log still reports itself as capturing after a write failure")
+	}
+	if status.Reason == "" {
+		t.Error("the log gave up without saying why")
+	}
+	if status.Complete() {
+		t.Error("a capture that failed reports itself complete")
+	}
+}
+
+func TestPumpReportsAClientItCanNoLongerWriteTo(t *testing.T) {
+	// The forwarding path is not telemetry. If the client's end is gone, the
+	// session is over and saying so is how the shim exits.
+	err := tee.Pump(failing{}, strings.NewReader("{\"id\":1}\n"), tee.ServerToClient, nil)
+
+	if err == nil {
+		t.Fatal("Pump reported success although the client could not be written to")
+	}
+}
+
+func TestPumpReportsAServerItCanNoLongerReadFrom(t *testing.T) {
+	err := tee.Pump(io.Discard, brokenReader{}, tee.ServerToClient, nil)
+
+	if err == nil {
+		t.Fatal("Pump reported success although the stream failed")
+	}
+}
+
+func TestWithNoSinkTheTrafficStillPassesThrough(t *testing.T) {
+	// No log configured is the fail-open case in its strongest form, and
+	// forwarding must not depend on capture being on.
+	said := "{\"id\":1}\n"
+	var toClient bytes.Buffer
+
+	if err := tee.Pump(&toClient, strings.NewReader(said), tee.ServerToClient, nil); err != nil {
+		t.Fatalf("Pump: %v", err)
+	}
+	if toClient.String() != said {
+		t.Errorf("the client received %q, want %q", toClient.String(), said)
+	}
+}
+
+func TestALogWithNoClockUsesTheWallClock(t *testing.T) {
+	var out bytes.Buffer
+	log := tee.NewLog(&out, nil)
+
+	log.Record(tee.ServerToClient, []byte(`{"id":1}`))
+	log.Close()
+
+	entries := decode(t, out.String())
+	ts, _ := entries[0]["ts"].(string)
+	at, err := time.Parse(time.RFC3339Nano, ts)
+	if err != nil {
+		t.Fatalf("recorded ts %q is not a timestamp: %v", ts, err)
+	}
+	if time.Since(at) > time.Minute {
+		t.Errorf("recorded ts = %v, want roughly now", at)
+	}
+}
+
+func TestARecordedFrameCarriesWhenItWentPast(t *testing.T) {
+	entries := captured(t, tee.ServerToClient, `{"id":1}`)
+
+	if ts, _ := entries[0]["ts"].(string); !strings.HasPrefix(ts, "2026-08-16T12:00:00") {
+		t.Errorf("recorded ts = %v, want the frame's own time", entries[0]["ts"])
+	}
+}
+
+// gated is a disk that has stopped answering: every write blocks until the test
+// lets it go. It stands in for a wedged filesystem without a sleep, so the
+// backpressure question is answered by the shape of the code rather than by a
+// timing guess.
+type gated struct {
+	open chan struct{}
+	once sync.Once
+}
+
+func newGated() *gated { return &gated{open: make(chan struct{})} }
+
+func (g *gated) Write(p []byte) (int, error) {
+	<-g.open
+	return len(p), nil
+}
+
+func (g *gated) release() { g.once.Do(func() { close(g.open) }) }
+
+// failing is a writer whose every write fails.
+type failing struct{}
+
+func (failing) Write([]byte) (int, error) { return 0, errors.New("no space left on device") }
+
+// brokenReader is a stream that fails rather than ending.
+type brokenReader struct{}
+
+func (brokenReader) Read([]byte) (int, error) { return 0, errors.New("connection reset") }


### PR DESCRIPTION
## Problem

Everything up to here runs one arm, and a one-arm run measures nothing. The number that matters is a difference, and it is only meaningful if the two arms were the same agent, on the same repository, at the same commit, under the same budget, **differing in exactly one thing**.

That claim is what the entire corpus rests on. A failure here would mean every recorded number is suspect, and nothing about it would look wrong.

## What the proof caught

Running it found a real leak, which is the point of building it.

Removing the directory that holds the Sense binary from the baseline's `PATH` is not enough. On a machine where Sense is installed the way a user installs it, the baseline arm still found `sense` through a directory the bench never configured — and dropping that directory would have taken `git` and `rg` with it.

**Both arms now get a directory of symlinks** to every executable the host PATH offers, and they differ in exactly one link. The sense arm's link points at the build under test rather than whatever the host happens to have installed. The host's own precedence survives, so a tool resolves to the same binary the operator would get.

## Changes

- **`lab/internal/probe`** runs both arms under one supervising process and reports what the pair proved: routes the sense arm is missing, routes the baseline can still reach, persisted state either arm could read, signs each transcript used Sense, frames captured, and every way the arms differ apart from Sense access. `Sound()` is true only when all of that is clean.
- **The routes split in two.** The repository files and the binary on PATH are the *treatment*: the sense arm must have every one, the baseline none. Persisted memory is *not* a treatment — it is state carried between runs — so it must be absent from **both** arms. An arm reading a memory directory is measuring a previous session, which is worse than an asymmetry because it moves both arms the same way.
- **`channels.ToolNames`** asks the MCP server what it offers instead of carrying a written-down list, for the same reason the repository routes are derived. A server offering none is refused: an empty list makes every transcript check pass, which is the shape of a leak that reads as a clean bill of health.
- **`channels.UsedBy`** reports what a transcript actually used. An invocation is matched at a *command position* inside a recorded shell command, so `git log | sense search x` is caught and a repository whose prose says "makes sense" is not. A list of subcommands here would have been exactly the written-down list this avoids.
- **`probe.BaselineWall`** is a named function rather than an assignment, because the relationship is easy to get backwards and getting it backwards is invisible in a result.
- **`lab/internal/cell`** now supervises a *function* rather than a session spec — supervision is all it knows about — and an arm cut short by an interruption records an incomplete cell naming the burned run instead of returning an error with nothing on disk.

## Test plan

- `make ci` green: build, tests, per-file coverage floor with no new exception, zero complexity suppressions, lint clean.
- `shadow.go` 100%, `tools.go` 97.9%, `cell.go` 98%, `probe.go` 92.3%. The residual in `probe.go` is read-error returns on files the run itself just wrote; no test was written to move that number.
- Both arms run end to end against a real git repository, hermetically, with a stand-in agent that reaches the MCP server through the registration and a stand-in that cannot.
- The failure cases each have their own test: a baseline that invoked the binary, a baseline that named a Sense tool, a baseline worktree carrying the registration, a sense arm that never touched Sense, a sense arm missing a route, and an interruption after the first arm.
- `sense-lab run` is deliberately unchanged. It still runs the walking skeleton's single-arm path; wiring the driver is the authoring loop's, and the both-arms proof lives where it can be tested without building a binary per case.