### PR TITLE
bench(lab): choose and judge the replay of a banked cell

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -87,6 +87,7 @@ linters:
             - "**/lab/internal/loop/**"
             - "**/lab/internal/mine/**"
             - "**/lab/internal/validate/**"
+            - "**/lab/internal/replay/**"
           deny:
             - pkg: os
               desc: "the lab's pure core must not read a disk; recall may not depend on the state of one"
@@ -123,7 +124,7 @@ linters:
       # fixtures, and forbidding that would only push the reads into a helper
       # package and prove nothing.
       - linters: [depguard]
-        path: lab/internal/(score|plan|judge|tally|gate|phase|loop|mine|validate)/.*_test\.go
+        path: lab/internal/(score|plan|judge|tally|gate|phase|loop|mine|validate|replay)/.*_test\.go
       # dupword: SQL NULL repetitions and embedded Ruby/test fixtures are fine
       - linters: [dupword]
         path: _test\.go

--- a/lab/internal/replay/replay.go
+++ b/lab/internal/replay/replay.go
@@ -1,0 +1,250 @@
+// Package replay chooses a banked cell to re-run live and rules on what came
+// back.
+//
+// Everything measured so far has been measured against recordings: the scorer
+// reproduces recorded scores, the gates reproduce recorded decisions, the miner
+// reproduces misses found by hand. All of that proves the pure layer reads the
+// past correctly, and none of it proves the instrument can produce a result.
+// Between a recorded transcript and a live cell sit isolation, supervision, the
+// tee, the session, the judge and the verdict layer, and every one of them is
+// new.
+//
+// # The model has to match, and that is the trap
+//
+// A banked number is a number for a model. There is a recorded case: a banked
+// mastodon cell measured +0.625 on one model and 0.00 on its successor, because
+// the newer baseline arm closed the axis the scenario tested. Replayed on the
+// wrong model that cell looks like a broken instrument while being a working one
+// measuring a changed world.
+//
+// So [Pick] pins the model. If the banked model is unreachable it picks a
+// different CELL, never a different model, and it reports the cell it could not
+// replay: a number banked on a retired model is history rather than a live
+// result.
+//
+// # Agreement is a band, not a number
+//
+// The measured same-cell spreads run from 0.077 to 0.250, so agreement means
+// landing inside the cell's own recorded spread rather than reproducing its
+// margin exactly.
+//
+// # What a disagreement means, in order
+//
+// First suspect the new instrument, then the environment, then the world. Not
+// the reverse: the whole point of choosing a banked cell is that its answer is
+// known, so a replay that disagrees is a bug in sense-lab until something else
+// is demonstrated.
+//
+// And that ordering needs a stopping point or it is a licence to debug
+// indefinitely. When the instrument and the environment both check out, the next
+// step is to run the pair again. One live pair is n=1 against a spread that
+// reaches 0.250, so a single disagreement is inside ordinary variance, and two
+// independent pairs disagreeing the same way is a different claim from one.
+package replay
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// Bar is the margin a cell must clear to be a win. A replay is judged against
+// the banked margin rather than against this, but the choice of cell is not: a
+// cell that banked near the bar cannot tell a broken instrument from ordinary
+// variance.
+const Bar = 0.50
+
+// Cell is one banked result: what it measured, on which model, with what
+// run-to-run spread, and the scenario it measured.
+type Cell struct {
+	Repo  string
+	Model string
+	// Margin is the banked delta on the discriminator group.
+	Margin float64
+	// Spread is the widest gap between that cell's own runs. It is the band
+	// agreement is judged in.
+	Spread float64
+	// Scenario pins the version that was measured. A replay of a different
+	// scenario is not a replay.
+	Scenario string
+}
+
+// Unambiguous reports whether this cell's worst run is still clear of the bar.
+//
+// A cell that banked near the bar cannot distinguish a broken instrument from
+// ordinary variance, so it cannot answer the question a replay is asking.
+func (c Cell) Unambiguous() bool { return c.Margin-c.Spread > Bar }
+
+func (c Cell) String() string {
+	return fmt.Sprintf("%s on %s: banked %.3f, spread %.3f, scenario %s",
+		c.Repo, c.Model, c.Margin, c.Spread, c.Scenario)
+}
+
+// Skipped is a banked cell that cannot be replayed, and why. It is reported
+// rather than dropped: that a cell can no longer be replayed is itself a fact
+// about the corpus.
+type Skipped struct {
+	Cell Cell
+	Why  string
+}
+
+func (s Skipped) String() string { return s.Cell.String() + " — " + s.Why }
+
+// Pick chooses the cell to replay from the banked corpus, given the models that
+// can still be reached.
+//
+// It picks the cell whose worst run is furthest clear of the bar, because a
+// disagreement there is unambiguous. Every cell it did not pick is reported with
+// the reason, so a corpus that has quietly become unreplayable says so.
+func Pick(banked []Cell, reachable []string) (Cell, []Skipped, error) {
+	var best Cell
+	var found bool
+	var skipped []Skipped
+	for _, c := range banked {
+		switch {
+		case !slices.Contains(reachable, c.Model):
+			skipped = append(skipped, Skipped{c, fmt.Sprintf("%s is unreachable, and a banked number is a number for a model", c.Model)})
+		case !c.Unambiguous():
+			skipped = append(skipped, Skipped{c, fmt.Sprintf("its worst run lands at %.3f against a bar of %.2f, so a disagreement could be ordinary variance",
+				c.Margin-c.Spread, Bar)})
+		case !found || c.Margin-c.Spread > best.Margin-best.Spread:
+			if found {
+				skipped = append(skipped, Skipped{best, "another cell is further clear of the bar"})
+			}
+			best, found = c, true
+		default:
+			skipped = append(skipped, Skipped{c, "another cell is further clear of the bar"})
+		}
+	}
+	if !found {
+		return Cell{}, skipped, fmt.Errorf("no banked cell can be replayed: %d were considered, and picking a different model instead of a different cell is what this refuses",
+			len(banked))
+	}
+	return best, skipped, nil
+}
+
+// Verdict is what a live pair said about a banked cell.
+type Verdict struct {
+	Cell     Cell
+	Measured float64
+	Agrees   bool
+	// StillAWin says the live pair clears the bar. It is separate from Agrees:
+	// a cell can land outside its recorded spread and still be a win, and those
+	// are different facts.
+	StillAWin bool
+}
+
+func (v Verdict) String() string {
+	verb := "DISAGREES with"
+	if v.Agrees {
+		verb = "agrees with"
+	}
+	return fmt.Sprintf("%.3f %s the banked %.3f ±%.3f on %s",
+		v.Measured, verb, v.Cell.Margin, v.Cell.Spread, v.Cell.Repo)
+}
+
+// Compare rules on a live measurement against its banked cell.
+//
+// Agreement is landing inside the cell's own recorded spread, in either
+// direction. Demanding the banked number exactly would fail on the instrument's
+// own noise; allowing anything above it would let a broken measurement pass by
+// being generous.
+func Compare(c Cell, measured float64) Verdict {
+	return Verdict{
+		Cell:      c,
+		Measured:  measured,
+		Agrees:    measured >= c.Margin-c.Spread && measured <= c.Margin+c.Spread,
+		StillAWin: measured >= Bar,
+	}
+}
+
+// Step is what to do next about a disagreement.
+type Step string
+
+const (
+	// Settled: the replay agreed and there is nothing to investigate.
+	Settled Step = "the replay agreed; nothing to investigate"
+	// SuspectTheInstrument is always first. The cell's answer is known, so a
+	// disagreement is a bug in sense-lab until something else is demonstrated.
+	SuspectTheInstrument Step = "suspect sense-lab: the cell's answer is known, so a disagreement is a bug here until something else is shown"
+	// SuspectTheEnvironment is second: the checkout, the index, the subject, the
+	// channels the arm actually had.
+	SuspectTheEnvironment Step = "suspect the environment: the checkout, the index, the subject and the channels each arm reached"
+	// RunASecondPair is the stopping point. One pair is n=1 against a spread
+	// that reaches 0.250.
+	RunASecondPair Step = "run the pair once more: one live pair is n=1, and the measured same-cell spread reaches 0.250"
+	// TheWorldMoved is reached only after all three. It is a real answer and it
+	// is the last one, not the first.
+	TheWorldMoved Step = "the world moved: two independent pairs disagree the same way, and the instrument and environment both check out"
+)
+
+// Checks is what has been ruled out so far, and how many live pairs have been
+// run.
+type Checks struct {
+	InstrumentClean  bool
+	EnvironmentClean bool
+	// Pairs is how many independent live pairs have disagreed the same way.
+	Pairs int
+}
+
+// Investigate reports the next step, in the one order that does not let a
+// conclusion about the world be reached first.
+func Investigate(v Verdict, done Checks) Step {
+	switch {
+	case v.Agrees:
+		return Settled
+	case !done.InstrumentClean:
+		return SuspectTheInstrument
+	case !done.EnvironmentClean:
+		return SuspectTheEnvironment
+	case done.Pairs < 2:
+		return RunASecondPair
+	}
+	return TheWorldMoved
+}
+
+// Inputs are what a replay pins. Every one of them is a thing that, changed,
+// makes the comparison meaningless.
+type Inputs struct {
+	Model    string
+	Scenario string
+	Wall     string
+	Prompt   string
+	Gold     string
+	Subject  string
+}
+
+// Drift reports every pinned input that differs between the banked run and the
+// replay.
+//
+// It exists because "nothing was adjusted to make it land" is a claim, and a
+// replay tuned until it agrees has proven that tuning works. This is how the
+// claim is checked rather than asserted.
+func Drift(banked, live Inputs) []string {
+	var out []string
+	for _, f := range []struct {
+		name          string
+		before, after string
+	}{
+		{"model", banked.Model, live.Model},
+		{"scenario", banked.Scenario, live.Scenario},
+		{"wall", banked.Wall, live.Wall},
+		{"prompt", banked.Prompt, live.Prompt},
+		{"gold", banked.Gold, live.Gold},
+		{"subject", banked.Subject, live.Subject},
+	} {
+		if f.before != f.after {
+			out = append(out, fmt.Sprintf("%s: banked %q, replayed %q", f.name, f.before, f.after))
+		}
+	}
+	return out
+}
+
+// Pinned reports whether nothing moved, and says what did.
+func Pinned(banked, live Inputs) (bool, string) {
+	drift := Drift(banked, live)
+	if len(drift) == 0 {
+		return true, "every pinned input matches the banked run"
+	}
+	return false, "this is not a replay: " + strings.Join(drift, "; ")
+}

