### PR TITLE
bench(lab): admit a repository with one command

### DIFF
--- a/lab/README.md
+++ b/lab/README.md
@@ -35,7 +35,19 @@ Start by looking at what is already declared:
 
 Then, to bench one repository:
 
-**1. Declare the repository** — `lab/repos/<id>.json`:
+**1. Admit the repository** — one command clones it, pins it and indexes it:
+
+```bash
+./bin/sense-lab repo -campaign runs/campaigns/<key> -sense ./bin/sense \
+    discourse/discourse
+```
+
+The name is a github handle, a url, a path to a clone you already have, or the
+id of a repository already admitted. It prints what it resolved — the id, the
+url and the revision — before it writes anything, then clones under
+`runs/checkouts/`, records the revision the clone is actually at in
+`lab/repos/<id>.json`, and writes what the index holds to
+`<campaign>/<id>/index/index.json`:
 
 ```json
 {"id": "discourse", "url": "https://github.com/discourse/discourse.git",
@@ -43,9 +55,12 @@ Then, to bench one repository:
  "languages": ["ruby"], "stack": "ruby"}
 ```
 
-Clone it locally and check it out at that commit. Every run takes a worktree
-from your clone at the pinned commit, so the clone is the only thing that has to
-exist on disk.
+Running it again on an admitted repository admits nothing and prints where it
+stands. A clone the lab made is moved back to its pin if it has drifted; a clone
+you handed in is read and never written to, and a mismatch there is refused.
+
+Every run takes a worktree from that clone at the pinned commit, so the clone is
+the only thing that has to exist on disk.
 
 **2. Write the scenario** — three files beside each other in
 `lab/scenarios/<id>/`:

