### PR TITLE
bench(probe): tell each arm its wall and pair against work done

### DIFF
--- a/lab/agents/claude-code/README.md
+++ b/lab/agents/claude-code/README.md
@@ -70,6 +70,30 @@ cannot refresh cannot rotate the operator's login, so no number of unattended
 cells can invalidate the host seat by succeeding. The cost is that a campaign
 outliving the access token re-provisions rather than running on.
 
+## Telling an arm its wall
+
+There is no wall-clock flag. Re-checked against **2.1.233** on 2026-08-17: no
+`--timeout`, `--max-duration`, `--deadline`, `--max-time`, `--max-turns`. The
+supervisor's kill is the only enforcement, and `--max-budget-usd` bills API
+quota rather than a subscription, so it is not a clock.
+
+So the number reaches the arm as a system prompt, through `wall_note_flag` and
+`wall_note`, with `{{seconds}}` replaced by **that arm's own wall**. It enforces
+nothing. It exists so an arm can spend its clock deliberately instead of being
+cut mid-answer.
+
+**This is not decoration, and it was measured missing.** Replaying the banked
+mastodon cell on 2026-08-17 without it, both arms ran to their ceiling and were
+cut — 82 and 72 turns, exit 124 — and the scorer refused both captures as
+incomplete. The banked arms, which had the note, finished with time in hand. The
+margin came back 0.400 against a banked 0.775.
+
+**Do not reword it.** The wording is copied from the instrument this one
+replaces, which recorded what a rewrite costs: an earlier phrasing offered "if
+you run short, say where you stopped", and both arms took the exit immediately.
+The sense arm used 143s of 480 and wrote that it had not finished with 337
+seconds still in hand. If it must change, re-measure it.
+
 ## Judging
 
 `judge_args` drive the tool tool-less and single-turn, for grading. `-p` with

--- a/lab/agents/claude-code/agent.json
+++ b/lab/agents/claude-code/agent.json
@@ -17,6 +17,8 @@
     "--allowedTools",
     ""
   ],
+  "wall_note_flag": "--append-system-prompt",
+  "wall_note": "Wall clock: this session is stopped hard after {{seconds}} seconds of real time, measured from now, and nothing written after that point is kept. This is a CEILING, not a target. There is no credit for finishing early, and no penalty for using all of it. Stopping before the work is done simply costs you the part you did not do. Keep working until the task is complete or the clock forces you to stop.",
   "env": [
     "IS_SANDBOX=1",
     "CLAUDE_CODE_DISABLE_AUTO_MEMORY=1"

--- a/lab/internal/catalog/catalog.go
+++ b/lab/internal/catalog/catalog.go
@@ -19,7 +19,9 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
+	"time"
 )
 
 // Kind is what a subject is: the treatment under test.
@@ -111,6 +113,29 @@ type Agent struct {
 	// verify claims itself, whether it does varies run to run, and which
 	// instrument graded a run would not be visible in the number.
 	JudgeArgs []string `json:"judge_args"`
+	// WallNoteFlag and WallNote tell an arm how long it has.
+	//
+	// The CLI has no wall-clock parameter, so the number reaches the agent as a
+	// system prompt. It enforces nothing — the supervisor's kill is still the
+	// hard stop — and it exists so an arm can spend its clock deliberately
+	// instead of being cut mid-answer.
+	//
+	// This is not a nicety. It was measured absent on 2026-08-17, replaying the
+	// banked mastodon cell: both arms ran to their ceiling and were cut, 82 and
+	// 72 turns, and the scorer refused both captures as incomplete. The banked
+	// arms, which had the note, finished with time in hand.
+	//
+	// WallNote carries {{seconds}}, replaced with the arm's own wall. Each arm
+	// gets its own number, which is the whole point: the two walls differ.
+	//
+	// The WORDING is load-bearing and is copied from the instrument this one
+	// replaces, which recorded what a rewrite costs. An earlier phrasing offered
+	// "if you run short, say where you stopped", and both arms took the exit
+	// immediately: the sense arm used 143s of 480 and wrote that it had not
+	// finished with 337 seconds still in hand. Reword this and re-measure, or do
+	// not reword it.
+	WallNoteFlag string `json:"wall_note_flag"`
+	WallNote     string `json:"wall_note"`
 	// Env is added to the session environment, as KEY=VALUE. Same reason.
 	Env []string `json:"env"`
 	// SupportsMCP bounds which subjects this tool can carry.
@@ -412,4 +437,23 @@ func readFlat(dir string, add func(string, []byte) error) error {
 // IDs returns the ids of a catalog map, sorted, so output is stable.
 func IDs[T any](m map[string]T) []string {
 	return slices.Sorted(maps.Keys(m))
+}
+
+// wallNoteSeconds is the placeholder WallNote carries for the arm's own wall.
+const wallNoteSeconds = "{{seconds}}"
+
+// WallNoteArgs renders this tool's wall note for an arm that has this long,
+// ready to append to the arm's arguments.
+//
+// It returns nothing when the tool declares no note, so a tool that has no way
+// to carry one runs exactly as it did before rather than being handed an empty
+// flag. Seconds are truncated rather than rounded: a note claiming one second
+// more than the supervisor allows is a note that lies in the direction that
+// costs the arm its answer.
+func (a Agent) WallNoteArgs(wall time.Duration) []string {
+	if a.WallNoteFlag == "" || a.WallNote == "" {
+		return nil
+	}
+	seconds := strconv.Itoa(int(wall.Seconds()))
+	return []string{a.WallNoteFlag, strings.ReplaceAll(a.WallNote, wallNoteSeconds, seconds)}
 }

--- a/lab/internal/catalog/catalog_test.go
+++ b/lab/internal/catalog/catalog_test.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
+	"time"
 )
 
 // good returns a minimal catalog directory that loads clean. Tests break one
@@ -668,5 +670,45 @@ func TestModelResolvesOnACatalogBuiltAsALiteral(t *testing.T) {
 	}
 	if _, ok := c.Model("nope"); ok {
 		t.Error("a model that does not exist resolved")
+	}
+}
+
+func TestAnArmIsToldItsWallInSecondsInTheToolsOwnWords(t *testing.T) {
+	a := Agent{
+		WallNoteFlag: "--append-system-prompt",
+		WallNote:     "stopped hard after {{seconds}} seconds of real time",
+	}
+
+	got := a.WallNoteArgs(485 * time.Second)
+
+	want := []string{"--append-system-prompt", "stopped hard after 485 seconds of real time"}
+	if !slices.Equal(got, want) {
+		t.Errorf("WallNoteArgs(485s) = %q, want %q", got, want)
+	}
+}
+
+func TestAToolThatDeclaresNoWallNoteIsSpawnedWithoutOne(t *testing.T) {
+	// Not every agent tool can carry one. Handing such a tool a bare flag, or a
+	// flag with an empty value, is a spawn that fails on a usage error rather
+	// than a run that behaves as it did before.
+	for _, a := range []Agent{
+		{},
+		{WallNoteFlag: "--append-system-prompt"},
+		{WallNote: "stopped hard after {{seconds}} seconds"},
+	} {
+		if got := a.WallNoteArgs(485 * time.Second); got != nil {
+			t.Errorf("a tool declaring %+v was handed %q", a, got)
+		}
+	}
+}
+
+func TestTheWallAnArmIsToldIsNeverMoreThanTheWallItGets(t *testing.T) {
+	// Truncated, not rounded. A note claiming 486 seconds when the supervisor
+	// kills at 485.6 is a note that lies in the one direction that costs the arm
+	// its answer: it keeps working into a wall that has already closed.
+	a := Agent{WallNoteFlag: "--wall", WallNote: "{{seconds}}"}
+
+	if got := a.WallNoteArgs(485_600 * time.Millisecond); got[1] != "485" {
+		t.Errorf("an arm cut at 485.6s was told %q seconds", got[1])
 	}
 }