--- a/lab/internal/replay/replay_test.go
+++ b/lab/internal/replay/replay_test.go
@@ -1,0 +1,340 @@
+package replay_test
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/lab/internal/replay"
+)
+
+// The fixture is the real banked corpus: five cells across two campaigns, with
+// each cell's margin and its own run-to-run spread derived from the runs it was
+// banked on.
+func banked(t *testing.T) []replay.Cell {
+	t.Helper()
+	b, err := os.ReadFile("testdata/banked.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var rows []struct {
+		Repo     string  `json:"repo"`
+		Model    string  `json:"model"`
+		Margin   float64 `json:"margin"`
+		Spread   float64 `json:"spread"`
+		Scenario string  `json:"scenario"`
+	}
+	if err := json.Unmarshal(b, &rows); err != nil {
+		t.Fatal(err)
+	}
+	out := make([]replay.Cell, len(rows))
+	for i, r := range rows {
+		out[i] = replay.Cell{Repo: r.Repo, Model: r.Model, Margin: r.Margin, Spread: r.Spread, Scenario: r.Scenario}
+	}
+	return out
+}
+
+const opus = "claude-opus-5"
+
+// A cell that banked near the bar cannot tell a broken instrument from ordinary
+// variance, so the corpus picks its own cell and it is not the highest margin.
+func TestThePickIsTheCellWhoseWorstRunIsFurthestClearOfTheBar(t *testing.T) {
+	got, skipped, err := replay.Pick(banked(t), []string{opus})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Repo != "mastodon" {
+		t.Fatalf("picked %s, want mastodon: banked 0.775 with a spread of 0.050 is the only cell comfortably clear of the bar", got.Repo)
+	}
+	if len(skipped) != 4 {
+		t.Fatalf("skipped %d cells, want the other 4 reported: %v", len(skipped), skipped)
+	}
+
+	// discourse banked HIGHER than the bar and wider than mastodon, so a
+	// highest-margin pick would have taken it and could not have told a broken
+	// instrument from noise.
+	why := map[string]string{}
+	for _, s := range skipped {
+		why[s.Cell.Repo] = s.Why
+	}
+	if !strings.Contains(why["discourse"], "ordinary variance") {
+		t.Errorf("discourse was skipped for the wrong reason: %q", why["discourse"])
+	}
+	if !strings.Contains(why["chatwoot"], "ordinary variance") {
+		t.Errorf("chatwoot was skipped for the wrong reason: %q", why["chatwoot"])
+	}
+}
+
+// A cell exactly at the bar is not comfortably clear of it. bitwarden-server
+// banked 0.750 with a spread of 0.250, so its worst run lands exactly on 0.50.
+func TestACellWhoseWorstRunLandsOnTheBarIsNotUnambiguous(t *testing.T) {
+	for _, c := range banked(t) {
+		if c.Repo != "bitwarden-server" {
+			continue
+		}
+		if c.Unambiguous() {
+			t.Errorf("%s is treated as unambiguous, and its worst run is exactly the bar", c)
+		}
+		return
+	}
+	t.Fatal("bitwarden-server is not in the corpus")
+}
+
+// The trap: a banked number is a number for a model. Replayed on the wrong one,
+// a cell looks like a broken instrument while being a working one measuring a
+// changed world.
+func TestAnUnreachableModelPicksADifferentCellNeverADifferentModel(t *testing.T) {
+	corpus := append(banked(t), replay.Cell{
+		Repo: "aspnetcore", Model: "claude-opus-4-7", Margin: 0.900, Spread: 0.050,
+	})
+
+	// The retired model's cell is the best on paper. It must not be picked, and
+	// no other model may be substituted for it.
+	got, skipped, err := replay.Pick(corpus, []string{opus})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Model != opus {
+		t.Fatalf("picked a cell on %s, and only %s is reachable", got.Model, opus)
+	}
+	if got.Repo != "mastodon" {
+		t.Errorf("picked %s; the best reachable cell is mastodon", got.Repo)
+	}
+
+	var reported bool
+	for _, s := range skipped {
+		if s.Cell.Repo == "aspnetcore" {
+			reported = true
+			if !strings.Contains(s.Why, "number for a model") {
+				t.Errorf("the unreplayable cell does not say why: %q", s.Why)
+			}
+		}
+	}
+	if !reported {
+		t.Error("a cell that can no longer be replayed was dropped rather than recorded")
+	}
+}
+
+// A corpus with nothing replayable is an error rather than a pick nobody
+// checked, because the alternative is picking a different model.
+func TestACorpusWithNothingReplayableRefusesRatherThanSubstituting(t *testing.T) {
+	_, skipped, err := replay.Pick(banked(t), []string{"gpt-5.6-sol"})
+	if err == nil {
+		t.Fatal("a cell was picked with no reachable model")
+	}
+	if len(skipped) != 5 {
+		t.Errorf("reported %d unreplayable cells, want all 5", len(skipped))
+	}
+	if _, _, err := replay.Pick(nil, []string{opus}); err == nil {
+		t.Fatal("an empty corpus produced a pick")
+	}
+}
+
+// Agreement is a band. The measured same-cell spreads run from 0.077 to 0.250,
+// so demanding the banked number exactly would fail on the instrument's own
+// noise.
+func TestAgreementIsTheCellsOwnSpreadInBothDirections(t *testing.T) {
+	c := replay.Cell{Repo: "mastodon", Model: opus, Margin: 0.775, Spread: 0.050}
+	for _, tc := range []struct {
+		measured float64
+		agrees   bool
+		why      string
+	}{
+		{0.775, true, "the banked margin itself"},
+		{0.725, true, "the bottom of the band"},
+		{0.825, true, "the top of the band"},
+		{0.700, false, "below the band"},
+		{0.900, false, "above the band: a measurement that overshoots is not agreement"},
+	} {
+		if got := replay.Compare(c, tc.measured); got.Agrees != tc.agrees {
+			t.Errorf("%.3f (%s): agrees=%v, want %v", tc.measured, tc.why, got.Agrees, tc.agrees)
+		}
+	}
+}
+
+// Landing outside the recorded band and clearing the bar are different facts,
+// and a replay that reported only one of them would hide the other.
+func TestDisagreeingAndStillWinningAreSeparateFacts(t *testing.T) {
+	c := replay.Cell{Repo: "mastodon", Model: opus, Margin: 0.775, Spread: 0.050}
+
+	high := replay.Compare(c, 0.950)
+	if high.Agrees || !high.StillAWin {
+		t.Errorf("0.950 against 0.775 ±0.050: agrees=%v win=%v, want a disagreement that is still a win",
+			high.Agrees, high.StillAWin)
+	}
+	low := replay.Compare(c, 0.200)
+	if low.Agrees || low.StillAWin {
+		t.Errorf("0.200: agrees=%v win=%v, want neither", low.Agrees, low.StillAWin)
+	}
+	if !strings.Contains(low.String(), "DISAGREES") {
+		t.Errorf("a disagreement does not read as one: %q", low.String())
+	}
+}
+
+// The ordering is the whole discipline: the cell's answer is known, so a
+// disagreement is a bug here until something else is demonstrated. And it needs
+// a stopping point, or it is a licence to debug indefinitely.
+func TestADisagreementWalksInstrumentThenEnvironmentThenASecondPairThenTheWorld(t *testing.T) {
+	c := replay.Cell{Repo: "mastodon", Model: opus, Margin: 0.775, Spread: 0.050}
+	v := replay.Compare(c, 0.200)
+
+	walk := []struct {
+		done replay.Checks
+		want replay.Step
+	}{
+		{replay.Checks{}, replay.SuspectTheInstrument},
+		{replay.Checks{InstrumentClean: true}, replay.SuspectTheEnvironment},
+		{replay.Checks{InstrumentClean: true, EnvironmentClean: true, Pairs: 1}, replay.RunASecondPair},
+		{replay.Checks{InstrumentClean: true, EnvironmentClean: true, Pairs: 2}, replay.TheWorldMoved},
+	}
+	for _, step := range walk {
+		if got := replay.Investigate(v, step.done); got != step.want {
+			t.Errorf("with %+v the next step is %q, want %q", step.done, got, step.want)
+		}
+	}
+}
+
+// The world is the last answer, never the first. Reaching it with the
+// instrument unchecked is exactly the reverse ordering the discipline forbids.
+func TestTheWorldCannotBeBlamedBeforeTheInstrumentAndTheEnvironment(t *testing.T) {
+	c := replay.Cell{Repo: "mastodon", Model: opus, Margin: 0.775, Spread: 0.050}
+	v := replay.Compare(c, 0.200)
+
+	for _, done := range []replay.Checks{
+		{Pairs: 5},
+		{EnvironmentClean: true, Pairs: 5},
+		{InstrumentClean: true, Pairs: 5},
+	} {
+		if got := replay.Investigate(v, done); got == replay.TheWorldMoved {
+			t.Errorf("with %+v the world was blamed before the instrument and the environment were ruled out", done)
+		}
+	}
+}
+
+// One pair is n=1 against a spread that reaches 0.250, so a single disagreement
+// is inside ordinary variance.
+func TestOnePairIsNeverEnoughToConcludeAnything(t *testing.T) {
+	c := replay.Cell{Repo: "mastodon", Model: opus, Margin: 0.775, Spread: 0.050}
+	v := replay.Compare(c, 0.200)
+	clean := replay.Checks{InstrumentClean: true, EnvironmentClean: true, Pairs: 1}
+	if got := replay.Investigate(v, clean); got != replay.RunASecondPair {
+		t.Errorf("after one clean pair the next step is %q, want a second pair", got)
+	}
+}
+
+func TestAnAgreementHasNothingToInvestigate(t *testing.T) {
+	c := replay.Cell{Repo: "mastodon", Model: opus, Margin: 0.775, Spread: 0.050}
+	v := replay.Compare(c, 0.760)
+	if got := replay.Investigate(v, replay.Checks{}); got != replay.Settled {
+		t.Errorf("an agreement produced %q", got)
+	}
+}
+
+// "Nothing was adjusted to make it land" is a claim, and a replay tuned until it
+// agrees has proven that tuning works. This is how the claim is checked.
+func TestEveryPinnedInputThatMovedIsNamed(t *testing.T) {
+	was := replay.Inputs{
+		Model: opus, Scenario: "sha256:27dfc6000a5e98f3", Wall: "1800s",
+		Prompt: "sha256:aaa", Gold: "sha256:bbb", Subject: "sense-main",
+	}
+	if pinned, why := replay.Pinned(was, was); !pinned {
+		t.Fatalf("an unchanged replay was reported as adjusted: %s", why)
+	} else if !strings.Contains(why, "every pinned input matches") {
+		t.Errorf("the clean case does not say so: %q", why)
+	}
+
+	live := was
+	live.Wall = "2700s"
+	live.Gold = "sha256:ccc"
+	pinned, why := replay.Pinned(was, live)
+	if pinned {
+		t.Fatal("a replay with a longer wall and different gold was reported as pinned")
+	}
+	for _, want := range []string{"wall", "1800s", "2700s", "gold", "not a replay"} {
+		if !strings.Contains(why, want) {
+			t.Errorf("the drift report does not carry %q: %q", want, why)
+		}
+	}
+	if got := replay.Drift(was, live); len(got) != 2 {
+		t.Errorf("named %d drifted inputs, want both: %v", len(got), got)
+	}
+}
+
+// Each pinned input is checked. One that was never compared is one a replay
+// could quietly change.
+func TestEveryPinnedInputIsActuallyCompared(t *testing.T) {
+	base := replay.Inputs{
+		Model: "a", Scenario: "a", Wall: "a", Prompt: "a", Gold: "a", Subject: "a",
+	}
+	changes := []struct {
+		name  string
+		apply func(*replay.Inputs)
+	}{
+		{"model", func(i *replay.Inputs) { i.Model = "b" }},
+		{"scenario", func(i *replay.Inputs) { i.Scenario = "b" }},
+		{"wall", func(i *replay.Inputs) { i.Wall = "b" }},
+		{"prompt", func(i *replay.Inputs) { i.Prompt = "b" }},
+		{"gold", func(i *replay.Inputs) { i.Gold = "b" }},
+		{"subject", func(i *replay.Inputs) { i.Subject = "b" }},
+	}
+	for _, c := range changes {
+		live := base
+		c.apply(&live)
+		drift := replay.Drift(base, live)
+		if len(drift) != 1 || !strings.Contains(drift[0], c.name) {
+			t.Errorf("changing the %s produced %v", c.name, drift)
+		}
+	}
+}
+
+// Every cell the pick did not take is reported readably, whether it lost on
+// reach, on ambiguity, or simply to a better cell.
+func TestASecondUnambiguousCellLosesToTheBetterOneAndSaysSo(t *testing.T) {
+	corpus := []replay.Cell{
+		{Repo: "mastodon", Model: opus, Margin: 0.775, Spread: 0.050, Scenario: "sha256:27dfc600"},
+		{Repo: "aspnetcore", Model: opus, Margin: 0.700, Spread: 0.050, Scenario: "sha256:aaaa"},
+		{Repo: "rails", Model: opus, Margin: 0.556, Spread: 0.222, Scenario: "sha256:3f210bcd"},
+	}
+	got, skipped, err := replay.Pick(corpus, []string{opus})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Repo != "mastodon" {
+		t.Fatalf("picked %s, want the cell furthest clear of the bar", got.Repo)
+	}
+	if len(skipped) != 2 {
+		t.Fatalf("skipped %d, want 2: %v", len(skipped), skipped)
+	}
+
+	why := map[string]string{}
+	for _, s := range skipped {
+		why[s.Cell.Repo] = s.String()
+	}
+	// aspnetcore is clear of the bar and simply lost.
+	if !strings.Contains(why["aspnetcore"], "further clear of the bar") {
+		t.Errorf("the runner-up was skipped for the wrong reason: %q", why["aspnetcore"])
+	}
+	// Every skip line names its cell, its margin and its model, so a reader can
+	// act on it without opening the corpus.
+	for repo, line := range why {
+		for _, want := range []string{repo, opus, "banked", "spread"} {
+			if !strings.Contains(line, want) {
+				t.Errorf("the skip line for %s does not carry %q: %q", repo, want, line)
+			}
+		}
+	}
+}
+
+// The picked cell reads as itself, and an agreement reads as an agreement.
+func TestThePickAndAnAgreementBothReadPlainly(t *testing.T) {
+	c := replay.Cell{Repo: "mastodon", Model: opus, Margin: 0.775, Spread: 0.050, Scenario: "sha256:27dfc600"}
+	for _, want := range []string{"mastodon", opus, "0.775", "0.050", "sha256:27dfc600"} {
+		if !strings.Contains(c.String(), want) {
+			t.Errorf("the cell line does not carry %q: %q", want, c.String())
+		}
+	}
+	if got := replay.Compare(c, 0.760).String(); !strings.Contains(got, "agrees with") {
+		t.Errorf("an agreement does not read as one: %q", got)
+	}
+}

