### PR TITLE
bench(lab): extract the executor, compare three subjects, freeze the old bench

### DIFF
--- a/bench/FROZEN.md
+++ b/bench/FROZEN.md
@@ -1,0 +1,54 @@
+# FROZEN
+
+**This tree stopped moving on 2026-08-18**, at the commit that adds this record.
+Apart from the record itself, the last commit to change anything under it is
+`98a7789` (2026-08-13).
+
+`bench/` was the global competitive bench: one board across many repositories,
+Sense against a baseline and against other tools. It is replaced by the
+comparison in `lab/`, which scores baseline, Sense and a competitor side by side
+on one scenario at one budget, through the same measurement as everything else.
+
+`improvement-loop/`, the vertical instrument, froze earlier in cycle 07 and
+carries its own record.
+
+## What frozen means
+
+- **no new runs** here; all measurement happens in `lab/`
+- **no edits, including fixes.** A frozen tree with a known defect is readable.
+  A tree someone patched on the last day is a tree whose final state nobody can
+  reason about
+- **it stays in the repository** as history: 2,473 files, of which 464 are
+  recorded transcripts, plus the incident write-ups that are the reason several
+  rules in the new instrument exist
+- **nothing reads it at runtime.** The only mentions anywhere are run-path
+  strings inside two of the new instrument's test fixtures, which name a
+  `bench/` directory *inside a campaign tree* and have nothing to do with this
+  one. Checked rather than assumed: with this whole tree moved out of the
+  repository, `go test -count=1 ./...` in `lab/` passes in every package
+- its documents — `README.md`, `SCORING.md`, `end-goal.md`, the driver scripts —
+  still read as live instructions. They are **historical**
+
+**Deletion is a separate decision, later.** A frozen tree costs disk and nothing
+else, and the write-ups under `results/` are the record of how several
+measurement rules were learned.
+
+## What is in it
+
+| | |
+|---|---|
+| verticals | `ruby-rails` (246 transcripts), `python-django` (118), `go` (64) |
+| global results | `results/`, with `baseline/`, `sense/`, `probe/` and one competitor tree (`gitnexus/`) |
+| pinned repositories | 58, in `PINNED_COMMITS.json`, captured 2026-05-16 |
+| write-ups kept | the judge calibration and variance notes, the citation-hallucination note, and the provenance incident of 2026-07-11 |
+
+## Why it is retired rather than carried across
+
+Its adoption layer measured code-intelligence tools against each other on axes
+that only make sense between such tools. The replacement deliberately does not
+carry that: a competitor is scored on **the same cited recall as everything
+else**, so a competitor result can be checked against the rest of the corpus
+rather than standing alone on a scale of its own.
+
+**Nothing from this tree has been published, and nothing from its successor has
+either.** That decision is taken separately, with the leakage question in view.

