### PR TITLE
bench(jellyfin): drive the first fresh-repo campaign to a park

### DIFF
--- a/lab/campaigns/dotnet-jellyfin/README.md
+++ b/lab/campaigns/dotnet-jellyfin/README.md
@@ -1,0 +1,76 @@
+# dotnet-jellyfin
+
+The first campaign authored on sense-lab against a repository nobody had benched.
+
+Its purpose was to test the instrument, not the repository: take a repo with no scenario and try
+to drive it to a measured result without a human hand-running a phase and without a gate being
+bypassed. **Any verdict counts** — a win, a park, or an honest refusal to pay — because the loop
+cannot record a loss.
+
+**That condition was not met, and the failure is the finding.** Reaching the handoff required a
+transition the declared phase graph does not offer, and the sweep that justified stopping is
+hand-run analysis standing in place of the `author` phase. Recorded as instrument defect §5 and
+as a failed Done-means bullet, not filed quietly.
+
+## Result
+
+**Parked at cycle 1** with the retention axis **open and one question measured**, and a product
+change handed up.
+
+| | |
+|---|---|
+| repository | jellyfin @ `ae8723026d97b6d0f926638803edef338919b794` |
+| anchor | `IPathManager` |
+| phases | index → author → minibench |
+| verdicts | `AUTO` → `DRAFT` → `REQUESTION` |
+| mini-bench, n=1 per arm, `claude-opus-5` (headline, **single-model**) | baseline **0.9286** (13 of 14) · sense **1.0000** (14 of 14) · delta **+0.0714** |
+| cells | 1, unscored, both arms, channel proof SOUND |
+| spend ceiling | 40 per campaign, **untested** at 2 runs |
+| published | no article, no numbers outside this repository; the scenario and its gold are deliberately withheld from git — see the handoff |
+
+The baseline held above the 0.50 gate, so this question does not discriminate. Its route was six
+tool calls and 91 seconds: grep the anchor, read the four intermediary names out of that output,
+then one shell loop over the four. The anchor was dark; the intermediaries were not, and they are
+what had to be dark.
+
+**The axis is not closed.** A re-question changes the rows and therefore the baseline, and only
+one set of rows has been measured. The campaign parked for a different reason, below.
+
+## Why one arm only
+
+Single-model by design. The headline arm is `claude-opus-5`; the confirmation arms arrive with
+cycle 08's adapters, which was the deliberate trade for running this campaign a week earlier.
+
+## What it found
+
+A **product defect** that turned out to be the campaign's own binding constraint: Sense returns
+an empty, `"complete"` answer for every C# type declared in a block-scoped `namespace X { }`. Of
+the 40 interfaces this repository declares, 17 resolve and 23 return nothing at any confidence —
+every one of the 23 block-scoped, with a single block-scoped exception. The invisible side is the
+most-held: `ILibraryManager` (121 files declare a field of it), `IServerConfigurationManager`
+(71), `IFileSystem` (66), `IUserManager` (65). Those are exactly the anchors whose rings a grep
+alternation could not have covered.
+
+**That is why it parked.** Not because the axis is dead, but because re-questioning five more
+times against the sixteen small interfaces Sense can see — when the fix puts the other 23 on the
+table — spends against a pool that is about to change. An operator judgement, recorded as one.
+
+Plus **five instrument defects**, routed to cycle 05. The sharpest is that a measured-dead axis
+has no route to a park: `REQUESTION` routes back to authoring, `NO-ANCHOR` is defined by row
+count rather than by whether the ring is coverable, and `handoff` is reachable only from the
+six-cycle ceiling.
+
+Two of the five were written back into `lab/plans/author.md` during the campaign: a first-cycle
+branch for the RUN step that has no input on a repository with no history, and the removal of
+three Done-when bullets requiring `stamp`, `verify` and a rubric check — commands that do not
+exist, so the phase could never report itself done by its own criteria.
+
+## The record
+
+`record/` carries the campaign as it was measured: the index summary, the mini-bench with its
+quoted figures and the baseline's route, the handoff, and the defect list with the killer checks
+that were run before each finding was stated — and the ones that were not, named as not run.
+
+It is a copy. The live tree is under `runs/campaigns/dotnet-jellyfin/`, which is gitignored
+because a cell of a real repository is hundreds of megabytes — see defect §6. The scenario, its
+gold and its rubric stay there deliberately and are not committed.

--- a/lab/campaigns/dotnet-jellyfin/campaign.json
+++ b/lab/campaigns/dotnet-jellyfin/campaign.json
@@ -1,0 +1,18 @@
+{
+  "key": "dotnet-jellyfin",
+  "judge": "claude-opus-4-7",
+  "subjects": [
+    "untreated",
+    "sense-main"
+  ],
+  "repos": [
+    "jellyfin"
+  ],
+  "arms": [
+    {
+      "role": "headline",
+      "model": "claude-opus-5",
+      "runs": 2
+    }
+  ]
+}