--- a/lab/internal/replay/testdata/banked.json
+++ b/lab/internal/replay/testdata/banked.json
@@ -1,0 +1,37 @@
+[
+ {
+  "repo": "discourse",
+  "model": "claude-opus-5",
+  "margin": 0.7083,
+  "spread": 0.4167,
+  "scenario": "sha256:1def723310067e48"
+ },
+ {
+  "repo": "mastodon",
+  "model": "claude-opus-5",
+  "margin": 0.775,
+  "spread": 0.05,
+  "scenario": "sha256:27dfc6000a5e98f3"
+ },
+ {
+  "repo": "rails",
+  "model": "claude-opus-5",
+  "margin": 0.5556,
+  "spread": 0.2222,
+  "scenario": "sha256:3f210bcde96c18e1"
+ },
+ {
+  "repo": "chatwoot",
+  "model": "claude-opus-5",
+  "margin": 0.5769,
+  "spread": 0.5385,
+  "scenario": "sha256:24f720898c0385b9"
+ },
+ {
+  "repo": "bitwarden-server",
+  "model": "claude-opus-5",
+  "margin": 0.75,
+  "spread": 0.25,
+  "scenario": "sha256:a4012313daeeb8e9"
+ }
+]


### PR DESCRIPTION
## ⚠ The paid run is outstanding — this PR does not complete its pitch

