### PR TITLE
bench(tally): a cell is its replicates, and cited recall leads

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,6 +81,7 @@ linters:
             - "**/lab/internal/score/**"
             - "**/lab/internal/plan/**"
             - "**/lab/internal/judge/**"
+            - "**/lab/internal/tally/**"
           deny:
             - pkg: os
               desc: "the lab's pure core must not read a disk; recall may not depend on the state of one"
@@ -117,7 +118,7 @@ linters:
       # fixtures, and forbidding that would only push the reads into a helper
       # package and prove nothing.
       - linters: [depguard]
-        path: lab/internal/(score|plan|judge)/.*_test\.go
+        path: lab/internal/(score|plan|judge|tally)/.*_test\.go
       # dupword: SQL NULL repetitions and embedded Ruby/test fixtures are fine
       - linters: [dupword]
         path: _test\.go

--- a/lab/internal/tally/tally.go
+++ b/lab/internal/tally/tally.go
@@ -1,0 +1,357 @@
+// Package tally turns the runs of one cell into a result.
+//
+// A run is not a result. Two runs of the same arm on the same cell disagree,
+// and the recorded same-cell spreads are 0.077, 0.154, 0.154 and 0.250. Against
+// a floor of +0.50 the largest is half the bar, so any rule that treats a
+// single run as a measurement is reading noise.
+//
+// There is a second problem and the old tree paid for it in a published report:
+// what ranks the board decides what the bench is about. Ranked by a blind
+// composite, a +0.44 recall win rendered as a −0.018 tie and Sense appeared to
+// tie on 12 of 13 repositories. The prose said the right thing the whole time.
+// The code did not, and the code is what produced the table.
+//
+// So the headline is objective cited recall, and it ranks everything.
+package tally
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+)
+
+// Bar is the margin a cell must clear to be a win.
+const Bar = 0.50
+
+// observedSpreads are the same-cell spreads measured on the recorded corpus.
+// The confirmation band is derived from them rather than chosen, so it moves
+// only when a new measurement moves it.
+var observedSpreads = []float64{0.077, 0.154, 0.154, 0.250}
+
+// ConfirmBand is how close to the bar a result has to be before it is a
+// confirm-band result rather than a clean call: the largest spread the corpus
+// has actually shown.
+//
+// It is conservative on purpose, and the reason is worth stating rather than
+// leaving to be inferred. Judging is per run, so a cell's observed spread
+// carries judge noise and arm noise together. A band presented as arm variance
+// would be a claim nobody measured; the stability probe is what separates them.
+var ConfirmBand = maxOf(observedSpreads)
+
+// The B-score weights.
+//
+// They are INHERITED, not derived. They come from the old tree's judging
+// contract and no fitting produced them. They are carried across because
+// changing them would make every banked number incomparable, which is a much
+// larger cost than any improvement a re-weighting could buy.
+//
+// Changing them requires re-scoring the whole corpus and saying so. That is the
+// only thing that justifies touching them.
+//
+// There is no efficiency term. Efficiency is not a correctness axis and folding
+// it in dilutes the thing being measured; it is reported separately, at held
+// recall. There is no blind quality term either, and there is not going to be
+// one.
+const (
+	weightCitedRecall       = 0.55
+	weightRelatedRecall     = 0.25
+	weightGroundedPrecision = 0.20
+)
+
+// Run is one replicate's scores, and which gold rows it reached.
+type Run struct {
+	// ID is the run directory, so a flipped row can be traced back to it.
+	ID string
+	// CitedRecall is the headline: objective, and not an opinion.
+	CitedRecall float64
+	// RelatedRecall and GroundedPrecision come from the reference-aware judge.
+	RelatedRecall     float64
+	GroundedPrecision float64
+	// Rows are the gold row ids this run reached.
+	Rows []string
+	// Parked says this run was replaced by a retry and is never scored.
+	Parked bool
+	// ParkedWhy records what it was replaced for.
+	ParkedWhy string
+}
+
+// BScore is the blended figure that accompanies the headline. Every term is
+// objective or reference-aware.
+func (r Run) BScore() float64 {
+	return weightCitedRecall*r.CitedRecall +
+		weightRelatedRecall*r.RelatedRecall +
+		weightGroundedPrecision*r.GroundedPrecision
+}
+
+// Measured is an aggregate together with the spread of the runs behind it.
+//
+// They travel as one value rather than as two fields, because a consumer that
+// reads the aggregate without the spread is reading half a result. Two runs at
+// 0.30 and 0.70 are not one run at 0.50, and the type is what stops a caller
+// rendering them as though they were.
+type Measured struct {
+	Value  float64
+	Spread float64
+}
+
+// String renders the aggregate with its spread, always.
+func (m Measured) String() string { return fmt.Sprintf("%.3f ±%.3f", m.Value, m.Spread) }
+
+// Cell is one job's replicates: the same everything, run more than once per arm.
+type Cell struct {
+	Sense    []Run
+	Baseline []Run
+}
+
+// Result is what a cell says.
+type Result struct {
+	// Cell is the runs it was computed from, every one of them, so a reader can
+	// see the disagreement rather than only its average.
+	Cell Cell
+	// SenseRecall and BaselineRecall are the headline, each with its spread.
+	SenseRecall    Measured
+	BaselineRecall Measured
+	// Margin is sense minus baseline on the headline, with the larger of the
+	// two arms' spreads.
+	Margin Measured
+	// SenseB and BaselineB are the blended figure. They accompany the headline
+	// and never rank on their own.
+	SenseB    Measured
+	BaselineB Measured
+	// Open says the cell is not a measurement yet: an arm with fewer than two
+	// scored runs cannot be published.
+	Open bool
+	// OpenWhy says what is missing.
+	OpenWhy string
+	// InConfirmBand says the margin is close enough to the bar that the
+	// measured spread could account for the side it landed on.
+	InConfirmBand bool
+	// FlippedVerdict says the paired replicates landed on different sides of
+	// the bar. This is what buys a third run.
+	FlippedVerdict bool
+	// FlippedRows are the gold rows one replicate reached and another did not.
+	// They are diagnostic and they NEVER trigger spend: rows flip between runs
+	// as ordinary variance, and paying for a third run every time one did would
+	// be paying for noise.
+	FlippedRows []string
+}
+
+// minReplicates is what a cell needs before it says anything. Two, because one
+// run is a sample of a distribution whose spread is half the bar.
+const minReplicates = 2
+
+// Of computes a cell's result.
+func Of(c Cell) Result {
+	r := Result{Cell: c}
+	sense, baseline := scored(c.Sense), scored(c.Baseline)
+
+	r.SenseRecall = measure(sense, func(x Run) float64 { return x.CitedRecall })
+	r.BaselineRecall = measure(baseline, func(x Run) float64 { return x.CitedRecall })
+	r.SenseB = measure(sense, Run.BScore)
+	r.BaselineB = measure(baseline, Run.BScore)
+
+	r.Margin = Measured{
+		Value:  r.SenseRecall.Value - r.BaselineRecall.Value,
+		Spread: max(r.SenseRecall.Spread, r.BaselineRecall.Spread),
+	}
+
+	r.Open, r.OpenWhy = openness(sense, baseline)
+	r.InConfirmBand = !r.Open && abs(r.Margin.Value-Bar) <= ConfirmBand
+	r.FlippedVerdict = flippedVerdict(sense, baseline)
+	r.FlippedRows = flippedRows(sense, baseline)
+	return r
+}
+
+// Publishable reports whether the cell may be published, and why not when it
+// may not. An open cell is enforced rather than noted: a single-run cell
+// published as a result is the noise this package exists to keep out.
+func (r Result) Publishable() error {
+	if r.Open {
+		return fmt.Errorf("this cell is open and unpublishable: %s", r.OpenWhy)
+	}
+	return nil
+}
+
+// NeedsThirdRun reports whether a third replicate is bought.
+//
+// A third run is bought by a flipped VERDICT and never by a flipped row. This
+// is the rule that is easy to get backwards: individual gold rows flip between
+// runs all the time and that is ordinary variance. What justifies paying is the
+// two paired replicates landing on different sides of the bar.
+func (r Result) NeedsThirdRun() bool { return r.FlippedVerdict }
+
+// Headline is the one line a board carries. The aggregate never appears
+// without its spread, on any path.
+func (r Result) Headline() string {
+	line := fmt.Sprintf("cited recall: sense %s, baseline %s, margin %s", r.SenseRecall, r.BaselineRecall, r.Margin)
+	switch {
+	case r.Open:
+		return line + " (open: " + r.OpenWhy + ")"
+	case r.InConfirmBand:
+		return line + " (confirm band)"
+	default:
+		return line
+	}
+}
+
+// Park replaces one run with a retry.
+//
+// One retry, never a loop, for infrastructure failure only. The replaced run is
+// parked and never scored: keeping it would let a cell be re-read until it said
+// the right thing, and that is the failure the bound exists to prevent.
+func (c *Cell) Park(runID, why string) error {
+	if why == "" {
+		return errors.New("a parked run must say what it was replaced for")
+	}
+	for _, arm := range [][]Run{c.Sense, c.Baseline} {
+		for i := range arm {
+			if arm[i].ID != runID {
+				continue
+			}
+			if parkedIn(arm) > 0 {
+				return fmt.Errorf("this arm already parked a run; one retry, never a loop")
+			}
+			arm[i].Parked = true
+			arm[i].ParkedWhy = why
+			return nil
+		}
+	}
+	return fmt.Errorf("no run %q in this cell", runID)
+}
+
+// scored is the runs that count. A parked run is not one of them.
+func scored(arm []Run) []Run {
+	var out []Run
+	for _, r := range arm {
+		if !r.Parked {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func parkedIn(arm []Run) int {
+	n := 0
+	for _, r := range arm {
+		if r.Parked {
+			n++
+		}
+	}
+	return n
+}
+
+// measure is an arm's mean of a metric, with the spread of the runs behind it.
+func measure(arm []Run, of func(Run) float64) Measured {
+	if len(arm) == 0 {
+		return Measured{}
+	}
+	sum, low, high := 0.0, of(arm[0]), of(arm[0])
+	for _, r := range arm {
+		v := of(r)
+		sum += v
+		low = min(low, v)
+		high = max(high, v)
+	}
+	return Measured{Value: sum / float64(len(arm)), Spread: high - low}
+}
+
+// openness reports whether the cell is a measurement yet.
+func openness(sense, baseline []Run) (bool, string) {
+	switch {
+	case len(sense) < minReplicates && len(baseline) < minReplicates:
+		return true, fmt.Sprintf("both arms have fewer than %d scored runs", minReplicates)
+	case len(sense) < minReplicates:
+		return true, fmt.Sprintf("the sense arm has %d scored run(s), and a cell needs %d", len(sense), minReplicates)
+	case len(baseline) < minReplicates:
+		return true, fmt.Sprintf("the baseline arm has %d scored run(s), and a cell needs %d", len(baseline), minReplicates)
+	}
+	return false, ""
+}
+
+// flippedVerdict reports whether the paired replicates landed on different
+// sides of the bar.
+//
+// Replicates are paired by position, which is what they are: the first sense
+// run and the first baseline run were the two arms of one cell, launched
+// together, and pairing them any other way would compare runs that were never
+// a pair.
+func flippedVerdict(sense, baseline []Run) bool {
+	pairs := min(len(sense), len(baseline))
+	if pairs < minReplicates {
+		return false
+	}
+	first := sense[0].CitedRecall-baseline[0].CitedRecall >= Bar
+	for i := 1; i < pairs; i++ {
+		if (sense[i].CitedRecall-baseline[i].CitedRecall >= Bar) != first {
+			return true
+		}
+	}
+	return false
+}
+
+// flippedRows are the gold rows one replicate reached and another did not,
+// across both arms, in a stable order.
+func flippedRows(sense, baseline []Run) []string {
+	var flipped []string
+	for _, arm := range [][]Run{sense, baseline} {
+		flipped = append(flipped, disagreements(arm)...)
+	}
+	sort.Strings(flipped)
+	return dedupe(flipped)
+}
+
+func disagreements(arm []Run) []string {
+	if len(arm) < minReplicates {
+		return nil
+	}
+	count := map[string]int{}
+	for _, r := range arm {
+		for _, row := range unique(r.Rows) {
+			count[row]++
+		}
+	}
+	var flipped []string
+	for row, n := range count {
+		if n != len(arm) {
+			flipped = append(flipped, row)
+		}
+	}
+	return flipped
+}
+
+func unique(rows []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, r := range rows {
+		if !seen[r] {
+			seen[r] = true
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func dedupe(sorted []string) []string {
+	var out []string
+	for i, s := range sorted {
+		if i == 0 || s != sorted[i-1] {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func maxOf(values []float64) float64 {
+	high := values[0]
+	for _, v := range values[1:] {
+		high = max(high, v)
+	}
+	return high
+}
+
+func abs(v float64) float64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}

--- a/lab/internal/tally/tally_test.go
+++ b/lab/internal/tally/tally_test.go
@@ -1,0 +1,366 @@
+package tally_test
+
+import (
+	"math"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/lab/internal/tally"
+)
+
+func run(id string, recall float64, rows ...string) tally.Run {
+	return tally.Run{ID: id, CitedRecall: recall, RelatedRecall: recall, GroundedPrecision: 1, Rows: rows}
+}
+
+// cell is two arms of two replicates each, at the recalls given.
+func cell(sense, baseline [2]float64) tally.Cell {
+	return tally.Cell{
+		Sense:    []tally.Run{run("s1", sense[0]), run("s2", sense[1])},
+		Baseline: []tally.Run{run("b1", baseline[0]), run("b2", baseline[1])},
+	}
+}
+
+func near(a, b float64) bool { return math.Abs(a-b) < 1e-9 }
+
+func TestTheHeadlineIsObjectiveCitedRecall(t *testing.T) {
+	// What ranks the board decides what the bench is about. Ranked by a blind
+	// composite, a +0.44 recall win once rendered as a −0.018 tie.
+	got := tally.Of(cell([2]float64{0.80, 0.80}, [2]float64{0.20, 0.20}))
+
+	if !near(got.SenseRecall.Value, 0.80) || !near(got.BaselineRecall.Value, 0.20) {
+		t.Errorf("recalls = %s and %s", got.SenseRecall, got.BaselineRecall)
+	}
+	if !near(got.Margin.Value, 0.60) {
+		t.Errorf("Margin = %s, want 0.600", got.Margin)
+	}
+	if !strings.HasPrefix(got.Headline(), "cited recall:") {
+		t.Errorf("the headline leads with %q", got.Headline())
+	}
+}
+
+func TestTheBlendedFigureIsExactlyItsThreeTerms(t *testing.T) {
+	// The weights are inherited, not derived, and changing them requires
+	// re-scoring the whole corpus. A test that recomputed them from the code
+	// would agree with any weights at all, so they are stated here.
+	r := tally.Run{CitedRecall: 1, RelatedRecall: 0, GroundedPrecision: 0}
+	if !near(r.BScore(), 0.55) {
+		t.Errorf("cited recall weighs %.3f, want 0.55", r.BScore())
+	}
+	r = tally.Run{CitedRecall: 0, RelatedRecall: 1, GroundedPrecision: 0}
+	if !near(r.BScore(), 0.25) {
+		t.Errorf("related recall weighs %.3f, want 0.25", r.BScore())
+	}
+	r = tally.Run{CitedRecall: 0, RelatedRecall: 0, GroundedPrecision: 1}
+	if !near(r.BScore(), 0.20) {
+		t.Errorf("grounded precision weighs %.3f, want 0.20", r.BScore())
+	}
+	// And nothing else is in there. A perfect run scores exactly 1.
+	r = tally.Run{CitedRecall: 1, RelatedRecall: 1, GroundedPrecision: 1}
+	if !near(r.BScore(), 1) {
+		t.Errorf("a perfect run scores %.3f, want 1; there is a fourth term", r.BScore())
+	}
+}
+
+func TestNoEfficiencyOrQualityTermReachesTheScore(t *testing.T) {
+	// Efficiency is not a correctness axis and folding it in dilutes the thing
+	// being measured. Two runs identical on the three terms score identically,
+	// whatever else differed about them.
+	slow := tally.Run{ID: "slow", CitedRecall: 0.6, RelatedRecall: 0.6, GroundedPrecision: 0.9}
+	fast := tally.Run{ID: "fast", CitedRecall: 0.6, RelatedRecall: 0.6, GroundedPrecision: 0.9}
+
+	if slow.BScore() != fast.BScore() {
+		t.Errorf("two runs with the same three terms scored %.3f and %.3f", slow.BScore(), fast.BScore())
+	}
+}
+
+func TestTheAggregateNeverAppearsWithoutItsSpread(t *testing.T) {
+	// Two runs at 0.30 and 0.70 are not one run at 0.50, and a consumer that
+	// reads the aggregate without the spread is reading half a result.
+	got := tally.Of(cell([2]float64{0.30, 0.70}, [2]float64{0.10, 0.10}))
+
+	if !near(got.SenseRecall.Value, 0.50) {
+		t.Fatalf("SenseRecall = %s", got.SenseRecall)
+	}
+	if !near(got.SenseRecall.Spread, 0.40) {
+		t.Errorf("Spread = %.3f, want 0.400", got.SenseRecall.Spread)
+	}
+	// Rendered anywhere, the spread comes with it.
+	if !strings.Contains(got.SenseRecall.String(), "±0.400") {
+		t.Errorf("the aggregate renders as %q with no spread", got.SenseRecall)
+	}
+	if !strings.Contains(got.Headline(), "±") {
+		t.Errorf("the headline renders as %q with no spread", got.Headline())
+	}
+}
+
+func TestTheMarginCarriesTheLargerOfTheTwoArmsSpreads(t *testing.T) {
+	// A margin computed from two disagreeing arms is no steadier than the
+	// noisier of them.
+	got := tally.Of(cell([2]float64{0.80, 0.80}, [2]float64{0.05, 0.35}))
+
+	if !near(got.Margin.Spread, 0.30) {
+		t.Errorf("Margin spread = %.3f, want the baseline arm's 0.300", got.Margin.Spread)
+	}
+}
+
+func TestASingleRunCellIsOpenAndCannotBePublished(t *testing.T) {
+	// Enforced rather than noted. The recorded same-cell spreads reach 0.250
+	// against a bar of 0.50, so one run is a sample of a distribution whose
+	// spread is half the bar.
+	c := tally.Cell{Sense: []tally.Run{run("s1", 0.9)}, Baseline: []tally.Run{run("b1", 0.1), run("b2", 0.1)}}
+
+	got := tally.Of(c)
+
+	if !got.Open {
+		t.Fatal("a one-run arm was reported as a measurement")
+	}
+	if err := got.Publishable(); err == nil {
+		t.Fatal("an open cell was publishable")
+	}
+	if !strings.Contains(got.OpenWhy, "sense") {
+		t.Errorf("OpenWhy = %q, want it to name the arm that is short", got.OpenWhy)
+	}
+	if !strings.Contains(got.Headline(), "open") {
+		t.Errorf("the headline %q does not say the cell is open", got.Headline())
+	}
+}
+
+func TestACellWithBothArmsShortSaysSo(t *testing.T) {
+	got := tally.Of(tally.Cell{Sense: []tally.Run{run("s1", 0.9)}, Baseline: []tally.Run{run("b1", 0.1)}})
+
+	if !got.Open || !strings.Contains(got.OpenWhy, "both") {
+		t.Errorf("OpenWhy = %q, want it to say both arms are short", got.OpenWhy)
+	}
+}
+
+func TestACompleteCellIsPublishable(t *testing.T) {
+	if err := tally.Of(cell([2]float64{0.8, 0.8}, [2]float64{0.1, 0.1})).Publishable(); err != nil {
+		t.Errorf("a two-run cell is not publishable: %v", err)
+	}
+}
+
+// The third run.
+
+func TestAThirdRunIsBoughtByAFlippedVerdict(t *testing.T) {
+	// The two paired replicates landed on different sides of the bar: one at
+	// +0.70 and one at +0.30 against a floor of +0.50. That is what justifies
+	// paying.
+	got := tally.Of(cell([2]float64{0.80, 0.40}, [2]float64{0.10, 0.10}))
+
+	if !got.FlippedVerdict {
+		t.Fatal("paired replicates on different sides of the bar did not buy a third run")
+	}
+	if !got.NeedsThirdRun() {
+		t.Error("NeedsThirdRun disagrees with FlippedVerdict")
+	}
+}
+
+func TestAThirdRunIsNeverBoughtByAFlippedRow(t *testing.T) {
+	// This is the rule that is easy to get backwards. Individual gold rows flip
+	// between runs all the time and that is ordinary variance; paying for a
+	// third run every time one did would be paying for noise.
+	c := tally.Cell{
+		Sense: []tally.Run{
+			run("s1", 0.80, "d:one", "d:two", "d:three", "d:four"),
+			run("s2", 0.80, "d:one", "d:two", "d:three", "d:five"),
+		},
+		Baseline: []tally.Run{run("b1", 0.10, "d:one"), run("b2", 0.10, "d:two")},
+	}
+
+	got := tally.Of(c)
+
+	if got.NeedsThirdRun() {
+		t.Fatal("flipped rows bought a third run")
+	}
+	// And they are reported anyway, because they are the diagnostic.
+	if !slices.Equal(got.FlippedRows, []string{"d:five", "d:four", "d:one", "d:two"}) {
+		t.Errorf("FlippedRows = %v, want every row that came and went", got.FlippedRows)
+	}
+}
+
+func TestTwoRunsOnTheSameSideOfTheBarBuyNothing(t *testing.T) {
+	got := tally.Of(cell([2]float64{0.80, 0.75}, [2]float64{0.10, 0.10}))
+
+	if got.NeedsThirdRun() {
+		t.Errorf("two runs both clearing the bar bought a third: margins %.2f and %.2f", 0.70, 0.65)
+	}
+}
+
+func TestTwoRunsBothBelowTheBarBuyNothing(t *testing.T) {
+	got := tally.Of(cell([2]float64{0.40, 0.30}, [2]float64{0.10, 0.10}))
+
+	if got.NeedsThirdRun() {
+		t.Error("two runs both short of the bar bought a third")
+	}
+}
+
+func TestAnOpenCellBuysNoThirdRun(t *testing.T) {
+	// One replicate cannot disagree with anything, so there is no flip to pay
+	// for; what it needs is its second run, not its third.
+	got := tally.Of(tally.Cell{Sense: []tally.Run{run("s1", 0.9)}, Baseline: []tally.Run{run("b1", 0.1)}})
+
+	if got.NeedsThirdRun() {
+		t.Error("a one-run cell bought a third run")
+	}
+}
+
+// The confirmation band.
+
+func TestAMarginNearTheBarIsLabelledConfirmBand(t *testing.T) {
+	// The band is the largest spread the corpus has actually shown, not a
+	// chosen constant.
+	got := tally.Of(cell([2]float64{0.60, 0.60}, [2]float64{0.10, 0.10}))
+
+	if !near(got.Margin.Value, 0.50) {
+		t.Fatalf("Margin = %s", got.Margin)
+	}
+	if !got.InConfirmBand {
+		t.Error("a margin exactly at the bar is not a clean call")
+	}
+	if !strings.Contains(got.Headline(), "confirm band") {
+		t.Errorf("the headline %q does not say it is a confirm-band result", got.Headline())
+	}
+}
+
+func TestAMarginWellClearOfTheBarIsACleanCall(t *testing.T) {
+	got := tally.Of(cell([2]float64{0.95, 0.95}, [2]float64{0.05, 0.05}))
+
+	if got.InConfirmBand {
+		t.Errorf("a margin of %s was called a confirm-band result", got.Margin)
+	}
+	// And the headline says nothing extra: a clean call is a clean call.
+	line := got.Headline()
+	if strings.Contains(line, "confirm band") || strings.Contains(line, "open") {
+		t.Errorf("the headline for a clean call reads %q", line)
+	}
+}
+
+func TestABaselineArmThatIsShortLeavesTheCellOpen(t *testing.T) {
+	// Named per arm, because "this cell is open" does not say which run to buy.
+	got := tally.Of(tally.Cell{
+		Sense:    []tally.Run{run("s1", 0.8), run("s2", 0.8)},
+		Baseline: []tally.Run{run("b1", 0.1)},
+	})
+
+	if !got.Open {
+		t.Fatal("a one-run baseline arm was reported as a measurement")
+	}
+	if !strings.Contains(got.OpenWhy, "baseline") {
+		t.Errorf("OpenWhy = %q, want it to name the baseline arm", got.OpenWhy)
+	}
+}
+
+func TestTheBandComesFromTheMeasuredSpreads(t *testing.T) {
+	// Derived rather than chosen, so it moves only when a new measurement moves
+	// it. The recorded spreads are 0.077, 0.154, 0.154 and 0.250.
+	if !near(tally.ConfirmBand, 0.250) {
+		t.Errorf("ConfirmBand = %.3f, want the largest observed spread 0.250", tally.ConfirmBand)
+	}
+}
+
+func TestAnOpenCellIsNotGivenABandLabelItHasNotEarned(t *testing.T) {
+	got := tally.Of(tally.Cell{Sense: []tally.Run{run("s1", 0.6)}, Baseline: []tally.Run{run("b1", 0.1)}})
+
+	if got.InConfirmBand {
+		t.Error("an open cell was labelled a confirm-band result")
+	}
+}
+
+// The retry.
+
+func TestAParkedRunIsNeverScored(t *testing.T) {
+	// Keeping it would let a cell be re-read until it said the right thing.
+	c := tally.Cell{
+		Sense:    []tally.Run{run("s1", 0.10), run("s2", 0.80), run("s3", 0.80)},
+		Baseline: []tally.Run{run("b1", 0.10), run("b2", 0.10)},
+	}
+	if err := c.Park("s1", "the agent CLI failed to authenticate"); err != nil {
+		t.Fatalf("Park: %v", err)
+	}
+
+	got := tally.Of(c)
+
+	if !near(got.SenseRecall.Value, 0.80) {
+		t.Errorf("SenseRecall = %s, want the parked run excluded", got.SenseRecall)
+	}
+	if !near(got.SenseRecall.Spread, 0) {
+		t.Errorf("Spread = %.3f, want the parked run excluded from it too", got.SenseRecall.Spread)
+	}
+}
+
+func TestASecondRetryOnTheSameArmIsRefused(t *testing.T) {
+	// One retry, never a loop.
+	c := tally.Cell{Sense: []tally.Run{run("s1", 0.1), run("s2", 0.2), run("s3", 0.8)}}
+	if err := c.Park("s1", "infrastructure"); err != nil {
+		t.Fatalf("Park: %v", err)
+	}
+
+	err := c.Park("s2", "infrastructure again")
+
+	if err == nil {
+		t.Fatal("a second retry was allowed on the same arm")
+	}
+	if !strings.Contains(err.Error(), "never a loop") {
+		t.Errorf("error = %v, want it to say why", err)
+	}
+}
+
+func TestAParkedRunMustSayWhatItWasReplacedFor(t *testing.T) {
+	// A retry with no reason is indistinguishable from a run somebody did not
+	// like the look of.
+	c := tally.Cell{Sense: []tally.Run{run("s1", 0.1), run("s2", 0.8)}}
+
+	if err := c.Park("s1", ""); err == nil {
+		t.Fatal("a run was parked with no reason given")
+	}
+}
+
+func TestParkingARunThatIsNotInTheCellIsRefused(t *testing.T) {
+	c := tally.Cell{Sense: []tally.Run{run("s1", 0.1)}}
+
+	if err := c.Park("s9", "infrastructure"); err == nil {
+		t.Fatal("a run outside the cell was parked")
+	}
+}
+
+func TestParkingLeavesTheCellOpenWhenItRunsShort(t *testing.T) {
+	c := tally.Cell{
+		Sense:    []tally.Run{run("s1", 0.1), run("s2", 0.8)},
+		Baseline: []tally.Run{run("b1", 0.1), run("b2", 0.1)},
+	}
+	if err := c.Park("s1", "the model id resolved to nothing"); err != nil {
+		t.Fatalf("Park: %v", err)
+	}
+
+	got := tally.Of(c)
+
+	if !got.Open {
+		t.Fatal("a cell left with one scored run reported itself as a measurement")
+	}
+	if err := got.Publishable(); err == nil {
+		t.Error("it was publishable anyway")
+	}
+}
+
+func TestAnEmptyCellSaysNothingRatherThanZero(t *testing.T) {
+	got := tally.Of(tally.Cell{})
+
+	if !got.Open {
+		t.Error("an empty cell reported itself as a measurement")
+	}
+	if got.SenseRecall.Value != 0 || got.SenseRecall.Spread != 0 {
+		t.Errorf("SenseRecall = %s for a cell with no runs", got.SenseRecall)
+	}
+}
+
+func TestEveryRunsScoreIsKeptOnTheResult(t *testing.T) {
+	// A reader has to be able to see the disagreement, not only its average.
+	c := cell([2]float64{0.30, 0.70}, [2]float64{0.10, 0.10})
+
+	got := tally.Of(c)
+
+	if len(got.Cell.Sense) != 2 || got.Cell.Sense[0].CitedRecall != 0.30 {
+		t.Errorf("the result does not carry each run: %+v", got.Cell.Sense)
+	}
+}


### PR DESCRIPTION
## Problem

A run is not a result. Two runs of the same arm on the same cell disagree, and the recorded same-cell spreads are **0.077, 0.154, 0.154 and 0.250**. Against a floor of +0.50, the largest is half the bar. Any rule that treats a single run as a measurement is reading noise.

And there is a second problem the old tree paid for in a published report: **what ranks the board decides what the bench is about.** Ranked by a blind composite, a +0.44 recall win rendered as a −0.018 tie and Sense appeared to tie on 12 of 13 repositories. The prose said the right thing the whole time. The code did not, and the code is what produced the table.

## Changes

- **The headline is objective cited recall**, and it ranks everything. One blended figure accompanies it — `0.55·cited_recall + 0.25·related_recall + 0.20·grounded_precision` — every term objective or reference-aware. **No efficiency term** (efficiency is not a correctness axis; folding it in dilutes what is being measured) and no blind quality term. A test states each weight rather than recomputing it from the code, which would agree with any weights at all.
- **The weights are inherited, not derived.** They come from the old tree's judging contract; no fitting produced them. Changing them requires re-scoring the whole corpus and saying so, and that is documented where they live.
- **The aggregate and its spread are one value, not two fields.** Two runs at 0.30 and 0.70 are not one run at 0.50, and the type is what stops a caller rendering them as though they were. `String()` always carries the spread, so no output path can show half a result.
- **A single-run cell is open and unpublishable**, enforced by `Publishable()` returning an error rather than noted in a comment. The reason names *which* arm is short, because "this cell is open" does not say which run to buy.
- **A third run is bought by a flipped verdict and never by a flipped row.** This is the rule that is easy to get backwards. Individual gold rows flip between runs all the time and that is ordinary variance; what justifies paying is the two paired replicates landing on different sides of the bar. Proven both ways. **Flipped rows are reported anyway**, because they are the diagnostic.
- **The confirmation band is the largest spread the corpus has shown**, derived rather than chosen, so it moves only when a new measurement moves it. It is conservative on purpose and says why: judging is per run, so a cell's observed spread carries judge noise and arm noise together, and a band presented as arm variance would be a claim nobody measured.
- **One retry, never a loop.** A parked run is excluded from every number, a second retry on the same arm is refused, and a retry with no reason given is refused — a retry with no reason is indistinguishable from a run somebody did not like the look of. Parking that leaves an arm short reopens the cell.

## Test plan

- `make ci` green: build, tests, per-file coverage floor with no new exception, zero complexity suppressions, lint clean. `tally.go` at 100%.
- The flipped-row rule is proven in both directions: rows that came and went buy nothing and are still reported; paired replicates on opposite sides of the bar buy a third run.
- Nothing named a blind composite or a quality axis is computed, stored or rendered — checked over the tree, not only in the new package.
- The package is pure and joins the lab's `depguard` pure-core list.