### PR TITLE
ci(deps): group the codeql-action bumps into one pull request

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,17 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    groups:
+      # codeql-action/init and codeql-action/analyze are one action in two
+      # halves, pinned to the same SHA in codeql.yml. CodeQL refuses to run when
+      # they disagree, so a PR that bumps only one of them fails with
+      # "CodeQL job status was configuration error" and cannot be merged on its
+      # own — and merging it anyway would break the analysis on main until its
+      # sibling landed. Measured 2026-08-17 on two such PRs, both red.
+      # One group, one PR, both halves moving together.
+      codeql:
+        patterns:
+          - "github/codeql-action*"
     commit-message:
       prefix: "ci(deps)"
     open-pull-requests-limit: 5


### PR DESCRIPTION
Keeps the CodeQL security scan working when its action gets updated. Right now every update to it arrives as two pull requests that each break the scan, so the safe move is to merge neither and the scan quietly falls behind.

## Problem

`codeql-action/init` and `codeql-action/analyze` are two halves of one action, pinned to the same SHA in `codeql.yml`. CodeQL refuses to run when the halves disagree.

The `github-actions` ecosystem in the dependabot config had no `groups` key at all, so dependabot opens one pull request per action and splits that pair every single time. Each half arrives alone, and each one fails with `CodeQL job status was configuration error`, because it would move one half and leave the other behind. Neither can be merged on its own, and merging one anyway would leave the analysis broken on main until its sibling landed.

Measured on 2026-08-17: two open pull requests bumping 4.37.6 to 4.37.7, one for each half, both red for exactly this reason while every other check on them passed.

## Summary

Groups `codeql-action` so both halves move together in a single pull request.

## Changes

- Added a `codeql` group to the `github-actions` ecosystem matching `github/codeql-action*`, with the reason recorded inline so the next person does not have to rediscover it from two red pull requests.

## Architecture Highlights

- Only `codeql-action` is grouped, deliberately. Unrelated actions keep arriving as their own reviewable pull request, which is worth more than a smaller pull request count. The pattern was checked against `codeql-action/init`, `codeql-action/analyze`, `taiki-e/install-action` and `actions/checkout` to confirm it catches both halves and nothing else.

## Test Plan

- [x] Config parses as valid YAML.
- [x] Pattern matches both `github/codeql-action/init` and `github/codeql-action/analyze`.
- [x] Pattern does not match unrelated actions, so they keep their own pull requests.
- [ ] Next dependabot run opens a single pull request moving both halves, and it passes `analyze`.