**What shipped:** everything that decides and judges a replay — the cell choice, the model pin, the agreement band, the investigation ordering and the pinned-input diff, all tested against the real banked corpus.

**What did not:** the live paid cell. Two arms, two runs each on the banked model, plus judge calls. It needs real spend and hours of wall time, and it is a human trigger rather than something an autonomous build can do. The pitch stays **Building** until that run lands and its verdict is recorded.

Everything decided here is what would otherwise be decided badly, under time pressure, at the moment of spending. Choosing which cell *after* a disagreement is how a replay gets tuned until it agrees.

## Problem

Everything measured so far has been measured against recordings: the scorer reproduces recorded scores, the gates reproduce recorded decisions, the miner reproduces misses found by hand. All of that proves the pure layer reads the past correctly. None of it proves the instrument can produce a result — between a recorded transcript and a live cell sit isolation, supervision, the tee, the session, the judge and the verdict layer, and every one of them is new.

## Changes

- **The model is pinned, and that is the trap this exists for.** A banked number is a number for a model. One recorded cell measured **+0.625 on one model and 0.00 on its successor**, because the newer baseline arm closed the axis the scenario tested — replayed on the wrong model that cell looks like a broken instrument while being a working one measuring a changed world. An unreachable model picks a different **cell**, never a different model, and a corpus with nothing replayable refuses rather than substituting.
- **A cell that can no longer be replayed is reported, not dropped**, because a number banked on a retired model is history rather than a live result.
- **The pick is the cell whose worst run is furthest clear of the bar**, not the highest margin. A cell that banked near the bar cannot tell a broken instrument from ordinary variance.
- **Agreement is the cell's own recorded spread, in both directions.** Demanding the banked number exactly would fail on the instrument's own noise; allowing anything above it would let a broken measurement pass by being generous. Landing outside the band and still clearing the bar are kept as separate facts.
- **A disagreement walks instrument, then environment, then a second pair, then the world.** Not the reverse: the whole point of choosing a banked cell is that its answer is known. And the ordering has a stopping point, or it is a licence to debug indefinitely — one live pair is n=1 against a spread that reaches 0.250.
- **The pinned inputs are diffed.** "Nothing was adjusted to make it land" is a claim, and a replay tuned until it agrees has proven that tuning works.

