### PR TITLE
bench(lab): decide whether a candidate earned its way in

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -85,6 +85,8 @@ linters:
             - "**/lab/internal/gate/**"
             - "**/lab/internal/phase/**"
             - "**/lab/internal/loop/**"
+            - "**/lab/internal/mine/**"
+            - "**/lab/internal/validate/**"
           deny:
             - pkg: os
               desc: "the lab's pure core must not read a disk; recall may not depend on the state of one"
@@ -121,7 +123,7 @@ linters:
       # fixtures, and forbidding that would only push the reads into a helper
       # package and prove nothing.
       - linters: [depguard]
-        path: lab/internal/(score|plan|judge|tally|gate|phase|loop)/.*_test\.go
+        path: lab/internal/(score|plan|judge|tally|gate|phase|loop|mine|validate)/.*_test\.go
       # dupword: SQL NULL repetitions and embedded Ruby/test fixtures are fine
       - linters: [dupword]
         path: _test\.go

--- a/lab/internal/record/fromvalidate.go
+++ b/lab/internal/record/fromvalidate.go
@@ -1,0 +1,31 @@
+package record
+
+import (
+	"time"
+
+	"github.com/luuuc/sense/lab/internal/validate"
+)
+
+// FromValidate records a measured candidate, whichever way it went.
+//
+// A rejection is a result and is recorded with its numbers, not discarded. The
+// next person to have the same idea should find the measurement rather than
+// repeat it, and a path that only writes down its successes is a path that
+// invites the same experiment twice.
+func FromValidate(dir, candidate string, o validate.Outcome, now time.Time) (Validation, error) {
+	v := Validation{
+		Candidate:  candidate,
+		Before:     map[string]float64{},
+		After:      map[string]float64{},
+		Regression: o.Reason(),
+		CorpusSize: o.CorpusSize,
+		Decision:   o.Decision,
+		Reason:     o.Reason(),
+	}
+	for _, t := range o.Targets {
+		key := t.Cell + "/" + t.Model
+		v.Before[key] = t.Before
+		v.After[key] = t.After
+	}
+	return RecordValidation(dir, v, now)
+}