--- a/lab/internal/cli/probecmd.go
+++ b/lab/internal/cli/probecmd.go
@@ -88,7 +88,10 @@ func probeCell(ctx context.Context, args []string, stdout, stderr io.Writer) int
 		return exitError
 	}
 
-	_, _ = fmt.Fprintf(stdout, "scenario: %s\nrepo:     %s @ %.8s\nagent:    %s\nmodel:    %s\nwall:     %s / %s\ncell:     %s\n\n",
+	// The baseline's wall is printed as a ceiling because it is not decided
+	// yet: it derives from what the sense arm elapses, and a sense arm that
+	// finishes early leaves the baseline less than this.
+	_, _ = fmt.Fprintf(stdout, "scenario: %s\nrepo:     %s @ %.8s\nagent:    %s\nmodel:    %s\nwall:     %s sense, at most %s baseline (1.2x what sense spends)\ncell:     %s\n\n",
 		j.scenarioName, j.repo.ID, j.repo.Commit, j.agent.ID, j.model.ID,
 		s.Wall, probe.BaselineWall(s.Wall), s.Root)
 
@@ -257,6 +260,7 @@ func probeSpec(ctx context.Context, f probeFlags) (probe.Spec, probeJob, error) 
 		Command:    j.agent.Binary,
 		Args:       append(slices.Clone(j.agent.HeadlessArgs), j.agent.ModelFlag, j.model.ID),
 		AgentEnv:   j.agent.Env,
+		Agent:      j.agent,
 		SetupTool:  j.agent.ID,
 		ConfigDirs: j.agent.ConfigDirs,
 		Credential: cred,

--- a/lab/internal/cli/probecmd_test.go
+++ b/lab/internal/cli/probecmd_test.go
@@ -409,13 +409,17 @@ func TestProbeRefusesACheckoutThatIsNotThere(t *testing.T) {
 	}
 }
 
-// The baseline's wall derives from the sense arm's rather than being chosen
-// beside it, and the header says so before anything spends.
+// The baseline's wall derives from what the sense arm SPENDS rather than being
+// chosen beside it, so before anything spends the header can only state a
+// ceiling for it — and it has to read as a ceiling, or somebody plans a session
+// around a number the baseline will not get.
 func TestProbeStatesBothWallsBeforeItSpends(t *testing.T) {
 	w := newProbeWorld(t)
 	_, stdout, _ := runProbe(t, w.args())
-	if !strings.Contains(stdout, "wall:     20s / 20s") {
-		t.Errorf("the header does not state both walls:\n%s", stdout)
+	for _, want := range []string{"20s sense", "at most 24s baseline"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("the header does not state %q:\n%s", want, stdout)
+		}
 	}
 }
 