--- a/lab/internal/compare/compare.go
+++ b/lab/internal/compare/compare.go
@@ -1,0 +1,139 @@
+// Package compare renders three or more subjects on one scenario, side by side.
+//
+// It is pure: it takes scored results and returns a table. The running is
+// `run` over a subject list, which the engine already does; what was missing
+// was somewhere for the answer to be read.
+//
+// **The same headline and the same rules as every other output.** Objective
+// cited recall, per gold group, with the spread beside it. There is no
+// competitor-specific axis here and there is not going to be one: a comparison
+// that measured a rival on a scale of its own would be a comparison nobody
+// could check against the rest of the corpus.
+package compare
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Subject is one treatment's result on one gold group.
+type Subject struct {
+	// ID is the subject's catalog id.
+	ID string
+	// Baseline marks the untreated arm, which every delta is measured against.
+	// A comparison with no baseline in it has nothing to be a delta from.
+	Baseline bool
+	// Recall is the run's cited recall for this group, and Runs how many runs
+	// it is the mean of. Spread is the gap between the best and worst of them,
+	// which is what says whether a delta is bigger than the noise.
+	Recall float64
+	Runs   int
+	Spread float64
+	// Executor is where this subject ran, and Containerised says it paid
+	// container overhead inside its measured wall. That difference is about
+	// isolation and not about code intelligence, so the table states it rather
+	// than leaving a reader to infer it.
+	Executor      string
+	Containerised bool
+	// Why says what makes this number provisional, and empty means it is not.
+	Why string
+}
+
+// Delta is this subject's recall against the baseline's.
+func (s Subject) Delta(baseline float64) float64 { return s.Recall - baseline }
+
+// Report is one gold group, every subject on it.
+type Report struct {
+	Scenario string
+	Repo     string
+	Group    string
+	Model    string
+	Wall     string
+	Subjects []Subject
+}
+
+// Baseline is the untreated arm's recall, and whether there is one at all.
+func (r Report) Baseline() (float64, bool) {
+	for _, s := range r.Subjects {
+		if s.Baseline {
+			return s.Recall, true
+		}
+	}
+	return 0, false
+}
+
+// Render is the table a human reads.
+//
+// Subjects are ordered baseline first and then by recall, descending, so the
+// row a reader looks for is where they look — and so **a subject that loses is
+// in the same table as one that wins**, in its own place. A comparison that
+// omitted the places Sense ties or loses would measure nothing, and that rule
+// does not soften when the other name is a rival's.
+func (r Report) Render() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "scenario   %s\n", r.Scenario)
+	fmt.Fprintf(&b, "repo       %s\n", r.Repo)
+	fmt.Fprintf(&b, "group      %s\n", r.Group)
+	fmt.Fprintf(&b, "model      %s\n", r.Model)
+	fmt.Fprintf(&b, "budget     %s, the same for every subject\n\n", r.Wall)
+
+	base, hasBase := r.Baseline()
+	fmt.Fprintf(&b, "  %-16s %8s %8s %8s %6s  %s\n", "subject", "recall", "delta", "spread", "runs", "where it ran")
+	for _, s := range r.ordered() {
+		delta := "-"
+		if hasBase && !s.Baseline {
+			delta = fmt.Sprintf("%+.4f", s.Delta(base))
+		}
+		fmt.Fprintf(&b, "  %-16s %8.4f %8s %8.4f %6d  %s\n",
+			s.ID, s.Recall, delta, s.Spread, s.Runs, s.where())
+	}
+
+	if !hasBase {
+		b.WriteString("\nNO BASELINE: nothing here is a delta, because there is no untreated arm to be a delta from.\n")
+	}
+	for _, s := range r.ordered() {
+		if s.Why != "" {
+			fmt.Fprintf(&b, "\nPROVISIONAL (%s): %s\n", s.ID, s.Why)
+		}
+	}
+	if r.anyContainerised() {
+		b.WriteString("\nCONTAINER OVERHEAD: the subjects marked `container` paid their container's setup\n" +
+			"inside the measured wall. That difference is about isolation, not about code intelligence.\n")
+	}
+	b.WriteString("\nNOT PUBLISHED: this comparison describes someone else's product and goes no further\n" +
+		"than this repository until that is decided separately.\n")
+	return b.String()
+}
+
+func (s Subject) where() string {
+	if s.Containerised {
+		return s.Executor + " (paid container overhead inside the wall)"
+	}
+	return s.Executor
+}
+
+func (r Report) anyContainerised() bool {
+	for _, s := range r.Subjects {
+		if s.Containerised {
+			return true
+		}
+	}
+	return false
+}
+
+// ordered is the baseline first, then by recall descending, then by id so two
+// subjects that tie do not swap places between renders.
+func (r Report) ordered() []Subject {
+	out := append([]Subject(nil), r.Subjects...)
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Baseline != out[j].Baseline {
+			return out[i].Baseline
+		}
+		if out[i].Recall != out[j].Recall {
+			return out[i].Recall > out[j].Recall
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
+}

--- a/lab/internal/compare/compare_test.go
+++ b/lab/internal/compare/compare_test.go
@@ -1,0 +1,173 @@
+package compare_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/lab/internal/compare"
+)
+
+func aReport(subjects ...compare.Subject) compare.Report {
+	return compare.Report{
+		Scenario: "locate the run supervisor", Repo: "selfcheck", Group: "supervisor",
+		Model: "claude-opus-5", Wall: "6m0s", Subjects: subjects,
+	}
+}
+
+// Every delta is against the untreated arm, and a table without one must not
+// print deltas against whatever happened to come first.
+func TestEveryDeltaIsAgainstTheUntreatedArm(t *testing.T) {
+	out := aReport(
+		compare.Subject{ID: "untreated", Baseline: true, Recall: 0.25, Runs: 2, Executor: "isolated-home"},
+		compare.Subject{ID: "sense-main", Recall: 0.75, Runs: 2, Executor: "isolated-home"},
+		compare.Subject{ID: "archmcp", Recall: 0.50, Runs: 2, Executor: "isolated-home"},
+	).Render()
+
+	if !strings.Contains(out, "+0.5000") {
+		t.Errorf("the treated arm's delta against the baseline is missing:\n%s", out)
+	}
+	if !strings.Contains(out, "+0.2500") {
+		t.Errorf("the competitor's delta against the baseline is missing:\n%s", out)
+	}
+}
+
+// A comparison with no untreated arm has nothing to be a delta from, and
+// printing one anyway would invent a number.
+func TestAComparisonWithNoBaselineSaysSoRatherThanInventingDeltas(t *testing.T) {
+	out := aReport(
+		compare.Subject{ID: "sense-main", Recall: 0.75, Runs: 2, Executor: "isolated-home"},
+		compare.Subject{ID: "archmcp", Recall: 0.50, Runs: 2, Executor: "isolated-home"},
+	).Render()
+
+	if !strings.Contains(out, "NO BASELINE") {
+		t.Errorf("a comparison with nothing to compare against read as a normal one:\n%s", out)
+	}
+	if strings.Contains(out, "+0.") || strings.Contains(out, "-0.") {
+		t.Errorf("deltas were printed with no baseline to take them from:\n%s", out)
+	}
+}
+
+// The rule that does not soften when the other name is a rival's: a subject
+// that loses or ties is in the table, in its own place.
+func TestASubjectThatLosesIsInTheTable(t *testing.T) {
+	out := aReport(
+		compare.Subject{ID: "untreated", Baseline: true, Recall: 0.60, Runs: 2, Executor: "isolated-home"},
+		compare.Subject{ID: "sense-main", Recall: 0.40, Runs: 2, Executor: "isolated-home"},
+		compare.Subject{ID: "archmcp", Recall: 0.60, Runs: 2, Executor: "isolated-home"},
+	).Render()
+
+	if !strings.Contains(out, "-0.2000") {
+		t.Errorf("a subject that lost to the baseline is not reported as losing:\n%s", out)
+	}
+	if !strings.Contains(out, "+0.0000") {
+		t.Errorf("a subject that tied the baseline is not reported as tying:\n%s", out)
+	}
+}
+
+// Container setup lands inside the measured wall, so a comparison in which one
+// subject is containerised and another is not carries a difference that is
+// about isolation rather than about code intelligence. A reader must not have
+// to infer it.
+func TestTheTableStatesWhichSubjectsPaidContainerOverhead(t *testing.T) {
+	out := aReport(
+		compare.Subject{ID: "untreated", Baseline: true, Recall: 0.25, Runs: 2, Executor: "isolated-home"},
+		compare.Subject{ID: "rival", Recall: 0.50, Runs: 2, Executor: "container", Containerised: true},
+	).Render()
+
+	if !strings.Contains(out, "CONTAINER OVERHEAD") {
+		t.Errorf("a mixed comparison does not say who paid container overhead:\n%s", out)
+	}
+	if !strings.Contains(out, "paid container overhead inside the wall") {
+		t.Errorf("the containerised subject's row does not say so:\n%s", out)
+	}
+}
+
+func TestAComparisonWhereNobodyIsContainerisedSaysNothingAboutOverhead(t *testing.T) {
+	out := aReport(
+		compare.Subject{ID: "untreated", Baseline: true, Recall: 0.25, Runs: 2, Executor: "isolated-home"},
+		compare.Subject{ID: "sense-main", Recall: 0.75, Runs: 2, Executor: "isolated-home"},
+	).Render()
+
+	if strings.Contains(out, "CONTAINER OVERHEAD") {
+		t.Errorf("a note about overhead nobody paid:\n%s", out)
+	}
+}
+
+// The mark travels. A number derived from a capture that was cut off is a
+// provisional result rather than a clean low one, and a table that dropped the
+// mark would be the exact failure the mark exists to prevent.
+func TestAProvisionalSubjectCarriesItsMarkIntoTheTable(t *testing.T) {
+	out := aReport(
+		compare.Subject{ID: "untreated", Baseline: true, Recall: 0.25, Runs: 2, Executor: "isolated-home"},
+		compare.Subject{ID: "sense-main", Recall: 0.10, Runs: 1, Executor: "isolated-home",
+			Why: "the session did not finish; there is no closing result event"},
+	).Render()
+
+	if !strings.Contains(out, "PROVISIONAL (sense-main)") {
+		t.Errorf("a provisional number reads as a clean low one:\n%s", out)
+	}
+	if !strings.Contains(out, "did not finish") {
+		t.Errorf("the mark does not say what made it provisional:\n%s", out)
+	}
+}
+
+// The spread is what says whether a delta is bigger than the noise, so it is
+// beside every number rather than in a footnote.
+func TestTheSpreadIsBesideEveryNumber(t *testing.T) {
+	out := aReport(
+		compare.Subject{ID: "untreated", Baseline: true, Recall: 0.25, Runs: 3, Spread: 0.12, Executor: "isolated-home"},
+		compare.Subject{ID: "sense-main", Recall: 0.75, Runs: 3, Spread: 0.30, Executor: "isolated-home"},
+	).Render()
+
+	for _, want := range []string{"0.1200", "0.3000", "spread"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the table does not carry %q:\n%s", want, out)
+		}
+	}
+}
+
+// The baseline reads first because that is where a reader looks for it, and two
+// subjects that tie must not swap places between renders.
+func TestTheOrderIsBaselineFirstThenByRecallAndIsStable(t *testing.T) {
+	r := aReport(
+		compare.Subject{ID: "zulu", Recall: 0.50, Runs: 1, Executor: "isolated-home"},
+		compare.Subject{ID: "sense-main", Recall: 0.75, Runs: 1, Executor: "isolated-home"},
+		compare.Subject{ID: "untreated", Baseline: true, Recall: 0.25, Runs: 1, Executor: "isolated-home"},
+		compare.Subject{ID: "alpha", Recall: 0.50, Runs: 1, Executor: "isolated-home"},
+	)
+
+	out := r.Render()
+	order := []string{"untreated", "sense-main", "alpha", "zulu"}
+	at := -1
+	for _, id := range order {
+		i := strings.Index(out, "  "+id+" ")
+		if i <= at {
+			t.Fatalf("%s is out of order in:\n%s", id, out)
+		}
+		at = i
+	}
+	if again := r.Render(); again != out {
+		t.Error("two renders of the same report differ, so nobody can diff them")
+	}
+}
+
+// A comparison describes someone else's product. Publishing it is a separate
+// decision, and the output says so rather than relying on whoever reads it to
+// remember.
+func TestTheTableSaysItIsNotPublished(t *testing.T) {
+	out := aReport(compare.Subject{ID: "untreated", Baseline: true, Recall: 0.25, Runs: 1, Executor: "isolated-home"}).Render()
+
+	if !strings.Contains(out, "NOT PUBLISHED") {
+		t.Errorf("the comparison does not say it goes no further than this repository:\n%s", out)
+	}
+}
+
+// Every subject is asked the same question at the same budget, and the table
+// says which budget rather than leaving it to a run record nobody opens.
+func TestTheBudgetIsOnTheTable(t *testing.T) {
+	out := aReport(compare.Subject{ID: "untreated", Baseline: true, Recall: 0.25, Runs: 1, Executor: "isolated-home"}).Render()
+
+	if !strings.Contains(out, "6m0s, the same for every subject") {
+		t.Errorf("the budget is missing from the table:\n%s", out)
+	}
+}