--- a/lab/campaigns/dotnet-jellyfin/record/handoff.md
+++ b/lab/campaigns/dotnet-jellyfin/record/handoff.md
@@ -1,0 +1,137 @@
+# handoff — dotnet-jellyfin / jellyfin
+
+**The campaign parked at cycle 1 with the retention axis OPEN and one question measured, and
+hands up a product change with the numbers attached.**
+
+Every number here is `claude-opus-5`, the headline arm, **single-model**, n=1 per arm. Cycle 08
+brings the confirmation arms.
+
+**A phase could not be run, and the pitch's first Done-means bullet is NOT met.** The campaign
+did not go from no scenario to a verdict without a human hand-running a phase: reaching this
+handoff required a transition the declared graph does not offer, and the sweep that justified
+stopping is hand-run analysis standing in place of the `author` phase. That is recorded as
+instrument defect §5 and as a failed bullet, not filed as a defect and left reading as passed.
+
+This is the first campaign driven end to end on sense-lab against a repository nobody had
+benched. Its verdict is a park, and **a park is a result**: the instrument was what was under
+test, not the repository.
+
+## Position
+
+| | |
+|---|---|
+| campaign | `dotnet-jellyfin` |
+| repository | jellyfin @ `ae8723026d97b6d0f926638803edef338919b794` |
+| cycles used | 1 of 6 |
+| phases run | index → author → minibench |
+| verdicts | `AUTO` → `DRAFT` → `REQUESTION` |
+| paid runs | 2 (one cell, both arms, x1, unscored) |
+| ceiling | 40 per campaign. **Untested**: 40 is `defaultCeiling` in `lab/internal/cli/statuscmd.go:14`, whose own comment says the page only reports it. At 2 runs, nothing could have intervened and nothing did. Reported as untested, not as held |
+| published | nothing |
+
+## What was measured
+
+**index.** 2137 files, 11410 symbols, 23698 edges, embeddings complete, quoted from
+`sense_status` over MCP.
+
+**author.** Anchor `IPathManager`, chosen on ring diversity after sweeping 45 candidate
+interfaces over MCP. Fourteen `dependents` rows, one file each, ten areas, every credit opened
+and read by hand, every chain audited at its construction site. `sense-lab validate`: 17 rows, 0
+quarantined, and none of the fourteen scoring rows inside the covering grep.
+
+**minibench.** Both arms, real wall, unscored, channel proof SOUND.
+
+| | baseline | sense | delta |
+|---|---|---|---|
+| `dependents`, n=1 per arm | **0.9286** (13 of 14) | **1.0000** (14 of 14) | **+0.0714** |
+
+`REQUESTION`: the baseline held above 0.50, so the question does not discriminate. Its route was
+six tool calls and 91 seconds — grep the anchor, read the four intermediary names out of that
+output, then one shell loop over the four. The anchor was dark; the vias were not, and the vias
+are what had to be dark.
+
+## Why it parked here rather than re-questioning five more times
+
+**Not because the axis is closed.** One question has been measured, and a re-question changes the
+rows and therefore the baseline. What follows is a listing that ORDERS candidates; under NO GREP
+SCREEN IS A GATE and THE FIRST MEASUREMENT IS A REAL BASELINE ARM it may not kill a draft, and it
+does not kill this one.
+
+- The ring is **one hop deep** — `via_satisfiers` is 1 on all fourteen rows and every `chain` is
+  a single carrier — so there is no depth question available to *either* arm.
+- Across **all 64 interfaces declared in a file-scoped namespace** in this repository, the best
+  via diversity is five (`IItemTypeLookup`, 18 files) and the next is four (`IPathManager`, 14
+  files). bitwarden-server's banked mini-bench, baseline 0.125, had **nine vias over 31 ring
+  files**. A four-term alternation is one shell loop; a nine-term one over twelve areas is not.
+
+**And that sweep is scoped to the sixteen interfaces Sense can currently see**, which is defect
+§4 rather than a scoping choice — so it cannot speak for the 23 it cannot see. The second,
+different probe that would settle those was not run.
+
+The comparison to bitwarden's nine vias is suggestive and is **not** a mechanism: that cell's own
+recorded diagnosis attributes its 0.125 to a baseline that *never took the second hop*
+(`lab/scenarios/bitwarden-server/bitwarden-server.yaml:20-22`), not to an alternation it could
+not afford. Ours took the second hop in one loop. Which of the two separates them is unmeasured.
+
+**So the reason for parking is not that the axis is dead.** It is that the campaign's binding
+constraint is a product defect whose fix changes the pool a re-question would run against: 23 of
+the 40 interfaces this repository declares are invisible to the instrument, and they are the
+large, diverse ones. Buying five more cells against the small sixteen, when the fix puts the
+other 23 on the table, spends against a pool that is about to change. That is an operator
+judgement and it is recorded as one.
+
+**AXIS-DEAD IS NEVER REPO-DEAD**, and nothing here rules on jellyfin.
+
+## The swap handed up
+
+**Sense returns an empty, `"complete"` answer for every C# type declared in a block-scoped
+`namespace X { }`.** File-scoped `namespace X;` resolves 16 of 16; block-scoped resolves 1 of 24.
+Reproduced in twelve lines of C# where the only difference is the namespace syntax. Not the
+confidence gate — still empty at `min_confidence: 0.0`. Located at
+`internal/extract/csharp/csharp.go:71`, where `isClass` lists `namespace_declaration` and never
+`file_scoped_namespace_declaration`, a node kind that appears nowhere under `internal/`.
+
+**Why it is the swap and not a side note.** The 24 interfaces Sense cannot see are precisely the
+large, diverse ones whose rings a grep alternation could not cover — `ILibraryManager` (121 files
+declare a field of it), `IServerConfigurationManager` (71), `IFileSystem` (66), `IUserManager`
+(65). The sixteen it can see are the small ones. **The campaign's binding constraint and the
+campaign's finding are the same fact**, and the honest reading of this park is that the axis is
+closed *at the product's current behaviour* and worth re-opening after the fix.
+
+Full detail, with the killers that were run before the finding was stated, in
+`../instrument-defects.md` §4. Routed to 07-02.
+
+## Instrument defects, routed to cycle 05
+
+Five, in `../instrument-defects.md`. The one that matters most is §5: **a measured-dead axis has
+no route to a park**, because `REQUESTION` routes to authoring, `NO-ANCHOR` is defined by row
+count rather than by whether the ring is coverable, and `handoff` is reachable only from the
+six-cycle ceiling or from a report. This handoff was therefore written by operator decision on
+the measurement, not by a declared transition. No gate was bypassed — no gate exists on this
+edge, and that is the defect.
+
+## Publishing: the scenario and its gold are deliberately NOT committed
+
+This repository is public, so committing gold publishes it, and PUBLISHED GOLD LEAKS, SO A
+HELD-OUT SET IS PERMANENT makes that irreversible.
+
+**What is committed:** this handoff, the defect list, the index summary, the campaign config and
+the README — the record of what was measured and what was found.
+
+**What is not:** `scenario.draft.yaml`, `scenario.draft.gold.yaml` and
+`scenario.draft.rubric.yaml`. They stay in the untracked run tree at
+`runs/campaigns/dotnet-jellyfin/jellyfin/1/author/`.
+
+That is a deliberate hold, not an oversight, and it is deliberately the *reversible* choice: gold
+can be committed later, it cannot be un-published. The handoff above says this axis may be worth
+re-opening after the C# fix, and re-opening a scenario whose gold is public is exactly what the
+law prevents.
+
+**It also flags an inconsistency for a human.** `lab/scenarios/*/` gold is already tracked on
+`main` for five scenarios, so either "published" is a term of art here meaning an article and
+those are fine, or the same law applies to them and it has already been broken five times. This
+campaign took the conservative reading and did not resolve the question. Cycle 02's `published` /
+`held_out` fields do not exist in `lab/internal/`, so the declared leakage check has nothing to
+read either way.
+
+No numbers and no article are published anywhere outside this repository.