--- a/lab/internal/record/fromvalidate_test.go
+++ b/lab/internal/record/fromvalidate_test.go
@@ -1,0 +1,121 @@
+package record_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/lab/internal/record"
+	"github.com/luuuc/sense/lab/internal/validate"
+)
+
+func measured(targetAfter, bankedAfter float64) validate.Candidate {
+	return validate.Candidate{
+		Surface: "blast",
+		Targets: []validate.Target{
+			{Cell: "aspnetcore", Model: "claude-opus-5", Before: 0.310, After: targetAfter, Predict: validate.Up},
+		},
+		Regressions: []validate.Regression{
+			{Banked: validate.Banked{Cell: "bitwarden-server", Model: "claude-opus-5",
+				Margin: 0.625, Spread: 0.077, Surfaces: []string{"blast"}}, After: bankedAfter},
+			{Banked: validate.Banked{Cell: "mastodon", Model: "claude-opus-5",
+				Margin: 0.530, Spread: 0.125, Surfaces: []string{"blast"}}, After: 0.530},
+		},
+	}
+}
+
+// The whole chain, after the fact: a finding, the candidate it justified, the
+// measurement, and the decision, reachable from either end.
+func TestAValidationLandsOnTheChainAndIsTraceableBothWays(t *testing.T) {
+	dir := t.TempDir()
+	f := recordFinding(t, dir)
+	c := recordCandidate(t, dir, f.ID)
+
+	o, err := validate.Run(measured(0.620, 0.625))
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, err := record.FromValidate(dir, c.ID, o, tuesday)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.Decision != validate.Accepted {
+		t.Fatalf("a clean candidate landed as %s", v.Decision)
+	}
+	if v.CorpusSize != 2 {
+		t.Errorf("the record lost the corpus size: %d", v.CorpusSize)
+	}
+	if got := v.Before["aspnetcore/claude-opus-5"]; got != 0.310 {
+		t.Errorf("the record lost the before figure: %v", v.Before)
+	}
+	if got := v.After["aspnetcore/claude-opus-5"]; got != 0.620 {
+		t.Errorf("the record lost the after figure: %v", v.After)
+	}
+
+	chain, err := record.Trace(dir, v.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if chain.Finding.ID != f.ID {
+		t.Errorf("the decision does not trace back to its finding")
+	}
+	if len(chain.Evidence()) == 0 {
+		t.Error("the decision does not reach the transcripts behind it")
+	}
+}
+
+// A rejection is a result. The next person with the same idea should find the
+// measurement rather than repeat it, and a path that writes down only its
+// successes invites the same experiment twice.
+func TestARejectionIsRecordedWithItsNumbers(t *testing.T) {
+	dir := t.TempDir()
+	c := recordCandidate(t, dir, recordFinding(t, dir).ID)
+
+	o, err := validate.Run(measured(0.620, 0.400))
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, err := record.FromValidate(dir, c.ID, o, tuesday)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.Decision != validate.Rejected {
+		t.Fatalf("a candidate that broke a banked cell landed as %s", v.Decision)
+	}
+	for _, want := range []string{"bitwarden-server", "0.625", "0.400", "1 of 2 banked cells held"} {
+		if !strings.Contains(v.Reason, want) {
+			t.Errorf("the recorded rejection does not carry %q: %q", want, v.Reason)
+		}
+	}
+
+	// And it is findable by someone coming to the same idea later.
+	chain, err := record.Trace(dir, c.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(chain.Validations) != 1 || chain.Validations[0].Decision != validate.Rejected {
+		t.Errorf("the rejection is not on the candidate's chain: %+v", chain.Validations)
+	}
+}
+
+// The single-model label and the blind spot are properties of the validation and
+// have to survive being written down.
+func TestTheSingleModelLabelAndTheBlindSpotSurviveOntoTheRecord(t *testing.T) {
+	dir := t.TempDir()
+	c := recordCandidate(t, dir, recordFinding(t, dir).ID)
+
+	blind := measured(0.620, 0.625)
+	blind.Surface = "conventions"
+	o, err := validate.Run(blind)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, err := record.FromValidate(dir, c.ID, o, tuesday)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"single-model", "none of the changed surface"} {
+		if !strings.Contains(v.Regression, want) {
+			t.Errorf("the record lost %q: %q", want, v.Regression)
+		}
+	}
+}

--- a/lab/internal/validate/validate.go
+++ b/lab/internal/validate/validate.go
@@ -1,0 +1,268 @@
+// Package validate decides whether a candidate change to Sense earned its way
+// in.
+//
+// "Earned" has a definition and it is three things: the change moves the cells
+// its hypothesis named, it does not regress the ones it did not, and the
+// movement is not confined to one model.
+//
+// # The corpus is small and that matters
+//
+// The banked corpus is four cells. A regression suite of four is thin enough
+// that a change can pass it and still be wrong, so every result reports the
+// corpus size alongside it: a pass reads as "four of four held" rather than as
+// "no regressions". A result that hid the denominator would be the same claim
+// with the doubt removed.
+//
+// # The blind spot is measured, not assumed
+//
+// The corpus catches a break in something it covers. It says nothing about a
+// break in something it does not, which with four cells is the likelier real
+// case. So an [Outcome] records whether the surface the candidate touches is
+// exercised by the corpus at all. "The corpus does not cover this" is worth more
+// than the pass, because it is what says how much a green regression run means.
+//
+// # Nothing here ships anything
+//
+// This produces a verdict and its evidence. The numbers decide the verdict; a
+// human decides to ship. There is no automatic acceptance, and a rejection is a
+// result that is recorded with its numbers rather than discarded, so the next
+// person with the same idea finds the measurement instead of repeating it.
+package validate
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// Direction is what a hypothesis predicted about a cell.
+type Direction string
+
+const (
+	// Up predicts the margin grows: the change helps this cell.
+	Up Direction = "up"
+	// Down predicts it shrinks, which is what a candidate that trades one cell
+	// for another says out loud rather than discovers.
+	Down Direction = "down"
+)
+
+// Target is a cell the hypothesis named, and what it predicted.
+type Target struct {
+	Cell    string
+	Model   string
+	Before  float64
+	After   float64
+	Predict Direction
+}
+
+// Moved reports whether this cell went the way the hypothesis said.
+//
+// A cell that did not move at all has not moved in the predicted direction. A
+// hypothesis that survives "nothing happened" predicts nothing.
+func (t Target) Moved() bool {
+	switch t.Predict {
+	case Up:
+		return t.After > t.Before
+	case Down:
+		return t.After < t.Before
+	}
+	return false
+}
+
+func (t Target) String() string {
+	return fmt.Sprintf("%s on %s: %.3f to %.3f, predicted %s", t.Cell, t.Model, t.Before, t.After, t.Predict)
+}
+
+// Banked is one cell the corpus already holds: the margin it was banked at, the
+// run-to-run spread it was banked with, and the surfaces its runs exercised.
+type Banked struct {
+	Cell   string
+	Model  string
+	Margin float64
+	// Spread is the recorded run-to-run variance for this cell. A cell that
+	// lands inside its own spread has held: a regression suite that demanded an
+	// exact number would fail on the instrument's own noise.
+	Spread float64
+	// Surfaces are the Sense surfaces this cell's runs exercised. They are what
+	// makes the blind spot measurable rather than assumed.
+	Surfaces []string
+}
+
+// Held reports whether a re-measured margin is still inside this cell's spread.
+func (b Banked) Held(after float64) bool { return after >= b.Margin-b.Spread }
+
+// Regression is one banked cell re-measured.
+type Regression struct {
+	Banked Banked
+	After  float64
+}
+
+func (r Regression) Held() bool { return r.Banked.Held(r.After) }
+
+func (r Regression) String() string {
+	verb := "held"
+	if !r.Held() {
+		verb = "FELL"
+	}
+	return fmt.Sprintf("%s on %s %s: banked %.3f ±%.3f, now %.3f",
+		r.Banked.Cell, r.Banked.Model, verb, r.Banked.Margin, r.Banked.Spread, r.After)
+}
+
+// Candidate is what is being measured: the surface it changes, the cells it
+// predicted, and the corpus it is checked against.
+type Candidate struct {
+	// Surface is the Sense surface the change touches. It is what the blind spot
+	// is measured against.
+	Surface     string
+	Targets     []Target
+	Regressions []Regression
+}
+
+// Outcome is the verdict and everything behind it.
+type Outcome struct {
+	Decision string
+	// Reasons is every reason the decision was reached, not the first. An author
+	// who fixes one thing only to be refused by the next has learned nothing
+	// about the change.
+	Reasons []string
+	// CorpusSize travels with every result. Four of four held and forty of forty
+	// held are different claims.
+	CorpusSize int
+	// Models is every model the movement was seen on, and CrossModel says there
+	// was more than one. A candidate validated on a single model is recorded as
+	// single-model, never as confirmed.
+	Models     []string
+	CrossModel bool
+	// BlindSpot says the corpus exercises none of the surface this change
+	// touches, so a pass says nothing about it. Recorded as a fact rather than
+	// left implicit.
+	BlindSpot bool
+	Targets   []Target
+	Corpus    []Regression
+}
+
+// The verdicts. There is no third: a validation that neither accepts nor rejects
+// has not finished.
+const (
+	Accepted = "accepted"
+	Rejected = "rejected"
+)
+
+// Reason is the whole verdict in one line, and it always carries the
+// denominator.
+func (o Outcome) Reason() string {
+	head := fmt.Sprintf("%s: %d of %d banked cells held", o.Decision, o.heldCount(), o.CorpusSize)
+	if !o.CrossModel {
+		head += ", single-model"
+	}
+	if o.BlindSpot {
+		head += ", and the corpus exercises none of the changed surface"
+	}
+	if len(o.Reasons) == 0 {
+		return head
+	}
+	return head + "; " + strings.Join(o.Reasons, "; ")
+}
+
+func (o Outcome) heldCount() int {
+	var n int
+	for _, r := range o.Corpus {
+		if r.Held() {
+			n++
+		}
+	}
+	return n
+}
+
+// Run measures a candidate and returns the verdict with its evidence.
+//
+// It refuses a candidate whose corpus is nothing but the cells its own
+// hypothesis named: a change measured only against its own intent has been
+// measured against nothing.
+func Run(c Candidate) (Outcome, error) {
+	if len(c.Targets) == 0 {
+		return Outcome{}, fmt.Errorf("a candidate that predicts no cell; there would be nothing for it to be right or wrong about")
+	}
+	if err := independent(c); err != nil {
+		return Outcome{}, err
+	}
+
+	o := Outcome{
+		Decision:   Accepted,
+		CorpusSize: len(c.Regressions),
+		Targets:    c.Targets,
+		Corpus:     c.Regressions,
+		Models:     modelsOf(c),
+	}
+	o.CrossModel = len(o.Models) > 1
+	o.BlindSpot = blindTo(c)
+
+	for _, t := range c.Targets {
+		if !t.Moved() {
+			o.reject(fmt.Sprintf("%s did not move as predicted", t))
+		}
+	}
+	for _, r := range c.Regressions {
+		if !r.Held() {
+			o.reject(r.String())
+		}
+	}
+	return o, nil
+}
+
+func (o *Outcome) reject(why string) {
+	o.Decision = Rejected
+	o.Reasons = append(o.Reasons, why)
+}
+
+// independent refuses a corpus that is only the candidate's own targets.
+//
+// A change validated on the cells its hypothesis named, with nothing else behind
+// it, is a change measured against its own intent. The corpus has to contain at
+// least one cell the candidate did not ask about.
+func independent(c Candidate) error {
+	if len(c.Regressions) == 0 {
+		return fmt.Errorf("a candidate checked against no banked cell is measured against its own intent")
+	}
+	named := map[string]bool{}
+	for _, t := range c.Targets {
+		named[t.Cell+"/"+t.Model] = true
+	}
+	for _, r := range c.Regressions {
+		if !named[r.Banked.Cell+"/"+r.Banked.Model] {
+			return nil
+		}
+	}
+	return fmt.Errorf("every banked cell in this corpus is one the hypothesis named; a change measured only against the cells it targeted is measured against its own intent")
+}
+
+// modelsOf is every model a target actually moved on. It is the movement that
+// has to be cross-model, not the measurement: running an unchanged cell on five
+// models confirms nothing.
+func modelsOf(c Candidate) []string {
+	var out []string
+	for _, t := range c.Targets {
+		if t.Moved() && !slices.Contains(out, t.Model) {
+			out = append(out, t.Model)
+		}
+	}
+	slices.Sort(out)
+	return out
+}
+
+// blindTo reports whether the corpus exercises none of the surface the candidate
+// changes.
+//
+// A candidate that names no surface is blind by definition: nothing can be said
+// about coverage of a surface nobody stated.
+func blindTo(c Candidate) bool {
+	if c.Surface == "" {
+		return true
+	}
+	for _, r := range c.Regressions {
+		if slices.Contains(r.Banked.Surfaces, c.Surface) {
+			return false
+		}
+	}
+	return true
+}

--- a/lab/internal/validate/validate_test.go
+++ b/lab/internal/validate/validate_test.go
@@ -1,0 +1,269 @@
+package validate_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/lab/internal/validate"
+)
+
+// The four banked cells, with the surfaces their runs exercised. Four is what
+// exists, and the thinness is the point of half the tests below.
+func corpus(after ...float64) []validate.Regression {
+	banked := []validate.Banked{
+		{Cell: "bitwarden-server", Model: "claude-opus-5", Margin: 0.625, Spread: 0.077, Surfaces: []string{"blast"}},
+		{Cell: "mastodon", Model: "claude-opus-5", Margin: 0.530, Spread: 0.125, Surfaces: []string{"blast"}},
+		{Cell: "discourse", Model: "claude-opus-5", Margin: 1.000, Spread: 0.250, Surfaces: []string{"blast", "graph"}},
+		{Cell: "chatwoot", Model: "gpt-5.6-sol", Margin: 0.775, Spread: 0.100, Surfaces: []string{"graph"}},
+	}
+	out := make([]validate.Regression, len(banked))
+	for i, b := range banked {
+		held := b.Margin
+		if i < len(after) {
+			held = after[i]
+		}
+		out[i] = validate.Regression{Banked: b, After: held}
+	}
+	return out
+}
+
+// improves is a candidate that helps the cell its hypothesis named, on two
+// models, touching a surface the corpus exercises.
+func improves() validate.Candidate {
+	return validate.Candidate{
+		Surface: "blast",
+		Targets: []validate.Target{
+			{Cell: "aspnetcore", Model: "claude-opus-5", Before: 0.310, After: 0.620, Predict: validate.Up},
+			{Cell: "aspnetcore", Model: "gpt-5.6-sol", Before: 0.280, After: 0.540, Predict: validate.Up},
+		},
+		Regressions: corpus(),
+	}
+}
+
+func run(t *testing.T, c validate.Candidate) validate.Outcome {
+	t.Helper()
+	o, err := validate.Run(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return o
+}
+
+// The path is proven in both directions. A path that has only ever said yes has
+// not been tested.
+func TestACandidateThatMovesItsTargetsAndBreaksNothingIsAccepted(t *testing.T) {
+	o := run(t, improves())
+	if o.Decision != validate.Accepted {
+		t.Fatalf("a clean candidate was %s: %s", o.Decision, o.Reason())
+	}
+	if len(o.Reasons) != 0 {
+		t.Errorf("an accepted candidate carries refusals: %v", o.Reasons)
+	}
+	if !o.CrossModel {
+		t.Error("movement on two models was not recorded as cross-model")
+	}
+}
+
+// The synthetic regression: a deliberate break in something the corpus covers.
+// It has to be caught, and caught on the numbers rather than on a judgement.
+func TestADeliberateRegressionInACoveredCellIsRejectedOnTheNumbers(t *testing.T) {
+	c := improves()
+	// bitwarden-server was banked at 0.625 with a spread of 0.077, so 0.400 is
+	// outside its own noise by a wide margin.
+	c.Regressions = corpus(0.400)
+
+	o := run(t, c)
+	if o.Decision != validate.Rejected {
+		t.Fatalf("a candidate that broke a banked cell was %s", o.Decision)
+	}
+	if len(o.Reasons) != 1 {
+		t.Fatalf("rejected for %d reasons, want the one cell that fell: %v", len(o.Reasons), o.Reasons)
+	}
+	for _, want := range []string{"bitwarden-server", "0.625", "0.400"} {
+		if !strings.Contains(o.Reasons[0], want) {
+			t.Errorf("the refusal does not carry %q: %q", want, o.Reasons[0])
+		}
+	}
+}
+
+// A cell that wobbles inside its own recorded spread has held. A suite that
+// demanded an exact number would fail on the instrument's own noise.
+func TestACellInsideItsRecordedSpreadHasHeld(t *testing.T) {
+	c := improves()
+	// Banked at 0.625 ± 0.077. 0.560 is inside; 0.540 is not.
+	c.Regressions = corpus(0.560)
+	if o := run(t, c); o.Decision != validate.Accepted {
+		t.Errorf("a cell inside its own spread was called a regression: %s", o.Reason())
+	}
+
+	c.Regressions = corpus(0.540)
+	if o := run(t, c); o.Decision != validate.Rejected {
+		t.Errorf("a cell outside its own spread was called a hold: %s", o.Reason())
+	}
+}
+
+// A hypothesis that survives "nothing happened" predicts nothing.
+func TestATargetThatDidNotMoveIsARejection(t *testing.T) {
+	c := improves()
+	c.Targets[0].After = c.Targets[0].Before
+
+	o := run(t, c)
+	if o.Decision != validate.Rejected {
+		t.Fatalf("a target that did not move was %s", o.Decision)
+	}
+	if !strings.Contains(o.Reason(), "did not move as predicted") {
+		t.Errorf("the refusal does not say what failed: %q", o.Reason())
+	}
+}
+
+// A candidate that trades one cell for another says so out loud, and is judged
+// against what it said rather than against improvement in general.
+func TestAPredictedFallIsAMoveAndAnUnpredictedRiseIsNot(t *testing.T) {
+	c := improves()
+	c.Targets[1].Predict = validate.Down
+	c.Targets[1].Before, c.Targets[1].After = 0.540, 0.280
+	if o := run(t, c); o.Decision != validate.Accepted {
+		t.Errorf("a predicted fall was treated as a regression: %s", o.Reason())
+	}
+
+	c.Targets[1].Before, c.Targets[1].After = 0.280, 0.540
+	if o := run(t, c); o.Decision != validate.Rejected {
+		t.Errorf("a cell that rose when a fall was predicted was accepted: %s", o.Reason())
+	}
+}
+
+// Every reason, not the first. Someone who fixes one and is refused by the next
+// has learned nothing about the change.
+func TestEveryFailureIsReportedNotTheFirst(t *testing.T) {
+	c := improves()
+	c.Targets[0].After = c.Targets[0].Before
+	c.Regressions = corpus(0.400, 0.200)
+
+	o := run(t, c)
+	if len(o.Reasons) != 3 {
+		t.Fatalf("reported %d reasons, want the target and both fallen cells: %v", len(o.Reasons), o.Reasons)
+	}
+}
+
+// The corpus size travels with the result. A pass reads as "four of four held",
+// never as "no regressions".
+func TestEveryResultCarriesTheCorpusSize(t *testing.T) {
+	o := run(t, improves())
+	if o.CorpusSize != 4 {
+		t.Errorf("corpus size %d, want 4", o.CorpusSize)
+	}
+	if !strings.Contains(o.Reason(), "4 of 4 banked cells held") {
+		t.Errorf("the result hides its denominator: %q", o.Reason())
+	}
+
+	broken := improves()
+	broken.Regressions = corpus(0.400)
+	if got := run(t, broken).Reason(); !strings.Contains(got, "3 of 4 banked cells held") {
+		t.Errorf("a rejection hides its denominator: %q", got)
+	}
+}
+
+// The blind spot is measured rather than assumed. The corpus catching a break in
+// something it covers says nothing about a break in something it does not, and
+// with four cells that is the likelier real case.
+func TestARegressionInASurfaceTheCorpusDoesNotCoverPassesAndIsRecordedAsABlindSpot(t *testing.T) {
+	c := improves()
+	c.Surface = "conventions"
+
+	o := run(t, c)
+	if o.Decision != validate.Accepted {
+		t.Fatalf("the corpus claimed to catch a break in a surface it never exercises: %s", o.Reason())
+	}
+	if !o.BlindSpot {
+		t.Fatal("a pass over a surface the corpus does not cover was not recorded as a blind spot")
+	}
+	if !strings.Contains(o.Reason(), "none of the changed surface") {
+		t.Errorf("the blind spot is not on the result: %q", o.Reason())
+	}
+
+	// And a surface the corpus does exercise is not a blind spot, so the mark
+	// is not simply always set.
+	if run(t, improves()).BlindSpot {
+		t.Error("a candidate touching a covered surface was called a blind spot")
+	}
+}
+
+// A candidate that names no surface cannot have its coverage assessed, and
+// silence is not coverage.
+func TestACandidateThatNamesNoSurfaceIsBlindByDefinition(t *testing.T) {
+	c := improves()
+	c.Surface = ""
+	if !run(t, c).BlindSpot {
+		t.Error("a candidate naming no surface was reported as covered")
+	}
+}
+
+// A candidate validated on one model is recorded as single-model, never as
+// confirmed. Cycle 08 brings the other tools; until then this is a fact about
+// the validation, not a footnote.
+func TestMovementOnOneModelIsRecordedAsSingleModel(t *testing.T) {
+	c := improves()
+	c.Targets = c.Targets[:1]
+
+	o := run(t, c)
+	if o.CrossModel {
+		t.Error("movement on one model was reported as cross-model")
+	}
+	if len(o.Models) != 1 || o.Models[0] != "claude-opus-5" {
+		t.Errorf("models %v, want the one it moved on", o.Models)
+	}
+	if !strings.Contains(o.Reason(), "single-model") {
+		t.Errorf("the result does not say it is single-model: %q", o.Reason())
+	}
+}
+
+// It is the MOVEMENT that has to be cross-model, not the measurement. Running an
+// unchanged cell on five models confirms nothing.
+func TestAModelWhereNothingMovedDoesNotMakeAResultCrossModel(t *testing.T) {
+	c := improves()
+	c.Targets[1].After = c.Targets[1].Before
+
+	o := run(t, c)
+	if o.CrossModel {
+		t.Errorf("a model where nothing moved counted toward cross-model: %v", o.Models)
+	}
+}
+
+// A change validated only on the cells its own hypothesis named has been
+// measured against its own intent.
+func TestACandidateCannotBeValidatedOnlyAgainstTheCellsItTargeted(t *testing.T) {
+	own := []validate.Regression{{
+		Banked: validate.Banked{Cell: "aspnetcore", Model: "claude-opus-5", Margin: 0.310, Spread: 0.05},
+		After:  0.620,
+	}}
+	c := improves()
+	c.Targets = c.Targets[:1]
+	c.Regressions = own
+
+	if _, err := validate.Run(c); err == nil {
+		t.Fatal("a candidate was validated against nothing but its own targets")
+	}
+
+	c.Regressions = nil
+	if _, err := validate.Run(c); err == nil {
+		t.Fatal("a candidate was validated against no banked cell at all")
+	}
+}
+
+func TestACandidateThatPredictsNothingIsRefused(t *testing.T) {
+	c := improves()
+	c.Targets = nil
+	if _, err := validate.Run(c); err == nil {
+		t.Fatal("a candidate predicting no cell was validated")
+	}
+}
+
+// A prediction that is not a direction predicts nothing, and must not pass by
+// default.
+func TestATargetWithNoPredictedDirectionHasNotMoved(t *testing.T) {
+	c := improves()
+	c.Targets[0].Predict = ""
+	if o := run(t, c); o.Decision != validate.Rejected {
+		t.Errorf("a target with no predicted direction was accepted: %s", o.Reason())
+	}
+}


### PR DESCRIPTION
## Problem

A candidate change to Sense has to earn its way in, and "earn" has a definition: it moves the cells it targeted, it does not regress the ones it did not, and the movement is not an artifact of one model. Nothing in the instrument did that.

**The corpus is small and that matters.** Four banked cells is thin enough that a change can pass it and still be wrong, which is worth stating rather than discovering.

## Summary

`lab/internal/validate` measures a candidate against three checks and produces a verdict with its evidence. `record.FromValidate` writes it onto the chain, whichever way it went.

## Changes

- **Three checks.** The target cells move in the direction the hypothesis predicted; every banked cell holds; the movement is not confined to one model.
- **A cell holds if it lands inside its own recorded spread.** A suite demanding an exact number would fail on the instrument's own noise, and the banked spreads are real — 0.077, 0.125, 0.250.
- **The corpus size travels with every result.** A pass reads as "four of four held", never as "no regressions". A result that hid the denominator would be the same claim with the doubt removed.
- **The blind spot is measured, not assumed.** When the corpus exercises none of the surface a change touches, the pass says nothing about it, and the outcome records that. With four cells, a break in something the corpus does not cover is the likelier real case, and "the corpus does not cover this" is worth more than the pass.
- **Single-model is a label, not a footnote.** Movement seen on one model is recorded as single-model, never as cross-model confirmed. And it is the *movement* that must be cross-model, not the measurement: running an unchanged cell on five models confirms nothing.
- **A target that did not move has not moved as predicted.** A hypothesis that survives "nothing happened" predicts nothing, and a prediction that is not a direction predicts nothing either.
- **Every reason, not the first.** Someone who fixes one failure only to be refused by the next has learned nothing about the change.
- **A corpus made only of the candidate's own targets is refused**, because that is a change measured against its own intent.
- **Nothing ships anything.** The numbers decide the verdict; a human decides to ship. A rejection is recorded with its numbers rather than discarded, so the next person with the same idea finds the measurement instead of repeating it.

## Recorded during the build

**The synthetic regression is a test, not a checked-in broken Sense.** Putting a deliberate one-line regression into the product and running a real campaign against it would cost a campaign to prove arithmetic. The path is proven on measured numbers instead, in both directions and in the blind spot. The real thing lands in the flywheel cycle, against a real change.

## Test Plan

- `make ci` green: build, tests, per-file coverage floor with no new exception, zero complexity suppressions, lint clean.
- 100% line and function coverage on the new package.
- **Both directions**: a candidate that moves its targets and breaks nothing is accepted; one that breaks a covered banked cell is rejected, and the refusal carries the cell, its banked margin and its new one.
- **The blind spot asserted as a pass**: a change to a surface no banked cell exercises passes the corpus and is recorded as a blind spot — and a change to a covered surface is asserted *not* to be one, so the mark is not always set.
- The spread boundary tested from both sides: 0.560 against a banked 0.625 ± 0.077 holds, 0.540 does not.
- A model where nothing moved is asserted *not* to count toward cross-model.
- A predicted fall is a move; an unpredicted rise is not.
- Three failures from one candidate, to prove "every reason" is not "the first reason".
- The full chain end to end: finding, candidate, measurement, decision, traced from the decision back to the transcripts and from the finding forward to the verdict — for a rejection as well as an acceptance.