--- a/lab/internal/executor/container.go
+++ b/lab/internal/executor/container.go
@@ -1,0 +1,93 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/luuuc/sense/lab/internal/isolate"
+)
+
+// ContainerID is the catalog id of the escalation executor.
+const ContainerID = "container"
+
+// Container runs an arm inside a container image, for a subject that cannot be
+// contained by a disposable home.
+//
+// ESCALATION, never the default, and the reason is in the measurement rather
+// than in taste: a container's setup lands inside the measured wall, so a
+// comparison in which one subject is containerised and another is not carries a
+// difference that is about isolation and not about code intelligence. Whoever
+// escalates a subject records why, and the comparison says which subjects paid
+// the overhead.
+//
+// **No host credential and no host agent config is ever mounted in.** The
+// authenticated agent runs on the host; the subject runs in here. That
+// direction is the whole point of the executor, and the catalog says so
+// already: this executor preserves no auth mode at all, which is why the
+// planner refuses a subject that needs one before anything spawns.
+type Container struct {
+	// Runtime is the container command, e.g. `docker`. Config rather than a
+	// constant so a machine with another runtime is a setting rather than a
+	// fork.
+	Runtime string
+	// Image is what the arm runs inside.
+	Image string
+	// WorkDir is where the repository is mounted inside the container.
+	WorkDir string
+}
+
+func (c Container) ID() string { return ContainerID }
+
+// Prepare builds the same run directory tree as the default executor, because
+// the run's evidence lives on this machine either way: the transcript, the
+// record and the capture are written to the host and read months later.
+//
+// What differs is only where the COMMAND runs, which is Command's business.
+func (c Container) Prepare(_ context.Context, s isolate.Spec) (isolate.Env, error) {
+	return isolate.Prepare(s)
+}
+
+// Command wraps the argv so it runs inside the image, with the repository
+// mounted and nothing else.
+//
+// One mount, and it is the repository. Not HOME, which is where a credential
+// would be; not the config directory, which is where an agent's login would be.
+// A container that mounted either would be a container that received host
+// credentials, which is the one thing this executor exists to prevent.
+func (c Container) Command(env isolate.Env, argv []string) []string {
+	work := c.WorkDir
+	if work == "" {
+		work = "/repo"
+	}
+	wrapped := []string{
+		c.Runtime, "run", "--rm", "-i",
+		"--network", "none",
+		"-v", env.Repo + ":" + work,
+		"-w", work,
+		c.Image,
+	}
+	return append(wrapped, argv...)
+}
+
+func (c Container) Release(_ context.Context, env isolate.Env) error { return isolate.Release(env) }
+
+// Available reports whether this runtime can actually start a container here.
+//
+// Asked before a campaign rather than discovered by a burned arm: a runtime
+// that is installed but not running fails at spawn, which costs the arm and
+// reads in a score exactly like a model with nothing to say.
+func (c Container) Available(ctx context.Context) error {
+	if c.Runtime == "" {
+		return fmt.Errorf("no container runtime declared")
+	}
+	out, err := exec.CommandContext(ctx, c.Runtime, "version", "--format", "{{.Server.Version}}").Output()
+	if err != nil {
+		return fmt.Errorf("%s cannot start a container here: %w", c.Runtime, err)
+	}
+	if strings.TrimSpace(string(out)) == "" {
+		return fmt.Errorf("%s answered with no server version, so nothing is running to start a container", c.Runtime)
+	}
+	return nil
+}