--- a/lab/campaigns/dotnet-jellyfin/record/index.json
+++ b/lab/campaigns/dotnet-jellyfin/record/index.json
@@ -1,0 +1,21 @@
+{
+  "repo": "jellyfin",
+  "url": "https://github.com/jellyfin/jellyfin.git",
+  "revision": "ae8723026d97b6d0f926638803edef338919b794",
+  "checkout": "runs/checkouts/jellyfin",
+  "scanned_at": "2026-08-17T21:24:54Z",
+  "sense_version": "1.14.1-dev+gb5b78be",
+  "files": 2137,
+  "symbols": 11410,
+  "edges": 23698,
+  "embeddings": 11410,
+  "embedding_coverage": 1,
+  "languages": {
+    "csharp": {
+      "files": 2137,
+      "symbols": 11410,
+      "tier": "standard"
+    }
+  },
+  "profile_tier": "medium"
+}

--- a/lab/campaigns/dotnet-jellyfin/record/instrument-defects.md
+++ b/lab/campaigns/dotnet-jellyfin/record/instrument-defects.md
@@ -1,0 +1,222 @@
+# Instrument defects found by the first live campaign
+
+Campaign `dotnet-jellyfin`, repository `jellyfin`, cycle 1. **Six entries: five instrument
+defects routed to cycle 05, and one PRODUCT defect (§4) routed to 07-02.** None is a defect in
+the campaign.
+Recorded as they were found, with the output that shows them.
+
+## 1. `lab/plans/author.md` RUN step 1 cannot run on a fresh repository — cycle 05
+
+The step reads:
+
+> **What the arms have ACTUALLY cited, per gold row, across every run on disk.** Rarest-cited
+> first, scoped to the HEADLINE model's results root
+
+On a repository with no scenario there are no runs on disk, so there is no citation ranking,
+no free-row class and no unreachable class. The plan's first RUN step is written for a
+re-entry and the plan says nothing about the first cycle on a new repository — which is the
+only case 07-01 exercises.
+
+The step is not merely skippable: three of the eight DECIDE rules (7, "drop what the ranking
+says is free or unreachable", and the re-question rules) read from its output. This campaign
+had to author gold with that class unknown, and nothing in the plan says that is what a first
+cycle does.
+
+**Route:** cycle 05, `lab/plans/author.md`. It needs a first-cycle branch saying what stands
+in for the ranking when there is no history, and saying plainly that the free-row class is
+unmeasured rather than empty.
+
+## 2. `author.md` step 8 names commands that do not exist — cycle 05
+
+The step reads:
+
+> After writing the yaml and the rubric: render the prompt, check the rubric, check gold
+> confidence on the `dependents` group, then stamp and verify the gold audit. `stamp` writes
+> one TODO row per gold item; you replace each by opening the file and reading the credit.
+> `verify` fails while any TODO remains.
+
+And the Done-when list requires "The gold audit verifies: zero TODO rows, gold unchanged under
+a finished sheet."
+
+There is no such command:
+
+```
+$ sense-lab
+Commands:
+  catalog  plan  run  probe  score  validate  rescore  status  gate  version
+$ grep -rln 'func stampCmd\|"stamp"\|"verify"' lab/internal/cli/
+$ echo $?
+1                       # no output, no match
+```
+
+`sense-lab validate` covers part of it — it audits gold rows against the checkout and reports
+quarantines and covering-grep flags — but there is no rubric check, no gold-confidence check,
+no prompt render, and no stamp sheet. Four of the nine Done-when bullets in `author.md` are
+therefore unverifiable as written.
+
+This one is half-known: the plan's own "Questioned, not changed" section says the RUN steps
+name computations rather than commands and binds the fix to **cycle 07**. What that note does
+not say is that the *Done-when* list still requires the artifacts of the missing commands, so
+the phase cannot report itself done by its own criteria. That is the part this campaign found.
+
+**Route:** cycle 05, `lab/plans/author.md`. Either the commands are built, or the Done-when
+list stops requiring their artifacts. It may not stay as it is.
+
+## 3. No answer-forms page exists for a new campaign, and nothing creates one — cycle 05
+
+`author.md` DECIDE says:
+
+> **Read the campaign's answer-forms page FIRST if it exists.**
+
+For `dotnet-jellyfin` it does not, because the campaign is new. The plan handles the absence
+("a form absent from it is not forbidden; it is unmeasured, and saying so in the header is the
+whole obligation") but no phase in the graph ever *writes* that page, so a campaign's second
+cycle reads the same empty absence as its first and the measurement is lost.
+
+**Route:** cycle 05. The obvious owner is `report.md` or `harvest.md` — whichever phase holds
+a measured form should append it.
+
+## 4. `sense_blast` and `sense_graph` return an empty, "complete" answer for C# interfaces declared in a block-scoped namespace — routed to 07-02
+
+This is a **product** defect, not an instrument one, and it is the finding 07-02 takes.
+Recorded here because it was found by this campaign and it constrained this campaign's anchor.
+
+Measured over MCP against the pinned jellyfin clone. 45 candidates were swept (every interface
+held as an injected field in four or more files). **Five of the 45 are not declared in this
+repository at all** — `ILogger`, `ILoggerFactory`, `IHttpClientFactory`, `IHttpContextAccessor`,
+`IMemoryCache`, which are .NET framework interfaces — and they return `total_affected: null`,
+which is *absent from the index*, a different thing from an empty answer. They are excluded, and
+the arithmetic below is over the **40 interfaces this repository declares**, which is every one
+of the 45 that has a declaration site:
+
+| namespace style | resolve (total_affected > 0) | empty |
+|---|---|---|
+| file-scoped `namespace X;` | **16 of 16** | 0 |
+| block-scoped `namespace X { }` | **1 of 24** | **23** |
+| **total declared here** | **17 of 40** | **23** |
+
+**Negative space, checked rather than assumed.** There are zero file-scoped failures, and
+exactly one block-scoped success — `IDirectoryService`, at `total_affected` 2. The dichotomy is
+one exception away from clean, and that exception is named rather than rounded off.
+
+The empty side includes this repository's most-held interfaces: `ILibraryManager` (121 files
+declare a field of it), `IServerConfigurationManager` (71), `IFileSystem` (66), `IUserManager`
+(65). For `ILibraryManager`, `sense_graph` returns every edge list empty — including
+`inherited_by`, against a literal `Emby.Server.Implementations/Library/LibraryManager.cs:65:
+public class LibraryManager : ILibraryManager` — and reports:
+
+```
+"completeness":{"verdict":"complete","resolved":0,
+ "advice":"Complete resolvable edge set — act on it, do not re-grep."}
+```
+
+An agent told the empty set is complete, and told not to re-grep, will act on nothing.
+
+The assembly confound is dead: both groups span `MediaBrowser.Controller`,
+`MediaBrowser.Model` and `MediaBrowser.Common`, and the empty side is the *more* used side, so
+it is not a story about unused symbols.
+
+**Not the confidence gate.** The killer was run before the finding was stated. At
+`min_confidence: 0.0` both tools are still empty:
+
+```
+graph ILibraryManager @ min_confidence 0.0 -> edges {} , low_confidence_hidden None
+blast ILibraryManager @ min_confidence 0.0 -> total_affected 0, direct 0, ring None
+```
+
+So the edges are absent from the index rather than hidden by the default floor.
+
+**Reproduced in twelve lines.** Two directories, the same code in each, differing only in
+namespace syntax, scanned and queried over MCP:
+
+```
+=== IBlockThing ===   namespace Demo.Block { ... }
+ qualified: Demo.Block.IBlockThing
+ edges: ALL EMPTY
+=== IFileThing ===    namespace Demo.File;
+ qualified: IFileThing
+ edges: {'composed_by': 1}
+```
+
+**Where it lives.** `internal/extract/csharp/csharp.go:71` lists `namespace_declaration` in
+`isClass` — the block-scoped form — and never `file_scoped_namespace_declaration`, which
+appears nowhere under `internal/`. So the block-scoped form opens a naming scope and its
+symbols are namespace-qualified, while the file-scoped form is walked straight through and its
+symbols stay bare. References are written bare in both cases. Which of the two is the defect is
+07-02's design call; that both exist and disagree is the finding.
+
+**Effect on this campaign:** the anchor had to come from the sixteen. On a block-scoped anchor
+the retention question could not have been asked at all.
+
+## 5. A measured-dead axis has no route to a park, and the verdict that names it does not exist — cycle 05
+
+This is the defect this campaign exists to find, and it is the most consequential one here.
+
+Cycle 1 returned `REQUESTION`, correctly: the baseline held at 0.9286, above the 0.50 gate. The
+plan's instruction for that verdict is *"The lever is the QUESTION, not the anchor"*.
+
+But the sweep that followed measured that **no question on this anchor can move cited recall**:
+the ring is one hop deep (`via_satisfiers` 1 on all 14 rows, every `chain` a single carrier), and
+across all 64 file-scoped interfaces in the repository the best via diversity is five, so every
+candidate ring is covered by a short alternation the anchor's own grep hands over. The answer set
+*is* the ring, and the ring *is* what the alternation prints.
+
+The graph has no transition for that state:
+
+- `REQUESTION` routes to `author`, which is the lever that has just been measured empty.
+- `NO-ANCHOR` is defined narrowly — *"only when the shown blast set itself cannot carry twelve
+  dependent files"* — and this anchor carries fourteen. So the verdict that would allow a
+  re-anchor is unavailable by its own criterion, even though the anchor demonstrably cannot carry
+  any question of this form.
+- `handoff` is reachable only from the authoring ceiling (six cycles) or from `report` with a
+  `DIAGNOSIS`, and neither is reachable from here without buying five more mini-benches on an
+  axis the arithmetic has already closed.
+
+So the loop's only declared move is to spend five more cells confirming a result the sweep
+already proves. **A lever the verdict called for that has no route in the graph** is one of the
+five failure conditions 07-01 enumerates, and this is one.
+
+**What is missing is a verdict, not a transition.** `NO-ANCHOR` counts rows and areas; nothing in
+the enum expresses *"the ring is large enough and is covered by one cheap alternation"*, which is
+the property that actually decides whether a retention question can discriminate. The
+mini-bench's own kill record on bitwarden-server (`new [A-Za-z]*Tokenable`, one regex printing
+the whole answer set) is the same property, and it had no verdict there either.
+
+**Route:** cycle 05, `lab/internal/phase/phase.go` and `lab/plans/minibench.md`. The candidate
+shape is a verdict that says the axis is closed on this anchor with the numbers attached, routing
+to `handoff` rather than to `author`.
+
+**What this campaign did, stated plainly rather than hidden.** It parked at cycle 1 and wrote a
+handoff, which is **not** a transition the declared graph offers from `minibench`. That was an
+operator decision taken on the measurement.
+
+**And it is the pitch's FIRST failure condition, not its third.** "A gate that had to be
+bypassed" would be the lesser reading, and saying "no gate was bypassed because no gate exists
+on this edge" is self-serving: the operator did not slip past a gate, the operator manufactured
+a transition the graph does not offer. That is **"a phase that could not be run"**, and the
+Done-means bullet *"one repository goes from no scenario to a verdict without a human
+hand-running a phase"* is therefore **NOT MET**. It is marked unmet in the pitch rather than
+left reading as satisfied with a defect filed beside it.
+
+The same reading applies to the sweep that justified stopping: it is hand-run analysis standing
+in for the `author` phase the graph declares, and the pitch's rabbit hole warns against
+hand-running a phase to keep things moving. This hand-ran one to *stop* things, which is the
+mirror image and no better.
+
+## 6. The run tree that holds every phase artifact is gitignored, and no plan says to keep a copy — cycle 05
+
+`/runs/` is ignored wholesale, for a good and documented reason: one cell of a real repository is
+hundreds of megabytes and tens of thousands of files, and the same line stops `sense scan`
+indexing them.
+
+But the phase artifacts live in that same tree — `index.json`, `minibench.md`, `handoff.md`, the
+scenario, the gold, the rubric. They are kilobytes of markdown and yaml, and they are the entire
+record of what a campaign measured. Nothing in the phase graph or in any plan says to copy them
+anywhere durable, so on a fresh clone a completed campaign has no record at all and 07-01's
+"recorded with its numbers and its route" is satisfied only until someone runs `git clean`.
+
+This campaign copied them by hand into `lab/campaigns/dotnet-jellyfin/record/`, which follows the
+convention `lab/campaigns/csharp-aspnet/` already sets for tracked campaign material.
+
+**Route:** cycle 05. Either a phase writes the record out, or the ignore rule narrows to the
+heavy directories (`*/home/`, `*/repo/`, `*/raw/`) and keeps the artifacts.

