### PR TITLE
bench(lab): write the method down as the phase plans

### DIFF
--- a/lab/KILLERS.md
+++ b/lab/KILLERS.md
@@ -1,0 +1,47 @@
+# The five killers
+
+They bind the person reading a result rather than the binary. `LAWS.md` says they live outside it,
+and this is where they live: a tracked file, because an instructions file that is not in the
+repository is one a fresh session does not have.
+
+**Before reporting ANY pattern as a finding — in a plan's artifact, a report, a handoff page, a
+ledger entry — name the check that would kill it and RUN it.** Run, not consider.
+
+| killer | the question | precedent |
+|---|---|---|
+| **confound** | does X co-vary with campaign, size, model or date? cross-tab it | a "declared-family law" was the VERTICAL split; chatwoot scored 0.09 and redmine 0.77 running the same prompt |
+| **per-unit** | does the aggregate hold per row? | castability separated the repositories cleanly and predicted the OPPOSITE per row |
+| **arithmetic** | is it mechanically possible, or mechanically necessary? | `delta = sense − base` and `sense ≤ 1.00`, so `+0.50` REQUIRES `base ≤ 0.50`: ten of twenty paid cells were dead before they ran |
+| **negative space** | what did I NOT search? | `\.Permission = ` misses `\.Permission, err = `: a finding reported as "written in exactly ONE place" was wrong |
+| **n** | how many INDEPENDENT observations? is the new number inside the old variance? | n=1 plus a retro-fit is a story, and it carries "hypothesis" in its title or it does not ship |
+
+## The rule that makes them work
+
+**A confirming check is not evidence; it is the absence of a test.**
+
+The failure mode is running the check that CONFIRMS, calling it a finding, and running the killer
+afterwards. **That ordering is the whole bug.** The killer is run before the finding is stated, not
+after it.
+
+Checking costs one command. Retracting costs a document rewrite, a memory rewrite, and a wrong path
+someone else has to read.
+
+## Quote it or you have not verified it
+
+Every factual claim leaving a judgment step is **quoted command output**, or it is labelled an
+assumption. Before stating a finding, quote the output that shows it.
+
+**Negative claims need a second, different probe before they are stated at all**: cannot, no,
+never, dead, nonexistent, not reached. One probe that returns nothing is a probe that may have
+looked in the wrong place.
+
+## Run and decide
+
+Every step in a plan is one or the other.
+
+**RUN** — indexing, gates, stamping, rendering, the phase order. Follow it exactly. No improvising a
+substitute, no hand-rolling what a script already does. If the step looks wrong, **say so and
+stop**; do not route around it.
+
+**DECIDE** — anchor choice, gold curation, the pay call, diagnosis routing. Judgment is the job, and
+every claim leaving it obeys the rule above.

--- a/lab/internal/loop/loop_test.go
+++ b/lab/internal/loop/loop_test.go
@@ -18,6 +18,7 @@ var levers = []struct {
 }{
 	{phase.Author, phase.NoAnchor, "no group in this repo has a question the anchor could carry"},
 	{phase.Minibench, phase.Requestion, "baseline reached 14 of 18 rows in nine tool calls"},
+	{phase.Expand, phase.Requestion, "gold row d:notifier does not hold at its line"},
 	{phase.Validate, phase.DoNotPay, "credit table: 4 free rows floor the baseline at 0.286"},
 }
 