--- a/lab/internal/executor/executor.go
+++ b/lab/internal/executor/executor.go
@@ -1,0 +1,70 @@
+// Package executor is where a run happens, as an interface over the two ways
+// that has turned out to mean.
+//
+// The interface was deferred from cycle 03 on purpose. An interface with one
+// implementation is indirection rather than abstraction, and one written ahead
+// of its second implementation is a guess about a shape nobody has seen. It is
+// extracted here, from two things that both work, and it has three methods
+// because that is what the two of them differ in — not because three is a good
+// number.
+//
+// Where they disagreed was the design input. Both prepare a place and both give
+// it back; what neither could share is how a command is spawned, because one
+// runs it on this machine and the other runs it inside something else. So that
+// is a method, and everything the two do identically stayed out of the
+// interface.
+package executor
+
+import (
+	"context"
+
+	"github.com/luuuc/sense/lab/internal/isolate"
+)
+
+// Executor is where and how one arm runs.
+type Executor interface {
+	// ID is the catalog id this executor was declared under, so a run can
+	// record where it happened.
+	ID() string
+	// Prepare builds the place one arm runs in and reports what a session
+	// inside it sees. It spawns nothing.
+	Prepare(ctx context.Context, s isolate.Spec) (isolate.Env, error)
+	// Command turns the argv an arm would run into the argv that runs it HERE.
+	//
+	// This is the whole of the difference between the two implementations, and
+	// it is why the interface exists at all: on this machine the argv is the
+	// argv, and inside a container it has to be handed to something else first.
+	Command(env isolate.Env, argv []string) []string
+	// Release gives the place back, keeping whatever evidence the run left.
+	//
+	// Release rather than a bare removal, because a run that is about to be
+	// diagnosed must survive the process that made it: what goes is the
+	// disposable state, and what stays is the transcript, the record and the
+	// capture.
+	Release(ctx context.Context, env isolate.Env) error
+}
+
+// Of resolves an executor by the id a subject declares.
+//
+// A LOOKUP whose keys are catalog ids, which is the same rule the transcript
+// formats follow: a subject names where it runs, and nothing here decides that
+// by knowing what a subject is.
+func Of(id string, c Container) (Executor, error) {
+	switch id {
+	case IsolatedHomeID:
+		return IsolatedHome{}, nil
+	case ContainerID:
+		return c, nil
+	default:
+		return nil, &UnknownError{ID: id}
+	}
+}
+
+// UnknownError is an executor id nothing implements. It is its own type because
+// "you named an executor that does not exist" is a catalog problem and reads
+// differently from a run that failed.
+type UnknownError struct{ ID string }
+
+func (e *UnknownError) Error() string {
+	return "no executor called " + e.ID + "; the ones that exist are " + IsolatedHomeID + " and " + ContainerID
+}

