### PR TITLE
bench(lab): record the chain from an observation to a change

### DIFF
--- a/lab/internal/record/frommine.go
+++ b/lab/internal/record/frommine.go
@@ -1,0 +1,38 @@
+package record
+
+import (
+	"time"
+
+	"github.com/luuuc/sense/lab/internal/mine"
+)
+
+// FromMine records the miner's output as findings, with the runs it was mined
+// from as the evidence.
+//
+// It exists so the miner's output lands without hand-editing. The retired tree's
+// failure was exactly the gap this closes: miner output in a log file, an empty
+// findings directory, and three loose write-ups under a different campaign
+// connected to nothing.
+//
+// The runs are the whole mined set rather than the subset each finding fired on.
+// A finding says "3 of 6 runs" and the evidence is those six: knowing which
+// three requires opening them, and a record that named only the three would make
+// the denominator unverifiable.
+func FromMine(dir string, found []mine.Finding, runs []string, now time.Time) ([]Finding, error) {
+	out := make([]Finding, 0, len(found))
+	for _, f := range found {
+		recorded, err := RecordFinding(dir, Finding{
+			Surface:       string(f.Surface),
+			Detector:      f.Detector,
+			Subject:       f.Subject,
+			Detail:        f.String(),
+			Runs:          runs,
+			Discriminator: f.Discriminator,
+		}, now)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, recorded)
+	}
+	return out, nil
+}