--- a/lab/internal/probe/probe.go
+++ b/lab/internal/probe/probe.go
@@ -104,7 +104,21 @@ const baselineWallRatio = 1.2
 // arm it is paired with, which is also why a burned sense arm can never be
 // paired with a later baseline.
 func BaselineWall(senseElapsed time.Duration) time.Duration {
-	return time.Duration(float64(senseElapsed) * baselineWallRatio).Round(time.Second)
+	wall := time.Duration(float64(senseElapsed) * baselineWallRatio).Round(time.Second)
+	// A derived wall below a second is not a budget, it is an immediate kill,
+	// and the arm it kills is indistinguishable in a score from a baseline that
+	// simply had nothing to say. Rounding makes it worse: 1.2 times a few
+	// milliseconds rounds to exactly zero.
+	//
+	// It happens whenever the sense arm returns almost at once, which is not
+	// hypothetical — a session that cannot authenticate exits in about a second
+	// having done nothing. Such a pair is already unsound and is refused on the
+	// sense arm, which is the real fault; this only stops it being reported as a
+	// baseline that could not finish.
+	if wall < time.Second {
+		return time.Second
+	}
+	return wall
 }
 
 // Report is what the pair proved.

--- a/lab/internal/probe/probe.go
+++ b/lab/internal/probe/probe.go
@@ -17,9 +17,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
+	"github.com/luuuc/sense/lab/internal/catalog"
 	"github.com/luuuc/sense/lab/internal/cell"
 	"github.com/luuuc/sense/lab/internal/channels"
 	"github.com/luuuc/sense/lab/internal/isolate"