--- a/lab/internal/phase/phase.go
+++ b/lab/internal/phase/phase.go
@@ -115,7 +115,7 @@ var Graph = []Phase{
 	{Index, "repo.json", "index.json", []Verdict{Auto}},
 	{Author, "slate.md", "scenario.draft.yaml", []Verdict{Draft, NoAnchor}},
 	{Minibench, "scenario.draft.yaml", "minibench.md", []Verdict{Proceed, Requestion, NoAnchor}},
-	{Expand, "minibench.md", "scenario.yaml", []Verdict{Auto}},
+	{Expand, "minibench.md", "scenario.yaml", []Verdict{Auto, Requestion}},
 	{Preflight, "scenario.yaml", "preflight.json", []Verdict{Auto}},
 	{Validate, "scenario.yaml", "pay-call.md", []Verdict{Pay, DoNotPay}},
 	{Bench, "scenario.yaml", "cells.json", []Verdict{Auto}},
@@ -147,8 +147,14 @@ type step struct {
 var reAuthor = map[step]bool{
 	{Author, NoAnchor}:      true,
 	{Minibench, Requestion}: true,
-	{Minibench, NoAnchor}:   true,
-	{Validate, DoNotPay}:    true,
+	// Expansion carries the discriminator step over verbatim. When it cannot —
+	// a gold row that does not hold at its line, or a step that cannot be
+	// written without naming a gold file — the mini-bench number has stopped
+	// describing the scenario, and that is a re-question rather than a phase
+	// that quietly writes nothing and stalls the loop.
+	{Expand, Requestion}:  true,
+	{Minibench, NoAnchor}: true,
+	{Validate, DoNotPay}:  true,
 }
 
 // forward is every transition that is not a re-entry.
@@ -191,6 +197,7 @@ var Levers = []Lever{
 	{"NO-ANCHOR from a draft", Author, NoAnchor, 1, Author},
 	{"REQUESTION from a mini-bench", Minibench, Requestion, 1, Author},
 	{"NO-ANCHOR from a mini-bench", Minibench, NoAnchor, 1, Author},
+	{"REQUESTION from an expansion", Expand, Requestion, 1, Author},
 	{"DO-NOT-PAY from a validation", Validate, DoNotPay, 1, Author},
 	{"the authoring ceiling", Author, NoAnchor, AuthoringCeiling, Handoff},
 	{"DoD FAIL from a harvest", Harvest, DoDFail, 1, Report},

--- a/lab/internal/phase/phase_test.go
+++ b/lab/internal/phase/phase_test.go
@@ -62,6 +62,7 @@ func TestTheSameVerdictReAuthorsBelowTheCeilingAndParksAtIt(t *testing.T) {
 		{phase.Author, phase.NoAnchor},
 		{phase.Minibench, phase.Requestion},
 		{phase.Minibench, phase.NoAnchor},
+		{phase.Expand, phase.Requestion},
 		{phase.Validate, phase.DoNotPay},
 	}
 	for _, l := range backLevers {

--- a/lab/internal/plans/plans.go
+++ b/lab/internal/plans/plans.go
@@ -1,0 +1,208 @@
+// Package plans reads the phase plans and checks them against the declared
+// graph.
+//
+// The binary holds no prompt logic by design: how a scenario is crafted, how a
+// mini-bench is read, how a pay call is made and how a win is confirmed all live
+// as prose in files a human wrote. The moment a phase's instructions are
+// assembled in code they stop being reviewable by reading a file, and the binary
+// starts holding opinions.
+//
+// So this package loads. It never composes: a plan's body is the bytes after its
+// header, handed on unchanged, and there is nowhere here for a sentence to be
+// added to one.
+//
+// # The header
+//
+// Four keys, one per line, between two fences, and then the plan:
+//
+//	---
+//	phase: minibench
+//	reads: scenario.draft.yaml
+//	writes: minibench.md
+//	emits: [PROCEED, REQUESTION, NO-ANCHOR]
+//	---
+//
+// It is a fixed set of keys rather than general YAML so that a malformed
+// contract fails to parse instead of parsing into something plausible.
+//
+// # What the checks can and cannot catch
+//
+// They catch a plan naming a verdict that does not exist, an artifact the graph
+// does not know, a phase with no plan and a plan with no phase. Nothing here
+// catches a plan that is subtly wrong. Those defects are only discoverable by
+// spending money against a real repository, which is a reason to expect
+// revisions back rather than a reason to write the plans differently.
+package plans
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/luuuc/sense/lab/internal/phase"
+)
+
+// Plan is one phase's plan file: its declared contract, and the prose under it.
+type Plan struct {
+	Path   string
+	Phase  phase.Name
+	Reads  string
+	Writes string
+	Emits  []phase.Verdict
+	// Body is everything after the header, verbatim. Nothing in this package
+	// writes to it.
+	Body []byte
+}
+
+// fence opens and closes the header block.
+const fence = "---\n"
+
+// Load reads every plan in dir.
+func Load(dir string) ([]Plan, error) {
+	// The pattern is fixed, so the only error Glob defines cannot happen. A
+	// directory that is missing or empty comes back with no names, and the
+	// refusal below is the answer to both.
+	names, _ := filepath.Glob(filepath.Join(dir, "*.md"))
+	slices.Sort(names)
+	var out []Plan
+	for _, name := range names {
+		b, err := os.ReadFile(name)
+		if err != nil {
+			return nil, fmt.Errorf("read plan %s: %w", name, err)
+		}
+		p, err := parse(b)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", name, err)
+		}
+		p.Path = name
+		out = append(out, p)
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no plans in %s; a phase graph with no plan files is a graph nobody can run", dir)
+	}
+	return out, nil
+}
+
+// parse splits a plan into its declared header and its prose.
+//
+// The header is a fixed set of keys rather than general YAML: four fields, one
+// per line, so that a plan whose contract is malformed fails here rather than
+// parsing into something plausible.
+func parse(b []byte) (Plan, error) {
+	rest, ok := bytes.CutPrefix(b, []byte(fence))
+	if !ok {
+		return Plan{}, fmt.Errorf("no header; every plan declares the phase it belongs to")
+	}
+	head, body, ok := bytes.Cut(rest, []byte(fence))
+	if !ok {
+		return Plan{}, fmt.Errorf("unterminated header")
+	}
+	p := Plan{Body: body}
+	for _, line := range strings.Split(string(head), "\n") {
+		key, value, ok := strings.Cut(line, ": ")
+		if !ok {
+			continue
+		}
+		switch strings.TrimSpace(key) {
+		case "phase":
+			p.Phase = phase.Name(value)
+		case "reads":
+			p.Reads = value
+		case "writes":
+			p.Writes = value
+		case "emits":
+			p.Emits = verdicts(value)
+		}
+	}
+	if p.Phase == "" {
+		return Plan{}, fmt.Errorf("the header names no phase")
+	}
+	return p, nil
+}
+
+func verdicts(value string) []phase.Verdict {
+	value = strings.TrimSuffix(strings.TrimPrefix(strings.TrimSpace(value), "["), "]")
+	var out []phase.Verdict
+	for _, v := range strings.Split(value, ",") {
+		if v = strings.TrimSpace(v); v != "" {
+			out = append(out, phase.Verdict(v))
+		}
+	}
+	return out
+}
+
+// Check reports every disagreement between the plans in dir and the graph.
+//
+// All of them, not the first: an author who fixes one line only to be refused by
+// the next has learned nothing about the set.
+func Check(dir string) []error {
+	loaded, err := Load(dir)
+	if err != nil {
+		return []error{err}
+	}
+	var problems []error
+	seen := map[phase.Name]string{}
+	for _, p := range loaded {
+		if at, dup := seen[p.Phase]; dup {
+			problems = append(problems, fmt.Errorf("%s and %s both claim phase %s", at, p.Path, p.Phase))
+			continue
+		}
+		seen[p.Phase] = p.Path
+		problems = append(problems, p.check()...)
+	}
+	for _, declared := range phase.Graph {
+		if _, ok := seen[declared.Name]; !ok {
+			problems = append(problems, fmt.Errorf("phase %s has no plan file; a phase with no plan is a phase nobody can run",
+				declared.Name))
+		}
+	}
+	return problems
+}
+
+// check compares one plan against its row in the graph.
+func (p Plan) check() []error {
+	declared, ok := phase.Lookup(p.Phase)
+	if !ok {
+		return []error{fmt.Errorf("%s names phase %q, which the graph does not declare", p.Path, p.Phase)}
+	}
+	var problems []error
+	if p.Reads != declared.Reads {
+		problems = append(problems, fmt.Errorf("%s reads %q; phase %s reads %q",
+			p.Path, p.Reads, p.Phase, declared.Reads))
+	}
+	if p.Writes != declared.Writes {
+		problems = append(problems, fmt.Errorf("%s writes %q; phase %s writes %q",
+			p.Path, p.Writes, p.Phase, declared.Writes))
+	}
+	problems = append(problems, p.checkVerdicts(declared)...)
+	if len(bytes.TrimSpace(p.Body)) == 0 {
+		problems = append(problems, fmt.Errorf("%s has a header and no plan under it", p.Path))
+	}
+	return problems
+}
+
+// checkVerdicts holds the plan's enum to the graph's, in both directions.
+//
+// A plan naming a verdict the graph does not know is a plan whose routing cannot
+// be tested. A plan missing one the graph knows is worse and quieter: it is a
+// case the phase really meets and has been given no instruction for, which is
+// how a phase writes nothing and stalls a campaign at three in the morning.
+func (p Plan) checkVerdicts(declared phase.Phase) []error {
+	var problems []error
+	for _, v := range p.Emits {
+		if !declared.Emits(v) {
+			problems = append(problems, fmt.Errorf("%s emits %q; phase %s emits %v",
+				p.Path, v, p.Phase, declared.Verdicts))
+		}
+	}
+	for _, v := range declared.Verdicts {
+		if !slices.Contains(p.Emits, v) {
+			problems = append(problems, fmt.Errorf("%s does not say what to do on %q, which phase %s can emit",
+				p.Path, v, p.Phase))
+		}
+	}
+	return problems
+}

--- a/lab/internal/plans/plans_test.go
+++ b/lab/internal/plans/plans_test.go
@@ -1,0 +1,221 @@
+package plans_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/lab/internal/phase"
+	"github.com/luuuc/sense/lab/internal/plans"
+)
+
+// theRealPlans is lab/plans, relative to this package.
+const theRealPlans = "../../plans"
+
+// The plans are the method. This is the check that they and the graph still
+// describe the same loop, and it runs against the shipped files rather than a
+// fixture, because a fixture would only prove the checker works.
+func TestEveryPhaseHasAPlanAndEveryPlanMatchesItsPhase(t *testing.T) {
+	for _, err := range plans.Check(theRealPlans) {
+		t.Error(err)
+	}
+}
+
+func TestEveryJudgmentPhaseCarriesItsPrecedent(t *testing.T) {
+	loaded, err := plans.Load(theRealPlans)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range loaded {
+		if len(p.Emits) < 2 {
+			continue
+		}
+		if !bytes.Contains(p.Body, []byte("## Precedent")) {
+			t.Errorf("%s decides between %d verdicts and carries no precedent; an instruction with no "+
+				"measured case behind it is the one that gets talked out of", p.Path, len(p.Emits))
+		}
+	}
+}
+
+// A plan whose body is composed rather than read is a binary holding opinions.
+// The body is the file's own bytes after the header, and nothing is added to it.
+func TestAPlansBodyIsTheFileVerbatim(t *testing.T) {
+	loaded, err := plans.Load(theRealPlans)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range loaded {
+		raw, err := os.ReadFile(p.Path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.HasSuffix(raw, p.Body) {
+			t.Errorf("%s: the loaded body is not the tail of the file on disk", p.Path)
+		}
+	}
+}
+
+// write puts one plan in a temporary directory. The checks are about
+// disagreement with the graph, so every fixture starts from a plan that agrees.
+func write(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// onePlan is a directory holding a single well-formed plan, plus whatever the
+// test adds.
+func onePlan(t *testing.T, name, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	write(t, dir, name, body)
+	return dir
+}
+
+const goodBoard = `---
+phase: board
+reads: harvest.json
+writes: board.md
+emits: [AUTO]
+---
+
+The board plan.
+`
+
+func problems(t *testing.T, dir string) string {
+	t.Helper()
+	var found []string
+	for _, err := range plans.Check(dir) {
+		found = append(found, err.Error())
+	}
+	return strings.Join(found, "\n")
+}
+
+func TestAPlanIsHeldToItsPhasesArtifacts(t *testing.T) {
+	dir := onePlan(t, "board.md", strings.Replace(goodBoard, "reads: harvest.json", "reads: report.md", 1))
+	got := problems(t, dir)
+	if !strings.Contains(got, "harvest.json") {
+		t.Errorf("a plan reading the wrong artifact was not caught:\n%s", got)
+	}
+}
+
+func TestAPlanIsHeldToItsPhasesOutput(t *testing.T) {
+	dir := onePlan(t, "board.md", strings.Replace(goodBoard, "writes: board.md", "writes: results.md", 1))
+	got := problems(t, dir)
+	if !strings.Contains(got, "writes") {
+		t.Errorf("a plan writing the wrong artifact was not caught:\n%s", got)
+	}
+}
+
+// A plan naming a verdict the graph does not know is a plan whose routing
+// cannot be tested.
+func TestAPlanCannotEmitAVerdictItsPhaseDoesNotHave(t *testing.T) {
+	dir := onePlan(t, "board.md", strings.Replace(goodBoard, "emits: [AUTO]", "emits: [AUTO, PAY]", 1))
+	got := problems(t, dir)
+	if !strings.Contains(got, "PAY") {
+		t.Errorf("a plan emitting a verdict outside its enum was not caught:\n%s", got)
+	}
+}
+
+// The quieter half: a case the phase really meets, with no instruction for it.
+func TestAPlanMustSayWhatToDoOnEveryVerdictItsPhaseCanEmit(t *testing.T) {
+	dir := onePlan(t, "harvest.md", `---
+phase: harvest
+reads: report.md
+writes: harvest.json
+emits: [WIN CONFIRMED]
+---
+
+## Precedent
+
+The harvest plan.
+`)
+	got := problems(t, dir)
+	if !strings.Contains(got, "DoD FAIL") {
+		t.Errorf("a plan silent on a verdict its phase emits was not caught:\n%s", got)
+	}
+}
+
+func TestAPlanForAPhaseTheGraphDoesNotDeclareIsCaught(t *testing.T) {
+	dir := onePlan(t, "triage.md", `---
+phase: triage
+reads: a.json
+writes: b.json
+emits: [AUTO]
+---
+
+The triage plan.
+`)
+	got := problems(t, dir)
+	if !strings.Contains(got, "triage") {
+		t.Errorf("a plan for a phase that does not exist was not caught:\n%s", got)
+	}
+}
+
+func TestAPhaseWithNoPlanIsCaught(t *testing.T) {
+	got := problems(t, onePlan(t, "board.md", goodBoard))
+	for _, p := range phase.Graph {
+		if p.Name == phase.Board {
+			continue
+		}
+		if !strings.Contains(got, string(p.Name)) {
+			t.Errorf("phase %s has no plan and was not reported:\n%s", p.Name, got)
+		}
+	}
+}
+
+func TestTwoPlansCannotClaimTheSamePhase(t *testing.T) {
+	dir := onePlan(t, "board.md", goodBoard)
+	write(t, dir, "board-2.md", goodBoard)
+	got := problems(t, dir)
+	if !strings.Contains(got, "both claim") {
+		t.Errorf("two plans for one phase were not caught:\n%s", got)
+	}
+}
+
+func TestAHeaderWithNoPlanUnderItIsCaught(t *testing.T) {
+	dir := onePlan(t, "board.md", "---\nphase: board\nreads: harvest.json\nwrites: board.md\nemits: [AUTO]\n---\n\n")
+	got := problems(t, dir)
+	if !strings.Contains(got, "no plan under it") {
+		t.Errorf("an empty plan was not caught:\n%s", got)
+	}
+}
+
+func TestAMalformedHeaderIsRefusedRatherThanParsedIntoSomethingPlausible(t *testing.T) {
+	for _, tc := range []struct{ name, body, want string }{
+		{"no header", "# board\n\nprose\n", "no header"},
+		{"unterminated header", "---\nphase: board\n", "unterminated"},
+		{"no phase", "---\nreads: harvest.json\n---\n\nprose\n", "names no phase"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := problems(t, onePlan(t, "board.md", tc.body))
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("%s was not caught:\n%s", tc.name, got)
+			}
+		})
+	}
+}
+
+func TestADirectoryWithNoPlansIsAnErrorRatherThanACleanBill(t *testing.T) {
+	if got := problems(t, t.TempDir()); !strings.Contains(got, "no plans") {
+		t.Errorf("an empty plans directory reported clean:\n%s", got)
+	}
+	if _, err := plans.Load(filepath.Join(t.TempDir(), "nowhere")); err == nil {
+		t.Error("a plans directory that does not exist loaded cleanly")
+	}
+}
+
+func TestAnUnreadablePlanIsAnError(t *testing.T) {
+	dir := onePlan(t, "board.md", goodBoard)
+	locked := filepath.Join(dir, "board.md")
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o644) })
+	if _, err := plans.Load(dir); err == nil {
+		t.Error("a plan that could not be read loaded cleanly")
+	}
+}