--- a/lab/internal/executor/executor_test.go
+++ b/lab/internal/executor/executor_test.go
@@ -1,0 +1,216 @@
+package executor_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/lab/internal/executor"
+	"github.com/luuuc/sense/lab/internal/isolate"
+)
+
+func aSpec(t *testing.T) isolate.Spec {
+	t.Helper()
+	return isolate.Spec{Root: filepath.Join(t.TempDir(), "run"), Arm: isolate.Baseline, HostPath: "/usr/bin"}
+}
+
+// Both implementations satisfy the interface without special cases. If they had
+// disagreed about what a method means, the interface would be the wrong shape
+// and the disagreement would be the design input — this is where that is
+// checked rather than assumed.
+func TestBothExecutorsPrepareAndReleaseTheSameWay(t *testing.T) {
+	for _, e := range []executor.Executor{
+		executor.IsolatedHome{},
+		executor.Container{Runtime: "docker", Image: "alpine:3"},
+	} {
+		t.Run(e.ID(), func(t *testing.T) {
+			env, err := e.Prepare(context.Background(), aSpec(t))
+			if err != nil {
+				t.Fatalf("prepare: %v", err)
+			}
+			if env.Repo == "" || env.Home == "" {
+				t.Fatal("a prepared environment has nowhere to run")
+			}
+			if err := e.Release(context.Background(), env); err != nil {
+				t.Fatalf("release: %v", err)
+			}
+		})
+	}
+}
+
+// The whole of the difference between the two, and the reason the interface has
+// a third method at all.
+func TestTheDefaultExecutorRunsTheArgvAsItIs(t *testing.T) {
+	argv := []string{"claude", "-p", "--model", "opus"}
+
+	got := executor.IsolatedHome{}.Command(isolate.Env{}, argv)
+
+	if !slices.Equal(got, argv) {
+		t.Errorf("command = %v, want the argv unchanged", got)
+	}
+}
+
+// One mount, and it is the repository. Not HOME, where a credential would be;
+// not the config directory, where an agent's login would be. A container that
+// mounted either would be a container that received host credentials, which is
+// the one thing this executor exists to prevent.
+func TestTheContainerMountsTheRepositoryAndNothingElse(t *testing.T) {
+	env := isolate.Env{Layout: isolate.Layout{
+		Repo: "/runs/cell/sense/repo", Home: "/runs/cell/sense/home", Config: "/runs/cell/sense/config",
+	}}
+	c := executor.Container{Runtime: "docker", Image: "alpine:3", WorkDir: "/repo"}
+
+	got := c.Command(env, []string{"rival", "--scan"})
+
+	line := strings.Join(got, " ")
+	if !strings.Contains(line, "-v /runs/cell/sense/repo:/repo") {
+		t.Errorf("the repository is not mounted: %s", line)
+	}
+	for _, forbidden := range []string{env.Home, env.Config} {
+		if strings.Contains(line, forbidden) {
+			t.Errorf("%s was mounted into the container: %s", forbidden, line)
+		}
+	}
+	if !strings.HasSuffix(line, "alpine:3 rival --scan") {
+		t.Errorf("the arm's own command is not what runs inside: %s", line)
+	}
+	// No network, because a subject that can reach the internet from inside the
+	// container is a subject whose run is not reproducible.
+	if !strings.Contains(line, "--network none") {
+		t.Errorf("the container can reach the network: %s", line)
+	}
+}
+
+func TestAContainerWithNoWorkDirStillHasOne(t *testing.T) {
+	got := executor.Container{Runtime: "docker", Image: "alpine:3"}.Command(
+		isolate.Env{Layout: isolate.Layout{Repo: "/r"}}, []string{"x"})
+
+	if !slices.Contains(got, "-w") {
+		t.Errorf("no working directory inside the container: %v", got)
+	}
+}
+
+// An executor a subject names and nothing implements is a catalog problem, and
+// it reads differently from a run that failed.
+func TestAnExecutorNothingImplementsIsRefusedByName(t *testing.T) {
+	if _, err := executor.Of("kubernetes", executor.Container{}); err == nil {
+		t.Fatal("an executor nothing implements resolved")
+	} else if !strings.Contains(err.Error(), "kubernetes") {
+		t.Errorf("error = %q, want it to name what was asked for", err)
+	}
+}
+
+func TestEachDeclaredExecutorResolvesToItsImplementation(t *testing.T) {
+	for _, id := range []string{executor.IsolatedHomeID, executor.ContainerID} {
+		e, err := executor.Of(id, executor.Container{Runtime: "docker", Image: "alpine:3"})
+		if err != nil {
+			t.Fatalf("resolve %s: %v", id, err)
+		}
+		if e.ID() != id {
+			t.Errorf("resolved %s to an executor calling itself %s", id, e.ID())
+		}
+	}
+}
+
+// A runtime that is installed but not running fails at spawn, which costs the
+// arm and reads in a score exactly like a model with nothing to say. It is
+// asked before a campaign instead.
+func TestAContainerRuntimeThatCannotStartAnythingIsRefusedBeforeARunIsSpent(t *testing.T) {
+	for _, tc := range []struct{ what, runtime string }{
+		{"no runtime declared at all", ""},
+		{"a runtime that is not on this machine", "no-such-container-runtime"},
+	} {
+		t.Run(tc.what, func(t *testing.T) {
+			if err := (executor.Container{Runtime: tc.runtime}).Available(context.Background()); err == nil {
+				t.Fatal("a runtime that cannot start a container was reported as ready")
+			}
+		})
+	}
+}
+
+// And the positive case, on a machine that has one. Skipped rather than faked
+// where there is none: a stand-in here would be a test of the stand-in.
+func TestAWorkingContainerRuntimeIsReportedAsReady(t *testing.T) {
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("no container runtime on this machine")
+	}
+	c := executor.Container{Runtime: "docker", Image: "alpine:3"}
+
+	if err := c.Available(context.Background()); err != nil {
+		t.Skipf("a container runtime is installed but not running: %v", err)
+	}
+}
+
+// The argv the container executor builds has to actually run something, or
+// this is a test of string formatting. Skipped where there is no runtime,
+// because a stand-in container would be a test of the stand-in.
+func TestTheContainerActuallyRunsTheArmsCommandAgainstTheRepository(t *testing.T) {
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("no container runtime on this machine")
+	}
+	c := executor.Container{Runtime: "docker", Image: "alpine:3", WorkDir: "/repo"}
+	if err := c.Available(context.Background()); err != nil {
+		t.Skipf("a container runtime is installed but not running: %v", err)
+	}
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "marker.txt"), []byte("the repository"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	argv := c.Command(isolate.Env{Layout: isolate.Layout{Repo: repo, Home: "/host/home"}},
+		[]string{"cat", "marker.txt"})
+	out, err := exec.CommandContext(context.Background(), argv[0], argv[1:]...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("run inside the container: %v\n%s", err, out)
+	}
+
+	if !strings.Contains(string(out), "the repository") {
+		t.Errorf("the command did not see the repository it was given:\n%s", out)
+	}
+}
+
+// And the host's home is not in there. Asserted on what the container can
+// actually see rather than on the argv, because the argv is what we wrote and
+// the mount table is what happened.
+func TestTheContainerCannotSeeTheHostsHome(t *testing.T) {
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("no container runtime on this machine")
+	}
+	c := executor.Container{Runtime: "docker", Image: "alpine:3", WorkDir: "/repo"}
+	if err := c.Available(context.Background()); err != nil {
+		t.Skipf("a container runtime is installed but not running: %v", err)
+	}
+	home := t.TempDir()
+	if err := os.WriteFile(filepath.Join(home, ".credentials.json"), []byte("a token"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	argv := c.Command(isolate.Env{Layout: isolate.Layout{Repo: t.TempDir(), Home: home, Config: home}},
+		[]string{"sh", "-c", "ls " + home + " 2>&1 || true"})
+	out, err := exec.CommandContext(context.Background(), argv[0], argv[1:]...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("run inside the container: %v\n%s", err, out)
+	}
+
+	if strings.Contains(string(out), "a token") || strings.Contains(string(out), ".credentials.json") {
+		t.Errorf("the host's home reached the container:\n%s", out)
+	}
+}
+
+// A runtime that answers with nothing is the shape that matters: the command
+// exists and exits zero, and there is still no daemon to start a container. An
+// availability check that read that as ready would pass on exactly the machine
+// where the arm is about to be burned.
+func TestARuntimeThatAnswersWithNothingIsNotReady(t *testing.T) {
+	c := executor.Container{Runtime: "true", Image: "alpine:3"}
+
+	if err := c.Available(context.Background()); err == nil {
+		t.Fatal("a runtime that reported no server version was read as ready")
+	} else if !strings.Contains(err.Error(), "no server version") {
+		t.Errorf("error = %q, want it to say nothing is running", err)
+	}
+}

--- a/lab/internal/executor/isolatedhome.go
+++ b/lab/internal/executor/isolatedhome.go
@@ -1,0 +1,31 @@
+package executor
+
+import (
+	"context"
+
+	"github.com/luuuc/sense/lab/internal/isolate"
+)
+
+// IsolatedHomeID is the catalog id of the default executor.
+const IsolatedHomeID = "isolated-home"
+
+// IsolatedHome runs an arm on this machine, in a disposable HOME with a
+// shadowed PATH. It is the DEFAULT and it stays the default: process isolation
+// is not free, and a subject in a container is a subject whose measured wall
+// includes container overhead.
+type IsolatedHome struct{}
+
+func (IsolatedHome) ID() string { return IsolatedHomeID }
+
+// Prepare is cycle 03's, unchanged. The interface was extracted around it
+// rather than the other way round, which is the point: the working
+// implementation did not move to fit an interface.
+func (IsolatedHome) Prepare(_ context.Context, s isolate.Spec) (isolate.Env, error) {
+	return isolate.Prepare(s)
+}
+
+// Command runs the argv as it is. There is nothing between the arm and the
+// machine.
+func (IsolatedHome) Command(_ isolate.Env, argv []string) []string { return argv }
+
+func (IsolatedHome) Release(_ context.Context, env isolate.Env) error { return isolate.Release(env) }

--- a/lab/subjects/archmcp/subject.json
+++ b/lab/subjects/archmcp/subject.json
@@ -16,10 +16,18 @@
     "home/Library/Application Support/go"
   ],
   "install": [
-    ["go", "install", "./cmd/archmcp"]
+    [
+      "go",
+      "install",
+      "./cmd/archmcp"
+    ]
   ],
   "setup": [],
   "cleanup": [
-    ["rm", "-f", "bin/archmcp"]
+    [
+      "sh",
+      "-c",
+      "rm -f \"$HOME/bin/archmcp\""
+    ]
   ]
 }


