### PR TITLE
bench(lab): install a competitor, and prove what it leaves behind

### DIFF
--- a/lab/internal/catalog/catalog.go
+++ b/lab/internal/catalog/catalog.go
@@ -61,6 +61,26 @@ type Subject struct {
 	Executor string `json:"executor"`
 	// Agents are the agent tool ids this subject can be driven through.
 	Agents []string `json:"agents"`
+	// Touches are the paths this subject may write, relative to the arm's HOME
+	// or repository, and it is a DECLARATION rather than a description: what a
+	// subject actually wrote is compared against it, and anything outside is a
+	// finding about that subject.
+	//
+	// Empty for a subject nobody has run yet. Its first run is a discovery run
+	// in the strictest isolation available, and the declaration is written from
+	// what was observed — never copied from the subject's own documentation,
+	// which says what it intends to do.
+	Touches []string `json:"touches"`
+	// Install, Setup and Cleanup are what this subject does to a machine,
+	// each a list of argv.
+	//
+	// Command lists rather than a script, so a person can read what a
+	// competitor's installer will do before it runs on their machine. They
+	// arrive here, in cycle 08, with their consumer: cycle 01 deliberately
+	// refused to invent them while nothing ran them.
+	Install [][]string `json:"install"`
+	Setup   [][]string `json:"setup"`
+	Cleanup [][]string `json:"cleanup"`
 }
 
 // Agent is the harness that runs a model: the CLI, and how to talk to it.

--- a/lab/internal/catalog/validate.go
+++ b/lab/internal/catalog/validate.go
@@ -50,6 +50,7 @@ func (c *Catalog) checkSubject(s Subject) []string {
 	if len(s.Agents) == 0 {
 		p = append(p, fmt.Sprintf("subject %s: names no agent tools, so nothing can drive it", s.ID))
 	}
+	p = append(p, checkSubjectCommands(s)...)
 	if s.Executor == "" {
 		p = append(p, fmt.Sprintf("subject %s: names no executor, so there is nowhere to run it", s.ID))
 	} else if _, ok := c.Executors[s.Executor]; !ok {
@@ -69,6 +70,31 @@ func (c *Catalog) checkSubject(s Subject) []string {
 				p = append(p, fmt.Sprintf("subject %s needs MCP but agent %s does not support it", s.ID, a))
 			}
 		}
+	}
+	return p
+}
+
+// checkSubjectCommands refuses a command nothing could run, and a subject that
+// installs something without saying how to remove it.
+//
+// The second is the one that matters. A subject with an install and no cleanup
+// leaves whatever it wrote on the machine, every later run on that machine
+// reads it, and the symptom looks like drift rather than like a leak.
+func checkSubjectCommands(s Subject) []string {
+	var p []string
+	for _, stage := range []struct {
+		what string
+		cmds [][]string
+	}{{"install", s.Install}, {"setup", s.Setup}, {"cleanup", s.Cleanup}} {
+		for i, argv := range stage.cmds {
+			if len(argv) == 0 {
+				p = append(p, fmt.Sprintf("subject %s: %s step %d is an empty command", s.ID, stage.what, i+1))
+			}
+		}
+	}
+	if len(s.Install) > 0 && len(s.Cleanup) == 0 {
+		p = append(p, fmt.Sprintf("subject %s: installs something and declares no cleanup, so whatever it "+
+			"writes stays on the machine and every later run reads it", s.ID))
 	}
 	return p
 }