--- a/lab/plans/author.md
+++ b/lab/plans/author.md
@@ -1,0 +1,264 @@
+---
+phase: author
+reads: slate.md
+writes: scenario.draft.yaml
+emits: [DRAFT, NO-ANCHOR]
+---
+
+# author
+
+## Task
+
+Pick this repository's contract, write the two-step probe scenario that asks for its scattered
+dependents, and hand-audit its gold, so the next phase can measure a real baseline against it.
+
+## Scope
+
+You write one scenario and its gold. **Out of scope:** running either arm, the seven-step
+expansion, the paid bench, editing a script, any other repository. You do not decide whether the
+scenario discriminates; a two-arm run does that next, and it is spawned by the binary.
+
+If a script here is broken, write one line naming it in `notes` and stop. Do not fix it.
+
+## Run
+
+`slate.md` names the repository, the campaign and the anchor if one is carried. Every rejection
+so far is beside it, oldest first, and **all of them are read, not only the last one.**
+
+Reading only the latest read is how six attempts oscillated between "the plain search got
+everything" and "neither arm got anything" without ever landing in between.
+
+1. **What the arms have ACTUALLY cited, per gold row, across every run on disk.** Rarest-cited
+   first, scoped to the HEADLINE model's results root and not to every root: mixing model
+   generations reorders the middle and hides the split, measured 2026-08-03, because a weak
+   model's near-total failure lifts rows the headline model finds easily.
+
+   Three classes, and only one of them is worth gold:
+
+   - **baseline low, sense high** — the discriminator. Build the group from these.
+   - **cited by every run, both arms** — free. Each one hands the baseline a row before it does
+     any work. Ten such rows put a floor of 0.43 under the baseline on the measured mastodon
+     gold, which no rewording can undo.
+   - **0 of N on BOTH arms** — hard or unreachable. Check the row against the blast payload
+     before keeping it: absent from the payload means the tool cannot serve it and the row can
+     only ever score zero. Two mastodon spec rows sat at 0 of 12 across two models for exactly
+     that reason.
+
+   **n matters here and the ranking says what it has.** At n=2 one row looked like a perfect
+   discriminator (baseline 0 of 2) and was 4 of 5 by n=5. Do not re-gold off fewer than about
+   five runs per arm; below that the ordering is noise.
+
+2. **The retention listing, for the KIND of question you may ask.** A LISTING, never a gate. It
+   reports anchors whose dependents HOLD the contract rather than call it. A non-empty ring puts
+   the strongest measured question kind on the menu; an empty one takes it off, and says nothing
+   else about the repository.
+
+3. **Candidate anchors**, as a LISTING. Never a gate, never a ranking you defer to.
+
+4. **The seam profile, for three candidates.** This is the one number that has separated wins
+   from ties across three verticals.
+
+   `PRECISION` is dependents divided by grep hits. **LOWER IS BETTER**, and the calibration is on
+   the record: a banked +1.00 cell profiled at 0.078 (37 dependents in 474 hits); a deliberate
+   control tie profiled at 0.78 (29 dependents in 37 files, near-transcription); a dead cell sat
+   near 0.94 and handed its baseline 17 of 18 rows in one grep. Record `SCATTER` beside it. A
+   precision ABOVE 1.00 means false caller edges, not darkness: check a sample by hand before
+   believing it.
+
+5. **What the arm is actually SHOWN**, for the leading candidate, at MCP defaults. Pass no
+   `min_confidence`. The shown set is cap-limited, so raising it does not add rows, it changes
+   which rows win the same slots. **Every dependents row you write must appear here.**
+
+6. **Open every candidate row and pin the line that actually touches the contract.** The blast
+   payload gives the enclosing definition, not the dependency line.
+
+7. **Memorization, per candidate row, on a famous repository.** Cut what comes back recited. A
+   famous repository is not disqualified; a memorized row is.
+
+8. After writing the yaml and the rubric: render the prompt, check the rubric, check gold
+   confidence on the `dependents` group, then stamp and verify the gold audit. `stamp` writes one
+   TODO row per gold item; you replace each by opening the file and reading the credit. `verify`
+   fails while any TODO remains.
+
+## Decide
+
+The KIND of question first, then the contract, then every gold row.
+
+### The kind of question
+
+**Read the campaign's answer-forms page FIRST if it exists.** Each stack answers differently and
+the per-campaign page is where that is written down, with the n under every claim. It carries
+three things this shared plan cannot: the forms already MEASURED to fail here (do not re-buy
+them), the forms measured to win here, and the mechanisms killed by a run so they are not
+re-proposed.
+
+Measured 2026-08-12: php-laravel spent 36 attempts across 3 repositories and the plain arm's
+floor was the binding constraint in every one, because the form being asked for — "every place
+that calls or holds X" — is one regex in PHP, where the same form banks +0.775 in Ruby. Same
+plan, same laws, opposite outcome, and nothing in the plan said so.
+
+That page ORDERS what to try. It never gates a draft, and a form absent from it is not
+forbidden; it is unmeasured, and saying so in the header is the whole obligation.
+
+A search prints occurrences. So a question whose true answer IS a list of occurrences is one the
+plain arm can print, and no wording makes it otherwise. Two kinds have been measured.
+
+- **"Find everything that uses X."** An occurrence list, and the evidence cuts BOTH ways, so read
+  it before choosing. It is the shape of one repository's banked win (baseline 7 of 23, sense 19
+  of 23, +0.53), so the kind is not disqualifying. It is also the shape of five straight failures
+  on the same repository, where the plain arm scored 0.81, 0.16, 0.09, 1.00, 1.00 and the gap
+  never opened. The banked one sat at step 4 of a 7-step session; the five failures were asked
+  cold. If you write this kind, say in the header what makes yours the first sort and not the
+  second.
+- **"What HOLDS X, and what stays alive when X goes away."** Not who calls it: who keeps a handle
+  on it, through a field, an embedded value or a wiring the call sites never name. The strongest
+  measured kind in this bench: +0.58, +0.67, +0.80 and +1.00 on four cells, on gold the plain arm
+  could not print because the link is established in a file the dependent never mentions.
+  **Available only where the retention listing is non-empty.** Measured 2026-08-03: zero rings on
+  either Ruby repository swept, top twelve anchors each, so in a stack with no ring this kind is
+  off the menu and proposing it anyway writes an unanswerable question.
+
+You are not limited to these two. What you may NOT do is ship an occurrence list and hope. Write
+one sentence in the yaml header: **what the answer to this question is, that is not a list of the
+places a name appears.** If you cannot write that sentence, you have kind one.
+
+Do not test this with a grep. No pre-run census, no coverage count: the run is what decides, and
+the loop has been wrong about this before in both directions.
+
+### Then the contract, the question, and every gold row
+
+1. **Take the repository's central contract** — the model or type everything hangs off, the thing
+   a maintainer would actually rework. Not a clever corner.
+2. **Rank the candidates by seam profile, lowest precision first.** Precision RANKS; it never
+   kills. An anchor is not rejected here for anything a grep prints. The two-arm run in the next
+   phase is what rejects.
+3. **Frame it as a teardown audit**: "what depends on this before I rework it". Recurring, real,
+   and it forces enumeration rather than a single lookup.
+4. **Name the MECHANISM that carries the dependents** and write it into the axis: an association,
+   a shared concern, a value passed as a constructor argument, a narrowed interface retained in a
+   field, duck-typed dispatch, a derived query. This sentence is the scenario's whole thesis and
+   the next phase measures it.
+5. **Split the pool.** The contract itself and its obvious write path are ANCHORS: both arms reach
+   them and they do NOT score. The scattered residue is the `dependents` group and it decides
+   everything.
+6. **One row per FILE.** A group listing several symbols from one file rewards a single read.
+7. **Drop what the ranking says is free or unreachable.** A row every run cites is a gift to the
+   baseline; a row no run has ever cited, and that the blast payload does not carry, is dead
+   weight that only dilutes the group. Both are measured facts from step 1, not estimates, and
+   they are the one place a row may be cut without a run.
+8. **The ask names the MECHANISM, never the INVENTORY.** The neutrality check reads tokens, so a
+   list of functional categories passes it clean and still hands over the answer. Say HOW
+   dependents hide, never WHERE they live. Steering off the anchors is fine.
+9. **The prompt is neutral** — no paths, class names, counts, tool names, or answer shape — and
+   **every step demands `file:line`.** Without it the task grades at mention level and both arms
+   tie.
+
+Prefer rows whose line can only be identified by opening the file. That is a preference at
+authoring time and nothing more: it is a hand estimate of a baseline, and the next phase measures
+the baseline for real. It may not kill a draft, and no per-row grep census belongs in this phase.
+
+### Re-question: you were routed back with a rejection
+
+**Keep the anchor. Change the question.** The precedent both ways: a tied `serialize_payload`
+axis became a winning `Status` teardown audit on the same repository, and a dead
+dispatch-tracing axis on a storage batch became a winning retention audit on the SAME TYPE.
+Re-scouting a new contract throws away the only measured thing you own.
+
+**Aim at the window, not at the opposite of the last failure.** The window is: the plain arm at
+or below 0.50 AND our arm at least 0.50 above it. Both conditions at once. A rewrite that only
+fixes the last cycle's complaint lands on the other side of the window and burns a cycle proving
+it — measured, five cycles, 0.81 then 0.16 then 0.09 then 1.00 then 1.00.
+
+So before drafting, write the trajectory down as a list and say which side of the window each
+cycle fell on. Then state, in one line in the yaml header, **which side you are correcting from
+and how far you intend to move**. A cycle that lands on the far side is not progress; it is the
+same cycle mirrored.
+
+Read all the carried rejections, not the last one. Each names the rows the plain arm took and the
+route it used. Rows it has taken in EVERY cycle are the ones no wording has protected, and
+re-golding onto rows it missed once is betting on a sloppy run. **Re-gold from what it has missed
+CONSISTENTLY.**
+
+Write the superseded question into the yaml header with the number that killed it. Nothing is
+deleted: the previous draft stays on disk in the attempt history, and the question is rewritten
+in place.
+
+### Re-anchoring is a separate decision
+
+`NO-ANCHOR` says an anchor is owed. It does not pick one, and it does not throw away the one that
+failed. A sub-floor cell is a question the anchor could not carry, not necessarily a bad anchor,
+so re-anchoring never happens as a side effect of a re-question.
+
+## Precedent
+
+- A banked +1.00 cell profiled at precision 0.078: 37 dependents in 474 grep hits.
+- A deliberate control tie profiled at 0.78: 29 dependents in 37 files, near-transcription.
+- A dead cell near 0.94 handed its baseline 17 of 18 rows in one grep, in nine tool calls and 157
+  seconds of a 480 second wall.
+- Ten free rows put a floor of 0.43 under the baseline on the measured mastodon gold.
+- Five cycles on one repository: 0.81, 0.16, 0.09, 1.00, 1.00. The question moved; the window
+  was never hit.
+- php-laravel, 2026-08-12: 36 attempts across 3 repositories, the plain arm's floor binding in
+  every one, on a form that banks +0.775 in Ruby.
+- Zero retention rings on either Ruby repository swept, 2026-08-03, top twelve anchors each.
+
+## Artifact
+
+`scenario.draft.yaml`: a TWO-step scenario with `name`, `repo`, `contract_symbol`,
+`contract_file`, `description`, `steps`, `scoring`, `gold`. A header comment carries the seam
+profile (precision, scatter, hit counts) and the axis sentence.
+
+    step 1  "Map the <contract> contract"                        orientation; its gold is the non-scoring anchors
+    step 2  "Audit every dependent of the <contract> contract"    THE discriminator
+
+The rubric carries exactly two top-level keys, `audience` and `steps`, one rubric step per
+scenario step, names matching verbatim and in order, each declaring `map_quality`, `specificity`,
+`justification` and `uncertainty`. It carries no `repo` key.
+
+A gold row is:
+
+    - {id: d:<slug>, group: dependents, match: [<path fragment>], relation: "<path>:<line> <the exact expression> - one phrase on HOW it uses the contract"}
+
+The verdict is `DRAFT` or `NO-ANCHOR`, with one line of notes carrying the chosen anchor's
+precision.
+
+`NO-ANCHOR` only after three candidates were profiled and none can yield twelve dependent files
+across six areas from its shown blast set. It is a property of the pool, never of what a grep
+prints: `NO-ANCHOR` reached from a token grep is a report about grep, not about the repository.
+
+## Done when
+
+- The scenario has two steps and the rubric has two matching steps in order.
+- `dependents` holds at least twelve rows across at least six areas, one file each.
+- No `dependents` row appears in the `contract` group.
+- The rendered prompt shows no path, symbol, count or tool name.
+- The rubric check passes.
+- The gold confidence check on the `dependents` group passes.
+- The gold audit verifies: zero TODO rows, gold unchanged under a finished sheet.
+- The seam profile is in the yaml header and the anchor's precision is in the notes.
+- The yaml header names the ANSWER FORM this draft uses and its line on the campaign's
+  answer-forms page: measured-to-win, under test, or unmeasured. A form that page records as
+  MEASURED TO FAIL needs the sentence saying what is different this time, or it is the same cycle
+  re-bought.
+- The yaml header carries the one sentence saying what the answer is that is NOT a list of the
+  places a name appears. If the honest answer is "it is a list of occurrences", say so in the
+  notes rather than dressing it up.
+- On a re-question: the header carries the trajectory of every previous cycle, which side of the
+  window each fell on, and which side this draft corrects from.
+
+## Do not
+
+- Do not kill a draft with a grep census, a coverage count or an import dump. The run kills.
+- Do not take a credit from a script tally; open the file and read the line, every row.
+- Do not delete anything on a re-entry. The anchor stays and the question is rewritten in place.
+- Do not spawn a subagent. Only the binary spawns.
+
+## Questioned, not changed
+
+**The RUN steps name what to compute, not which script to invoke.** The old plan named a specific
+command per step — the citation ranking, the retention sweep, the anchor listing, the seam profile,
+the shown-set probe, the memorization probe, the gold audit — and those scripts have not been
+ported into this tree. Naming a path that does not exist would be worse than naming the
+computation, because a plan is followed literally. **Cycle 07 binds each step to its command, and
+until it does this plan is followed by hand.** Recorded rather than quietly dropped: the exact
+commands are the part of this plan most likely to be lost in the move.

