### PR TITLE
bench(lab): declare the phase graph as routable data

### DIFF
--- a/lab/internal/phase/phase.go
+++ b/lab/internal/phase/phase.go
@@ -1,0 +1,260 @@
+// Package phase declares the order in which a repository becomes a benched
+// result, as data rather than as control flow.
+//
+// It exists because that order is the most valuable thing the old tree knows
+// and the least tested thing in it. There the order is a 1204-line bash driver:
+// a chain of functions, each calling the next, with the state in a JSON file
+// beside it. Every lever in the loop — a draft with no anchor, a mini-bench that
+// says re-question, a refusal to pay, an authoring ceiling — can only be
+// exercised by running the thing that produces those verdicts, which means agent
+// sessions, wall time and money. So the routing is the least-tested part of the
+// most consequential system.
+//
+// Declared as data, the whole routing layer is pure: feed it a phase, a verdict
+// and a cycle count, assert the transition. No agent, no network, no spend.
+//
+// # Two invariants this encodes rather than respects
+//
+// A phase never chooses the next phase. It emits a verdict; [Next] decides. The
+// phase that measures a scenario is never the phase that wrote it, and that is
+// structural here rather than conventional: no verdict in any enum names a
+// phase, so there is no value a phase could emit that selects its own successor.
+//
+// A phase never spawns. Only the binary spawns, because a phase agent that
+// spawns its own judge is grading itself. Nothing in this package spawns
+// anything, and nothing it returns tells a caller to.
+//
+// # An exit code is a claim; the artifact is the fact
+//
+// [Advance] refuses to move on from a phase whose output artifact is not there,
+// whatever the phase reported about itself. The old driver learned this and
+// added the check in one place, by hand, at the phase where the defect happened
+// to bite. It bites once per phase otherwise, so here it is in the one function
+// every phase passes through.
+package phase
+
+import "fmt"
+
+// Name is one phase of the loop.
+type Name string
+
+// The eleven phases. Handoff is not in the chain: it is reached only at the
+// authoring ceiling, or when a benched cell is handed up as a swap.
+const (
+	Index     Name = "index"
+	Author    Name = "author"
+	Minibench Name = "minibench"
+	Expand    Name = "expand"
+	Preflight Name = "preflight"
+	Validate  Name = "validate"
+	Bench     Name = "bench"
+	Report    Name = "report"
+	Harvest   Name = "harvest"
+	Board     Name = "board"
+	Handoff   Name = "handoff"
+)
+
+// Done is not a phase. It is what the loop reaches when a win is on the board,
+// and it is a name rather than an empty string so that a caller reading a
+// transition cannot mistake "finished" for "unset".
+const Done Name = "done"
+
+// Verdict is what a phase emits. It is an enum per phase and never free text: a
+// phase that can return anything is a phase whose routing cannot be tested.
+type Verdict string
+
+// The verdicts. Auto belongs to the phases that make no judgement — they either
+// produce their artifact or they do not, and the artifact check is what holds
+// them.
+const (
+	Auto         Verdict = "AUTO"
+	Draft        Verdict = "DRAFT"
+	NoAnchor     Verdict = "NO-ANCHOR"
+	Proceed      Verdict = "PROCEED"
+	Requestion   Verdict = "REQUESTION"
+	Pay          Verdict = "PAY"
+	DoNotPay     Verdict = "DO-NOT-PAY"
+	Win          Verdict = "WIN"
+	Diagnosis    Verdict = "DIAGNOSIS"
+	WinConfirmed Verdict = "WIN CONFIRMED"
+	DoDFail      Verdict = "DoD FAIL"
+)
+
+// AuthoringCeiling is how many authoring cycles a repository gets before it
+// parks for a human. The sixth re-entry goes to [Handoff] rather than back to
+// [Author], which is why [Next] cannot be written without the count.
+const AuthoringCeiling = 6
+
+// Phase is one phase declared: what it reads, what it writes, and everything it
+// is allowed to say.
+//
+// Reads and Writes are the artifacts, named relative to the phase's directory in
+// the run tree. They are here rather than in the runner because the plan files
+// are written against them: a plan whose stated input does not match its phase's
+// row is a broken plan, and that is only checkable if the row exists.
+type Phase struct {
+	Name     Name
+	Reads    string
+	Writes   string
+	Verdicts []Verdict
+}
+
+// Emits reports whether v is in this phase's enum.
+func (p Phase) Emits(v Verdict) bool {
+	for _, known := range p.Verdicts {
+		if known == v {
+			return true
+		}
+	}
+	return false
+}
+
+// Graph is every phase, in the order a campaign walks them. Handoff is last
+// because it is not walked to: it is arrived at.
+var Graph = []Phase{
+	{Index, "repo.json", "index.json", []Verdict{Auto}},
+	{Author, "slate.md", "scenario.draft.yaml", []Verdict{Draft, NoAnchor}},
+	{Minibench, "scenario.draft.yaml", "minibench.md", []Verdict{Proceed, Requestion, NoAnchor}},
+	{Expand, "minibench.md", "scenario.yaml", []Verdict{Auto}},
+	{Preflight, "scenario.yaml", "preflight.json", []Verdict{Auto}},
+	{Validate, "scenario.yaml", "pay-call.md", []Verdict{Pay, DoNotPay}},
+	{Bench, "scenario.yaml", "cells.json", []Verdict{Auto}},
+	{Report, "cells.json", "report.md", []Verdict{Win, Diagnosis}},
+	{Harvest, "report.md", "harvest.json", []Verdict{WinConfirmed, DoDFail}},
+	{Board, "harvest.json", "board.md", []Verdict{Auto}},
+	{Handoff, "campaign.json", "handoff.md", []Verdict{Auto}},
+}
+
+// Lookup reports the declared phase named n.
+func Lookup(n Name) (Phase, bool) {
+	for _, p := range Graph {
+		if p.Name == n {
+			return p, true
+		}
+	}
+	return Phase{}, false
+}
+
+// step keys a transition on the pair that decides it.
+type step struct {
+	from    Name
+	verdict Verdict
+}
+
+// reAuthor is every verdict that sends work back to authoring. These are the
+// transitions the ceiling bounds, and they are a separate table from the
+// forward ones for exactly that reason: a re-entry is the thing being counted.
+var reAuthor = map[step]bool{
+	{Author, NoAnchor}:      true,
+	{Minibench, Requestion}: true,
+	{Minibench, NoAnchor}:   true,
+	{Validate, DoNotPay}:    true,
+}
+
+// forward is every transition that is not a re-entry.
+//
+// Report's diagnosis goes to handoff rather than back to authoring, and that is
+// the shape of the rule that the loop cannot record a loss: it wins, it parks,
+// or it hands up a swap with the numbers attached. Harvest's DoD failure goes
+// back to report for diagnosis and never to the board, because a cell that
+// failed its confirmation checks is not a result to publish.
+var forward = map[step]Name{
+	{Index, Auto}:           Author,
+	{Author, Draft}:         Minibench,
+	{Minibench, Proceed}:    Expand,
+	{Expand, Auto}:          Preflight,
+	{Preflight, Auto}:       Validate,
+	{Validate, Pay}:         Bench,
+	{Bench, Auto}:           Report,
+	{Report, Win}:           Harvest,
+	{Report, Diagnosis}:     Handoff,
+	{Harvest, WinConfirmed}: Board,
+	{Harvest, DoDFail}:      Report,
+	{Board, Auto}:           Done,
+	{Handoff, Auto}:         Done,
+}
+
+// Lever is one routed re-entry, named. The table exists because a done-means of
+// "every lever a real campaign has used is exercised" is only checkable against
+// a fixed list, and a list held in whoever remembers it is not one.
+type Lever struct {
+	Name    string
+	From    Name
+	Verdict Verdict
+	Cycle   int
+	To      Name
+}
+
+// Levers is that list. Any lever a recorded campaign used that is missing from
+// here is a hole in the test set, not merely a gap in the documentation.
+var Levers = []Lever{
+	{"NO-ANCHOR from a draft", Author, NoAnchor, 1, Author},
+	{"REQUESTION from a mini-bench", Minibench, Requestion, 1, Author},
+	{"NO-ANCHOR from a mini-bench", Minibench, NoAnchor, 1, Author},
+	{"DO-NOT-PAY from a validation", Validate, DoNotPay, 1, Author},
+	{"the authoring ceiling", Author, NoAnchor, AuthoringCeiling, Handoff},
+	{"DoD FAIL from a harvest", Harvest, DoDFail, 1, Report},
+}
+
+// Next reports the phase that follows a verdict, and it is a pure function of
+// (phase, verdict, cycle count).
+//
+// The count is passed in and never held. The sixth NO-ANCHOR parks the
+// repository instead of re-entering authoring, so the ceiling cannot be
+// expressed without it — and a count this package held would be a count that
+// resets when the process does, in a binary that runs unattended.
+func Next(from Name, v Verdict, cycle int) (Name, error) {
+	p, ok := Lookup(from)
+	if !ok {
+		return "", fmt.Errorf("no phase named %q", from)
+	}
+	if !p.Emits(v) {
+		return "", fmt.Errorf("phase %s cannot emit %q; it emits %v", from, v, p.Verdicts)
+	}
+	if cycle < 1 {
+		return "", fmt.Errorf("phase %s: authoring cycle %d; the count is 1-based and the first cycle is 1", from, cycle)
+	}
+	if reAuthor[step{from, v}] {
+		if cycle >= AuthoringCeiling {
+			return Handoff, nil
+		}
+		return Author, nil
+	}
+	// Every verdict of every phase is in one of the two tables, and a test walks
+	// the graph to keep it that way. There is no third case to handle here: a
+	// verdict added without a transition fails that test rather than returning a
+	// runtime error nobody would see until a campaign stalled.
+	return forward[step{from, v}], nil
+}
+
+// Outcome is everything a phase reports. There is no field here naming a
+// successor, and that absence is the invariant: a phase says what happened, and
+// the graph says what happens next.
+type Outcome struct {
+	Phase   Name
+	Verdict Verdict
+	// Cycle is which authoring cycle this repository is on, 1-based.
+	Cycle int
+}
+
+// Advance validates an outcome against the graph and reports the next phase.
+//
+// wrote reports whether the phase's output artifact is on disk. It is injected
+// rather than read here so this package stays pure, and it is consulted for
+// every phase rather than for the ones where a missing artifact has already
+// caused an incident.
+//
+// The phase's exit code is deliberately absent. A phase that reported success
+// and wrote nothing has not finished, and a phase that reported failure and
+// wrote its artifact has: the artifact is the fact.
+func Advance(o Outcome, wrote func(artifact string) bool) (Name, error) {
+	p, ok := Lookup(o.Phase)
+	if !ok {
+		return "", fmt.Errorf("no phase named %q", o.Phase)
+	}
+	if !wrote(p.Writes) {
+		return "", fmt.Errorf("phase %s did not write %s; an exit code is a claim and the artifact is the fact",
+			p.Name, p.Writes)
+	}
+	return Next(o.Phase, o.Verdict, o.Cycle)
+}

