### PR TITLE
bench(03-06): credentials are a channel

### DIFF
--- a/lab/agents/claude-code/README.md
+++ b/lab/agents/claude-code/README.md
@@ -35,6 +35,41 @@ exception.
 
 Subscription or API key.
 
+**A seat is not an environment variable.** It lives in the platform credential
+store, which the tool locates through `HOME` — so a run with a disposable one
+looks for a store that is not there and exits in about a second with "Not logged
+in", at zero cost. Linking the host store in is worse than leaving it out: a
+denied read returns a sentinel the strict read path short-circuits on, so it
+never reaches the file fallback, while an absent store is unambiguously null and
+always falls back. Measured 2026-08-17, a linked store passed twice and then
+failed ten times in a row with a real-`HOME` control passing throughout.
+
+The route the bench uses instead is `CLAUDE_CONFIG_DIR` per run, provisioned with
+`.credentials.json` at mode `0600` holding `accessToken`, `expiresAt` and
+`scopes`. `scopes` is the gate: measured field by field, a token with an expiry
+and no scopes reads as logged out. **This file path is undocumented on macOS** —
+the published docs name it for Linux and Windows only — so it is verified against
+the shipped binary's credential store and re-verified when that binary moves.
+
+**`CLAUDE_CODE_OAUTH_TOKEN` is not used, and the mechanism is why.** When it is
+set the tool writes a plaintext credential, and its fallback combiner then
+deletes the operator's keychain entry on exit
+([#37512](https://github.com/anthropics/claude-code/issues/37512), closed as not
+planned). The delete fires only when the keychain read returned non-null, the
+keychain write then failed, and the plaintext write succeeded — so a disposable
+`HOME`, which makes that first read null, cannot trigger it today. The variable
+is still out of the allowlist: a bench that only fails to destroy the operator's
+login by accident of another design decision is one refactor from destroying it.
+
+`claude setup-token` mints a one-year token for non-interactive use, and it is
+consumed through that same variable. It is held in reserve for a campaign that
+outlives an access token, not used as the default door.
+
+The provisioned credential deliberately carries no refresh token: a run that
+cannot refresh cannot rotate the operator's login, so no number of unattended
+cells can invalidate the host seat by succeeding. The cost is that a campaign
+outliving the access token re-provisions rather than running on.
+
 ## Judging
 
 `judge_args` drive the tool tool-less and single-turn, for grading. `-p` with

--- a/lab/agents/claude-code/agent.json
+++ b/lab/agents/claude-code/agent.json
@@ -28,5 +28,8 @@
   ],
   "config_dirs": [
     ".claude"
-  ]
+  ],
+  "config_dir_var": "CLAUDE_CONFIG_DIR",
+  "keychain_service": "Claude Code-credentials",
+  "credential_key": "claudeAiOauth"
 }

--- a/lab/executors/README.md
+++ b/lab/executors/README.md
@@ -3,10 +3,11 @@
 Where and how a run happens. Two facts about each one are read before anything
 spawns, and both come from the design docs rather than from imagination.
 
-**Neither executor exists yet.** Cycle 03 builds isolated-home; cycle 08 builds
-the container. They are declared here because the planner must be able to refuse
-an impossible combination before either exists — a job that cannot authenticate
-is a burned arm, and its partner goes with it.
+**Only isolated-home exists.** Cycle 03 built it, 03-06 finished its
+authentication, and cycle 08 builds the container. Both are declared here because
+the planner must be able to refuse an impossible combination before either
+exists — a job that cannot authenticate is a burned arm, and its partner goes
+with it.
 
 That means these are the one place in the catalog that describes code rather
 than an ecosystem fact, and they are the one place most likely to be wrong. Both
@@ -16,21 +17,34 @@ files carry their source.
 
 `preserves_auth: ["subscription", "api_key"]`
 
-- *subscription* is verbatim from `02-architecture.md`: isolated-home "keeps the
-  host subscription usable".
-- *api_key* comes from `03-01`, which sets the environment allowlist: "Start
-  from empty, add what the agent tool genuinely needs (`PATH`, `TERM`,
-  **credentials the tool requires**)".
+**Both are now true of the implementation, and neither was when this was
+written.** The line claimed since cycle 03 that isolated-home "keeps the host
+subscription usable"; it was never implemented and never tested, and the first
+live cell produced two empty arms because of it. 03-06 made it true.
 
-The second one was questioned on review, because `02-architecture.md` mentions
-only the subscription and describes the environment as scrubbed. It is recorded
-here because it decides real money: four of the five arms in the frozen
-csharp-aspnet campaign reach their model by API key, and dropping it would
-reject arms that genuinely ran. **If cycle 03's allowlist turns out not to pass
-credentials, this line is wrong in the expensive direction — a false accept —
-and it is the first thing to check.**
+- *subscription* holds because the operator's credential is read once in the
+  attended parent and provisioned into a per-run config directory that
+  `CLAUDE_CONFIG_DIR` points the session at. The host keychain is never linked
+  in, and the provisioned credential carries no refresh token, so no run can
+  rotate the operator's login.
+- *api_key* holds through the environment allowlist, which carries
+  `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` with their reasons. This was the
+  entry questioned on review as a possible false accept in the expensive
+  direction — four of the five arms in the frozen csharp-aspnet campaign reach
+  their model by API key. It was checked rather than argued: the allowlist does
+  pass them, and there is a test per credential variable saying so.
 
-`isolates_global_config: true` is verbatim: "Strong config isolation".
+**macOS only, and that is a decision rather than an omission** (2026-08-17). The
+subscription route is measured there; nothing in the implementation branches on
+the platform, and the file it writes is the store Linux uses as its primary one,
+which is a reason to expect it to hold and not a reason to claim it does. 08-05
+stands up a container, which is a Linux box with a credential story of its own,
+and that is where the measurement happens. Until it exists, **no campaign may
+report a Linux result on this route.**
+
+`isolates_global_config: true` is verbatim: "Strong config isolation". It is also
+now literal: the run's config directory is its own, outside the disposable HOME,
+and it is removed when the run is released.
 
 ## container
 

