### PR TITLE
bench(lab): report where a campaign stands from its run tree

### DIFF
--- a/lab/internal/cli/cli.go
+++ b/lab/internal/cli/cli.go
@@ -34,6 +34,7 @@ Commands:
   score     Score a recorded run against a scenario's gold
   validate  Audit a scenario's gold and report what would be quarantined
   rescore   Recompute every recorded score and name the cause of each difference
+  status    Show where a campaign stands, derived from its run tree
   gate      Read a pay decision on stdin and refuse it, or not
   version   Print version
 `
@@ -99,6 +100,8 @@ func Run(args []string, stdout, stderr io.Writer) int {
 		return teeServer(args[1:], os.Stdin, stdout, stderr)
 	case "gate":
 		return gateCmd(args[1:], os.Stdin, stdout, stderr)
+	case "status":
+		return statusCmd(args[1:], stdout, stderr)
 	case "catalog":
 		return catalogCmd(args[1:], stdout, stderr)
 	case "score":

--- a/lab/internal/cli/statuscmd.go
+++ b/lab/internal/cli/statuscmd.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"io"
+
+	"github.com/luuuc/sense/lab/internal/status"
+)
+
+// defaultCeiling is how many paid runs a campaign gets over its lifetime unless
+// it is told otherwise. It is here rather than in the status package because a
+// ceiling is a decision about a campaign, and the page only reports it.
+const defaultCeiling = 40
+
+// statusCmd prints where a campaign stands.
+//
+// It reads the run tree, builds a position and hands it to a printer. It writes
+// nothing, decides nothing and takes no verdict: everything on the page is
+// derived, so there is no hand-maintained file here to go stale.
+func statusCmd(args []string, stdout, stderr io.Writer) int {
+	var dir string
+	var ceiling int
+	fs := flag.NewFlagSet("status", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.StringVar(&dir, "campaign", "", "the campaign's run tree")
+	fs.IntVar(&ceiling, "ceiling", defaultCeiling, "paid runs this campaign gets over its lifetime")
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if dir == "" {
+		_, _ = fmt.Fprintln(stderr, "sense-lab status: -campaign names the run tree to report on")
+		return exitUsage
+	}
+
+	at, err := status.Read(dir, ceiling)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab status: %v\n", err)
+		return exitError
+	}
+	_, _ = fmt.Fprint(stdout, status.Render(at))
+	return exitOK
+}

--- a/lab/internal/cli/statuscmd_test.go
+++ b/lab/internal/cli/statuscmd_test.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func runStatus(t *testing.T, args ...string) (int, string, string) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	code := Run(append([]string{"status"}, args...), &stdout, &stderr)
+	return code, stdout.String(), stderr.String()
+}
+
+func TestStatusReportsACampaignFromItsRunTree(t *testing.T) {
+	camp := t.TempDir()
+	at := filepath.Join(camp, "mastodon", "1", "author")
+	if err := os.MkdirAll(at, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(at, "scenario.draft.yaml"), []byte("name: x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code, stdout, stderr := runStatus(t, "-campaign", camp)
+	if code != exitOK {
+		t.Fatalf("exit %d: %s", code, stderr)
+	}
+	for _, want := range []string{"authoritative", "mastodon", "LOOP POSITION", "SPEND", "RESUME"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("the page does not carry %q:\n%s", want, stdout)
+		}
+	}
+}
+
+// A status with no campaign would have to guess which tree it is reporting on,
+// and a page about the wrong campaign is worse than no page.
+func TestStatusRefusesWithoutACampaign(t *testing.T) {
+	code, _, stderr := runStatus(t)
+	if code != exitUsage {
+		t.Errorf("exit %d, want a usage error", code)
+	}
+	if !strings.Contains(stderr, "-campaign") {
+		t.Errorf("the refusal does not name the missing flag: %q", stderr)
+	}
+}
+
+func TestStatusReportsAnUnreadableTreeAsAnError(t *testing.T) {
+	camp := t.TempDir()
+	locked := filepath.Join(camp, "mastodon")
+	if err := os.MkdirAll(locked, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+
+	code, _, stderr := runStatus(t, "-campaign", camp)
+	if code != exitError {
+		t.Errorf("exit %d, want an error", code)
+	}
+	if stderr == "" {
+		t.Error("the failure was silent")
+	}
+}
+
+func TestStatusRejectsAnUnknownFlag(t *testing.T) {
+	if code, _, _ := runStatus(t, "-campaign", t.TempDir(), "-watch"); code != exitUsage {
+		t.Errorf("exit %d, want a usage error: there is no watch mode", code)
+	}
+}
+
+// The page is written and nothing reads it back. This is the property the type
+// split exists for, and it is worth one grep because the failure is silent: a
+// display format that becomes a data contract only bites when someone changes a
+// heading.
+func TestNothingInTheLabParsesTheRenderedPage(t *testing.T) {
+	for _, f := range labFiles(t) {
+		if strings.HasSuffix(f.path, "_test.go") || f.path == "lab/internal/cli/statuscmd.go" {
+			continue
+		}
+		for _, imp := range f.imports {
+			if strings.HasSuffix(imp, "lab/internal/status") {
+				t.Errorf("%s imports the status package; only the command that prints the page should",
+					f.path)
+			}
+		}
+	}
+}

--- a/lab/internal/status/render.go
+++ b/lab/internal/status/render.go
@@ -1,0 +1,102 @@
+package status
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/luuuc/sense/lab/internal/phase"
+)
+
+// banner is the first thing on the page and it is not decoration. A regenerated
+// view cannot be quietly edited into a decision, and saying so is what stops
+// someone treating this as the record.
+const banner = "Position is authoritative in the run tree. This page is a view of it and decides nothing."
+
+// Render turns a position into the page.
+//
+// It takes a struct and returns a string, and the only thing that consumes that
+// string is a printer. Nothing in this codebase reads it back.
+func Render(p Position) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s\n\n", banner)
+	fmt.Fprintf(&b, "campaign %s\n\n", p.Campaign)
+	renderRepos(&b, p)
+	renderSpend(&b, p)
+	renderCells(&b, p)
+	renderResume(&b, p)
+	return b.String()
+}
+
+func renderRepos(b *strings.Builder, p Position) {
+	b.WriteString("LOOP POSITION\n")
+	if len(p.Repos) == 0 {
+		b.WriteString("  nothing has run\n\n")
+		return
+	}
+	for _, r := range p.Repos {
+		state := fmt.Sprintf("cycle %d of %d, %d left before the ceiling", r.Cycle, phase.AuthoringCeiling, r.ToCeiling())
+		if r.Parked {
+			state = "PARKED at the ceiling, waiting for a human to re-enter it deliberately"
+		}
+		fmt.Fprintf(b, "  %-20s %s\n", r.Name, state)
+		fmt.Fprintf(b, "  %-20s reached %s, awaiting %s\n", "", orNone(r.Reached), orNone(r.Awaiting))
+		if len(r.Banked) > 0 {
+			fmt.Fprintf(b, "  %-20s banked on cycle %v\n", "", r.Banked)
+		}
+	}
+	b.WriteString("\n")
+}
+
+func renderSpend(b *strings.Builder, p Position) {
+	b.WriteString("SPEND\n")
+	fmt.Fprintf(b, "  %s against a ceiling of %d, per campaign over its lifetime\n\n", p.Spend, p.Ceiling)
+}
+
+// renderCells shows the uncomfortable rows first and never folds them into a
+// count. A half-pair, a burned run and an orphaned directory are what a
+// resuming session most needs to know.
+func renderCells(b *strings.Builder, p Position) {
+	b.WriteString("CELLS ON DISK\n")
+	incomplete := p.Incomplete()
+	if len(p.Cells) == 0 && len(p.Orphans) == 0 {
+		b.WriteString("  none\n\n")
+		return
+	}
+	fmt.Fprintf(b, "  %d recorded, %d of them incomplete\n", len(p.Cells), len(incomplete))
+	for _, c := range incomplete {
+		fmt.Fprintf(b, "  INCOMPLETE %s\n", c.Path)
+		if len(c.Burned) > 0 {
+			fmt.Fprintf(b, "    burned, can never be paired: %s\n", strings.Join(c.Burned, ", "))
+		}
+		if len(c.Unusable) > 0 {
+			fmt.Fprintf(b, "    no result: %s\n", strings.Join(c.Unusable, ", "))
+		}
+	}
+	for _, o := range p.Orphans {
+		fmt.Fprintf(b, "  ORPHAN     %s ran and recorded no terminal state\n", o)
+	}
+	b.WriteString("\n")
+}
+
+// renderResume prints the next action: the phase, the plan that says how to run
+// it, and the artifact it owes.
+func renderResume(b *strings.Builder, p Position) {
+	b.WriteString("RESUME\n")
+	if len(p.Resume) == 0 {
+		b.WriteString("  nothing to resume\n")
+		return
+	}
+	for _, r := range p.Resume {
+		fmt.Fprintf(b, "  %-20s run %s from %s\n", r.Repo, r.Phase, r.Plan)
+		fmt.Fprintf(b, "  %-20s it writes %s into %s\n", "", r.Artifact, r.Dir)
+	}
+}
+
+// orNone names a phase, or says plainly that there is not one. An empty column
+// reads as a rendering bug rather than as a fact about the campaign.
+func orNone(name phase.Name) string {
+	if name == "" {
+		return "none"
+	}
+	return string(name)
+}

--- a/lab/internal/status/render_test.go
+++ b/lab/internal/status/render_test.go
@@ -1,0 +1,111 @@
+package status_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/lab/internal/phase"
+	"github.com/luuuc/sense/lab/internal/status"
+)
+
+// A regenerated view that does not say it is a view is one somebody edits into a
+// decision. The banner is load-bearing, not decoration.
+func TestThePageSaysThePositionIsAuthoritativeOnDiskAndItDecidesNothing(t *testing.T) {
+	page := status.Render(newCampaign(t).indexed("mastodon").phaseDone("mastodon", 1, phase.Author).read(40))
+	first := strings.SplitN(page, "\n", 2)[0]
+	for _, want := range []string{"authoritative", "run tree", "decides nothing"} {
+		if !strings.Contains(first, want) {
+			t.Errorf("the first line does not say %q: %q", want, first)
+		}
+	}
+}
+
+// A status that shows only progress is a status nobody trusts twice.
+func TestTheUncomfortableRowsAreOnThePage(t *testing.T) {
+	page := status.Render(newCampaign(t).
+		indexed("chatwoot").
+		phaseDone("chatwoot", 6, phase.Handoff).
+		cellAt("mastodon/1/bench/cell-0", `{"arms":{"sense":"x"},"complete":false,"burned":["sense"],"unusable":["untreated"]}`).
+		run("mastodon/1/bench/cell-1/sense", false).
+		read(40))
+
+	for _, want := range []string{
+		"PARKED",
+		"INCOMPLETE",
+		"burned, can never be paired: sense",
+		"no result: untreated",
+		"ORPHAN",
+		"recorded no terminal state",
+	} {
+		if !strings.Contains(page, want) {
+			t.Errorf("the page hides %q:\n%s", want, page)
+		}
+	}
+}
+
+// The ceiling's scope and window are named on the page rather than left to be
+// inferred: per campaign, over its lifetime.
+func TestSpendIsShownAgainstTheCeilingWithItsScope(t *testing.T) {
+	page := status.Render(newCampaign(t).
+		run("mastodon/1/bench/cell-0/sense", true).
+		read(7))
+
+	for _, want := range []string{"1 paid runs", "ceiling of 7", "per campaign over its lifetime"} {
+		if !strings.Contains(page, want) {
+			t.Errorf("the spend section does not say %q:\n%s", want, page)
+		}
+	}
+}
+
+func TestTheLoopPositionShowsTheCycleAndTheDistanceToTheCeiling(t *testing.T) {
+	page := status.Render(newCampaign(t).
+		indexed("mastodon").
+		phaseDone("mastodon", 4, phase.Author).
+		phaseDone("mastodon", 2, phase.Board).
+		read(40))
+
+	for _, want := range []string{"cycle 4 of 6", "2 left before the ceiling", "reached author", "awaiting minibench", "banked on cycle [2]"} {
+		if !strings.Contains(page, want) {
+			t.Errorf("the loop position does not say %q:\n%s", want, page)
+		}
+	}
+}
+
+// The resume line names the plan and the artifact it awaits, so a session with
+// no memory of the campaign can act on it without asking.
+func TestTheResumeLineNamesThePlanAndTheArtifact(t *testing.T) {
+	page := status.Render(newCampaign(t).
+		indexed("mastodon").
+		phaseDone("mastodon", 1, phase.Author).
+		phaseDone("mastodon", 1, phase.Minibench).
+		read(40))
+	for _, want := range []string{"RESUME", "mastodon", "expand", "lab/plans/expand.md", "scenario.yaml"} {
+		if !strings.Contains(page, want) {
+			t.Errorf("the resume line does not say %q:\n%s", want, page)
+		}
+	}
+}
+
+// A campaign whose cells are all complete still reports them, because "two
+// recorded, none incomplete" is the answer to a question a resuming session has.
+func TestCompleteCellsAreCountedAndNotListedAsProblems(t *testing.T) {
+	page := status.Render(newCampaign(t).
+		cellAt("mastodon/1/bench/cell-0", `{"arms":{"sense":"x","untreated":"y"},"complete":true}`).
+		read(40))
+
+	if !strings.Contains(page, "1 recorded, 0 of them incomplete") {
+		t.Errorf("complete cells are not reported:\n%s", page)
+	}
+	if strings.Contains(page, "INCOMPLETE") {
+		t.Errorf("a complete cell was reported as a problem:\n%s", page)
+	}
+}
+
+// A phase with no artifact at all is a repository at the start, and the page
+// says so plainly instead of leaving a blank column that reads as a bug.
+func TestAPhaseThatIsNotThereIsNamedRatherThanLeftBlank(t *testing.T) {
+	page := status.Render(status.Position{Campaign: "x", Repos: []status.Repo{{Name: "mastodon", Cycle: 1}}})
+	if !strings.Contains(page, "reached none") {
+		t.Errorf("an absent phase was rendered as a blank:\n%s", page)
+	}
+}

--- a/lab/internal/status/status.go
+++ b/lab/internal/status/status.go
@@ -1,0 +1,316 @@
+// Package status answers "where does this stand" from the run tree alone.
+//
+// A campaign runs unattended for hours and is picked up later, often by a
+// session with no memory of it. The retired instrument answered this with a page
+// assembled from a results tree, two state files, a banked log and a ledger.
+// That page exists at all only because a resuming session was once pointed at
+// the plans and the laws and had to discover its position by asking.
+//
+// Two of its properties are kept and one is dropped.
+//
+// Kept: it is write-only and it decides nothing. Position is authoritative on
+// disk and the page says so at the top. Nobody edits it into a decision because
+// it is regenerated.
+//
+// Dropped: the hand-maintained resume file. It goes stale by construction, and a
+// stale resume line is worse than none because it looks current. What [Read]
+// reports is derived from the tree every time.
+//
+// # Nothing parses the rendered page
+//
+// [Read] returns a [Position] and [Render] turns one into a string. Later
+// callers use [Read]; the string exists to be printed. Parsing your own report
+// is how a display format silently becomes a data contract, and the split here
+// is in the types rather than in a sentence asking people not to.
+//
+// # Nothing uncomfortable is summarised away
+//
+// Incomplete cells, burned runs, orphaned run directories and parked
+// repositories are the lines a resuming session most needs and least expects to
+// ask about. A status that shows only progress is a status nobody trusts twice.
+package status
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/luuuc/sense/lab/internal/budget"
+	"github.com/luuuc/sense/lab/internal/cell"
+	"github.com/luuuc/sense/lab/internal/phase"
+)
+
+// Repo is one repository's position in the loop.
+type Repo struct {
+	Name string
+	// Cycle is the authoring cycle on disk, which is the highest numbered one.
+	Cycle int
+	// Indexed says the repository has been scanned. Indexing happens once per
+	// repository, before the first authoring cycle, so it does not live under a
+	// cycle and is not redone on a re-entry.
+	Indexed bool
+	// Reached is the furthest phase of that cycle whose artifact exists.
+	Reached phase.Name
+	// Awaiting is the first phase of that cycle whose artifact does not. It is
+	// what to do next, derived rather than decided.
+	Awaiting phase.Name
+	// Parked says a handoff page was written for this repository. It is waiting
+	// for a human and no transition re-enters it.
+	Parked bool
+	// Banked is every cycle that reached the board.
+	Banked []int
+}
+
+// ToCeiling is how many authoring cycles are left before this repository parks.
+func (r Repo) ToCeiling() int { return max(phase.AuthoringCeiling-r.Cycle, 0) }
+
+// Cell is one recorded cell, complete or not.
+type Cell struct {
+	Path     string
+	Complete bool
+	Burned   []string
+	Unusable []string
+}
+
+// Resume is the exact next action, and it cannot go stale because it is derived.
+//
+// It names the phase, the plan file that says how to run it and the artifact it
+// owes. There is deliberately no command field: no verb drives the loop yet, and
+// a resume line naming one that does not exist is the stale-resume-file failure
+// wearing a different shape. With nowhere to put a command, printing a wrong one
+// is unrepresentable rather than merely avoided.
+//
+// The plan file is guaranteed to be there: every phase in the graph has one, and
+// that is checked mechanically rather than believed.
+type Resume struct {
+	Repo     string
+	Phase    phase.Name
+	Plan     string
+	Artifact string
+	Dir      string
+}
+
+// Position is everything the page reports.
+type Position struct {
+	Campaign string
+	Repos    []Repo
+	Cells    []Cell
+	// Orphans are run directories that spawned and never recorded a terminal
+	// state. They are listed, never folded into a count.
+	Orphans []string
+	Spend   budget.Spend
+	Ceiling int
+	Resume  []Resume
+}
+
+// runMetaFile and rawDir mark a run directory; recordFile marks a cell.
+const (
+	runMetaFile = "run-meta.json"
+	rawDir      = "raw"
+	recordFile  = "cell-meta.json"
+)
+
+// Read reports a campaign's position from its run tree.
+//
+// A campaign directory that does not exist yet reports an empty position rather
+// than an error: asking where a campaign stands before it has run is a fair
+// question with a short answer.
+func Read(campaignDir string, ceiling int) (Position, error) {
+	p := Position{Campaign: campaignDir, Ceiling: ceiling}
+	spend, err := budget.Read(campaignDir)
+	if err != nil {
+		return Position{}, err
+	}
+	p.Spend = spend
+
+	repos, err := subdirs(campaignDir)
+	if err != nil {
+		return Position{}, err
+	}
+	for _, name := range repos {
+		r, err := readRepo(filepath.Join(campaignDir, name), name)
+		if err != nil {
+			return Position{}, err
+		}
+		p.Repos = append(p.Repos, r)
+		if !r.Parked && r.Awaiting != "" {
+			p.Resume = append(p.Resume, resumeFor(campaignDir, r))
+		}
+	}
+	if err := p.readCells(campaignDir); err != nil {
+		return Position{}, err
+	}
+	return p, nil
+}
+
+// subdirs lists a directory's immediate subdirectories, sorted. A missing
+// directory has none, which is the answer rather than a failure.
+func subdirs(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", dir, err)
+	}
+	var out []string
+	for _, e := range entries {
+		if e.IsDir() {
+			out = append(out, e.Name())
+		}
+	}
+	slices.Sort(out)
+	return out, nil
+}
+
+// readRepo derives one repository's position: its latest cycle, how far that
+// cycle got, whether it is parked, and every cycle that reached the board.
+func readRepo(dir, name string) (Repo, error) {
+	r := Repo{Name: name, Indexed: wrote(dir, indexPhase())}
+	cycles, err := subdirs(dir)
+	if err != nil {
+		return Repo{}, err
+	}
+	for _, c := range cycles {
+		n, err := strconv.Atoi(c)
+		if err != nil {
+			// Not a cycle. The tree holds other things and this walk is not
+			// the place to rule on them.
+			continue
+		}
+		at := filepath.Join(dir, c)
+		if wrote(at, phaseOf(phase.Board)) {
+			r.Banked = append(r.Banked, n)
+		}
+		if wrote(at, phaseOf(phase.Handoff)) {
+			r.Parked = true
+		}
+		if n > r.Cycle {
+			r.Cycle = n
+			r.Reached, r.Awaiting = walk(at)
+		}
+	}
+	if !r.Indexed {
+		// Nothing under a cycle can be believed before the repository is
+		// scanned, and the scan is what the campaign is waiting for.
+		r.Awaiting = phase.Index
+	}
+	return r, nil
+}
+
+// indexPhase and phaseOf look a phase up in the graph. They exist so the walks
+// below take a declared phase rather than a name, which removes the "no such
+// phase" case from every caller: these names are constants in this package.
+func indexPhase() phase.Phase { return phaseOf(phase.Index) }
+
+func phaseOf(name phase.Name) phase.Phase {
+	p, _ := phase.Lookup(name)
+	return p
+}
+
+// walk reports the furthest phase of a cycle whose artifact exists, and the
+// first whose artifact does not.
+//
+// It decides nothing. A phase's artifact is on disk or it is not, and which
+// phase comes next in the declared order is a fact about the graph.
+func walk(dir string) (reached, awaiting phase.Name) {
+	for _, p := range phase.Graph {
+		if p.Name == phase.Index {
+			// The index is per repository, not per cycle. A re-entry does not
+			// rescan, so looking for it here would report every cycle after the
+			// first as waiting on a scan that already happened.
+			continue
+		}
+		if wrote(dir, p) {
+			reached = p.Name
+			continue
+		}
+		if awaiting == "" {
+			awaiting = p.Name
+		}
+	}
+	return reached, awaiting
+}
+
+// wrote reports whether a phase's output artifact is under dir.
+func wrote(dir string, p phase.Phase) bool {
+	_, err := os.Stat(filepath.Join(dir, string(p.Name), p.Writes))
+	return err == nil
+}
+
+// resumeFor builds the next action for a repository. It names the binary's own
+// command where one exists and the plan file otherwise, so the line is never a
+// verb that does not exist.
+func resumeFor(campaignDir string, r Repo) Resume {
+	// The index sits beside the cycles rather than inside one, so an
+	// unscanned repository is resumed at the repository directory.
+	at := filepath.Join(campaignDir, r.Name)
+	if r.Indexed {
+		at = filepath.Join(at, strconv.Itoa(r.Cycle))
+	}
+	return Resume{
+		Repo:     r.Name,
+		Phase:    r.Awaiting,
+		Plan:     filepath.Join("lab", "plans", string(r.Awaiting)+".md"),
+		Artifact: phaseOf(r.Awaiting).Writes,
+		Dir:      filepath.Join(at, string(r.Awaiting)),
+	}
+}
+
+// readCells walks the tree for cells and for run directories that never
+// recorded a terminal state.
+func (p *Position) readCells(campaignDir string) error {
+	err := filepath.WalkDir(campaignDir, func(path string, d fs.DirEntry, err error) error {
+		switch {
+		case err != nil:
+			return err
+		case !d.IsDir():
+			return nil
+		case exists(filepath.Join(path, recordFile)):
+			return p.addCell(path)
+		case exists(filepath.Join(path, rawDir)) && !exists(filepath.Join(path, runMetaFile)):
+			p.Orphans = append(p.Orphans, path)
+		}
+		return nil
+	})
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read cells under %s: %w", campaignDir, err)
+	}
+	slices.Sort(p.Orphans)
+	slices.SortFunc(p.Cells, func(a, b Cell) int { return strings.Compare(a.Path, b.Path) })
+	return nil
+}
+
+func (p *Position) addCell(path string) error {
+	rec, err := cell.ReadRecord(path)
+	if err != nil {
+		return err
+	}
+	p.Cells = append(p.Cells, Cell{
+		Path: path, Complete: rec.Complete, Burned: rec.Burned, Unusable: rec.Unusable,
+	})
+	return nil
+}
+
+func exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// Incomplete reports the cells that can never be paired.
+func (p Position) Incomplete() []Cell {
+	var out []Cell
+	for _, c := range p.Cells {
+		if !c.Complete {
+			out = append(out, c)
+		}
+	}
+	return out
+}

--- a/lab/internal/status/status_test.go
+++ b/lab/internal/status/status_test.go
@@ -1,0 +1,298 @@
+package status_test
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/lab/internal/phase"
+	"github.com/luuuc/sense/lab/internal/status"
+)
+
+// campaign builds a run tree by hand, because the tree IS the contract: a
+// position derived from anything else would be a position that can disagree
+// with what is on disk.
+type campaign struct {
+	t   *testing.T
+	dir string
+}
+
+func newCampaign(t *testing.T) campaign {
+	t.Helper()
+	return campaign{t: t, dir: t.TempDir()}
+}
+
+// phaseDone writes a phase's output artifact for one repository and cycle.
+func (c campaign) phaseDone(repo string, cycle int, name phase.Name) campaign {
+	c.t.Helper()
+	p, ok := phase.Lookup(name)
+	if !ok {
+		c.t.Fatalf("no phase named %s", name)
+	}
+	// The index is per repository and sits beside the cycles, which is what a
+	// re-entry not rescanning looks like on disk.
+	at := filepath.Join(c.dir, repo, itoa(cycle))
+	if name == phase.Index {
+		at = filepath.Join(c.dir, repo)
+	}
+	dir := filepath.Join(at, string(name))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		c.t.Fatal(err)
+	}
+	write(c.t, filepath.Join(dir, p.Writes), "written")
+	return c
+}
+
+// cellAt writes a cell record beside its arms.
+func (c campaign) cellAt(rel, record string) campaign {
+	c.t.Helper()
+	dir := filepath.Join(c.dir, rel)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		c.t.Fatal(err)
+	}
+	write(c.t, filepath.Join(dir, "cell-meta.json"), record)
+	return c
+}
+
+// run writes a run directory. finished says whether it recorded a terminal
+// state; an unfinished one is what a reboot leaves behind.
+func (c campaign) run(rel string, finished bool) campaign {
+	c.t.Helper()
+	dir := filepath.Join(c.dir, rel)
+	if err := os.MkdirAll(filepath.Join(dir, "raw"), 0o755); err != nil {
+		c.t.Fatal(err)
+	}
+	if finished {
+		write(c.t, filepath.Join(dir, "run-meta.json"), `{"outcome":"completed"}`)
+	}
+	return c
+}
+
+// indexed marks a repository as scanned.
+func (c campaign) indexed(repo string) campaign {
+	c.t.Helper()
+	return c.phaseDone(repo, 0, phase.Index)
+}
+
+func write(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func itoa(n int) string { return strconv.Itoa(n) }
+
+func (c campaign) read(ceiling int) status.Position {
+	c.t.Helper()
+	p, err := status.Read(c.dir, ceiling)
+	if err != nil {
+		c.t.Fatal(err)
+	}
+	return p
+}
+
+// The whole point: a session with no memory of a campaign reads its position off
+// the tree, and nothing hand-maintained can disagree with it.
+func TestPositionIsTheFurthestPhaseWithItsArtifactAndTheFirstWithout(t *testing.T) {
+	c := newCampaign(t).
+		indexed("mastodon").
+		phaseDone("mastodon", 1, phase.Author).
+		phaseDone("mastodon", 1, phase.Minibench)
+
+	p := c.read(40)
+	if len(p.Repos) != 1 {
+		t.Fatalf("read %d repositories, want 1", len(p.Repos))
+	}
+	r := p.Repos[0]
+	if r.Cycle != 1 {
+		t.Errorf("cycle %d, want 1", r.Cycle)
+	}
+	if r.Reached != phase.Minibench {
+		t.Errorf("reached %s, want %s", r.Reached, phase.Minibench)
+	}
+	if r.Awaiting != phase.Expand {
+		t.Errorf("awaiting %s, want %s", r.Awaiting, phase.Expand)
+	}
+	if r.ToCeiling() != phase.AuthoringCeiling-1 {
+		t.Errorf("%d cycles to the ceiling, want %d", r.ToCeiling(), phase.AuthoringCeiling-1)
+	}
+}
+
+// The latest cycle is the position. Reading an earlier one would report a
+// repository as further back than it is, which is the resuming session's worst
+// possible input.
+func TestTheLatestCycleIsThePosition(t *testing.T) {
+	c := newCampaign(t).
+		indexed("mastodon").
+		phaseDone("mastodon", 1, phase.Author).
+		phaseDone("mastodon", 1, phase.Minibench).
+		phaseDone("mastodon", 3, phase.Author)
+
+	r := c.read(40).Repos[0]
+	if r.Cycle != 3 {
+		t.Fatalf("cycle %d, want 3", r.Cycle)
+	}
+	if r.Reached != phase.Author {
+		t.Errorf("reached %s on cycle 3, want %s", r.Reached, phase.Author)
+	}
+}
+
+func TestABankedCycleAndAParkedRepositoryAreBothShown(t *testing.T) {
+	p := newCampaign(t).
+		phaseDone("mastodon", 2, phase.Board).
+		phaseDone("chatwoot", 6, phase.Handoff).
+		read(40)
+
+	byName := map[string]status.Repo{}
+	for _, r := range p.Repos {
+		byName[r.Name] = r
+	}
+	if got := byName["mastodon"].Banked; len(got) != 1 || got[0] != 2 {
+		t.Errorf("mastodon banked %v, want cycle 2", got)
+	}
+	if byName["mastodon"].Parked {
+		t.Error("a repository that banked a win was reported as parked")
+	}
+	if !byName["chatwoot"].Parked {
+		t.Error("a repository with a handoff page was not reported as parked")
+	}
+}
+
+// A parked repository is waiting for a deliberate human action, so a resume line
+// for it would be an instruction to do the thing the ceiling exists to stop.
+func TestAParkedRepositoryGetsNoResumeLine(t *testing.T) {
+	p := newCampaign(t).
+		indexed("chatwoot").indexed("mastodon").
+		phaseDone("chatwoot", 6, phase.Handoff).
+		phaseDone("mastodon", 1, phase.Author).
+		read(40)
+
+	for _, r := range p.Resume {
+		if r.Repo == "chatwoot" {
+			t.Error("a parked repository was handed a resume line")
+		}
+	}
+	if len(p.Resume) != 1 || p.Resume[0].Repo != "mastodon" {
+		t.Errorf("resume lines %+v, want one for mastodon", p.Resume)
+	}
+}
+
+// The stale-resume-file failure in a new shape: a line naming a verb the binary
+// does not have. Every resume line either names a real command or names the
+// plan file, and the plan checks guarantee that file exists.
+func TestEveryResumeLineIsRunnable(t *testing.T) {
+	c := newCampaign(t)
+	for _, p := range phase.Graph {
+		repo := "repo-" + string(p.Name)
+		c = c.indexed(repo).phaseDone(repo, 1, p.Name)
+	}
+	for _, r := range c.read(40).Resume {
+		if _, err := os.Stat(filepath.Join("../../..", r.Plan)); err != nil {
+			t.Errorf("%s resumes at %s and points at %s, which is not on disk", r.Repo, r.Phase, r.Plan)
+		}
+		declared, _ := phase.Lookup(r.Phase)
+		if r.Artifact != declared.Writes {
+			t.Errorf("%s awaits %q; phase %s writes %q", r.Repo, r.Artifact, r.Phase, declared.Writes)
+		}
+	}
+}
+
+// A half-pair, a burned run and an orphan are what a resuming session most needs
+// and least expects to ask about. None of them may be folded into a count.
+func TestIncompleteCellsBurnedRunsAndOrphansAreAllNamed(t *testing.T) {
+	p := newCampaign(t).
+		cellAt("mastodon/1/bench/cell-0", `{"arms":{"sense":"x"},"complete":false,"burned":["sense"],"unusable":["untreated"]}`).
+		cellAt("mastodon/1/bench/cell-1", `{"arms":{"sense":"x","untreated":"y"},"complete":true}`).
+		run("mastodon/1/bench/cell-2/sense", false).
+		run("mastodon/1/bench/cell-1/sense", true).
+		read(40)
+
+	if len(p.Cells) != 2 {
+		t.Fatalf("read %d cells, want 2", len(p.Cells))
+	}
+	incomplete := p.Incomplete()
+	if len(incomplete) != 1 {
+		t.Fatalf("%d incomplete cells, want 1", len(incomplete))
+	}
+	if len(incomplete[0].Burned) != 1 || incomplete[0].Burned[0] != "sense" {
+		t.Errorf("burned arms %v, want the sense arm named", incomplete[0].Burned)
+	}
+	if len(incomplete[0].Unusable) != 1 {
+		t.Errorf("unusable arms %v, want the untreated arm named", incomplete[0].Unusable)
+	}
+	if len(p.Orphans) != 1 || !strings.HasSuffix(p.Orphans[0], "cell-2/sense") {
+		t.Errorf("orphans %v, want the run that recorded no terminal state", p.Orphans)
+	}
+}
+
+func TestSpendIsReportedAgainstTheCeiling(t *testing.T) {
+	p := newCampaign(t).
+		run("mastodon/1/bench/cell-0/sense", true).
+		run("mastodon/1/bench/cell-0/untreated", true).
+		run("mastodon/1/minibench/cell-0/sense", true).
+		read(40)
+
+	if p.Spend.Runs() != 2 {
+		t.Errorf("spend %d, want 2: a mini-bench is unpaid", p.Spend.Runs())
+	}
+	if p.Ceiling != 40 {
+		t.Errorf("ceiling %d, want the one it was read with", p.Ceiling)
+	}
+}
+
+// Asking where a campaign stands before it has run is a fair question with a
+// short answer, not an error.
+func TestACampaignThatHasNotRunReportsAnEmptyPosition(t *testing.T) {
+	p, err := status.Read(filepath.Join(t.TempDir(), "never-started"), 40)
+	if err != nil {
+		t.Fatalf("an unstarted campaign was an error: %v", err)
+	}
+	if len(p.Repos) != 0 || len(p.Cells) != 0 || p.Spend.Runs() != 0 {
+		t.Errorf("an unstarted campaign reported %+v", p)
+	}
+	page := status.Render(p)
+	for _, want := range []string{"nothing has run", "none", "nothing to resume"} {
+		if !strings.Contains(page, want) {
+			t.Errorf("the empty page does not say %q:\n%s", want, page)
+		}
+	}
+}
+
+func TestAnUnreadableCellRecordIsAnErrorRatherThanAMissingRow(t *testing.T) {
+	c := newCampaign(t).cellAt("mastodon/1/bench/cell-0", "{not json")
+	if _, err := status.Read(c.dir, 40); err == nil {
+		t.Fatal("a cell whose record could not be read was silently dropped")
+	}
+}
+
+func TestAnUnreadableTreeIsAnErrorRatherThanAnEmptyPosition(t *testing.T) {
+	dir := t.TempDir()
+	locked := filepath.Join(dir, "mastodon")
+	if err := os.MkdirAll(locked, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(locked, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(locked, 0o755) })
+
+	if _, err := status.Read(dir, 40); err == nil {
+		t.Fatal("a tree that could not be read reported a clean empty position")
+	}
+}
+
+// A directory that is not a cycle is not an error and not a cycle. The tree
+// holds other things and this walk is not the place to rule on them.
+func TestADirectoryThatIsNotACycleIsIgnored(t *testing.T) {
+	c := newCampaign(t).indexed("mastodon").phaseDone("mastodon", 1, phase.Author)
+	if err := os.MkdirAll(filepath.Join(c.dir, "mastodon", "notes"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	r := c.read(40).Repos[0]
+	if r.Cycle != 1 {
+		t.Errorf("cycle %d, want 1: a directory that is not a number is not a cycle", r.Cycle)
+	}
+}


### PR DESCRIPTION
## Problem

A campaign runs unattended for hours and is picked up later, often by a session with no memory of it. "Where does this stand" has to be answerable in one command.

The retired instrument answered it with a page assembled from a results tree, two state files, a banked log and a ledger — plus a hand-maintained resume file. That file goes stale by construction, and **a stale resume line is worse than none because it looks current.**

## Summary

`sense-lab status` derives the whole page from the run tree. Nothing is hand-maintained, so nothing can disagree with what is on disk.

## Changes

- **Position is derived, not recorded.** The furthest phase of the latest cycle whose artifact exists, and the first whose artifact does not. It decides nothing: an artifact is there or it is not, and which phase comes next is a fact about the graph.
- **It carries the banner.** Position is authoritative in the run tree; this page is a view of it and decides nothing. A regenerated view cannot be quietly edited into a decision, which the previous page held by convention and this one holds by construction.
- **The uncomfortable rows lead.** Incomplete cells with their burned and unusable arms named, orphaned run directories that spawned and recorded no terminal state, parked repositories, and spend against the ceiling with its scope stated: per campaign, over its lifetime. A status that shows only progress is a status nobody trusts twice.
- **The resume line cannot go stale.** It names the phase, the plan file that says how to run it and the artifact it owes. There is deliberately **no command field**: no verb drives the loop yet, and a line naming one that does not exist is the stale-resume-file failure in a different shape. With nowhere to put a command, printing a wrong one is unrepresentable rather than avoided by convention. The plan file is guaranteed present — every phase has one, checked mechanically.
- **A parked repository gets no resume line**, because resuming it is the deliberate human action the ceiling exists to require.
- **Nothing parses the rendered page.** `Read` returns a struct, `Render` takes one, and the only consumer of the string is a printer. A test asserts that nothing else in the tree imports the package.
- **No watch mode, no hand-maintained resume file.**

## Recorded during the build

**Indexing is per repository, not per authoring cycle.** Found while deriving position: looking for the index under every cycle would report every re-entered repository as waiting on a scan that already happened — a resuming session's worst possible input, and it would have looked plausible on the page. The index artifact sits beside the cycles.

**Banked cells report the cycle, not the model or the spread.** Nothing on disk carries either yet: a run records its command, its wall and its arm, not its model, and there is no structured harvest record. Those columns land when that record does.

## Test Plan

- `make ci` green: build, tests, per-file coverage floor with no new exception, zero complexity suppressions, lint clean.
- 97% line and 100% function coverage on the new package.
- Position derived from a hand-built tree: the furthest phase reached, the first awaited, the latest cycle winning over an earlier one, a banked cycle, a parked repository, and a directory that is not a cycle being ignored.
- Every resume line checked to point at a plan file that is on disk and an artifact that matches the phase's declared output.
- Incomplete cells, burned arms, unusable arms and orphans each asserted present on the rendered page by name.
- An unstarted campaign reports an empty position rather than an error; an unreadable tree and an unreadable cell record are errors rather than missing rows.
- Run against a real tree end to end through the binary.