--- a/lab/campaigns/dotnet-jellyfin/record/minibench.md
+++ b/lab/campaigns/dotnet-jellyfin/record/minibench.md
@@ -1,0 +1,168 @@
+# minibench — dotnet-jellyfin / jellyfin / cycle 1
+
+**Verdict: REQUESTION.** The baseline holds above 0.50.
+
+Every number on this page is `claude-opus-5`, the headline arm, **single-model**. n=1 per arm.
+
+## The numbers, quoted from the credit table
+
+Both arms x1, real wall, unscored. `sense-lab score -group dependents`, checkout pinned at
+`ae8723026d97b6d0f926638803edef338919b794`.
+
+```
+════════ sense
+gold group dependents
+cited      14 of 14
+recall     1.00
+grounding   17 of 38 cited locations do not resolve at the pinned commit
+
+════════ baseline
+gold group dependents
+cited      13 of 14
+recall     0.93
+grounding   18 of 42 cited locations do not resolve at the pinned commit
+missed     d:dto-service
+```
+
+|  | baseline | sense | delta |
+|---|---|---|---|
+| `dependents` | **0.9286** (13 of 14) | **1.0000** (14 of 14) | **+0.0714** |
+
+- Baseline gate, at or below 0.50: **FAILS** at 0.9286.
+- Delta gate, at least +0.50: **FAILS** at +0.0714.
+- **n = 1 per arm.** A delta carries the run count that produced it: this one is n=1.
+- Side of the window: **BASELINE-TOO-HIGH by 0.43**.
+
+Arithmetic ceiling: recall caps at 1.00, so a baseline at 0.9286 caps the delta at 0.0714. The
+sense arm was already at the cap. Nothing about the sense arm is the constraint here.
+
+## Arm health
+
+| | outcome | exit | wall | took | watchdog |
+|---|---|---|---|---|---|
+| sense | completed | 0 | 480s | 124.7s | none |
+| baseline | completed | 0 | 150s | 91.5s | none |
+
+Both walls uncensored. The baseline's 150s wall is `sense wall x 1.2` off the sense arm's 124.7s,
+as the rule requires. Neither arm ran out of clock, so CANNOT-FINISH-AT-BUDGET does not apply.
+
+Channel proof, from `sense-lab probe`:
+
+```
+  sense arm routes       all present
+  baseline arm routes    none reachable
+  persisted memory       unreadable by both arms
+  Sense in the baseline  no sign of it
+  arms differ in         nothing but Sense access
+  MCP frames captured    15
+SOUND: the two arms differed in Sense access and nothing else.
+```
+
+The sense arm did reach: it called `sense_blast`, `sense_graph`, `sense_search`,
+`sense_conventions` and `sense_status`, and reached synthesis inside its wall. So this is a
+measurement of the baseline, not of an instrument that failed to answer.
+
+## The rows the baseline took, and the route it used
+
+It took 13 of the 14 in **six tool calls and 91 seconds** of a 150 second wall. Missed only
+`d:dto-service`. The route, quoted:
+
+```
+  Bash  grep -rn "IPathManager" --include=*.cs . | head -60
+  Bash  find . -name "PathManager.cs" -o -name "IPathManager.cs" | head
+  Bash  grep -rn --include="*.cs" "IPathManager" .
+  Bash  cat -n MediaBrowser.Controller/IO/IPathManager.cs && cat -n Emby.Server.Implementations/Library/PathManager.cs
+  Bash  for i in ITrickplayManager IChapterManager IExternalDataManager ISubtitleEncoder IAttachmentExtractor; do echo "=== $i"; grep -rn --include="*.cs" "$i" ...
+  Bash  grep -rn --include="*.cs" -E "EncodingHelper ..."
+```
+
+**The mechanism that killed it.** The second ring was supposed to be unreachable by name,
+and it is — none of the 14 gold files contains the string `IPathManager`. But the four
+intermediaries are not unreachable by name: the classes that declare `IPathManager` appear in
+the anchor's own grep output, so call three hands the agent the via names for free. Once it has
+the four names, **one alternation prints the entire ring**. The anchor's darkness bought
+nothing, because what had to be dark was the vias, not the anchor.
+
+This is the same family as the `new [A-Za-z]*Tokenable` kill recorded on bitwarden-server — one
+regex covering the whole answer set — reached by a different route: there the covering string
+was a shared lexical suffix, here it is a four-term list the anchor's own grep hands over.
+
+## What the sweep says, and what it may not say
+
+**It is a LISTING. It orders candidates; it does not close an axis.** NO GREP SCREEN IS A GATE
+and PRECISION RANKS, IT NEVER KILLS both bind here, and so does THE FIRST MEASUREMENT IS A REAL
+BASELINE ARM: *"a hand estimate of a baseline is not evidence about a baseline"*. One question
+has been measured on this repository. One.
+
+What was measured, over MCP at defaults:
+
+**1. The ring is one hop deep.** Every row's `chain` is a single carrier
+(`ChapterManager > IPathManager`), and `via_satisfiers` is 1 for all 14. There is no third ring
+in the shown payload, so a depth question is unavailable to the *sense* arm as well as to the
+baseline — GOLD RAILS requires every blast-sourced row to appear in what the agent is shown.
+
+**2. Ring diversity across the interfaces Sense can currently see.** All 64 interfaces declared
+in a file-scoped namespace were swept. Only three carry a ring of eight or more files:
+
+| anchor | vias | ring files | max via share | areas |
+|---|---|---|---|---|
+| IItemTypeLookup | 5 | 18 | 0.67 | 9 |
+| IPathManager | 4 | 14 | 0.43 | 10 |
+| IAttachmentExtractor | 1 | 9 | 1.00 | 3 |
+
+**That sweep is scoped to the file-scoped sixteen, and the scoping is not a choice — it is
+defect §4.** Block-scoped interfaces return nothing at all, so this listing is taken with the
+instrument this same record declares blind on 23 of the 40 interfaces the repository declares.
+It therefore cannot support a claim about *every anchor this repository offers*; it supports a
+claim about the subset Sense can currently see. The second, different probe that would settle
+the rest — sweeping the block-scoped interfaces by hand, or re-sweeping after the fix — **was
+not run**.
+
+**3. A comparison that is suggestive and is not a mechanism.** bitwarden-server's banked
+mini-bench held its baseline to 0.125 with nine vias over 31 ring files
+(`lab/scenarios/bitwarden-server/bitwarden-server.yaml:146`). It is tempting to read via count
+as the cause. **The recorded diagnosis of that cell says something else** — same file, lines
+20-22: *"The baseline's route was a hand-rolled one-hop interface walk (9 of its 15 calls); it
+took the two rows one hop from a direct injector ... and never took a second hop."* The
+mechanism on the record is a hop that baseline never took, not an alternation it could not
+afford. Our baseline took the second hop in one shell loop. Whether via count or hop-taking is
+what separates them is **unmeasured**, and this cycle does not settle it.
+
+## Where this leaves the axis
+
+**Open, with one question measured.** Not closed. A re-question changes the rows and therefore
+changes the baseline, and nothing here has measured a second set of rows.
+
+What the cycle does establish is narrower and still worth having: on this anchor, with this
+question, the baseline assembled the set in six calls because the anchor's own grep hands over
+the four intermediary names. Any re-question on this anchor has to defeat that specific route,
+and the ring's one-hop depth removes the obvious way to.
+
+## Why the campaign parked anyway
+
+Not because the axis is closed. Because **its binding constraint is a product defect, and the
+fix changes the candidate pool it would be re-questioning against.**
+
+23 of the 40 interfaces this repository declares return an empty blast at any confidence
+(`../instrument-defects.md` §4), and they are the large, diverse ones — `ILibraryManager` (121
+files declare a field of it), `IServerConfigurationManager` (71), `IFileSystem` (66),
+`IUserManager` (65). The sixteen Sense can see are the small ones. Re-questioning five more
+times against the small sixteen, when the fix would put the other 23 on the table, is buying
+cells against a pool that is about to change.
+
+That is a judgement, it is the operator's, and it is recorded as one. **AXIS-DEAD IS NEVER
+REPO-DEAD**, and nothing here rules on jellyfin.
+
+## The grounding rate, decomposed before it is quoted
+
+The scorer reported `17 of 38` sense and `18 of 42` baseline cited locations not resolving at
+the pinned commit. AN UNGROUNDED RATE IS A FORM ARTIFACT UNTIL DECOMPOSED forbids quoting that
+as a fabrication rate, and it is **not decomposed here** — this cycle did not run the
+decomposition, so the raw figures are recorded as raw figures and nothing is concluded from
+them.
+
+Two things can be said. The rates are close between the arms (0.447 sense, 0.429 baseline), so
+there is no arm asymmetry of the kind that produced the recorded discourse scare. And the
+question the decomposition would answer — **whether any of the sense arm's 14 credits rests on
+a citation that does not resolve** — is open, so the 1.0000 in the table above carries that
+caveat until someone runs it.