### PR DESCRIPTION
## Problem

Three things land together because each needed the other two.

Some subjects cannot be contained by a disposable home, and there has to be somewhere to put them rather than a decision to bench them anyway. The `Executor` interface has been deferred since cycle 03 on purpose — an interface with one implementation is indirection, not abstraction — and the container is the second implementation. And the comparison itself had nowhere to be rendered.

## Summary

The interface is extracted from two working implementations, the container is real and stays an escalation, the comparison renders three subjects on one scenario at one budget, and the old global bench is frozen.

**The first real comparison is a tie.**

## Changes

**The interface, extracted rather than invented.** Three methods, because that is exactly where the two implementations differ: both prepare a place and both give it back, and what neither can share is how a command is spawned — on this machine the argv is the argv, inside a container it has to be handed to something else first. Both satisfy it with no special cases. Nothing was generalised for a third executor that does not exist.

**The container, and what it is allowed to see.** It runs the arm's own command inside an image with **one mount, the repository** — not HOME, where a credential would be, and not the config directory, where an agent's login would be. Asserted by running a real container and checking what it can see, rather than by reading back the arguments we wrote: the argv is our claim, the mount table is what happened. It is escalation and it stayed escalation — process isolation is not free, and a subject in a container is a subject whose measured wall includes container overhead. Nothing needed escalating here.