--- a/lab/plans/bench.md
+++ b/lab/plans/bench.md
@@ -1,0 +1,60 @@
+---
+phase: bench
+reads: scenario.yaml
+writes: cells.json
+emits: [AUTO]
+---
+
+# bench
+
+## Task
+
+Run the paid cells: every arm the campaign declares, against the validated scenario, at the real
+wall, with both subjects of each cell run under one supervising process.
+
+## Scope
+
+You run what preflight planned. **Out of scope:** authoring, re-questioning, scoring, judging, any
+cell the pay call did not clear.
+
+## Decide
+
+Nothing is judged here, and one thing is refused.
+
+**A cell is never split across processes.** Both arms are launched by the same supervising
+process, because killing a session between the two arms does not merely cost time: the finished arm
+is burned, it can never be paired, and the money spent on it is gone. Catching a half-pair after
+the fact is not preventing it.
+
+**An interruption is recorded, not raised.** A cell stopped part way writes a record naming the
+arms that finished and can never be paired, and the arms that have no result at all. Without that
+record nothing on disk names the burned arm, and a later pass would pair it.
+
+**Every arm gets its declared runs.** The recorded same-cell spread reaches 0.250 against a bar of
+0.50, so one run is a sample of a distribution whose spread is half the bar. A cell short of its
+replicates is not a measurement and the gates refuse to publish it.
+
+## Precedent
+
+- Recorded same-cell spread: 0.077 to 0.250 of the group, against a bar of 0.50.
+- A half-pair whose finished arm was burned because its partner never ran, and the earlier
+  instrument's response, which was a function that detected it afterwards.
+
+## Artifact
+
+`cells.json`: every cell, its arms, their run directories, whether the cell is complete, and by
+name the arms that are burned or have no result.
+
+## Done when
+
+- Every planned job ran or is named as unusable, and nothing is silently absent.
+- Each cell's record says whether it is complete, and names its burned and unusable arms.
+- A run that hit its wall is recorded as its own outcome and not as a failure. It is a result, and
+  reporting it as success would let a stalled arm pass unnoticed.
+
+## Do not
+
+- Do not raise a wall to rescue a stalled arm. Cannot-finish-at-budget is a result.
+- Do not re-run an arm to get a better number. One retry, never a loop, and a replaced run is
+  never scored.
+- Do not spawn a subagent. Only the binary spawns.

--- a/lab/plans/board.md
+++ b/lab/plans/board.md
@@ -1,0 +1,54 @@
+---
+phase: board
+reads: harvest.json
+writes: board.md
+emits: [AUTO]
+---
+
+# board
+
+## Task
+
+Bank the confirmed win: write it onto the board with every figure it was confirmed at.
+
+## Scope
+
+You record a result that is already decided. **Out of scope:** re-scoring, re-reading, re-judging,
+choosing what to publish, any cell that is not confirmed.
+
+## Decide
+
+Nothing. A cell reaches this phase only with a confirmed win behind it.
+
+**Objective recall is the headline and the blind composite never leads.** A board ranked by the
+composite published a +0.44 win as a tie while the document saying so was right for months. The
+ordering is not a presentation choice.
+
+**Cost is recorded and never gates.** Costing more is a product finding, not a stopper, so a cell
+that wins its discriminator while spending more still wins. There is nowhere on this board for a
+cost to refuse a result.
+
+## Precedent
+
+- The reporter that ranked by the blind composite and published a +0.44 win as a tie.
+- A banked cell carrying a contract group at baseline 0.75, which is why gating on any group rather
+  than the discriminator group would refuse a cell that was paid for and published.
+
+## Artifact
+
+`board.md`: the cell, the repository, the arms, the per-run figures, the spread, the routing state
+of every arm, and the build the headline column was banked at.
+
+## Done when
+
+- Every figure on the board is quoted from the harvest record.
+- The headline is objective recall.
+- Every arm appears, including the ones that never routed.
+- The build the win was banked at is recorded, so a later reader can tell whether a board is
+  comparable to this one.
+
+## Do not
+
+- Do not re-round a figure, and do not write one that is not in the harvest record.
+- Do not omit an arm because it did poorly. A never-routed arm is a finding.
+- Do not spawn a subagent. Only the binary spawns.

