### PR TITLE
bench(lab): carry the rejection forward and bound the loop

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -83,6 +83,8 @@ linters:
             - "**/lab/internal/judge/**"
             - "**/lab/internal/tally/**"
             - "**/lab/internal/gate/**"
+            - "**/lab/internal/phase/**"
+            - "**/lab/internal/loop/**"
           deny:
             - pkg: os
               desc: "the lab's pure core must not read a disk; recall may not depend on the state of one"
@@ -119,7 +121,7 @@ linters:
       # fixtures, and forbidding that would only push the reads into a helper
       # package and prove nothing.
       - linters: [depguard]
-        path: lab/internal/(score|plan|judge|tally|gate)/.*_test\.go
+        path: lab/internal/(score|plan|judge|tally|gate|phase|loop)/.*_test\.go
       # dupword: SQL NULL repetitions and embedded Ruby/test fixtures are fine
       - linters: [dupword]
         path: _test\.go

--- a/lab/internal/budget/budget.go
+++ b/lab/internal/budget/budget.go
@@ -1,0 +1,135 @@
+// Package budget reports what a campaign has spent, by reading the run tree.
+//
+// It never holds a counter. A ceiling kept in a variable is a ceiling that
+// resets when the process does, and this binary spends money unattended: a
+// campaign restarted after a crash would start again from zero and spend its
+// whole budget a second time without anything looking wrong.
+//
+// So spend is recomputed, every time, from the directories that exist. That is
+// also why it cannot be double-counted across a restart: the total is the size
+// of a SET of run directories, not a running sum something adds to. Reading it
+// twice gives the same answer because reading it does not change it.
+//
+// # The unit is paid runs
+//
+// Not dollars. Nothing on disk records a price — the model files carry an id, a
+// provider and the tools that can drive them, and no rate — so a dollar figure
+// here would be a number this package invented. A paid run is the thing the
+// campaign actually decides to spend, and it is a fact in the tree.
+//
+// # The scope is the campaign, over its lifetime
+//
+// Not per repository, because a campaign that burns its budget on one repository
+// has made a decision worth stopping. Not per calendar period, because a month
+// boundary is not a fact about the work. [Read] is handed a campaign directory
+// and walks all of it.
+package budget
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/luuuc/sense/lab/internal/phase"
+)
+
+// runMetaFile is what a run writes when it reaches a terminal state, and
+// rawDir is the capture directory a run creates before it spawns anything.
+// A directory holding rawDir is a run; whether it holds runMetaFile is whether
+// that run finished.
+const (
+	runMetaFile = "run-meta.json"
+	rawDir      = "raw"
+)
+
+// Spend is what a campaign has spent, as the runs that produced it.
+//
+// Orphaned is not folded into Recorded and is not dropped. A bench run that
+// started and never wrote a terminal record still spent its money, and a ceiling
+// that ignores it undercounts by exactly the runs nobody can account for — which
+// are the ones a resuming session most needs to see.
+type Spend struct {
+	Recorded []string
+	Orphaned []string
+}
+
+// Runs is the campaign's spend: every paid run in the tree, accounted or not.
+func (s Spend) Runs() int { return len(s.Recorded) + len(s.Orphaned) }
+
+func (s Spend) String() string {
+	if len(s.Orphaned) == 0 {
+		return fmt.Sprintf("%d paid runs", s.Runs())
+	}
+	return fmt.Sprintf("%d paid runs, %d of them orphaned with no terminal record", s.Runs(), len(s.Orphaned))
+}
+
+// Read reports the spend recorded under a campaign directory.
+//
+// A paid run is one under the bench phase. Mini-bench and validation runs are
+// unscored and unpaid by law, and counting them against the ceiling would refuse
+// a campaign for the runs it does to avoid spending.
+//
+// A campaign directory that does not exist yet has spent nothing, which is a
+// fact rather than an error: the ceiling is checked before the first run as well
+// as after the hundredth.
+func Read(campaignDir string) (Spend, error) {
+	var s Spend
+	err := filepath.WalkDir(campaignDir, func(path string, d fs.DirEntry, err error) error {
+		switch {
+		case err != nil:
+			return err
+		case !d.IsDir() || !paid(campaignDir, path):
+			return nil
+		}
+		if !exists(filepath.Join(path, rawDir)) {
+			return nil
+		}
+		if exists(filepath.Join(path, runMetaFile)) {
+			s.Recorded = append(s.Recorded, path)
+		} else {
+			s.Orphaned = append(s.Orphaned, path)
+		}
+		return nil
+	})
+	if errors.Is(err, fs.ErrNotExist) {
+		return Spend{}, nil
+	}
+	if err != nil {
+		return Spend{}, fmt.Errorf("read spend under %s: %w", campaignDir, err)
+	}
+	slices.Sort(s.Recorded)
+	slices.Sort(s.Orphaned)
+	return s, nil
+}
+
+func exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// paid reports whether a path sits under the bench phase. It reads the phase
+// name from the graph rather than repeating the string, so a renamed phase
+// cannot silently make every paid run invisible to the ceiling.
+func paid(root, path string) bool {
+	// The walk only ever yields paths under root, so a relative path always
+	// exists. An empty one contains no bench segment, which is the same answer.
+	rel, _ := filepath.Rel(root, path)
+	return slices.Contains(strings.Split(filepath.ToSlash(rel), "/"), string(phase.Bench))
+}
+
+// Ceiling refuses a campaign that has reached its spend ceiling.
+//
+// It refuses rather than warns. A ceiling that warns is a ceiling that gets
+// passed at the moment someone believes the next run will work, and that belief
+// is what the ceiling exists to bound.
+func Ceiling(s Spend, ceiling int) error {
+	if s.Runs() >= ceiling {
+		return fmt.Errorf("this campaign has spent %s against a ceiling of %d over its lifetime",
+			s, ceiling)
+	}
+	return nil
+}