--- a/lab/plans/author.md
+++ b/lab/plans/author.md
@@ -28,6 +28,25 @@ so far is beside it, oldest first, and **all of them are read, not only the last
 Reading only the latest read is how six attempts oscillated between "the plain search got
 everything" and "neither arm got anything" without ever landing in between.
 
+0. **Fewer than about five runs per arm on disk? Step 1 has no input you may trust, and you say
+   so.** At zero there is no citation ranking at all; below five the ordering is noise by step
+   1's own measurement — a row that read as a perfect discriminator at n=2 was 4 of 5 by n=5.
+   Both cases are the same case, and the threshold is the law's rather than any one campaign's.
+
+   Nothing stands in for the ranking. A hand estimate of which rows are free is exactly the
+   substitute A GOLD ROW SHOULD COST A READ forbids from a phase that runs before the two-arm
+   bench. Write one line in the yaml header saying the free-row class is **unmeasured rather
+   than empty**, and carry on from step 2.
+
+   **Half of DECIDE rule 7 is skipped, not all of it.** Its free-and-unreachable-by-citation
+   half has no input. Its other half — a row the blast payload does not carry is dead weight —
+   needs no run history, and step 5 binds unconditionally: every `dependents` row you write must
+   appear in what the arm is shown.
+
+   *(Added by the first live campaign, dotnet-jellyfin cycle 1, at n=0. Keyed to five rather than
+   to zero in council review, so the case the campaign never saw — two or three recorded runs — is
+   covered too.)*
+
 1. **What the arms have ACTUALLY cited, per gold row, across every run on disk.** Rarest-cited
    first, scoped to the HEADLINE model's results root and not to every root: mixing model
    generations reorders the middle and hides the split, measured 2026-08-03, because a weak
