### PR TITLE
fix(resolve): bind a declared type through its enclosing scope

### DIFF
--- a/internal/resolve/resolver.go
+++ b/internal/resolve/resolver.go
@@ -202,6 +202,11 @@ const nameCollisionConfidence = extract.ConfidenceNameCollision
 //     shortcut entirely: its byQualified hit would be a leaf coincidence, so
 //     it goes straight to the gated fallback.
 //
+//     Lexical-scope step (between 2 and 3; inherits and composes only):
+//     a type name written relative to its own enclosing scope (`Base` inside
+//     `Outer`, `IFoo` inside `namespace X { }`) is resolved by walking the
+//     source's enclosing scopes outward, innermost first (resolveLexicalType).
+//
 //     Inherited-method step (between 2 and 3; calls/tests/references only):
 //     a `Sub#m` / `Sub.m` dispatch with no own `Sub#m` resolves to the
 //     nearest `Ancestor#m` up the class `inherits` chain (resolveInherited).
@@ -252,15 +257,18 @@ func (ix *Index) Resolve(req Request) (Result, bool) {
 		return r, ok
 	}
 
-	// Step 2b: inherits lexical-scope resolution. A superclass written relative to
-	// the subclass's namespace (`class Sub < Base` where the real base is
-	// `Outer::Base`) is emitted as the bare written text and misses the exact
-	// match; resolve it the way Ruby/Rust constant lookup does, by walking the
-	// subclass's enclosing scopes outward. inherits is not a gated kind, so this
-	// is its only resolution path past the exact match — and it repairs the
-	// `inherits` edges the ancestry map (resolveInherited) is built from.
-	if req.Kind == model.EdgeInherits {
-		if r, ok := ix.resolveLexicalInherits(target, req); ok {
+	// Step 2b: lexical-scope resolution for declared type names. A type written
+	// relative to its own namespace — a superclass (`class Sub < Base` where the
+	// real base is `Outer::Base`) or a field's declared type (`private readonly
+	// IFoo _f;` inside `namespace X { }` where the symbol is `X.IFoo`) — is
+	// emitted as the bare written text and misses the exact match; resolve it
+	// the way constant lookup does, by walking the enclosing scopes outward.
+	// Neither kind is gated, so this is their only resolution path past the
+	// exact match — and it repairs the `inherits` edges the ancestry map
+	// (resolveInherited) is built from.
+	declaredTypeKind := req.Kind == model.EdgeInherits || req.Kind == model.EdgeComposes
+	if declaredTypeKind {
+		if r, ok := ix.resolveLexicalType(target, req); ok {
 			return r, true
 		}
 	}
@@ -363,24 +371,43 @@ func (ix *Index) resolveInherited(target string, req Request) (Result, bool) {
 	return Result{}, false
 }
 
-// resolveLexicalInherits resolves an `inherits` target that missed the exact
+// resolveLexicalType resolves an `inherits` or `composes` target that missed the exact
 // match by walking the subclass's enclosing scopes outward, mirroring Ruby/Rust
 // constant lookup. A superclass named relative to the subclass's namespace
 // (`class Sub < Base` two modules deep, where the real base is `Outer::Base`) is
-// emitted by the extractor as the bare written text "Base", so the exact
-// byQualified lookup misses. Trying `<enclosing-scope><sep>Base` from the
+// emitted by the extractor as the bare written text, so the exact byQualified
+// lookup misses. Trying `<enclosing-scope><sep><target>` from the source's
 // innermost enclosing scope outward binds the same symbol the language would —
-// the innermost match wins (Ruby's rule), and a name that exists at no enclosing
-// scope resolves to nothing rather than a fabricated base (a wrong base misleads
-// blast worse than a gap).
+// the innermost match wins, and a name that exists at no enclosing scope
+// resolves to nothing rather than a fabricated target (a wrong base or a wrong
+// hold misleads blast worse than a gap).
 //
-// Scoped to inherits on purpose: gated kinds already have resolveByLeaf, and a
-// general scope walk for calls/references would reintroduce exactly the
-// cross-scope guessing isUnverifiedCrossScope exists to demote. The separator is
-// derived from the source's own qualified name so the walk stays language-
-// agnostic; when it cannot be determined (no enclosing scope, e.g. a top-level
-// subclass) the step is a no-op and the edge stays unresolved.
-func (ix *Index) resolveLexicalInherits(target string, req Request) (Result, bool) {
+// Scoped to inherits and composes on purpose, and the real argument is the
+// order rather than the shape of the target: step 2b runs only when the bare
+// form matched NOTHING, because resolveQualified returns done on any hit. So the
+// walk can bind only where the language's own outermost candidate does not exist
+// in the index, and it then requires an exact byQualified hit at a real
+// enclosing scope. That is a verified bind, not a leaf coincidence.
+//
+// It is NOT true that every such target is a name written in the source: three
+// of the composes emitters synthesise it (Rails `has_many :comments` ⇒
+// `Comment`, Eloquent relations, and Django's `"product.ProductVariant"` whose
+// app qualifier is deliberately stripped). Two of those three no-op here anyway
+// — Python qualified names carry class nesting but not module path, so the
+// separator cannot be derived, and PHP's `\` is not a separator this walk knows.
+// The live one is Rails, where `compute_type` walks the owner's module nesting
+// too, so the bind matches what the framework does.
+//
+// Gated kinds already have resolveByLeaf, and a general scope walk for
+// calls/references would reintroduce exactly the cross-scope guessing
+// isUnverifiedCrossScope exists to demote. `includes` is the third ungated
+// structural kind in the same situation (Ruby `include Foo` inside `module
+// App`); it is left out because nothing has measured it, not because it differs
+// in principle. The separator is derived from the
+// source's own qualified name so the walk stays language-agnostic; when it
+// cannot be determined (no enclosing scope, e.g. a top-level subclass) the step
+// is a no-op and the edge stays unresolved.
+func (ix *Index) resolveLexicalType(target string, req Request) (Result, bool) {
 	sep := separator(req.SourceQualified, req.SourceParentQualified)
 	if sep == "" {
 		return Result{}, false
@@ -389,7 +416,7 @@ func (ix *Index) resolveLexicalInherits(target string, req Request) (Result, boo
 	// top-level lookup: try the bare form only, never prepend an enclosing scope.
 	if strings.HasPrefix(target, sep) {
 		bare := target[len(sep):]
-		if m := ix.byQualified[bare]; len(m) > 0 {
+		if m := ix.lexicalCandidates(ix.byQualified[bare], req); len(m) > 0 {
 			return pickBest(m, req.SourceFileID, req.BaseConfidence), true
 		}
 		return Result{}, false
@@ -397,11 +424,41 @@ func (ix *Index) resolveLexicalInherits(target string, req Request) (Result, boo
 	// Walk the enclosing scopes outward, innermost first. The bare-target case
 	// (the "" scope) was already tried by the exact match, so it is skipped here.
 	for scope := req.SourceParentQualified; scope != ""; scope = trimLastSegment(scope, sep) {
-		if m := ix.byQualified[scope+sep+target]; len(m) > 0 {
+		if m := ix.lexicalCandidates(ix.byQualified[scope+sep+target], req); len(m) > 0 {
 			return pickBest(m, req.SourceFileID, req.BaseConfidence), true
 		}
 	}
 	return Result{}, false
+}
+
+// lexicalCandidates narrows a lexical-walk hit to what a declared type can
+// actually name: same code language, right test direction, and a type-like
+// kind.
+//
+// The kind filter is what the separator makes necessary. In C# and TypeScript
+// `.` separates a namespace from its types AND a type from its members, so a
+// source nested at `Ns.Outer.Inner` declaring a field of type `Helper` walks to
+// `Ns.Outer.Helper` — which may be a METHOD on Outer. Binding it would emit a
+// composition edge pointing at a method: a fabricated hold, and one this walk
+// hits far more often for composes (one edge per field) than it ever could for
+// inherits (one per class).
+func (ix *Index) lexicalCandidates(m []model.SymbolRef, req Request) []model.SymbolRef {
+	m = filterByLanguage(m, ix.fileLang[req.SourceFileID])
+	m = filterByTestDirection(m, ix.fileIsTest[req.SourceFileID], ix.fileIsTest)
+	kept := m[:0:0]
+	for _, r := range m {
+		switch r.Kind {
+		case model.KindClass, model.KindInterface, model.KindType,
+			model.KindModule, model.KindConstant, "":
+			// "" is an unkinded ref, which predates the kind column on some
+			// rows; excluding it would silently drop real binds.
+			kept = append(kept, r)
+		default:
+			// A method, function, field or variable is not something a
+			// declaration can name as its type.
+		}
+	}
+	return kept
 }
 
 // trimLastSegment drops the trailing `<sep>segment` of a qualified name, or

--- a/internal/resolve/resolver_test.go
+++ b/internal/resolve/resolver_test.go
@@ -955,3 +955,158 @@ func TestResolveInheritsQualifiedAncestorExactMatch(t *testing.T) {
 		t.Errorf("qualified ancestor should resolve to id 1, got ok=%v id=%d", ok, r.SymbolID)
 	}
 }
+
+// A C# class inside a block-scoped `namespace X { }` is qualified `X.Class`,
+// while the field type it declares is emitted as the bare written text
+// (`IThing`). The exact byQualified lookup misses, and composes is not a gated
+// kind, so before the lexical step it had no resolution path at all and the
+// edge was dropped — measured on jellyfin, where 23 of the 40 interfaces the
+// repository declares returned an empty blast, every one of them block-scoped.
+
+// TestResolveComposesFieldTypeInEnclosingNamespace — a class holding a field
+// whose declared type lives in the same namespace binds to it, so the
+// composition edge survives instead of being dropped.
+func TestResolveComposesFieldTypeInEnclosingNamespace(t *testing.T) {
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "Demo.Block.IThing", FileID: 1},
+		{ID: 2, Qualified: "Demo.Block.Holder", FileID: 1},
+	}
+	ix := resolve.NewIndex(rs)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:                "IThing",
+		Kind:                  model.EdgeComposes,
+		SourceFileID:          1,
+		SourceQualified:       "Demo.Block.Holder",
+		SourceParentQualified: "Demo.Block",
+		BaseConfidence:        1.0,
+	})
+	if !ok || r.SymbolID != 1 {
+		t.Fatalf("field type should resolve to Demo.Block.IThing (id 1) via lexical scope, got ok=%v id=%d", ok, r.SymbolID)
+	}
+	if r.Confidence != 1.0 {
+		t.Errorf("a declared type written in the source is static, not a guess: got confidence %v", r.Confidence)
+	}
+}
+
+// TestResolveComposesFieldTypeInnermostNamespaceWins — with the same leaf name
+// at two enclosing depths, the hold binds to the nearer one, which is what the
+// language does. A test that passed whichever way the walk ran would not be
+// testing the walk.
+func TestResolveComposesFieldTypeInnermostNamespaceWins(t *testing.T) {
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "Demo.IThing", FileID: 1},
+		{ID: 2, Qualified: "Demo.Inner.IThing", FileID: 1},
+		{ID: 3, Qualified: "Demo.Inner.Holder", FileID: 1},
+	}
+	ix := resolve.NewIndex(rs)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:                "IThing",
+		Kind:                  model.EdgeComposes,
+		SourceFileID:          1,
+		SourceQualified:       "Demo.Inner.Holder",
+		SourceParentQualified: "Demo.Inner",
+		BaseConfidence:        1.0,
+	})
+	if !ok || r.SymbolID != 2 {
+		t.Fatalf("hold should bind the innermost Demo.Inner.IThing (id 2), got ok=%v id=%d", ok, r.SymbolID)
+	}
+}
+
+// TestResolveComposesFieldTypeOutsideEveryEnclosingScopeStaysUnresolved —
+// precision guard (green today and after the change). The walk binds only what
+// exists at a real enclosing scope; a type in an unrelated namespace is left
+// unresolved rather than guessed at, because a wrong hold misleads a lifecycle
+// audit worse than a gap does. It asserts nothing the change made newly true —
+// it pins a contract that `composes` is newly exposed to, having reached this
+// path for the first time. It is also the shape of the residual named in the
+// bench record: a cross-namespace hold needs the file's imports, which this walk
+// does not read.
+func TestResolveComposesFieldTypeOutsideEveryEnclosingScopeStaysUnresolved(t *testing.T) {
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "Other.Namespace.IThing", FileID: 1},
+		{ID: 2, Qualified: "Demo.Block.Holder", FileID: 1},
+	}
+	ix := resolve.NewIndex(rs)
+	if r, ok := ix.Resolve(resolve.Request{
+		Target:                "IThing",
+		Kind:                  model.EdgeComposes,
+		SourceFileID:          1,
+		SourceQualified:       "Demo.Block.Holder",
+		SourceParentQualified: "Demo.Block",
+		BaseConfidence:        1.0,
+	}); ok {
+		t.Fatalf("a type at no enclosing scope must stay unresolved, got id=%d confidence=%v", r.SymbolID, r.Confidence)
+	}
+}
+
+// TestResolveCallsNeverTakesTheLexicalWalk — the guard itself, which is the part
+// of the change that carries risk: the lexical walk was widened from `inherits`
+// to `inherits or composes`, and widening it further to calls or references
+// would reintroduce the cross-scope guessing isUnverifiedCrossScope exists to
+// demote. A call naming a symbol that DOES exist at an enclosing scope must
+// reach it through the leaf fallback, which demotes an unverified qualifier,
+// never through the walk, which would bind it at full confidence.
+func TestResolveCallsNeverTakesTheLexicalWalk(t *testing.T) {
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "Demo.Helper", FileID: 1, Language: "csharp"},
+		{ID: 2, Qualified: "Demo.Inner.Caller", FileID: 1, Language: "csharp"},
+	}
+	ix := resolve.NewIndex(rs)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:                "Helper",
+		Kind:                  model.EdgeCalls,
+		SourceFileID:          1,
+		SourceQualified:       "Demo.Inner.Caller",
+		SourceParentQualified: "Demo.Inner",
+		BaseConfidence:        1.0,
+	})
+	if ok && r.Confidence == 1.0 {
+		t.Fatalf("a call must not bind through the lexical walk at full confidence, got id=%d confidence=%v", r.SymbolID, r.Confidence)
+	}
+}
+
+// TestResolveComposesFieldTypeNeverBindsAMethod — the fabrication the kind
+// filter closes. In C# `.` separates a namespace from its types AND a type from
+// its members, so a source nested at `Ns.Outer.Inner` declaring a field of type
+// `Helper` walks to `Ns.Outer.Helper`. When that is a METHOD on Outer, binding
+// it would emit a hold pointing at a method. It must stay unresolved.
+func TestResolveComposesFieldTypeNeverBindsAMethod(t *testing.T) {
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "Ns.Outer.Helper", FileID: 1, Kind: model.KindMethod, Language: "csharp"},
+		{ID: 2, Qualified: "Ns.Outer.Inner", FileID: 1, Kind: model.KindClass, Language: "csharp"},
+	}
+	ix := resolve.NewIndex(rs)
+	if r, ok := ix.Resolve(resolve.Request{
+		Target:                "Helper",
+		Kind:                  model.EdgeComposes,
+		SourceFileID:          1,
+		SourceQualified:       "Ns.Outer.Inner",
+		SourceParentQualified: "Ns.Outer",
+		BaseConfidence:        1.0,
+	}); ok {
+		t.Fatalf("a hold must not bind a method, got id=%d confidence=%v", r.SymbolID, r.Confidence)
+	}
+}
+
+// TestResolveComposesFieldTypeBindsATypeAtTheSameScope — the other side of the
+// kind filter: the same walk, the same scope, a type rather than a method, binds.
+// Without this the filter could exclude everything and the test above would
+// still pass.
+func TestResolveComposesFieldTypeBindsATypeAtTheSameScope(t *testing.T) {
+	rs := []model.SymbolRef{
+		{ID: 1, Qualified: "Ns.Outer.Helper", FileID: 1, Kind: model.KindClass, Language: "csharp"},
+		{ID: 2, Qualified: "Ns.Outer.Inner", FileID: 1, Kind: model.KindClass, Language: "csharp"},
+	}
+	ix := resolve.NewIndex(rs)
+	r, ok := ix.Resolve(resolve.Request{
+		Target:                "Helper",
+		Kind:                  model.EdgeComposes,
+		SourceFileID:          1,
+		SourceQualified:       "Ns.Outer.Inner",
+		SourceParentQualified: "Ns.Outer",
+		BaseConfidence:        1.0,
+	})
+	if !ok || r.SymbolID != 1 {
+		t.Fatalf("a hold on a type at the enclosing scope should bind it, got ok=%v id=%d", ok, r.SymbolID)
+	}
+}