--- a/lab/internal/record/record.go
+++ b/lab/internal/record/record.go
@@ -1,0 +1,375 @@
+// Package record keeps the chain from an observation to a shipped change.
+//
+// The miner produces observations. Between one and a product change there are
+// three steps that otherwise happen in someone's head and in prose: deciding an
+// observation is a finding, forming a hypothesis about which surface is at
+// fault, and proposing a change.
+//
+// Unrecorded, that chain has two failure modes and the retired tree shows both.
+// One campaign's miner output sits in a log file, its findings directory is
+// empty, and the findings that were written up live as three loose markdown
+// files under a different campaign, connected to nothing. And "why was this
+// change made to Sense" is answerable only by someone who remembers.
+//
+// # Three records, each pointing at the last
+//
+// A finding is what the miner saw. A candidate is a proposed change with its
+// hypothesis. A validation is that candidate measured, with the decision and its
+// reason.
+//
+// A finding may exist without a candidate, and most will. That is the honest
+// state of most observations, and a schema that pressured every finding into a
+// candidate would manufacture work.
+//
+// A candidate may not exist without a finding. A change with no observed problem
+// behind it is taste, and taste does not earn its way in on this bench.
+//
+// # Evidence is a path, never a copy
+//
+// A finding names run directories. One that embedded a transcript excerpt would
+// drift from the transcript the moment either was touched, and the run tree is
+// already the source of truth.
+//
+// A finding also inherits the state of its evidence: invalidating a run marks
+// every finding that cites it. A finding whose evidence is entirely invalidated
+// is marked rather than deleted, because the fact that it was once observed is
+// itself worth keeping.
+//
+// # It is a record, not a tracker
+//
+// No states beyond what is needed, no assignment, no triage, no priority. Every
+// state added is a state someone has to maintain by hand. And no database:
+// three record types with ids pointing at each other is not a schema, it is
+// files with ids, and if querying them ever genuinely hurts, that is the moment
+// SQLite was always waiting for.
+package record
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+)
+
+// The three record kinds, which are also their directories.
+const (
+	kindFinding    = "findings"
+	kindCandidate  = "candidates"
+	kindValidation = "validations"
+)
+
+// stamp is how a time is written. Absolute and to the second, because a
+// hypothesis is only "before" a validation if both can be compared later by a
+// reader who was not there.
+const stamp = time.RFC3339
+
+// Finding is what the miner saw, and where the evidence for it is.
+type Finding struct {
+	ID string `json:"id"`
+	// Surface is the Sense surface at fault. A finding without one is a number
+	// again, and it is refused.
+	Surface  string `json:"surface"`
+	Detector string `json:"detector"`
+	Subject  string `json:"subject"`
+	Detail   string `json:"detail"`
+	// Runs are paths into the run tree. Never a copy of what is in them.
+	Runs []string `json:"runs"`
+	// Invalidated names the runs that have since been invalidated. It is a
+	// subset of Runs and nothing is removed from Runs: a finding that quietly
+	// dropped its dead evidence would look like a finding with less support
+	// rather than one whose support was withdrawn.
+	Invalidated []string `json:"invalidated,omitempty"`
+	// Dead says every run behind this finding has been invalidated. The finding
+	// stays, because it was once observed.
+	Dead          bool   `json:"dead,omitempty"`
+	Discriminator bool   `json:"discriminator,omitempty"`
+	RecordedAt    string `json:"recorded_at"`
+}
+
+// Standing reports whether this finding still has evidence.
+func (f Finding) Standing() bool { return !f.Dead }
+
+// Candidate is a proposed change to Sense.
+type Candidate struct {
+	ID string `json:"id"`
+	// Finding is the observation behind it. Required.
+	Finding    string `json:"finding"`
+	Surface    string `json:"surface"`
+	Hypothesis string `json:"hypothesis"`
+	// HypothesisAt is when the hypothesis was written down. It is compared
+	// against a validation's time, because a hypothesis written afterwards is a
+	// description.
+	HypothesisAt string `json:"hypothesis_at"`
+	// TargetCells are the cells this change expects to move.
+	TargetCells []string `json:"target_cells,omitempty"`
+}
+
+// Validation is a candidate measured.
+type Validation struct {
+	ID        string `json:"id"`
+	Candidate string `json:"candidate"`
+	// Before and After are the cells' margins, keyed by cell.
+	Before map[string]float64 `json:"before,omitempty"`
+	After  map[string]float64 `json:"after,omitempty"`
+	// Regression is what the banked corpus said, and CorpusSize is how many
+	// cells said it. The size travels with the result: a pass over four cells
+	// and a pass over forty are different claims.
+	Regression string `json:"regression"`
+	CorpusSize int    `json:"corpus_size"`
+	Decision   string `json:"decision"`
+	Reason     string `json:"reason"`
+	RanAt      string `json:"ran_at"`
+}
+
+// The decisions a validation can reach. There is no third: a validation that
+// neither accepts nor rejects is a validation that has not finished.
+const (
+	Accepted = "accepted"
+	Rejected = "rejected"
+)
+
+// RecordFinding writes a finding.
+//
+// The id is derived from what the finding is about rather than generated, so
+// running the miner again over the same corpus updates the finding it already
+// wrote instead of creating a second one beside it.
+func RecordFinding(dir string, f Finding, now time.Time) (Finding, error) {
+	if f.Surface == "" {
+		return Finding{}, fmt.Errorf("a finding with no surface: the route from a number to a fix runs through a surface")
+	}
+	if len(f.Runs) == 0 {
+		return Finding{}, fmt.Errorf("finding %q cites no run; evidence is a path into the run tree", f.Subject)
+	}
+	f.ID = id("f", f.Surface, f.Detector, f.Subject)
+	f.RecordedAt = now.Format(stamp)
+	slices.Sort(f.Runs)
+	return f, write(dir, kindFinding, f.ID, f)
+}
+
+// RecordCandidate writes a proposed change.
+//
+// It refuses a candidate whose finding is not on disk. A change with no observed
+// problem behind it is taste, and a finding id that names nothing is the same
+// thing with a reference attached.
+func RecordCandidate(dir string, c Candidate, now time.Time) (Candidate, error) {
+	if c.Hypothesis == "" {
+		return Candidate{}, fmt.Errorf("a candidate with no hypothesis; there would be nothing for the measurement to be about")
+	}
+	f, err := readFinding(dir, c.Finding)
+	if err != nil {
+		return Candidate{}, err
+	}
+	if c.Surface == "" {
+		c.Surface = f.Surface
+	}
+	c.ID = id("c", c.Finding, c.Hypothesis)
+	c.HypothesisAt = now.Format(stamp)
+	return c, write(dir, kindCandidate, c.ID, c)
+}
+
+// RecordValidation writes a candidate's measurement.
+//
+// It refuses a validation that ran before its hypothesis was written down. A
+// hypothesis recorded afterwards is a description of what happened, and the
+// whole point of writing it first is that it can be wrong.
+func RecordValidation(dir string, v Validation, now time.Time) (Validation, error) {
+	c, err := readCandidate(dir, v.Candidate)
+	if err != nil {
+		return Validation{}, err
+	}
+	if v.Decision != Accepted && v.Decision != Rejected {
+		return Validation{}, fmt.Errorf("validation of %s decided %q; it accepts or it rejects", v.Candidate, v.Decision)
+	}
+	if v.Reason == "" {
+		return Validation{}, fmt.Errorf("validation of %s gives no reason; a decision nobody can re-read is a decision nobody can revisit", v.Candidate)
+	}
+	written, err := time.Parse(stamp, c.HypothesisAt)
+	if err != nil {
+		return Validation{}, fmt.Errorf("candidate %s has an unreadable hypothesis time %q: %w", c.ID, c.HypothesisAt, err)
+	}
+	if now.Before(written) {
+		return Validation{}, fmt.Errorf("this validation ran at %s and candidate %s wrote its hypothesis at %s; a hypothesis recorded after the measurement is a description",
+			now.Format(stamp), c.ID, c.HypothesisAt)
+	}
+	v.ID = id("v", v.Candidate, now.Format(stamp))
+	v.RanAt = now.Format(stamp)
+	return v, write(dir, kindValidation, v.ID, v)
+}
+
+// InvalidateRun marks every finding that cites a run, and reports them.
+//
+// Nothing is deleted. A finding whose evidence is entirely withdrawn is marked
+// dead and kept, because it was once observed and that is worth knowing.
+func InvalidateRun(dir, run string) ([]Finding, error) {
+	all, err := Findings(dir)
+	if err != nil {
+		return nil, err
+	}
+	var touched []Finding
+	for _, f := range all {
+		if !slices.Contains(f.Runs, run) || slices.Contains(f.Invalidated, run) {
+			continue
+		}
+		f.Invalidated = append(f.Invalidated, run)
+		slices.Sort(f.Invalidated)
+		f.Dead = len(f.Invalidated) == len(f.Runs)
+		if err := write(dir, kindFinding, f.ID, f); err != nil {
+			return nil, err
+		}
+		touched = append(touched, f)
+	}
+	return touched, nil
+}
+
+// Chain is one observation and everything that came of it. It answers both
+// directions: forward from a finding to whether anything was done, and backward
+// from a change to the transcripts it came from.
+type Chain struct {
+	Finding     Finding
+	Candidates  []Candidate
+	Validations []Validation
+}
+
+// Evidence is where to look: the run directories behind the finding.
+func (c Chain) Evidence() []string { return c.Finding.Runs }
+
+// Trace reports the chain around any record id, whichever end it is given.
+func Trace(dir, recordID string) (Chain, error) {
+	findingID, err := findingBehind(dir, recordID)
+	if err != nil {
+		return Chain{}, err
+	}
+	f, err := readFinding(dir, findingID)
+	if err != nil {
+		return Chain{}, err
+	}
+	chain := Chain{Finding: f}
+
+	candidates, err := Candidates(dir)
+	if err != nil {
+		return Chain{}, err
+	}
+	validations, err := Validations(dir)
+	if err != nil {
+		return Chain{}, err
+	}
+	for _, c := range candidates {
+		if c.Finding != f.ID {
+			continue
+		}
+		chain.Candidates = append(chain.Candidates, c)
+		for _, v := range validations {
+			if v.Candidate == c.ID {
+				chain.Validations = append(chain.Validations, v)
+			}
+		}
+	}
+	return chain, nil
+}
+
+// findingBehind resolves any id to the finding at the head of its chain.
+func findingBehind(dir, recordID string) (string, error) {
+	switch {
+	case strings.HasPrefix(recordID, "f-"):
+		return recordID, nil
+	case strings.HasPrefix(recordID, "c-"):
+		c, err := readCandidate(dir, recordID)
+		return c.Finding, err
+	case strings.HasPrefix(recordID, "v-"):
+		v, err := read[Validation](dir, kindValidation, recordID)
+		if err != nil {
+			return "", err
+		}
+		c, err := readCandidate(dir, v.Candidate)
+		return c.Finding, err
+	}
+	return "", fmt.Errorf("%q is not a record id", recordID)
+}
+
+// Findings, Candidates and Validations list what is on disk, by id.
+func Findings(dir string) ([]Finding, error) { return list[Finding](dir, kindFinding) }
+
+func Candidates(dir string) ([]Candidate, error) { return list[Candidate](dir, kindCandidate) }
+
+func Validations(dir string) ([]Validation, error) { return list[Validation](dir, kindValidation) }
+
+func readFinding(dir, recordID string) (Finding, error) {
+	if recordID == "" {
+		return Finding{}, fmt.Errorf("no finding behind this candidate; a change with no observed problem behind it is taste")
+	}
+	f, err := read[Finding](dir, kindFinding, recordID)
+	if err != nil {
+		return Finding{}, fmt.Errorf("finding %s: %w", recordID, err)
+	}
+	return f, nil
+}
+
+func readCandidate(dir, recordID string) (Candidate, error) {
+	if recordID == "" {
+		return Candidate{}, fmt.Errorf("no candidate behind this validation")
+	}
+	c, err := read[Candidate](dir, kindCandidate, recordID)
+	if err != nil {
+		return Candidate{}, fmt.Errorf("candidate %s: %w", recordID, err)
+	}
+	return c, nil
+}
+
+func list[T any](dir, kind string) ([]T, error) {
+	names, _ := filepath.Glob(filepath.Join(dir, kind, "*.json"))
+	slices.Sort(names)
+	out := make([]T, 0, len(names))
+	for _, name := range names {
+		b, err := os.ReadFile(name)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", name, err)
+		}
+		var v T
+		if err := json.Unmarshal(b, &v); err != nil {
+			return nil, fmt.Errorf("%s is not a readable record: %w", name, err)
+		}
+		out = append(out, v)
+	}
+	return out, nil
+}
+
+func read[T any](dir, kind, recordID string) (T, error) {
+	var v T
+	b, err := os.ReadFile(filepath.Join(dir, kind, recordID+".json"))
+	if err != nil {
+		return v, err
+	}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return v, fmt.Errorf("unreadable record: %w", err)
+	}
+	return v, nil
+}
+
+func write(dir, kind, recordID string, v any) error {
+	at := filepath.Join(dir, kind)
+	if err := os.MkdirAll(at, 0o755); err != nil {
+		return fmt.Errorf("prepare %s: %w", at, err)
+	}
+	// The records are fixed structs of strings, numbers and maps of them, so
+	// encoding cannot fail.
+	b, _ := json.MarshalIndent(v, "", "  ")
+	if err := os.WriteFile(filepath.Join(at, recordID+".json"), append(b, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", recordID, err)
+	}
+	return nil
+}
+
+// id derives a record's name from what it is about.
+//
+// Derived rather than generated, so the same observation recorded twice is the
+// same record. A generated id would turn a re-run of the miner into a second
+// copy of every finding it already wrote, and nothing about the pile would say
+// they were the same thing.
+func id(prefix string, parts ...string) string {
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+	return fmt.Sprintf("%s-%x", prefix, sum[:6])
+}

--- a/lab/internal/record/record_test.go
+++ b/lab/internal/record/record_test.go
@@ -1,0 +1,528 @@
+package record_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/lab/internal/mine"
+	"github.com/luuuc/sense/lab/internal/record"
+)
+
+// The clock is passed in rather than read, so "the hypothesis was written before
+// the measurement" is a fact a test can set up rather than one it has to wait
+// for.
+var (
+	monday  = time.Date(2026, 8, 3, 9, 0, 0, 0, time.UTC)
+	tuesday = monday.Add(24 * time.Hour)
+)
+
+func aFinding() record.Finding {
+	return record.Finding{
+		Surface:       "blast",
+		Detector:      "cited-not-returned",
+		Subject:       "g:cloud-signup-validate",
+		Detail:        "CloudOrganizationSignUpCommand.cs was cited and never returned",
+		Runs:          []string{"campaigns/csharp/bitwarden/1/bench/cell-0/sense", "campaigns/csharp/bitwarden/1/bench/cell-1/sense"},
+		Discriminator: true,
+	}
+}
+
+func recordFinding(t *testing.T, dir string) record.Finding {
+	t.Helper()
+	f, err := record.RecordFinding(dir, aFinding(), monday)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+func recordCandidate(t *testing.T, dir, finding string) record.Candidate {
+	t.Helper()
+	c, err := record.RecordCandidate(dir, record.Candidate{
+		Finding:     finding,
+		Hypothesis:  "the resolver drops a file when the dependency is established through a constructor argument",
+		TargetCells: []string{"bitwarden-server/claude-opus-5"},
+	}, monday)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+// The route from a number to a fix runs through a surface, so a finding that
+// names none is a number again.
+func TestAFindingCannotBeRecordedWithoutASurface(t *testing.T) {
+	f := aFinding()
+	f.Surface = ""
+	if _, err := record.RecordFinding(t.TempDir(), f, monday); err == nil {
+		t.Fatal("a finding with no surface was recorded")
+	}
+}
+
+// Evidence is a path into the run tree. A finding citing nothing is an opinion.
+func TestAFindingCannotBeRecordedWithoutEvidence(t *testing.T) {
+	f := aFinding()
+	f.Runs = nil
+	if _, err := record.RecordFinding(t.TempDir(), f, monday); err == nil {
+		t.Fatal("a finding citing no run was recorded")
+	}
+}
+
+// A change with no observed problem behind it is taste, and a finding id that
+// names nothing on disk is the same thing with a reference attached.
+func TestACandidateCannotBeRecordedWithoutAFindingBehindIt(t *testing.T) {
+	dir := t.TempDir()
+	for _, finding := range []string{"", "f-deadbeefdead"} {
+		_, err := record.RecordCandidate(dir, record.Candidate{
+			Finding: finding, Hypothesis: "the resolver drops constructor-argument dependencies",
+		}, monday)
+		if err == nil {
+			t.Errorf("a candidate behind finding %q was recorded", finding)
+		}
+	}
+}
+
+func TestACandidateCannotBeRecordedWithoutAHypothesis(t *testing.T) {
+	dir := t.TempDir()
+	f := recordFinding(t, dir)
+	if _, err := record.RecordCandidate(dir, record.Candidate{Finding: f.ID}, monday); err == nil {
+		t.Fatal("a candidate with no hypothesis was recorded")
+	}
+}
+
+// A hypothesis written after the measurement is a description. The whole point
+// of writing it first is that it can be wrong.
+func TestAValidationCannotPredateItsCandidatesHypothesis(t *testing.T) {
+	dir := t.TempDir()
+	c := recordCandidate(t, dir, recordFinding(t, dir).ID)
+
+	before := monday.Add(-time.Hour)
+	_, err := record.RecordValidation(dir, record.Validation{
+		Candidate: c.ID, Regression: "4 of 4 cells held", CorpusSize: 4,
+		Decision: record.Accepted, Reason: "the target cell moved from 0.31 to 0.62",
+	}, before)
+	if err == nil {
+		t.Fatal("a validation that ran before its hypothesis was written was recorded")
+	}
+	if !strings.Contains(err.Error(), "description") {
+		t.Errorf("the refusal does not say why it matters: %v", err)
+	}
+}
+
+// It accepts or it rejects. A third state is a validation that has not finished
+// wearing the clothes of one that has.
+func TestAValidationDecidesAndSaysWhy(t *testing.T) {
+	dir := t.TempDir()
+	c := recordCandidate(t, dir, recordFinding(t, dir).ID)
+
+	for _, tc := range []struct{ name, decision, reason string }{
+		{"no decision", "", "the cell moved"},
+		{"a third state", "needs more work", "the cell moved"},
+		{"no reason", record.Rejected, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := record.RecordValidation(dir, record.Validation{
+				Candidate: c.ID, Decision: tc.decision, Reason: tc.reason, CorpusSize: 4,
+			}, tuesday)
+			if err == nil {
+				t.Errorf("%s was recorded", tc.name)
+			}
+		})
+	}
+}
+
+func TestAValidationCannotBeRecordedWithoutACandidate(t *testing.T) {
+	dir := t.TempDir()
+	for _, candidate := range []string{"", "c-deadbeefdead"} {
+		_, err := record.RecordValidation(dir, record.Validation{
+			Candidate: candidate, Decision: record.Accepted, Reason: "it moved",
+		}, tuesday)
+		if err == nil {
+			t.Errorf("a validation behind candidate %q was recorded", candidate)
+		}
+	}
+}
+
+// Invalidating a run is checked through the findings rather than through the
+// code that marks them: the property is that a finding pointing at a dead run
+// says so, not that a function was called.
+func TestInvalidatingARunMarksEveryFindingThatCitesIt(t *testing.T) {
+	dir := t.TempDir()
+	recordFinding(t, dir)
+
+	other := aFinding()
+	other.Subject = "w:price-increase-scheduler"
+	other.Runs = []string{"campaigns/csharp/bitwarden/1/bench/cell-0/sense"}
+	if _, err := record.RecordFinding(dir, other, monday); err != nil {
+		t.Fatal(err)
+	}
+
+	elsewhere := aFinding()
+	elsewhere.Subject = "g:invite-users-null"
+	elsewhere.Runs = []string{"campaigns/rails/mastodon/1/bench/cell-0/sense"}
+	if _, err := record.RecordFinding(dir, elsewhere, monday); err != nil {
+		t.Fatal(err)
+	}
+
+	dead := "campaigns/csharp/bitwarden/1/bench/cell-0/sense"
+	touched, err := record.InvalidateRun(dir, dead)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(touched) != 2 {
+		t.Fatalf("marked %d findings, want the 2 that cite the run", len(touched))
+	}
+
+	byID := map[string]record.Finding{}
+	all, err := record.Findings(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range all {
+		byID[f.Subject] = f
+	}
+
+	// One of the two still has a live run behind it, so it is marked and stands.
+	partly := byID["g:cloud-signup-validate"]
+	if len(partly.Invalidated) != 1 || partly.Invalidated[0] != dead {
+		t.Errorf("the surviving finding does not name its dead run: %v", partly.Invalidated)
+	}
+	if !partly.Standing() {
+		t.Error("a finding with one live run left was marked dead")
+	}
+	if len(partly.Runs) != 2 {
+		t.Errorf("the dead run was dropped from the evidence: %v; withdrawn support is not less support",
+			partly.Runs)
+	}
+
+	// The other's only evidence is gone. It is marked, not deleted: it was once
+	// observed and that is worth keeping.
+	gone := byID["w:price-increase-scheduler"]
+	if gone.Standing() {
+		t.Error("a finding whose only run was invalidated still stands")
+	}
+	if _, ok := byID["w:price-increase-scheduler"]; !ok {
+		t.Error("a finding whose evidence died was deleted")
+	}
+
+	// A finding citing a different run is untouched.
+	if len(byID["g:invite-users-null"].Invalidated) != 0 {
+		t.Error("a finding citing another run was marked")
+	}
+}
+
+// Invalidating the same run twice must not double-count it into a false death.
+func TestInvalidatingTheSameRunTwiceChangesNothingTheSecondTime(t *testing.T) {
+	dir := t.TempDir()
+	f := recordFinding(t, dir)
+	dead := f.Runs[0]
+
+	if _, err := record.InvalidateRun(dir, dead); err != nil {
+		t.Fatal(err)
+	}
+	again, err := record.InvalidateRun(dir, dead)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(again) != 0 {
+		t.Errorf("the second invalidation marked %d findings", len(again))
+	}
+	all, err := record.Findings(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all[0].Invalidated) != 1 || all[0].Dead {
+		t.Errorf("invalidating one run twice killed a finding with two: %+v", all[0])
+	}
+}
+
+// "Why was this change made to Sense" is answerable from the change, through
+// its candidate, to its finding, to the transcripts.
+func TestTheChainIsQueryableFromEitherEnd(t *testing.T) {
+	dir := t.TempDir()
+	f := recordFinding(t, dir)
+	c := recordCandidate(t, dir, f.ID)
+	v, err := record.RecordValidation(dir, record.Validation{
+		Candidate:  c.ID,
+		Before:     map[string]float64{"bitwarden-server/claude-opus-5": 0.31},
+		After:      map[string]float64{"bitwarden-server/claude-opus-5": 0.62},
+		Regression: "4 of 4 banked cells held", CorpusSize: 4,
+		Decision: record.Accepted, Reason: "the target cell moved +0.31 and no banked cell fell",
+	}, tuesday)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Backward: from the change to the transcripts.
+	fromChange, err := record.Trace(dir, v.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fromChange.Finding.ID != f.ID {
+		t.Errorf("the validation traced to finding %s, want %s", fromChange.Finding.ID, f.ID)
+	}
+	if got := fromChange.Evidence(); len(got) != 2 {
+		t.Errorf("the chain reaches %d run directories, want the finding's 2", len(got))
+	}
+
+	// Forward: from the finding to whether anything came of it.
+	fromFinding, err := record.Trace(dir, f.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fromFinding.Candidates) != 1 || fromFinding.Candidates[0].ID != c.ID {
+		t.Errorf("the finding does not reach its candidate: %+v", fromFinding.Candidates)
+	}
+	if len(fromFinding.Validations) != 1 || fromFinding.Validations[0].Decision != record.Accepted {
+		t.Errorf("the finding does not reach its decision: %+v", fromFinding.Validations)
+	}
+
+	// And from the middle.
+	fromCandidate, err := record.Trace(dir, c.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fromCandidate.Finding.ID != f.ID || len(fromCandidate.Validations) != 1 {
+		t.Errorf("the candidate does not reach both ends: %+v", fromCandidate)
+	}
+}
+
+// Most findings never become a candidate. That is the honest state of most
+// observations, not a gap to be filled.
+func TestAFindingWithNoCandidateTracesCleanly(t *testing.T) {
+	dir := t.TempDir()
+	f := recordFinding(t, dir)
+	chain, err := record.Trace(dir, f.ID)
+	if err != nil {
+		t.Fatalf("a finding nobody acted on could not be traced: %v", err)
+	}
+	if len(chain.Candidates) != 0 || len(chain.Validations) != 0 {
+		t.Errorf("a finding with no candidate reached %+v", chain)
+	}
+}
+
+func TestAnIdThatIsNotARecordIsRefused(t *testing.T) {
+	dir := t.TempDir()
+	for _, bad := range []string{"", "mastodon", "x-1234"} {
+		if _, err := record.Trace(dir, bad); err == nil {
+			t.Errorf("%q was traced", bad)
+		}
+	}
+}
+
+// The miner's output lands without hand-editing. This is the gap the retired
+// tree fell into: miner output in a log file and an empty findings directory.
+func TestTheMinersOutputLandsAsFindings(t *testing.T) {
+	dir := t.TempDir()
+	runs := []string{"campaigns/csharp/bitwarden/1/bench/cell-0/sense", "campaigns/csharp/bitwarden/1/bench/cell-1/sense"}
+	found := []mine.Finding{
+		{Detector: "cited-not-returned", Surface: mine.Blast, Subject: "g:cloud-signup-validate",
+			Detail: "cited and never returned", Runs: 3, Total: 6, Discriminator: true},
+		{Detector: "empty-returns", Surface: mine.Graph, Subject: "sense_graph:ClaimsMap",
+			Detail: "returned nothing", Runs: 1, Total: 6},
+	}
+
+	landed, err := record.FromMine(dir, found, runs, monday)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(landed) != 2 {
+		t.Fatalf("landed %d findings, want 2", len(landed))
+	}
+	on := map[string]record.Finding{}
+	for _, f := range landed {
+		on[f.Subject] = f
+	}
+	if got := on["g:cloud-signup-validate"]; got.Surface != "blast" || !got.Discriminator {
+		t.Errorf("the discriminator miss lost its surface or its mark: %+v", got)
+	}
+	if !strings.Contains(on["g:cloud-signup-validate"].Detail, "3/6") {
+		t.Errorf("the finding lost its counts: %q", on["g:cloud-signup-validate"].Detail)
+	}
+	if got := on["sense_graph:ClaimsMap"]; got.Discriminator {
+		t.Error("an empty-return finding was marked as a discriminator miss")
+	}
+	for _, f := range landed {
+		if len(f.Runs) != len(runs) {
+			t.Errorf("%s cites %d runs, want the mined set of %d", f.Subject, len(f.Runs), len(runs))
+		}
+	}
+}
+
+// Running the miner again over the same corpus must update what it already
+// wrote. A generated id would leave a second copy of every finding with nothing
+// in the pile saying they are the same thing.
+func TestMiningTwiceDoesNotDuplicateAFinding(t *testing.T) {
+	dir := t.TempDir()
+	runs := []string{"campaigns/csharp/bitwarden/1/bench/cell-0/sense"}
+	found := []mine.Finding{{Detector: "empty-returns", Surface: mine.Graph,
+		Subject: "sense_graph:ClaimsMap", Detail: "returned nothing", Runs: 1, Total: 6}}
+
+	if _, err := record.FromMine(dir, found, runs, monday); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := record.FromMine(dir, found, runs, tuesday); err != nil {
+		t.Fatal(err)
+	}
+	all, err := record.Findings(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("mining the same corpus twice left %d findings", len(all))
+	}
+	if all[0].RecordedAt != tuesday.Format(time.RFC3339) {
+		t.Errorf("the second run did not update the record: recorded at %s", all[0].RecordedAt)
+	}
+}
+
+// A miner finding whose surface is empty would land as an unrecordable finding,
+// and the failure must be reported rather than half-written.
+func TestAMinerFindingWithNoSurfaceIsRefusedRatherThanLandedBlank(t *testing.T) {
+	dir := t.TempDir()
+	_, err := record.FromMine(dir, []mine.Finding{{Detector: "cited-not-returned", Subject: "g:one"}},
+		[]string{"run-1"}, monday)
+	if err == nil {
+		t.Fatal("a finding with no surface landed")
+	}
+	all, err := record.Findings(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 0 {
+		t.Errorf("a refused batch left %d findings behind", len(all))
+	}
+}
+
+func TestAnUnreadableRecordIsAnErrorRatherThanAMissingRow(t *testing.T) {
+	dir := t.TempDir()
+	recordFinding(t, dir)
+	if err := writeGarbage(dir); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := record.Findings(dir); err == nil {
+		t.Fatal("an unreadable record was silently skipped")
+	}
+}
+
+// writeGarbage puts an unreadable record beside a good one.
+func writeGarbage(dir string) error {
+	return os.WriteFile(filepath.Join(dir, "findings", "f-000000000000.json"), []byte("{not json"), 0o644)
+}
+
+// A record that cannot be written is a chain link that silently does not exist,
+// and the whole value of the chain is that it is complete.
+func TestARecordThatCannotBeWrittenIsAnError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	if _, err := record.RecordFinding(dir, aFinding(), monday); err == nil {
+		t.Fatal("a finding was reported as recorded into a directory that cannot be written")
+	}
+}
+
+func TestAnUnreadableCandidateOrValidationBreaksTheTraceLoudly(t *testing.T) {
+	dir := t.TempDir()
+	f := recordFinding(t, dir)
+	c := recordCandidate(t, dir, f.ID)
+	v, err := record.RecordValidation(dir, record.Validation{
+		Candidate: c.ID, Decision: record.Accepted, Reason: "the cell moved", CorpusSize: 4,
+	}, tuesday)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	corrupt(t, dir, "validations", v.ID)
+	if _, err := record.Trace(dir, v.ID); err == nil {
+		t.Error("a trace through an unreadable validation reported a clean chain")
+	}
+	if _, err := record.Validations(dir); err == nil {
+		t.Error("an unreadable validation was silently skipped")
+	}
+
+	corrupt(t, dir, "candidates", c.ID)
+	if _, err := record.Trace(dir, c.ID); err == nil {
+		t.Error("a trace through an unreadable candidate reported a clean chain")
+	}
+	if _, err := record.Candidates(dir); err == nil {
+		t.Error("an unreadable candidate was silently skipped")
+	}
+}
+
+// The hypothesis time is what "before the measurement" is compared against. An
+// unreadable one is not a pass.
+func TestACandidateWithAnUnreadableHypothesisTimeCannotBeValidated(t *testing.T) {
+	dir := t.TempDir()
+	c := recordCandidate(t, dir, recordFinding(t, dir).ID)
+	c.HypothesisAt = "last tuesday"
+	writeRaw(t, dir, "candidates", c.ID, c)
+
+	_, err := record.RecordValidation(dir, record.Validation{
+		Candidate: c.ID, Decision: record.Accepted, Reason: "the cell moved", CorpusSize: 4,
+	}, tuesday)
+	if err == nil {
+		t.Fatal("a candidate whose hypothesis time cannot be read was validated")
+	}
+}
+
+func TestInvalidatingARunOverUnreadableFindingsIsAnError(t *testing.T) {
+	dir := t.TempDir()
+	f := recordFinding(t, dir)
+	corrupt(t, dir, "findings", f.ID)
+	if _, err := record.InvalidateRun(dir, "campaigns/csharp/bitwarden/1/bench/cell-0/sense"); err == nil {
+		t.Fatal("invalidating a run over unreadable findings reported success")
+	}
+}
+
+func corrupt(t *testing.T, dir, kind, recordID string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, kind, recordID+".json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeRaw(t *testing.T, dir, kind, recordID string, v any) {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, kind, recordID+".json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A candidate whose finding has gone from disk is a broken chain, and the trace
+// says so rather than returning a chain with a blank head.
+func TestATraceThroughAMissingFindingIsAnError(t *testing.T) {
+	dir := t.TempDir()
+	f := recordFinding(t, dir)
+	c := recordCandidate(t, dir, f.ID)
+	if err := os.Remove(filepath.Join(dir, "findings", f.ID+".json")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := record.Trace(dir, c.ID); err == nil {
+		t.Fatal("a candidate whose finding is gone traced cleanly")
+	}
+}
+
+func TestARecordFileThatCannotBeOpenedIsAnError(t *testing.T) {
+	dir := t.TempDir()
+	f := recordFinding(t, dir)
+	at := filepath.Join(dir, "findings", f.ID+".json")
+	if err := os.Chmod(at, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(at, 0o644) })
+
+	if _, err := record.Findings(dir); err == nil {
+		t.Fatal("a record that could not be opened was skipped")
+	}
+}


### PR DESCRIPTION
## Problem

The miner produces observations. Between an observation and a shipped product change there are three steps that currently happen in someone's head and in prose: deciding an observation is a finding, forming a hypothesis about which surface is at fault, and proposing a change.

Unrecorded, that chain has two failure modes and the retired tree shows both. **Findings evaporate**: one campaign's miner output sits in a log file, its findings directory is empty, and the findings that did get written up live as three loose markdown files under a different campaign, connected to nothing. **And the chain cannot be audited backwards**: "why was this change made to Sense" should be answerable from the change, through its candidate, to its finding, to the transcripts, and today it is answerable only by someone who remembers.

## Summary

`lab/internal/record` keeps three record types with ids pointing at each other, on disk, as files.

## Changes

- **A finding cannot be recorded without a surface**, because the route from a number to a fix runs through one, or **without evidence**, because a finding citing nothing is an opinion.
- **A candidate cannot be recorded without a finding that is on disk.** A change with no observed problem behind it is taste, and a finding id naming nothing is the same thing with a reference attached. **A finding may exist without a candidate, and most will** — that is the honest state of most observations, and a schema pressuring every finding into a candidate would manufacture work.
- **A validation cannot predate its candidate's hypothesis.** A hypothesis written afterwards is a description, and the whole point of writing it first is that it can be wrong. An unreadable hypothesis time is a refusal, not a pass.
- **A validation accepts or it rejects, and it gives a reason.** There is no third state, and the corpus size travels with the regression result: a pass over four cells and a pass over forty are different claims.
- **Evidence is a path into the run tree, never a copy.** A finding that embedded a transcript excerpt would drift from the transcript the moment either was touched.
- **A finding inherits the state of its evidence.** Invalidating a run marks every finding that cites it. Nothing is removed from the evidence list — a finding that dropped its dead runs would read as weakly supported rather than as one whose support was withdrawn — and a finding whose support is entirely withdrawn is marked rather than deleted, because it was once observed.
- **The chain is queryable from either end**, and from the middle: from a change back to the transcripts, and from a finding forward to whether anything came of it.
- **The miner's output lands without hand-editing**, and re-mining the same corpus updates rather than duplicates, because ids are derived from what a record is about.
- **It is a record, not a tracker.** No states, no assignment, no triage, no priority. And no database: the package doc names the condition under which SQLite would be justified rather than pretending it never will be.

## Test Plan

- `make ci` green: build, tests, per-file coverage floor with no new exception, zero complexity suppressions, lint clean.
- 96% line and 100% function coverage on the new package.
- Invalidation is checked **through the findings on disk**, not through a return value, with three outcomes in one setup: one finding partly invalidated and standing, one fully invalidated and marked dead but present, one citing a different run and untouched. So "marks every finding" cannot be satisfied by marking all of them.
- Invalidating the same run twice changes nothing the second time — the append-twice bug would kill a finding that still has live evidence.
- Every refusal has its own case: no surface, no evidence, no finding, a finding id naming nothing, no hypothesis, a validation before its hypothesis, an unreadable hypothesis time, no decision, a third decision, no reason, no candidate.
- The chain traced from the validation, from the finding and from the candidate.
- A finding nobody acted on traces cleanly, because most findings never become a candidate.
- Mining twice leaves one finding, updated.
- A refused batch leaves nothing half-written; an unwritable directory, an unreadable record and a missing finding are all errors rather than silent gaps.