@@ -75,10 +94,18 @@ everything" and "neither arm got anything" without ever landing in between.
 7. **Memorization, per candidate row, on a famous repository.** Cut what comes back recited. A
    famous repository is not disqualified; a memorized row is.
 
-8. After writing the yaml and the rubric: render the prompt, check the rubric, check gold
-   confidence on the `dependents` group, then stamp and verify the gold audit. `stamp` writes one
-   TODO row per gold item; you replace each by opening the file and reading the credit. `verify`
-   fails while any TODO remains.
+8. After writing the yaml and the rubric, audit the gold: `sense-lab validate -scenario <yaml>
+   -checkout <clone> -commit <pin>`. It resolves every row against the pinned checkout, reports
+   what would be quarantined, and flags the rows a covering grep for the anchor already prints.
+
+   **`stamp` and `verify` do not exist**, and neither does a rubric check, a gold-confidence
+   check or a prompt render. They are named for cycle 07 and are not built. Until they are, the
+   gold audit is `validate` plus opening every row by hand, which DO NOT below already requires.
+
+   *(Corrected by the first live campaign, dotnet-jellyfin cycle 1: the step named five absent
+   things — `stamp`, `verify`, a rubric check, a gold-confidence check and a prompt render — and
+   the Done-when list below required their artifacts, so the phase could not report itself done
+   by its own criteria.)*
 
 ## Decide
 