--- a/lab/internal/catalog/catalog.go
+++ b/lab/internal/catalog/catalog.go
@@ -317,11 +317,22 @@ type Executor struct {
 // is why languages, frameworks and stack live here. `cohort` is deliberately
 // absent: nothing selects on it yet.
 type Repo struct {
-	ID        string   `json:"id"`
-	URL       string   `json:"url"`
-	Commit    string   `json:"commit"`
+	ID     string `json:"id"`
+	URL    string `json:"url"`
+	Commit string `json:"commit"`
+	// Checkout is a clone somebody handed in, and its presence is the
+	// ownership record: a repository with none is cloned by the lab under its
+	// own clones root, and one the lab made is one it may move back to its pin.
+	// Empty for every repository admitted from a handle or a url, which is why
+	// it is `omitempty`: a field that says "the lab owns this" by being absent
+	// should be absent.
+	Checkout  string   `json:"checkout,omitempty"`
 	Languages []string `json:"languages"`
-	Stack     string   `json:"stack"`
+	// Stack is `omitempty` for the same reason Checkout is: admission cannot
+	// know it — a stack is a judgement about what a repository IS, not
+	// something a scan reports — and writing an empty one would read as a
+	// repository somebody decided had no stack.
+	Stack string `json:"stack,omitempty"`
 }
 
 // ErrNoConfig is returned when the config directory is not there at all. It is

--- a/lab/internal/cli/cli.go
+++ b/lab/internal/cli/cli.go
@@ -28,6 +28,7 @@ const usage = `sense-lab — the bench instrument for Sense
 Usage: sense-lab <command> [flags]
 
 Commands:
+  repo      Admit a repository: resolve it, clone it, pin it and index it
   catalog   Show the subjects, agents, models, repositories and executors in the config
   plan      Show what a campaign would run, and every rejection with its reason
   run       Run one scenario against one repository
@@ -82,6 +83,10 @@ func Run(args []string, stdout, stderr io.Writer) int {
 		return exitUsage
 	}
 	switch args[0] {
+	case "repo":
+		// Admission clones and scans, both of them long, so it dies with the
+		// binary for the same reason a run does.
+		return admitSignals(args[1:], stdout, stderr)
 	case "plan":
 		return planCmd(args[1:], stdout, stderr)
 	case "run":

--- a/lab/internal/cli/repocmd.go
+++ b/lab/internal/cli/repocmd.go
@@ -1,0 +1,218 @@
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/luuuc/sense/lab/internal/catalog"
+	"github.com/luuuc/sense/lab/internal/repo"
+)
+
+// defaultCheckouts is the lab's own clones root. Ownership is what makes a
+// correction safe, and it is decided by where a clone lives: the lab fixes what
+// it made, and reads what it was given.
+const defaultCheckouts = "runs/checkouts"
+
+// repoFlags is where a repository is admitted from and where the evidence of it
+// lands.
+type repoFlags struct {
+	config    string
+	campaign  string
+	checkouts string
+	senseBin  string
+	name      string
+}
+
+func parseRepoFlags(args []string, stderr io.Writer) (repoFlags, error) {
+	var f repoFlags
+	fs := flag.NewFlagSet("repo", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	configFlag(fs, &f.config)
+	fs.StringVar(&f.campaign, "campaign", "", "the campaign's run tree, where the index artifact lands (required)")
+	fs.StringVar(&f.checkouts, "checkouts", defaultCheckouts, "the lab's own clones root")
+	fs.StringVar(&f.senseBin, "sense", "sense", "the Sense binary that indexes the repository")
+	if err := fs.Parse(args); err != nil {
+		return f, err
+	}
+	// The name is positional and comes after the flags, which is how every Go
+	// flag set reads its arguments: `sense-lab repo -campaign X owner/name`.
+	if fs.NArg() != 1 {
+		return f, fmt.Errorf("name exactly one repository: an id already admitted, a path to a clone, `owner/name`, or a url")
+	}
+	if f.campaign == "" {
+		return f, fmt.Errorf("-campaign names the run tree the index artifact belongs to")
+	}
+	f.name = fs.Arg(0)
+	return f, nil
+}
+
+// admitRepo is the one command that admits a repository: resolve it, clone it,
+// pin it at the tree it got, scan it, and record what the index holds.
+//
+// A repository the catalog already holds is not admitted again. It prints where
+// that repository stands and stops, because the crank calls this on every
+// invocation and admission has to be idempotent for that to be safe.
+func admitRepo(ctx context.Context, args []string, stdout, stderr io.Writer) int {
+	f, err := parseRepoFlags(args, stderr)
+	if err != nil {
+		if err != flag.ErrHelp {
+			_, _ = fmt.Fprintf(stderr, "sense-lab repo: %v\n", err)
+		}
+		return exitUsage
+	}
+
+	c, err := catalog.Load(f.config)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab repo: %v\n", err)
+		return exitError
+	}
+	r, err := repo.Resolve(f.name, catalog.IDs(c.Repos), repo.OnDisk)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab repo: %v\n", err)
+		return exitError
+	}
+
+	p, err := repo.Prepare(ctx, targetFor(c, r), f.checkouts, announce(stdout))
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab repo: %v\n", err)
+		return exitError
+	}
+	if p.Admitted {
+		_, _ = fmt.Fprint(stdout, position(f.campaign, p))
+		return exitOK
+	}
+	return admitNew(ctx, f, p, stdout, stderr)
+}
+
+// targetFor is what admission acts on. A repository the catalog holds brings
+// its own url, its checkout and its pin: re-admitting it must reach the same
+// tree it reached last time, and the recorded pin is the only thing that says
+// which that is.
+func targetFor(c *catalog.Catalog, r repo.Resolution) repo.Target {
+	if known, ok := c.Repos[r.ID]; ok {
+		return repo.Target{ID: known.ID, URL: known.URL, Checkout: known.Checkout, Pin: known.Commit}
+	}
+	return repo.Target{ID: r.ID, URL: r.URL, Checkout: r.Path}
+}
+
+// announce prints what was decided, before anything is written.
+//
+// The whole ordering exists for this line. Nothing has been cloned, moved or
+// recorded when it prints, so a wrong repository is visible in the scrollback
+// rather than three phases later — and it is a statement rather than a prompt,
+// because an interactive question in the run path is what the crank cannot
+// answer.
+func announce(stdout io.Writer) func(repo.Plan) error {
+	return func(p repo.Plan) error {
+		_, _ = fmt.Fprintf(stdout, "id:       %s\nurl:      %s\nrevision: %s\ncheckout: %s (%s)\n\n",
+			p.ID, p.URL, p.Revision, p.Checkout, sentence(p))
+		return nil
+	}
+}
+
+// sentence says what the checkout is about to have done to it, in words.
+func sentence(p repo.Plan) string {
+	switch p.Action() {
+	case repo.MakeIt:
+		return "the lab will clone it"
+	case repo.Adopt:
+		return "already at this revision"
+	case repo.Correct:
+		return fmt.Sprintf("the lab's own clone, at %.12s, moving back to its pin", p.At)
+	case repo.Read:
+		return "yours, read and never written to"
+	default:
+		// Refused: a handed-in checkout at some other revision. The line says
+		// where it is, and the refusal below says why it stays there.
+		return fmt.Sprintf("yours, at %.12s", p.At)
+	}
+}
+
+// admitNew indexes a repository that has never been admitted and records it.
+func admitNew(ctx context.Context, f repoFlags, p repo.Plan, stdout, stderr io.Writer) int {
+	if p.URL == "" {
+		// A repository with no url is one nothing can re-clone, and every
+		// command after this reads the catalog: recording it would leave a
+		// config directory that fails to load until somebody edits it by hand.
+		// It is refused here, before a scan is spent on it.
+		_, _ = fmt.Fprintf(stderr, "sense-lab repo: %s has no origin, so there is no url to record and "+
+			"nothing could clone it again. Give the clone an origin, or admit it by url\n", p.Checkout)
+		return exitError
+	}
+	i, err := repo.Scan(ctx, f.senseBin, p, time.Now())
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab repo: %v\n", err)
+		return exitError
+	}
+	artifact := indexArtifact(f.campaign, p.ID)
+	if err := repo.Write(artifact, i); err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab repo: %v\n", err)
+		return exitError
+	}
+	if !i.Indexed() {
+		// The artifact says what happened and the repository is not admitted on
+		// the strength of it. Writing the repository file here would advance a
+		// repository whose index does not exist, and every phase after this one
+		// would read it as a repository Sense has nothing to say about.
+		_, _ = fmt.Fprintf(stdout, "index:    %s\n\n%s\n", artifact, i.Shortfall)
+		return exitError
+	}
+	if err := writeRepoFile(f.config, p, i); err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab repo: %v\n", err)
+		return exitError
+	}
+	_, _ = fmt.Fprintf(stdout, "index:    %d files, %d symbols, %d edges, %d embeddings, %v\nartifact: %s\nrepo:     %s\n",
+		i.Files, i.Symbols, i.Edges, i.Embeddings, i.Names(), artifact, repoFile(f.config, p.ID))
+	return exitOK
+}
+
+// writeRepoFile records the repository, and it happens last on purpose.
+//
+// The languages come from the scan rather than from a judgement about the
+// repository, so the file cannot be written before there is an index to read
+// them off. That ordering is also what makes a failed clone or a failed scan
+// leave nothing behind: a repository file is the lab saying this repository is
+// ready, and it is written when that is true.
+func writeRepoFile(config string, p repo.Plan, i repo.Index) error {
+	r := catalog.Repo{ID: p.ID, URL: p.URL, Commit: p.Revision, Languages: i.Names()}
+	if !p.Owned {
+		r.Checkout = p.Checkout
+	}
+	return repo.Write(repoFile(config, p.ID), r)
+}
+
+func repoFile(config, id string) string { return filepath.Join(config, "repos", id+".json") }
+
+// indexArtifact is where the index phase's artifact lands: beside the cycles
+// rather than inside one, because a repository is scanned once and a re-entry
+// does not rescan it.
+func indexArtifact(campaign, id string) string {
+	return filepath.Join(campaign, id, "index", "index.json")
+}
+
+// position is what a repository that is already admitted gets instead of an
+// admission: where its checkout is, what it is pinned at, and whether it has
+// been indexed.
+func position(campaign string, p repo.Plan) string {
+	indexed := "no"
+	if _, err := os.Stat(indexArtifact(campaign, p.ID)); err == nil {
+		indexed = "yes"
+	}
+	return fmt.Sprintf("admitted: nothing to do\nindexed:  %s\n", indexed)
+}
+
+// admitSignals runs admission under the same signal handling a session gets. A
+// clone is minutes of network and a scan is minutes of CPU, and an interrupt
+// that did not reach them would leave both running behind a returned command.
+func admitSignals(args []string, stdout, stderr io.Writer) int {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return admitRepo(ctx, args, stdout, stderr)
+}

--- a/lab/internal/cli/repocmd_test.go
+++ b/lab/internal/cli/repocmd_test.go
@@ -1,0 +1,528 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// admissionStatus is what the stand-in server answers, trimmed to the keys the
+// artifact reads.
+const admissionStatus = `{"index":{"files":12,"symbols":40,"edges":55,"embeddings":40,"coverage":1},` +
+	`"languages":{"go":{"files":12,"symbols":40,"tier":"full"}},"profile":{"tier":"small"},` +
+	`"version":{"binary":"1.14.1-test"}}`
+
+// senseStandIn indexes and answers sense_status, and nothing else. Admission
+// runs the product binary the way a user would, so the stand-in is a binary
+// too.
+//
+// It is permissive on purpose: what it stands in for here is a scan that
+// happened, so that the wiring around it — which files are written, which are
+// not, and in what order — is what these tests are about. Whether the exchange
+// the lab sends is one Sense answers, and whether the server is asked in the
+// checkout, are pinned in lab/internal/repo against the real binary.
+func senseStandIn(t *testing.T, status string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the stand-in is a shell script")
+	}
+	quoted, err := json.Marshal(status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(t.TempDir(), "sense")
+	script := `#!/bin/sh
+set -e
+case "$1" in
+scan) mkdir -p "$3/.sense" ;;
+mcp)
+  while IFS= read -r line; do
+    case "$line" in
+      *'"tools/call"'*) printf '{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":%s}]}}\n' '` + string(quoted) + `' ;;
+    esac
+  done
+  ;;
+esac
+`
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return bin
+}
+
+// sourceRepo is a repository to admit: real git, two commits, so a test can
+// move one and see what admission does about it.
+func sourceRepo(t *testing.T) (dir, first string) {
+	t.Helper()
+	dir = t.TempDir()
+	git(t, dir, "init", "-q", "-b", "main")
+	if err := os.WriteFile(filepath.Join(dir, "app.go"), []byte("package app\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, dir, "add", ".")
+	git(t, dir, "-c", "user.email=lab@example.test", "-c", "user.name=lab", "commit", "-q", "-m", "first")
+	// A real clone knows where it came from, and that origin is what a handed-in
+	// repository is recorded with.
+	git(t, dir, "remote", "add", "origin", "https://example.test/"+filepath.Base(dir)+".git")
+	return dir, git(t, dir, "rev-parse", "HEAD")
+}
+
+func git(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// commit moves a checkout forward, which is how a clone drifts off its pin.
+func commit(t *testing.T, dir, name string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git(t, dir, "add", ".")
+	git(t, dir, "-c", "user.email=lab@example.test", "-c", "user.name=lab", "commit", "-q", "-m", name)
+}
+
+// admission is one run of the command, with the paths a test cares about.
+type admission struct {
+	config, campaign, checkouts, sense string
+}
+
+func newAdmission(t *testing.T, status string) admission {
+	t.Helper()
+	root := t.TempDir()
+	config := filepath.Join(root, "lab")
+	// The catalog reads all five kinds, so an admission runs against a config
+	// directory that is empty rather than absent — which is what a first
+	// admission actually meets.
+	for _, kind := range []string{"subjects", "agents", "models", "repos", "executors"} {
+		if err := os.MkdirAll(filepath.Join(config, kind), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return admission{
+		config:    config,
+		campaign:  filepath.Join(root, "campaign"),
+		checkouts: filepath.Join(root, "checkouts"),
+		sense:     senseStandIn(t, status),
+	}
+}
+
+func (a admission) run(t *testing.T, name string) (int, string, string) {
+	t.Helper()
+	return dispatch(t, "repo", "-config", a.config, "-campaign", a.campaign,
+		"-checkouts", a.checkouts, "-sense", a.sense, name)
+}
+
+func (a admission) repoFile(id string) string { return filepath.Join(a.config, "repos", id+".json") }
+func (a admission) artifact(id string) string {
+	return filepath.Join(a.campaign, id, "index", "index.json")
+}
+
+// The whole point of the command: a repository nobody declared goes from a name
+// to a pinned clone, an index artifact and a repository file, in one call.
+func TestAUrlIsClonedPinnedIndexedAndRecorded(t *testing.T) {
+	source, head := sourceRepo(t)
+	a := newAdmission(t, admissionStatus)
+
+	code, stdout, stderr := a.run(t, "file://"+source)
+
+	if code != 0 {
+		t.Fatalf("exit = %d: %s", code, stderr)
+	}
+	if !strings.Contains(stdout, "the lab will clone it") {
+		t.Errorf("stdout = %q, want it to say what it was about to do", stdout)
+	}
+
+	var r struct {
+		ID, URL, Commit, Checkout string
+		Languages                 []string
+	}
+	readJSON(t, a.repoFile(filepath.Base(source)), &r)
+	if r.Commit != head {
+		t.Errorf("commit = %q, want the revision the clone is at (%q)", r.Commit, head)
+	}
+	if r.Checkout != "" {
+		t.Errorf("checkout = %q, want none: the lab made this clone and owns it", r.Checkout)
+	}
+	if len(r.Languages) != 1 || r.Languages[0] != "go" {
+		t.Errorf("languages = %v, want what the scan found", r.Languages)
+	}
+
+	var i struct {
+		Revision, Checkout string
+		Symbols            int
+	}
+	readJSON(t, a.artifact(filepath.Base(source)), &i)
+	if i.Symbols != 40 || i.Revision != head {
+		t.Errorf("artifact = %+v, want the counts and the pin", i)
+	}
+	if _, err := os.Stat(filepath.Join(a.checkouts, filepath.Base(source))); err != nil {
+		t.Errorf("the clone is not under the lab's own root: %v", err)
+	}
+}
+
+// The pin is read out of the clone. A repository file whose sha is not the sha
+// the clone sits at gives every later worktree the wrong tree, and nothing
+// about a result says so.
+func TestAHandedInCloneIsReadAndRecordedAtItsOwnHead(t *testing.T) {
+	source, head := sourceRepo(t)
+	a := newAdmission(t, admissionStatus)
+
+	code, stdout, stderr := a.run(t, source)
+
+	if code != 0 {
+		t.Fatalf("exit = %d: %s", code, stderr)
+	}
+	if !strings.Contains(stdout, "read and never written to") {
+		t.Errorf("stdout = %q, want it to say the clone is not the lab's", stdout)
+	}
+	var r struct{ Commit, Checkout, URL string }
+	readJSON(t, a.repoFile(filepath.Base(source)), &r)
+	if r.Commit != head {
+		t.Errorf("commit = %q, want %q", r.Commit, head)
+	}
+	if r.Checkout != source {
+		t.Errorf("checkout = %q, want the handed-in path recorded, which is what says the lab does not own it", r.Checkout)
+	}
+	if r.URL != "https://example.test/"+filepath.Base(source)+".git" {
+		t.Errorf("url = %q, want the clone's own origin", r.URL)
+	}
+}
+
+// Admission is idempotent because the crank calls it on every invocation. A
+// second call admits nothing and rewrites nothing.
+func TestRe_runningOnAnAdmittedRepositoryWritesNothing(t *testing.T) {
+	source, _ := sourceRepo(t)
+	a := newAdmission(t, admissionStatus)
+	id := filepath.Base(source)
+	if code, _, stderr := a.run(t, source); code != 0 {
+		t.Fatalf("first admission: %s", stderr)
+	}
+	before := read(t, a.repoFile(id))
+	artifactBefore := read(t, a.artifact(id))
+
+	code, stdout, stderr := a.run(t, id)
+
+	if code != 0 {
+		t.Fatalf("exit = %d: %s", code, stderr)
+	}
+	if !strings.Contains(stdout, "admitted: nothing to do") || !strings.Contains(stdout, "indexed:  yes") {
+		t.Errorf("stdout = %q, want where the repository stands", stdout)
+	}
+	if read(t, a.repoFile(id)) != before {
+		t.Error("the repository file was rewritten by a second admission")
+	}
+	if read(t, a.artifact(id)) != artifactBefore {
+		t.Error("the repository was re-indexed by a second admission")
+	}
+}
+
+// The lab fixes what it made: an unattended crank must not park a repository on
+// a stale tree nobody is watching.
+func TestALabOwnedCloneThatDriftedIsPutBack(t *testing.T) {
+	source, head := sourceRepo(t)
+	a := newAdmission(t, admissionStatus)
+	id := filepath.Base(source)
+	if code, _, stderr := a.run(t, "file://"+source); code != 0 {
+		t.Fatalf("first admission: %s", stderr)
+	}
+	clone := filepath.Join(a.checkouts, id)
+	commit(t, clone, "drift.go")
+
+	code, stdout, stderr := a.run(t, id)
+
+	if code != 0 {
+		t.Fatalf("exit = %d: %s", code, stderr)
+	}
+	if !strings.Contains(stdout, "moving back to its pin") {
+		t.Errorf("stdout = %q, want it to say the clone is being corrected", stdout)
+	}
+	if at := git(t, clone, "rev-parse", "HEAD"); at != head {
+		t.Errorf("the clone is at %q, want its pin %q", at, head)
+	}
+}
+
+// And it reads what it was given: a clone somebody handed in is their working
+// tree, and the lab does not perform a checkout in it.
+func TestAHandedInCloneThatDriftedIsRefusedRatherThanMoved(t *testing.T) {
+	source, head := sourceRepo(t)
+	a := newAdmission(t, admissionStatus)
+	if code, _, stderr := a.run(t, source); code != 0 {
+		t.Fatalf("first admission: %s", stderr)
+	}
+	commit(t, source, "theirs.go")
+	moved := git(t, source, "rev-parse", "HEAD")
+
+	code, _, stderr := a.run(t, filepath.Base(source))
+
+	if code == 0 {
+		t.Fatal("a handed-in clone at the wrong revision was accepted")
+	}
+	if !strings.Contains(stderr, "read and never moved") {
+		t.Errorf("stderr = %q, want the refusal to say why", stderr)
+	}
+	if at := git(t, source, "rev-parse", "HEAD"); at != moved {
+		t.Errorf("the handed-in clone is at %q, want it left where its owner put it (%q)", at, moved)
+	}
+	if at := head; at == moved {
+		t.Fatal("the test did not move the clone")
+	}
+}
+
+// A scan that indexed nothing writes an artifact that says so and does not
+// advance the repository. Recording it would put a repository every later phase
+// reads as dark into the catalog.
+func TestAScanThatIndexedNothingWritesTheFindingAndAdmitsNothing(t *testing.T) {
+	source, _ := sourceRepo(t)
+	a := newAdmission(t, `{"index":{"files":0,"symbols":0},"languages":{},"version":{"binary":"1.14.1-test"}}`)
+
+	code, stdout, _ := a.run(t, source)
+
+	if code == 0 {
+		t.Fatal("an unindexed repository was admitted")
+	}
+	var i struct{ Shortfall string }
+	readJSON(t, a.artifact(filepath.Base(source)), &i)
+	if !strings.Contains(i.Shortfall, "0 symbols") {
+		t.Errorf("artifact shortfall = %q, want it to say what was indexed", i.Shortfall)
+	}
+	if !strings.Contains(stdout, "0 symbols") {
+		t.Errorf("stdout = %q, want the finding printed as well as recorded", stdout)
+	}
+	if _, err := os.Stat(a.repoFile(filepath.Base(source))); !os.IsNotExist(err) {
+		t.Error("a repository file was written for a repository with no index")
+	}
+}
+
+// An unreachable repository is the most common first run for anybody but the
+// author. Git's message is passed through, and nothing is left behind.
+func TestAnUnreachableRepositoryLeavesNoRepositoryFile(t *testing.T) {
+	a := newAdmission(t, admissionStatus)
+
+	code, stdout, stderr := a.run(t, "file:///nonexistent/nowhere.git")
+
+	if code == 0 {
+		t.Fatal("an unreachable repository was admitted")
+	}
+	if !strings.Contains(stderr, "/nonexistent/nowhere.git") {
+		t.Errorf("stderr = %q, want the resolved url beside git's message", stderr)
+	}
+	if stdout != "" {
+		t.Errorf("stdout = %q, want nothing announced for a repository that could not be read", stdout)
+	}
+	if _, err := os.Stat(a.repoFile("nowhere")); !os.IsNotExist(err) {
+		t.Error("a repository file was written for a repository that was never cloned")
+	}
+}
+
+func TestAdmissionRefusesWhatItCannotResolve(t *testing.T) {
+	a := newAdmission(t, admissionStatus)
+
+	code, _, stderr := a.run(t, "jellyfin")
+
+	if code == 0 {
+		t.Fatal("a bare word was admitted as a repository")
+	}
+	if !strings.Contains(stderr, "not an admitted id") {
+		t.Errorf("stderr = %q, want it to say what it tried", stderr)
+	}
+}
+
+func TestAdmissionNeedsOneNameAndACampaign(t *testing.T) {
+	a := newAdmission(t, admissionStatus)
+
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"no repository named", []string{"repo", "-config", a.config, "-campaign", a.campaign}},
+		{"two repositories named", []string{"repo", "-config", a.config, "-campaign", a.campaign, "a", "b"}},
+		{"no campaign", []string{"repo", "-config", a.config, "owner/name"}},
+		{"an unknown flag", []string{"repo", "-nope"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if code, _, _ := dispatch(t, tc.args...); code != 2 {
+				t.Errorf("exit = %d, want a usage error", code)
+			}
+		})
+	}
+}
+
+func TestAdmissionCannotRunWithoutAConfigDirectory(t *testing.T) {
+	absent := filepath.Join(t.TempDir(), "no-such-config")
+
+	code, _, stderr := dispatch(t, "repo", "-config", absent, "-campaign", t.TempDir(), "owner/name")
+
+	if code == 0 || !strings.Contains(stderr, "no config directory") {
+		t.Errorf("exit = %d, stderr = %q; want it to name the missing config", code, stderr)
+	}
+}
+
+func readJSON(t *testing.T, path string, into any) {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(b, into); err != nil {
+		t.Fatalf("%s: %v", path, err)
+	}
+}
+
+// A clone with no origin is refused before a scan is spent on it. Recording it
+// would leave a repository nothing can clone again, in a config directory that
+// then fails to load until somebody edits it by hand.
+func TestACloneWithNoOriginIsRefusedRatherThanRecorded(t *testing.T) {
+	source := t.TempDir()
+	git(t, source, "init", "-q")
+	git(t, source, "-c", "user.email=lab@example.test", "-c", "user.name=lab", "commit", "-q", "--allow-empty", "-m", "first")
+	a := newAdmission(t, admissionStatus)
+
+	code, _, stderr := a.run(t, source)
+
+	if code == 0 {
+		t.Fatal("a clone with no origin was admitted")
+	}
+	if !strings.Contains(stderr, "no origin") {
+		t.Errorf("stderr = %q, want it to say what is missing", stderr)
+	}
+	if _, err := os.Stat(a.artifact(filepath.Base(source))); !os.IsNotExist(err) {
+		t.Error("the repository was scanned anyway")
+	}
+}
+
+// A repository admitted before it was indexed reads as admitted and not
+// indexed. The two facts are separate on disk, so the position says both.
+func TestPositionReportsARepositoryThatWasNeverIndexed(t *testing.T) {
+	source, head := sourceRepo(t)
+	a := newAdmission(t, admissionStatus)
+	if err := os.MkdirAll(filepath.Dir(a.repoFile("thing")), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(a.repoFile("thing"),
+		[]byte(`{"id":"thing","url":"file://`+source+`","commit":"`+head+`","checkout":"`+source+`","languages":["go"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code, stdout, stderr := a.run(t, "thing")
+
+	if code != 0 {
+		t.Fatalf("exit = %d: %s", code, stderr)
+	}
+	if !strings.Contains(stdout, "indexed:  no") {
+		t.Errorf("stdout = %q, want it to say the repository has no index", stdout)
+	}
+}
+
+// A clone that is already at its pin is adopted rather than replaced, and the
+// line says so: re-cloning a repository the lab already has is minutes of
+// network for no change.
+func TestALabOwnedCloneAtItsPinIsAdopted(t *testing.T) {
+	source, _ := sourceRepo(t)
+	a := newAdmission(t, admissionStatus)
+	if code, _, stderr := a.run(t, "file://"+source); code != 0 {
+		t.Fatalf("first admission: %s", stderr)
+	}
+
+	before := read(t, a.artifact(filepath.Base(source)))
+
+	code, stdout, stderr := a.run(t, filepath.Base(source))
+
+	if code != 0 {
+		t.Fatalf("exit = %d: %s", code, stderr)
+	}
+	if !strings.Contains(stdout, "already at this revision") {
+		t.Errorf("stdout = %q, want it to say the clone was adopted", stdout)
+	}
+	if read(t, a.artifact(filepath.Base(source))) != before {
+		t.Error("the repository was re-cloned and re-indexed; adoption is what stops minutes of network for no change")
+	}
+}
+
+// A scan that could not run at all is a failure of this phase and is recorded
+// as one: nothing is written, and the repository is not admitted.
+func TestAScanThatCouldNotRunAdmitsNothing(t *testing.T) {
+	source, _ := sourceRepo(t)
+	a := newAdmission(t, admissionStatus)
+	a.sense = filepath.Join(t.TempDir(), "no-such-sense")
+
+	code, _, stderr := a.run(t, source)
+
+	if code == 0 {
+		t.Fatal("a repository nothing could index was admitted")
+	}
+	if !strings.Contains(stderr, "index") {
+		t.Errorf("stderr = %q, want it to name the phase that failed", stderr)
+	}
+	if _, err := os.Stat(a.repoFile(filepath.Base(source))); !os.IsNotExist(err) {
+		t.Error("a repository file was written for a repository that was never indexed")
+	}
+}
+
+// An artifact that cannot be written is a failure rather than a silent
+// admission: the index phase owes an artifact, and a repository admitted
+// without one is a repository whose index nobody can read.
+func TestAnArtifactThatCannotBeWrittenAdmitsNothing(t *testing.T) {
+	source, _ := sourceRepo(t)
+	a := newAdmission(t, admissionStatus)
+	blocked(t, a.artifact(filepath.Base(source)))
+
+	code, _, stderr := a.run(t, source)
+
+	if code == 0 {
+		t.Fatal("a repository whose artifact could not be written was admitted")
+	}
+	if stderr == "" {
+		t.Error("nothing was reported")
+	}
+	if _, err := os.Stat(a.repoFile(filepath.Base(source))); !os.IsNotExist(err) {
+		t.Error("a repository file was written without its index artifact")
+	}
+}
+
+// And the same the other way: a repository file that cannot be written is
+// reported rather than swallowed, because the next command reads the catalog.
+func TestARepositoryFileThatCannotBeWrittenIsReported(t *testing.T) {
+	source, _ := sourceRepo(t)
+	a := newAdmission(t, admissionStatus)
+	repos := filepath.Join(a.config, "repos")
+	if err := os.Chmod(repos, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(repos, 0o755) })
+
+	code, _, stderr := a.run(t, source)
+
+	if code == 0 {
+		t.Fatal("a repository nothing recorded was reported as admitted")
+	}
+	if !strings.Contains(stderr, "repos") {
+		t.Errorf("stderr = %q, want it to name what could not be written", stderr)
+	}
+	// The index artifact stands, so whoever fixes the directory re-runs and the
+	// scan is not spent twice.
+	if _, err := os.Stat(a.artifact(filepath.Base(source))); err != nil {
+		t.Errorf("the index artifact was lost with the repository file: %v", err)
+	}
+}
+
+// blocked puts a file where a directory has to go, which is the simplest thing
+// a write cannot get past.
+func blocked(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(filepath.Dir(path)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Dir(path), []byte("in the way"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/lab/internal/repo/checkout.go
+++ b/lab/internal/repo/checkout.go
@@ -1,0 +1,286 @@
+package repo
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// runner is how this package reaches git, so a test can drive an outcome a real
+// repository cannot be made to produce. The real one is gitCommand.
+type runner func(ctx context.Context, dir string, args ...string) ([]byte, error)
+
+// gitCommand runs one git call and passes its own message through on failure.
+//
+// Nothing is added to what git said beyond the arguments it was given. A lab
+// error that paraphrases a git error is a second place for the truth to live,
+// and the most common first run for anybody but the author is a private or
+// unreachable repository, where git's message is the whole answer.
+//
+// There is no timeout: a clone of a large repository legitimately takes
+// minutes, and a wall short enough to catch a wedged one would kill it. The
+// context is the caller's, and an interrupt reaches the child through it.
+func gitCommand(ctx context.Context, dir string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...)
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(errBuf.String()))
+	}
+	return out, nil
+}
+
+// Target is the repository admission is about to act on: what it is called,
+// where it comes from, where its checkout is, and what it is already pinned at.
+//
+// Checkout is empty for a repository the lab clones itself, and that emptiness
+// is the ownership record. The lab fixes what it made and reads what it was
+// given, so a checkout it can name from the id alone is one it may move, and a
+// path somebody handed in is one it may not.
+type Target struct {
+	ID  string
+	URL string
+	// Checkout is a handed-in directory. Empty means the lab's own clones root.
+	Checkout string
+	// Pin is the revision already recorded for this repository, empty for one
+	// that has never been admitted.
+	Pin string
+}
+
+// Action is what admission is about to do to a checkout.
+type Action string
+
+const (
+	// MakeIt: there is no checkout yet, so the lab clones one.
+	MakeIt Action = "clone"
+	// Adopt: a checkout is already there at the revision wanted. A clone that
+	// is already right is adopted rather than replaced.
+	Adopt Action = "adopt"
+	// Correct: a lab-owned checkout has drifted off the pin and goes back to
+	// it. An unattended crank must not park a repository on a stale tree
+	// nobody is watching.
+	Correct Action = "correct"
+	// Read: a handed-in checkout at the revision wanted, read and never
+	// written to.
+	Read Action = "read"
+	// Refuse: a handed-in checkout at some other revision. It is somebody's
+	// working tree and the lab does not perform a checkout in it.
+	Refuse Action = "refuse"
+)
+
+// Plan is what admission decided, before it has written anything.
+//
+// It is announced first, every time. This is not a confirmation prompt — the
+// run path forbids one — it is the command saying what it decided, so a wrong
+// repository is visible in the scrollback rather than three phases later.
+type Plan struct {
+	ID       string
+	URL      string
+	Revision string
+	Checkout string
+	// At is the revision the checkout sits at now, empty when there is none.
+	At string
+	// Owned says the lab made this checkout.
+	Owned bool
+	// Admitted says the catalog already holds this repository.
+	Admitted bool
+}
+
+// Action is what this plan does to the checkout.
+func (p Plan) Action() Action {
+	switch {
+	case p.At == "":
+		return MakeIt
+	case p.At == p.Revision:
+		if p.Owned {
+			return Adopt
+		}
+		return Read
+	case p.Owned:
+		return Correct
+	}
+	return Refuse
+}
+
+// Prepare puts the checkout at the revision the plan names and reports the
+// revision it ended up at.
+//
+// The order is the point. Everything that decides happens first and touches
+// nothing; announce is handed the decision; only then does anything reach a
+// disk. A caller whose announce returns an error stops the whole admission
+// there, with the directory as it found it.
+func Prepare(ctx context.Context, t Target, root string, announce func(Plan) error) (Plan, error) {
+	return prepare(ctx, t, root, announce, gitCommand)
+}
+
+func prepare(ctx context.Context, t Target, root string, announce func(Plan) error, git runner) (Plan, error) {
+	p, err := planFor(ctx, t, root, git)
+	if err != nil {
+		return Plan{}, err
+	}
+	if err := announce(p); err != nil {
+		return p, err
+	}
+	if err := apply(ctx, p, git); err != nil {
+		return p, err
+	}
+	// The pin is read back out of the tree rather than carried over from the
+	// plan. A revision that was asked for is a request; the one the checkout
+	// sits at is the fact, and every later worktree is taken from that tree.
+	at, err := head(ctx, p.Checkout, git)
+	if err != nil {
+		return p, err
+	}
+	if p.Admitted && at != p.Revision {
+		// The last line of defence for the whole package. A repository already
+		// pinned may not come back from here at some other revision, however
+		// that happened, because the pin is what every worktree after this is
+		// taken at.
+		return p, fmt.Errorf("%s is pinned at %.12s and its checkout is at %.12s after being prepared; "+
+			"a run against that tree would record a commit it did not use", p.ID, p.Revision, at)
+	}
+	p.At, p.Revision = at, at
+	return p, nil
+}
+
+// planFor reads what is there and decides what admission will do. It writes
+// nothing, which is what makes announcing its result before acting worth
+// anything.
+func planFor(ctx context.Context, t Target, root string, git runner) (Plan, error) {
+	p := Plan{ID: t.ID, URL: t.URL, Admitted: t.Pin != "", Checkout: t.Checkout, Owned: t.Checkout == ""}
+	if p.Owned {
+		p.Checkout = filepath.Join(root, t.ID)
+	}
+	if OnDisk(p.Checkout) {
+		at, err := head(ctx, p.Checkout, git)
+		if err != nil {
+			return Plan{}, debris(p, err)
+		}
+		p.At = at
+	}
+	if p.URL == "" {
+		// A handed-in clone knows where it came from, and reading it is the
+		// only way to record a url for one. A clone with no origin keeps an
+		// empty url, and the catalog's own validation is what reports that.
+		if out, err := git(ctx, p.Checkout, "remote", "get-url", "origin"); err == nil {
+			p.URL = strings.TrimSpace(string(out))
+		}
+	}
+	rev, err := wanted(ctx, t, p, git)
+	if err != nil {
+		return Plan{}, err
+	}
+	p.Revision = rev
+	return p, nil
+}
+
+// wanted is the revision this admission is aiming at: the recorded pin if there
+// is one, the checkout's own head if it is already there, and otherwise
+// whatever the remote's default branch points at right now.
+func wanted(ctx context.Context, t Target, p Plan, git runner) (string, error) {
+	switch {
+	case t.Pin != "":
+		return t.Pin, nil
+	case p.At != "":
+		return p.At, nil
+	}
+	out, err := git(ctx, ".", "ls-remote", "--", p.URL, "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("read the head of %s: %w", p.URL, err)
+	}
+	sha, _, ok := strings.Cut(strings.TrimSpace(string(out)), "\t")
+	if !ok || sha == "" {
+		return "", fmt.Errorf("%s answered no head revision, so there is nothing to pin", p.URL)
+	}
+	return sha, nil
+}
+
+// apply carries the plan out.
+func apply(ctx context.Context, p Plan, git runner) error {
+	switch p.Action() {
+	case MakeIt:
+		if err := os.MkdirAll(filepath.Dir(p.Checkout), 0o755); err != nil {
+			return fmt.Errorf("prepare the clones root: %w", err)
+		}
+		// `--` before the url, because everything after it is an operand
+		// however it is spelled. The resolver already refuses anything that is
+		// not a handle, a url or a directory, so a url that reads as an option
+		// cannot get here — and this is the second lock on a door that opens
+		// onto running whatever an argument names.
+		if _, err := git(ctx, filepath.Dir(p.Checkout), "clone", "--", p.URL, filepath.Base(p.Checkout)); err != nil {
+			return fmt.Errorf("clone %s: %w", p.URL, err)
+		}
+		if !p.Admitted {
+			// A first admission is pinned at whatever it cloned, and that is
+			// the revision this clone lands on by default.
+			return nil
+		}
+		// A repository that was already admitted and whose clone is gone is
+		// re-cloned at ITS pin, not at whatever the default branch points at
+		// today. Without this the tree would move under a repository file that
+		// did not, which is precisely the disagreement admission exists to
+		// prevent — and nothing about a later result would show it.
+		if _, err := git(ctx, p.Checkout, "checkout", "--detach", "--quiet", p.Revision); err != nil {
+			return fmt.Errorf("put the new clone of %s at its pin %.12s: %w", p.ID, p.Revision, err)
+		}
+		return nil
+	case Correct:
+		if _, err := git(ctx, p.Checkout, "fetch", "--quiet", "origin", p.Revision); err != nil {
+			// A revision already in the clone needs no fetch, and a remote that
+			// refuses to serve one by sha is common. Either way the checkout
+			// below is what decides, and it reports its own failure.
+			_, _ = git(ctx, p.Checkout, "fetch", "--quiet", "origin")
+		}
+		if _, err := git(ctx, p.Checkout, "checkout", "--detach", "--quiet", p.Revision); err != nil {
+			return fmt.Errorf("move %s back to its pin %.12s: %w", p.Checkout, p.Revision, err)
+		}
+		return nil
+	case Refuse:
+		return fmt.Errorf("%s is at %.12s and this repository is pinned at %.12s, and the lab did not "+
+			"make that checkout: it is yours, so it is read and never moved. Check it out at the pin "+
+			"yourself, or hand in a different clone", p.Checkout, p.At, p.Revision)
+	default:
+		return nil
+	}
+}
+
+// debris says what to do about a directory that is in the checkout's place and
+// is not a repository.
+//
+// The case is ordinary rather than exotic: a clone is minutes of network, and
+// an interrupt part way through leaves a half-made directory under the lab's
+// own root. Every admission after that finds a directory, fails to read a
+// revision out of it, and reports "not a git repository" about a repository
+// that is not in the catalog and so has no pin to recover from. The way out is
+// one `rm -rf`, and it is the message's job to say so — the lab does not delete
+// a directory on its own, even one it made, because the same code path would
+// delete a clone somebody handed in if the ownership rule ever moved.
+func debris(p Plan, err error) error {
+	if !p.Owned {
+		return err
+	}
+	return fmt.Errorf("%w. %s is the lab's own clone directory and it is not a repository, "+
+		"which is what an interrupted clone leaves behind; remove it and run this again", err, p.Checkout)
+}
+
+// head is the revision a checkout sits at.
+func head(ctx context.Context, dir string, git runner) (string, error) {
+	out, err := git(ctx, dir, "rev-parse", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("read the revision of %s: %w", dir, err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// OnDisk reports whether a path is a directory. It is what [Resolve] is handed
+// as its on-disk test, so a path resolves and a checkout is found here by one
+// rule rather than by two that could drift apart.
+func OnDisk(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && fi.IsDir()
+}

--- a/lab/internal/repo/checkout_test.go
+++ b/lab/internal/repo/checkout_test.go
@@ -1,0 +1,505 @@
+package repo
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeGit answers git calls and records them, so a test can drive an outcome a
+// real repository cannot be made to produce — a remote whose head moves between
+// the question and the clone, most of all.
+//
+// Two things it deliberately cannot tell you, both covered by the real-git
+// tests at the end of this file and in the command's own tests. It keys answers
+// by VERB and ignores the directory, so nothing here would notice git being run
+// in the wrong place. And an unanswered verb comes back empty rather than
+// failing, so a test that forgets to state a revision is testing a repository
+// pinned at nothing.
+type fakeGit struct {
+	// answer is keyed by the git verb.
+	answer map[string]string
+	// stuck says a checkout does not move the tree, which is how a correction
+	// that reported success and silently did not take is expressed.
+	stuck bool
+	fail  map[string]error
+	calls [][]string
+}
+
+func (f *fakeGit) run(_ context.Context, dir string, args ...string) ([]byte, error) {
+	f.calls = append(f.calls, append([]string{dir}, args...))
+	verb := args[0]
+	if err, ok := f.fail[verb]; ok {
+		return nil, err
+	}
+	if verb == "checkout" && !f.stuck {
+		// A checkout moves the tree, so what the next rev-parse reads back
+		// moves with it. Without this the fake would let a correction that
+		// went nowhere pass for one that worked.
+		f.answer["rev-parse"] = args[len(args)-1]
+	}
+	return []byte(f.answer[verb] + "\n"), nil
+}
+
+// ran reports whether a verb was called at all.
+func (f *fakeGit) ran(verb string) bool {
+	for _, c := range f.calls {
+		if c[1] == verb {
+			return true
+		}
+	}
+	return false
+}
+
+// wrote reports whether anything that changes a checkout was called. It is the
+// question every "nothing was touched" claim in this file rests on.
+func (f *fakeGit) wrote() bool {
+	return f.ran("clone") || f.ran("checkout") || f.ran("fetch")
+}
+
+// The ordering is the whole reason the announcement exists: a caller that stops
+// at the announcement stops with the disk as it found it. Without that, printing
+// the resolution proves nothing, because a wrong repository would already be
+// cloned by the time anybody read the line.
+func TestNothingIsWrittenWhenTheAnnouncementIsRefused(t *testing.T) {
+	root := t.TempDir()
+	git := &fakeGit{answer: map[string]string{"ls-remote": "abc123\tHEAD"}}
+	stop := errors.New("the operator stopped here")
+
+	_, err := prepare(context.Background(), Target{ID: "thing", URL: "https://example.test/thing.git"},
+		root, func(Plan) error { return stop }, git.run)
+
+	if !errors.Is(err, stop) {
+		t.Fatalf("err = %v, want the announcement's own error", err)
+	}
+	if git.wrote() {
+		t.Errorf("git calls = %v, want nothing that changes a checkout", git.calls)
+	}
+	if _, err := os.Stat(filepath.Join(root, "thing")); !os.IsNotExist(err) {
+		t.Error("the checkout was made anyway; the announcement is not a stopping point")
+	}
+}
+
+// A revision that was asked for is a request; the one the checkout sits at is
+// the fact. They can differ — the default branch moves between the question and
+// the clone — and recording the request would pin every later worktree to a
+// tree this clone is not at.
+func TestThePinIsReadOutOfTheCloneRatherThanOutOfTheRequest(t *testing.T) {
+	git := &fakeGit{answer: map[string]string{
+		"ls-remote": "aaaaaaaaaaaa\tHEAD",
+		"rev-parse": "bbbbbbbbbbbb",
+	}}
+	var announced Plan
+
+	p, err := prepare(context.Background(), Target{ID: "thing", URL: "https://example.test/thing.git"},
+		t.TempDir(), func(p Plan) error { announced = p; return nil }, git.run)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if announced.Revision != "aaaaaaaaaaaa" {
+		t.Errorf("announced revision = %q, want what the remote said when it was asked", announced.Revision)
+	}
+	if p.Revision != "bbbbbbbbbbbb" {
+		t.Errorf("recorded pin = %q, want the revision the clone is at", p.Revision)
+	}
+}
+
+// The lab fixes what it made. An unattended crank must not park a repository on
+// a stale tree nobody is watching, so a clone under the lab's own root goes back
+// to its pin.
+func TestALabOwnedCloneAtTheWrongRevisionIsCorrected(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "thing"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	git := &fakeGit{answer: map[string]string{"rev-parse": "drifted", "remote": "https://example.test/thing.git"}}
+
+	p, err := prepare(context.Background(), Target{ID: "thing", URL: "https://example.test/thing.git", Pin: "pinned"},
+		root, func(Plan) error { return nil }, git.run)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !git.ran("checkout") {
+		t.Fatalf("git calls = %v, want the clone moved back to its pin", git.calls)
+	}
+	if p.Revision != "pinned" {
+		t.Errorf("pin = %q, want the revision the corrected clone reads back as", p.Revision)
+	}
+	for _, c := range git.calls {
+		if c[1] == "checkout" && c[len(c)-1] != "pinned" {
+			t.Errorf("checkout %v, want it to name the pin", c)
+		}
+	}
+}
+
+// And the lab reads what it was given. A clone somebody handed in is their
+// working tree: moving it would be the lab performing a checkout in a directory
+// it does not own, which is a data-loss shape rather than a correction.
+func TestAHandedInCloneAtTheWrongRevisionIsRefusedWithItsReason(t *testing.T) {
+	handed := t.TempDir()
+	git := &fakeGit{answer: map[string]string{"rev-parse": "aaaaaaaaaaaabbbb", "remote": "https://example.test/thing.git"}}
+
+	_, err := prepare(context.Background(), Target{ID: "thing", Checkout: handed, Pin: "ccccccccccccdddd"},
+		t.TempDir(), func(Plan) error { return nil }, git.run)
+
+	if err == nil {
+		t.Fatal("a handed-in clone at the wrong revision was accepted")
+	}
+	for _, want := range []string{handed, "aaaaaaaaaaaa", "cccccccccccc"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("err = %q, want it to name %q", err, want)
+		}
+	}
+	if git.wrote() {
+		t.Errorf("git calls = %v, want nothing written to somebody else's clone", git.calls)
+	}
+}
+
+// The same clone at the pin is read and left alone. A repository that is
+// already right is adopted rather than re-cloned.
+func TestACloneAlreadyAtItsRevisionIsAdoptedRatherThanReplaced(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "thing"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	git := &fakeGit{answer: map[string]string{"rev-parse": "settled"}}
+
+	p, err := prepare(context.Background(), Target{ID: "thing", URL: "u", Pin: "settled"},
+		root, func(Plan) error { return nil }, git.run)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if git.wrote() {
+		t.Errorf("git calls = %v, want a clone that is already right left alone", git.calls)
+	}
+	if p.Revision != "settled" {
+		t.Errorf("pin = %q, want the revision it was already at", p.Revision)
+	}
+}
+
+// A handed-in clone knows where it came from, and reading it is the only way a
+// url gets recorded for one.
+func TestTheUrlOfAHandedInCloneIsReadOutOfIt(t *testing.T) {
+	handed := t.TempDir()
+	git := &fakeGit{answer: map[string]string{"rev-parse": "here", "remote": "git@example.test:team/thing.git"}}
+
+	p, err := prepare(context.Background(), Target{ID: "thing", Checkout: handed},
+		t.TempDir(), func(Plan) error { return nil }, git.run)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if p.URL != "git@example.test:team/thing.git" {
+		t.Errorf("URL = %q, want the clone's own origin", p.URL)
+	}
+	if p.Owned {
+		t.Error("Owned = true for a handed-in clone; the lab would then feel free to move it")
+	}
+}
+
+// A clone with no origin keeps an empty url rather than an invented one. The
+// catalog's own validation is what reports that, in one place.
+func TestACloneWithNoOriginKeepsAnEmptyUrl(t *testing.T) {
+	handed := t.TempDir()
+	git := &fakeGit{
+		answer: map[string]string{"rev-parse": "here"},
+		fail:   map[string]error{"remote": errors.New("no such remote origin")},
+	}
+
+	p, err := prepare(context.Background(), Target{ID: "thing", Checkout: handed},
+		t.TempDir(), func(Plan) error { return nil }, git.run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.URL != "" {
+		t.Errorf("URL = %q, want none", p.URL)
+	}
+}
+
+// The most common first run for anybody but the author is a repository they
+// cannot reach, and git's own message is the whole answer. Nothing is added to
+// it but the url that was resolved, because a lab error that paraphrases a git
+// error is a second place for the truth to live.
+func TestAnUnreachableRepositoryFailsWithGitsOwnMessage(t *testing.T) {
+	git := &fakeGit{fail: map[string]error{"ls-remote": errors.New("repository not found")}}
+	announced := false
+
+	_, err := prepare(context.Background(), Target{ID: "thing", URL: "https://example.test/thing.git"},
+		t.TempDir(), func(Plan) error { announced = true; return nil }, git.run)
+
+	if err == nil {
+		t.Fatal("an unreachable repository resolved to a plan")
+	}
+	for _, want := range []string{"repository not found", "https://example.test/thing.git"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("err = %q, want it to carry %q", err, want)
+		}
+	}
+	if announced {
+		t.Error("a plan was announced for a repository that could not be read")
+	}
+}
+
+// A remote that answers with no head is not a repository anything can be pinned
+// against, and an empty pin would be recorded as one.
+func TestARemoteThatNamesNoHeadIsRefused(t *testing.T) {
+	git := &fakeGit{answer: map[string]string{"ls-remote": ""}}
+
+	_, err := prepare(context.Background(), Target{ID: "thing", URL: "u"},
+		t.TempDir(), func(Plan) error { return nil }, git.run)
+
+	if err == nil || !strings.Contains(err.Error(), "nothing to pin") {
+		t.Fatalf("err = %v, want a refusal naming what is missing", err)
+	}
+}
+
+func TestAFailedCloneCarriesTheUrlItFailedOn(t *testing.T) {
+	git := &fakeGit{
+		answer: map[string]string{"ls-remote": "abc\tHEAD"},
+		fail:   map[string]error{"clone": errors.New("could not read Username")},
+	}
+
+	_, err := prepare(context.Background(), Target{ID: "thing", URL: "https://example.test/thing.git"},
+		t.TempDir(), func(Plan) error { return nil }, git.run)
+
+	if err == nil {
+		t.Fatal("a failed clone was accepted")
+	}
+	for _, want := range []string{"could not read Username", "https://example.test/thing.git"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("err = %q, want it to carry %q", err, want)
+		}
+	}
+}
+
+// A correction asks for the one revision first and falls back to fetching the
+// whole remote, because a host that refuses to serve a sha by name is common and
+// the checkout is what decides either way.
+func TestACorrectionFallsBackToAFullFetchWhenTheShaCannotBeAskedFor(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "thing"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	git := &fakeGit{
+		answer: map[string]string{"rev-parse": "drifted"},
+		fail:   map[string]error{"fetch": errors.New("server does not allow request for unadvertised object")},
+	}
+
+	if _, err := prepare(context.Background(), Target{ID: "thing", URL: "u", Pin: "pinned"},
+		root, func(Plan) error { return nil }, git.run); err != nil {
+		t.Fatal(err)
+	}
+
+	var fetches int
+	for _, c := range git.calls {
+		if c[1] == "fetch" {
+			fetches++
+		}
+	}
+	if fetches != 2 {
+		t.Errorf("fetch calls = %d, want the sha asked for and then the remote", fetches)
+	}
+}
+
+// A correction that cannot reach the pin fails rather than leaving the clone
+// wherever it drifted to.
+func TestACorrectionThatCannotReachThePinFails(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "thing"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	git := &fakeGit{
+		answer: map[string]string{"rev-parse": "drifted"},
+		fail:   map[string]error{"checkout": errors.New("pathspec did not match")},
+	}
+
+	_, err := prepare(context.Background(), Target{ID: "thing", URL: "u", Pin: "pinnedaaaaaa"},
+		root, func(Plan) error { return nil }, git.run)
+
+	if err == nil || !strings.Contains(err.Error(), "pinnedaaaaaa") {
+		t.Fatalf("err = %v, want a failure naming the pin it could not reach", err)
+	}
+}
+
+// A checkout whose revision cannot be read is not a checkout, and guessing one
+// would pin the repository at nothing.
+func TestACheckoutWhoseRevisionCannotBeReadIsRefused(t *testing.T) {
+	handed := t.TempDir()
+	git := &fakeGit{fail: map[string]error{"rev-parse": errors.New("not a git repository")}}
+
+	_, err := prepare(context.Background(), Target{ID: "thing", Checkout: handed},
+		t.TempDir(), func(Plan) error { return nil }, git.run)
+
+	if err == nil || !strings.Contains(err.Error(), "not a git repository") {
+		t.Fatalf("err = %v, want git's own message", err)
+	}
+}
+
+// The revision read back after a successful clone is the pin, so a clone that
+// lands and then cannot be read is a failure rather than an empty pin.
+func TestAPinThatCannotBeReadBackIsAFailure(t *testing.T) {
+	git := &fakeGit{
+		answer: map[string]string{"ls-remote": "abc\tHEAD"},
+		fail:   map[string]error{"rev-parse": errors.New("unknown revision")},
+	}
+
+	if _, err := prepare(context.Background(), Target{ID: "thing", URL: "u"},
+		t.TempDir(), func(Plan) error { return nil }, git.run); err == nil {
+		t.Fatal("a clone whose revision could not be read was recorded anyway")
+	}
+}
+
+// The real runner, exercised once: git's own message has to survive the wrapper,
+// because every refusal above is only as good as what reaches it.
+func TestTheRealRunnerPassesGitsMessageThrough(t *testing.T) {
+	_, err := gitCommand(context.Background(), t.TempDir(), "rev-parse", "HEAD")
+
+	if err == nil {
+		t.Fatal("rev-parse in an empty directory succeeded")
+	}
+	if !strings.Contains(err.Error(), "rev-parse") || !strings.Contains(strings.ToLower(err.Error()), "git repository") {
+		t.Errorf("err = %q, want git's own words", err)
+	}
+}
+
+// Prepare is what the command calls, and it reaches the real git. One pass
+// through it proves the seam below is the same code path.
+func TestPrepareReachesRealGit(t *testing.T) {
+	dir, head := oneCommitRepo(t)
+
+	p, err := Prepare(context.Background(), Target{ID: "thing", Checkout: dir}, t.TempDir(), func(Plan) error { return nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Revision != head {
+		t.Errorf("pin = %q, want the checkout's head %q", p.Revision, head)
+	}
+	if p.Action() != Read {
+		t.Errorf("Action = %s, want %s for a handed-in clone", p.Action(), Read)
+	}
+}
+
+// oneCommitRepo is a real repository with one commit, which is all the pin
+// needs to be read out of something.
+func oneCommitRepo(t *testing.T) (dir, head string) {
+	t.Helper()
+	dir = t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"-c", "user.email=lab@example.test", "-c", "user.name=lab", "commit", "-q", "--allow-empty", "-m", "first"},
+	} {
+		if _, err := gitCommand(context.Background(), dir, args...); err != nil {
+			t.Fatal(err)
+		}
+	}
+	out, err := gitCommand(context.Background(), dir, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir, strings.TrimSpace(string(out))
+}
+
+// A clone the lab made and somebody deleted is re-made AT ITS PIN, not at
+// whatever the default branch points at today. The tree would otherwise move
+// under a repository file that did not, which is the disagreement this package
+// exists to prevent.
+func TestAnAdmittedRepositoryWhoseCloneIsGoneIsRemadeAtItsPin(t *testing.T) {
+	git := &fakeGit{answer: map[string]string{"rev-parse": "whatever-the-branch-is-at"}}
+
+	p, err := prepare(context.Background(), Target{ID: "thing", URL: "u", Pin: "pinnedaaaaaa"},
+		t.TempDir(), func(Plan) error { return nil }, git.run)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !git.ran("clone") || !git.ran("checkout") {
+		t.Fatalf("git calls = %v, want it cloned and put at its pin", git.calls)
+	}
+	if p.Revision != "pinnedaaaaaa" {
+		t.Errorf("pin = %q, want the repository's own pin", p.Revision)
+	}
+}
+
+// And if it cannot be put there, that is a failure rather than a repository
+// quietly re-pinned at a tree nobody chose.
+func TestARemadeCloneThatCannotReachItsPinIsAFailure(t *testing.T) {
+	git := &fakeGit{
+		answer: map[string]string{"rev-parse": "somewhere-else"},
+		fail:   map[string]error{"checkout": errors.New("reference is not a tree")},
+	}
+
+	_, err := prepare(context.Background(), Target{ID: "thing", URL: "u", Pin: "pinnedaaaaaa"},
+		t.TempDir(), func(Plan) error { return nil }, git.run)
+
+	if err == nil || !strings.Contains(err.Error(), "pinnedaaaaaa") {
+		t.Fatalf("err = %v, want a failure naming the pin", err)
+	}
+}
+
+// The last line of defence: a repository already pinned may not come back from
+// admission at some other revision, however that happened.
+func TestAnAdmittedRepositoryNeverComesBackAtADifferentRevision(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "thing"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A correction that reports success and leaves the tree where it was.
+	git := &fakeGit{answer: map[string]string{"rev-parse": "movedbbbbbbb"}, stuck: true}
+
+	_, err := prepare(context.Background(), Target{ID: "thing", URL: "u", Pin: "pinnedaaaaaa"},
+		root, func(Plan) error { return nil }, git.run)
+
+	if err == nil || !strings.Contains(err.Error(), "did not use") {
+		t.Fatalf("err = %v, want a refusal rather than a silent re-pin", err)
+	}
+}
+
+// A clone is minutes of network and an interrupt part way through leaves a
+// half-made directory behind. Every admission after that finds a directory,
+// cannot read a revision out of it, and — for a repository that is not in the
+// catalog and so has no pin to recover from — says only "not a git repository".
+// The way out is one removal, and the message is what says so.
+func TestAHalfMadeCloneSaysHowToGetOutOfIt(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "thing"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	git := &fakeGit{fail: map[string]error{"rev-parse": errors.New("not a git repository")}}
+
+	_, err := prepare(context.Background(), Target{ID: "thing", URL: "u"},
+		root, func(Plan) error { return nil }, git.run)
+
+	if err == nil {
+		t.Fatal("a half-made clone was admitted")
+	}
+	for _, want := range []string{"not a git repository", filepath.Join(root, "thing"), "remove it"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("err = %q, want it to carry %q", err, want)
+		}
+	}
+}
+
+// The same message would be wrong about a directory the lab did not make, so it
+// is not said there: a handed-in path that is not a repository is the operator's
+// to explain, and telling them to delete it is telling them to delete their own
+// directory.
+func TestTheRemovalIsOnlySuggestedForTheLabsOwnDirectory(t *testing.T) {
+	handed := t.TempDir()
+	git := &fakeGit{fail: map[string]error{"rev-parse": errors.New("not a git repository")}}
+
+	_, err := prepare(context.Background(), Target{ID: "thing", Checkout: handed},
+		t.TempDir(), func(Plan) error { return nil }, git.run)
+
+	if err == nil {
+		t.Fatal("a directory that is not a repository was admitted")
+	}
+	if strings.Contains(err.Error(), "remove it") {
+		t.Errorf("err = %q, want no advice to delete a directory the lab does not own", err)
+	}
+}

--- a/lab/internal/repo/index.go
+++ b/lab/internal/repo/index.go
@@ -1,0 +1,218 @@
+package repo
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Language is one language's share of an index, as Sense reports it.
+type Language struct {
+	Files   int    `json:"files"`
+	Symbols int    `json:"symbols"`
+	Tier    string `json:"tier"`
+}
+
+// Index is the index phase's artifact: what an index over this checkout holds,
+// and the answer it was quoted from.
+//
+// The counts are quoted from `sense_status` rather than estimated, and the
+// whole answer is kept beside them under Status. A field this record does not
+// name is still readable by whoever reads the artifact next, which is the
+// difference between a summary and a measurement.
+type Index struct {
+	Repo              string              `json:"repo"`
+	URL               string              `json:"url"`
+	Revision          string              `json:"revision"`
+	Checkout          string              `json:"checkout"`
+	ScannedAt         string              `json:"scanned_at"`
+	SenseVersion      string              `json:"sense_version"`
+	Files             int                 `json:"files"`
+	Symbols           int                 `json:"symbols"`
+	Edges             int                 `json:"edges"`
+	Embeddings        int                 `json:"embeddings"`
+	EmbeddingCoverage float64             `json:"embedding_coverage"`
+	Languages         map[string]Language `json:"languages"`
+	ProfileTier       string              `json:"profile_tier"`
+	// Shortfall is present only when the scan indexed nothing, and it says so
+	// in a sentence rather than by leaving a reader to notice two zeroes.
+	//
+	// The failure it exists to prevent is a misreading rather than a crash: an
+	// index quietly short of its symbols is how a repository gets called dark
+	// when the tool simply did not run, and the authoring phase reads this file
+	// to decide exactly that.
+	Shortfall string `json:"shortfall,omitempty"`
+	// Status is the `sense_status` answer as it was returned.
+	Status json.RawMessage `json:"sense_status"`
+}
+
+// Indexed reports whether the scan produced an index worth authoring against.
+func (i Index) Indexed() bool { return i.Shortfall == "" }
+
+// statusExchange is the smallest conversation that gets `sense_status` out of
+// the Sense MCP server: initialise, say so, ask.
+//
+// The server is asked rather than the index file read, and that is the law
+// rather than a preference: the MCP server is the channel a benched agent
+// actually has, and a count taken from the SQLite file would measure a channel
+// nobody has.
+const statusExchange = `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"sense-lab","version":"1"}}}
+{"jsonrpc":"2.0","method":"notifications/initialized"}
+{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"sense_status","arguments":{}}}
+`
+
+// Scan indexes the checkout and records what the index holds.
+//
+// It runs the product binary the way a user would: `sense scan` over the
+// checkout, then the server. If Sense is slow or wrong on a repository, that is
+// a finding about the product and this records it rather than working around
+// it.
+func Scan(ctx context.Context, senseBin string, p Plan, at time.Time) (Index, error) {
+	// -dir, not a positional path: sense scan silently ignores positionals.
+	// -embed, because the count this artifact records has to be the final one:
+	// embedding continues in the background otherwise, and the number written
+	// here would be whatever it had reached by the time the process exited.
+	scan := exec.CommandContext(ctx, senseBin, "scan", "-dir", p.Checkout, "-embed")
+	if out, err := scan.CombinedOutput(); err != nil {
+		return Index{}, fmt.Errorf("index %s: %w: %s", p.Checkout, err, bytes.TrimSpace(out))
+	}
+
+	raw, err := senseStatus(ctx, senseBin, p.Checkout)
+	if err != nil {
+		return Index{}, err
+	}
+	return record(raw, p, at)
+}
+
+// senseStatus asks the server what the index holds, in the checkout.
+//
+// The working directory is the whole measurement. The server reads the index of
+// wherever it is started, so a status taken anywhere else answers about another
+// repository entirely — with counts that look exactly as plausible as the right
+// ones.
+//
+// Its stderr is carried into the error for the same reason git's is: "exit
+// status 1" is not something anybody can act on, and the server's own message
+// says which of the several things went wrong.
+func senseStatus(ctx context.Context, senseBin, dir string) (json.RawMessage, error) {
+	cmd := exec.CommandContext(ctx, senseBin, "mcp")
+	cmd.Dir = dir
+	cmd.Stdin = strings.NewReader(statusExchange)
+	var errBuf bytes.Buffer
+	cmd.Stderr = &errBuf
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("ask the sense server for the status of %s: %w: %s",
+			dir, err, bytes.TrimSpace(errBuf.Bytes()))
+	}
+	return statusInReply(out)
+}
+
+// statusInReply pulls the tool's answer out of the server's replies. The answer
+// is a document inside a text field, which is how MCP carries one.
+func statusInReply(out []byte) (json.RawMessage, error) {
+	var reply struct {
+		ID     int `json:"id"`
+		Result struct {
+			Content []struct {
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"result"`
+	}
+	r := bufio.NewReader(bytes.NewReader(out))
+	for {
+		line, err := r.ReadBytes('\n')
+		if len(line) > 0 {
+			reply.Result.Content = nil
+			if json.Unmarshal(line, &reply) == nil && reply.ID == 2 && len(reply.Result.Content) > 0 {
+				text := json.RawMessage(reply.Result.Content[0].Text)
+				if !json.Valid(text) {
+					return nil, fmt.Errorf("the sense server's status was not a document: %.120s", text)
+				}
+				return text, nil
+			}
+		}
+		if err != nil {
+			return nil, fmt.Errorf("the sense server never answered sense_status")
+		}
+	}
+}
+
+// record turns the server's answer into the artifact.
+func record(raw json.RawMessage, p Plan, at time.Time) (Index, error) {
+	var s struct {
+		Index struct {
+			Files      int     `json:"files"`
+			Symbols    int     `json:"symbols"`
+			Edges      int     `json:"edges"`
+			Embeddings int     `json:"embeddings"`
+			Coverage   float64 `json:"coverage"`
+		} `json:"index"`
+		Languages map[string]Language `json:"languages"`
+		Profile   struct {
+			Tier string `json:"tier"`
+		} `json:"profile"`
+		Version struct {
+			Binary string `json:"binary"`
+		} `json:"version"`
+	}
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return Index{}, fmt.Errorf("read the sense server's status: %w", err)
+	}
+	i := Index{
+		Repo: p.ID, URL: p.URL, Revision: p.Revision, Checkout: p.Checkout,
+		ScannedAt:    at.UTC().Format(time.RFC3339),
+		SenseVersion: s.Version.Binary,
+		Files:        s.Index.Files,
+		Symbols:      s.Index.Symbols,
+		Edges:        s.Index.Edges,
+		Embeddings:   s.Index.Embeddings,
+
+		EmbeddingCoverage: s.Index.Coverage,
+		Languages:         s.Languages,
+		ProfileTier:       s.Profile.Tier,
+		Status:            raw,
+	}
+	if i.Files == 0 || i.Symbols == 0 {
+		i.Shortfall = fmt.Sprintf("the scan of %s indexed %d files and %d symbols, so there is no index "+
+			"to author against. This is the tool failing to run, not a repository with nothing in it, "+
+			"and nothing downstream may read it as either", p.Checkout, i.Files, i.Symbols)
+	}
+	return i, nil
+}
+
+// Write puts a record where its phase declares it, creating the directory it
+// belongs in. Both files admission leaves behind go through here — the index
+// artifact and the repository file — so they are indented the same way and a
+// person diffing one against last month's is reading a diff of the content.
+func Write(path string, record any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("prepare %s: %w", filepath.Dir(path), err)
+	}
+	b, err := json.MarshalIndent(record, "", "  ")
+	if err != nil {
+		return fmt.Errorf("render %s: %w", path, err)
+	}
+	return os.WriteFile(path, append(b, '\n'), 0o644)
+}
+
+// Names is the languages an index found, sorted. It is what the repository file
+// records, and it comes from the scan rather than from a judgement about the
+// repository: a vertical query selects on it, so a guess here is a repository
+// that silently never matches.
+func (i Index) Names() []string {
+	out := make([]string, 0, len(i.Languages))
+	for name := range i.Languages {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/lab/internal/repo/index_test.go
+++ b/lab/internal/repo/index_test.go
@@ -1,0 +1,431 @@
+package repo
+
+import (
+	"context"
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// realStatus is the shape `sense_status` actually answers in, trimmed to the
+// keys this artifact reads. It is quoted from a real answer rather than
+// invented, because a record that parses a shape the server does not send is a
+// record of nothing.
+const realStatus = `{"index":{"path":".sense/index.db","size_bytes":33419264,"files":2137,"symbols":11410,` +
+	`"edges":23698,"embeddings":11410,"coverage":1},"languages":{"csharp":{"files":2137,"symbols":11410,` +
+	`"tier":"standard"},"go":{"files":12,"symbols":40,"tier":"full"}},"profile":{"tier":"medium"},` +
+	`"version":{"binary":"1.14.1-dev+gb5b78be","schema":5},"next_steps":[]}`
+
+// fakeSense stands in for the product, and it is deliberately strict about the
+// three things the caller has to get right: it refuses to answer anywhere but
+// the checkout, it records the argv it was given, and it answers sense_status
+// only after an initialise and only when that is the tool asked for.
+//
+// A permissive stand-in was worse than none here. An earlier one answered any
+// line carrying `tools/call` from any directory, and under it the server could
+// be asked in the wrong repository, the scan could lose its flags, and the
+// handshake could be deleted outright, with the suite green through all of it.
+func fakeSense(t *testing.T, status string) (bin string, argv func() string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the stand-in is a shell script")
+	}
+	dir := t.TempDir()
+	bin = filepath.Join(dir, "sense")
+	log := filepath.Join(dir, "argv")
+	script := `#!/bin/sh
+set -e
+echo "$@" >> "` + log + `"
+case "$1" in
+scan) mkdir -p "$3/.sense"; printf 'index' > "$3/.sense/index.db" ;;
+mcp)
+  if [ "$PWD" != "$SENSE_EXPECTED_DIR" ]; then
+    echo "asked in $PWD, not in $SENSE_EXPECTED_DIR" >&2
+    exit 9
+  fi
+  ready=""
+  while IFS= read -r line; do
+    case "$line" in
+      *'"initialize"'*) ready=1 ;;
+      *'"sense_status"'*)
+        [ -n "$ready" ] || { echo "asked before the handshake" >&2; exit 9; }
+        printf '{"jsonrpc":"2.0","id":1,"result":{"serverInfo":{}}}\n'
+        printf '{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":%s}]}}\n' "$STATUS"
+        ;;
+    esac
+  done
+  ;;
+esac
+`
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The status document is carried in the environment rather than baked into
+	// the script, so a test can vary the one thing it is varying.
+	t.Setenv("STATUS", mustQuote(t, status))
+	return bin, func() string {
+		b, err := os.ReadFile(log)
+		if err != nil {
+			t.Fatalf("the stand-in was never run: %v", err)
+		}
+		return string(b)
+	}
+}
+
+// mustQuote renders the status document as the JSON string the MCP text field
+// carries it in.
+func mustQuote(t *testing.T, status string) string {
+	t.Helper()
+	b, err := json.Marshal(status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+func scanned(t *testing.T, status string) Index {
+	t.Helper()
+	i, _ := scannedWithArgv(t, status)
+	return i
+}
+
+func scannedWithArgv(t *testing.T, status string) (Index, string) {
+	t.Helper()
+	checkout := t.TempDir()
+	bin, argv := fakeSense(t, status)
+	// The server answers about the index of wherever it is started, so the
+	// stand-in refuses to answer anywhere else and this is what it compares
+	// against.
+	t.Setenv("SENSE_EXPECTED_DIR", checkout)
+	at := time.Date(2026, 8, 19, 10, 30, 0, 0, time.UTC)
+	i, err := Scan(context.Background(), bin,
+		Plan{ID: "jellyfin", URL: "https://example.test/jellyfin.git", Revision: "abc123", Checkout: checkout}, at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return i, argv()
+}
+
+// The counts are quoted from the server, never estimated, and the whole answer
+// is kept beside them: a field this record does not name is still readable by
+// whoever reads the artifact next.
+func TestTheArtifactQuotesWhatTheServerAnswered(t *testing.T) {
+	i := scanned(t, realStatus)
+
+	for _, tc := range []struct {
+		what      string
+		got, want any
+	}{
+		{"files", i.Files, 2137},
+		{"symbols", i.Symbols, 11410},
+		{"edges", i.Edges, 23698},
+		{"embeddings", i.Embeddings, 11410},
+		{"embedding coverage", i.EmbeddingCoverage, float64(1)},
+		{"profile tier", i.ProfileTier, "medium"},
+		{"sense version", i.SenseVersion, "1.14.1-dev+gb5b78be"},
+		{"scanned at", i.ScannedAt, "2026-08-19T10:30:00Z"},
+		{"revision", i.Revision, "abc123"},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s = %v, want %v", tc.what, tc.got, tc.want)
+		}
+	}
+	if !json.Valid(i.Status) {
+		t.Error("the server's own answer was not kept beside the counts")
+	}
+	if !i.Indexed() {
+		t.Error("a repository with 11410 symbols reads as unindexed")
+	}
+}
+
+// The languages come from the scan rather than from a judgement about the
+// repository: a vertical query selects on them, so a guess is a repository that
+// silently never matches.
+func TestTheLanguagesComeFromTheScanAndAreSorted(t *testing.T) {
+	i := scanned(t, realStatus)
+
+	got := i.Names()
+	if len(got) != 2 || got[0] != "csharp" || got[1] != "go" {
+		t.Errorf("Names() = %v, want the indexed languages in order", got)
+	}
+	if i.Languages["csharp"].Tier != "standard" {
+		t.Errorf("csharp tier = %q, want what the server said", i.Languages["csharp"].Tier)
+	}
+}
+
+// A scan that indexed nothing says so in a sentence. This is the failure the
+// index plan explicitly forbids softening: an index quietly short of its symbols
+// is how a repository gets called dark when the tool simply did not run, and the
+// authoring phase reads this file to decide exactly that.
+func TestAScanThatIndexedNothingSaysSo(t *testing.T) {
+	for _, tc := range []struct{ name, index string }{
+		{"nothing at all", `{"files":0,"symbols":0}`},
+		{"files and no symbols, which is the half-scan", `{"files":900,"symbols":0}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			i := scanned(t, `{"index":`+tc.index+`,"languages":{},"version":{"binary":"1.14.1"}}`)
+
+			if i.Indexed() {
+				t.Fatal("an index with no symbols reads as indexed")
+			}
+			if !strings.Contains(i.Shortfall, "0 symbols") {
+				t.Errorf("shortfall = %q, want it to say what was indexed", i.Shortfall)
+			}
+		})
+	}
+}
+
+func TestAFailedScanCarriesTheToolsOwnOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the stand-in is a shell script")
+	}
+	bin := filepath.Join(t.TempDir(), "sense")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\necho 'no grammar for this tree' >&2\nexit 3\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Scan(context.Background(), bin, Plan{ID: "x", Checkout: t.TempDir()}, time.Now())
+
+	if err == nil {
+		t.Fatal("a scan that exited 3 was recorded as an index")
+	}
+	if !strings.Contains(err.Error(), "no grammar for this tree") {
+		t.Errorf("err = %q, want the tool's own output", err)
+	}
+}
+
+// The server is asked and it may not answer. A missing answer is a failure
+// rather than an artifact full of zeroes, which would read exactly like a
+// repository Sense found nothing in.
+func TestAServerThatNeverAnswersIsAFailureRatherThanAnEmptyIndex(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the stand-in is a shell script")
+	}
+	bin := filepath.Join(t.TempDir(), "sense")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\ncase \"$1\" in scan) exit 0 ;; mcp) cat > /dev/null ;; esac\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Scan(context.Background(), bin, Plan{ID: "x", Checkout: t.TempDir()}, time.Now())
+
+	if err == nil || !strings.Contains(err.Error(), "never answered") {
+		t.Fatalf("err = %v, want a refusal naming the unanswered call", err)
+	}
+}
+
+func TestASenseBinaryThatCannotBeRunNamesWhatItCouldNotIndex(t *testing.T) {
+	checkout := t.TempDir()
+
+	_, err := Scan(context.Background(), filepath.Join(t.TempDir(), "absent"),
+		Plan{ID: "x", Checkout: checkout}, time.Now())
+
+	if err == nil {
+		t.Fatal("a missing sense binary produced an index")
+	}
+	if !strings.Contains(err.Error(), checkout) {
+		t.Errorf("err = %q, want it to name the checkout it could not index", err)
+	}
+}
+
+func TestStatusInReplyReadsTheAnswerOutOfTheStream(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		reply string
+		want  string
+	}{
+		{"the answer, past the handshake",
+			"{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}\n" +
+				`{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"{\"index\":{\"files\":7}}"}]}}` + "\n",
+			`{"index":{"files":7}}`},
+		{"an earlier reply that carries content of its own is not the answer",
+			`{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"{\"index\":{\"files\":999}}"}]}}` + "\n" +
+				`{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"{\"index\":{\"files\":7}}"}]}}` + "\n",
+			`{"index":{"files":7}}`},
+		{"an answer with no trailing newline",
+			`{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"{\"index\":{}}"}]}}`,
+			`{"index":{}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := statusInReply([]byte(tc.reply))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("statusInReply = %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+// A reply that carries nothing is not answered with somebody else's content.
+// The decoder reuses what it decoded last, so without the reset an earlier
+// reply's document is returned as the answer to a call that failed — the status
+// of nothing, recorded as the status of this repository.
+func TestAFailedCallIsNotAnsweredWithAnEarlierReply(t *testing.T) {
+	reply := `{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"{\"index\":{\"files\":999}}"}]}}` + "\n" +
+		`{"jsonrpc":"2.0","id":2,"error":{"code":-32603,"message":"no index"}}` + "\n"
+
+	_, err := statusInReply([]byte(reply))
+
+	if err == nil {
+		t.Fatal("a failed call was answered with an earlier reply's document")
+	}
+}
+
+// A server that answered with prose rather than a document is refused. Recording
+// it would put something no reader can parse where the counts belong.
+func TestAnAnswerThatIsNotADocumentIsRefused(t *testing.T) {
+	_, err := statusInReply([]byte(`{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"no index here"}]}}` + "\n"))
+
+	if err == nil || !strings.Contains(err.Error(), "not a document") {
+		t.Fatalf("err = %v, want a refusal naming what came back", err)
+	}
+}
+
+// A document the record cannot read is a failure. The alternative is an
+// artifact of zeroes that reads as a dark repository.
+func TestAStatusThatCannotBeReadIsAFailure(t *testing.T) {
+	_, err := record(json.RawMessage(`{"index":[]}`), Plan{}, time.Now())
+
+	if err == nil {
+		t.Fatal("a status of the wrong shape was recorded")
+	}
+}
+
+func TestWriteMakesThePhaseDirectoryAndLeavesReadableJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "campaign", "jellyfin", "index", "index.json")
+
+	if err := Write(path, scanned(t, realStatus)); err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var back Index
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("the artifact does not read back: %v", err)
+	}
+	if back.Symbols != 11410 {
+		t.Errorf("symbols = %d, want what was written", back.Symbols)
+	}
+	if !strings.HasSuffix(string(b), "\n") {
+		t.Error("the artifact does not end in a newline")
+	}
+	// A clean index says nothing about a shortfall, rather than saying "".
+	if strings.Contains(string(b), "shortfall") {
+		t.Error("a clean index carries a shortfall field")
+	}
+}
+
+func TestWriteReportsADirectoryItCannotMake(t *testing.T) {
+	blocked := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(blocked, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Write(filepath.Join(blocked, "index", "index.json"), Index{}); err == nil {
+		t.Fatal("writing under a file succeeded")
+	}
+}
+
+// Every artifact this package leaves behind goes through one writer, so a
+// record it cannot render is refused rather than half-written.
+func TestWriteRefusesARecordItCannotRender(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "index.json")
+
+	if err := Write(path, Index{EmbeddingCoverage: math.NaN()}); err == nil {
+		t.Fatal("a record that is not renderable was written")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("a file was left behind by a write that failed")
+	}
+}
+
+// The scan runs over the checkout by flag and blocks on embeddings, and both of
+// those are load-bearing rather than stylistic: `sense scan` ignores a
+// positional path outright, and without -embed the embedding count recorded here
+// is whatever the background pass had reached when the process exited.
+func TestTheScanIsRunOverTheCheckoutAndWaitsForItsEmbeddings(t *testing.T) {
+	_, argv := scannedWithArgv(t, realStatus)
+
+	if !strings.Contains(argv, "scan -dir ") {
+		t.Errorf("argv = %q, want the checkout passed as -dir; a positional path is silently ignored", argv)
+	}
+	if !strings.Contains(argv, "-embed") {
+		t.Errorf("argv = %q, want -embed, or the embedding count is whatever it had reached", argv)
+	}
+}
+
+// The server answers about the index of wherever it was started, so a status
+// taken anywhere else describes another repository entirely — with counts that
+// look exactly as plausible as the right ones. The stand-in refuses to answer
+// outside the checkout, which is what makes every other test in this file a
+// test of the right repository.
+func TestTheServerIsAskedInTheCheckout(t *testing.T) {
+	bin, _ := fakeSense(t, realStatus)
+	t.Setenv("SENSE_EXPECTED_DIR", "/somewhere/else")
+
+	_, err := Scan(context.Background(), bin, Plan{ID: "x", Checkout: t.TempDir()}, time.Now())
+
+	if err == nil {
+		t.Fatal("the server was asked somewhere other than the checkout and the answer was recorded")
+	}
+}
+
+// A server that fails says why, and its own words are what reach the operator.
+// Without this the whole failure reads as "exit status 9", which is not
+// something anybody can act on.
+func TestAServerThatFailsCarriesItsOwnMessage(t *testing.T) {
+	bin, _ := fakeSense(t, realStatus)
+	t.Setenv("SENSE_EXPECTED_DIR", "/somewhere/else")
+
+	_, err := Scan(context.Background(), bin, Plan{ID: "x", Checkout: t.TempDir()}, time.Now())
+
+	if err == nil || !strings.Contains(err.Error(), "not in /somewhere/else") {
+		t.Fatalf("err = %v, want the server's own message", err)
+	}
+}
+
+// The one pass against the real server. Everything else in this file is written
+// against a stand-in, and a stand-in cannot tell whether the exchange this
+// package sends is one the product actually answers — which is a whole phase
+// that would fail only when it is run for real, against a repository somebody
+// waited to clone.
+func TestTheRealServerAnswersTheExchangeWeSend(t *testing.T) {
+	bin := builtSense(t)
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "app.go"), []byte("package app\n\ntype Category struct{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	i, err := Scan(context.Background(), bin, Plan{ID: "x", Checkout: dir}, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if i.Symbols == 0 || i.SenseVersion == "" {
+		t.Errorf("the real server answered %+v, want counts and a version", i)
+	}
+}
+
+// builtSense is the product binary this repository builds, or a skip. It is not
+// built here: `make build` and `make ci` both make it, and building a CGO binary
+// inside a test would be minutes per run.
+func builtSense(t *testing.T) string {
+	t.Helper()
+	bin, err := filepath.Abs(filepath.Join("..", "..", "..", "bin", "sense"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(bin); err != nil {
+		t.Skip("bin/sense is not built; run make build")
+	}
+	return bin
+}

--- a/lab/internal/repo/resolve.go
+++ b/lab/internal/repo/resolve.go
@@ -1,0 +1,120 @@
+// Package repo admits a repository to the lab: it works out what was named,
+// clones it, pins it at the tree it actually got, and records what an index
+// over that tree holds.
+//
+// Admission used to be three manual acts that nothing checked against each
+// other — a clone, a hand-written `repos/<id>.json` with a sha copied out of
+// it, and a scan — and the failure that produced is silent. A sha in the json
+// that is not the sha the clone sits at gives every later run a worktree at the
+// wrong tree, and nothing about a result says so.
+//
+// The package is split by what it may do. [Resolve] decides, and it is pure: it
+// reaches no network and no disk, so what a name resolves to can be table
+// tested. Everything below it acts, and it acts only after the decision has
+// been announced.
+package repo
+
+import (
+	"fmt"
+	"regexp"
+	"slices"
+	"strings"
+)
+
+// Kind is what an input turned out to name.
+type Kind string
+
+const (
+	// Known is a repository the catalog already holds. Nothing is admitted:
+	// the command prints where it stands.
+	Known Kind = "known"
+	// Local is a path that exists on disk, handed in by whoever ran the
+	// command. The lab reads it and never writes to it.
+	Local Kind = "local"
+	// Handle is `owner/name`, which is a github repository.
+	Handle Kind = "handle"
+	// Remote is anything carrying a scheme, taken verbatim.
+	Remote Kind = "remote"
+)
+
+// Resolution is what an input came to: which repository, by which reading.
+type Resolution struct {
+	Kind Kind
+	ID   string
+	// URL is where the repository comes from. Empty for a [Local] path, whose
+	// origin can only be read out of the clone.
+	URL string
+	// Path is the handed-in directory, set for [Local] and nothing else.
+	Path string
+}
+
+// handle is `owner/name` and nothing else: two segments of the characters
+// github allows in a name, with no scheme, no host and no third segment. It is
+// deliberately strict, because everything it does not match falls through to a
+// refusal rather than to a guess at a url.
+var handle = regexp.MustCompile(`^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$`)
+
+// scheme is a url's leading `git@host:` or `xxx://`. The scp-like form is
+// matched too, because that is what a private repository is usually handed in
+// as and treating it as a path would refuse it for not existing.
+var scheme = regexp.MustCompile(`^([A-Za-z][A-Za-z0-9+.-]*://|[^/]+@[^/:]+:)`)
+
+// Resolve works out which repository an input names.
+//
+// The order is the contract, and it is first match wins: a known id, then a
+// path on disk, then `owner/name`, then a url. The ambiguous case is real — a
+// local directory named `owner/name` is readable both ways — and it resolves as
+// the path, because a directory that is there is evidence and a handle is a
+// guess.
+//
+// It is pure. `known` is the catalog's ids and `onDisk` reports whether a path
+// is a directory; both are the caller's to supply, so nothing here decides a
+// repository by reaching for a network that may answer differently tomorrow.
+func Resolve(in string, known []string, onDisk func(string) bool) (Resolution, error) {
+	in = strings.TrimSpace(in)
+	switch {
+	case in == "":
+		return Resolution{}, fmt.Errorf("name a repository: an id already admitted, a path to a clone, `owner/name`, or a url")
+	case slices.Contains(known, in):
+		return Resolution{Kind: Known, ID: in}, nil
+	case onDisk(in):
+		return Resolution{Kind: Local, ID: idOfPath(in), Path: in}, nil
+	case handle.MatchString(in):
+		// The suffix is trimmed before the url is built, not after: a handle
+		// typed as `owner/thing.git` is the same repository as `owner/thing`,
+		// and appending to the untrimmed name would resolve it to a url ending
+		// `.git.git` — which clones nothing, at the end of a phase.
+		owner, name, _ := strings.Cut(in, "/")
+		name = trimGit(name)
+		return Resolution{Kind: Handle, ID: name, URL: "https://github.com/" + owner + "/" + name + ".git"}, nil
+	case scheme.MatchString(in):
+		return Resolution{Kind: Remote, ID: idOfURL(in), URL: in}, nil
+	}
+	return Resolution{}, fmt.Errorf("cannot read %q as a repository: it is not an admitted id, "+
+		"there is no such directory, and it is neither `owner/name` nor a url", in)
+}
+
+// idOfPath and idOfURL take the repository's own name as its id, which is the
+// convention every repository file already follows: `discourse/discourse` is
+// `discourse`, and so is a clone of it sitting in a directory of that name.
+//
+// Two repositories whose names collide would collide here. That is left alone
+// rather than defended against with a disambiguating suffix nobody would
+// recognise: the second admission finds the first's id already known, prints
+// where that repository stands, and the collision is visible in the scrollback
+// instead of buried in an id.
+func idOfPath(path string) string {
+	path = strings.TrimRight(path, "/")
+	if i := strings.LastIndex(path, "/"); i >= 0 {
+		path = path[i+1:]
+	}
+	return trimGit(path)
+}
+
+func idOfURL(url string) string {
+	url = strings.TrimRight(url, "/")
+	url = url[strings.LastIndexAny(url, "/:")+1:]
+	return trimGit(url)
+}
+
+func trimGit(name string) string { return strings.TrimSuffix(name, ".git") }