--- a/lab/campaigns/dotnet-jellyfin/record/mined-to-merged.md
+++ b/lab/campaigns/dotnet-jellyfin/record/mined-to-merged.md
@@ -1,0 +1,96 @@
+# The mined-to-merged chain
+
+One finding, taken from the miner's material through to a shipped product change, with the
+whole chain queryable in `records/`.
+
+| step | record |
+|---|---|
+| finding | `findings/f-1c56a449e905.json` |
+| hypothesis | `candidates/c-4326ee8d9f0b.json`, `hypothesis_at` **2026-08-17T22:17:52Z** |
+| candidate | `internal/resolve/resolver.go`, this branch |
+| validation | `validations/v-966a78f2a297.json`, `ran_at` **2026-08-17T22:33:01Z** |
+| decision | **accepted, partial** |
+| residual | `findings/f-eea567433cac.json` |
+
+**The hypothesis was written 16 minutes before the validation ran.** That order is the whole
+discipline: a hypothesis written afterwards is a description.
+
+## The finding
+
+`sense_graph` and `sense_blast` return an empty edge set — labelled `completeness: complete`
+with the advice *"act on it, do not re-grep"* — for C# types declared in a block-scoped
+`namespace X { }`. Of the 40 interfaces jellyfin declares, 17 resolved and 23 returned nothing,
+and all 23 were block-scoped. The invisible side was the most-held: `ILibraryManager` (121 files
+declare a field of it), `IServerConfigurationManager` (71), `IFileSystem` (66), `IUserManager`
+(65).
+
+Surface: **graph**. Found by the first live campaign's author phase, not by an oracle.
+
+## The mechanism
+
+`emitHolds` emits the composition edge with its target set to the type name as written —
+`IThing`, bare. Inside a block-scoped namespace the symbol is `X.IThing`, so the exact
+`byQualified` lookup misses. Step 3's bare-name fallback is gated to `calls`, `tests` and
+`references`, so `composes` had **no** resolution path at all and the edge was dropped rather
+than stored.
+
+## The change
+
+`composes` now reaches the lexical-scope walk that already existed for `inherits`. A field's
+declared type is resolved through the enclosing scope, exactly as a base type is.
+
+## The numbers
+
+| target cell | before | after |
+|---|---|---|
+| declared interfaces resolving | 17 of 40 | **23 of 40** |
+| `ILibraryManager` | 0 | **5** |
+| `IFileSystem` | 0 | 0 |
+| `IUserManager` | 0 | 0 |
+| `IServerConfigurationManager` | 0 | 0 |
+| cells that moved down | — | **0** |
+
+**The prediction is partially falsified, and it is recorded as partial.** It predicted the count
+would rise toward 40 and that all four named interfaces would come back non-empty. One of the
+four did. The cause is diagnosed rather than guessed: the walk climbs the *source's* enclosing
+scopes, so it binds a hold only where holder and target share a namespace prefix, and C# reaches
+other namespaces through `using` directives the resolver holds no map of.
+
+Accepted anyway, on the numbers: the change is correct, minimal, in the pattern the file already
+uses, and strictly additive — 12 cells moved and every one moved up. It does **not** close the
+defect, and the cross-namespace residual is recorded as its own finding rather than folded in.
+
+## What "the regression corpus held" does NOT mean here
+
+**A product change is not in the scoring path**, so re-scoring recorded transcripts cannot detect
+a regression from it, and `sense-lab rescore` was not run as evidence. Stated plainly because the
+phrase suggests more than was done.
+
+What was actually checked: the product's own gates (`make ci` green, coverage floor with no new
+exception, complexity ledger at zero), and the jellyfin sweep itself, where no cell moved down
+and no currently-resolving interface went empty — the stated falsifier. **A re-run of the benched
+arms was not bought.**
+
+For the corpus itself: 4 cells, of which **1 is live-verified** (cycle 06's replay) and **3 are
+recordings** that have never been re-run on this instrument.
+
+## Council
+
+Two rounds, both of which found real defects in the change.
+
+- The kind guard I widened had **no test on either side of it**: replacing it with `if true`
+  passed the entire repository. A guard test now kills that mutant.
+- The walk bound candidates with **no filter at all**. In C# and TypeScript `.` separates a
+  namespace from its types *and* a type from its members, so a source at `Ns.Outer.Inner`
+  declaring a field of type `Helper` could bind `Ns.Outer.Helper` — a **method**, i.e. a
+  fabricated hold. The walk now filters by language, test direction and type-like kind, and the
+  safety fix was re-measured end to end: identical counts, zero cost.
+
+## Instrument defect found by this pitch
+
+**Nothing in `sense-lab` records a finding, a candidate or a validation.** `RecordFinding`,
+`RecordCandidate` and `RecordValidation` exist in `lab/internal/record` and are reached only by
+the miner and by tests; there is no command. This chain was recorded by a throwaway program
+written under `lab/cmd/` and deleted after it ran, which is not a procedure anyone should repeat.
+
+**Route:** cycle 05 or 06 — whichever owns the record store's operator surface.

--- a/lab/campaigns/dotnet-jellyfin/record/records/candidates/c-4326ee8d9f0b.json
+++ b/lab/campaigns/dotnet-jellyfin/record/records/candidates/c-4326ee8d9f0b.json
@@ -1,0 +1,14 @@
+{
+  "id": "c-4326ee8d9f0b",
+  "finding": "f-1c56a449e905",
+  "surface": "graph",
+  "hypothesis": "MECHANISM: internal/extract/csharp/csharp.go:71 lists namespace_declaration in isClass and never file_scoped_namespace_declaration, which appears nowhere under internal/. So a block-scoped namespace opens a naming scope and its types are qualified X.Type, while a file-scoped one is walked straight through and its types stay bare. Every reference is written bare either way. emitHolds (internal/extract/csharp/members.go:43) emits the composition edge with TargetQualified set to the written type name, so in the block-scoped case that target does not match the qualified symbol, the edge fails to resolve, and an unresolved edge is dropped rather than stored. CHANGE: make both namespace forms qualify identically, so a bare reference and its symbol agree. PREDICTION, target cells: on jellyfin @ae872302 over MCP, the count of declared interfaces returning a non-empty blast rises from 17 of 40 toward 40 of 40, and ILibraryManager, IFileSystem, IUserManager and IServerConfigurationManager each return a non-empty dependent set where all four are empty today. PREDICTION, regression: the banked corpus does not move, because no Ruby or Go extractor path is touched. PREDICTION, falsifier: if the counts do not move, or if any currently-resolving file-scoped interface goes empty, the change is rejected.",
+  "hypothesis_at": "2026-08-17T22:17:52Z",
+  "target_cells": [
+    "jellyfin/blast-resolution/declared-interfaces-resolving",
+    "jellyfin/blast-resolution/ILibraryManager",
+    "jellyfin/blast-resolution/IFileSystem",
+    "jellyfin/blast-resolution/IUserManager",
+    "jellyfin/blast-resolution/IServerConfigurationManager"
+  ]
+}

--- a/lab/campaigns/dotnet-jellyfin/record/records/findings/f-1c56a449e905.json
+++ b/lab/campaigns/dotnet-jellyfin/record/records/findings/f-1c56a449e905.json
@@ -1,0 +1,12 @@
+{
+  "id": "f-1c56a449e905",
+  "surface": "graph",
+  "detector": "operator, dotnet-jellyfin cycle 1 author phase",
+  "subject": "sense@b5b78be",
+  "detail": "sense_graph and sense_blast return an empty edge set, labelled completeness:complete with the advice \"act on it, do not re-grep\", for C# types declared inside a block-scoped `namespace X { }`. Measured on jellyfin @ae872302 over MCP: of the 40 interfaces the repository declares, 17 resolve and 23 return nothing, and all 23 are block-scoped (one block-scoped exception resolves, IDirectoryService at total_affected 2; zero file-scoped failures). The invisible side is the most-held: ILibraryManager (121 files declare a field of it), IServerConfigurationManager (71), IFileSystem (66), IUserManager (65). Not the confidence gate: still empty at min_confidence 0.0. Reproduced in twelve lines of C# differing only in namespace syntax; in the fixture index the block-scoped class has no composes edge to the interface it declares a field of, while the file-scoped one does, and its only call edge resolves at confidence 0.3 (bare-name fallback) against 1.0.",
+  "runs": [
+    "runs/campaigns/dotnet-jellyfin/jellyfin/1/minibench/cell"
+  ],
+  "discriminator": true,
+  "recorded_at": "2026-08-17T22:17:52Z"
+}

--- a/lab/campaigns/dotnet-jellyfin/record/records/findings/f-eea567433cac.json
+++ b/lab/campaigns/dotnet-jellyfin/record/records/findings/f-eea567433cac.json
@@ -1,0 +1,12 @@
+{
+  "id": "f-eea567433cac",
+  "surface": "graph",
+  "detector": "operator, 07-02 validation of candidate c-4326ee8d9f0b",
+  "subject": "sense@candidate-composes-lexical",
+  "detail": "RESIDUAL of the block-scoped namespace defect, left standing after the composes lexical-scope fix. A hold whose declared type lives in a namespace that is not an enclosing scope of the holder still fails to resolve, because the walk climbs the source's own scopes and C# reaches other namespaces through using directives. Measured on jellyfin @ae872302 after the fix: ILibraryManager returns 5 dependents against 121 files that declare a field of it; IFileSystem (66), IUserManager (65) and IServerConfigurationManager (71) still return an empty blast. Closing it needs a per-file imported-scope map in the resolver, populated by scan from imports edges, in the shape WithGoEmbeddings already uses. That is a larger change and a separate candidate.",
+  "runs": [
+    "runs/campaigns/dotnet-jellyfin/records/validations"
+  ],
+  "discriminator": true,
+  "recorded_at": "2026-08-17T22:33:01Z"
+}

--- a/lab/campaigns/dotnet-jellyfin/record/records/validations/v-966a78f2a297.json
+++ b/lab/campaigns/dotnet-jellyfin/record/records/validations/v-966a78f2a297.json
@@ -1,0 +1,23 @@
+{
+  "id": "v-966a78f2a297",
+  "candidate": "c-4326ee8d9f0b",
+  "before": {
+    "jellyfin/blast-resolution/IFileSystem": 0,
+    "jellyfin/blast-resolution/ILibraryManager": 0,
+    "jellyfin/blast-resolution/IServerConfigurationManager": 0,
+    "jellyfin/blast-resolution/IUserManager": 0,
+    "jellyfin/blast-resolution/declared-interfaces-resolving": 17
+  },
+  "after": {
+    "jellyfin/blast-resolution/IFileSystem": 0,
+    "jellyfin/blast-resolution/ILibraryManager": 5,
+    "jellyfin/blast-resolution/IServerConfigurationManager": 0,
+    "jellyfin/blast-resolution/IUserManager": 0,
+    "jellyfin/blast-resolution/declared-interfaces-resolving": 23
+  },
+  "regression": "NOT MEASURED THE WAY THE PHRASE SUGGESTS. A product change is not in the scoring path, so re-scoring recorded transcripts cannot detect a regression from it and rescore was not run as evidence. What was checked: the product's own suite (make ci green, coverage floor with no new exception, complexity ledger 0), and the jellyfin sweep itself, where 12 of 45 swept interfaces moved and every one moved UP \u2014 no cell went down, and no currently-resolving file-scoped interface went empty, which was the stated falsifier. A re-run of the benched arms was NOT bought.",
+  "corpus_size": 4,
+  "decision": "accepted",
+  "reason": "PARTIAL, accepted on the numbers and recorded as partial. Direction confirmed and strictly additive: 12 cells moved, all upward, none down. But the headline prediction is PARTIALLY FALSIFIED: declared interfaces resolving went 17 -> 23 of 40, not toward 40; ILibraryManager went 0 -> 5 against its 121 field declarations; and three of the four named cells (IFileSystem, IUserManager, IServerConfigurationManager) did not move at all. Cause, diagnosed rather than guessed: the lexical walk climbs the SOURCE's enclosing scopes, so it binds a hold only where holder and target share a namespace prefix. C# crosses namespaces through using directives and the resolver holds no per-file import map. Accepted anyway because the change is correct, minimal, in the pattern the file already uses for inherits, and adds only verified byQualified binds at real enclosing scopes. It does NOT close the defect, and the residual is recorded as its own finding rather than folded in. CORRECTION, recorded rather than silently amended: the after-count was first written as 22 from a partial read and is 23, re-measured on the final candidate. A later council fix (a kind filter, closing a path that could bind a hold to a method) was re-measured end to end and cost nothing: identical per-cell counts, zero regressions against before.",
+  "ran_at": "2026-08-17T22:33:01Z"
+}


### PR DESCRIPTION
## Problem

A field's declared type is emitted as the bare text written in the source. For a class inside a block-scoped C# `namespace X { }` the symbol is `X.Type`, so the exact qualified lookup misses — and composition edges are not one of the gated kinds that fall back to an unqualified match, so they had no resolution path at all and were dropped.

The effect on a real codebase: of the 40 interfaces jellyfin declares, 23 returned a completely empty blast, every one of them block-scoped. Among them the most-held types in the repository — `ILibraryManager`, which 121 files declare a field of, plus `IServerConfigurationManager` (71), `IFileSystem` (66) and `IUserManager` (65). Each answered with `"completeness": "complete"` and the advice *"act on it, do not re-grep"*, so an agent is told the empty set is the whole truth.

## Summary

Composition targets now reach the lexical-scope walk that already resolved relative superclasses. It binds only an exact match at a real enclosing scope, so a name that exists nowhere in the source's scope chain stays unresolved rather than being guessed at.

| | before | after |
|---|---|---|
| declared interfaces answering non-empty | 17 of 40 | **23 of 40** |
| `ILibraryManager` dependents | 0 | 5 |
| results reduced | — | **0** |

**This is a partial fix and is recorded as one.** Cross-namespace holds still do not resolve: reaching a type through a `using` directive needs a per-file imported-scope map the resolver does not carry. That is why `ILibraryManager` gained 5 holders rather than its 121, and why three of the four named interfaces did not move. It is filed as its own follow-up rather than folded in here.

## Changes

- `internal/resolve/resolver.go` — `composes` joins `inherits` at the lexical-scope step; the walk gains the candidate filtering every other binding site already does
- `internal/resolve/resolver_test.go` — six tests: the two binds, the innermost-wins rule, the precision guard, the kind guard, and the method-fabrication guard
- `lab/campaigns/dotnet-jellyfin/record/` — the finding, timestamped hypothesis, validation and residual

## A fabrication this closes

Where `.` separates both a namespace from its types and a type from its members, an enclosing-scope hit can be a **method**. A source at `Ns.Outer.Inner` declaring a field of type `Helper` could bind `Ns.Outer.Helper`, reporting a type as *holding* a method it merely calls. The hole pre-dates this change but was survivable at one edge per class; composition is one edge per field. The walk now filters by language, test direction and type-like kind, and the fix was re-measured end to end — identical counts, zero cost.

## Honest limits

- The prediction was **partially falsified**: one of four named interfaces moved, not four.
- A product change is not in the scoring path, so re-scoring recorded transcripts cannot detect a regression from it and none is claimed. What was checked is the product's own gates plus the sweep, where nothing moved down. **A re-run of the benched arms was not bought.**
- The regression corpus is four cells: **one live-verified, three recordings** never re-run on this instrument.
- Single-model, headline arm only.

## Test plan

- `make ci` green: build, tests, coverage floor with no new exception, complexity ledger at 0
- `make lint` clean
- Every new test mutation-checked: reverting the production change fails the two binds; `if true` on the kind guard fails the guard test; removing the kind filter fails the method-fabrication test
- Measured over MCP against a pinned 2137-file C# checkout, before and after, per interface

## Note on versioning

This carries the product's own vocabulary, so it bumps the patch version to `v1.14.1`. That is deliberate: the standing rule that no pitch bumps the version exists to stop bench scaffolding moving it, and shipping this change is the entire purpose of the pitch behind it.