@@ -231,10 +258,30 @@ prints: `NO-ANCHOR` reached from a token grep is a report about grep, not about 
 - The scenario has two steps and the rubric has two matching steps in order.
 - `dependents` holds at least twelve rows across at least six areas, one file each.
 - No `dependents` row appears in the `contract` group.
-- The rendered prompt shows no path, symbol, count or tool name.
-- The rubric check passes.
-- The gold confidence check on the `dependents` group passes.
-- The gold audit verifies: zero TODO rows, gold unchanged under a finished sheet.
+- The prompt shows no path, symbol, count or tool name. No render command exists; the prompt is
+  `description` plus each `steps[].prompt` and two fixed boilerplate sentences
+  (`lab/internal/scenario/scenario.go:48-57`), so the check is performed by reading those fields
+  in the yaml.
+- `sense-lab validate` reports that it resolved every gold row at the pinned commit — the count,
+  not the word "skipped" — and quarantines none. **Read the report, not only the exit code:**
+  `validatecmd.go:64-69` prints `resolving skipped` and continues with a nil resolver when the
+  checkout cannot be opened, and `:77-80` exits non-zero only on a quarantine, so a wrong
+  `-checkout` or a bad pin produces a green run that verified nothing.
+- Every `dependents` row's `relation` carries a `path:line` and the exact expression standing at
+  that line, and `validate` resolves all of them. That is the hand-read leaving a trace; a bullet
+  asserting the author was diligent is not checkable and is not one.
+
+  *(The rubric check, the gold-confidence check and the stamp sheet were removed from this list
+  by the first live campaign: the commands they name do not exist, so the bullets could never be
+  satisfied. Restore them when cycle 07 builds the commands.*
+
+  *A fourth bullet requiring no `dependents` row inside the covering grep was written and then
+  removed in the same campaign's council review. It rebuilt a retired concept — NO GREP SCREEN IS
+  A GATE, IN ANY FORM — in the one place the shape cannot reach, and it is unsatisfiable on the
+  shipped corpus: on discourse, 19 of 23 gold rows lie inside a grep for `Category`, so at least
+  8 of its 12 `dependents` rows would fail it. `goldcheck.go:68` refuses to quarantine on that
+  reason for exactly this reason. Record the covering grep in the yaml header as an input to the
+  step 4 ranking; never let it decide.)*
 - The seam profile is in the yaml header and the anchor's precision is in the notes.
 - The yaml header names the ANSWER FORM this draft uses and its line on the campaign's
   answer-forms page: measured-to-win, under test, or unmeasured. A form that page records as