--- a/lab/internal/subject/competitor.go
+++ b/lab/internal/subject/competitor.go
@@ -1,0 +1,184 @@
+package subject
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/luuuc/sense/lab/internal/channels"
+)
+
+// A subject that is not Sense arrives with an installer, may write to the home
+// directory, may register itself with the agent tool, may start a background
+// process, and may leave state behind that changes the next run. Every one of
+// those is a contamination channel, and unlike Sense's, nobody here knows what
+// they are in advance.
+//
+// So the shape is: declare what it touches, run it, and CHECK the declaration
+// against what happened. A subject's own documentation describes what it
+// intends to do; only a run says what it does.
+
+// Plan is what a subject does to a machine, as the catalog declares it.
+//
+// Command LISTS rather than a script, so what a subject does is readable
+// without running it. A script would be one opaque string in a config file, and
+// the whole point of this declaration is that a person can read it before a
+// competitor's installer runs on their machine.
+type Plan struct {
+	// Touches are the paths this subject may write, relative to the arm's HOME
+	// or to its repository. It is a DECLARATION, checked against what the
+	// subject actually wrote, and it starts out empty for a subject nobody has
+	// run yet.
+	Touches []string
+	// Install, Setup and Cleanup are run in that order around a session, each
+	// as argv.
+	Install [][]string
+	Setup   [][]string
+	Cleanup [][]string
+}
+
+// Env is where a subject's commands run: its own repository, its own disposable
+// HOME, and the environment the arm was given.
+//
+// It carries the arm's environment rather than the host's, which is the
+// credential rule made structural: a subject is handed the repository and
+// whatever its own setup needs, and never the host's tokens or the host's agent
+// configuration. There is nothing here to pass them through.
+type Env struct {
+	Repo    string
+	Home    string
+	Environ []string
+}
+
+// Prepare installs and sets up a subject, and reports every path that appeared
+// under its HOME or its repository while it ran.
+//
+// The observation is the point. On a subject's FIRST run there is nothing to
+// check against, so this is a discovery run: what it returns is what the
+// declaration should say, written from what happened rather than from what the
+// subject's documentation claims.
+func Prepare(ctx context.Context, p Plan, env Env) ([]string, error) {
+	before, err := state(env)
+	if err != nil {
+		return nil, err
+	}
+	for _, stage := range []struct {
+		what string
+		cmds [][]string
+	}{{"install", p.Install}, {"setup", p.Setup}} {
+		if err := runAll(ctx, stage.what, stage.cmds, env); err != nil {
+			return nil, err
+		}
+	}
+	after, err := state(env)
+	if err != nil {
+		return nil, err
+	}
+	return appeared(before, after), nil
+}
+
+// Remove runs the subject's cleanup and reports what survived it.
+//
+// An empty result is the only acceptable outcome, and it is CHECKED rather than
+// inferred from a clean exit. An uninstaller that leaves a config entry behind
+// contaminates every subsequent run on that machine, and the symptom looks like
+// drift rather than like a leak.
+func Remove(ctx context.Context, p Plan, env Env, installed []string) ([]string, error) {
+	if err := runAll(ctx, "cleanup", p.Cleanup, env); err != nil {
+		return nil, err
+	}
+	now, err := state(env)
+	if err != nil {
+		return nil, err
+	}
+	var left []string
+	for _, path := range installed {
+		if _, still := now[path]; still {
+			left = append(left, path)
+		}
+	}
+	return left, nil
+}
+
+// Undeclared names the paths a subject wrote that its declaration does not
+// cover.
+//
+// A declared path covers itself and everything under it, because a subject that
+// says it writes a directory has said what the directory is for. Anything else
+// is a finding about the subject, and it belongs in that subject's README with
+// a date and a version — measured, not read out of its documentation.
+func Undeclared(wrote []string, declared []string) []string {
+	var out []string
+	for _, path := range wrote {
+		if !covered(path, declared) {
+			out = append(out, path)
+		}
+	}
+	return out
+}
+
+func covered(path string, declared []string) bool {
+	for _, d := range declared {
+		if path == d || strings.HasPrefix(path, strings.TrimSuffix(d, "/")+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// state is every file under the arm's HOME and repository, by path.
+//
+// Both, because the two failure modes are different: a subject that writes into
+// the repository has changed what the next arm sees, and one that writes into
+// HOME has changed what every later run on that machine sees.
+func state(env Env) (map[string]string, error) {
+	all := map[string]string{}
+	for _, root := range []struct{ prefix, dir string }{{"home", env.Home}, {"repo", env.Repo}} {
+		if root.dir == "" {
+			continue
+		}
+		// .git and .sense are machinery rather than anything a subject did, and
+		// both are large enough to make this the slowest step in a run.
+		tree, err := channels.Tree(root.dir, ".git", ".sense")
+		if err != nil {
+			return nil, fmt.Errorf("read the %s tree: %w", root.prefix, err)
+		}
+		for rel, hash := range tree {
+			all[path.Join(root.prefix, rel)] = hash
+		}
+	}
+	return all, nil
+}
+
+// appeared is what the second state holds that the first did not, or holds
+// differently. Sorted, because a set of paths a human reads in a different
+// order every run is a set nobody can diff.
+func appeared(before, after map[string]string) []string {
+	var out []string
+	for p, hash := range after {
+		if before[p] != hash {
+			out = append(out, p)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// runAll runs one stage's commands in order, stopping at the first failure.
+func runAll(ctx context.Context, what string, cmds [][]string, env Env) error {
+	for i, argv := range cmds {
+		if len(argv) == 0 {
+			return fmt.Errorf("%s step %d is an empty command", what, i+1)
+		}
+		cmd := exec.CommandContext(ctx, argv[0], argv[1:]...) // #nosec G204 -- the argv a subject declares
+		cmd.Dir = env.Repo
+		cmd.Env = env.Environ
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("%s step %d (%s): %w: %s", what, i+1, argv[0], err, out)
+		}
+	}
+	return nil
+}

--- a/lab/internal/subject/competitor_test.go
+++ b/lab/internal/subject/competitor_test.go
@@ -1,0 +1,229 @@
+package subject_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/lab/internal/subject"
+)
+
+// A subject that is not Sense arrives with an installer and nobody knows what
+// it touches in advance. These tests are about the observation, not about any
+// particular subject: the stand-ins write files the way an installer does.
+
+func anEnv(t *testing.T) subject.Env {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the stand-in subjects are shell commands")
+	}
+	root := t.TempDir()
+	repo, home := filepath.Join(root, "repo"), filepath.Join(root, "home")
+	for _, dir := range []string{repo, home} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return subject.Env{Repo: repo, Home: home, Environ: []string{"HOME=" + home, "PATH=" + os.Getenv("PATH")}}
+}
+
+// The discovery run. A subject's first run has nothing to check against, so
+// what it produces IS the declaration — written from what happened rather than
+// from what the subject's documentation claims it does.
+func TestAFirstRunReportsEveryPathTheSubjectActuallyWrote(t *testing.T) {
+	env := anEnv(t)
+	plan := subject.Plan{
+		Install: [][]string{{"sh", "-c", "mkdir -p " + env.Home + "/bin && echo binary > " + env.Home + "/bin/tool"}},
+		Setup:   [][]string{{"sh", "-c", "echo config > " + env.Home + "/.toolrc; echo snapshot > snapshot.json"}},
+		Cleanup: [][]string{{"sh", "-c", "rm -f " + env.Home + "/bin/tool " + env.Home + "/.toolrc snapshot.json"}},
+	}
+
+	wrote, err := subject.Prepare(context.Background(), plan, env)
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	// Both trees, because the two failures are different: a subject that writes
+	// into the repository changes what the next arm sees, and one that writes
+	// into HOME changes what every later run on that machine sees.
+	for _, want := range []string{"home/bin/tool", "home/.toolrc", "repo/snapshot.json"} {
+		if !slices.Contains(wrote, want) {
+			t.Errorf("the discovery run missed %s; it reported %v", want, wrote)
+		}
+	}
+}
+
+// Cleanup is proven, not trusted. An uninstaller that leaves a config entry
+// behind contaminates every subsequent run on that machine, and the symptom
+// looks like drift rather than like a leak.
+func TestASubjectThatDoesNotCleanUpCompletelyIsCaught(t *testing.T) {
+	env := anEnv(t)
+	plan := subject.Plan{
+		Install: [][]string{{"sh", "-c", "mkdir -p " + env.Home + "/bin && echo binary > " + env.Home + "/bin/tool"}},
+		Setup:   [][]string{{"sh", "-c", "echo config > " + env.Home + "/.toolrc"}},
+		// The uninstaller its author wrote: it takes the binary and forgets the
+		// config it left beside it.
+		Cleanup: [][]string{{"sh", "-c", "rm -f " + env.Home + "/bin/tool"}},
+	}
+
+	wrote, err := subject.Prepare(context.Background(), plan, env)
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	left, err := subject.Remove(context.Background(), plan, env, wrote)
+	if err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	if !slices.Contains(left, "home/.toolrc") {
+		t.Errorf("a config left behind by the uninstaller was not caught; survivors: %v", left)
+	}
+	if slices.Contains(left, "home/bin/tool") {
+		t.Error("a file the cleanup did remove was reported as surviving it")
+	}
+}
+
+// A clean exit is not a clean machine. This is the case that must not pass by
+// accident: the subject removes everything, and the check says so.
+func TestASubjectThatCleansUpCompletelyLeavesNothing(t *testing.T) {
+	env := anEnv(t)
+	plan := subject.Plan{
+		Install: [][]string{{"sh", "-c", "mkdir -p " + env.Home + "/bin && echo binary > " + env.Home + "/bin/tool"}},
+		Cleanup: [][]string{{"sh", "-c", "rm -f " + env.Home + "/bin/tool"}},
+	}
+
+	wrote, err := subject.Prepare(context.Background(), plan, env)
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	left, err := subject.Remove(context.Background(), plan, env, wrote)
+	if err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	if len(left) != 0 {
+		t.Errorf("a subject that removed everything was reported as leaving %v", left)
+	}
+}
+
+// A subject that writes outside its declaration is a finding about that
+// subject, and it belongs in that subject's README with a date and a version.
+func TestWhatASubjectWroteOutsideItsDeclarationIsNamed(t *testing.T) {
+	wrote := []string{"home/bin/tool", "home/.config/tool/state.db", "repo/snapshot.json", "home/.hidden-cache"}
+
+	// A declared directory covers what is under it: a subject that says it
+	// writes a directory has said what the directory is for.
+	got := subject.Undeclared(wrote, []string{"home/bin", "home/.config", "repo/snapshot.json"})
+
+	if len(got) != 1 || got[0] != "home/.hidden-cache" {
+		t.Errorf("undeclared = %v, want only the path no declaration covers", got)
+	}
+}
+
+// A declaration that names a prefix of a path must not cover it: `home/bin`
+// covers `home/bin/tool`, and it does not cover `home/binary-cache`.
+func TestADeclarationCoversADirectoryAndNotANameThatMerelyStartsTheSame(t *testing.T) {
+	got := subject.Undeclared([]string{"home/binary-cache"}, []string{"home/bin"})
+
+	if len(got) != 1 {
+		t.Errorf("undeclared = %v, want the path the declaration does not actually cover", got)
+	}
+}
+
+// A command that cannot run has to stop the subject rather than be skipped: a
+// half-installed competitor that then gets benched is a measurement of nothing.
+func TestAStageThatFailsStopsTheSubject(t *testing.T) {
+	env := anEnv(t)
+	plan := subject.Plan{Install: [][]string{{"sh", "-c", "exit 3"}}}
+
+	if _, err := subject.Prepare(context.Background(), plan, env); err == nil {
+		t.Fatal("a subject whose install failed was reported as prepared")
+	} else if !strings.Contains(err.Error(), "install step 1") {
+		t.Errorf("error = %q, want it to name the stage and the step", err)
+	}
+}
+
+func TestAnEmptyCommandIsRefusedRatherThanRun(t *testing.T) {
+	env := anEnv(t)
+	plan := subject.Plan{Setup: [][]string{{}}}
+
+	if _, err := subject.Prepare(context.Background(), plan, env); err == nil {
+		t.Fatal("an empty command was accepted")
+	}
+}
+
+// The credential rule, made structural. A competitor gets its repository and
+// whatever its own setup needs; it does not get the host's tokens or the host's
+// agent configuration, and there is no field here through which they could
+// arrive.
+func TestASubjectRunsWithTheArmsEnvironmentAndNothingElse(t *testing.T) {
+	env := anEnv(t)
+	t.Setenv("A_HOST_SECRET", "sk-do-not-leak")
+	plan := subject.Plan{
+		Setup:   [][]string{{"sh", "-c", "env > " + env.Home + "/seen-env"}},
+		Cleanup: [][]string{{"sh", "-c", "rm -f " + env.Home + "/seen-env"}},
+	}
+
+	if _, err := subject.Prepare(context.Background(), plan, env); err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	b, err := os.ReadFile(filepath.Join(env.Home, "seen-env"))
+	if err != nil {
+		t.Fatalf("read what the subject saw: %v", err)
+	}
+	if strings.Contains(string(b), "sk-do-not-leak") {
+		t.Errorf("a host secret reached the subject:\n%s", b)
+	}
+}
+
+// A tree that cannot be read is a check that cannot be made, and an unmade
+// check must not read as a clean one: a subject reported as touching nothing
+// because nothing could be looked at is the worst possible pass.
+func TestATreeThatCannotBeReadFailsRatherThanReportingNothing(t *testing.T) {
+	env := anEnv(t)
+	gone := subject.Env{Repo: env.Repo, Home: filepath.Join(env.Home, "not-there"), Environ: env.Environ}
+
+	if _, err := subject.Prepare(context.Background(), subject.Plan{}, gone); err == nil {
+		t.Fatal("a subject whose HOME could not be read was reported as touching nothing")
+	}
+}
+
+// The same on the way out. An over-eager uninstaller that removes the directory
+// the check reads leaves nothing to check, and that must fail rather than pass.
+func TestACleanupThatRemovesWhatTheCheckReadsFailsTheCheck(t *testing.T) {
+	env := anEnv(t)
+	plan := subject.Plan{
+		Install: [][]string{{"sh", "-c", "echo binary > " + env.Home + "/tool"}},
+		Cleanup: [][]string{{"sh", "-c", "rm -rf " + env.Home}},
+	}
+	wrote, err := subject.Prepare(context.Background(), plan, env)
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	if _, err := subject.Remove(context.Background(), plan, env, wrote); err == nil {
+		t.Fatal("a cleanup that removed the directory under inspection was reported as clean")
+	}
+}
+
+// A subject with no HOME of its own is checked on its repository alone, rather
+// than being checked against the whole of whatever HOME happens to be.
+func TestASubjectWithNoHomeIsCheckedOnItsRepositoryAlone(t *testing.T) {
+	env := anEnv(t)
+	only := subject.Env{Repo: env.Repo, Environ: env.Environ}
+	plan := subject.Plan{Setup: [][]string{{"sh", "-c", "echo snapshot > snapshot.json"}}}
+
+	wrote, err := subject.Prepare(context.Background(), plan, only)
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	if len(wrote) != 1 || wrote[0] != "repo/snapshot.json" {
+		t.Errorf("wrote = %v, want only what appeared in the repository", wrote)
+	}
+}

--- a/lab/subjects/archmcp/README.md
+++ b/lab/subjects/archmcp/README.md
@@ -1,0 +1,57 @@
+# archmcp
+
+A competing local MCP server that generates architectural snapshots of a
+repository. `github.com/dejo1307/archmcp`, read at `986d9dc` (2026-03-06).
+
+**Operational facts only, dated and tied to a version.** Nothing here is a
+judgement about the product, and nothing here was read out of its
+documentation: every line below is what a discovery run observed.
+
+## Discovery run, 2026-08-18
+
+Installed from source with `go install ./cmd/archmcp`, in a disposable HOME with
+nothing in it, on Go 1.25.12 / darwin-arm64. The declared cleanup was then run
+and what survived it was compared against what appeared.
+
+| | paths |
+|---|---|
+| written under the arm's HOME | 2,185 |
+| removed by the declared cleanup | 1 |
+| surviving it | 2,184 |
+
+The one removed is the binary, `home/bin/archmcp`. What survives is the Go
+toolchain's own state, in three trees:
+
+| tree | paths | what it is |
+|---|---|---|
+| `home/gocache` | 1,615 | the build cache |
+| `home/go` | 562 | the module cache, including the archmcp module and its dependencies |
+| `home/Library/Application Support/go` | 7 | the toolchain's telemetry counters |
+
+**Attribution, stated because it matters.** Those three trees are written by the
+Go toolchain during the install, not by archmcp's own code. That does not make
+them nothing: state left in a HOME is state every later run against that HOME
+reads, whoever wrote it.
+
+**What actually contains them is the disposable HOME, not the cleanup.** Each
+arm gets its own, and releasing an arm destroys it, so nothing here survives a
+run. The declaration above says so explicitly rather than leaving a cleanup that
+removes one file in 2,185 looking complete.
+
+**A subject installed from source cannot prove its own cleanup**, and that is
+the finding this run produced. It is the input to the escalation question in
+08-05: a subject that cannot be contained by a disposable home goes in a
+container, and this one is contained by the disposable home — which is why it
+does not.
+
+## Nothing from the host reaches it
+
+Its commands run with the arm's own environment: its repository, its own HOME,
+and its own PATH. There is no path through which the host's credentials or the
+host's agent configuration could arrive, and that is structural rather than a
+policy — the type that carries the environment carries nothing else.
+
+## Not yet benched
+
+This subject has been installed, run and removed. It has not been scored against
+anything, and no comparison has been published. That is 08-05.

--- a/lab/subjects/archmcp/subject.json
+++ b/lab/subjects/archmcp/subject.json
@@ -1,0 +1,25 @@
+{
+  "id": "archmcp",
+  "kind": "competitor",
+  "needs_mcp": true,
+  "needs_isolated_config": false,
+  "executor": "isolated-home",
+  "agents": [
+    "claude-code",
+    "codex",
+    "opencode"
+  ],
+  "touches": [
+    "home/bin",
+    "home/go",
+    "home/gocache",
+    "home/Library/Application Support/go"
+  ],
+  "install": [
+    ["go", "install", "./cmd/archmcp"]
+  ],
+  "setup": [],
+  "cleanup": [
+    ["rm", "-f", "bin/archmcp"]
+  ]
+}


### PR DESCRIPTION
## Problem

Until now there have been two subjects, baseline and Sense, and both are known quantities: one installs nothing, the other installs what `sense setup` writes. A competitor is neither.

It arrives with an installer, may write to the home directory, may register itself with the agent tool globally, may start a background process, and may leave state behind that changes the next run. Every one of those is a contamination channel, and unlike Sense's, **nobody knows what they are in advance.**

## Summary

`subject.json` grows install, setup and cleanup — each a command list rather than a script, so a person can read what a competitor's installer will do to their machine before it runs. They arrive here with their consumer; cycle 01 deliberately refused to invent them while nothing ran them.

Cleanup is **proven, not trusted**: snapshot the arm's HOME and repository, run the subject, clean up, and compare.

The first real subject fails that check.

## Changes

**The mechanism.** A subject declares what it `touches`; a discovery run reports every path that actually appeared under its HOME or its repository; a removal reports what survived the cleanup; and anything written outside the declaration is named. A declared directory covers what is under it, and a name that merely shares a prefix is not covered.

**The credential rule, made structural.** A subject's commands run with the arm's own environment — its repository, its own HOME, its own PATH. There is no field through which the host's tokens or the host's agent configuration could arrive, and a planted host secret was checked not to reach one.

**The first real competitor**, installed from source into a disposable HOME with nothing in it:

| | paths |
|---|---|
| written under the arm's HOME | 2,185 |
| removed by the declared cleanup | 1 |
| surviving it | 2,184 |

The one removed is the binary. What survives is the Go toolchain's own state: 1,615 paths of build cache, 562 of module cache, 7 of telemetry counters.

**Two things are true at once, and both are in the subject's README.** Those trees are written by the toolchain during the install rather than by the competitor's own code — and state left in a HOME is state every later run against that HOME reads, whoever wrote it. What actually contains them is the disposable HOME, destroyed when the arm is released, **not the cleanup**. The declaration says so, rather than leaving a cleanup that removes one file in 2,185 looking complete.

So **a subject installed from source cannot prove its own cleanup.** That is the input to the escalation question in the next pitch: this one is contained by the disposable home, so it does not need a container.

**The declaration was written from the run, never from the documentation** — a subject's documentation says what it intends to do, and only a run says what it does. Its README carries operational facts only, dated and tied to a commit, with no evaluative language: these are public statements about someone else's product.

## Test plan

- `make ci` green: build, tests, coverage floor with no new exception, zero complexity suppressions. 96.3% on the file added.
- The tests are about the observation rather than about any one subject: a stand-in that forgets the config file its uninstaller left behind, one that cleans up completely, one whose install fails part way, and one whose cleanup deletes the directory the check reads — which must fail rather than pass, because a subject reported as touching nothing because nothing could be looked at is the worst possible pass.