--- a/lab/internal/repo/resolve_test.go
+++ b/lab/internal/repo/resolve_test.go
@@ -1,0 +1,119 @@
+package repo
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The resolver decides which repository a name means, and getting that wrong
+// quietly is worse than refusing: every phase after it reads a repository
+// nobody chose. So the whole order is table tested, including the one case
+// where two readings are both defensible.
+func TestResolveReadsANameByTheDocumentedOrder(t *testing.T) {
+	known := []string{"discourse"}
+	nowhere := func(string) bool { return false }
+	everywhere := func(string) bool { return true }
+	thisOne := func(path string) bool {
+		return path == "/clones/rails" || path == "/clones/rails/" || path == "owner/name"
+	}
+
+	for _, tc := range []struct {
+		name string
+		in   string
+		// onDisk is per case, because the order is only testable where the
+		// readings compete: what a name resolves to depends on what is there.
+		onDisk func(string) bool
+		want   Resolution
+	}{
+		{"an id the catalog already holds is not admitted again",
+			"discourse", nowhere, Resolution{Kind: Known, ID: "discourse"}},
+		{"a path that exists is a local clone",
+			"/clones/rails", thisOne, Resolution{Kind: Local, ID: "rails", Path: "/clones/rails"}},
+		{"owner/name is a github repository",
+			"jellyfin/jellyfin", nowhere, Resolution{Kind: Handle, ID: "jellyfin",
+				URL: "https://github.com/jellyfin/jellyfin.git"}},
+		{"a name that is not the owner's is still the repository's",
+			"rails/activerecord", nowhere, Resolution{Kind: Handle, ID: "activerecord",
+				URL: "https://github.com/rails/activerecord.git"}},
+		{"anything with a scheme is taken verbatim",
+			"https://gitlab.test/team/thing.git", nowhere, Resolution{Kind: Remote, ID: "thing",
+				URL: "https://gitlab.test/team/thing.git"}},
+		{"an scp-like url is a url, not a path that is missing",
+			"git@github.com:owner/private.git", nowhere, Resolution{Kind: Remote, ID: "private",
+				URL: "git@github.com:owner/private.git"}},
+		{"a trailing slash does not become the id",
+			"/clones/rails/", thisOne, Resolution{Kind: Local, ID: "rails", Path: "/clones/rails/"}},
+		{"surrounding whitespace is not part of a name",
+			"  jellyfin/jellyfin  ", nowhere, Resolution{Kind: Handle, ID: "jellyfin",
+				URL: "https://github.com/jellyfin/jellyfin.git"}},
+		// The ambiguity is real rather than theoretical: `owner/name` is a
+		// handle and a relative directory at the same time. The path wins,
+		// because a directory that is there is evidence and a handle is a
+		// guess — and a run that cloned github while the operator meant the
+		// clone in front of them would be measuring somebody else's tree.
+		{"a path that exists beats a handle that would read the same",
+			"owner/name", thisOne, Resolution{Kind: Local, ID: "name", Path: "owner/name"}},
+		// And an admitted id beats both. Admission has to be idempotent for
+		// the crank to call it on every invocation, and a second reading of an
+		// admitted id would re-admit it.
+		{"an admitted id beats a directory of the same name",
+			"discourse", everywhere, Resolution{Kind: Known, ID: "discourse"}},
+		// A `.git` suffix is how a clone directory and a url both spell the
+		// same repository, and an id carrying it would make one repository
+		// admittable twice under two names.
+		{"a .git suffix is not part of an id, in a handle",
+			"owner/thing.git", nowhere, Resolution{Kind: Handle, ID: "thing",
+				URL: "https://github.com/owner/thing.git"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Resolve(tc.in, known, tc.onDisk)
+			if err != nil {
+				t.Fatalf("Resolve(%q) = %v", tc.in, err)
+			}
+			if got != tc.want {
+				t.Errorf("Resolve(%q) = %+v, want %+v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveRefusesWhatItCannotRead(t *testing.T) {
+	for _, tc := range []struct{ name, in string }{
+		{"nothing at all", ""},
+		{"only whitespace", "   "},
+		{"a bare word that is neither an id nor a path", "jellyfin"},
+		{"three segments, which is not a handle", "github.com/owner/name"},
+		// The resolver is the door: every name that gets past it is handed to
+		// git as an operand. A name that reads as an option would otherwise
+		// reach `git clone`, where `--upload-pack` runs whatever it names.
+		{"a name that would read as a git option", "--upload-pack=touch /tmp/pwned"},
+		{"a name that would read as a git option, with a slash in it", "-c/protocol.ext.allow=always"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := Resolve(tc.in, nil, func(string) bool { return false }); err == nil {
+				t.Errorf("Resolve(%q) resolved; a guess here is a repository nobody chose", tc.in)
+			}
+		})
+	}
+}
+
+// OnDisk is what the command hands Resolve, and it is the same test the
+// checkout side uses to find one. A file is not a checkout.
+func TestOnDiskIsDirectoriesOnly(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "README")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !OnDisk(dir) {
+		t.Error("OnDisk(a directory) = false")
+	}
+	if OnDisk(file) {
+		t.Error("OnDisk(a file) = true; a file is not a clone")
+	}
+	if OnDisk(filepath.Join(dir, "absent")) {
+		t.Error("OnDisk(nothing) = true")
+	}
+}

--- a/lab/repos/README.md
+++ b/lab/repos/README.md
@@ -9,6 +9,11 @@ the commit it is pinned at, its languages and its stack.
  "languages": ["ruby"], "stack": "ruby"}
 ```
 
+`sense-lab repo <handle|url|path>` writes one of these. The commit is read back
+out of the clone rather than copied by hand, and `checkout` is present only for
+a clone somebody handed in: its absence is what says the lab made this one and
+may move it back to its pin.
+
 Empty on purpose. The repositories this instrument was built against were
 removed once it was finished, because they were how it was crafted rather than
 what it is for. See `../README.md` for the path from here to a scored cell.


### PR DESCRIPTION
## Problem

Admitting a repository to the bench is three manual acts today and nothing checks that they agree with each other: a human clones it, hand-writes `lab/repos/<id>.json` with a commit copied out of the clone, and runs `sense scan` over it.

Two things go wrong and only one of them is loud. A sha typed into the json that is not the sha the clone sits at produces a worktree at the wrong tree for every run afterwards, and nothing says so. A scan that indexed half the tree produces a repository that reads as dark when the tool simply did not finish.

## Summary

`sense-lab repo <handle|url|path>` does the whole thing: resolve, clone, pin, index, record.

The resolver is pure and its order is first match wins — an admitted id, a path on disk, `owner/name`, then a url. A local directory named `owner/name` resolves as the path, because a directory that is there is evidence and a handle is a guess.

Nothing is written before the resolution is printed. Everything that decides runs first and touches nothing; the decision is announced; only then does anything reach a disk. The recorded pin is read back out of the clone rather than carried over from the request.

Ownership decides what may be moved: a clone the lab made and that drifted goes back to its pin, and a clone somebody handed in is read and never written to, with a mismatch refused and its reason given.

Re-running on an admitted repository admits nothing and prints where it stands, because the crank will call this on every invocation.

## Changes

- `lab/internal/repo`: the pure resolver, the checkout (clone, adopt, correct or refuse) and the index phase, which runs `sense scan` and reads its counts through the MCP server in the checkout
- `lab/internal/cli/repocmd.go`: the command, its announcement, and the two records it writes — the index artifact and the repository file, the latter written last and only when there is an index to read its languages off
- `catalog.Repo` gains `checkout`, whose absence is the ownership record
- `lab/README.md` and `lab/repos/README.md`: the first step of the shortest useful path is now this command

## Test plan

- `make ci` green: coverage floor with no new exception, zero complexity suppressions, lint clean
- new files hold 98.8–100% line coverage
- five mutations that a first draft of the tests let through are now killed, each verified by making the mutation and watching a named test fail: dropping `-embed` from the scan, asking the server outside the checkout, deleting the MCP handshake, selecting the reply without its id, and reusing an earlier reply's document for a call that failed
- the exchange is pinned against the real `sense` binary, not only against the stand-in
- end to end against a real repository: clone, pin, index, record, then a second run that admits nothing