### PR TITLE
ci(deps): bump codeql-action from 4.37.6 to 4.37.7

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,7 @@ jobs:
         run: ./scripts/fetch-deps.sh --local
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: go
 
@@ -44,4 +44,4 @@ jobs:
         run: make build
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7


### PR DESCRIPTION
Moves the CodeQL security scan onto 4.37.7. It arrived as two pull requests that each broke the scan, so this is the two of them as the single change they always had to be.

## Problem

`codeql-action/init` and `codeql-action/analyze` are two halves of one action, pinned to the same SHA in `codeql.yml`. CodeQL refuses to run when the halves disagree.

Dependabot opened one pull request per half. Each moved one half and left the other behind, so each failed with `CodeQL job status was configuration error` while every other check on them passed. Neither could be merged alone, and merging one anyway would have left the analysis broken on main until its sibling landed.

## Summary

Bumps both halves to 4.37.7 in one commit, so the pair stays consistent and the analysis keeps running.

## Changes

- `codeql-action/init` and `codeql-action/analyze` both go from 4.37.6 to 4.37.7.

## Architecture Highlights

- Both pin `ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd`, confirmed against the upstream repository as the commit the annotated `v4.37.7` tag dereferences to, rather than taken on trust from the bump.
- The dependabot config change that stops the pair being split in future is deliberately a separate pull request. It only affects future runs, so it could not have fixed this one.

## Test Plan

- [x] Both halves pin the same SHA.
- [x] That SHA is the commit behind the upstream `v4.37.7` tag.
- [x] Workflow parses as valid YAML.
- [ ] `analyze` passes on this pull request, which is the check both original pull requests failed.