--- a/lab/plans/expand.md
+++ b/lab/plans/expand.md
@@ -1,0 +1,130 @@
+---
+phase: expand
+reads: minibench.md
+writes: scenario.yaml
+emits: [AUTO, REQUESTION]
+---
+
+# expand
+
+## Task
+
+Expand the measured two-step question into the full seven-step work session, without moving the
+discriminator the mini-bench just proved.
+
+## Scope
+
+You rewrite one scenario and extend its gold and rubric. **Out of scope:** changing the anchor,
+changing the discriminator step's question, re-running either arm, the paid bench, editing a
+script, any other repository.
+
+If the mini-bench verdict on disk is not `PROCEED`, write one line in the notes and stop.
+
+## Run
+
+1. Read `minibench.md` and the draft scenario before writing anything.
+
+2. Rewrite the scenario to the seven steps below, then extend the rubric to match.
+
+3. Pull the shown set again for the anchors and specs you are adding.
+
+4. Open every added row and pin the line that actually touches the contract.
+
+5. Render the prompt, check the rubric, check gold confidence on the `dependents` group, then
+   stamp and verify the gold audit.
+
+## Decide
+
+### The seven steps
+
+Every banked win in this bench is this session. Only the contract noun and the axis sentence
+change between repositories; the skeleton does not.
+
+    1. Orient in the codebase        where the contract sits, how the code is organized
+    2. Map the <contract> contract   what it exposes and what it pulls in: concerns, embeds,
+                                     associations. file:line for each piece
+    3. Trace the write path          how the thing is created, or torn down, and what runs
+                                     around it. Which parts run inline and which asynchronously
+    4. Audit every dependent         THE DISCRIMINATOR. Carried over VERBATIM
+    5. Trace the guards              how code confirms it is acting on a real, current instance
+                                     before acting. file:line throughout
+    6. Assess the blast radius       which dependents are at risk, ranked, and what must be
+                                     re-verified. A missed high-risk dependent is the one that
+                                     pages someone
+    7. The change and verification   what you will edit, every dependent grouped by area, and
+       map                           the specs that must be updated
+
+The steps accumulate: each is worked in order in one session, so by step 4 both arms have already
+spent context and wall on steps 1 to 3. **That is part of the measurement, not decoration.**
+
+### The rules that do not bend
+
+- **Step 4 is byte-identical to the probe scenario's step 2**, and its `dependents` gold is
+  byte-identical too. Move either and the mini-bench number stops describing this scenario. If you
+  believe step 4 needs a rewrite, that is a `REQUESTION`, not an expansion.
+- **New gold goes in NON-SCORING groups.** `contract`, `write-path` (or `teardown`) and `specs`
+  are what both arms reach. Adding to `dependents` here is untested gold: it never faced a
+  baseline.
+- **The prompt stays neutral** — no paths, class names, counts, tool names, or answer shape — and
+  **every step demands `file:line`.**
+- **The ask names the MECHANISM, never the INVENTORY.** The neutrality check reads tokens, so a
+  list of functional categories passes it clean and still hands over the answer. Read the finished
+  prompt back and quote any phrase that identifies a single gold row's file.
+- **Every step carries its checks**: a response richness floor, and tool-reach checks recorded at
+  the adoption layer so reach is recorded without scoring the answer.
+- **One item per FILE**, hand-audited at its real line, in every group.
+
+## Precedent
+
+Every banked win in this bench came from this seven-step skeleton, and the discriminator has
+always been step 4, after three steps of accumulated context and wall. The one recorded attempt
+to measure the discriminator cold — the same question asked as step 1 of a short session — is
+among the five failures on that repository, where the plain arm scored 0.81, 0.16, 0.09, 1.00 and
+1.00 and the gap never opened.
+
+## Artifact
+
+`scenario.yaml`, rewritten to seven steps with `name`, `repo`, `contract_symbol`,
+`contract_file`, `description`, `steps`, `scoring`, `gold`. The header comment carries the seam
+profile, the axis sentence, the mini-bench figures, and any superseded question with the number
+that killed it.
+
+The rubric is extended to seven matching steps, names verbatim and in order, each declaring
+`map_quality`, `specificity`, `justification` and `uncertainty`.
+
+The verdict is `AUTO` when the expansion holds, and the scenario is committed once it exists.
+
+`REQUESTION` only if expanding revealed that step 4 cannot survive verbatim: a gold row that does
+not hold at its line, or a step that cannot be written without naming a gold file. It carries the
+row or the phrase that failed, and it re-enters authoring with the anchor kept.
+
+## Done when
+
+- The scenario has seven steps in the order above; the rubric has seven matching names in order.
+- Step 4's prompt and the `dependents` gold are unchanged from the probe scenario, verified by
+  diffing rather than by reading.
+- Every step's prompt contains `file:line`.
+- The rendered prompt shows no path, symbol, count or tool name.
+- The rubric check passes.
+- The gold confidence check on the `dependents` group passes.
+- The gold audit verifies.
+- The finished ask has been read back as an inventory check, with any offending phrase quoted and
+  rewritten as a mechanism.
+
+## Do not
+
+- Do not add rows to `dependents`, and do not reword step 4. Both invalidate the measurement.
+- Do not take a credit from a script tally; open the file and read the line, every added row.
+- Do not spawn a subagent. Only the binary spawns.
+
+## Questioned, not changed
+
+The declared graph gave expansion `AUTO` alone. Porting this plan found the hole: the old plan
+emits `REQUESTION` when step 4 cannot survive verbatim, and a phase with no verdict for a case it
+really meets writes nothing and stalls the loop. `REQUESTION` was added to this phase's enum and
+to the lever table, because a lever a recorded campaign used and the table does not carry is a
+hole in the test set rather than a plan to bend around it.
+
+The old plan also named its passing verdict `SCENARIO`. That is `AUTO` here, since the graph's
+auto phases are the ones that make no judgement, and this one does not: it either carries the
+discriminator over or it re-questions.

--- a/lab/plans/handoff.md
+++ b/lab/plans/handoff.md
@@ -1,0 +1,121 @@
+---
+phase: handoff
+reads: campaign.json
+writes: handoff.md
+emits: [AUTO]
+---
+
+# handoff
+
+## Task
+
+Six attempts have not produced a payable question on this repository, or a paid cell came back
+below the bar. Write the one page, in plain words, that lets a human decide what happens next.
+
+## Scope
+
+You write one summary of work that already happened. **Out of scope:** authoring another question,
+running anything, re-scoring, editing a scenario or its gold, recommending a wall change, any other
+repository. **You are not a seventh attempt.**
+
+This is a HANDOFF, not a post-mortem. The repository is not dead, the anchor may be fine, and the
+loop has simply run out of its own judgment. Say what was measured and what you would do.
+
+## Run
+
+1. **The numbers, one row per attempt.** This is the mechanical spine of the summary. Each row
+   carries the cycle number, the phase that rejected it, the verdict, the question's name, and the
+   `dependents` recall both arms actually scored.
+
+2. **The reads, in order.** Each names the rows the baseline took and the route it took them by.
+
+3. **What each attempt actually ASKED.** **Do not take this from a title or a `name:` field**:
+   measured attempts with opposite outcomes have carried identical ones. Read the real thing: the
+   axis sentence in each yaml header and the discriminator step's prompt.
+
+   The archived reads from step 2 are the other half: each one says what the previous question
+   failed at, which is what the next attempt was trying to fix. Pair them up, so the table shows a
+   sequence of different ideas and not six copies of one title.
+
+4. **The current scenario's seam profile**, for the anchor line of the recommendation.
+
+## Decide
+
+Two things, and only these.
+
+**What the pattern is.** Read the rows together, not one at a time. The useful reading is whether
+the baseline's number MOVED across attempts. Six attempts clustered at the same baseline recall is
+one finding: the route is the same every time and the questions differ only in words. Six scattered
+numbers is a different one: the questions differ but none has found the gap yet. Say which of the
+two you are looking at, and quote the numbers that show it.
+
+**What you would do next.** One recommendation, one line of why, and at most one alternative. The
+honest options are: keep this anchor and change the kind of question, take a different contract in
+this repository, or swap the repository for its declared backup. Pick one. Do not list all three as
+equals and leave the human to sort it out.
+
+### How to write it
+
+The reader is not inside this bench and should not have to be. Write for someone who has never
+read a plan in this folder.
+
+- **Short sentences. Plain words.** If a six-year-old would not know the word, use a different word
+  or explain it in the same sentence.
+- **No jargon and no codenames.** Not `dependents`, not `cited recall`, not "the discriminator
+  group", not `+0.50`, not phase names. Say "the scattered places in the code that use it", "how
+  many of those it found and pointed to exactly", "the bar we need to beat".
+- **Every number gets its meaning in words next to it.** "13 out of 16 (about 8 in 10)".
+- **Positive and factual.** Every attempt taught something and the summary says what. Nothing here
+  says a repository that has banked a win before cannot again. No blame, no hand-wringing, no
+  apologising.
+- **Lead with the outcome.** The first line says what happened and what is being asked of the
+  reader. No preamble.
+- **One page.** If it does not fit, cut the detail, never the recommendation.
+
+Every number written is quoted from the attempt history or from a read on disk. If you cannot quote
+it, leave it out.
+
+## Precedent
+
+The plain-language rule is not a style preference. The page exists because a resuming session was
+once pointed at the plans and the laws and had to discover its position by asking, and because a
+reader outside the bench cannot act on a bare delta.
+
+## Artifact
+
+`handoff.md`, with exactly these five headings:
+
+    # What happened     two or three sentences. Opens with: we tried six ways of asking, none
+                        beat the bar yet, here is the picture so you can choose
+    # The attempts      a table: attempt, what it asked in plain words, what the plain search
+                        found, what our tool found, did it beat the bar
+    # What worked       the things that went right, named. There will be several
+    # What did not      the pattern across the attempts, in one short paragraph
+    # What I would do   one recommendation, one line of why, at most one alternative
+
+## Done when
+
+- The table has one row per attempt in the history, in order, none missing.
+- No two rows describe the question the same way. If two attempts read alike, you took the title
+  instead of the ask; go back to the axis sentence and the discriminator prompt.
+- Every number in the file is quoted from the attempt history or a read on disk.
+- No bench jargon survives a read-back: no group names, no phase names, no bare deltas.
+- `# What worked` is not empty.
+- `# What I would do` names ONE recommendation.
+
+## After this page
+
+**The repository is parked until a human re-enters it deliberately.** It is not automatically
+re-enterable. The fresh cycle count is what a human gets *if* they choose to resume it, not an
+automatic second life, and that difference is a loop that stops rather than one that quietly spends
+six more cycles.
+
+## Do not
+
+- Do not author a seventh question, edit a scenario, or run either arm. You summarise.
+- Do not call the repository or the anchor dead; the attempts bound what was tried, nothing more.
+- Do not spawn a subagent. Only the binary spawns.
+
+## Questioned, not changed
+
+Nothing yet.