## What the pick already says, from the real corpus

**mastodon on claude-opus-5**, banked at 0.775 with a run-to-run spread of 0.050, so its worst run lands at 0.725 against a bar of 0.50. It is the only banked cell comfortably clear of the confirmation band:

| cell | banked | spread | worst run | why not |
|---|---|---|---|---|
| mastodon | 0.775 | 0.050 | 0.725 | **picked** |
| discourse | 0.708 | 0.417 | 0.291 | a disagreement could be ordinary variance |
| chatwoot | 0.577 | 0.538 | 0.039 | same |
| rails | 0.556 | 0.222 | 0.334 | same |
| bitwarden-server | 0.750 | 0.250 | 0.500 | lands exactly on the bar |

## Test Plan

- `make ci` green: build, tests, per-file coverage floor with no new exception, zero complexity suppressions, lint clean.
- 97% line and 100% function coverage on the new package.
- **The fixture is the real banked corpus** — five cells across two campaigns, each margin and spread derived from the runs it was banked on. The corpus picks its own cell, and the answer is not the obvious one: a highest-margin pick would have taken discourse.
- A retired model's cell is the best on paper and is refused, with the reason recorded; a corpus with no reachable model errors rather than substituting.
- The agreement band tested at the margin, both edges, and outside on both sides — including that overshooting is not agreement.
- The investigation ordering asserted by **trying to violate it three ways**, so the world cannot be blamed before the instrument and the environment.
- Each of the six pinned inputs asserted to be individually compared, so one that was never checked is one a replay could quietly change.