--- a/lab/internal/catalog/catalog.go
+++ b/lab/internal/catalog/catalog.go
@@ -80,6 +80,22 @@ type Agent struct {
 	// `.local/share/opencode` — and a single field would check one and call the
 	// arm clean, which is half the configured surface silently missing.
 	ConfigDirs []string `json:"config_dirs"`
+	// ConfigDirVar is the environment variable that points the tool at a config
+	// directory, e.g. "CLAUDE_CONFIG_DIR". It is how a run is handed its own
+	// credential, so it is the door authentication comes through — per tool,
+	// because no two tools spell it alike and a tool that has none takes none.
+	ConfigDirVar string `json:"config_dir_var"`
+	// KeychainService is the item the tool keeps its login under in the platform
+	// credential store, read once by the attended parent so a run never has to
+	// reach a keychain of its own. Empty means this tool has no such store, and
+	// then the config directory is the only source.
+	KeychainService string `json:"keychain_service"`
+	// CredentialKey is the object the credential lives under inside that store's
+	// document. Config rather than a constant for the same reason as the rest:
+	// a key compiled in would be right for one tool and read nothing for the
+	// next, and a run with no credential looks exactly like a model with
+	// nothing to say.
+	CredentialKey string `json:"credential_key"`
 	// HeadlessArgs drive the tool with no terminal attached. They live here
 	// rather than in code because they are ecosystem facts: they change when
 	// somebody else ships a release, and no two tools spell them alike.

--- a/lab/internal/catalog/validate.go
+++ b/lab/internal/catalog/validate.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -95,7 +96,39 @@ func checkAgent(a Agent) []string {
 		p = append(p, fmt.Sprintf("agent %s: no config dirs, so there is nowhere to check for "+
 			"leaked state and the check would read the whole disposable HOME", a.ID))
 	}
-	return p
+	return append(p, checkCredentialRoute(a)...)
+}
+
+// checkCredentialRoute refuses a HALF-declared credential route.
+//
+// The three fields are all-or-nothing: the variable points a run at its config
+// directory, the keychain item is where the operator's own login is read from,
+// and the key is the object it lives under in both. Declaring some of them
+// produces a route that cannot carry a credential, and the run then falls back
+// to key authentication and reads as a model with nothing to say — which is the
+// failure this whole route exists to end, re-entering through the catalog.
+//
+// None of the three is the same as some of them: a tool that takes no config
+// directory legitimately declares nothing here and authenticates by key.
+func checkCredentialRoute(a Agent) []string {
+	declared := map[string]string{
+		"config_dir_var":   a.ConfigDirVar,
+		"keychain_service": a.KeychainService,
+		"credential_key":   a.CredentialKey,
+	}
+	var missing []string
+	for name, value := range declared {
+		if value == "" {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) == 0 || len(missing) == len(declared) {
+		return nil
+	}
+	slices.Sort(missing)
+	return []string{fmt.Sprintf("agent %s: a half-declared credential route, missing %v. All three or "+
+		"none: a partial route cannot carry a credential, and the run falls back to key authentication "+
+		"and produces an arm that reads as a model with nothing to say", a.ID, missing)}
 }
 
 func (c *Catalog) checkModel(m Model) []string {

--- a/lab/internal/catalog/validate_test.go
+++ b/lab/internal/catalog/validate_test.go
@@ -1,0 +1,42 @@
+package catalog
+
+import "testing"
+
+// The credential route is all-or-nothing. A half-declared one cannot carry a
+// credential, so the run falls back to key authentication and produces an arm
+// that reads as a model with nothing to say — which is the failure the route
+// exists to end, re-entering through the catalog.
+func TestAHalfDeclaredCredentialRouteIsRefused(t *testing.T) {
+	full := Agent{
+		ID: "tool", Binary: "b", ModelFlag: "-m", ConfigDirs: []string{".tool"},
+		HeadlessArgs: []string{"-p"}, AuthModes: []string{"subscription"},
+		ConfigDirVar: "TOOL_CONFIG_DIR", KeychainService: "Tool-credentials", CredentialKey: "toolOauth",
+	}
+	for _, tc := range []struct {
+		what  string
+		drop  func(*Agent)
+		wants bool
+	}{
+		{"the whole route declared", func(*Agent) {}, false},
+		// A tool that takes no config directory authenticates by key, and
+		// declaring none of the three is how it says so.
+		{"no route at all", func(a *Agent) { a.ConfigDirVar, a.KeychainService, a.CredentialKey = "", "", "" }, false},
+		{"no variable to point the run at its config", func(a *Agent) { a.ConfigDirVar = "" }, true},
+		{"nowhere to read the operator's own login", func(a *Agent) { a.KeychainService = "" }, true},
+		{"no key the credential lives under", func(a *Agent) { a.CredentialKey = "" }, true},
+	} {
+		t.Run(tc.what, func(t *testing.T) {
+			a := full
+			tc.drop(&a)
+
+			problems := checkCredentialRoute(a)
+
+			if tc.wants && len(problems) == 0 {
+				t.Fatal("a half-declared credential route was accepted")
+			}
+			if !tc.wants && len(problems) != 0 {
+				t.Fatalf("a legitimate route was refused: %v", problems)
+			}
+		})
+	}
+}

--- a/lab/internal/channels/channels.go
+++ b/lab/internal/channels/channels.go
@@ -106,6 +106,13 @@ type Arm struct {
 	// ConfigDirs are the agent tool's per-user state directories, relative to
 	// Home.
 	ConfigDirs []string
+	// ConfigDir is the run's own config directory, where the tool keeps its
+	// per-user state when it is pointed at one directly. It is checked as well as
+	// the HOME-relative names above, because a tool given an explicit config
+	// directory writes its persisted memory there and nowhere under HOME — and a
+	// memory check looking only under HOME would then pass by looking in the
+	// wrong place, which reads exactly like a clean arm.
+	ConfigDir string
 }
 
 // Absent reports every channel the arm can still reach, by name. An empty
@@ -138,6 +145,15 @@ func (c Channel) reachedBy(a Arm) string {
 	case Home:
 		for _, state := range a.ConfigDirs {
 			if dir := MemoryDir(a.Home, state, a.Repo); exists(dir) {
+				return fmt.Sprintf("%s: %s exists", c.Name, dir)
+			}
+		}
+		// The same directory, where a tool pointed at an explicit config
+		// directory would actually put it. The config directory itself is not
+		// checked for existence: the run creates it, so its presence says
+		// nothing, and only what the tool persisted inside it does.
+		if a.ConfigDir != "" {
+			if dir := MemoryDir(a.ConfigDir, "", a.Repo); exists(dir) {
 				return fmt.Sprintf("%s: %s exists", c.Name, dir)
 			}
 		}

--- a/lab/internal/cli/probecmd.go
+++ b/lab/internal/cli/probecmd.go
@@ -82,7 +82,7 @@ func probeCell(ctx context.Context, args []string, stdout, stderr io.Writer) int
 		return exitUsage
 	}
 
-	s, j, err := probeSpec(f)
+	s, j, err := probeSpec(ctx, f)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "sense-lab probe: %v\n", err)
 		return exitError
@@ -117,28 +117,79 @@ func probeCell(ctx context.Context, args []string, stdout, stderr io.Writer) int
 // would have, and it costs a full wall per arm to discover.
 var labBinary = os.Executable
 
-// credentialPresent refuses a cell whose session could not authenticate.
+// hostCredential is the read of the operator's store, in the attended parent. It
+// is a variable so a test can state what the host holds without needing a login.
+var hostCredential = isolate.HostCredential
+
+// cellCredential resolves and validates the credential both arms will be given,
+// before anything spawns.
 //
-// It asks whether a credential is REACHABLE, not what the executor claims to
-// preserve. preserves_auth says what CAN survive isolation; this is whether
-// there is anything to survive, and the difference is two empty arms.
+// It asks whether a credential is USABLE FOR THE WHOLE CELL, which is two
+// corrections at once. It used to ask whether an environment variable was set:
+// that missed the seat case entirely, because a seat lives in a store rather
+// than in the environment, and it also passed a credential that expires part way
+// through. A token that outlives the sense arm and dies during the baseline
+// burns the finished arm — it can never be paired, because the baseline's budget
+// derives from the sense arm it ran with. That is the half-pair hazard arriving
+// through the credential instead of through an interrupt, so it is refused here,
+// where every other unrunnable combination is refused.
 //
-// Only the environment is checked, and that is a limitation rather than a
-// design. A seat lives in the platform credential store, which a disposable
-// HOME cannot reach non-interactively: macOS locates the login keychain through
-// HOME, and its ACL denies a session with no GUI context. Measured 2026-08-17,
-// linking the store in worked twice and then failed ten times with the control
-// passing throughout. Cycle 03-06 owns the fix; until it lands, an isolated
-// cell authenticates by key.
-func credentialPresent() error {
+// A key-based host needs none of this: the key is an allowlisted variable and it
+// reaches the session that way, with no expiry anyone can read.
+func cellCredential(ctx context.Context, a catalog.Agent, until time.Time) (isolate.Credential, error) {
+	route := credentialRoute(a)
+	// A tool that declares no credential route has no file a credential could be
+	// provisioned into, so a seat cannot reach it however good the token is. It
+	// authenticates by key or not at all.
+	if route.Key == "" {
+		if keyInEnvironment() {
+			return isolate.Credential{}, nil
+		}
+		return isolate.Credential{}, fmt.Errorf("%s declares no credential route, so it can only be "+
+			"authenticated by key; set one of %v, or both arms reach no model and produce empty runs",
+			a.ID, isolate.Credentials())
+	}
+
+	c, err := hostCredential(ctx, os.LookupEnv, route)
+	if err != nil {
+		if keyInEnvironment() {
+			return isolate.Credential{}, nil
+		}
+		return isolate.Credential{}, fmt.Errorf("no credential for this cell: %w. Log in with `%s` and /login, "+
+			"or set one of %v; without either, both arms reach no model and produce empty runs",
+			err, a.Binary, isolate.Credentials())
+	}
+	if c.ExpiresBefore(until) {
+		return isolate.Credential{}, fmt.Errorf("the credential expires at %s, before this cell can finish at %s: "+
+			"the arm that ran first would be paid for and could never be paired. Log in again with `%s` "+
+			"and re-run", c.Expiry().Format(time.RFC3339), until.Format(time.RFC3339), a.Binary)
+	}
+	return c, nil
+}
+
+// credentialRoute is the agent tool's credential route, as the catalog declares
+// it. The first config directory is the one the credential lives in; the rest
+// are other state directories the contamination checks look inside.
+func credentialRoute(a catalog.Agent) isolate.Route {
+	r := isolate.Route{
+		ConfigDirVar: a.ConfigDirVar,
+		Keychain:     a.KeychainService,
+		Key:          a.CredentialKey,
+	}
+	if len(a.ConfigDirs) > 0 {
+		r.ConfigDir = a.ConfigDirs[0]
+	}
+	return r
+}
+
+// keyInEnvironment reports whether the host authenticates by key instead.
+func keyInEnvironment() bool {
 	for _, name := range isolate.Credentials() {
 		if v, ok := os.LookupEnv(name); ok && v != "" {
-			return nil
+			return true
 		}
 	}
-	return fmt.Errorf("no credential in the environment: the disposable HOME carries none of its own and a "+
-		"seat cannot be reached from one until 03-06 lands, so both arms would reach no model and produce "+
-		"empty runs. Set one of %v", isolate.Credentials())
+	return false
 }
 
 // probeJob is what the catalog resolved, kept beside the spec so the header can
@@ -149,7 +200,7 @@ type probeJob struct {
 }
 
 // probeSpec resolves the catalog and the scenario into one cell to run.
-func probeSpec(f probeFlags) (probe.Spec, probeJob, error) {
+func probeSpec(ctx context.Context, f probeFlags) (probe.Spec, probeJob, error) {
 	c, err := catalog.Load(f.config)
 	if err != nil {
 		return probe.Spec{}, probeJob{}, err
@@ -171,8 +222,8 @@ func probeSpec(f probeFlags) (probe.Spec, probeJob, error) {
 		return probe.Spec{}, probeJob{}, err
 	}
 
-	// A credential the session can actually reach, checked before anything
-	// spawns.
+	// A credential the session can actually reach, and one that outlives the
+	// cell, resolved before anything spawns.
 	//
 	// The executor's preserves_auth says what a mode CAN survive isolation, not
 	// that a credential is there today. Measured 2026-08-17: both arms of a cell
@@ -180,7 +231,13 @@ func probeSpec(f probeFlags) (probe.Spec, probeJob, error) {
 	// disposable HOME carries no credential of its own and none was in the
 	// environment to pass through. That is two arms produced and a cell wasted,
 	// and it is exactly the kind of thing this command exists to refuse first.
-	if err := credentialPresent(); err != nil {
+	//
+	// Both walls, not one. The arms run in sequence, so the cell ends after the
+	// sense arm's wall and the baseline's, and a credential good for only the
+	// first produces the burned arm this whole layer exists to prevent.
+	until := time.Now().Add(f.wall + probe.BaselineWall(f.wall))
+	cred, err := cellCredential(ctx, j.agent, until)
+	if err != nil {
 		return probe.Spec{}, probeJob{}, err
 	}
 
@@ -202,6 +259,8 @@ func probeSpec(f probeFlags) (probe.Spec, probeJob, error) {
 		AgentEnv:   j.agent.Env,
 		SetupTool:  j.agent.ID,
 		ConfigDirs: j.agent.ConfigDirs,
+		Credential: cred,
+		Route:      credentialRoute(j.agent),
 		SenseBin:   f.senseBin,
 		LabBin:     labBin,
 		HostPath:   os.Getenv("PATH"),

--- a/lab/internal/cli/probecmd_test.go
+++ b/lab/internal/cli/probecmd_test.go
@@ -2,13 +2,16 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"errors"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/luuuc/sense/lab/internal/isolate"
 )
@@ -498,10 +501,11 @@ func TestProbeRejectsAFlagItDoesNotHave(t *testing.T) {
 }
 
 // The failure that produced two empty arms: the disposable HOME carries no
-// credential of its own, and there was none in the environment to pass through.
-// The executor's preserves_auth says what CAN survive isolation, not that
-// anything is there to survive.
-func TestACellWithNoCredentialInTheEnvironmentIsRefusedBeforeSpawning(t *testing.T) {
+// credential of its own, there was none in the operator's store this run could
+// read, and none in the environment to pass through. The executor's
+// preserves_auth says what CAN survive isolation, not that anything is there to
+// survive.
+func TestACellWithNoCredentialAnywhereIsRefusedBeforeSpawning(t *testing.T) {
 	w := newProbeWorld(t)
 	for _, name := range isolate.Credentials() {
 		t.Setenv(name, "")
@@ -537,5 +541,219 @@ func TestAnyOneCredentialSatisfiesTheCheck(t *testing.T) {
 				t.Errorf("%s did not satisfy the credential check:\n%s\n%s", name, stdout, stderr)
 			}
 		})
+	}
+}
+
+// hostHolding makes the operator's store answer with the given credential, and
+// restores the real read afterwards. It is how a seat-based host is stated
+// without a login: CI has none and can never be given one.
+func hostHolding(t *testing.T, c isolate.Credential, err error) {
+	t.Helper()
+	was := hostCredential
+	t.Cleanup(func() { hostCredential = was })
+	hostCredential = func(context.Context, func(string) (string, bool), isolate.Route) (isolate.Credential, error) {
+		return c, err
+	}
+}
+
+// aSeat is a credential good for the given span from now.
+func aSeat(good time.Duration) isolate.Credential {
+	return isolate.Credential{
+		AccessToken: "seat-token",
+		ExpiresAt:   time.Now().Add(good).UnixMilli(),
+		Scopes:      []string{"user:inference"},
+	}
+}
+
+// The half-pair hazard arriving through the credential. A token that outlives
+// the sense arm and dies during the baseline burns the finished arm: it is paid
+// for and can never be paired, because the baseline's budget derives from the
+// sense arm it ran with. Presence is not the question; lasting the whole cell is.
+func TestACredentialThatDiesPartWayThroughTheCellIsRefusedBeforeSpawning(t *testing.T) {
+	w := newProbeWorld(t)
+	for _, name := range isolate.Credentials() {
+		t.Setenv(name, "")
+	}
+	// Good for one wall, and the cell needs two: the arms run in sequence.
+	hostHolding(t, aSeat(90*time.Second), nil)
+	w.declareCredentialRoute(t)
+
+	code, _, stderr := runProbe(t, w.args("-wall", "60s"))
+	if code != exitError {
+		t.Fatalf("exit %d, want an error", code)
+	}
+	if !strings.Contains(stderr, "expires") {
+		t.Errorf("the refusal names something other than expiry: %q", stderr)
+	}
+	if strings.Contains(stderr, "no credential") {
+		t.Errorf("an expiring credential was reported as an absent one: %q", stderr)
+	}
+	if _, err := os.Stat(w.out); err == nil {
+		t.Error("a cell directory was created for a credential that could not last the cell")
+	}
+}
+
+func TestACredentialThatOutlivesBothWallsIsAccepted(t *testing.T) {
+	w := newProbeWorld(t)
+	for _, name := range isolate.Credentials() {
+		t.Setenv(name, "")
+	}
+	hostHolding(t, aSeat(time.Hour), nil)
+	w.declareCredentialRoute(t)
+
+	code, stdout, stderr := runProbe(t, w.args("-wall", "60s"))
+	if code == exitError {
+		t.Fatalf("a credential good for the whole cell was refused:\n%s\n%s", stdout, stderr)
+	}
+}
+
+// The seat and the key are two doors, and a host with the key needs neither the
+// store nor an expiry it cannot read.
+func TestAKeyBasedHostRunsWithNoStoreAtAll(t *testing.T) {
+	w := newProbeWorld(t)
+	hostHolding(t, isolate.Credential{}, errors.New("no store on this machine"))
+	t.Setenv("ANTHROPIC_API_KEY", "a-test-key")
+
+	code, stdout, stderr := runProbe(t, w.args())
+	if code == exitError {
+		t.Fatalf("a key-based host was refused for having no store:\n%s\n%s", stdout, stderr)
+	}
+}
+
+// Every arm of a seat-based cell is handed the credential, and nothing else from
+// the operator's store reaches it. This is the positive-space check cycle 03's
+// test set never had: every other isolation test asks what an arm CANNOT reach.
+//
+// Read off what the SESSION saw rather than off the file, because the file is
+// gone by the time the cell returns — release takes the credential and keeps the
+// evidence, which is the other half of this pitch.
+func TestBothArmsAreProvisionedWithTheCredentialAndNothingElse(t *testing.T) {
+	w := newProbeWorld(t)
+	for _, name := range isolate.Credentials() {
+		t.Setenv(name, "")
+	}
+	hostHolding(t, aSeat(time.Hour), nil)
+	w.declareCredentialRoute(t)
+
+	if code, stdout, stderr := runProbe(t, w.args()); code == exitError {
+		t.Fatalf("exit %d:\n%s\n%s", code, stdout, stderr)
+	}
+
+	for _, arm := range []string{"sense", "baseline"} {
+		said := armTranscript(t, w.out, arm)
+		fields := fieldLine(said, "CRED_FIELDS=")
+		if fields == "" {
+			t.Fatalf("the %s arm read no credential:\n%s", arm, said)
+		}
+		want := "fakeOauth accessToken expiresAt scopes"
+		if got := strings.Join(strings.Fields(fields), " "); got != want {
+			t.Errorf("the %s arm's credential carries %q, want %q", arm, got, want)
+		}
+	}
+}
+
+// The session is pointed at that credential by the tool's own variable, taken
+// from the catalog. Without it the file is written where nothing reads it, and
+// the arm exits in a second reading as a model with nothing to say — which is
+// the shape of the failure this pitch was written for.
+func TestTheSessionIsPointedAtItsOwnConfigDirectory(t *testing.T) {
+	w := newProbeWorld(t)
+	for _, name := range isolate.Credentials() {
+		t.Setenv(name, "")
+	}
+	hostHolding(t, aSeat(time.Hour), nil)
+	w.declareCredentialRoute(t)
+
+	if code, stdout, stderr := runProbe(t, w.args()); code == exitError {
+		t.Fatalf("exit %d:\n%s\n%s", code, stdout, stderr)
+	}
+
+	for _, arm := range []string{"sense", "baseline"} {
+		want := filepath.Join(w.out, arm, "config")
+		if got := fieldLine(armTranscript(t, w.out, arm), "CONFIG_DIR="); got != want {
+			t.Errorf("the %s arm saw config directory %q, want %q", arm, got, want)
+		}
+	}
+}
+
+// Nothing the cell keeps may carry the token. A cell directory is read back for
+// months by the scorer, the miner and status, so this walks all of it — the run
+// records, the transcripts, the MCP capture and the cell record — rather than
+// the one file a test could pick knowing where the token is.
+func TestNothingTheCellKeepsCarriesTheToken(t *testing.T) {
+	w := newProbeWorld(t)
+	for _, name := range isolate.Credentials() {
+		t.Setenv(name, "")
+	}
+	hostHolding(t, aSeat(time.Hour), nil)
+	w.declareCredentialRoute(t)
+
+	if code, stdout, stderr := runProbe(t, w.args()); code == exitError {
+		t.Fatalf("exit %d:\n%s\n%s", code, stdout, stderr)
+	}
+
+	if err := filepath.WalkDir(w.out, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil //nolint:nilerr // an unreadable entry is not a finding
+		}
+		b, readErr := os.ReadFile(path) // #nosec G304 -- the test's own cell directory
+		if readErr == nil && strings.Contains(string(b), "seat-token") {
+			rel, _ := filepath.Rel(w.out, path)
+			t.Errorf("%s carries the credential, in a directory kept for months", rel)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("walk the cell: %v", err)
+	}
+}
+
+// armTranscript is what one arm said, which survives release.
+func armTranscript(t *testing.T, cell, arm string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(cell, arm, "session", "raw", "stdout"))
+	if err != nil {
+		t.Fatalf("read the %s arm's transcript: %v", arm, err)
+	}
+	return string(b)
+}
+
+// fieldLine is the value the stand-in reported for one key.
+func fieldLine(said, key string) string {
+	for _, line := range strings.Split(said, "\n") {
+		if v, ok := strings.CutPrefix(line, key); ok {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+// recordingAgentScript is the stand-in agent, plus two lines: it reports the
+// config directory it was pointed at and the FIELD NAMES of the credential it
+// found there.
+//
+// The names rather than the values, deliberately. A stand-in that echoed the
+// token would put it in a transcript that is kept for months, which is the thing
+// this pitch forbids — and it would make the test that checks for that pass by
+// accident of its own setup.
+const recordingAgentScript = `#!/bin/sh
+printf 'CONFIG_DIR=%s\n' "$FAKE_CONFIG_DIR"
+printf 'CRED_FIELDS=%s\n' "$(grep -o '"[a-zA-Z]*":' "$FAKE_CONFIG_DIR/.credentials.json" | tr -d '":' | tr '\n' ' ')"
+` + fakeAgentScript
+
+// declareCredentialRoute rewrites the world's agent to declare a credential
+// route, the way the shipped catalog does: a config variable, a store item and
+// the key the credential lives under. Without one, an agent authenticates by
+// key and no file is provisioned at all.
+func (w probeWorld) declareCredentialRoute(t *testing.T) {
+	t.Helper()
+	bin := writeScript(t, filepath.Join(t.TempDir(), "recording-agent"), recordingAgentScript)
+	at := filepath.Join(w.config, "agents", "fake", "agent.json")
+	body := `{"id":"fake","binary":"` + bin + `","model_flag":"--model",` +
+		`"config_dirs":[".fake"],"config_dir_var":"FAKE_CONFIG_DIR",` +
+		`"keychain_service":"Fake-credentials","credential_key":"fakeOauth",` +
+		`"headless_args":["-c"],"judge_args":["-c"],"env":[],"supports_mcp":true,` +
+		`"auth_modes":["subscription","api_key"]}`
+	if err := os.WriteFile(at, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/lab/internal/isolate/cleanup_test.go
+++ b/lab/internal/isolate/cleanup_test.go
@@ -1,0 +1,161 @@
+package isolate
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// The rule that picks a cleanup shape, stated on its own. It is "does this
+// directory hold evidence", NOT "did this run finish": keying off the run record
+// deletes the directory of a run that crashed before writing one, and that
+// directory holds the transcript of the crash.
+func TestEvidenceRatherThanCompletionDecidesWhatIsKept(t *testing.T) {
+	for _, tc := range []struct {
+		what  string
+		write map[string]string
+		want  bool
+	}{
+		{"a run that produced nothing at all", nil, false},
+		{"a run that wrote only its record", map[string]string{"artifacts/run-meta.json": "{}"}, true},
+		{"a crashed run with a transcript and no record", map[string]string{"session/raw/stdout": "half an answer"}, true},
+		{"a run with only a capture", map[string]string{"logs/session.log": "output"}, true},
+		{"a tree of empty directories", map[string]string{"artifacts/": "", "logs/": ""}, false},
+	} {
+		t.Run(tc.what, func(t *testing.T) {
+			root := t.TempDir()
+			for rel, body := range tc.write {
+				at := filepath.Join(root, rel)
+				if strings.HasSuffix(rel, "/") {
+					if err := os.MkdirAll(at, 0o755); err != nil {
+						t.Fatal(err)
+					}
+					continue
+				}
+				if err := os.MkdirAll(filepath.Dir(at), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(at, []byte(body), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if got := HoldsEvidence(root); got != tc.want {
+				t.Errorf("HoldsEvidence = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A run directory outlives its purpose by months, so the token in it must not.
+func TestReleaseTakesTheCredentialAndLeavesTheEvidence(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "run")
+	c := aCredential()
+	env, err := Prepare(Spec{Root: root, Arm: Sense, Credential: c, Route: aRoute()})
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	transcript := filepath.Join(env.Root, "session", "raw", "stdout")
+	if err := os.MkdirAll(filepath.Dir(transcript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(transcript, []byte("what the arm said"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Release(env); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+
+	if _, err := os.Stat(CredentialPath(env.Config)); err == nil {
+		t.Error("the credential survived release, in a directory that is kept for months")
+	}
+	// The disposable HOME goes too, and for a reason no assertion about our own
+	// stand-in could cover: it holds whatever the agent tool decided to write
+	// about itself, and a tool that copies its credential into its own state
+	// would put a token in a kept directory. Removing it makes the guarantee
+	// independent of the tool's behaviour.
+	if _, err := os.Stat(env.Home); err == nil {
+		t.Error("the disposable HOME survived release; whatever the tool wrote there is kept for months")
+	}
+	b, err := os.ReadFile(transcript)
+	if err != nil {
+		t.Fatalf("release destroyed the evidence it exists to keep: %v", err)
+	}
+	if string(b) != "what the arm said" {
+		t.Errorf("transcript = %q, want it untouched", b)
+	}
+}
+
+func TestReleaseWithNoRunRootIsRefused(t *testing.T) {
+	if err := Release(Env{}); err == nil {
+		t.Fatal("release reported success with nothing to release")
+	}
+}
+
+// The proof half, the same as the rest of cleanup: a removal that reported
+// nothing is not a removal that happened.
+func TestReleaseFailsWhileTheCredentialDirectoryRemains(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "run")
+	env, err := Prepare(Spec{Root: root, Arm: Sense, Credential: aCredential(), Route: aRoute()})
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	// A config directory that cannot be removed, so the removal reports success
+	// on nothing and the proof is the only thing standing between the run and a
+	// token kept for months.
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("a read-only parent does not stop removal here")
+	}
+	if err := os.Chmod(filepath.Dir(env.Config), 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(filepath.Dir(env.Config), 0o700) })
+
+	if err := Release(env); err == nil {
+		t.Fatal("release reported success although the credential is still there")
+	}
+}
+
+// "I could not check" is not "it is gone". Cleaning up against something that is
+// not the parent repository must be reported, or a caller pointed at the wrong
+// place reads as clean and the real registration is still there.
+func TestRemovingAWorktreeFromSomethingThatIsNotARepositoryIsReported(t *testing.T) {
+	notARepository := t.TempDir()
+
+	err := RemoveWorktree(context.Background(), notARepository, filepath.Join(notARepository, "repo"))
+	if err == nil {
+		t.Fatal("a removal against a parent that could not be listed reported success")
+	}
+}
+
+// The rabbit hole the pitch names, at the one place it can still bite: a
+// directory nobody can read must not be mistaken for an empty one.
+//
+// The costs are not symmetric. Reading "I could not look" as "nothing is there"
+// deletes a run that was paid for and can never be recreated; reading it the
+// other way keeps a directory somebody removes by hand.
+func TestADirectoryThatCannotBeReadCountsAsHoldingEvidence(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("an unreadable directory does not stop a walk here")
+	}
+	root := t.TempDir()
+	unreadable := filepath.Join(root, "session")
+	if err := os.MkdirAll(unreadable, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(unreadable, "stdout"), []byte("what the arm said"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(unreadable, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(unreadable, 0o700) })
+
+	if !HoldsEvidence(root) {
+		t.Fatal("a run directory nobody could read was reported as holding nothing; Finish would delete it")
+	}
+}

--- a/lab/internal/isolate/credential.go
+++ b/lab/internal/isolate/credential.go
@@ -1,0 +1,177 @@
+package isolate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Credential is the whole of what a run is given to reach a model.
+//
+// Three fields, and the shape is measured rather than assumed. Eight shapes were
+// written into an isolated run's config directory on 2026-08-17 and asked for one
+// word: `accessToken` alone does not authenticate, `accessToken` with an expiry
+// does not, and `accessToken` with an expiry and `subscriptionType` does not.
+// Scopes is the gate. The smallest thing that authenticates is these three.
+//
+// What is deliberately NOT here is the point of the type. The host store also
+// holds a refresh token and the operator's connector tokens, and neither reaches
+// a model. A run that cannot refresh cannot rotate the operator's login, so no
+// number of unattended cells can invalidate the host seat by succeeding; and a
+// run with no connector tokens holds no credentials for services that have
+// nothing to do with this measurement. Both are safety properties, not tidiness.
+type Credential struct {
+	AccessToken string   `json:"accessToken"`
+	ExpiresAt   int64    `json:"expiresAt"`
+	Scopes      []string `json:"scopes"`
+}
+
+// Route is how a credential reaches one agent tool, as the catalog describes it.
+//
+// Every field is a per-tool identifier, and not one of them is compiled in. A
+// config directory name, a variable, a keychain item or a JSON key written into
+// this package would be right for one tool and silently wrong for every other —
+// the same rule the contamination checks already follow, and the reason the
+// binary-identifier probe exists.
+type Route struct {
+	// ConfigDirVar is the variable that points the tool at a config directory.
+	// It is the door: a per-run value is what makes authentication a channel
+	// with a stated direction rather than an accident of what HOME reaches.
+	ConfigDirVar string
+	// ConfigDir is the tool's config directory name relative to HOME, used to
+	// find the OPERATOR's own credential when ConfigDirVar is unset on the host.
+	ConfigDir string
+	// Keychain is the platform store item the tool keeps its login under, read
+	// once by the attended parent. Empty means the tool has no platform store.
+	Keychain string
+	// Key is the object the credential lives under inside the store document.
+	Key string
+}
+
+// credentialFile is where the agent tool looks inside its config directory.
+//
+// Undocumented on macOS and load-bearing here: the published docs name this file
+// on Linux and Windows only, and the shipped binary contradicts them. Its
+// credential store is a two-backend combiner that reads the keychain first and
+// falls back to this path, with the directory honouring the tool's config
+// variable. Read from the shipped binary at 2.1.233; re-read when the binary
+// moves, because no doc page will announce a change here.
+//
+// The NAME is the one credential fact that is not per tool: it is the dotfile
+// convention rather than a tool identifier, and it carries no tool's name.
+const credentialFile = ".credentials.json"
+
+// Empty reports a credential that was never provided.
+//
+// That is what a key-based host hands a run: the key is an allowlisted
+// environment variable, the tool reads it from there, and no file is written at
+// all. It is a different thing from an INVALID credential, which is a mistake
+// and is refused rather than skipped.
+func (c Credential) Empty() bool {
+	return c.AccessToken == "" && c.ExpiresAt == 0 && len(c.Scopes) == 0
+}
+
+// Valid reports whether a credential could be used at all. An empty token or an
+// empty scope list is a credential that will read as logged out, which costs a
+// full wall per arm to discover.
+func (c Credential) Valid() bool {
+	return c.AccessToken != "" && c.ExpiresAt > 0 && len(c.Scopes) > 0
+}
+
+// ExpiresBefore reports whether the credential runs out before a moment a caller
+// has to reach.
+//
+// A cell asks this about its own end rather than about now: a token that outlives
+// the sense arm and dies during the baseline produces a burned arm and a cell
+// that can never be paired, which is the half-pair hazard arriving through the
+// credential instead of through an interrupt.
+func (c Credential) ExpiresBefore(t time.Time) bool {
+	return time.UnixMilli(c.ExpiresAt).Before(t)
+}
+
+// Expiry is when the credential runs out, for a message that can name it.
+func (c Credential) Expiry() time.Time { return time.UnixMilli(c.ExpiresAt) }
+
+// CredentialPath is where a run's credential lives, given its config directory.
+func CredentialPath(configDir string) string { return filepath.Join(configDir, credentialFile) }
+
+// Write provisions one run's credential into its config directory.
+//
+// It is a pure function of its arguments and a path: no keychain, no login, no
+// host. That is what lets the whole of this decision be tested in CI, which has
+// no credential and can never be given one.
+//
+// It builds the document field by field rather than marshalling something read
+// from the host, so a field the host store gains later cannot arrive here by
+// default. The only way another key reaches a run is for someone to add it to
+// Credential and say why.
+func (r Route) Write(configDir string, c Credential) error {
+	if r.Key == "" {
+		return fmt.Errorf("provision credential into %s: the agent tool names no credential key, "+
+			"so the document would be written where nothing reads it", configDir)
+	}
+	if !c.Valid() {
+		return fmt.Errorf("provision credential into %s: the credential carries no token, no expiry or no scopes, "+
+			"and a run given one reads as logged out", configDir)
+	}
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		return fmt.Errorf("prepare the run's config directory: %w", err)
+	}
+	// A struct of a string, an int and a string slice cannot fail to encode.
+	//
+	// Marshalling a bearer token is the whole job here, not an accident: the
+	// agent tool reads its credential from this file and there is no other route
+	// into an isolated run. What keeps it safe is the mode below, the fact that
+	// the document holds three fields and no refresh token, and that cleanup
+	// proves the file gone.
+	b, _ := json.MarshalIndent(map[string]Credential{r.Key: c}, "", "  ") // #nosec G117 -- provisioning a credential is this function
+
+	// 0600 because the file is a plaintext bearer token for as long as the run
+	// lasts. WriteFile does not chmod a file that already exists, and Prepare
+	// refuses a root that does, so there is no pre-existing file to inherit a
+	// mode from.
+	if err := os.WriteFile(CredentialPath(configDir), append(b, '\n'), 0o600); err != nil {
+		return fmt.Errorf("provision credential into %s: %w", configDir, err)
+	}
+	return nil
+}
+
+// Read reads a credential out of a config directory, host or run.
+//
+// It is the reverse of Write and takes the same narrow view: whatever else the
+// document holds is dropped rather than carried, so reading the operator's own
+// config directory yields the three fields and not the connector tokens beside
+// them.
+func (r Route) Read(configDir string) (Credential, error) {
+	path := CredentialPath(configDir)
+	b, err := os.ReadFile(path) // #nosec G304 -- a config directory the caller named
+	if err != nil {
+		return Credential{}, fmt.Errorf("read credential from %s: %w", path, err)
+	}
+	c, err := r.decode(b)
+	if err != nil {
+		return Credential{}, fmt.Errorf("read credential from %s: %w", path, err)
+	}
+	return c, nil
+}
+
+// decode pulls the three fields worth carrying out of a store document.
+//
+// It is shared by the file and the platform store because both hold the same
+// document: the combiner writes one shape and reads it from either backend.
+func (r Route) decode(b []byte) (Credential, error) {
+	if r.Key == "" {
+		return Credential{}, fmt.Errorf("the agent tool names no credential key")
+	}
+	var doc map[string]Credential
+	if err := json.Unmarshal(b, &doc); err != nil {
+		return Credential{}, err
+	}
+	c, ok := doc[r.Key]
+	if !ok {
+		return Credential{}, fmt.Errorf("no %s object", r.Key)
+	}
+	return c, nil
+}

--- a/lab/internal/isolate/credential_test.go
+++ b/lab/internal/isolate/credential_test.go
@@ -1,0 +1,400 @@
+package isolate
+
+import (
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+// aRoute is a credential route of the shape a catalog declares, stated once so a
+// test that is about something else does not have to. The names are a test's
+// own: this package compiles none of them in.
+func aRoute() Route {
+	return Route{
+		ConfigDirVar: "TOOL_CONFIG_DIR",
+		ConfigDir:    ".tool",
+		Keychain:     "Tool-credentials",
+		Key:          "toolOauth",
+	}
+}
+
+// aCredential is a usable credential, stated once so a test that is about
+// something else does not have to.
+func aCredential() Credential {
+	return Credential{
+		AccessToken: "sk-ant-oat-example",
+		ExpiresAt:   time.Now().Add(24 * time.Hour).UnixMilli(),
+		Scopes:      []string{"user:inference", "user:profile"},
+	}
+}
+
+func TestTheProvisionedFileCarriesOnlyTheThreeFieldsThatAuthenticate(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "config")
+
+	if err := aRoute().Write(dir, aCredential()); err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+
+	b, err := os.ReadFile(CredentialPath(dir))
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	var doc map[string]map[string]any
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatalf("the provisioned file is not JSON: %v", err)
+	}
+	oauth, ok := doc[aRoute().Key]
+	if !ok {
+		t.Fatalf("no %s object; the combiner reads that key and nothing else", aRoute().Key)
+	}
+	want := map[string]bool{"accessToken": true, "expiresAt": true, "scopes": true}
+	for key := range oauth {
+		if !want[key] {
+			t.Errorf("the provisioned file carries %q, which a run does not need to reach a model", key)
+		}
+		delete(want, key)
+	}
+	for key := range want {
+		t.Errorf("the provisioned file is missing %q; measured 2026-08-17, a run without it reads as logged out", key)
+	}
+}
+
+func TestNoRefreshTokenOrConnectorTokenCanReachARun(t *testing.T) {
+	// The safety property, asserted on the bytes rather than on the type: a run
+	// that cannot refresh cannot rotate the operator's login, and a run with no
+	// mcpOAuth holds no credentials for the operator's connectors. Both are
+	// invisible in any bench result, so nothing else would catch a regression.
+	dir := filepath.Join(t.TempDir(), "config")
+	if err := aRoute().Write(dir, aCredential()); err != nil {
+		t.Fatalf("provision: %v", err)
+	}
+
+	b, err := os.ReadFile(CredentialPath(dir))
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	for _, forbidden := range []string{"refreshToken", "mcpOAuth"} {
+		if strings.Contains(string(b), forbidden) {
+			t.Errorf("%s reached a run's credential file:\n%s", forbidden, b)
+		}
+	}
+}
+
+func TestTheProvisionedCredentialIsNotReadableByAnyoneElse(t *testing.T) {
+	// Asserted on what PREPARE builds, not on a bare Write into a fresh path.
+	// The two differ, and the difference is the whole point: Prepare has already
+	// created the config directory, and MkdirAll does not chmod one that exists,
+	// so a Write into a directory made at 0755 leaves it at 0755. Testing Write
+	// alone passes on a directory no run ever has.
+	root := filepath.Join(t.TempDir(), "run")
+	env, err := Prepare(Spec{Root: root, Arm: Baseline, Credential: aCredential(), Route: aRoute()})
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	info, err := os.Stat(CredentialPath(env.Config))
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("credential file mode is %o, want 600", perm)
+	}
+	parent, err := os.Stat(env.Config)
+	if err != nil {
+		t.Fatalf("stat the config directory: %v", err)
+	}
+	// A 0600 file inside a world-listable directory still tells everyone on the
+	// machine that the credential is there and what it is called.
+	if perm := parent.Mode().Perm(); perm&0o077 != 0 {
+		t.Errorf("the config directory is %o, which lets someone else list the credential beside it", perm)
+	}
+}
+
+func TestAnUnusableCredentialIsRefusedRatherThanWritten(t *testing.T) {
+	full := aCredential()
+	for _, tc := range []struct {
+		what string
+		cred Credential
+	}{
+		{"no token at all", Credential{ExpiresAt: full.ExpiresAt, Scopes: full.Scopes}},
+		{"no expiry", Credential{AccessToken: full.AccessToken, Scopes: full.Scopes}},
+		// Scopes is the gate: measured 2026-08-17, a token with an expiry and no
+		// scopes returns "Not logged in" for a full wall's worth of nothing.
+		{"no scopes", Credential{AccessToken: full.AccessToken, ExpiresAt: full.ExpiresAt}},
+	} {
+		t.Run(tc.what, func(t *testing.T) {
+			dir := filepath.Join(t.TempDir(), "config")
+
+			if err := aRoute().Write(dir, tc.cred); err == nil {
+				t.Fatal("a credential that cannot authenticate was provisioned; the run would burn a wall to find out")
+			}
+			if _, err := os.Stat(CredentialPath(dir)); err == nil {
+				t.Error("a refused credential was written anyway")
+			}
+		})
+	}
+}
+
+func TestProvisioningReportsAConfigDirectoryItCannotCreate(t *testing.T) {
+	// A file where the directory should be. The run must not proceed believing it
+	// has a credential.
+	blocked := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(blocked, []byte("x"), 0o600); err != nil {
+		t.Fatalf("set up: %v", err)
+	}
+
+	if err := aRoute().Write(filepath.Join(blocked, "config"), aCredential()); err == nil {
+		t.Fatal("provisioning reported success with nowhere to write")
+	}
+}
+
+func TestReadingACredentialTakesTheThreeFieldsAndLeavesTheRest(t *testing.T) {
+	// The host's own store, which holds the operator's connector tokens and the
+	// refresh token beside the login. Reading it must not carry them along.
+	dir := t.TempDir()
+	host := `{
+	  "toolOauth": {
+	    "accessToken": "sk-ant-oat-host",
+	    "refreshToken": "sk-ant-ort-host",
+	    "expiresAt": 1799999999000,
+	    "scopes": ["user:inference"],
+	    "subscriptionType": "max"
+	  },
+	  "mcpOAuth": {"some-connector": {"accessToken": "connector-token"}}
+	}`
+	if err := os.WriteFile(CredentialPath(dir), []byte(host), 0o600); err != nil {
+		t.Fatalf("set up: %v", err)
+	}
+
+	c, err := aRoute().Read(dir)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if c.AccessToken != "sk-ant-oat-host" {
+		t.Errorf("accessToken = %q, want the host's", c.AccessToken)
+	}
+	if c.ExpiresAt != 1799999999000 {
+		t.Errorf("expiresAt = %d, want the host's", c.ExpiresAt)
+	}
+	if len(c.Scopes) != 1 || c.Scopes[0] != "user:inference" {
+		t.Errorf("scopes = %v, want the host's", c.Scopes)
+	}
+
+	// The proof that the narrowing happened is what a run would then be given.
+	into := filepath.Join(t.TempDir(), "config")
+	if err := aRoute().Write(into, c); err != nil {
+		t.Fatalf("provision what was read: %v", err)
+	}
+	b, err := os.ReadFile(CredentialPath(into))
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	for _, forbidden := range []string{"refreshToken", "mcpOAuth", "connector-token", "subscriptionType"} {
+		if strings.Contains(string(b), forbidden) {
+			t.Errorf("%s survived the round trip from the host store into a run", forbidden)
+		}
+	}
+}
+
+func TestReadingReportsAStoreItCannotUse(t *testing.T) {
+	for _, tc := range []struct {
+		what     string
+		contents string
+		write    bool
+	}{
+		{what: "no file at all"},
+		{what: "not JSON", contents: "logged out", write: true},
+		{what: "some other document", contents: `{"somethingElse": {}}`, write: true},
+	} {
+		t.Run(tc.what, func(t *testing.T) {
+			dir := t.TempDir()
+			if tc.write {
+				if err := os.WriteFile(CredentialPath(dir), []byte(tc.contents), 0o600); err != nil {
+					t.Fatalf("set up: %v", err)
+				}
+			}
+
+			if _, err := aRoute().Read(dir); err == nil {
+				t.Fatal("a store that carries no credential was read as one")
+			}
+		})
+	}
+}
+
+func TestACredentialThatExpiresBeforeTheCellEndsIsKnownToExpire(t *testing.T) {
+	// The question a preflight has to ask. Asking whether it is valid NOW passes a
+	// credential that dies between the sense arm and the baseline, which burns the
+	// finished arm: it can never be paired.
+	now := time.Now()
+	c := Credential{
+		AccessToken: "t",
+		Scopes:      []string{"user:inference"},
+		ExpiresAt:   now.Add(30 * time.Minute).UnixMilli(),
+	}
+
+	if c.ExpiresBefore(now) {
+		t.Error("a credential good for another half hour was reported as already expired")
+	}
+	if !c.ExpiresBefore(now.Add(time.Hour)) {
+		t.Error("a credential that dies in half an hour was reported as good for an hour")
+	}
+	if got := c.Expiry(); got.Sub(now).Round(time.Minute) != 30*time.Minute {
+		t.Errorf("Expiry() = %v, which cannot name the expiry in a refusal", got)
+	}
+}
+
+func TestTheCredentialIsWrittenOnlyIntoTheRunsOwnConfigDirectory(t *testing.T) {
+	// A run directory is read back for months, so a token anywhere in it that is
+	// not the one file cleanup knows about is a token that outlives its purpose.
+	root := filepath.Join(t.TempDir(), "run")
+	c := aCredential()
+
+	env, err := Prepare(Spec{Root: root, Arm: Baseline, HostPath: "", Credential: c, Route: aRoute()})
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	var carrying []string
+	err = filepath.WalkDir(env.Root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || d.Type()&fs.ModeSymlink != 0 {
+			return nil //nolint:nilerr // an unreadable entry is not a finding
+		}
+		b, readErr := os.ReadFile(path) // #nosec G304 -- the test's own run directory
+		if readErr == nil && strings.Contains(string(b), c.AccessToken) {
+			carrying = append(carrying, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk the run directory: %v", err)
+	}
+	if want := []string{CredentialPath(env.Config)}; !slices.Equal(carrying, want) {
+		t.Errorf("files carrying the token = %v, want only %v", carrying, want)
+	}
+}
+
+func TestAKeyBasedRunIsGivenNoCredentialFileAtAll(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "run")
+
+	env, err := Prepare(Spec{Root: root, Arm: Baseline, Route: aRoute()})
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	if _, err := os.Stat(CredentialPath(env.Config)); err == nil {
+		t.Error("a run that was given no credential was provisioned with a file anyway")
+	}
+}
+
+func TestARunGivenAHalfFilledCredentialIsRefusedRatherThanRun(t *testing.T) {
+	// Distinct from the empty case above, and the distinction is the point: an
+	// absent credential is a key-based host, and a half-filled one is a mistake
+	// that would cost a wall per arm to discover.
+	root := filepath.Join(t.TempDir(), "run")
+
+	if _, err := Prepare(Spec{
+		Root:       root,
+		Arm:        Baseline,
+		Credential: Credential{AccessToken: "t"},
+		Route:      aRoute(),
+	}); err == nil {
+		t.Fatal("an environment was prepared around a credential that cannot authenticate")
+	}
+}
+
+func TestTheSessionIsPointedAtTheConfigDirectoryTheCredentialIsIn(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "run")
+	r := aRoute()
+
+	env, err := Prepare(Spec{Root: root, Arm: Baseline, Credential: aCredential(), Route: r})
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	got := envMap(t, env.Environ)
+	if got[r.ConfigDirVar] != env.Config {
+		t.Errorf("%s = %q, want the run's own config directory %q", r.ConfigDirVar, got[r.ConfigDirVar], env.Config)
+	}
+	if _, err := os.Stat(CredentialPath(got[r.ConfigDirVar])); err != nil {
+		t.Errorf("the directory the session is pointed at holds no credential: %v", err)
+	}
+	// Outside the disposable HOME, or the contamination proof reads a
+	// provisioned credential as persisted memory and every arm looks dirty.
+	if strings.HasPrefix(env.Config, env.Home+string(filepath.Separator)) {
+		t.Errorf("the config directory %q is inside the disposable HOME %q", env.Config, env.Home)
+	}
+}
+
+func TestAToolWithNoConfigVariableIsGivenNone(t *testing.T) {
+	// codex and opencode take no config-directory variable. Inventing one would
+	// set a variable in their session that means nothing, and setting some other
+	// tool's would be worse.
+	root := filepath.Join(t.TempDir(), "run")
+	r := aRoute()
+	r.ConfigDirVar = ""
+
+	env, err := Prepare(Spec{Root: root, Arm: Baseline, Credential: aCredential(), Route: r})
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	for _, kv := range env.Environ {
+		if strings.Contains(kv, "CONFIG_DIR=") {
+			t.Errorf("a config-directory variable was invented: %q", kv)
+		}
+	}
+}
+
+// A tool that names no credential key has nowhere its credential could be read
+// from, so a file written for it is a file nothing reads — and the run would
+// spend a full wall per arm discovering that it is logged out.
+func TestARouteWithNoCredentialKeyCannotProvisionOrRead(t *testing.T) {
+	keyless := aRoute()
+	keyless.Key = ""
+	dir := filepath.Join(t.TempDir(), "config")
+
+	if err := keyless.Write(dir, aCredential()); err == nil {
+		t.Error("a credential was written under no key at all")
+	}
+	if _, err := os.Stat(CredentialPath(dir)); err == nil {
+		t.Error("a refused credential was written anyway")
+	}
+
+	// And the same on the way in. The document deliberately HOLDS a usable
+	// credential under the empty key, so this cannot pass by the decode failing
+	// for some other reason: without the guard the read succeeds and hands back a
+	// credential from a key nothing writes under.
+	host := t.TempDir()
+	stored := `{"": {"accessToken":"t","expiresAt":1799999999000,"scopes":["user:inference"]}}`
+	if err := os.WriteFile(CredentialPath(host), []byte(stored), 0o600); err != nil {
+		t.Fatalf("set up: %v", err)
+	}
+	if _, err := keyless.Read(host); err == nil {
+		t.Error("a credential was read from a store with no key to read it under")
+	}
+}
+
+// The write can fail for reasons that have nothing to do with the credential —
+// a full disk, a read-only mount — and a run must not proceed believing it has
+// one. The failure has to arrive here, in the attended parent, rather than as an
+// arm that exits in a second reading as a model with nothing to say.
+func TestAConfigDirectoryThatCannotBeWrittenIntoIsReported(t *testing.T) {
+	if runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		t.Skip("a read-only directory does not stop writing here")
+	}
+	dir := filepath.Join(t.TempDir(), "config")
+	if err := os.MkdirAll(dir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	if err := aRoute().Write(dir, aCredential()); err == nil {
+		t.Fatal("provisioning reported success although the credential could not be written")
+	}
+}

--- a/lab/internal/isolate/env.go
+++ b/lab/internal/isolate/env.go
@@ -1,6 +1,7 @@
 package isolate
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -26,6 +27,15 @@ const (
 type Entry struct {
 	Name string
 	Why  string
+	// Credential says this entry carries authentication.
+	//
+	// It is a field rather than a reading of Why, and that is a correction. This
+	// used to be decided by looking for the word "authentication" inside the
+	// human-readable reason, which was tolerable only while a credential WAS an
+	// environment variable. The primary credential is now a file, so a function
+	// that string-matches comments to answer an authentication question is both
+	// wrong and the kind of wrong that reads as working.
+	Credential bool
 }
 
 // allowed is the environment allowlist, and it is an allowlist on purpose. A
@@ -39,21 +49,35 @@ type Entry struct {
 // HOME and the XDG variables are absent for a different reason: they are facts
 // about the disposable directory rather than about the host, so inheriting them
 // would defeat the whole package. Environ sets them.
+//
+// CLAUDE_CODE_OAUTH_TOKEN was here and is deliberately gone. When it is set the
+// agent tool writes a plaintext credential, and its fallback combiner then
+// deletes the operator's keychain entry on exit — so a bench run on a machine
+// where that variable is set can destroy the operator's own login, and nothing
+// in a bench result would show it (anthropics/claude-code#37512, closed as not
+// planned).
+//
+// The mechanism is recorded rather than the headline, because the mechanism is
+// what a later reader has to re-check. The delete fires only when the keychain
+// read returned non-null, the keychain write then failed, and the plaintext
+// write succeeded; a disposable HOME makes that first read null, so the branch
+// cannot fire today. The variable still goes: a bench that only fails to destroy
+// the operator's login by accident of another design decision is one refactor
+// away from destroying it. Seats are reached through the config directory now.
 var allowed = []Entry{
-	{"TERM", "an agent CLI that cannot resolve a terminal writes control codes into the capture, which then reach the scorer as text"},
-	{"LANG", "collation and case folding differ without it, and a scenario's gold is matched by string"},
-	{"LC_ALL", "same as LANG, and it wins over LANG where both are set"},
-	{"ANTHROPIC_API_KEY", "key-based authentication; without it such a run reaches no model and produces an empty arm"},
-	{"ANTHROPIC_AUTH_TOKEN", "key-based authentication against a gateway that takes a bearer token rather than a key"},
-	{"CLAUDE_CODE_OAUTH_TOKEN", "seat-based authentication; the disposable HOME carries no credential of its own"},
-	{"SSL_CERT_FILE", "a host with a custom CA store cannot reach the provider without it, and the failure reads as an empty arm"},
-	{"SSL_CERT_DIR", "same as SSL_CERT_FILE, for a store kept as a directory"},
-	{"HTTP_PROXY", "a host behind a proxy reaches nothing without it"},
-	{"HTTPS_PROXY", "same as HTTP_PROXY, and it is the one the provider is actually reached through"},
-	{"NO_PROXY", "a proxy without its exception list sends local traffic through the proxy"},
-	{"http_proxy", "the lowercase spelling; tooling is split on which it reads, and honouring only one is a proxy that works for half a session"},
-	{"https_proxy", "the lowercase spelling, as above"},
-	{"no_proxy", "the lowercase spelling, as above"},
+	{Name: "TERM", Why: "an agent CLI that cannot resolve a terminal writes control codes into the capture, which then reach the scorer as text"},
+	{Name: "LANG", Why: "collation and case folding differ without it, and a scenario's gold is matched by string"},
+	{Name: "LC_ALL", Why: "same as LANG, and it wins over LANG where both are set"},
+	{Name: "ANTHROPIC_API_KEY", Why: "key-based authentication; without it such a run reaches no model and produces an empty arm", Credential: true},
+	{Name: "ANTHROPIC_AUTH_TOKEN", Why: "key-based authentication against a gateway that takes a bearer token rather than a key", Credential: true},
+	{Name: "SSL_CERT_FILE", Why: "a host with a custom CA store cannot reach the provider without it, and the failure reads as an empty arm"},
+	{Name: "SSL_CERT_DIR", Why: "same as SSL_CERT_FILE, for a store kept as a directory"},
+	{Name: "HTTP_PROXY", Why: "a host behind a proxy reaches nothing without it"},
+	{Name: "HTTPS_PROXY", Why: "same as HTTP_PROXY, and it is the one the provider is actually reached through"},
+	{Name: "NO_PROXY", Why: "a proxy without its exception list sends local traffic through the proxy"},
+	{Name: "http_proxy", Why: "the lowercase spelling; tooling is split on which it reads, and honouring only one is a proxy that works for half a session"},
+	{Name: "https_proxy", Why: "the lowercase spelling, as above"},
+	{Name: "no_proxy", Why: "the lowercase spelling, as above"},
 }
 
 // Layout is the directory tree of one run's environment.
@@ -65,6 +89,17 @@ type Layout struct {
 	Repo string
 	// Home is the disposable HOME, holding config, cache, data and state.
 	Home string
+	// Config is the run's agent config directory, and it is the door
+	// authentication comes through. CLAUDE_CONFIG_DIR points at it directly,
+	// which is what lets a credential be provisioned into a run without the run
+	// being able to reach a host keychain.
+	//
+	// It sits beside the disposable HOME rather than inside it, and deliberately:
+	// the contamination proof reads persisted memory as "a tool state directory
+	// exists under HOME", and a provisioned credential inside one would make
+	// every arm read as contaminated. Outside, the two questions stay separate —
+	// which is also why the memory check is told where this is.
+	Config string
 	// Logs holds the session's capture.
 	Logs string
 	// Artifacts holds the transcript, the tool io capture and the run metadata.
@@ -77,6 +112,7 @@ func LayoutFor(root string) Layout {
 		Root:      root,
 		Repo:      filepath.Join(root, "repo"),
 		Home:      filepath.Join(root, "home"),
+		Config:    filepath.Join(root, "config"),
 		Logs:      filepath.Join(root, "logs"),
 		Artifacts: filepath.Join(root, "artifacts"),
 	}
@@ -87,26 +123,49 @@ func LayoutFor(root string) Layout {
 // hard-codes `~/.config` still lands inside the run directory.
 var homeSubdirs = []string{"config", "cache", "data", "state"}
 
+// dir is one directory to create, and the mode it needs.
+type dir struct {
+	path string
+	mode os.FileMode
+}
+
 // dirs is everything Prepare creates, parents first.
-func (l Layout) dirs() []string {
-	d := []string{l.Root, l.Home, l.Logs, l.Artifacts}
+//
+// The config directory is 0700 and the rest are 0755, because that one holds a
+// plaintext bearer token for the length of the run. The file is 0600, but a
+// world-listable directory around it still tells everyone on the machine that
+// the credential is there and what it is called — and the mode has to be set
+// HERE, at creation: MkdirAll does not chmod a directory that already exists, so
+// provisioning into one made at 0755 would leave it at 0755.
+func (l Layout) dirs() []dir {
+	d := []dir{
+		{l.Root, 0o755},
+		{l.Home, 0o755},
+		{l.Config, 0o700},
+		{l.Logs, 0o755},
+		{l.Artifacts, 0o755},
+	}
 	for _, sub := range homeSubdirs {
-		d = append(d, filepath.Join(l.Home, sub))
+		d = append(d, dir{filepath.Join(l.Home, sub), 0o755})
 	}
 	return d
 }
 
-// Credentials are the allowlisted variables that carry authentication. A
-// session that reaches none of them cannot reach a model, and the arm it
+// Credentials are the allowlisted variables that carry authentication.
+//
+// They are the alternative door, not the main one: a seat reaches a run through
+// the provisioned config directory, and these are how a key-based host reaches
+// one instead. A session that has neither cannot reach a model, and the arm it
 // produces is empty rather than failed.
 //
-// It is derived from the allowlist rather than written out again: a credential
+// It is derived from the allowlist rather than written out again — a credential
 // added there and forgotten here would be a variable the session carries and
-// nothing counts as authentication.
+// nothing counts as authentication — but derived from the flag on each entry
+// rather than from the wording of its reason.
 func Credentials() []string {
 	var out []string
 	for _, e := range allowed {
-		if strings.Contains(e.Why, "authentication") {
+		if e.Credential {
 			out = append(out, e.Name)
 		}
 	}
@@ -119,10 +178,18 @@ func Credentials() []string {
 //
 // lookup reads the host, so the decision is a pure function of its arguments and
 // a table test can state the whole of it. Production passes os.LookupEnv.
-func Environ(l Layout, path string, lookup func(string) (string, bool), agentEnv []string) []string {
+// configDirVar is the agent tool's own name for the variable that points it at a
+// config directory, and it comes from the catalog: a name compiled in here would
+// be right for one tool and silently wrong for every other, which is the same
+// rule the contamination checks follow. A tool that declares none is given none,
+// and it authenticates by key or not at all.
+func Environ(l Layout, path string, lookup func(string) (string, bool), agentEnv []string, configDirVar string) []string {
 	env := []string{
 		"HOME=" + l.Home,
 		"PATH=" + path,
+	}
+	if configDirVar != "" {
+		env = append(env, configDirVar+"="+l.Config)
 	}
 	for _, sub := range homeSubdirs {
 		env = append(env, "XDG_"+strings.ToUpper(sub)+"_HOME="+filepath.Join(l.Home, sub))

--- a/lab/internal/isolate/env_test.go
+++ b/lab/internal/isolate/env_test.go
@@ -37,7 +37,7 @@ func envMap(t *testing.T, env []string) map[string]string {
 func TestSessionSeesTheDisposableHomeAndXDGDirectories(t *testing.T) {
 	l := LayoutFor("/runs/r1")
 
-	got := envMap(t, Environ(l, "/usr/bin", noHost, nil))
+	got := envMap(t, Environ(l, "/usr/bin", noHost, nil, ""))
 
 	want := map[string]string{
 		"HOME":            "/runs/r1/home",
@@ -64,7 +64,7 @@ func TestHostVariablesOutsideTheAllowlistDoNotReachTheSession(t *testing.T) {
 		"EDITOR":                                   "vim",
 	})
 
-	got := envMap(t, Environ(LayoutFor("/runs/r1"), "/usr/bin", host, nil))
+	got := envMap(t, Environ(LayoutFor("/runs/r1"), "/usr/bin", host, nil, ""))
 
 	if got["TERM"] != "xterm" {
 		t.Errorf("TERM = %q, want the allowlisted host value", got["TERM"])
@@ -77,7 +77,7 @@ func TestHostVariablesOutsideTheAllowlistDoNotReachTheSession(t *testing.T) {
 }
 
 func TestAnAllowlistedVariableTheHostDoesNotSetIsNotInvented(t *testing.T) {
-	got := envMap(t, Environ(LayoutFor("/runs/r1"), "/usr/bin", noHost, nil))
+	got := envMap(t, Environ(LayoutFor("/runs/r1"), "/usr/bin", noHost, nil, ""))
 
 	// An empty ANTHROPIC_API_KEY is not the same as an absent one: a tool that
 	// checks for presence would take the empty string as api-key auth and fail
@@ -107,7 +107,7 @@ func TestPathIsNotInheritedFromTheHostAllowlist(t *testing.T) {
 	}
 
 	host := hostWith(map[string]string{"PATH": "/host/bin"})
-	got := envMap(t, Environ(LayoutFor("/runs/r1"), "/arm/bin", host, nil))
+	got := envMap(t, Environ(LayoutFor("/runs/r1"), "/arm/bin", host, nil, ""))
 	if got["PATH"] != "/arm/bin" {
 		t.Errorf("PATH = %q, want the arm's value /arm/bin", got["PATH"])
 	}
@@ -117,7 +117,7 @@ func TestTheAgentToolsOwnEnvironmentWinsOverADefault(t *testing.T) {
 	agentEnv := []string{"IS_SANDBOX=1", "TERM=dumb"}
 	host := hostWith(map[string]string{"TERM": "xterm"})
 
-	got := envMap(t, Environ(LayoutFor("/runs/r1"), "/usr/bin", host, agentEnv))
+	got := envMap(t, Environ(LayoutFor("/runs/r1"), "/usr/bin", host, agentEnv, ""))
 
 	if got["IS_SANDBOX"] != "1" {
 		t.Errorf("IS_SANDBOX = %q, want the agent tool's 1", got["IS_SANDBOX"])
@@ -166,5 +166,51 @@ func TestTheLayoutNamesTheWholeRunTree(t *testing.T) {
 	}
 	if l.Root != "/runs/r1" {
 		t.Errorf("Root = %q, want /runs/r1", l.Root)
+	}
+}
+
+// The correction this pitch made, stated so it cannot regress silently.
+//
+// Credentials() used to decide what a credential is by looking for the word
+// "authentication" inside each entry's human-readable reason. Both flagged
+// entries happen to carry that word today, so swapping the flag back for the
+// string match passes every other test in the tree — which is exactly the shape
+// of wrong that reads as working. The fixture breaks the coincidence: one entry
+// says "authentication" and is not a credential, one is a credential and never
+// says it.
+func TestWhatCountsAsACredentialIsDeclaredRatherThanReadOutOfAComment(t *testing.T) {
+	was := allowed
+	t.Cleanup(func() { allowed = was })
+	allowed = []Entry{
+		{Name: "TALKS_ABOUT_AUTH", Why: "not a credential, but its reason mentions authentication in passing"},
+		{Name: "THE_REAL_ONE", Why: "reaches a model, and says so without using the word", Credential: true},
+	}
+
+	got := Credentials()
+
+	if !slices.Equal(got, []string{"THE_REAL_ONE"}) {
+		t.Errorf("Credentials() = %v, want only the entry declared as one", got)
+	}
+}
+
+// The variable that leaves the allowlist, named so re-adding it is a test
+// failure rather than a comment nobody reads.
+//
+// The hazard is measured: when it is set the agent tool writes a plaintext
+// credential and its fallback combiner then deletes the operator's keychain
+// entry on exit. A disposable HOME means the branch cannot fire today, which is
+// a reason to record the mechanism and not a reason to keep the variable.
+func TestTheKeychainDestroyingVariableIsNotOnTheAllowlist(t *testing.T) {
+	const destroys = "CLAUDE_CODE_OAUTH_TOKEN"
+
+	if slices.ContainsFunc(allowed, func(e Entry) bool { return e.Name == destroys }) {
+		t.Fatalf("%s is on the environment allowlist; a run on a host that sets it can delete "+
+			"the operator's own login, and nothing in a bench result would show it", destroys)
+	}
+
+	// And it does not reach a session even when the host sets it.
+	host := hostWith(map[string]string{destroys: "a-token"})
+	if _, ok := envMap(t, Environ(LayoutFor("/runs/r1"), "/usr/bin", host, nil, ""))[destroys]; ok {
+		t.Errorf("%s reached the session", destroys)
 	}
 }

--- a/lab/internal/isolate/hostcred.go
+++ b/lab/internal/isolate/hostcred.go
@@ -1,0 +1,96 @@
+package isolate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+)
+
+// Reading the operator's credential is the effect half of this package, and it
+// is in its own file for that reason: the provisioner beside it is a pure
+// function of a Credential, so it can be tested with no keychain and no login,
+// which is the only reason CI can hold the whole of that decision. A provisioner
+// that read the store itself would make every environment test need a seat.
+//
+// It runs in the attended parent, once per cell, where the keychain is
+// reachable. A session never reads a store: it is handed a file.
+
+// HostConfigDir is the operator's own config directory: the tool's config
+// variable if the host sets it, and the HOME-relative default otherwise. It is
+// the same precedence the tool applies, so a host that has moved its config is
+// read where it actually is.
+func (r Route) HostConfigDir(lookup func(string) (string, bool)) (string, error) {
+	if r.ConfigDirVar != "" {
+		if v, ok := lookup(r.ConfigDirVar); ok && v != "" {
+			return v, nil
+		}
+	}
+	if r.ConfigDir == "" {
+		return "", errors.New("the agent tool declares no config directory, so its credential cannot be located")
+	}
+	home, ok := lookup("HOME")
+	if !ok || home == "" {
+		return "", errors.New("cannot locate the host config directory: HOME is not set")
+	}
+	return filepath.Join(home, r.ConfigDir), nil
+}
+
+// HostCredential reads the operator's credential from wherever it lives.
+//
+// The file first and the platform store second, which is the order the agent
+// tool's own sandbox provisioner uses. Both are tried on every platform rather
+// than switched on runtime.GOOS: the file is the primary store on Linux and an
+// undocumented but real one on macOS, and a machine with no `security` command
+// simply fails that read and falls through. A GOOS branch here would be a second
+// implementation nobody exercises.
+func HostCredential(ctx context.Context, lookup func(string) (string, bool), r Route) (Credential, error) {
+	dir, err := r.HostConfigDir(lookup)
+	if err != nil {
+		return Credential{}, err
+	}
+	if c, err := r.Read(dir); err == nil && c.Valid() {
+		return c, nil
+	}
+	c, err := r.keychain(ctx, lookup)
+	if err != nil {
+		return Credential{}, fmt.Errorf("no usable credential in %s or the platform store: %w", dir, err)
+	}
+	if !c.Valid() {
+		return Credential{}, errors.New("the platform store holds a credential with no token, expiry or scopes")
+	}
+	return c, nil
+}
+
+// keychainCmd builds the read. It is a variable so a test can state what the
+// store answered without needing one.
+var keychainCmd = func(ctx context.Context, account, service string) *exec.Cmd {
+	return exec.CommandContext(ctx, "security",
+		"find-generic-password", "-a", account, "-s", service, "-w")
+}
+
+// keychain reads the platform store.
+//
+// A failure here is ordinary rather than exceptional: the command does not exist
+// off macOS, the item is absent on a machine that has never logged in, and the
+// ACL denies a session with no GUI context. All three mean "no credential from
+// this source", and the caller says so.
+func (r Route) keychain(ctx context.Context, lookup func(string) (string, bool)) (Credential, error) {
+	if r.Keychain == "" {
+		return Credential{}, errors.New("the agent tool declares no platform credential store")
+	}
+	account, ok := lookup("USER")
+	if !ok || account == "" {
+		return Credential{}, errors.New("USER is not set, so the store cannot be addressed")
+	}
+	out, err := keychainCmd(ctx, account, r.Keychain).Output()
+	if err != nil {
+		return Credential{}, fmt.Errorf("read the platform credential store: %w", err)
+	}
+	c, err := r.decode(out)
+	if err != nil {
+		return Credential{}, fmt.Errorf("read the platform credential store: %w", err)
+	}
+	return c, nil
+}

--- a/lab/internal/isolate/hostcred_test.go
+++ b/lab/internal/isolate/hostcred_test.go
@@ -1,0 +1,220 @@
+package isolate
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// storeDocument is what a credential store holds: the login the tool reads, and
+// the operator's connector tokens and refresh token beside it.
+func storeDocument(t *testing.T, key string, c Credential) string {
+	t.Helper()
+	doc := map[string]any{
+		key: map[string]any{
+			"accessToken":  c.AccessToken,
+			"refreshToken": "sk-refresh-host",
+			"expiresAt":    c.ExpiresAt,
+			"scopes":       c.Scopes,
+		},
+		"mcpOAuth": map[string]any{"a-connector": map[string]string{"accessToken": "connector-token"}},
+	}
+	b, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("build the store document: %v", err)
+	}
+	return string(b)
+}
+
+// answeringKeychain makes the store return the given text, and restores the real
+// read afterwards.
+func answeringKeychain(t *testing.T, out string, fail bool) {
+	t.Helper()
+	original := keychainCmd
+	t.Cleanup(func() { keychainCmd = original })
+	keychainCmd = func(ctx context.Context, _, _ string) *exec.Cmd {
+		if fail {
+			return exec.CommandContext(ctx, "false")
+		}
+		// printf rather than echo: the payload is JSON and must arrive
+		// byte for byte.
+		return exec.CommandContext(ctx, "printf", "%s", out)
+	}
+}
+
+func TestTheHostConfigDirectoryIsWhereTheToolsOwnVariableSaysItIs(t *testing.T) {
+	r := aRoute()
+	host := hostWith(map[string]string{"HOME": "/home/op", r.ConfigDirVar: "/elsewhere/config"})
+
+	got, err := r.HostConfigDir(host)
+	if err != nil {
+		t.Fatalf("locate: %v", err)
+	}
+	if got != "/elsewhere/config" {
+		t.Errorf("host config dir = %q, want the value the host's own variable names", got)
+	}
+}
+
+func TestTheHostConfigDirectoryFallsBackToTheToolsDefaultUnderHome(t *testing.T) {
+	r := aRoute()
+	got, err := r.HostConfigDir(hostWith(map[string]string{"HOME": "/home/op"}))
+	if err != nil {
+		t.Fatalf("locate: %v", err)
+	}
+	if want := filepath.Join("/home/op", r.ConfigDir); got != want {
+		t.Errorf("host config dir = %q, want %q", got, want)
+	}
+}
+
+func TestAHostWhoseConfigDirectoryCannotBeLocatedIsReportedRatherThanGuessed(t *testing.T) {
+	for _, tc := range []struct {
+		what  string
+		route Route
+		host  map[string]string
+	}{
+		{"the tool declares no config directory", Route{Key: "k"}, map[string]string{"HOME": "/home/op"}},
+		{"nothing says where HOME is", aRoute(), nil},
+	} {
+		t.Run(tc.what, func(t *testing.T) {
+			if _, err := tc.route.HostConfigDir(hostWith(tc.host)); err == nil {
+				t.Fatal("a config directory was invented; a run would then be provisioned from nowhere")
+			}
+		})
+	}
+}
+
+func TestTheOperatorsFileIsPreferredOverThePlatformStore(t *testing.T) {
+	// The order the agent tool's own sandbox provisioner uses, and it is the half
+	// that works on a machine with no keychain at all.
+	r := aRoute()
+	dir := t.TempDir()
+	fromFile := aCredential()
+	fromFile.AccessToken = "from-the-file"
+	if err := os.WriteFile(CredentialPath(dir), []byte(storeDocument(t, r.Key, fromFile)), 0o600); err != nil {
+		t.Fatalf("set up: %v", err)
+	}
+	answeringKeychain(t, storeDocument(t, r.Key, aCredential()), false)
+
+	got, err := HostCredential(context.Background(), hostWith(map[string]string{
+		r.ConfigDirVar: dir, "USER": "op",
+	}), r)
+	if err != nil {
+		t.Fatalf("read the host credential: %v", err)
+	}
+	if got.AccessToken != "from-the-file" {
+		t.Errorf("accessToken = %q, want the file's", got.AccessToken)
+	}
+}
+
+func TestThePlatformStoreIsReadWhenThereIsNoFile(t *testing.T) {
+	r := aRoute()
+	want := aCredential()
+	want.AccessToken = "from-the-store"
+	answeringKeychain(t, storeDocument(t, r.Key, want), false)
+
+	got, err := HostCredential(context.Background(), hostWith(map[string]string{
+		r.ConfigDirVar: t.TempDir(), "USER": "op",
+	}), r)
+	if err != nil {
+		t.Fatalf("read the host credential: %v", err)
+	}
+	if got.AccessToken != "from-the-store" {
+		t.Errorf("accessToken = %q, want the store's", got.AccessToken)
+	}
+	// The narrowing has to happen on this path too, not only on the file one.
+	if got.Scopes == nil {
+		t.Error("scopes were dropped, and a run without them reads as logged out")
+	}
+}
+
+func TestAHostWithNoCredentialAnywhereIsReportedRatherThanReturnedEmpty(t *testing.T) {
+	// The measured failure this pitch exists for: a session handed nothing exits
+	// in about a second with "Not logged in", zero tokens, and the arm reads in a
+	// score exactly like a model that had nothing to say. It has to be an error
+	// here, in the attended parent, before anything spawns.
+	r := aRoute()
+	answeringKeychain(t, "", true)
+
+	_, err := HostCredential(context.Background(), hostWith(map[string]string{
+		r.ConfigDirVar: t.TempDir(), "USER": "op",
+	}), r)
+	if err == nil {
+		t.Fatal("a host with no credential read as authenticated")
+	}
+	if !strings.Contains(err.Error(), "credential") {
+		t.Errorf("error = %q, want it to name what is missing", err)
+	}
+}
+
+func TestAToolWithNoPlatformStoreIsNotAskedForOne(t *testing.T) {
+	// codex and opencode keep no keychain item. Shelling out for one would fail
+	// with a message about a store that tool does not have.
+	r := aRoute()
+	r.Keychain = ""
+	answeringKeychain(t, storeDocument(t, r.Key, aCredential()), false)
+
+	_, err := HostCredential(context.Background(), hostWith(map[string]string{
+		r.ConfigDirVar: t.TempDir(), "USER": "op",
+	}), r)
+	if err == nil {
+		t.Fatal("a credential arrived from a store the tool declares it does not have")
+	}
+}
+
+func TestAStoreThatCannotBeAddressedIsReported(t *testing.T) {
+	r := aRoute()
+	answeringKeychain(t, storeDocument(t, r.Key, aCredential()), false)
+
+	// No USER, so there is no account to ask the store about.
+	if _, err := HostCredential(context.Background(), hostWith(map[string]string{
+		r.ConfigDirVar: t.TempDir(),
+	}), r); err == nil {
+		t.Fatal("the store was read without an account to read it for")
+	}
+}
+
+func TestAStoreThatAnswersSomethingElseIsNotTakenAsACredential(t *testing.T) {
+	for _, tc := range []struct{ what, answer string }{
+		{"not JSON at all", "The specified item could not be found in the keychain."},
+		{"a document with no credential in it", `{"somethingElse": {}}`},
+		{"a credential with no scopes", `{"toolOauth": {"accessToken": "t", "expiresAt": 1799999999000}}`},
+	} {
+		t.Run(tc.what, func(t *testing.T) {
+			r := aRoute()
+			answeringKeychain(t, tc.answer, false)
+
+			if _, err := HostCredential(context.Background(), hostWith(map[string]string{
+				r.ConfigDirVar: t.TempDir(), "USER": "op",
+			}), r); err == nil {
+				t.Fatal("a store answer that is not a usable credential was accepted as one")
+			}
+		})
+	}
+}
+
+func TestAnUnusableFileFallsThroughToTheStoreRatherThanFailing(t *testing.T) {
+	// A stale or half-written file on the host must not stop a machine whose real
+	// login is in the platform store.
+	r := aRoute()
+	dir := t.TempDir()
+	if err := os.WriteFile(CredentialPath(dir), []byte(`{"toolOauth": {"accessToken": "t"}}`), 0o600); err != nil {
+		t.Fatalf("set up: %v", err)
+	}
+	want := aCredential()
+	want.AccessToken = "from-the-store"
+	answeringKeychain(t, storeDocument(t, r.Key, want), false)
+
+	got, err := HostCredential(context.Background(), hostWith(map[string]string{
+		r.ConfigDirVar: dir, "USER": "op",
+	}), r)
+	if err != nil {
+		t.Fatalf("read the host credential: %v", err)
+	}
+	if got.AccessToken != "from-the-store" {
+		t.Errorf("accessToken = %q, want the store's", got.AccessToken)
+	}
+}

--- a/lab/internal/isolate/isolate.go
+++ b/lab/internal/isolate/isolate.go
@@ -33,6 +33,19 @@ type Spec struct {
 	HostPath string
 	// AgentEnv is what the agent tool declares in agent.json, as KEY=VALUE.
 	AgentEnv []string
+	// Credential is what the run is given to reach a model, read from the host
+	// once by the attended parent.
+	//
+	// An empty one is legal and means a key-based host: the key is an allowlisted
+	// environment variable and no file is written. Whether the run has EITHER is
+	// not decided here — it is decided in the attended parent before anything
+	// spawns, because a session that reaches no model exits in about a second
+	// with "Not logged in" and reads in a score exactly like a model that had
+	// nothing to say. What Prepare refuses is a half-filled credential, which is
+	// a mistake rather than a choice.
+	Credential Credential
+	// Route is how that credential reaches this agent tool, from the catalog.
+	Route Route
 	// Lookup reads the host environment. nil means os.LookupEnv.
 	Lookup func(string) (string, bool)
 }
@@ -69,8 +82,8 @@ func Prepare(s Spec) (Env, error) {
 	}
 
 	l := LayoutFor(root)
-	for _, dir := range l.dirs() {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
+	for _, d := range l.dirs() {
+		if err := os.MkdirAll(d.path, d.mode); err != nil {
 			return Env{}, fmt.Errorf("prepare run environment: %w", err)
 		}
 	}
@@ -83,6 +96,17 @@ func Prepare(s Spec) (Env, error) {
 		return Env{}, err
 	}
 
+	// The credential goes in before anything can be spawned against this
+	// environment, and a bad one fails the preparation rather than the session:
+	// the alternative is discovering it a wall at a time, twice per cell. An
+	// empty one is a key-based host, which needs no file; a half-filled one is a
+	// mistake and is refused.
+	if !s.Credential.Empty() {
+		if err := s.Route.Write(l.Config, s.Credential); err != nil {
+			return Env{}, err
+		}
+	}
+
 	lookup := s.Lookup
 	if lookup == nil {
 		lookup = os.LookupEnv
@@ -90,11 +114,17 @@ func Prepare(s Spec) (Env, error) {
 	return Env{
 		Layout:  l,
 		Arm:     s.Arm,
-		Environ: Environ(l, bin, lookup, s.AgentEnv),
+		Environ: Environ(l, bin, lookup, s.AgentEnv, s.Route.ConfigDirVar),
 	}, nil
 }
 
 // Cleanup removes the whole environment and proves it is gone.
+//
+// It is the right shape for a throwaway directory — the channel probe, a refused
+// cell — and the wrong one for a measured arm, which is what Release is for.
+// HoldsEvidence decides which, and it decides from the directory rather than
+// from a flag a caller passes: a boolean at the call site is a boolean somebody
+// eventually gets backwards, silently, on the side that deletes the evidence.
 //
 // The proof is the point. RemoveAll returning nil says nothing was reported,
 // not that nothing remains, and a run that leaves state behind contaminates the
@@ -123,4 +153,106 @@ func gone(path string) error {
 	default:
 		return fmt.Errorf("verify cleanup of %s: %w", path, err)
 	}
+}
+
+// evidence are the places a later reader looks: the capture, the session's raw
+// transcript, and the run's own record.
+//
+// A run directory is kept for months so a result can be re-read, and what makes
+// it worth keeping is that one of these holds something.
+var evidence = []string{"artifacts", "logs", "session"}
+
+// HoldsEvidence reports whether a run directory holds anything a later reader
+// needs, which is what decides how it is cleaned up.
+//
+// The property is "does this directory hold evidence", NOT "did this run
+// finish", and the distinction is load-bearing. The obvious rule gets it
+// backwards: keying off the run record deletes the directory of a run that
+// crashed before writing one, and that directory holds the transcript of the
+// crash — the most valuable thing on the disk at that moment.
+func HoldsEvidence(root string) bool {
+	for _, dir := range evidence {
+		if holdsAFile(filepath.Join(root, dir)) {
+			return true
+		}
+	}
+	return false
+}
+
+// holdsAFile reports whether anything at all was written under a directory.
+//
+// A directory that cannot be read counts as holding something, and that is the
+// load-bearing half. "I could not look" is not "there is nothing there", and the
+// two answers have very different costs here: the false negative deletes a run
+// that was paid for and can never be recreated, and the false positive keeps a
+// directory somebody removes by hand. An earlier version returned false on an
+// unreadable directory while its comment claimed the opposite, which is the
+// rabbit hole this pitch names — do not delete a directory because it looks
+// unfinished.
+func holdsAFile(dir string) bool {
+	found := false
+	_ = filepath.WalkDir(dir, func(_ string, d fs.DirEntry, err error) error {
+		switch {
+		case errors.Is(err, fs.ErrNotExist):
+			// Never created. That is a real absence, not a failure to look.
+			return nil
+		case err != nil:
+			found = true
+			return fs.SkipAll
+		case !d.IsDir():
+			found = true
+			return fs.SkipAll
+		}
+		return nil
+	})
+	return found
+}
+
+// Release gives back what a finished run does not need and keeps what a later
+// reader does: the config directory and the disposable HOME go, the evidence
+// stays.
+//
+// It is the second cleanup shape, and it exists because the first one is wrong
+// for a measured arm. Cleanup removes the run root, which holds the transcript,
+// the capture and the record — the evidence the scorer, the miner and status all
+// read, for a run that is paid for and can never be recreated.
+//
+// The config directory goes because it holds the credential: a run directory
+// outlives its purpose by months, and a plaintext bearer token in one outlives
+// its purpose with it.
+//
+// The disposable HOME goes for the same reason and one more. It is not evidence
+// — the contamination checks read it, and they run before this — and it is
+// whatever the agent tool decided to write about itself, which is exactly the
+// thing nobody can enumerate in advance. A tool that copies its credential into
+// its own HOME state would put a token in a kept directory, and no assertion
+// about what our stand-in writes would catch it. Dropping the directory makes
+// the guarantee independent of the tool's behaviour rather than a claim about it.
+//
+// The arm's bin farm stays: it is symlinks and it carries nothing. Note what
+// that does NOT buy — run-meta.json records the arm's HOME as well as its PATH,
+// and the HOME path no longer resolves after a release. Both are kept as a
+// record of what the arm ran with, not as directories a later reader can walk.
+//
+// Both removals are proven rather than assumed, the way the rest of this package
+// proves its own: RemoveAll returning nil says nothing was reported.
+func Release(e Env) error {
+	if e.Root == "" {
+		return errors.New("release: no run root")
+	}
+	var errs []error
+	// A slice rather than a map: removal order and the joined error text are then
+	// the same on every run, and nondeterministic output ordering has cost this
+	// repository a diff before.
+	for _, part := range []struct{ what, at string }{
+		{"credential", e.Config},
+		{"disposable HOME", e.Home},
+	} {
+		if err := os.RemoveAll(part.at); err != nil {
+			errs = append(errs, fmt.Errorf("remove the run's %s at %s: %w", part.what, part.at, err))
+			continue
+		}
+		errs = append(errs, gone(part.at))
+	}
+	return errors.Join(errs...)
 }

--- a/lab/internal/isolate/worktree.go
+++ b/lab/internal/isolate/worktree.go
@@ -2,8 +2,11 @@ package isolate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
+	"path/filepath"
+	"strings"
 )
 
 // AddWorktree checks the parent repository out at a commit, at dest.
@@ -24,16 +27,63 @@ func AddWorktree(ctx context.Context, parent, commit, dest string) error {
 	return nil
 }
 
-// RemoveWorktree removes the worktree and proves it is gone.
+// RemoveWorktree removes the worktree and proves both it and its registration
+// are gone.
 //
 // The proof is the point, as it is for the rest of cleanup: git reporting
 // success says nothing was reported, and a worktree left behind is state the
 // next run inherits. --force because a session is expected to have dirtied the
 // tree, and a run that modified the repository must still clean up.
+//
+// The registration is checked separately from the directory because the two come
+// apart: a directory removed by something other than git leaves an entry behind,
+// and git then refuses to add a worktree at that path again. Three such entries
+// accumulated in one afternoon and had to be pruned by hand before a retry would
+// run, so `prune` runs first and the list is read back afterwards.
 func RemoveWorktree(ctx context.Context, parent, dest string) error {
 	cmd := exec.CommandContext(ctx, "git", "-C", parent, "worktree", "remove", "--force", dest)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("remove worktree %s: %w: %s", dest, err, out)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		// git refuses when the directory is already gone, and that is exactly the
+		// case that leaves a stale entry behind. Prune it — but only when the
+		// parent still names this path. Otherwise there was nothing here to
+		// remove, and reporting that is what catches a caller cleaning up
+		// somewhere it never ran.
+		if deregistered(ctx, parent, dest) == nil {
+			return fmt.Errorf("remove worktree %s: %w: %s", dest, err, out)
+		}
+		prune(ctx, parent)
 	}
-	return gone(dest)
+	// Both proofs run and both are reported. The directory and the registration
+	// come apart, so one of them passing says nothing about the other.
+	return errors.Join(gone(dest), deregistered(ctx, parent, dest))
+}
+
+// prune clears registrations whose worktrees are no longer on disk.
+//
+// Its result is deliberately not reported. Whether git was happy is not the
+// question; whether the entry is still listed is, and RemoveWorktree asks that
+// directly afterwards. A prune that failed and mattered shows up there.
+func prune(ctx context.Context, parent string) {
+	_ = exec.CommandContext(ctx, "git", "-C", parent, "worktree", "prune").Run()
+}
+
+// deregistered is the proof half: the parent repository no longer names dest.
+func deregistered(ctx context.Context, parent, dest string) error {
+	out, err := exec.CommandContext(ctx, "git", "-C", parent, "worktree", "list", "--porcelain").Output()
+	if err != nil {
+		return fmt.Errorf("list the worktrees of %s: %w", parent, err)
+	}
+	abs, _ := filepath.Abs(dest)
+	for _, line := range strings.Split(string(out), "\n") {
+		at, ok := strings.CutPrefix(line, "worktree ")
+		if !ok {
+			continue
+		}
+		if registered, _ := filepath.Abs(strings.TrimSpace(at)); registered == abs {
+			return fmt.Errorf("%s is still registered as a worktree of %s; the next attempt at that path "+
+				"would be refused", dest, parent)
+		}
+	}
+	return nil
 }

--- a/lab/internal/probe/probe.go
+++ b/lab/internal/probe/probe.go
@@ -47,6 +47,12 @@ type Spec struct {
 	AgentEnv   []string
 	SetupTool  string
 	ConfigDirs []string
+	// Credential is what both arms are given to reach a model. One value, not
+	// two: an asymmetry in what the arms could reach would be an asymmetry in
+	// what they could do, and nothing in a score would show it.
+	Credential isolate.Credential
+	// Route is how that credential reaches the agent tool, from the catalog.
+	Route isolate.Route
 	// SenseBin is the Sense binary and LabBin is this one.
 	SenseBin string
 	LabBin   string
@@ -140,6 +146,22 @@ func Run(ctx context.Context, s Spec) (Report, error) {
 	}
 
 	rec, err := cell.Run(ctx, s.Root, arms)
+
+	// Whatever happened, the checkouts go back — but only after the checks have
+	// read them, because the repository routes are proved by looking inside the
+	// worktree and a released one would read as an arm that never had Sense.
+	//
+	// This is the call that was missing: the removal has been correct and
+	// unreachable from the binary since cycle 03, and one mastodon pair left
+	// 230MB and about 19,700 files behind. It runs on every path, because an
+	// interrupted or refused attempt leaks exactly the registration a finished
+	// one would — three of those accumulated in a single afternoon.
+	report, checkErr := s.report(ctx, rec, err, sense, baseline)
+	return report, errors.Join(checkErr, s.release(ctx, sense, baseline))
+}
+
+// report is the cell's outcome, before anything is given back.
+func (s Spec) report(ctx context.Context, rec cell.Record, err error, sense, baseline session.Result) (Report, error) {
 	if err != nil {
 		return Report{}, err
 	}
@@ -151,8 +173,31 @@ func Run(ctx context.Context, s Spec) (Report, error) {
 		return Report{}, fmt.Errorf("the cell is incomplete: %v has no result, and %v can never be paired",
 			rec.Unusable, rec.Burned)
 	}
-
 	return s.check(ctx, sense, baseline)
+}
+
+// release gives back both arms' checkouts, in whichever shape each directory
+// calls for. An arm that never ran has no environment and nothing to give back.
+//
+// A release failure is reported rather than swallowed: it means a registration
+// or a credential is still there, and the next attempt at that path is refused.
+func (s Spec) release(ctx context.Context, arms ...session.Result) error {
+	// Detached from the caller's cancellation, deliberately. Release shells out to
+	// git, and the case that most needs releasing is the interrupted cell — where
+	// the context is already cancelled, so every one of those commands would be
+	// killed before it ran and the registration would leak exactly when it costs
+	// most. The removals are bounded work on local paths, not something a user
+	// waits on.
+	ctx = context.WithoutCancel(ctx)
+
+	var errs []error
+	for _, a := range arms {
+		if a.Env.Root == "" {
+			continue
+		}
+		errs = append(errs, session.Finish(ctx, s.Parent, a.Env))
+	}
+	return errors.Join(errs...)
 }
 
 // armRunner is one side of the pair, as the supervisor sees it: a function that
@@ -161,10 +206,12 @@ func Run(ctx context.Context, s Spec) (Report, error) {
 func (s Spec) armRunner(arm isolate.Arm, wall time.Duration, into *session.Result) func(context.Context, string) (run.Meta, error) {
 	return func(ctx context.Context, dir string) (run.Meta, error) {
 		res, err := session.Run(ctx, s.arm(dir, arm, wall))
+		// Recorded whether or not the arm succeeded. The environment is what has
+		// to be released, and an arm that failed or was cut still took a checkout.
+		*into = res
 		if err != nil {
 			return run.Meta{}, err
 		}
-		*into = res
 		return res.Meta, nil
 	}
 }
@@ -175,28 +222,43 @@ func (s Spec) armRunner(arm isolate.Arm, wall time.Duration, into *session.Resul
 // number without being visible in any of them.
 func (s Spec) arm(root string, arm isolate.Arm, wall time.Duration) session.Spec {
 	return session.Spec{
-		Root:      root,
-		Arm:       arm,
-		Parent:    s.Parent,
-		Commit:    s.Commit,
-		Prompt:    s.Prompt,
-		Command:   s.Command,
-		Args:      s.Args,
-		AgentEnv:  s.AgentEnv,
-		SetupTool: s.SetupTool,
-		SenseBin:  s.SenseBin,
-		LabBin:    s.LabBin,
-		HostPath:  s.HostPath,
-		Wall:      wall,
-		Grace:     s.Grace,
+		Root:       root,
+		Arm:        arm,
+		Credential: s.Credential,
+		Route:      s.Route,
+		Parent:     s.Parent,
+		Commit:     s.Commit,
+		Prompt:     s.Prompt,
+		Command:    s.Command,
+		Args:       s.Args,
+		AgentEnv:   s.AgentEnv,
+		SetupTool:  s.SetupTool,
+		SenseBin:   s.SenseBin,
+		LabBin:     s.LabBin,
+		HostPath:   s.HostPath,
+		Wall:       wall,
+		Grace:      s.Grace,
 	}
 }
 
 // check runs every proof against the pair that just ran.
-func (s Spec) check(ctx context.Context, sense, baseline session.Result) (Report, error) {
+func (s Spec) check(ctx context.Context, sense, baseline session.Result) (rep Report, removed error) {
 	r := Report{Sense: sense, Baseline: baseline}
 
-	derived, err := channels.Derive(ctx, s.SenseBin, s.SetupTool, filepath.Join(s.Root, "channel-probe"))
+	// The channel probe is a throwaway: a scratch project and a scratch HOME that
+	// exist only to read back what `sense setup` writes. It holds no capture, no
+	// transcript and no record, so it goes whole, and it goes whether or not the
+	// derivation succeeded.
+	//
+	// Through isolate.Cleanup rather than a bare RemoveAll, so this removal is
+	// proven like every other one here. A discarded RemoveAll error is the exact
+	// shape of cleanup this package refuses everywhere else.
+	probeDir := filepath.Join(s.Root, "channel-probe")
+	defer func() {
+		removed = errors.Join(removed, isolate.Cleanup(isolate.Env{Layout: isolate.Layout{Root: probeDir}}))
+	}()
+
+	derived, err := channels.Derive(ctx, s.SenseBin, s.SetupTool, probeDir)
 	if err != nil {
 		return Report{}, err
 	}
@@ -284,6 +346,7 @@ func armWorld(res session.Result, binary string, configDirs []string) channels.A
 	return channels.Arm{
 		Repo:        res.Env.Repo,
 		Home:        res.Env.Home,
+		ConfigDir:   res.Env.Config,
 		PathValue:   res.Meta.Path,
 		SenseBinary: binary,
 		ConfigDirs:  configDirs,

--- a/lab/internal/probe/probe_test.go
+++ b/lab/internal/probe/probe_test.go
@@ -332,6 +332,36 @@ if [ -f .mcp.json ]; then echo answered; else sleep 30; fi`}
 	if _, statErr := os.Stat(filepath.Join(s.Root, "cell-meta.json")); statErr != nil {
 		t.Errorf("no cell record was written: %v", statErr)
 	}
+	// And the checkouts still go back. This is the case that produced three
+	// stale registrations in one afternoon: an interrupted cell is exactly the
+	// one nobody cleans up, and git then refuses the retry at that path.
+	if list := worktreeList(t, s.Parent); strings.Contains(list, s.Root) {
+		t.Errorf("an interrupted cell left a registration behind:\n%s", list)
+	}
+}
+
+// The channel probe is a scratch project and a scratch HOME, built to read back
+// what `sense setup` writes. It holds no evidence and must not survive the cell.
+func TestTheChannelProbeDirectoryDoesNotSurviveTheCell(t *testing.T) {
+	s := spec(t)
+
+	if _, err := probe.Run(context.Background(), s); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(s.Root, "channel-probe")); !os.IsNotExist(err) {
+		t.Errorf("the channel probe directory is still there: %v", err)
+	}
+}
+
+// worktreeList is what the parent repository still names.
+func worktreeList(t *testing.T, parent string) string {
+	t.Helper()
+	out, err := exec.Command("git", "-C", parent, "worktree", "list").CombinedOutput()
+	if err != nil {
+		t.Fatalf("git worktree list: %v: %s", err, out)
+	}
+	return string(out)
 }
 
 func TestASenseArmThatCannotBePreparedStopsTheCell(t *testing.T) {
@@ -340,6 +370,12 @@ func TestASenseArmThatCannotBePreparedStopsTheCell(t *testing.T) {
 
 	if _, err := probe.Run(context.Background(), s); err == nil {
 		t.Fatal("Run reported success although the sense arm could not be prepared")
+	}
+
+	// A cell that could not prepare an arm has still taken a checkout, and it
+	// must give it back: a leaked registration makes git refuse the retry.
+	if list := worktreeList(t, s.Parent); strings.Contains(list, s.Root) {
+		t.Errorf("a refused cell left a registration behind:\n%s", list)
 	}
 }
 

--- a/lab/internal/run/run_test.go
+++ b/lab/internal/run/run_test.go
@@ -3,6 +3,7 @@ package run
 import (
 	"context"
 	"encoding/json"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -515,4 +516,39 @@ func TestTheRecordSaysHowMuchTheSessionActuallySaid(t *testing.T) {
 			t.Errorf("stdout_bytes = %d, want 0", m.StdoutBytes)
 		}
 	})
+}
+
+// A run directory is read back for months. The environment it ran with carries
+// a bearer token, so nothing recorded may echo it — asserted rather than assumed,
+// because the record is written by a struct someone could add a field to.
+func TestNothingRecordedAboutARunCarriesItsCredentials(t *testing.T) {
+	dir := t.TempDir()
+	const token = "sk-ant-oat-should-never-be-recorded"
+
+	if _, err := Session(context.Background(), dir, Spec{
+		// The session says nothing about the token, which is the case worth
+		// checking: a transcript that quoted it would be the agent's doing and a
+		// different problem. This is about what the LAB writes down.
+		Name: "sh", Args: []string{"-c", "echo done"},
+		Env:  []string{"LAB_TEST_TOKEN=" + token},
+		Arm:  "sense",
+		Wall: 10 * time.Second,
+	}); err != nil {
+		t.Fatalf("Session: %v", err)
+	}
+
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil //nolint:nilerr // an unreadable entry is not a finding
+		}
+		b, readErr := os.ReadFile(path) // #nosec G304 -- the test's own run directory
+		if readErr == nil && strings.Contains(string(b), token) {
+			rel, _ := filepath.Rel(dir, path)
+			t.Errorf("%s carries the session's credential", rel)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk the run directory: %v", err)
+	}
 }

--- a/lab/internal/session/session.go
+++ b/lab/internal/session/session.go
@@ -9,6 +9,7 @@ package session
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -42,6 +43,10 @@ type Spec struct {
 	SetupTool string
 	// AgentEnv is what the agent tool declares in agent.json, as KEY=VALUE.
 	AgentEnv []string
+	// Credential is what this arm is given to reach a model, and Route is how it
+	// gets there. Both come from the catalog side, never from a constant here.
+	Credential isolate.Credential
+	Route      isolate.Route
 	// SenseBin is the Sense binary, and LabBin is this binary, which the
 	// capture shim is invoked through.
 	SenseBin string
@@ -68,11 +73,13 @@ const captureLog = "sense-io.jsonl"
 // is about to be diagnosed must survive the process that made it.
 func Run(ctx context.Context, s Spec) (Result, error) {
 	env, err := isolate.Prepare(isolate.Spec{
-		Root:     s.Root,
-		Arm:      s.Arm,
-		SenseBin: s.SenseBin,
-		HostPath: s.HostPath,
-		AgentEnv: s.AgentEnv,
+		Root:       s.Root,
+		Arm:        s.Arm,
+		SenseBin:   s.SenseBin,
+		HostPath:   s.HostPath,
+		AgentEnv:   s.AgentEnv,
+		Credential: s.Credential,
+		Route:      s.Route,
 	})
 	if err != nil {
 		return Result{}, err
@@ -84,9 +91,16 @@ func Run(ctx context.Context, s Spec) (Result, error) {
 
 	wrote, err := prepareArm(ctx, s, env)
 	if err != nil {
-		return Result{}, err
+		// Give the checkout and its registration back before reporting, or an
+		// attempt that never produced an arm still costs the parent repository a
+		// stale entry — and git then refuses the next attempt at that path. Three
+		// of those accumulated in one afternoon and were pruned by hand. The
+		// removal's own error is not allowed to hide the real one.
+		return Result{Env: env}, errors.Join(err, isolate.RemoveWorktree(detached(ctx), s.Parent, env.Repo))
 	}
 
+	// Past this point the run directory holds a transcript, so a failure leaves
+	// evidence and the caller decides what to do with it through Finish.
 	m, err := run.Session(ctx, filepath.Join(env.Root, "session"), run.Spec{
 		Dir:        env.Repo,
 		Name:       s.Command,
@@ -99,7 +113,11 @@ func Run(ctx context.Context, s Spec) (Result, error) {
 		Grace:      s.Grace,
 	})
 	if err != nil {
-		return Result{}, err
+		// The environment is returned with the error, not swallowed with it: the
+		// checkout and its registration exist and have to be given back, and the
+		// caller cannot do that from a zero Result. An interrupted cell is exactly
+		// the case nobody cleans up.
+		return Result{Env: env}, err
 	}
 	return Result{Env: env, Meta: m}, nil
 }
@@ -186,14 +204,55 @@ func Capture(env isolate.Env) (status tee.Status, present bool, err error) {
 	return status, true, nil
 }
 
+// Finish gives back everything the run no longer needs, in whichever of the two
+// shapes the directory calls for.
+//
+// A directory holding a capture, a transcript or a record is a measured arm: it
+// gives back its checkout, its registration and its credential, and keeps the
+// evidence. One holding none is a throwaway and goes entirely.
+//
+// Which shape applies is read off the directory rather than passed in. A boolean
+// at the call site is a boolean somebody eventually gets backwards, silently, on
+// the side that deletes an arm that was paid for and can never be recreated.
+func Finish(ctx context.Context, parent string, env isolate.Env) error {
+	ctx = detached(ctx)
+	if isolate.HoldsEvidence(env.Root) {
+		return Release(ctx, parent, env)
+	}
+	return Cleanup(ctx, parent, env)
+}
+
+// Release gives back the worktree, its registration and the credential, and
+// keeps the run record. A finished arm is 230MB of checkout and about 19,700
+// files that nothing will read again, beside a transcript that will be read for
+// months.
+func Release(ctx context.Context, parent string, env isolate.Env) error {
+	if err := isolate.RemoveWorktree(detached(ctx), parent, env.Repo); err != nil {
+		return err
+	}
+	return isolate.Release(env)
+}
+
 // Cleanup removes the worktree and then the whole environment, and proves both
-// are gone.
+// are gone. It is the shape for a throwaway directory; Finish is what a caller
+// with a run directory should reach for.
 func Cleanup(ctx context.Context, parent string, env isolate.Env) error {
-	if err := isolate.RemoveWorktree(ctx, parent, env.Repo); err != nil {
+	if err := isolate.RemoveWorktree(detached(ctx), parent, env.Repo); err != nil {
 		return err
 	}
 	return isolate.Cleanup(env)
 }
+
+// detached drops the caller's cancellation, for the git commands cleanup shells
+// out to.
+//
+// The case that most needs cleaning up is the interrupted one, and there the
+// context is already cancelled — so every removal would be killed before it ran,
+// precisely when a leaked registration costs most. Every entry point here does
+// this for itself rather than trusting the caller to have done it: the removals
+// are bounded work on local paths, and being correct only because of who called
+// you is not being correct.
+func detached(ctx context.Context) context.Context { return context.WithoutCancel(ctx) }
 
 // LogPath is where a run's MCP capture lives.
 func LogPath(env isolate.Env) string { return filepath.Join(env.Artifacts, captureLog) }

--- a/lab/internal/session/session_test.go
+++ b/lab/internal/session/session_test.go
@@ -364,6 +364,27 @@ func TestAFailingSubjectPreparationStopsBeforeTheAgentSpawns(t *testing.T) {
 	}
 }
 
+// The environment comes back WITH the error, and that contract is load-bearing:
+// the caller releases what the failed attempt took, and it cannot do that from a
+// zero Result. Stated here, where it is defined, rather than only through the
+// cell-level test that depends on it.
+func TestAFailedArmStillHandsBackTheEnvironmentItTook(t *testing.T) {
+	s := spec(t, isolate.Sense)
+	s.SenseBin = fakeSenseWriting(t, "printf '{}' > .mcp.json")
+
+	res, err := session.Run(context.Background(), s)
+
+	if err == nil {
+		t.Fatal("an arm with no registration ran")
+	}
+	if res.Env.Root == "" {
+		t.Fatal("the failed arm reported no environment, so its caller has nothing to release")
+	}
+	if res.Env.Repo == "" || res.Env.Config == "" {
+		t.Errorf("the environment came back incomplete: %+v", res.Env)
+	}
+}
+
 func TestAnAgentThatCannotBeSpawnedIsReported(t *testing.T) {
 	s := spec(t, isolate.Baseline)
 	s.Command = filepath.Join(t.TempDir(), "no-such-agent")
@@ -570,4 +591,119 @@ func readCaptured(t *testing.T, path string) []map[string]any {
 		entries = append(entries, e)
 	}
 	return entries
+}
+
+// A measured arm gives back the disk and keeps the evidence. A worktree is a
+// full checkout — one mastodon pair put 230MB and about 19,700 files on disk —
+// and the transcript beside it is read for months.
+func TestAFinishedArmGivesBackItsCheckoutAndKeepsItsRecord(t *testing.T) {
+	s := spec(t, isolate.Sense)
+	s.Credential = aCredential()
+	s.Route = aRoute()
+	res, err := session.Run(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if err := session.Finish(context.Background(), s.Parent, res.Env); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	if _, err := os.Stat(res.Env.Repo); !os.IsNotExist(err) {
+		t.Errorf("the checkout is still on disk: %v", err)
+	}
+	if list := gitOut(t, s.Parent, "worktree", "list"); strings.Contains(list, res.Env.Repo) {
+		t.Errorf("the parent still lists the worktree:\n%s", list)
+	}
+	if _, err := os.Stat(isolate.CredentialPath(res.Env.Config)); err == nil {
+		t.Error("the credential survived, in a directory kept for months")
+	}
+	// The evidence the scorer, the miner and status all read.
+	for _, kept := range []string{
+		filepath.Join(res.Env.Root, "session", "run-meta.json"),
+		filepath.Join(res.Env.Root, "session", "raw", "stdout"),
+	} {
+		if _, err := os.Stat(kept); err != nil {
+			t.Errorf("Finish destroyed %s, which is what the arm was run to produce", kept)
+		}
+	}
+}
+
+// A directory that holds nothing is a throwaway and goes whole. The shape is a
+// property of the directory, not a flag the caller passes.
+func TestADirectoryHoldingNoEvidenceIsRemovedEntirely(t *testing.T) {
+	s := spec(t, isolate.Baseline)
+	res, err := session.Run(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// Everything a later reader would want, gone: this is now the shape of an
+	// attempt that produced nothing at all.
+	for _, dir := range []string{"session", "artifacts", "logs"} {
+		if err := os.RemoveAll(filepath.Join(res.Env.Root, dir)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := session.Finish(context.Background(), s.Parent, res.Env); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	if _, err := os.Stat(res.Env.Root); !os.IsNotExist(err) {
+		t.Errorf("a directory holding no evidence was kept: %v", err)
+	}
+}
+
+// The leak that produced three stale registrations in one afternoon: an attempt
+// that fails before the agent spawns has still taken a checkout, and git refuses
+// the next attempt at that path until somebody prunes by hand.
+func TestAnAttemptThatFailsBeforeSpawningLeaksNoRegistration(t *testing.T) {
+	s := spec(t, isolate.Sense)
+	// A setup that writes no registration, so the arm is refused after the
+	// worktree exists and before anything is spawned.
+	s.SenseBin = fakeSenseWriting(t, "printf '{}' > .mcp.json")
+
+	if _, err := session.Run(context.Background(), s); err == nil {
+		t.Fatal("an arm with no registration ran")
+	}
+
+	if list := gitOut(t, s.Parent, "worktree", "list"); strings.Contains(list, "run/repo") {
+		t.Errorf("a refused attempt left a registration behind:\n%s", list)
+	}
+}
+
+// The registration and the directory come apart, and the entry is what blocks
+// the retry. Removing the directory by any other means must still leave the
+// parent clean.
+func TestAWorktreeWhoseDirectoryVanishedIsStillDeregistered(t *testing.T) {
+	s := spec(t, isolate.Baseline)
+	res, err := session.Run(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if err := os.RemoveAll(res.Env.Repo); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := session.Finish(context.Background(), s.Parent, res.Env); err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	if list := gitOut(t, s.Parent, "worktree", "list"); strings.Contains(list, res.Env.Repo) {
+		t.Errorf("the parent still lists a worktree whose directory is gone:\n%s", list)
+	}
+}
+
+// aCredential is a usable seat, and aRoute the catalog names it reaches the tool
+// by. Both are the test's own: nothing here is compiled into the lab.
+func aCredential() isolate.Credential {
+	return isolate.Credential{
+		AccessToken: "seat-token",
+		ExpiresAt:   time.Now().Add(time.Hour).UnixMilli(),
+		Scopes:      []string{"user:inference"},
+	}
+}
+
+func aRoute() isolate.Route {
+	return isolate.Route{ConfigDirVar: "TOOL_CONFIG_DIR", ConfigDir: ".tool", Key: "toolOauth"}
 }


### PR DESCRIPTION
Implements [03-06, Credentials are a channel](https://github.com/luuuc/sense/blob/main/.doc/sense-lab/cycles/03-isolation-and-both-arms/03-06-credentials-are-a-channel.md). Bench-only: everything is under `lab/`, and the commits are `bench(...)` so the Sense version does not move (`git-cliff --bumped-version` is `v1.14.0` on both this branch and main).

## The problem

Cycle 03 settled a run's credentials in one clause of 03-01: *"add what the agent tool genuinely needs (`PATH`, `TERM`, credentials the tool requires)"*. That was implemented as an environment allowlist — **which assumes a credential is an environment variable.** On macOS with a subscription seat it is not, the assumption was never written down, and nothing could check it.

Measured 2026-08-17, attempting the first live cell of the replay: a session given a disposable `HOME` exits in **about one second** with `"result": "Not logged in · Please run /login"`, zero tokens, zero cost, with the operator logged in on the host throughout. Linking the host keychain in is not the fix either — it worked twice and then failed ten consecutive times with a real-`HOME` control passing throughout.

**The flakiness was the finding.** Two in twelve is worse than zero: an occasional pass produces an empty arm the rest of the time, and an empty arm is indistinguishable from a legitimate loss in a score.

## What this does

**Models authentication as a channel** with a stated direction: the operator's credential must reach the arm, and the subject's writes must not reach the host.

The door is the **config directory**, not `HOME` and not the keychain. The credential is read once in the attended parent, where the keychain is reachable, and provisioned into a per-run `CLAUDE_CONFIG_DIR` as `.credentials.json` at mode `0600` holding `accessToken`, `expiresAt` and `scopes` **and nothing else**.

- **The shape was measured, not assumed.** Eight shapes were written into an isolated run and asked for one word: `accessToken` alone does not authenticate, nor with an expiry, nor with an expiry and `subscriptionType`. **`scopes` is the gate.**
- **Dropping `refreshToken` is a safety property, not a tidy-up.** A run that cannot refresh cannot rotate the operator's login, so no number of unattended cells can invalidate the host seat by succeeding. The cost is stated: a campaign outliving the access token re-provisions rather than running on.
- **The host keychain is never linked in.** A denied read returns a sentinel the strict read path short-circuits on, so it never reaches the file fallback, while an absent store is unambiguously null and always falls back. Present-but-denied is a coin flip where absent is deterministic — which is the 2-of-12.
- **`CLAUDE_CODE_OAUTH_TOKEN` leaves the allowlist**, because when set it makes the tool delete the operator's keychain entry on exit ([#37512](https://github.com/anthropics/claude-code/issues/37512)). The recorded reason is the *mechanism*, not the headline: the delete needs a keychain read that returned non-null, which a disposable `HOME` makes impossible today. It still goes — a bench that only fails to destroy the operator's login by accident of another design decision is one refactor from destroying it.
- **The preflight asks about validity, not presence.** A credential that expires before now plus **both** walls is refused before anything spawns, naming expiry. A token that dies between the arms burns the first one: it is paid for and can never be paired.

**Cleanup gains a second shape**, folded in because it is the same surface and the same shaped question. `session.Cleanup` has been correct and unreachable from the binary since cycle 03; one mastodon pair left 230MB and ~19,700 files behind, and three stale worktree registrations accumulated in one afternoon.

- a directory holding a capture, transcript or record gives back its checkout, registration, credential and disposable HOME, and **keeps the evidence**; one holding none goes whole
- the shape is a property of the directory, never a flag a caller passes
- **evidence, not completion, decides** — a run that crashed before writing `run-meta.json` still holds the transcript of the crash, which is the most valuable thing on the disk at that moment
- no attempt leaks a registration, including a refused or interrupted one

## The review found four defects in production code

Each was a test written for a named hazard finding the hazard, and **none is visible in a bench result**:

1. the run's config directory was created at `0755`, so every provisioned credential sat in a world-listable directory — the mode assertion passed only because it tested a bare write into a path no run has
2. a failed arm discarded its environment, leaving the caller nothing to release
3. cleanup shelled out to git on the caller's context, so on an **interrupted** cell — the case that most needs releasing — every removal was killed before it ran
4. `HoldsEvidence` read "I could not look" as "nothing is there", which would have deleted the transcript of a paid run whose directory turned unreadable

Five mutations were run against the suspect tests; five bit.

The binary-identifier probe also caught `.claude`, `CLAUDE_CONFIG_DIR`, the keychain item and `claudeAiOauth` being compiled in. All four moved into `agent.json` as a credential route, and the validator now refuses a half-declared one.

## Gates

- `make ci` green: 96.0% total, every gated file at the floor, 0 lint issues, complexity ledger 0
- `make smoke` green
- qlty: `check --upstream=main` → no issues; `smells --all` → **96 on the branch, 96 on main, diff empty**
- coverage on files this adds: `credential.go` 100%, `hostcred.go` 93.9% line / 100% function
- reviewed by the council and by four rounds of test-spec review

## What is deliberately not proven

- **macOS only, and that is a decision rather than an omission.** The implementation branches on nothing — it writes a file at a path the config directory already decides, which is the mechanism Linux uses as its *primary* store. But it is measured on macOS alone, and **no campaign may report a Linux result on this route** until 08-05 stands up a container.
- **The live half is still owed.** A bare session is banked at 10/10 twice (four-field and the three-field shape this ships), keychain intact after every one. A **real cell** — which adds a worktree, a subject and an MCP registration to the same route — has not been run ten times yet. That is an operator procedure and correctly not a CI gate: a gate that cannot run is worse than an absent one, because it reads as coverage.

## What this unblocks

[06-04, The replay](https://github.com/luuuc/sense/blob/main/.doc/sense-lab/cycles/06-miner-candidates-replay/06-04-the-replay.md) cannot ship until this does. It needs one banked cell run live, and no cell can run under isolation without a credential. It is the first thing to re-run when this lands.