--- a/lab/internal/budget/budget_test.go
+++ b/lab/internal/budget/budget_test.go
@@ -1,0 +1,185 @@
+package budget_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/lab/internal/budget"
+)
+
+// paidRun writes a finished run directory: a capture directory and a terminal
+// record, which is what run.Session leaves behind.
+func paidRun(t *testing.T, dir string) {
+	t.Helper()
+	startedRun(t, dir)
+	if err := os.WriteFile(filepath.Join(dir, "run-meta.json"), []byte(`{"outcome":"completed"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// startedRun writes a run directory that spawned and never recorded a terminal
+// state, which is what a reboot or a power loss leaves behind.
+func startedRun(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, "raw"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSpendIsEveryBenchRunInTheTree(t *testing.T) {
+	camp := t.TempDir()
+	paidRun(t, filepath.Join(camp, "mastodon", "1", "bench", "cell-0", "sense"))
+	paidRun(t, filepath.Join(camp, "mastodon", "1", "bench", "cell-0", "untreated"))
+	paidRun(t, filepath.Join(camp, "chatwoot", "3", "bench", "cell-0", "sense"))
+
+	s, err := budget.Read(camp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Runs() != 3 {
+		t.Errorf("counted %d paid runs, want 3: %+v", s.Runs(), s)
+	}
+}
+
+// A mini-bench and a validation are unscored and unpaid by law. Counting them
+// would refuse a campaign for the runs it does in order to avoid spending.
+func TestUnpaidPhasesAreNotSpend(t *testing.T) {
+	camp := t.TempDir()
+	paidRun(t, filepath.Join(camp, "mastodon", "1", "minibench", "cell-0", "sense"))
+	paidRun(t, filepath.Join(camp, "mastodon", "1", "validate", "cell-0", "sense"))
+	paidRun(t, filepath.Join(camp, "mastodon", "1", "bench", "cell-0", "sense"))
+
+	s, err := budget.Read(camp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Runs() != 1 {
+		t.Errorf("counted %d paid runs, want 1: %+v", s.Runs(), s)
+	}
+}
+
+// A bench run that started and never wrote a terminal record still spent its
+// money. Dropping it undercounts the ceiling by exactly the runs nobody can
+// account for.
+func TestABenchRunWithNoTerminalRecordStillCountsAndIsNamed(t *testing.T) {
+	camp := t.TempDir()
+	paidRun(t, filepath.Join(camp, "mastodon", "1", "bench", "cell-0", "sense"))
+	startedRun(t, filepath.Join(camp, "mastodon", "1", "bench", "cell-0", "untreated"))
+
+	s, err := budget.Read(camp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Runs() != 2 {
+		t.Errorf("counted %d paid runs, want 2", s.Runs())
+	}
+	if len(s.Orphaned) != 1 || !strings.HasSuffix(s.Orphaned[0], "untreated") {
+		t.Errorf("the orphaned run is not named: %+v", s.Orphaned)
+	}
+	if !strings.Contains(s.String(), "orphaned") {
+		t.Errorf("the summary hides the orphan: %q", s.String())
+	}
+}
+
+// The cell and phase directories above a run are not runs. Counting a parent
+// would multiply every run by its depth in the tree.
+func TestOnlyRunDirectoriesAreCounted(t *testing.T) {
+	camp := t.TempDir()
+	paidRun(t, filepath.Join(camp, "mastodon", "1", "bench", "cell-0", "sense"))
+
+	s, err := budget.Read(camp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Runs() != 1 {
+		t.Errorf("counted %d, want 1: %+v", s.Runs(), s)
+	}
+}
+
+// The whole reason spend is read rather than held: a process that restarts must
+// see the same total, and reading twice must not add to it.
+func TestSpendIsTheSameAfterARestartAndIsNeverDoubleCounted(t *testing.T) {
+	camp := t.TempDir()
+	for _, arm := range []string{"sense", "untreated"} {
+		paidRun(t, filepath.Join(camp, "mastodon", "1", "bench", "cell-0", arm))
+	}
+
+	before, err := budget.Read(camp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A restart is a second Read with nothing in between, which is exactly what
+	// a resumed campaign does.
+	after, err := budget.Read(camp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if before.Runs() != after.Runs() {
+		t.Fatalf("spend moved from %d to %d without a run happening", before.Runs(), after.Runs())
+	}
+
+	paidRun(t, filepath.Join(camp, "mastodon", "2", "bench", "cell-0", "sense"))
+	next, err := budget.Read(camp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if next.Runs() != before.Runs()+1 {
+		t.Errorf("one run took the total from %d to %d", before.Runs(), next.Runs())
+	}
+}
+
+// The ceiling is checked before the first run as well as after the hundredth,
+// so a campaign with nothing on disk is a spend of zero rather than a failure.
+func TestACampaignThatHasRunNothingHasSpentNothing(t *testing.T) {
+	s, err := budget.Read(filepath.Join(t.TempDir(), "never-started"))
+	if err != nil {
+		t.Fatalf("an unstarted campaign was an error: %v", err)
+	}
+	if s.Runs() != 0 {
+		t.Errorf("an unstarted campaign has spent %d", s.Runs())
+	}
+	if s.String() != "0 paid runs" {
+		t.Errorf("summary reads %q", s.String())
+	}
+}
+
+// It refuses rather than warns: a ceiling that warns is passed at the moment
+// someone believes the next run will work.
+func TestTheCeilingRefusesAtItsLimitRatherThanAboveIt(t *testing.T) {
+	camp := t.TempDir()
+	for _, arm := range []string{"sense", "untreated"} {
+		paidRun(t, filepath.Join(camp, "mastodon", "1", "bench", "cell-0", arm))
+	}
+	s, err := budget.Read(camp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := budget.Ceiling(s, 3); err != nil {
+		t.Errorf("2 runs against a ceiling of 3 was refused: %v", err)
+	}
+	err = budget.Ceiling(s, 2)
+	if err == nil {
+		t.Fatal("2 runs against a ceiling of 2 was allowed; the next run would pass it")
+	}
+	if !strings.Contains(err.Error(), "lifetime") {
+		t.Errorf("the refusal does not name the window it applies over: %v", err)
+	}
+}
+
+func TestAnUnreadableCampaignTreeIsAnErrorRatherThanAZero(t *testing.T) {
+	camp := t.TempDir()
+	locked := filepath.Join(camp, "bench")
+	if err := os.MkdirAll(locked, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+
+	if _, err := budget.Read(camp); err == nil {
+		t.Fatal("a campaign tree that could not be read reported a spend of zero")
+	}
+}

--- a/lab/internal/cli/boundary_test.go
+++ b/lab/internal/cli/boundary_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"go/ast"
 	"go/parser"
 	"go/token"
 	"io/fs"
@@ -47,6 +48,12 @@ type labFile struct {
 // labFiles parses every .go file under lab/, test files included.
 func labFiles(t *testing.T) []labFile {
 	t.Helper()
+	return walkLab(t, parser.ImportsOnly, nil)
+}
+
+// walkLab parses every .go file under lab/ and hands each parsed file to see.
+func walkLab(t *testing.T, mode parser.Mode, see func(path string, f *ast.File)) []labFile {
+	t.Helper()
 	root := repoRoot(t)
 	fset := token.NewFileSet()
 	var out []labFile
@@ -66,9 +73,16 @@ func labFiles(t *testing.T) []labFile {
 		if !strings.HasSuffix(path, ".go") {
 			return nil
 		}
-		f, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		f, err := parser.ParseFile(fset, path, nil, mode)
 		if err != nil {
 			return err
+		}
+		if see != nil {
+			rel, err := filepath.Rel(root, path)
+			if err != nil {
+				return err
+			}
+			see(filepath.ToSlash(rel), f)
 		}
 		lf := labFile{pkg: f.Name.Name}
 		for _, spec := range f.Imports {
@@ -128,4 +142,38 @@ func TestLabNeverImportsSenseInternals(t *testing.T) {
 			}
 		}
 	}
+}
+
+// No human gate exists in the per-repo phases, which means no interactive
+// prompt exists anywhere in the run path. A campaign runs unattended for hours;
+// a phase that stopped to ask a question would hang until its wall killed it,
+// and the record would look like a session that could not finish at budget.
+//
+// The escape hatch is --manual, which stops BEFORE a phase and prints the
+// artifact it awaits. It never asks anything of a running session.
+//
+// os.Stdin is allowed in exactly two places, and neither is a prompt: cli.go
+// hands it to the commands that consume a stream, and main.go wires the process
+// up. Both pass it as a parameter rather than reading it, which is what keeps
+// the reading testable and what makes this list short enough to be checked.
+func TestNoPhaseInTheRunPathPromptsForInput(t *testing.T) {
+	streamConsumers := map[string]bool{
+		"lab/internal/cli/cli.go":   true,
+		"lab/cmd/sense-lab/main.go": true,
+	}
+	walkLab(t, parser.AllErrors, func(path string, f *ast.File) {
+		if strings.HasSuffix(path, "_test.go") || streamConsumers[path] {
+			return
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			sel, ok := n.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "Stdin" {
+				return true
+			}
+			if pkg, ok := sel.X.(*ast.Ident); ok && pkg.Name == "os" {
+				t.Errorf("%s reads os.Stdin; a campaign runs unattended and no phase may ask a human anything", path)
+			}
+			return true
+		})
+	})
 }

--- a/lab/internal/loop/loop.go
+++ b/lab/internal/loop/loop.go
@@ -1,0 +1,226 @@
+// Package loop holds a repository's position in the authoring cycle and the
+// rules for re-entering it.
+//
+// Authoring is a cycle, not a line. Most drafts do not become a benched win on
+// the first attempt, and what happens on the second attempt is where the method
+// lives. Three verdicts send work back — NO-ANCHOR from a draft, REQUESTION from
+// a mini-bench, DO-NOT-PAY from a validation — and each one is an opportunity to
+// lose the thing that made the previous attempt worth improving.
+//
+// # Nothing is deleted on re-entry
+//
+// The instinct when a draft fails is to clear it and start clean. That instinct
+// is what this package exists against, and the cost of yielding to it is
+// invisible: six unrelated attempts look exactly like six iterations from the
+// outside. So a re-entry appends the finished attempt to the history, carries
+// the table that rejected it, keeps the anchor, and lets the author rewrite the
+// question in place.
+//
+// # Re-anchoring is its own decision
+//
+// A sub-floor cell is a question the anchor could not carry, not necessarily a
+// bad anchor. A NO-ANCHOR verdict records that an anchor is needed; it does not
+// pick one. Only [State.ReAnchor] changes the anchor, and a re-question never
+// touches it.
+//
+// # The ceiling parks, it does not warn
+//
+// After the sixth authoring cycle on one repository the loop parks. A parked
+// repository is not automatically re-enterable: [State.Resume] is a deliberate
+// act, and the fresh cycle count is what a human gets if they choose to resume,
+// not an automatic second life. Without that, a loop that believes the next
+// attempt will work quietly spends six more cycles.
+//
+// The other ceiling, spend, is not here: it is read from disk by
+// lab/internal/budget, because a ceiling held in a variable is a ceiling that
+// resets when the process does, and this binary spends money unattended.
+package loop
+
+import (
+	"fmt"
+
+	"github.com/luuuc/sense/lab/internal/phase"
+)
+
+// Rejection is why an attempt was sent back. The table is the thing the next
+// attempt has to respond to: the mini-bench read, the credit table that refused
+// to pay, the reason a draft had no anchor.
+//
+// It is never empty on a re-entry, and that is enforced rather than expected. A
+// re-entry without its rejection is a fresh guess wearing the previous
+// attempt's number.
+type Rejection struct {
+	Phase   phase.Name
+	Verdict phase.Verdict
+	Table   string
+}
+
+func (r Rejection) String() string {
+	return fmt.Sprintf("%s emitted %s: %s", r.Phase, r.Verdict, r.Table)
+}
+
+// Attempt is one finished authoring cycle, kept forever.
+type Attempt struct {
+	Cycle    int
+	Anchor   string
+	Draft    string
+	Rejected Rejection
+}
+
+// State is one repository's position in the authoring loop.
+type State struct {
+	Repo string
+	// Cycle is the authoring cycle being run, 1-based. It is the input the
+	// ceiling is expressed in.
+	Cycle  int
+	Anchor string
+	Draft  string
+	// Attempts is every cycle that has already been rejected, oldest first.
+	// Nothing is ever removed from it.
+	Attempts []Attempt
+	// Carried is every rejection so far, oldest first. The next attempt reads
+	// all of them, not only the last: six attempts converging is what this
+	// makes possible and six unrelated drafts is what it prevents.
+	Carried []Rejection
+	// NeedsAnchor says the last verdict was NO-ANCHOR, so the next attempt owes
+	// a re-anchoring decision. The previous anchor is still here: recording that
+	// one is needed is not the same as discarding the one that failed.
+	NeedsAnchor bool
+	// Parked says the repository hit the authoring ceiling and is waiting for a
+	// human. Because names which ceiling and on what.
+	Parked  bool
+	Because string
+}
+
+// Start opens a repository's first authoring cycle.
+func Start(repo, anchor string) State {
+	return State{Repo: repo, Cycle: 1, Anchor: anchor}
+}
+
+// Drafted records what the author produced for the current cycle. The question
+// is rewritten in place; the previous draft is already in Attempts.
+func (s State) Drafted(draft string) State {
+	s.Draft = draft
+	return s
+}
+
+// Advance records a phase's verdict and reports where the loop goes next.
+//
+// wrote is the artifact check the graph refuses to advance without; it is passed
+// through so there is one way to leave a phase rather than two, and no path that
+// skips the check.
+func (s State) Advance(from phase.Name, v phase.Verdict, r Rejection, wrote func(string) bool) (State, phase.Name, error) {
+	if s.Parked {
+		return s, "", fmt.Errorf("%s is parked (%s); resuming it is a deliberate human action, not a transition",
+			s.Repo, s.Because)
+	}
+	next, err := phase.Advance(phase.Outcome{Phase: from, Verdict: v, Cycle: s.Cycle}, wrote)
+	if err != nil {
+		return s, "", err
+	}
+	if !s.isReEntry(from, v) {
+		return s, next, nil
+	}
+	if r.Table == "" {
+		return s, "", fmt.Errorf("%s emitted %s and carries no table; a re-entry without the thing that rejected it is a fresh guess",
+			from, v)
+	}
+	r.Phase, r.Verdict = from, v
+	if next == phase.Handoff {
+		return s.park(r), next, nil
+	}
+	return s.reEnter(r, v), next, nil
+}
+
+// isReEntry reports whether this verdict sends work back to authoring.
+//
+// It asks the graph at the first cycle rather than at the current one, which is
+// what separates a re-entry that the ceiling converted into a park from a
+// diagnosis that was always going to be handed up. The two land on the same
+// phase and mean opposite things.
+func (s State) isReEntry(from phase.Name, v phase.Verdict) bool {
+	at, err := phase.Next(from, v, 1)
+	return err == nil && at == phase.Author
+}
+
+// reEnter files the finished attempt and opens the next one. Nothing is
+// removed: the anchor stays, the prior draft is kept in the history, and the
+// rejection joins everything the next attempt has to answer.
+func (s State) reEnter(r Rejection, v phase.Verdict) State {
+	s.Attempts = append(append([]Attempt{}, s.Attempts...),
+		Attempt{Cycle: s.Cycle, Anchor: s.Anchor, Draft: s.Draft, Rejected: r})
+	s.Carried = append(append([]Rejection{}, s.Carried...), r)
+	s.Cycle++
+	s.NeedsAnchor = v == phase.NoAnchor
+	return s
+}
+
+// park files the attempt that hit the ceiling and stops the loop.
+func (s State) park(r Rejection) State {
+	s = s.reEnter(r, r.Verdict)
+	s.Parked = true
+	s.Because = fmt.Sprintf("%d authoring cycles on %s, which is the ceiling", phase.AuthoringCeiling, s.Repo)
+	return s
+}
+
+// ReAnchor is the only way the anchor changes.
+//
+// It refuses unless a verdict asked for one, so re-anchoring can never happen as
+// a side effect of re-questioning. The previous anchor is already in the
+// attempt history and is not touched here.
+func (s State) ReAnchor(anchor string) (State, error) {
+	if !s.NeedsAnchor {
+		return s, fmt.Errorf("%s was not asked to re-anchor; re-anchoring is its own decision and never a side effect of a re-question",
+			s.Repo)
+	}
+	if anchor == "" {
+		return s, fmt.Errorf("%s: re-anchoring to nothing is not a decision", s.Repo)
+	}
+	s.Anchor = anchor
+	s.NeedsAnchor = false
+	return s, nil
+}
+
+// Resume re-enters a parked repository, which is the deliberate human action the
+// park is waiting for.
+//
+// The next run gets a fresh cycle count. It keeps everything else: the anchor,
+// every attempt and every rejection, because the six cycles already spent are
+// what the seventh has to learn from.
+func (s State) Resume() (State, error) {
+	if !s.Parked {
+		return s, fmt.Errorf("%s is not parked; there is nothing to resume", s.Repo)
+	}
+	s.Parked = false
+	s.Because = ""
+	s.Cycle = 1
+	return s, nil
+}
+
+// Manual stops the loop before a named phase and says which artifact it was
+// going to produce, so a person can produce it by hand.
+//
+// It is the one escape hatch and there is deliberately no second. A
+// --skip-phase or a --resume-from would be a bypass with a friendlier name, and
+// the moment of frustration is exactly when it would be used.
+type Manual struct {
+	StopAt phase.Name
+}
+
+// NewManual refuses a phase the graph does not declare, so a typo stops the
+// campaign at the flag rather than never stopping it at all.
+func NewManual(at string) (Manual, error) {
+	if _, ok := phase.Lookup(phase.Name(at)); !ok {
+		return Manual{}, fmt.Errorf("no phase named %q to stop at", at)
+	}
+	return Manual{StopAt: phase.Name(at)}, nil
+}
+
+// Halt reports whether the loop stops before next, and what to hand it.
+func (m Manual) Halt(next phase.Name) (string, bool) {
+	if m.StopAt == "" || m.StopAt != next {
+		return "", false
+	}
+	p, _ := phase.Lookup(next)
+	return fmt.Sprintf("stopped before %s; it awaits %s and writes %s", next, p.Reads, p.Writes), true
+}

--- a/lab/internal/loop/loop_test.go
+++ b/lab/internal/loop/loop_test.go
@@ -1,0 +1,323 @@
+package loop_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/lab/internal/loop"
+	"github.com/luuuc/sense/lab/internal/phase"
+)
+
+func wrote(string) bool { return true }
+
+// The three verdicts that send work back, with the table each one carries.
+var levers = []struct {
+	from    phase.Name
+	verdict phase.Verdict
+	table   string
+}{
+	{phase.Author, phase.NoAnchor, "no group in this repo has a question the anchor could carry"},
+	{phase.Minibench, phase.Requestion, "baseline reached 14 of 18 rows in nine tool calls"},
+	{phase.Validate, phase.DoNotPay, "credit table: 4 free rows floor the baseline at 0.286"},
+}
+
+func TestEveryLeverCarriesTheTableThatRejectedItIntoTheNextAttempt(t *testing.T) {
+	for _, l := range levers {
+		s := loop.Start("mastodon", "the notification pipeline").Drafted("draft-1.yaml")
+		next, at, err := s.Advance(l.from, l.verdict, loop.Rejection{Table: l.table}, wrote)
+		if err != nil {
+			t.Fatalf("%s/%s: %v", l.from, l.verdict, err)
+		}
+		if at != phase.Author {
+			t.Fatalf("%s/%s routed to %s, want a re-entry into the author", l.from, l.verdict, at)
+		}
+		if len(next.Carried) != 1 {
+			t.Fatalf("%s/%s carried %d rejections, want 1", l.from, l.verdict, len(next.Carried))
+		}
+		got := next.Carried[0]
+		if got.Table != l.table || got.Phase != l.from || got.Verdict != l.verdict {
+			t.Errorf("%s/%s carried %+v, want the phase, the verdict and the table that refused it", l.from, l.verdict, got)
+		}
+	}
+}
+
+// A re-entry that carries nothing is a fresh guess wearing the previous
+// attempt's number, and it is the failure this whole package exists against.
+func TestAReEntryWithNoTableIsRefused(t *testing.T) {
+	s := loop.Start("mastodon", "the notification pipeline")
+	_, _, err := s.Advance(phase.Minibench, phase.Requestion, loop.Rejection{}, wrote)
+	if err == nil {
+		t.Fatal("a re-entry carrying no rejection was allowed")
+	}
+	if !strings.Contains(err.Error(), "fresh guess") {
+		t.Errorf("refusal does not say what is wrong: %v", err)
+	}
+}
+
+// A forward transition is not a re-entry, so it neither demands a table nor
+// files an attempt.
+func TestAForwardVerdictNeitherCarriesNorFiles(t *testing.T) {
+	s := loop.Start("mastodon", "the notification pipeline").Drafted("draft-1.yaml")
+	next, at, err := s.Advance(phase.Author, phase.Draft, loop.Rejection{}, wrote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if at != phase.Minibench {
+		t.Fatalf("a draft went to %s, want %s", at, phase.Minibench)
+	}
+	if next.Cycle != 1 || len(next.Attempts) != 0 || len(next.Carried) != 0 {
+		t.Errorf("a forward step changed the loop position: %+v", next)
+	}
+}
+
+// Six cycles, three different levers, and at the end everything the first
+// attempt knew is still there. This is the property the rewrite is most likely
+// to lose, because losing it is invisible.
+func TestNothingIsDeletedAcrossSixCycles(t *testing.T) {
+	s := loop.Start("mastodon", "the notification pipeline").Drafted("draft-1.yaml")
+	for cycle := 1; cycle < phase.AuthoringCeiling; cycle++ {
+		l := levers[(cycle-1)%len(levers)]
+		var err error
+		s, _, err = s.Advance(l.from, l.verdict, loop.Rejection{Table: l.table}, wrote)
+		if err != nil {
+			t.Fatalf("cycle %d: %v", cycle, err)
+		}
+		if s.NeedsAnchor {
+			if s, err = s.ReAnchor("the notification pipeline, from the delivery side"); err != nil {
+				t.Fatalf("cycle %d: %v", cycle, err)
+			}
+		}
+		s = s.Drafted("draft-" + string(rune('1'+cycle)) + ".yaml")
+	}
+
+	if s.Cycle != phase.AuthoringCeiling {
+		t.Fatalf("after five re-entries the loop is on cycle %d, want %d", s.Cycle, phase.AuthoringCeiling)
+	}
+	if len(s.Attempts) != phase.AuthoringCeiling-1 {
+		t.Errorf("kept %d attempts, want every one of the %d that were rejected",
+			len(s.Attempts), phase.AuthoringCeiling-1)
+	}
+	if len(s.Carried) != phase.AuthoringCeiling-1 {
+		t.Errorf("carried %d rejections, want all of them: the next attempt answers every one",
+			len(s.Carried))
+	}
+	for i, a := range s.Attempts {
+		if a.Cycle != i+1 {
+			t.Errorf("attempt %d is filed as cycle %d", i, a.Cycle)
+		}
+		if a.Draft == "" || a.Anchor == "" || a.Rejected.Table == "" {
+			t.Errorf("attempt %d lost something: %+v", i, a)
+		}
+	}
+	if s.Anchor == "" {
+		t.Error("the anchor was lost")
+	}
+}
+
+// A sub-floor cell is a question the anchor could not carry, not necessarily a
+// bad anchor. Re-questioning must leave the anchor exactly where it was.
+func TestReQuestioningNeverChangesTheAnchor(t *testing.T) {
+	const anchor = "the notification pipeline"
+	s := loop.Start("mastodon", anchor).Drafted("draft-1.yaml")
+	s, _, err := s.Advance(phase.Minibench, phase.Requestion, loop.Rejection{Table: "the probe read"}, wrote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Anchor != anchor {
+		t.Errorf("the anchor became %q after a re-question", s.Anchor)
+	}
+	if s.NeedsAnchor {
+		t.Error("a re-question asked for a new anchor; that is a separate decision")
+	}
+	if _, err := s.ReAnchor("something else"); err == nil {
+		t.Error("re-anchoring was allowed without a verdict asking for it")
+	}
+}
+
+// NO-ANCHOR records that an anchor is owed. It does not pick one, and it does
+// not throw away the one that failed.
+func TestANoAnchorVerdictAsksForAnAnchorRatherThanDiscardingOne(t *testing.T) {
+	const anchor = "the notification pipeline"
+	s := loop.Start("mastodon", anchor).Drafted("draft-1.yaml")
+	s, _, err := s.Advance(phase.Minibench, phase.NoAnchor, loop.Rejection{Table: "no row discriminated"}, wrote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !s.NeedsAnchor {
+		t.Fatal("NO-ANCHOR did not record that a re-anchoring is owed")
+	}
+	if s.Anchor != anchor {
+		t.Errorf("the failed anchor was discarded before a replacement was chosen: %q", s.Anchor)
+	}
+	if _, err := s.ReAnchor(""); err == nil {
+		t.Error("re-anchoring to nothing was accepted")
+	}
+	s, err = s.ReAnchor("the delivery side")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Anchor != "the delivery side" || s.NeedsAnchor {
+		t.Errorf("after re-anchoring: anchor %q, still owed %v", s.Anchor, s.NeedsAnchor)
+	}
+	if s.Attempts[0].Anchor != anchor {
+		t.Errorf("the history lost the anchor that was tried: %q", s.Attempts[0].Anchor)
+	}
+}
+
+// atTheCeiling drives a repository to its last authoring cycle through real
+// re-entries.
+//
+// Assigning the cycle by hand would assert the arithmetic of the ceiling while
+// proving nothing about whether five rejections actually reach it: a reEnter
+// that stopped counting would leave every ceiling test green.
+func atTheCeiling(t *testing.T) loop.State {
+	t.Helper()
+	s := loop.Start("mastodon", "the notification pipeline").Drafted("draft-1.yaml")
+	for s.Cycle < phase.AuthoringCeiling {
+		var err error
+		s, _, err = s.Advance(phase.Minibench, phase.Requestion,
+			loop.Rejection{Table: "the probe read"}, wrote)
+		if err != nil {
+			t.Fatalf("cycle %d: %v", s.Cycle, err)
+		}
+		s = s.Drafted("draft.yaml")
+	}
+	if s.Parked {
+		t.Fatalf("the loop parked before reaching cycle %d", phase.AuthoringCeiling)
+	}
+	return s
+}
+
+func TestTheSixthCycleParksInsteadOfReAuthoring(t *testing.T) {
+	s := atTheCeiling(t)
+	s, at, err := s.Advance(phase.Validate, phase.DoNotPay, loop.Rejection{Table: "the credit table"}, wrote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if at != phase.Handoff {
+		t.Fatalf("the ceiling routed to %s, want %s", at, phase.Handoff)
+	}
+	if !s.Parked {
+		t.Fatal("the ceiling did not park the repository")
+	}
+	if !strings.Contains(s.Because, "ceiling") {
+		t.Errorf("the park does not say why: %q", s.Because)
+	}
+	if len(s.Attempts) != phase.AuthoringCeiling || s.Attempts[len(s.Attempts)-1].Rejected.Table == "" {
+		t.Errorf("filed %d attempts; the one that hit the ceiling is filed like every other", len(s.Attempts))
+	}
+}
+
+// Parking is where the loop stops. A parked repository that any transition can
+// re-enter is a loop that quietly spends six more cycles.
+func TestAParkedRepositoryIsNotReEnteredByATransition(t *testing.T) {
+	s, _, err := atTheCeiling(t).Advance(phase.Author, phase.NoAnchor, loop.Rejection{Table: "no anchor"}, wrote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := s.Advance(phase.Author, phase.Draft, loop.Rejection{}, wrote); err == nil {
+		t.Fatal("a parked repository advanced")
+	}
+	if _, err := loop.Start("chatwoot", "an anchor").Resume(); err == nil {
+		t.Fatal("a repository that was never parked was resumed")
+	}
+}
+
+// The fresh budget a resumed repository gets is a fresh cycle count, and
+// nothing else: the six cycles already spent are what the seventh learns from.
+func TestResumingHandsAFreshCycleCountAndKeepsTheHistory(t *testing.T) {
+	s, _, err := atTheCeiling(t).Advance(phase.Validate, phase.DoNotPay, loop.Rejection{Table: "the credit table"}, wrote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	carried, attempts, anchor := len(s.Carried), len(s.Attempts), s.Anchor
+
+	s, err = s.Resume()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Parked || s.Because != "" {
+		t.Error("the repository is still parked after a deliberate resume")
+	}
+	if s.Cycle != 1 {
+		t.Errorf("resumed on cycle %d, want a fresh count starting at 1", s.Cycle)
+	}
+	if len(s.Carried) != carried || len(s.Attempts) != attempts || s.Anchor != anchor {
+		t.Error("the resume threw away the history it exists to learn from")
+	}
+}
+
+// A phase that reported success and wrote nothing has not finished, and there
+// is one way out of a phase rather than two.
+func TestAPhaseThatWroteNothingDoesNotMoveTheLoop(t *testing.T) {
+	s := loop.Start("mastodon", "the notification pipeline").Drafted("draft.yaml")
+	next, _, err := s.Advance(phase.Minibench, phase.Requestion, loop.Rejection{Table: "the read"},
+		func(string) bool { return false })
+	if err == nil {
+		t.Fatal("the loop advanced past a phase that wrote nothing")
+	}
+	if next.Cycle != 1 || len(next.Carried) != 0 {
+		t.Error("a refused transition still moved the loop")
+	}
+}
+
+// A diagnosis and a ceiling both land on handoff and mean opposite things: one
+// is a swap handed up with its numbers, the other is a repository parked.
+func TestABenchedDiagnosisIsHandedUpWithoutParkingTheRepository(t *testing.T) {
+	s := loop.Start("mastodon", "the notification pipeline").Drafted("draft.yaml")
+	s, at, err := s.Advance(phase.Report, phase.Diagnosis, loop.Rejection{}, wrote)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if at != phase.Handoff {
+		t.Fatalf("a diagnosis went to %s, want %s", at, phase.Handoff)
+	}
+	if s.Parked {
+		t.Error("a diagnosis parked the repository; only the authoring ceiling parks")
+	}
+}
+
+func TestManualStopsAtItsPhaseAndNamesTheArtifactItAwaits(t *testing.T) {
+	m, err := loop.NewManual("expand")
+	if err != nil {
+		t.Fatal(err)
+	}
+	msg, halted := m.Halt(phase.Expand)
+	if !halted {
+		t.Fatal("--manual expand did not stop at the expand phase")
+	}
+	p, _ := phase.Lookup(phase.Expand)
+	if !strings.Contains(msg, p.Reads) || !strings.Contains(msg, p.Writes) {
+		t.Errorf("the stop message does not name the artifacts: %q", msg)
+	}
+	if _, halted := m.Halt(phase.Bench); halted {
+		t.Error("--manual expand stopped at the bench phase")
+	}
+}
+
+func TestAnUnsetManualNeverStops(t *testing.T) {
+	var m loop.Manual
+	for _, p := range phase.Graph {
+		if _, halted := m.Halt(p.Name); halted {
+			t.Errorf("a campaign with no --manual stopped at %s", p.Name)
+		}
+	}
+}
+
+// A typo stops the campaign at the flag rather than never stopping it at all,
+// which is the failure mode of a stop-at that silently matches nothing.
+func TestManualRefusesAPhaseTheGraphDoesNotDeclare(t *testing.T) {
+	if _, err := loop.NewManual("minibensh"); err == nil {
+		t.Fatal("--manual accepted a phase that does not exist")
+	}
+}
+
+func TestARejectionReadsAsThePhaseTheVerdictAndTheTable(t *testing.T) {
+	r := loop.Rejection{Phase: phase.Validate, Verdict: phase.DoNotPay, Table: "4 free rows"}
+	got := r.String()
+	for _, want := range []string{"validate", "DO-NOT-PAY", "4 free rows"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("%q does not name %q", got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Authoring is a cycle, not a line. Most drafts do not become a benched win on the first attempt, and what happens on the second attempt is where the method lives.

Three verdicts send work back — `NO-ANCHOR` from a draft, `REQUESTION` from a mini-bench, `DO-NOT-PAY` from a validation — and each one is an opportunity to lose the thing that made the previous attempt worth improving. The instinct when a draft fails is to clear it and start clean, and the cost of yielding to it is invisible: six unrelated attempts look exactly like six iterations from the outside.

A loop that re-enters itself also needs a bound, and this binary spends money unattended.

## Summary

`lab/internal/loop` holds a repository's position in the authoring cycle and the rules for re-entering it. `lab/internal/budget` reports what a campaign has spent by reading the run tree rather than by holding a counter.

## Changes

- **A re-entry that carries no table is refused.** The rejection is a required input, not an optional one, so a re-entry cannot become a fresh guess wearing the previous attempt's number.
- **Nothing is deleted on re-entry.** The finished attempt is filed with its anchor, its draft and the rejection that stopped it, and the next attempt answers every rejection so far rather than only the last.
- **Re-anchoring is its own decision.** Only `ReAnchor` changes the anchor, and it refuses unless a verdict asked for one. A `NO-ANCHOR` records that an anchor is owed without discarding the one that failed, because a sub-floor cell is a question the anchor could not carry rather than necessarily a bad anchor.
- **The authoring ceiling parks.** After the sixth cycle the repository stops, and no transition re-enters it. `Resume` is the deliberate human action, and it hands a fresh cycle count while keeping the anchor, every attempt and every rejection.
- **A diagnosis and a ceiling both land on handoff and mean opposite things**, and they are told apart by asking the graph rather than by holding a flag: one is a swap handed up with its numbers, the other is a repository parked.
- **Spend is recomputed from disk, never accumulated.** The total is the size of a set of run directories, so reading it twice cannot change it and a restart cannot spend the budget twice. Orphaned bench runs are counted and named rather than dropped, because a run that started and never recorded a terminal state still spent its money.
- **The ceiling is per campaign over its lifetime**, and it refuses rather than warns.
- **No phase may ask a human anything.** The lab boundary test now walks every production file for a read of `os.Stdin`, allowed only where a stream is handed to a command. `--manual` stops *before* a phase and prints the artifact it awaits; there is no second bypass.

## Decisions recorded during the build

**Spend is counted in paid runs, not dollars.** Nothing on disk records a price — the model files carry an id, a provider and the tools that can drive them, and no rate — so a dollar figure would be a number the instrument invented.

**`budget.Ceiling` and `--manual` have no caller yet**, because no command drives the loop until the flywheel cycle. The mechanisms are here and tested; the flag and the pay-path check are wired when the driver lands.

## Test Plan

- `make ci` green: build, tests, per-file coverage floor with no new exception, zero complexity suppressions, lint clean.
- 100% line and function coverage on both new packages.
- Every lever carries its table into the next attempt, and a re-entry with an empty table is refused.
- Six cycles across three different levers, asserting the anchor, every prior draft and every rejection survive.
- The ceiling is reached by driving real re-entries rather than by assigning the cycle count, so the test proves the road as well as the guard.
- A parked repository refuses to advance; a repository that was never parked refuses to resume.
- Spend read twice without a run in between is unchanged, and one new run moves it by exactly one.
- The no-prompt check was verified to fail when its allowlist is narrowed, so it is not vacuous.