--- a/lab/internal/phase/phase_test.go
+++ b/lab/internal/phase/phase_test.go
@@ -1,0 +1,294 @@
+package phase_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/lab/internal/phase"
+)
+
+// always is the artifact check for a phase that did its job. Advance's own
+// refusal is tested with a check that says no.
+func always(string) bool { return true }
+
+func TestEveryLeverRoutesWhereItsTableSaysItDoes(t *testing.T) {
+	for _, l := range phase.Levers {
+		got, err := phase.Next(l.From, l.Verdict, l.Cycle)
+		if err != nil {
+			t.Fatalf("%s: %v", l.Name, err)
+		}
+		if got != l.To {
+			t.Errorf("%s: %s emitting %q on cycle %d went to %s, want %s",
+				l.Name, l.From, l.Verdict, l.Cycle, got, l.To)
+		}
+	}
+}
+
+// Levers is declared to be the fixed test set, so a re-entry that exists in the
+// routing and not in that list silently shrinks the set while every test stays
+// green. This walks the graph rather than the table, so the two cannot drift
+// together.
+func TestEveryReEntryIntoAuthoringIsANamedLever(t *testing.T) {
+	named := map[string]bool{}
+	for _, l := range phase.Levers {
+		named[string(l.From)+"/"+string(l.Verdict)] = true
+	}
+	for _, p := range phase.Graph {
+		// The index hands a fresh repository to the author. That is the way in,
+		// not a way back, and it carries no rejection.
+		if p.Name == phase.Index {
+			continue
+		}
+		for _, v := range p.Verdicts {
+			to, err := phase.Next(p.Name, v, 1)
+			if err != nil || to != phase.Author {
+				continue
+			}
+			if !named[string(p.Name)+"/"+string(v)] {
+				t.Errorf("%s emitting %q re-enters authoring and no lever names it", p.Name, v)
+			}
+		}
+	}
+}
+
+// The ceiling is the reason the transition takes a count at all: the same phase
+// and the same verdict route two different ways, and nothing but the count
+// separates them.
+func TestTheSameVerdictReAuthorsBelowTheCeilingAndParksAtIt(t *testing.T) {
+	backLevers := []struct {
+		from    phase.Name
+		verdict phase.Verdict
+	}{
+		{phase.Author, phase.NoAnchor},
+		{phase.Minibench, phase.Requestion},
+		{phase.Minibench, phase.NoAnchor},
+		{phase.Validate, phase.DoNotPay},
+	}
+	for _, l := range backLevers {
+		for cycle := 1; cycle < phase.AuthoringCeiling; cycle++ {
+			got, err := phase.Next(l.from, l.verdict, cycle)
+			if err != nil {
+				t.Fatalf("%s/%s cycle %d: %v", l.from, l.verdict, cycle, err)
+			}
+			if got != phase.Author {
+				t.Errorf("%s emitting %q on cycle %d went to %s, want a re-entry into %s",
+					l.from, l.verdict, cycle, got, phase.Author)
+			}
+		}
+		got, err := phase.Next(l.from, l.verdict, phase.AuthoringCeiling)
+		if err != nil {
+			t.Fatalf("%s/%s at the ceiling: %v", l.from, l.verdict, err)
+		}
+		if got != phase.Handoff {
+			t.Errorf("%s emitting %q on cycle %d went to %s, want %s: the repository parks at the ceiling",
+				l.from, l.verdict, phase.AuthoringCeiling, got, phase.Handoff)
+		}
+	}
+}
+
+// A DoD failure is a re-entry too, but not an authoring one, so the ceiling must
+// not swallow it: a cell whose confirmation checks failed on the sixth cycle is
+// still diagnosed rather than parked.
+func TestADoDFailureIsDiagnosedEvenAtTheAuthoringCeiling(t *testing.T) {
+	got, err := phase.Next(phase.Harvest, phase.DoDFail, phase.AuthoringCeiling)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != phase.Report {
+		t.Errorf("a DoD failure on cycle %d went to %s, want %s", phase.AuthoringCeiling, got, phase.Report)
+	}
+}
+
+// The loop cannot record a loss: a benched cell that is not a win is handed up
+// with its numbers, never quietly re-authored and never boarded.
+func TestABenchedCellThatIsNotAWinIsHandedUp(t *testing.T) {
+	got, err := phase.Next(phase.Report, phase.Diagnosis, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != phase.Handoff {
+		t.Errorf("a diagnosis went to %s, want %s", got, phase.Handoff)
+	}
+}
+
+func TestAWinWalksFromAnIndexToTheBoard(t *testing.T) {
+	walk := []struct {
+		at      phase.Name
+		verdict phase.Verdict
+		next    phase.Name
+	}{
+		{phase.Index, phase.Auto, phase.Author},
+		{phase.Author, phase.Draft, phase.Minibench},
+		{phase.Minibench, phase.Proceed, phase.Expand},
+		{phase.Expand, phase.Auto, phase.Preflight},
+		{phase.Preflight, phase.Auto, phase.Validate},
+		{phase.Validate, phase.Pay, phase.Bench},
+		{phase.Bench, phase.Auto, phase.Report},
+		{phase.Report, phase.Win, phase.Harvest},
+		{phase.Harvest, phase.WinConfirmed, phase.Board},
+		{phase.Board, phase.Auto, phase.Done},
+	}
+	at := phase.Index
+	for _, s := range walk {
+		if at != s.at {
+			t.Fatalf("the walk reached %s, want %s", at, s.at)
+		}
+		next, err := phase.Advance(phase.Outcome{Phase: at, Verdict: s.verdict, Cycle: 1}, always)
+		if err != nil {
+			t.Fatalf("%s: %v", at, err)
+		}
+		if next != s.next {
+			t.Fatalf("%s emitting %q went to %s, want %s", at, s.verdict, next, s.next)
+		}
+		at = next
+	}
+}
+
+func TestAPhaseCannotEmitAVerdictThatIsNotInItsEnum(t *testing.T) {
+	// PROCEED is a real verdict, and it belongs to the mini-bench. A draft that
+	// emitted it would route to expansion without a probe ever running.
+	_, err := phase.Next(phase.Author, phase.Proceed, 1)
+	if err == nil {
+		t.Fatal("the author was allowed to emit PROCEED")
+	}
+	if !strings.Contains(err.Error(), "cannot emit") {
+		t.Errorf("refusal does not say what was refused: %v", err)
+	}
+}
+
+func TestAnUnknownPhaseIsRefusedRatherThanRoutedFrom(t *testing.T) {
+	if _, err := phase.Next("triage", phase.Auto, 1); err == nil {
+		t.Fatal("routed from a phase the graph does not declare")
+	}
+	if _, err := phase.Advance(phase.Outcome{Phase: "triage", Verdict: phase.Auto, Cycle: 1}, always); err == nil {
+		t.Fatal("advanced from a phase the graph does not declare")
+	}
+}
+
+// The count is the ceiling's only input, so a zero is not a harmless default: it
+// is a repository whose cycles are not being counted at all.
+func TestACycleCountBelowOneIsRefused(t *testing.T) {
+	for _, cycle := range []int{0, -1} {
+		if _, err := phase.Next(phase.Author, phase.NoAnchor, cycle); err == nil {
+			t.Errorf("cycle %d was accepted", cycle)
+		}
+	}
+}
+
+// The artifact is the fact. A phase that reported success and wrote nothing has
+// not finished, and the graph is where that is caught rather than at the one
+// phase where it last bit.
+func TestAPhaseThatWroteNothingCannotAdvance(t *testing.T) {
+	for _, p := range phase.Graph {
+		verdict := p.Verdicts[0]
+		_, err := phase.Advance(phase.Outcome{Phase: p.Name, Verdict: verdict, Cycle: 1},
+			func(string) bool { return false })
+		if err == nil {
+			t.Errorf("%s advanced without writing %s", p.Name, p.Writes)
+			continue
+		}
+		if !strings.Contains(err.Error(), p.Writes) {
+			t.Errorf("%s: refusal does not name the missing artifact: %v", p.Name, err)
+		}
+	}
+}
+
+// Advance asks about the phase's own output, not some other phase's. Checking
+// the wrong artifact would let a phase ride on its predecessor's file.
+func TestAdvanceChecksThePhasesOwnOutputArtifact(t *testing.T) {
+	var asked []string
+	_, err := phase.Advance(phase.Outcome{Phase: phase.Minibench, Verdict: phase.Proceed, Cycle: 1},
+		func(a string) bool { asked = append(asked, a); return true })
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, _ := phase.Lookup(phase.Minibench)
+	if len(asked) != 1 || asked[0] != want.Writes {
+		t.Errorf("asked about %v, want exactly [%s]", asked, want.Writes)
+	}
+}
+
+// A phase emits a verdict and the graph decides. If a verdict could name a
+// phase, a phase could choose its own successor by saying its name, and the
+// separation between the phase that writes a scenario and the phase that
+// measures it would be a convention rather than a shape.
+func TestNoVerdictNamesAPhase(t *testing.T) {
+	for _, p := range phase.Graph {
+		for _, v := range p.Verdicts {
+			if _, ok := phase.Lookup(phase.Name(v)); ok {
+				t.Errorf("%s can emit %q, which is also a phase name", p.Name, v)
+			}
+		}
+	}
+}
+
+// A verdict with nowhere to go is a phase that stalls a campaign at three in the
+// morning, and it is only discoverable by emitting it.
+func TestEveryVerdictOfEveryPhaseRoutesSomewhereDeclared(t *testing.T) {
+	for _, p := range phase.Graph {
+		for _, v := range p.Verdicts {
+			to, err := phase.Next(p.Name, v, 1)
+			if err != nil {
+				t.Errorf("%s emitting %q: %v", p.Name, v, err)
+				continue
+			}
+			if to == phase.Done {
+				continue
+			}
+			if _, ok := phase.Lookup(to); !ok {
+				t.Errorf("%s emitting %q goes to %q, which is not a phase", p.Name, v, to)
+			}
+		}
+	}
+}
+
+// Every phase has to be arrivable, or it is a plan file nobody will ever run.
+func TestEveryPhaseIsReachedBySomeTransition(t *testing.T) {
+	reached := map[phase.Name]bool{phase.Index: true}
+	for _, p := range phase.Graph {
+		for _, v := range p.Verdicts {
+			for cycle := 1; cycle <= phase.AuthoringCeiling; cycle++ {
+				if to, err := phase.Next(p.Name, v, cycle); err == nil {
+					reached[to] = true
+				}
+			}
+		}
+	}
+	for _, p := range phase.Graph {
+		if !reached[p.Name] {
+			t.Errorf("no verdict leads to %s", p.Name)
+		}
+	}
+}
+
+// The plan files in 05-03 are written against these rows, so a phase with no
+// declared artifacts is a plan with no stated contract.
+func TestEveryPhaseDeclaresItsArtifactsAndAtLeastOneVerdict(t *testing.T) {
+	for _, p := range phase.Graph {
+		if p.Reads == "" || p.Writes == "" {
+			t.Errorf("%s declares reads=%q writes=%q", p.Name, p.Reads, p.Writes)
+		}
+		if len(p.Verdicts) == 0 {
+			t.Errorf("%s declares no verdict; a phase that says nothing cannot be routed from", p.Name)
+		}
+	}
+}
+
+func TestLookupReportsAnUndeclaredPhaseAsAbsent(t *testing.T) {
+	if _, ok := phase.Lookup("triage"); ok {
+		t.Error("the graph claims to declare a phase it does not have")
+	}
+}
+
+func TestEmitsIsFalseForAVerdictThePhaseDoesNotDeclare(t *testing.T) {
+	p, ok := phase.Lookup(phase.Board)
+	if !ok {
+		t.Fatal("the board is not in the graph")
+	}
+	if p.Emits(phase.DoDFail) {
+		t.Error("the board claims it can emit a DoD failure")
+	}
+	if !p.Emits(phase.Auto) {
+		t.Error("the board cannot emit the only verdict it has")
+	}
+}


### PR DESCRIPTION
## Problem

The order in which a repository becomes a benched result is the most valuable thing the bench instrument knows, and it is currently a 1204-line bash driver: a chain of functions, each calling the next, with the state in a JSON file beside it.

That has one consequence that costs more than the others. **Trying a routing change costs a paid campaign.** Every lever in the loop (a draft with no anchor, a mini-bench that says re-question, a refusal to pay, an authoring ceiling) can only be exercised by running the thing that produces those verdicts, which means agent sessions, wall time and money. So the routing is the least-tested part of the most consequential system.

## Summary

`lab/internal/phase` declares the eleven phases as data and routes between them with a pure function. Feed it a phase, a verdict and a cycle count, assert the transition: no agent, no network, no spend.

## Changes

- **Eleven phases declared**, each naming its input artifact, its output artifact and its verdict enum. A verdict is an enum per phase and never free text, because a phase that can return anything is a phase whose routing cannot be tested.
- **`Next` is a pure function of (phase, verdict, cycle count).** The count is passed in and never held: the sixth `NO-ANCHOR` parks the repository rather than re-entering authoring, so the ceiling cannot be expressed without it, and a count the graph held would reset when the process did.
- **A phase cannot select its own successor**, and that is checked by shape: no verdict in any enum is also a phase name, so there is no value a phase could emit that picks where it goes next.
- **`Advance` refuses a phase whose output artifact is absent**, whatever the phase reported about itself. The exit code is deliberately not an input. It lives in the one function every phase passes through rather than at the phase where the defect last bit.
- **The six levers are enumerated**, so "every lever a real campaign has used is exercised" is checkable against a fixed list rather than against whoever remembers it.
- **Report's diagnosis goes to handoff, not back to authoring**, and a DoD failure goes back for diagnosis and never to the board. The loop wins, it parks, or it hands up a swap with the numbers attached.

## Test Plan

- `make ci` green: build, tests, per-file coverage floor with no new exception, zero complexity suppressions, lint clean.
- 100% line and function coverage on the new package.
- Every lever routes where its table says, walked from the graph rather than read from the table, so the two cannot drift together.
- The same phase and verdict re-enter authoring on cycles 1 through 5 and park on cycle 6.
- A DoD failure is still diagnosed at the ceiling rather than swallowed by it.
- Every phase in the graph advances without its artifact refused by name, for all eleven.
- A full win walks index to board through `Advance`.