--- a/lab/plans/harvest.md
+++ b/lab/plans/harvest.md
@@ -1,0 +1,86 @@
+---
+phase: harvest
+reads: report.md
+writes: harvest.json
+emits: [WIN CONFIRMED, DoD FAIL]
+---
+
+# harvest
+
+## Task
+
+Run the five mechanical checks against a reported win and confirm it, or bounce it.
+
+## Scope
+
+Five checks against on-disk verifier output, in order, each numbered in the verdict. **Out of
+scope:** diagnosing a sub-floor cell, reading transcripts for causes, proposing levers,
+re-running anything, editing anything.
+
+**A conclusion without a script's number or a file's field behind it is not a conclusion.**
+
+## Run
+
+**The five checks. Run ALL, in order, and number each in the verdict.**
+
+1. **Discriminator.** The per-group verdict reports a win: a gold-group delta at or above +0.50
+   held across BOTH runs, or an efficiency-at-parity win where recall ties and the sense arm is
+   robustly cheaper. Quote the per-run numbers.
+
+2. **Sense adoption.** Every sense run made at least one MCP call. Quote each.
+
+3. **Leak-free baseline.** Every baseline run made zero MCP calls: no Sense leaked into the control
+   arm.
+
+4. **Leak-free prompt.** Render the prompt and confirm no gold identifier appears in it verbatim.
+   Identifiers the prompt names as given context are exempt only where the gold curation notes mark
+   them as out of gold or shown.
+
+5. **No hallucinated cites, and a legitimate baseline.** Spot-check at least two credited gold
+   dependents per arm: the credited identifier must actually appear in that run's transcript, which
+   is the guard against a basename matching by accident. Confirm every run scored without failing.
+
+## Decide
+
+**Confirm and stop.** When the five checks pass, write the verdict and end. Inventing problems in a
+clean win means the reading is over-tuned.
+
+**A run flag that does not move one of the five checks is not a finding.** A nonzero exit code on a
+run that still scored, a constrained flag, noisy logs: a recorded win stands unless a check itself
+fails.
+
+**Sub-floor is not yours.** If the numbers are below the bar, this cell should never have reached
+you: say so and stop. Diagnosis belongs to the report phase.
+
+- **`WIN CONFIRMED`** — all five pass, with the numbers for each.
+- **`DoD FAIL`** — one check fails. Name the check by number and the number or field that fails.
+  It goes back for diagnosis and **never to the board**: a cell that failed its confirmation checks
+  is not a result to publish.
+
+## Precedent
+
+The check that exists because of a specific failure is number 5: a credited gold dependent whose
+identifier never appeared in the transcript, credited on a basename that matched something else.
+Every check here is one that a recorded campaign needed.
+
+## Artifact
+
+`harvest.json`: the verdict, and the five checks with the number or field each was decided on.
+
+## Done when
+
+- All five checks ran, in order, and each is numbered in the verdict.
+- Every check carries the number or field it was decided on, quoted.
+- On a failure, exactly one check is named as the cause.
+
+## Do not
+
+- Do not fault-find a clean win.
+- Do not diagnose a sub-floor cell.
+- Do not spawn a subagent. Only the binary spawns.
+
+## Questioned, not changed
+
+**The RUN steps name what to compute, not which script to invoke**, because those scripts are not
+ported into this tree yet and a plan that names a path which does not exist is worse than one that
+names the computation. Cycle 07 binds each step to its command. See `author.md` for the full note.

--- a/lab/plans/index.md
+++ b/lab/plans/index.md
@@ -1,0 +1,56 @@
+---
+phase: index
+reads: repo.json
+writes: index.json
+emits: [AUTO]
+---
+
+# index
+
+## Task
+
+Clone the repository at its pinned revision, run `sense scan` over it, and record what the index
+holds. Nothing here judges anything.
+
+## Scope
+
+You prepare one repository. **Out of scope:** choosing an anchor, writing a scenario, running
+either arm, any other repository. If the clone or the scan fails, that is this phase's failure
+and it is recorded as one; it is never worked around.
+
+## Run
+
+1. Clone at the revision named in `repo.json`. A moving revision is not a measurement: two runs
+   months apart must see the same tree, and a floating branch means nothing on the board is
+   comparable to anything else on it.
+
+2. `sense scan` over the clone, then `sense_status` through the MCP server.
+
+3. Record, in `index.json`: the revision, the file and symbol counts, the language breakdown, the
+   edge count, and whether embeddings are present.
+
+## Decide
+
+Nothing. This phase emits `AUTO` and either writes its artifact or does not.
+
+The one thing it must not do is soften a failure. A scan that indexed half the tree produces an
+`index.json` that says so, and the authoring phase reads it. An index quietly short of its
+symbols is how a repository gets called dark when the tool simply did not run.
+
+## Artifact
+
+`index.json`, carrying the revision, the counts, and the `sense_status` output as it was
+returned.
+
+## Done when
+
+- The clone is at the pinned revision, and the revision is in `index.json`.
+- `sense scan` exited zero and `sense_status` was read through the MCP server, never by opening
+  the index file.
+- The counts in `index.json` are quoted from `sense_status`, not estimated.
+
+## Do not
+
+- Do not read the SQLite index directly. Sense is reached through the MCP server, because that
+  is the channel the benched agent actually has.
+- Do not spawn a subagent. Only the binary spawns.