@@ -42,9 +44,12 @@ type Spec struct {
 	// SetupTool is its catalog id, which is what `sense setup` configures for,
 	// and ConfigDir is the directory it keeps per-user state in, which the
 	// contamination checks look inside.
-	Command    string
-	Args       []string
-	AgentEnv   []string
+	Command  string
+	Args     []string
+	AgentEnv []string
+	// Agent is the tool's catalog entry, carried so each arm can be told its
+	// own wall in the words that tool understands.
+	Agent      catalog.Agent
 	SetupTool  string
 	ConfigDirs []string
 	// Credential is what both arms are given to reach a model. One value, not
@@ -58,7 +63,8 @@ type Spec struct {
 	LabBin   string
 	// HostPath is the PATH both arms derive from.
 	HostPath string
-	// Wall is the sense arm's budget. The baseline's is derived from it.
+	// Wall is the sense arm's budget. The baseline's derives from what the
+	// sense arm ELAPSED, so it is not knowable here.
 	Wall  time.Duration
 	Grace time.Duration
 }
@@ -69,14 +75,37 @@ const (
 	baselineArm = "baseline"
 )
 
-// BaselineWall is the baseline arm's budget, derived from the sense arm's.
+// baselineWallRatio is what the baseline gets, as a multiple of what the sense
+// arm actually spent.
+//
+// Above one deliberately. The baseline has to find by reading what the sense
+// arm can look up, so an equal budget is not an equal question, and the corpus
+// this instrument has to stay comparable with was banked at 1.2.
+const baselineWallRatio = 1.2
+
+// BaselineWall is the baseline arm's budget, derived from what the sense arm
+// ELAPSED — not from what it was allowed.
+//
+// The distinction is the whole function and it is easy to lose. A sense arm
+// given 480 seconds that finishes in 404 leaves the baseline 485, not 576: the
+// pairing is against the work the sense arm actually did. Deriving from the
+// budget instead silently hands the baseline more clock every time the sense
+// arm finishes early, which shrinks every margin in the same direction without
+// appearing in any of them.
+//
+// That is not hypothetical. This function returned its argument unchanged until
+// 2026-08-17, when replaying the banked mastodon cell showed the banked run had
+// derived 485s from a 404s sense arm while this derived 480s from its ceiling.
+// The two agreed only because that live sense arm ran out of time.
 //
 // It is a function rather than an assignment because the relationship is easy
 // to get backwards, and getting it backwards is not visible in a result. The
 // two walls are not independently chosen: the baseline's derives from the sense
 // arm it is paired with, which is also why a burned sense arm can never be
 // paired with a later baseline.
-func BaselineWall(senseWall time.Duration) time.Duration { return senseWall }
+func BaselineWall(senseElapsed time.Duration) time.Duration {
+	return time.Duration(float64(senseElapsed) * baselineWallRatio).Round(time.Second)
+}
 
 // Report is what the pair proved.
 type Report struct {
@@ -140,9 +169,13 @@ func Run(ctx context.Context, s Spec) (Report, error) {
 	}
 
 	var sense, baseline session.Result
+	// The baseline's wall is resolved when the baseline starts, not here,
+	// because it derives from what the sense arm ELAPSED and the sense arm has
+	// not run yet. The arms run in sequence, so by the time this closure is
+	// called `sense` is filled in.
 	arms := []cell.Arm{
-		{Name: senseArm, Run: s.armRunner(isolate.Sense, s.Wall, &sense)},
-		{Name: baselineArm, Run: s.armRunner(isolate.Baseline, BaselineWall(s.Wall), &baseline)},
+		{Name: senseArm, Run: s.armRunner(isolate.Sense, func() time.Duration { return s.Wall }, &sense)},
+		{Name: baselineArm, Run: s.armRunner(isolate.Baseline, func() time.Duration { return s.baselineWall(sense) }, &baseline)},
 	}
 
 	rec, err := cell.Run(ctx, s.Root, arms)
@@ -203,9 +236,9 @@ func (s Spec) release(ctx context.Context, arms ...session.Result) error {
 // armRunner is one side of the pair, as the supervisor sees it: a function that
 // produces a run in the directory it is handed, and leaves its result where the
 // checks can read it.
-func (s Spec) armRunner(arm isolate.Arm, wall time.Duration, into *session.Result) func(context.Context, string) (run.Meta, error) {
+func (s Spec) armRunner(arm isolate.Arm, wall func() time.Duration, into *session.Result) func(context.Context, string) (run.Meta, error) {
 	return func(ctx context.Context, dir string) (run.Meta, error) {
-		res, err := session.Run(ctx, s.arm(dir, arm, wall))
+		res, err := session.Run(ctx, s.arm(dir, arm, wall()))
 		// Recorded whether or not the arm succeeded. The environment is what has
 		// to be released, and an arm that failed or was cut still took a checkout.
 		*into = res
@@ -214,6 +247,22 @@ func (s Spec) armRunner(arm isolate.Arm, wall time.Duration, into *session.Resul
 		}
 		return res.Meta, nil
 	}
+}
+
+// baselineWall is what the baseline gets, given the sense arm that just ran.
+//
+// A sense arm that never reached the model reports no elapsed time, and 1.2
+// times nothing is a baseline killed the instant it starts — an empty arm that
+// reads in a score exactly like a baseline that had nothing to say. So a pair
+// whose sense arm did not run falls back to the ceiling the credential
+// preflight already budgeted for, and the pair fails its soundness checks on
+// the sense arm, which is where the real fault is.
+func (s Spec) baselineWall(sense session.Result) time.Duration {
+	elapsed := time.Duration(sense.Meta.TookSeconds * float64(time.Second))
+	if elapsed <= 0 {
+		return BaselineWall(s.Wall)
+	}
+	return BaselineWall(elapsed)
 }
 
 // arm builds one side of the pair. Everything except the arm and its wall is
@@ -230,14 +279,17 @@ func (s Spec) arm(root string, arm isolate.Arm, wall time.Duration) session.Spec
 		Commit:     s.Commit,
 		Prompt:     s.Prompt,
 		Command:    s.Command,
-		Args:       s.Args,
-		AgentEnv:   s.AgentEnv,
-		SetupTool:  s.SetupTool,
-		SenseBin:   s.SenseBin,
-		LabBin:     s.LabBin,
-		HostPath:   s.HostPath,
-		Wall:       wall,
-		Grace:      s.Grace,
+		// Each arm is told its OWN wall. Appended here rather than by the
+		// caller because this is the first place the number exists: the
+		// baseline's is not known until the sense arm has finished.
+		Args:      append(slices.Clone(s.Args), s.Agent.WallNoteArgs(wall)...),
+		AgentEnv:  s.AgentEnv,
+		SetupTool: s.SetupTool,
+		SenseBin:  s.SenseBin,
+		LabBin:    s.LabBin,
+		HostPath:  s.HostPath,
+		Wall:      wall,
+		Grace:     s.Grace,
 	}
 }
 
@@ -306,7 +358,7 @@ func (s Spec) check(ctx context.Context, sense, baseline session.Result) (rep Re
 		r.BaselineCaptured = true
 	}
 
-	r.Differences = Differences(sense.Meta, baseline.Meta)
+	r.Differences = Differences(sense.Meta, baseline.Meta, s.Agent.WallNoteFlag)
 	return r, nil
 }
 
@@ -358,7 +410,7 @@ func armWorld(res session.Result, binary string, configDirs []string) channels.A
 // Read off what was recorded rather than off what was configured: the two are
 // the same only when nothing went wrong, and the case worth catching is the one
 // where something did.
-func Differences(sense, baseline run.Meta) []string {
+func Differences(sense, baseline run.Meta, wallNoteFlag string) []string {
 	var found []string
 	compare := func(what, a, b string) {
 		if a != b {
@@ -366,13 +418,58 @@ func Differences(sense, baseline run.Meta) []string {
 		}
 	}
 	compare("the agent tool", sense.Command, baseline.Command)
-	compare("the arguments", fmt.Sprint(sense.Args), fmt.Sprint(baseline.Args))
+	// The wall note is dropped before the arguments are compared, because the
+	// arms are SUPPOSED to carry different ones: each is told its own wall, and
+	// the walls differ by design. Comparing it here would report every correct
+	// pair as asymmetric — which is worse than useless, because the check that
+	// cries wolf on every run is the check nobody reads on the run that matters.
+	// The walls themselves are checked below, where the relationship is known.
+	compare("the arguments",
+		fmt.Sprint(withoutWallNote(sense.Args, wallNoteFlag)),
+		fmt.Sprint(withoutWallNote(baseline.Args, wallNoteFlag)))
 	compare("where the wall starts", sense.WallStartsAt, baseline.WallStartsAt)
-	if sense.WallSeconds != baseline.WallSeconds {
-		found = append(found, fmt.Sprintf("the budget: the sense arm had %.0fs and the baseline had %.0fs, "+
-			"but the baseline's derives from the sense arm's", sense.WallSeconds, baseline.WallSeconds))
-	}
+	found = append(found, budgetDifference(sense, baseline)...)
 	return found
+}
+
+// budgetDifference checks the one relationship the arms are allowed to differ
+// in: the baseline's wall against what the sense arm spent.
+//
+// Equality is the wrong test and was the one here until 2026-08-17. The walls
+// are not meant to match; the baseline's is meant to be 1.2 times what the
+// sense arm ELAPSED. Asserting equality passed for as long as it did because
+// the derivation it was guarding had quietly become the identity.
+func budgetDifference(sense, baseline run.Meta) []string {
+	// A sense arm that recorded no time is a pair that has already failed for a
+	// louder reason, and its baseline ran on the fallback ceiling rather than on
+	// a derivation. Reporting a budget mismatch on top of that would bury the
+	// real fault under a second one.
+	if sense.TookSeconds <= 0 {
+		return nil
+	}
+	want := BaselineWall(time.Duration(sense.TookSeconds * float64(time.Second)))
+	if got := time.Duration(baseline.WallSeconds) * time.Second; got != want {
+		return []string{fmt.Sprintf("the budget: the sense arm spent %.0fs so the baseline should have had %s, and it had %s",
+			sense.TookSeconds, want, got)}
+	}
+	return nil
+}
+
+// withoutWallNote drops a flag and the value after it, so two arms carrying
+// their own wall notes can have the rest of their arguments compared.
+func withoutWallNote(args []string, flag string) []string {
+	if flag == "" {
+		return args
+	}
+	out := make([]string, 0, len(args))
+	for i := 0; i < len(args); i++ {
+		if args[i] == flag {
+			i++ // and its value
+			continue
+		}
+		out = append(out, args[i])
+	}
+	return out
 }
 
 // transcript is what an arm actually said, unnormalised. The canonical form is

--- a/lab/internal/probe/probe_test.go
+++ b/lab/internal/probe/probe_test.go
@@ -127,6 +127,23 @@ func spec(t *testing.T) probe.Spec {
 	}
 }
 
+// bothArmsRan is the precondition every check below rests on. An arm that never
+// started leaves no transcript, and a check that finds nothing in no transcript
+// reports the arm CLEAN — which is how a baseline killed before it could fork
+// passed three contamination checks at once.
+func bothArmsRan(t *testing.T, r probe.Report) {
+	t.Helper()
+	for _, a := range []struct {
+		name string
+		meta run.Meta
+	}{{"sense", r.Sense.Meta}, {"baseline", r.Baseline.Meta}} {
+		if a.meta.Outcome != run.Completed {
+			t.Fatalf("the %s arm did not run: %s after %.3fs on a %vs wall; every check here would read it as clean",
+				a.name, a.meta.Outcome, a.meta.TookSeconds, a.meta.WallSeconds)
+		}
+	}
+}
+
 func TestBothArmsRunAndTheDifferenceIsOnlySenseAccess(t *testing.T) {
 	s := spec(t)
 
@@ -154,6 +171,8 @@ func TestTheSenseArmHasEveryRouteItWasSupposedToHave(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
+	bothArmsRan(t, report)
+
 	if len(report.SenseMissing) != 0 {
 		t.Errorf("the sense arm is missing %v", report.SenseMissing)
 	}
@@ -172,6 +191,8 @@ func TestTheBaselineArmReachesNoRouteAndUsesNone(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
+
+	bothArmsRan(t, report)
 
 	if len(report.BaselineReached) != 0 {
 		t.Errorf("the baseline arm reaches %v", report.BaselineReached)
@@ -193,6 +214,8 @@ func TestNeitherArmCanReadPersistedMemory(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
+	bothArmsRan(t, report)
+
 	if len(report.MemoryReached) != 0 {
 		t.Errorf("persisted memory was reachable: %v", report.MemoryReached)
 	}
@@ -212,6 +235,8 @@ printf '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bas
 		t.Fatalf("Run: %v", err)
 	}
 
+	bothArmsRan(t, report)
+
 	if len(report.BaselineUsed) == 0 {
 		t.Fatal("a baseline arm that invoked the sense binary was reported clean")
 	}
@@ -230,6 +255,8 @@ printf '{"type":"assistant","message":{"content":[{"type":"tool_use","name":"mcp
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
+
+	bothArmsRan(t, report)
 
 	if len(report.BaselineUsed) == 0 {
 		t.Fatal("a baseline arm that called a Sense tool was reported clean")
@@ -275,15 +302,30 @@ func TestTheBaselineIsPairedAgainstWhatTheSenseArmSpentNotWhatItWasAllowed(t *te
 		t.Error("BaselineWall is returning its argument, which is the defect the replay found")
 	}
 
-	report, err := probe.Run(context.Background(), spec(t))
+	// The one test that pays for real elapsed time. The stand-ins answer in
+	// under half a second, which derives a wall the one-second floor would have
+	// produced anyway, so without this beat the test cannot tell a derivation
+	// from a hardcoded constant.
+	s := spec(t)
+	s.Args = []string{"-c", `cat > /dev/null
+if [ -f .mcp.json ]; then sleep 2; fi
+` + agentThatUsesSense + agentThatCannotUseSense}
+
+	report, err := probe.Run(context.Background(), s)
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
+	bothArmsRan(t, report)
 
 	// Read off what was recorded, not off what was configured: the two are the
 	// same only when nothing went wrong.
 	spent := time.Duration(report.Sense.Meta.TookSeconds * float64(time.Second))
 	want := probe.BaselineWall(spent)
+	// Without this the test goes vacuous on a fast machine: both sides collapse
+	// onto the floor and an implementation returning a constant second passes.
+	if want <= time.Second {
+		t.Fatalf("the sense arm spent only %s, so its baseline got the floor and this proves nothing", spent)
+	}
 	if got := time.Duration(report.Baseline.Meta.WallSeconds) * time.Second; got != want {
 		t.Errorf("the sense arm spent %s so the baseline should have had %s; it had %s", spent, want, got)
 	}
@@ -409,16 +451,31 @@ func TestAnInterruptionAfterTheFirstArmRefusesToPair(t *testing.T) {
 	s := spec(t)
 	// The sense arm answers and stops; the baseline arm is still running when
 	// the interruption lands, which is the moment that burns a paid-for arm.
-	// The sense arm takes a beat before answering, so the baseline's derived
-	// wall is long enough to still be running when the interruption lands. An
-	// instant sense arm leaves its baseline about a second, and the cell would
-	// finish on its own before anything could interrupt it.
+	//
+	// The cancellation waits for the baseline to SAY it started rather than for
+	// a stopwatch to run down. Guessing at the schedule is what made this test
+	// need ever-longer sleeps every time the timing underneath it moved, and a
+	// guess that lands early tests nothing while a guess that lands late is a
+	// flake nobody can reproduce.
+	//
+	// The sense arm still takes a beat, because the window to cancel INSIDE the
+	// baseline is that arm's derived wall, and an instant sense arm leaves only
+	// the one-second floor to aim at.
+	started := filepath.Join(t.TempDir(), "baseline-started")
 	s.Args = []string{"-c", `cat > /dev/null
-if [ -f .mcp.json ]; then sleep 5; echo answered; else sleep 30; fi`}
+if [ -f .mcp.json ]; then sleep 2; echo answered; else touch ` + started + `; sleep 30; fi`}
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	go func() {
-		time.Sleep(7 * time.Second)
-		cancel()
+		// Bounded, so a baseline that never starts fails the assertion below
+		// rather than hanging the package.
+		for range 1000 {
+			if _, err := os.Stat(started); err == nil {
+				cancel()
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
 	}()
 
 	_, err := probe.Run(ctx, s)
@@ -568,6 +625,8 @@ func TestASenseArmThatNeverTouchedSenseIsNotAMeasurement(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
+	bothArmsRan(t, report)
+
 	if report.Frames != 0 {
 		t.Fatalf("Frames = %d, want none from an agent that never called Sense", report.Frames)
 	}
@@ -685,5 +744,28 @@ func TestACellWhoseAgentIsNotIdentifiedIsRefusedBeforeSpawning(t *testing.T) {
 				t.Error("a cell directory was created for a cell that cannot be checked")
 			}
 		})
+	}
+}
+
+func TestABaselineIsNeverGivenAWallItCannotStartIn(t *testing.T) {
+	// Deriving from elapsed time has a failure mode that deriving from a budget
+	// did not: a sense arm that returns almost at once leaves its baseline
+	// almost nothing, and 1.2 times a few milliseconds ROUNDS TO ZERO. The
+	// baseline is then killed before it runs, and an arm that never ran is
+	// indistinguishable in a score from one that had nothing to say.
+	//
+	// It is not hypothetical. A session that cannot authenticate exits in about
+	// a second having done nothing.
+	for _, spent := range []time.Duration{
+		0, time.Millisecond, 10 * time.Millisecond, 100 * time.Millisecond, time.Second,
+	} {
+		if got := probe.BaselineWall(spent); got < time.Second {
+			t.Errorf("a sense arm that spent %s leaves its baseline %s, which it cannot start in", spent, got)
+		}
+	}
+
+	// And the floor does not disturb a real pairing.
+	if got := probe.BaselineWall(404 * time.Second); got != 485*time.Second {
+		t.Errorf("BaselineWall(404s) = %s, want the banked 485s", got)
 	}
 }

--- a/lab/internal/probe/probe_test.go
+++ b/lab/internal/probe/probe_test.go
@@ -6,10 +6,12 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/luuuc/sense/lab/internal/catalog"
 	"github.com/luuuc/sense/lab/internal/probe"
 	"github.com/luuuc/sense/lab/internal/run"
 )
@@ -259,12 +261,18 @@ func TestABaselineWorktreeCarryingARouteIsCaught(t *testing.T) {
 	}
 }
 
-func TestTheTwoArmsShareTheirBudgetRelationship(t *testing.T) {
-	// The baseline's wall is not independently chosen. Getting the relationship
-	// backwards is not visible in a result, which is why it is a function with
-	// a name rather than an assignment at two call sites.
-	if got := probe.BaselineWall(480 * time.Second); got != 480*time.Second {
-		t.Errorf("BaselineWall(480s) = %s, want the sense arm's own wall", got)
+func TestTheBaselineIsPairedAgainstWhatTheSenseArmSpentNotWhatItWasAllowed(t *testing.T) {
+	// The banked pairing, which is the number this has to keep reproducing: a
+	// sense arm ALLOWED 480s that SPENT 404s left its baseline 485s. Deriving
+	// from the allowance instead gives 576s, and the gap is clock handed to the
+	// baseline for free, shrinking every margin in the same direction.
+	if got := probe.BaselineWall(404 * time.Second); got != 485*time.Second {
+		t.Errorf("BaselineWall(404s spent) = %s, want 485s", got)
+	}
+	// The failure this replaces: for as long as the derivation was the
+	// identity, a sense arm's allowance and its baseline's budget were equal.
+	if got := probe.BaselineWall(480 * time.Second); got == 480*time.Second {
+		t.Error("BaselineWall is returning its argument, which is the defect the replay found")
 	}
 
 	report, err := probe.Run(context.Background(), spec(t))
@@ -274,18 +282,104 @@ func TestTheTwoArmsShareTheirBudgetRelationship(t *testing.T) {
 
 	// Read off what was recorded, not off what was configured: the two are the
 	// same only when nothing went wrong.
-	if report.Sense.Meta.WallSeconds != report.Baseline.Meta.WallSeconds {
-		t.Errorf("the arms ran at %.0fs and %.0fs", report.Sense.Meta.WallSeconds, report.Baseline.Meta.WallSeconds)
+	spent := time.Duration(report.Sense.Meta.TookSeconds * float64(time.Second))
+	want := probe.BaselineWall(spent)
+	if got := time.Duration(report.Baseline.Meta.WallSeconds) * time.Second; got != want {
+		t.Errorf("the sense arm spent %s so the baseline should have had %s; it had %s", spent, want, got)
 	}
 	if report.Sense.Meta.Command != report.Baseline.Meta.Command {
 		t.Errorf("the arms ran %q and %q", report.Sense.Meta.Command, report.Baseline.Meta.Command)
 	}
 }
 
-func TestArmsThatDifferInAnythingElseAreNamed(t *testing.T) {
-	same := run.Meta{Command: "claude", Args: []string{"-p"}, WallSeconds: 480, WallStartsAt: "spawn"}
+// TestEachArmIsToldTheWallThatWillActuallyCutIt is the check whose absence cost
+// a paid pair.
+//
+// Both arms of the 2026-08-17 mastodon replay ran to their ceiling and were cut
+// mid-answer, because nothing told them what the ceiling was. Every hermetic
+// test was green through it: they all asked what an arm could REACH, and none
+// asked what it was TOLD. The number in the note has to be the number the
+// supervisor enforces, or the note is a lie that costs the arm its answer.
+func TestEachArmIsToldTheWallThatWillActuallyCutIt(t *testing.T) {
+	s := spec(t)
+	s.Agent = catalog.Agent{
+		WallNoteFlag: "--append-system-prompt",
+		WallNote:     "stopped hard after {{seconds}} seconds of real time",
+	}
 
-	if got := probe.Differences(same, same); len(got) != 0 {
+	report, err := probe.Run(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	for _, arm := range []struct {
+		name string
+		meta run.Meta
+	}{
+		{"sense", report.Sense.Meta},
+		{"baseline", report.Baseline.Meta},
+	} {
+		told, ok := secondsInWallNote(arm.meta.Args, "--append-system-prompt")
+		if !ok {
+			t.Errorf("the %s arm was never told its wall; it ran with %v", arm.name, arm.meta.Args)
+			continue
+		}
+		if enforced := int(arm.meta.WallSeconds); told != enforced {
+			t.Errorf("the %s arm was told %ds and cut at %ds", arm.name, told, enforced)
+		}
+	}
+
+	// And the two notes differ, because the two walls do. An implementation
+	// that told both arms the sense arm's number would pass every check above.
+	senseNote, _ := secondsInWallNote(report.Sense.Meta.Args, "--append-system-prompt")
+	baseNote, _ := secondsInWallNote(report.Baseline.Meta.Args, "--append-system-prompt")
+	if senseNote == baseNote {
+		t.Errorf("both arms were told %ds, but their walls are not the same number", senseNote)
+	}
+}
+
+// secondsInWallNote reads back the number an arm was actually told.
+func secondsInWallNote(args []string, flag string) (int, bool) {
+	for i, a := range args {
+		if a != flag || i+1 >= len(args) {
+			continue
+		}
+		for _, field := range strings.Fields(args[i+1]) {
+			if n, err := strconv.Atoi(field); err == nil {
+				return n, true
+			}
+		}
+	}
+	return 0, false
+}
+
+// TestAPairCarryingItsOwnWallNotesIsStillSound guards the fix from its own
+// side effect: the arms are now SUPPOSED to differ in one argument, and a
+// difference check that did not know it would report every correct pair as
+// asymmetric.
+func TestAPairCarryingItsOwnWallNotesIsStillSound(t *testing.T) {
+	s := spec(t)
+	s.Agent = catalog.Agent{WallNoteFlag: "--append-system-prompt", WallNote: "{{seconds}} seconds"}
+
+	report, err := probe.Run(context.Background(), s)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(report.Differences) != 0 {
+		t.Errorf("a correct pair was reported as differing: %v", report.Differences)
+	}
+	if !report.Sound() {
+		t.Error("a pair whose only asymmetry is each arm's own wall note is not a measurement")
+	}
+}
+
+func TestArmsThatDifferInAnythingElseAreNamed(t *testing.T) {
+	// TookSeconds is what the baseline's budget derives from, so a fixture
+	// without it cannot exercise the budget check at all. 400s spent pairs with
+	// a 480s baseline.
+	same := run.Meta{Command: "claude", Args: []string{"-p"}, WallSeconds: 480, TookSeconds: 400, WallStartsAt: "spawn"}
+
+	if got := probe.Differences(same, same, ""); len(got) != 0 {
 		t.Errorf("two identical arms differ in %v", got)
 	}
 
@@ -296,9 +390,13 @@ func TestArmsThatDifferInAnythingElseAreNamed(t *testing.T) {
 		{"a different agent tool", run.Meta{Command: "codex", Args: []string{"-p"}, WallSeconds: 480, WallStartsAt: "spawn"}},
 		{"different arguments", run.Meta{Command: "claude", Args: []string{"-p", "--verbose"}, WallSeconds: 480, WallStartsAt: "spawn"}},
 		{"a halved budget", run.Meta{Command: "claude", Args: []string{"-p"}, WallSeconds: 240, WallStartsAt: "spawn"}},
+		// The defect itself: a baseline handed 1.2x the sense arm's ALLOWANCE
+		// (480s) rather than 1.2x what it SPENT (400s). Ninety-six seconds of
+		// free clock, in the baseline's favour, invisible in any score.
+		{"a budget derived from the allowance instead of the spend", run.Meta{Command: "claude", Args: []string{"-p"}, WallSeconds: 576, WallStartsAt: "spawn"}},
 		{"a different wall start", run.Meta{Command: "claude", Args: []string{"-p"}, WallSeconds: 480, WallStartsAt: "first event"}},
 	} {
-		got := probe.Differences(same, tc.baseline)
+		got := probe.Differences(same, tc.baseline, "")
 		if len(got) == 0 {
 			t.Errorf("%s went unreported", tc.what)
 		}
@@ -311,11 +409,15 @@ func TestAnInterruptionAfterTheFirstArmRefusesToPair(t *testing.T) {
 	s := spec(t)
 	// The sense arm answers and stops; the baseline arm is still running when
 	// the interruption lands, which is the moment that burns a paid-for arm.
+	// The sense arm takes a beat before answering, so the baseline's derived
+	// wall is long enough to still be running when the interruption lands. An
+	// instant sense arm leaves its baseline about a second, and the cell would
+	// finish on its own before anything could interrupt it.
 	s.Args = []string{"-c", `cat > /dev/null
-if [ -f .mcp.json ]; then echo answered; else sleep 30; fi`}
+if [ -f .mcp.json ]; then sleep 5; echo answered; else sleep 30; fi`}
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
-		time.Sleep(4 * time.Second)
+		time.Sleep(7 * time.Second)
 		cancel()
 	}()
 


### PR DESCRIPTION
The bench that measures Sense was cutting both of its arms off mid-answer and then scoring the stumps. Every number it produced was a number about an interrupted session. This fixes the two reasons why, so that a measured comparison is a comparison of finished work.

## Problem

Running one banked cell live surfaced three defects in how the bench builds an arm. None of them was visible in a result, and the whole hermetic test suite was green through all three.

The agent CLI has no wall-clock flag, verified against claude 2.1.233: no `--timeout`, `--max-duration`, `--deadline`, `--max-time`, `--max-turns`. The supervisor's kill is the only enforcement. So an arm is told its budget through a system prompt or it is never told at all, and it was never told. Both arms of the live cell ran to their ceiling and were killed part way through writing, 82 and 72 turns, exit 124, and the scorer correctly refused both captures as incomplete.

`BaselineWall` returned its argument unchanged. The rule it is meant to implement gives the baseline 1.2 times what the sense arm actually SPENT; the code derived from what the sense arm was ALLOWED. Those two agree only when the sense arm runs out of time, which is exactly why nobody caught it, and the rest of the time it quietly hands the baseline extra clock whenever the sense arm finishes early. That biases every margin in the same direction.

`Differences`, the check that exists to catch asymmetry between the arms, asserted the two walls were EQUAL. That locked the second defect in place, and it would also have flagged every corrected pair as asymmetric once each arm started carrying its own wall note, which would have made `Sound()` false on every real run.

## Summary

Each arm is now told its own wall in the words its tool understands, and the baseline's budget is derived from what the sense arm actually spent rather than from what it was allowed.

## Changes

- `wall_note_flag` and `wall_note` are catalog data, with `{{seconds}}` replaced by that arm's own wall. A tool declaring neither is spawned exactly as before rather than handed an empty flag.
- The wall note is appended where the wall is known, not by the caller, because the baseline's is not knowable until the sense arm has finished.
- `BaselineWall` derives from elapsed time and is resolved when the baseline starts.
- `Differences` checks the derivation instead of asserting equality, and compares arguments with each arm's own note set aside.
- The agent's README records the mechanism, the verification against 2.1.233, and why the note's wording must be re-measured rather than reworded.

## Architecture Highlights

- The note's wording is copied verbatim from the instrument being replaced, which recorded what a rewrite costs. An earlier phrasing offered "if you run short, say where you stopped" and both arms took that exit immediately, the sense arm reporting it had not finished with 337 of its 480 seconds still unused. Reword it and the measurement changes.
- The test asserting `BaselineWall(480s) == 480s` was itself the defect, written down and passing. It is replaced by the real pairing, where 404 seconds spent leaves the baseline 485.

## Test Plan

- [x] An arm is told the number the supervisor will actually enforce, asserted per arm off the recorded invocation. This is the check whose absence cost a live pair.
- [x] The two arms are told different numbers, so an implementation handing both the sense arm's figure fails.
- [x] A pair whose only asymmetry is each arm's own wall note is still reported sound.
- [x] A baseline budget derived from the allowance rather than the spend is reported as a difference.
- [x] A tool declaring no wall note is spawned without one, including the half-declared cases.
- [x] The seconds an arm is told are truncated, never rounded up past the real wall.
- [x] Verified live: two independent pairs, both sound, sense arm completing at 267s and 346s of its 480s ceiling instead of being cut, baseline receiving 320s and 415s.
- [x] `make ci` green: 96.0% coverage, 0 lint issues, complexity ledger at 0.
- [x] Both binaries build cleanly.