**The comparison**, on the same cited recall as everything else, with no competitor-specific axis:

```
scenario   locate the run supervisor (cycle 08)
repo       selfcheck @ ba007836
group      supervisor      model   claude-opus-5      budget 6m0s, same for every subject

  subject            recall    delta   spread   runs  where it ran
  untreated          0.5000        -   0.0000      1  isolated-home
  sense-main         0.5000  +0.0000   0.0000      1  isolated-home
  archmcp            0.0000  -0.5000   0.0000      1  isolated-home
```

Three things about that table, none of which flatter us:

- **Sense tied the baseline.** It is in the headline axis, in the same table as the win over the competitor. A bench that only flatters the tool measures nothing, and that rule does not soften when the other name is a rival's — or when the tie is ours.
- **n=1, so the spread is zero because there is one run, not because the runs agreed.** The gold group has two rows. This is a weak instrument for a delta of any size.
- **The sharpest difference is not in the headline axis at all.** Grounding the citations against the pinned checkout: 6 of the baseline's 8 do not resolve, and none of the Sense arm's 8 fail. Same recall, very different reliability — left as an observation rather than folded into the score.

The competitor's MCP server was registered and its three tools were offered to the agent, which used shell commands instead.

**One defect the check caught.** The competitor's declared cleanup was written repo-relative while its binary lands under the arm's HOME, so the first real run left it behind. Fixed, and the fixed declaration verified against the same arm.

**`bench/` is frozen**, with its record beside it: 2,473 files, 464 transcripts, three verticals, 58 pinned repositories, and the incident write-ups that are the reason several rules in the new instrument exist. Its adoption layer is deliberately not carried across — a competitor is scored on the same axis as everything else, so the result can be checked against the rest of the corpus rather than standing alone on a scale of its own.

**Nothing is published.** The comparison describes someone else's product and goes no further than this repository until that is decided separately. The rendered table says so itself.

## Test plan

- `make ci` and `make smoke` green: build, tests, coverage floor with no new exception, zero complexity suppressions.
- 100% coverage on the comparison and on all three executor files.
- The container tests run a real container and skip where there is none, rather than standing in a fake that would test the fake.
- The freeze's runtime-independence claim is tested, not asserted: with `bench/` moved out of the repository, `go test -count=1 ./...` in `lab/` passes in every package.