--- a/lab/plans/minibench.md
+++ b/lab/plans/minibench.md
@@ -1,0 +1,135 @@
+---
+phase: minibench
+reads: scenario.draft.yaml
+writes: minibench.md
+emits: [PROCEED, REQUESTION, NO-ANCHOR]
+---
+
+# minibench
+
+## Task
+
+Read the unscored two-arm run the binary just produced against the two-step probe scenario, and
+rule on one thing: is this question worth expanding into a full session.
+
+## Scope
+
+You read a run that already exists and issue one verdict. **Out of scope:** re-running anything,
+expanding the scenario, editing the yaml or its gold, re-scoring, raising a wall, the paid bench,
+any other repository.
+
+You do not re-author. A routed `REQUESTION` sends the credit table back to the authoring phase,
+which owns the rewrite.
+
+**Both arms are guaranteed to be MEASUREMENTS.** Run validity is mechanical, not a judgment: the
+runner classifies every run, retries a void arm once and parks the void one, and the phase halts
+rather than reaching you if a pair is still incomplete. So the three verdicts below are always
+issuable, and none of them is a comment on arm health.
+
+If you are ever handed a void arm anyway, that is a defect in the binary: **write it down and
+STOP.** Do not invent a fourth verdict, and do not average a harness artifact into a number.
+
+**Out of clock is not void.** An arm that hit its wall is valid, it is the arm's own result, and
+for the baseline it is the win condition.
+
+## Run
+
+1. **How many runs are you reading, and which are valid.** The cell may hold one pair or two: a
+   baseline that landed near the bar is re-run once before you are spawned. Print that first and
+   take the numbers from it.
+
+   **The number you rule on is the MEAN over VALID runs of that arm, never run 1 alone.**
+   Within-arm spread on one cell is 0.077 to 0.250 of the group — one to three gold rows — so a
+   single run is a draw, not a reading: one recorded cell read +0.538 on one run and +0.423 on
+   two. A run that is not valid is NOT averaged in and NOT counted: a dead half-pair once
+   averaged a 0.0 with a 0.944 and manufactured a phantom +0.528 cell.
+
+   If only one valid baseline run exists anyway, the second pair failed. Say so in the artifact
+   and rule on n=1 with that stated.
+
+2. **The credit table, both arms, per gold item.** This is your one mechanical input.
+
+3. **Arm health, before believing any floored number.** Wall clock against the wall, exit code,
+   whether the arm was cut off. A cut arm produces a false result in either direction.
+
+4. **What the sense arm did with its tools.**
+
+5. **How the BASELINE assembled its answer** — the route, not the number. Quote the route in your
+   artifact. One search that returned the candidate set, followed by reads of files the ask named
+   by function, means the question measured the PROMPT and not the contract. The precedent: nine
+   tool calls, one `grep -rn "Setting\."`, 17 of 18 dependents, 157 seconds of a 480 second wall.
+
+6. **What the sense arm cited that was never returned to it.** Scope the mine to THIS cycle's
+   pair; a campaign-wide root would blend in the cycles this question already replaced.
+
+## Decide
+
+**Both arms must pass, and the bar is arithmetic.** Quote the `dependents` group figures from the
+credit table and compare them in writing.
+
+- **`PROCEED`** — the baseline holds **at or below 0.50** of `dependents` AND the sense arm beats
+  it by **at least +0.50**. Both conditions, quoted. This is the shape of every banked win on the
+  record: a mini run at baseline 0 of 5 against sense 5 of 5 preceded a +1.00 cell.
+- **`REQUESTION`** — the baseline holds **above 0.50**. The question does not discriminate however
+  clean the scenario looks, because recall caps at 1.00 and a baseline at B caps the delta at
+  `1.00 − B`. The lever is the QUESTION, not the anchor: name, in your artifact, the rows the
+  baseline took and the route it used, so the next draft can ask something that route cannot
+  answer.
+- **`REQUESTION`** — the sense arm did not reach either. It never called `sense_blast`, dropped
+  what came back, or never reached synthesis inside the wall. A question the instrument cannot
+  answer is not a measurement of the baseline. Say which of the three it was.
+- **`NO-ANCHOR`** — only when the shown blast set itself cannot carry twelve dependent files,
+  which is a defect in the authoring phase, not a result. Everything else routes back for a
+  rewrite.
+
+**Cannot-finish-at-budget IS a result.** If an arm ran out of wall, that is the finding, not an
+obstacle. Never propose raising the wall.
+
+Every claim in the artifact is quoted output. A number you did not read out of the credit table or
+a run record does not go in the file.
+
+This cell is one or two runs per arm and **unscored**: it may not settle a win, a tie or a loss,
+and its number may never be cited anywhere. It decides one thing, which is whether this question
+gets a full session. State the n you ruled on, per arm: a delta carries the run count that
+produced it or it is not a delta.
+
+## Precedent
+
+- Within-arm spread on one cell: 0.077 to 0.250 of the group, one to three gold rows.
+- One cell read +0.538 on a single run and +0.423 over two.
+- A dead half-pair averaged 0.0 with 0.944 and manufactured a phantom +0.528 cell.
+- The baseline route that killed a scenario: nine tool calls, one `grep -rn "Setting\."`, 17 of 18
+  dependents, 157 seconds of a 480 second wall.
+- A mini run at baseline 0 of 5 against sense 5 of 5 preceded a +1.00 banked cell.
+
+## Artifact
+
+`minibench.md`, five headings:
+
+    # Verdict           PROCEED, REQUESTION or NO-ANCHOR, and the sentence that decides it
+    # Credit table      quoted, with the sense-only rows, the shared rows, the neither rows
+    # The two numbers   baseline dependents recall vs 0.50, and the delta vs +0.50, with the n per arm
+    # Baseline route    how it assembled the set, quoted
+    # If REQUESTION     the rows the baseline took, and what the next question must defeat
+
+## Done when
+
+- Both arms' transcripts were read from disk, not inferred from an exit code.
+- The credit table output is quoted.
+- The baseline's `dependents` recall is stated as a number and compared to 0.50 in writing.
+- The delta is stated as a number and compared to +0.50 in writing.
+- Arm health is quoted per arm, and no floored score is believed without it.
+- The n ruled on is stated per arm.
+- On `REQUESTION`, every row the baseline cited is listed by id.
+
+## Do not
+
+- Do not re-author, re-gold or edit the yaml. Name the lever; the authoring phase pulls it.
+- Do not propose raising a wall, extending a budget, or re-running to get a better sample.
+- Do not spawn a subagent. Only the binary spawns.
+
+## Questioned, not changed
+
+**The RUN steps name what to compute, not which script to invoke**, because those scripts are not
+ported into this tree yet and a plan that names a path which does not exist is worse than one that
+names the computation. Cycle 07 binds each step to its command. See `author.md` for the full note.

--- a/lab/plans/preflight.md
+++ b/lab/plans/preflight.md
@@ -1,0 +1,65 @@
+---
+phase: preflight
+reads: scenario.yaml
+writes: preflight.json
+emits: [AUTO]
+---
+
+# preflight
+
+## Task
+
+Expand the campaign into every job it implies and answer, for each one, whether it can run at all.
+
+## Scope
+
+You resolve configuration. **Out of scope:** running anything, spending anything, judging a
+scenario, any other campaign.
+
+## Run
+
+1. Expand the campaign: every repository, every subject, every arm.
+2. Resolve each job: does the model exist, can some tool drive it, is there an auth mode that
+   reaches it, does the executor exist.
+3. Reject the survivors of any cell that lost a subject.
+
+## Decide
+
+Nothing is judged. Every rejection carries a named reason, because a rejection without one is a
+mystery someone will route around by guessing.
+
+**A cell that lost a subject rejects its survivor.** This is the hazard the phase exists for, and
+without it preflight CREATES the failure rather than preventing it: if one subject of a cell
+resolves and the other does not, planning only the survivor guarantees a burned arm. The finished
+side can never be paired, and the baseline's budget derives from its partner's wall, so there is
+nothing to derive it from.
+
+Rejecting the survivor is the right direction. **A run that never happens costs nothing; a run
+that happens and cannot be paired costs its whole spend and yields no result.**
+
+## Precedent
+
+Two recorded failures have this shape:
+
+- An arm whose model id resolved to nothing returned empty at zero tokens, byte-identical in shape
+  to a session that ran and legitimately failed.
+- A half-pair whose finished arm was burned because its partner was never going to run.
+
+## Artifact
+
+`preflight.json`: every job that will run, and every rejection with its reason.
+
+## Done when
+
+- Every job in the matrix appears exactly once, either as a job or as a rejection.
+- Every rejection names its reason, and a survivor's rejection names why its partner failed rather
+  than merely reporting that one did.
+- A campaign that is malformed rather than merely unsatisfiable is an error, not a rejection list:
+  a campaign naming a subject the catalog does not have is a typo, and a campaign whose model no
+  tool can drive is a rejection with a reason. Those are different answers and they send someone
+  to different files.
+
+## Do not
+
+- Do not spend anything. This phase reads configuration.
+- Do not spawn a subagent. Only the binary spawns.

--- a/lab/plans/report.md
+++ b/lab/plans/report.md
@@ -1,0 +1,100 @@
+---
+phase: report
+reads: cells.json
+writes: report.md
+emits: [WIN, DIAGNOSIS]
+---
+
+# report
+
+## Task
+
+Read the benched cells and rule on one thing: is this a win, or is it a result to be handed up
+with its numbers.
+
+## Scope
+
+You read runs that already exist and issue one verdict. **Out of scope:** re-authoring the
+question, editing the scenario or its gold, re-scoring, running any arm, raising a wall, any other
+repository.
+
+You do not judge whether Sense did well. The numbers say that, without you.
+
+## Run
+
+1. **The build gate, before believing any column.** A non-zero exit means the installed Sense is
+   not the build the headline column was banked at. Stop and say so: there is no board to build
+   today.
+
+2. **The numbers**, per arm: the measured flag, the routing state, the run count, and whether the
+   two runs land in different dominant cells.
+
+3. **Per arm, the mechanism table and its routing states, run by run.**
+
+## Decide
+
+One verdict for the run set. The recipe, applied per arm:
+
+| what you see | what it is | what it earns |
+|---|---|---|
+| a harness failure in any run | the MCP server never came up: nothing was measured | re-run that arm |
+| fewer than 2 measured sense runs | an incomplete pair | re-run that arm |
+| the two runs land in different dominant cells | a split | re-run that arm, once, for a third run |
+| never routed, or search only | the server was up and the model did not use it | KEEP. A finding, not a fault |
+| routed, 2 measured runs | a measurement | KEEP |
+
+**A never-routed arm is never re-run to get a better number. It is the result.**
+
+Re-runs are bounded: an arm already re-run twice for the same reason is reported as it stands, with
+the reason named. Never raise a wall or a budget to rescue one.
+
+Then the verdict on the cell:
+
+- **`WIN`** — the discriminator group's delta holds at or above +0.50 across BOTH runs, or recall
+  ties and the sense arm is robustly cheaper. Quote the per-run numbers. It goes to harvest, where
+  the confirmation checks are run mechanically.
+- **`DIAGNOSIS`** — anything else. **The loop cannot record a loss**: it wins, it parks, or it
+  hands up a swap with the numbers attached. A sub-floor cell is handed up with its diagnosis
+  rather than quietly re-authored, because the cell was paid for and the finding belongs to
+  whoever decides what changes next.
+
+**Objective recall is the headline and the blind composite must never lead.** The precedent is
+expensive: the retired instrument's reporter ranked by the blind composite anyway and published a
++0.44 win as a tie. The document was right for months while the table was wrong.
+
+## Precedent
+
+- A published +0.44 win reported as a tie, because the reporter ranked by the blind composite while
+  the manifesto said objective recall leads.
+- Ten of twenty paid cells in the retired instrument were arithmetically dead before they ran, at a
+  baseline above 0.50.
+
+## Artifact
+
+`report.md`: one short section per arm, each carrying the arm's routing states, its measured run
+count, and the one line of quoted output the call was based on. Then the verdict, and on a
+diagnosis, what the numbers say and what it would take.
+
+## Done when
+
+- Every arm the campaign declares appears in the report.
+- Every claim is quoted output.
+- The discriminator delta is stated per run, not pooled, and compared to +0.50 in writing.
+- An arm that never routed is reported as a finding, in our own words, and not dressed as a model
+  failing.
+
+## Do not
+
+- Do not write a number you did not read out of the numbers, and do not re-round one.
+- Do not edit the scenario, its gold, its rubric, or any script.
+- Do not name a competing tool, promise a fix, or apologise for a gap. State it and move on.
+- Do not spawn a subagent. Only the binary spawns.
+
+## Questioned, not changed
+
+The retired instrument split this phase in two: a validity verdict on whether the run set was
+sound, and a separate reading written on top of an already-rendered board. Here the graph has one
+report phase, and the reading of what the numbers mean sits in it. The split is recorded because
+it had a reason — the reading was written after the figures were fixed, so no figure could be
+chosen to suit the sentence — and that property is held here by the rule that every claim is
+quoted output rather than by a phase boundary. Recorded rather than resolved.