### PR DESCRIPTION
## Problem

Everything the bench had done so far replayed known material: the scorer reproduced recorded scores, the gates reproduced recorded decisions, the miner reproduced misses found by hand. None of it proved the instrument could take a repository nobody had benched and drive it to a measured result.

## Summary

The first campaign authored on sense-lab against a fresh repository. jellyfin at a pinned commit, anchor `IPathManager`, driven through index → author → minibench to `AUTO` → `DRAFT` → `REQUESTION`, parked at cycle 1 with a product change handed up.

The mini-bench ran both arms at a real wall, unscored, channel proof SOUND:

| `dependents`, n=1 per arm, `claude-opus-5` (headline, single-model) | baseline | sense | delta |
|---|---|---|---|
| recall | 0.9286 (13 of 14) | 1.0000 (14 of 14) | +0.0714 |

The baseline assembled the answer set in six tool calls and 91 seconds. Its route is the finding: the anchor was perfectly dark — none of the 14 gold files contains its name — but the four intermediaries appear in the anchor's own grep output, so one shell loop over four names printed the entire ring.

**The axis is left open with one question measured, not closed.** A re-question changes the rows and therefore the baseline, and a ring sweep is a listing that orders candidates and may not kill a draft.

It parked because its binding constraint is a product defect. Of the 40 interfaces jellyfin declares, 23 return an empty blast at any confidence — every one declared in a block-scoped namespace — and they are the large, diverse ones whose rings a grep alternation could not have covered. Re-questioning five more times against the sixteen the instrument can see, when a fix puts the other 23 on the table, spends against a pool that is about to change.

## Changes

- `lab/campaigns/dotnet-jellyfin/` — campaign config and the record: index summary, mini-bench with quoted figures and the baseline's route, handoff, and the defect list
- `lab/plans/author.md` — two revisions the campaign proved necessary

## Findings

Six recorded. Five instrument defects routed to cycle 05, the sharpest being that a measured-dead axis has no route to a park: `REQUESTION` routes back to authoring, `NO-ANCHOR` is defined by row count rather than by whether the ring is coverable, and `handoff` is reachable only from the six-cycle ceiling.

One product defect, routed onward: `sense_blast` and `sense_graph` return an empty edge set labelled `"completeness": "complete"`, with the advice "act on it, do not re-grep", for every C# type declared in a block-scoped namespace. Reproduced in twelve lines where the only difference is namespace syntax; not the confidence gate, since it is still empty at `min_confidence: 0.0`.

## Honest limits

- The pitch's first Done-means bullet is marked **NOT MET**: reaching the handoff required a transition the declared graph does not offer, and the sweep that justified stopping is hand-run analysis standing in for a declared phase.
- The ring sweep is scoped to the interfaces the instrument can currently see, which is the defect itself; the second probe that would settle the rest was not run.
- The 45% ungrounded citation rate is recorded raw and undecomposed, with nothing concluded from it.
- The spend ceiling is reported as untested, not held: at 2 runs of 40, nothing could have intervened.
- The scenario, gold and rubric are deliberately withheld from git, since this repository is public and published gold leaks irreversibly. That five scenarios' gold is already tracked on `main` is flagged for a human rather than resolved here.

## Test plan

- `make ci` green: build, tests, coverage floor with no new exception, complexity ledger 0 entries
- No Go files changed, so the coverage bar and test review do not apply
- Council review, four blockers found and applied; plan revisions separately reviewed, three blockers found and applied — including one that rebuilt a retired concept and was unsatisfiable on the shipped corpus