--- a/lab/plans/validate.md
+++ b/lab/plans/validate.md
@@ -1,0 +1,123 @@
+---
+phase: validate
+reads: scenario.yaml
+writes: pay-call.md
+emits: [PAY, DO-NOT-PAY]
+---
+
+# validate
+
+## Task
+
+Read the unscored validation run the binary just produced against the full seven-step scenario,
+at the real wall, and rule on one thing: does this cell go to the paid bench, or back to the
+question.
+
+## Scope
+
+You read a run that already exists and issue one verdict. **Out of scope:** re-running anything,
+running the paid bench, editing the scenario or its gold, re-scoring, raising a wall, any other
+repository. You do not diagnose a paid loss; a separate phase owns that. You do not fix the
+harness.
+
+**Both arms are guaranteed to be MEASUREMENTS.** Run validity is mechanical, not a judgment: the
+runner classifies every run, retries a void arm once and parks the void one, and this phase halts
+rather than reaching you if a pair is still incomplete. So `PAY` and `DO-NOT-PAY` are always
+issuable and neither is a comment on arm health.
+
+If you are ever handed a void arm anyway, that is a defect in the binary: **write it down and
+STOP.** Never spend on a pair you cannot read.
+
+**Out of clock is not void.** An arm that hit its wall is valid, it is the arm's own result, and
+for the baseline it is the win condition.
+
+## Run
+
+1. **The credit table, both arms, per gold item.** This is your one mechanical input.
+
+2. **Arm health, before believing any floored number.** Wall clock against the wall, exit code,
+   whether the arm was cut off. A cut arm produces a false loss.
+
+3. **What the sense arm did with its tools.**
+
+4. **What it cited but was never returned, and where it fell back.** Scope the mine to THIS
+   validation cell; a campaign-wide root would blend in cells this scenario already replaced.
+
+5. **How the BASELINE assembled its answer** — the route, not the number.
+
+6. **The session row.** The mini-bench measured this same discriminator step in ISOLATION; this
+   run measures it after three steps of accumulated context and wall. Put both baseline
+   `dependents` figures side by side and state which way the session moved it. One row per cell is
+   how the loop learns whether the isolated step is a fair predictor of the session, and it is
+   free.
+
+## Decide
+
+**The bar is +0.50 on the `dependents` group, not a visible gap.** A cell can discriminate clearly
+and still be worth nothing: baseline 0.625 against sense 0.938 is a real, tool-driven gap of +0.31
+and it is a LOSS, because the floor is +0.50. Quote the delta and compare it to 0.50 explicitly
+before writing a verdict.
+
+Three readings, and only one of them pays.
+
+- **The baseline assembled too much of the set.** It cited the scattered residue at `path:line`,
+  not just the anchors, and the group delta is under +0.50. **DO-NOT-PAY.** The lever is the
+  QUESTION: name the rows the baseline took and the route it used, exactly as the mini-bench does,
+  so the next draft can defeat that route on the same anchor.
+- **Neither arm reached.** The sense arm never called `sense_blast`, dropped what came back, or
+  never reached synthesis inside the wall. **DO-NOT-PAY.** A scenario the instrument cannot answer
+  is not a measurement of the baseline.
+- **The sense arm reached what the baseline did not, by at least the floor.** The gap is in
+  `dependents`, at `path:line`, and the group delta is at or above +0.50. **PAY.**
+
+**Cannot-finish-at-budget IS a result.** If the sense arm ran out of wall, that is the verdict, not
+an obstacle. Never propose raising the wall to rescue it.
+
+Every claim in the artifact is quoted output. A number you did not read out of the credit table or
+a run record does not go in the file.
+
+This run is unscored: it may not settle a win, a tie or a loss, and its number may never be cited
+anywhere. It decides one thing, which is **whether money moves**.
+
+## Precedent
+
+- Baseline 0.625 against sense 0.938: a real, tool-driven +0.31 gap, and a loss, because the bar
+  is +0.50.
+- The arithmetic that makes the bar a screen and not a preference: `delta = sense − base` and
+  `sense ≤ 1.00`, so `+0.50` REQUIRES `base ≤ 0.50`. Ten of twenty paid cells in the retired
+  instrument were dead before they ran.
+
+## Artifact
+
+`pay-call.md`, five headings:
+
+    # Verdict         PAY or DO-NOT-PAY, and the single sentence that decides it
+    # Credit table    the sense-only rows, the shared rows, the neither rows
+    # Arm health      wall clock and exit per arm, quoted
+    # Session row     baseline dependents recall: isolated step vs full session
+    # If DO-NOT-PAY   which of the three readings, the rows the baseline took, and what the
+                      next question must defeat
+
+A `DO-NOT-PAY` keeps the anchor and the scenario on disk. The lever is the question, and the
+authoring phase rewrites it in place against this credit table.
+
+## Done when
+
+- Both arms' transcripts were read from disk, not inferred from an exit code.
+- The credit table output is quoted.
+- The `dependents` delta is stated as a number and compared to +0.50 in writing.
+- Arm health is quoted per arm, and no floored score is believed without it.
+- The session row carries both baseline figures and says which way the session moved it.
+- On `DO-NOT-PAY`, every row the baseline cited is listed by id.
+
+## Do not
+
+- Do not pay on a hand-grep, a proxy, or a scenario that "looks strong". The run decides.
+- Do not propose raising a wall, extending a budget, or re-running to get a better sample.
+- Do not spawn a subagent. Only the binary spawns.
+
+## Questioned, not changed
+
+**The RUN steps name what to compute, not which script to invoke**, because those scripts are not
+ported into this tree yet and a plan that names a path which does not exist is worse than one that
+names the computation. Cycle 07 binds each step to its command. See `author.md` for the full note.


### PR DESCRIPTION
## Problem

**This is the method.** Everything else in the rebuild is machinery that runs it.

The binary holds no prompt logic by design, so how a scenario is crafted, how a mini-bench is read, how a session is expanded, how a pay call is made and how a win is confirmed all live as prose in files a human wrote. In the retired instrument that is five files and 792 lines, the largest being authoring at 264.

Those lines are the distilled residue of a year: which asks discriminate, which gold rows can never score, what a mini-bench actually tells you, when to re-question and when to re-anchor. Almost none of it is derivable from first principles, and all of it was paid for.

**The risk is specific.** A rewrite ships a cleaner engine on day one and quietly loses the discipline, because the scoreboard stays green either way. These files, and `lab/LAWS.md`, are the only defence.

## Summary

`lab/plans/` holds one plan per phase in the graph, each written against the declared contract. `lab/internal/plans` checks them against that contract mechanically.

## Changes

- **Eleven plans, one per phase.** Each declares, in a four-key header, the phase it belongs to, the artifact it reads, the artifact it writes and its verdict enum. The header is a fixed set of keys rather than general YAML, so a malformed contract fails to parse instead of parsing into something plausible.
- **The checks run in both directions.** A plan naming a verdict the graph does not know is a plan whose routing cannot be tested. A plan *silent* on a verdict its phase can emit is worse and quieter: a case the phase really meets with no instruction for it, which is how a phase writes nothing and stalls a campaign at three in the morning. Also checked: every phase has a plan, every plan names a phase, no two plans claim one phase, and the artifacts match exactly.
- **The precedents survive.** Each plan carries the specific measured cases that justify its instructions — the seam-profile calibration, the free-row floor, the within-arm spread, the baseline route that killed a scenario, the arithmetic ceiling. Nine figures were spot-checked mechanically against their sources in the tree; none drifted.
- **The five killers** move to `lab/KILLERS.md`, tracked beside `LAWS.md`, because an instructions file that is not in the repository is one a fresh session does not have. With the rule that makes them work attached: a confirming check is not evidence, it is the absence of a test, and the killer runs before the finding is stated.
- **A plan's body is the file verbatim.** Nothing is composed; the loader hands on the bytes after the header and there is nowhere for a sentence to be added.

## The port found a hole in the graph

The old expand plan emits `REQUESTION` when the discriminator step cannot survive verbatim — a gold row that does not hold at its line, or a step that cannot be written without naming a gold file. The declared graph gave expansion `AUTO` alone, so a phase that genuinely meets that case would write nothing and stall the loop.

`REQUESTION` joins expansion's enum, the re-entry table and the lever list. A lever a recorded campaign used and the table does not carry is a hole in the test set, not a plan to bend around.

## Recorded during the build

**Eleven plans, not six.** The shaped contract table named six; the done-means says every phase in the graph has a plan, and the graph has eleven. The stricter reading won, and the mechanical check is total rather than partial.

**The largest loss in the move, stated rather than discovered.** The old plans named a specific command at every step — the citation ranking, the retention sweep, the seam profile, the shown-set probe, the gold audit. Those scripts are not ported into this tree, and a plan naming a path that does not exist is worse than one naming the computation, because a plan is followed literally. So the steps name what to compute, and **the flywheel cycle binds each one to its command.** It is recorded in `Questioned, not changed` on all five judgment plans.

## Test Plan

- `make ci` green: build, tests, per-file coverage floor with no new exception, zero complexity suppressions, lint clean.
- 100% line and function coverage on the new checker.
- The contract check runs against the shipped plans rather than a fixture, so the real files are the thing under test.
- Every failure mode has its own fixture: wrong input artifact, wrong output artifact, a verdict outside the enum, a verdict with no instruction, a plan for a phase that does not exist, a phase with no plan, two plans claiming one phase, a header with nothing under it, and three shapes of malformed header.
- Every judgment plan is checked to carry a precedent section.
- Nine precedent figures traced mechanically to their sources.