### PR TITLE
bench(lab): read where a repository stands, and answer with it

### DIFF
--- a/lab/README.md
+++ b/lab/README.md
@@ -56,8 +56,31 @@ url and the revision — before it writes anything, then clones under
 ```
 
 Running it again on an admitted repository admits nothing and prints where it
-stands. A clone the lab made is moved back to its pin if it has drifted; a clone
-you handed in is read and never written to, and a mismatch there is refused.
+stands: the cycle it is on, the phase it awaits, and every rejection the next
+attempt has to answer. A clone the lab made is moved back to its pin if it has
+drifted; a clone you handed in is read and never written to, and a mismatch
+there is refused.
+
+`-show` prints that page and stops, writing nothing. The exit code carries the
+standing, because this command belongs in a loop:
+
+| Code | Means |
+|---|---|
+| 0 | there is a phase to run |
+| 2 | `-show`: a position was printed and nothing was done |
+| 3 | finished: the repository reached the board |
+| 4 | parked at the authoring ceiling, re-entered only by a deliberate human act |
+| 5 | waiting on a human: a `PAY` nothing will spend on its own |
+| 6 | refused: the last verdict is not one its phase can emit |
+| 7 | refused: the verdict is usable and the artifact it owed is not there |
+
+So `while sense-lab repo <id>; do :; done` stops on a park, on a `PAY` and on
+either refusal, rather than spinning on any of them.
+
+Position is derived from the run tree every time — the authoring cycle is a
+directory name — except for the verdicts, which are recorded one file per
+attempt and never rewritten. There is no state file mapping a repository to a
+phase.
 
 Every run takes a worktree from that clone at the pinned commit, so the clone is
 the only thing that has to exist on disk.

--- a/lab/internal/cli/cli.go
+++ b/lab/internal/cli/cli.go
@@ -28,7 +28,7 @@ const usage = `sense-lab — the bench instrument for Sense
 Usage: sense-lab <command> [flags]
 
 Commands:
-  repo      Admit a repository: resolve it, clone it, pin it and index it
+  repo      Admit a repository, and say where it stands: -show prints and stops
   catalog   Show the subjects, agents, models, repositories and executors in the config
   plan      Show what a campaign would run, and every rejection with its reason
   run       Run one scenario against one repository

--- a/lab/internal/cli/repocmd.go
+++ b/lab/internal/cli/repocmd.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/luuuc/sense/lab/internal/catalog"
+	"github.com/luuuc/sense/lab/internal/position"
 	"github.com/luuuc/sense/lab/internal/repo"
 )
 
@@ -20,6 +22,32 @@ import (
 // it made, and reads what it was given.
 const defaultCheckouts = "runs/checkouts"
 
+// The exit codes `sense-lab repo` answers with. They are its API rather than a
+// display, because this command ends up in a shell loop and what that loop stops
+// on is this:
+//
+//	while sense-lab repo <id>; do :; done
+//
+// It terminates on a park, on a PAY and on either refusal, and `-show` never
+// returns 0 so it cannot be dropped into that loop and spin.
+//
+// Two of them are worth telling apart above all: a park is the method failing on
+// this repository, and a PAY is the method succeeding and waiting on a wallet.
+// So are the two refusals: an agent that misbehaved, against an agent that died.
+//
+// exitShown is the binary's usage code, and that is not a collision in practice:
+// the codes are read with the arguments in hand, and a caller that passed -show
+// knows a position was printed while one that did not knows its flags were
+// wrong.
+const (
+	exitShown    = exitUsage
+	exitFinished = 3
+	exitParked   = 4
+	exitWaiting  = 5
+	exitUnusable = 6
+	exitMissing  = 7
+)
+
 // repoFlags is where a repository is admitted from and where the evidence of it
 // lands.
 type repoFlags struct {
@@ -27,6 +55,7 @@ type repoFlags struct {
 	campaign  string
 	checkouts string
 	senseBin  string
+	show      bool
 	name      string
 }
 
@@ -38,6 +67,7 @@ func parseRepoFlags(args []string, stderr io.Writer) (repoFlags, error) {
 	fs.StringVar(&f.campaign, "campaign", "", "the campaign's run tree, where the index artifact lands (required)")
 	fs.StringVar(&f.checkouts, "checkouts", defaultCheckouts, "the lab's own clones root")
 	fs.StringVar(&f.senseBin, "sense", "sense", "the Sense binary that indexes the repository")
+	fs.BoolVar(&f.show, "show", false, "print the position and stop, writing nothing")
 	if err := fs.Parse(args); err != nil {
 		return f, err
 	}
@@ -79,16 +109,24 @@ func admitRepo(ctx context.Context, args []string, stdout, stderr io.Writer) int
 		return exitError
 	}
 
-	p, err := repo.Prepare(ctx, targetFor(c, r), f.checkouts, announce(stdout))
-	if err != nil {
+	p, err := repo.Prepare(ctx, targetFor(c, r), f.checkouts, announce(stdout, f.show))
+	switch {
+	case errors.Is(err, errShown):
+		// Stopped at the announcement, before anything was written. What a
+		// caller asked to see is the position, so it is printed from what is on
+		// disk rather than from anything this run did.
+		return standing(f, r.ID, stdout, exitShown)
+	case err != nil:
 		_, _ = fmt.Fprintf(stderr, "sense-lab repo: %v\n", err)
 		return exitError
 	}
 	if p.Admitted {
-		_, _ = fmt.Fprint(stdout, position(f.campaign, p))
-		return exitOK
+		return standing(f, p.ID, stdout, exitOK)
 	}
-	return admitNew(ctx, f, p, stdout, stderr)
+	if code := admitNew(ctx, f, p, stdout, stderr); code != exitOK {
+		return code
+	}
+	return standing(f, p.ID, stdout, exitOK)
 }
 
 // targetFor is what admission acts on. A repository the catalog holds brings
@@ -109,12 +147,49 @@ func targetFor(c *catalog.Catalog, r repo.Resolution) repo.Target {
 // rather than three phases later — and it is a statement rather than a prompt,
 // because an interactive question in the run path is what the crank cannot
 // answer.
-func announce(stdout io.Writer) func(repo.Plan) error {
+func announce(stdout io.Writer, show bool) func(repo.Plan) error {
 	return func(p repo.Plan) error {
 		_, _ = fmt.Fprintf(stdout, "id:       %s\nurl:      %s\nrevision: %s\ncheckout: %s (%s)\n\n",
 			p.ID, p.URL, p.Revision, p.Checkout, sentence(p))
+		if show {
+			return errShown
+		}
 		return nil
 	}
+}
+
+// errShown stops an admission at the announcement. -show is the same code path
+// as an admission up to the point where one would write something, which is
+// what makes it a preview of that admission rather than a second reading of the
+// same inputs.
+var errShown = errors.New("shown")
+
+// standing prints where the repository stands and answers with the code that
+// carries it.
+//
+// A position is a fact about the run tree, so it is read back off disk rather
+// than assembled from what this invocation happened to do.
+func standing(f repoFlags, id string, stdout io.Writer, ok int) int {
+	at, err := position.Read(f.campaign, id)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdout, "position: unreadable: %v\n", err)
+		return exitError
+	}
+	_, _ = fmt.Fprint(stdout, position.Render(at))
+	if code, stop := stopOn[at.Standing]; stop {
+		return code
+	}
+	return ok
+}
+
+// stopOn is every standing that ends the loop, and its code. A standing that is
+// not in here is one with a next phase to run.
+var stopOn = map[position.Standing]int{
+	position.Finished: exitFinished,
+	position.Parked:   exitParked,
+	position.Waiting:  exitWaiting,
+	position.Unusable: exitUnusable,
+	position.Missing:  exitMissing,
 }
 
 // sentence says what the checkout is about to have done to it, in words.
@@ -195,17 +270,6 @@ func repoFile(config, id string) string { return filepath.Join(config, "repos", 
 // does not rescan it.
 func indexArtifact(campaign, id string) string {
 	return filepath.Join(campaign, id, "index", "index.json")
-}
-
-// position is what a repository that is already admitted gets instead of an
-// admission: where its checkout is, what it is pinned at, and whether it has
-// been indexed.
-func position(campaign string, p repo.Plan) string {
-	indexed := "no"
-	if _, err := os.Stat(indexArtifact(campaign, p.ID)); err == nil {
-		indexed = "yes"
-	}
-	return fmt.Sprintf("admitted: nothing to do\nindexed:  %s\n", indexed)
 }
 
 // admitSignals runs admission under the same signal handling a session gets. A

--- a/lab/internal/cli/repocmd_test.go
+++ b/lab/internal/cli/repocmd_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -215,7 +216,7 @@ func TestRe_runningOnAnAdmittedRepositoryWritesNothing(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d: %s", code, stderr)
 	}
-	if !strings.Contains(stdout, "admitted: nothing to do") || !strings.Contains(stdout, "indexed:  yes") {
+	if !strings.Contains(stdout, "indexed:  yes") || !strings.Contains(stdout, "awaiting: author") {
 		t.Errorf("stdout = %q, want where the repository stands", stdout)
 	}
 	if read(t, a.repoFile(id)) != before {
@@ -418,8 +419,8 @@ func TestPositionReportsARepositoryThatWasNeverIndexed(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d: %s", code, stderr)
 	}
-	if !strings.Contains(stdout, "indexed:  no") {
-		t.Errorf("stdout = %q, want it to say the repository has no index", stdout)
+	if !strings.Contains(stdout, "indexed:  no") || !strings.Contains(stdout, "awaiting: index") {
+		t.Errorf("stdout = %q, want it to say the repository is waiting on its scan", stdout)
 	}
 }
 
@@ -524,5 +525,142 @@ func blocked(t *testing.T, path string) {
 	}
 	if err := os.WriteFile(filepath.Dir(path), []byte("in the way"), 0o644); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// The exit codes are this command's API, because it ends up in a shell loop:
+//
+//	while sense-lab repo <id>; do :; done
+//
+// Every code is asserted here, and every one that must stop that loop is
+// asserted to be non-zero in the same table — which is the property the loop
+// actually rests on.
+func TestTheExitCodeCarriesTheStanding(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		build func(t *testing.T, repoDir string)
+		show  bool
+		want  int
+	}{
+		{"a repository with a phase to run", func(*testing.T, string) {}, false, 0},
+		{"on the board", func(t *testing.T, dir string) {
+			artifact(t, filepath.Join(dir, "1", "board", "board.md"), "# board\n")
+		}, false, 3},
+		{"parked at the ceiling", func(t *testing.T, dir string) {
+			artifact(t, filepath.Join(dir, "6", "handoff", "handoff.md"), "# handoff\n")
+		}, false, 4},
+		{"waiting at a PAY", func(t *testing.T, dir string) {
+			artifact(t, filepath.Join(dir, "1", "validate", "pay-call.md"), "PAY\n")
+			attempt(t, dir, `{"cycle":1,"phase":"validate","verdict":"PAY","try":1}`)
+		}, false, 5},
+		{"refused: a verdict the phase cannot emit", func(t *testing.T, dir string) {
+			artifact(t, filepath.Join(dir, "1", "author", "scenario.draft.yaml"), "name: r\n")
+			attempt(t, dir, `{"cycle":1,"phase":"author","verdict":"WIN","try":1}`)
+		}, false, 6},
+		{"refused: the artifact the verdict claims is not there", func(t *testing.T, dir string) {
+			artifact(t, filepath.Join(dir, "1", "minibench", "minibench.md"), "# read\n")
+			attempt(t, dir, `{"cycle":1,"phase":"author","verdict":"DRAFT","try":1}`)
+		}, false, 7},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a, id := admitted(t)
+			tc.build(t, filepath.Join(a.campaign, id))
+
+			args := []string{"repo", "-config", a.config, "-campaign", a.campaign,
+				"-checkouts", a.checkouts, "-sense", a.sense}
+			if tc.show {
+				args = append(args, "-show")
+			}
+			code, stdout, stderr := dispatch(t, append(args, id)...)
+
+			if code != tc.want {
+				t.Errorf("exit = %d, want %d\n%s%s", code, tc.want, stdout, stderr)
+			}
+			if !strings.Contains(stdout, "standing:") {
+				t.Errorf("stdout = %q, want the position printed", stdout)
+			}
+		})
+	}
+}
+
+// -show is a preview of the admission, so it stops before the first thing an
+// admission would write. Without that it is a second reading of the inputs
+// rather than a look at what is about to happen.
+func TestShowWritesNothing(t *testing.T) {
+	source, _ := sourceRepo(t)
+	a := newAdmission(t, admissionStatus)
+
+	code, stdout, stderr := dispatch(t, "repo", "-config", a.config, "-campaign", a.campaign,
+		"-checkouts", a.checkouts, "-sense", a.sense, "-show", source)
+
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2: %s", code, stderr)
+	}
+	if !strings.Contains(stdout, "id:       "+filepath.Base(source)) {
+		t.Errorf("stdout = %q, want the resolution it was about to act on", stdout)
+	}
+	if _, err := os.Stat(a.repoFile(filepath.Base(source))); !os.IsNotExist(err) {
+		t.Error("a repository was admitted by a command asked only to show")
+	}
+	if _, err := os.Stat(a.artifact(filepath.Base(source))); !os.IsNotExist(err) {
+		t.Error("a repository was indexed by a command asked only to show")
+	}
+}
+
+// admitted is a repository already in the catalog, with a real checkout at its
+// pin, so a test can put a run tree under it and ask where it stands.
+func admitted(t *testing.T) (admission, string) {
+	t.Helper()
+	source, head := sourceRepo(t)
+	a := newAdmission(t, admissionStatus)
+	id := filepath.Base(source)
+	artifact(t, a.repoFile(id), `{"id":"`+id+`","url":"https://example.test/`+id+`.git","commit":"`+head+
+		`","checkout":"`+source+`","languages":["go"]}`)
+	artifact(t, a.artifact(id), `{"repo":"`+id+`","symbols":40}`)
+	return a, id
+}
+
+func artifact(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func attempt(t *testing.T, repoDir, body string) {
+	t.Helper()
+	var a struct {
+		Cycle int    `json:"cycle"`
+		Phase string `json:"phase"`
+		Try   int    `json:"try"`
+	}
+	if err := json.Unmarshal([]byte(body), &a); err != nil {
+		t.Fatal(err)
+	}
+	artifact(t, filepath.Join(repoDir, "attempts", fmt.Sprintf("%d-%s-%d.json", a.Cycle, a.Phase, a.Try)), body)
+}
+
+// A position that cannot be read is reported rather than answered with a
+// default one, which would be a repository at the start of its first cycle.
+func TestAPositionThatCannotBeReadIsReported(t *testing.T) {
+	a, id := admitted(t)
+	if err := os.RemoveAll(a.campaign); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(a.campaign, []byte("in the way"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code, stdout, _ := dispatch(t, "repo", "-config", a.config, "-campaign", a.campaign,
+		"-checkouts", a.checkouts, "-sense", a.sense, id)
+
+	if code != 1 {
+		t.Errorf("exit = %d, want the error code", code)
+	}
+	if !strings.Contains(stdout, "unreadable") {
+		t.Errorf("stdout = %q, want it to say the position could not be read", stdout)
 	}
 }

--- a/lab/internal/position/attempt.go
+++ b/lab/internal/position/attempt.go
@@ -1,0 +1,186 @@
+// Package position answers the question the crank has to answer before it does
+// anything: what is the next phase for this repository, and how many authoring
+// cycles has it already spent.
+//
+// It answers it from two inputs, and which input a fact comes from is the whole
+// design.
+//
+// The run tree holds which runs exist, what they wrote, and the authoring
+// cycle — which is already a directory name under `<campaign>/<repo>/<cycle>/`.
+// Those are DERIVED, every time, and never stored. A counter beside the fact it
+// counts is a counter that drifts from it, and the drift is invisible.
+//
+// The attempt records hold the verdict of each attempt, the table that rejected
+// it, and the anchor. Those are RECORDED, once, and never re-derived: a verdict
+// is a judgment, and no amount of reading a tree recovers one.
+//
+// The old driver held the same answer in a JSON map of repository to phase,
+// edited by whoever was debugging. That is a decision anyone can change by hand,
+// which made it the one number in the system with no evidence behind it.
+//
+// # It reports and never repairs
+//
+// Nothing here re-scores, re-judges, or tidies a run tree it finds odd. An odd
+// tree is reported as odd. There is no clock, no network and no subprocess, so
+// the same tree gives the same answer on any machine on any day.
+package position
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/luuuc/sense/lab/internal/phase"
+)
+
+// attemptsDir is where a repository's judgments live, beside its cycles rather
+// than inside one: an attempt names its cycle, and a reader that had to walk
+// every cycle directory to collect them would miss the ones whose cycle
+// directory does not exist.
+const attemptsDir = "attempts"
+
+// Attempt is one phase attempt and what it decided.
+//
+// It carries the judgment and nothing derivable. There is no timestamp: the
+// order of attempts is (cycle, phase, try), which the tree and the graph
+// already fix, and a clock in a record is one more thing to be wrong on a
+// machine whose clock is.
+type Attempt struct {
+	Cycle   int           `json:"cycle"`
+	Phase   phase.Name    `json:"phase"`
+	Verdict phase.Verdict `json:"verdict"`
+	// Try distinguishes two attempts at one phase in one cycle, which the graph
+	// allows: a DoD FAIL sends a harvest back to report inside the same cycle.
+	// It is 1-based and it is the caller's, because only the caller knows
+	// whether this is the same attempt being written twice or a new one.
+	Try int `json:"try"`
+	// Table is what rejected this attempt: the mini-bench read, the credit
+	// table that refused to pay, the reason a draft had no anchor. It is what
+	// the next attempt has to answer, and a re-entry without one is a fresh
+	// guess wearing the previous attempt's number.
+	Table  string `json:"table,omitempty"`
+	Anchor string `json:"anchor,omitempty"`
+}
+
+// Name is the attempt's file, and it is the attempt's identity.
+func (a Attempt) Name() string { return fmt.Sprintf("%d-%s-%d.json", a.Cycle, a.Phase, a.Try) }
+
+// Record writes one attempt, and refuses to write over one.
+//
+// The refusal is the open flag rather than a check, because append-only as a
+// convention survives until a bad night and append-only as an O_EXCL survives
+// the bad night. A verdict that has been recorded is history, and history is
+// lost on purpose or not at all.
+func Record(repoDir string, a Attempt) error {
+	if err := a.valid(); err != nil {
+		return err
+	}
+	dir := filepath.Join(repoDir, attemptsDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("prepare %s: %w", dir, err)
+	}
+	b, err := json.MarshalIndent(a, "", "  ")
+	if err != nil {
+		return fmt.Errorf("render the attempt: %w", err)
+	}
+	path := filepath.Join(dir, a.Name())
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return fmt.Errorf("record %s %s try %d: %w. A recorded verdict is not rewritten: "+
+			"if this is a new attempt it is a new try", a.Phase, a.Verdict, a.Try, err)
+	}
+	defer func() { _ = f.Close() }()
+	_, err = f.Write(append(b, '\n'))
+	return err
+}
+
+// valid refuses an attempt that could not be read back as a judgment.
+func (a Attempt) valid() error {
+	switch {
+	case a.Cycle < 1:
+		return fmt.Errorf("attempt at %s is in cycle %d; cycles are 1-based", a.Phase, a.Cycle)
+	case a.Try < 1:
+		return fmt.Errorf("attempt at %s is try %d; tries are 1-based", a.Phase, a.Try)
+	case a.Phase == "":
+		return fmt.Errorf("an attempt with no phase: nothing could say what was decided")
+	case a.Verdict == "":
+		return fmt.Errorf("attempt at %s emitted nothing; a phase that decided nothing did not finish", a.Phase)
+	}
+	return nil
+}
+
+// NextTry is the try number an attempt at this phase and cycle should carry.
+//
+// It is a pure function of what is already recorded rather than a counter, and
+// it is separate from [Record] on purpose: it says what the next attempt would
+// be, and [Record] still refuses if something took that number in between.
+func NextTry(attempts []Attempt, cycle int, p phase.Name) int {
+	next := 1
+	for _, a := range attempts {
+		if a.Cycle == cycle && a.Phase == p && a.Try >= next {
+			next = a.Try + 1
+		}
+	}
+	return next
+}
+
+// Attempts reads every attempt recorded for a repository, in the order they
+// happened: by cycle, then by where the phase sits in the graph, then by try.
+//
+// The order is derived from the graph rather than from a timestamp, so it is
+// the same order on a machine whose clock is wrong.
+func Attempts(repoDir string) ([]Attempt, error) {
+	entries, err := os.ReadDir(filepath.Join(repoDir, attemptsDir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			// A repository nothing has decided about yet. That is a position,
+			// not a failure.
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read the attempts of %s: %w", repoDir, err)
+	}
+	var out []Attempt
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(repoDir, attemptsDir, e.Name())
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", path, err)
+		}
+		var a Attempt
+		if err := json.Unmarshal(b, &a); err != nil {
+			return nil, fmt.Errorf("read %s: %w", path, err)
+		}
+		out = append(out, a)
+	}
+	slices.SortFunc(out, order)
+	return out, nil
+}
+
+// order sorts attempts into the order they can only have happened in.
+func order(a, b Attempt) int {
+	if a.Cycle != b.Cycle {
+		return a.Cycle - b.Cycle
+	}
+	if at, bt := graphIndex(a.Phase), graphIndex(b.Phase); at != bt {
+		return at - bt
+	}
+	return a.Try - b.Try
+}
+
+// graphIndex is where a phase sits in the declared order. A name the graph does
+// not know sorts last rather than first, so an unreadable record cannot displace
+// the phase that actually ran.
+func graphIndex(n phase.Name) int {
+	for i, p := range phase.Graph {
+		if p.Name == n {
+			return i
+		}
+	}
+	return len(phase.Graph)
+}

--- a/lab/internal/position/attempt_test.go
+++ b/lab/internal/position/attempt_test.go
@@ -1,0 +1,272 @@
+package position
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/lab/internal/phase"
+)
+
+// A recorded verdict is history. Append-only as a convention survives until a
+// bad night; append-only as an open flag survives the bad night, because the
+// second write fails rather than replacing a judgment nobody can recover.
+func TestARecordedAttemptIsNotWrittenOver(t *testing.T) {
+	dir := t.TempDir()
+	first := Attempt{Cycle: 1, Phase: phase.Author, Verdict: phase.Draft, Try: 1, Anchor: "BaseItem"}
+	if err := Record(dir, first); err != nil {
+		t.Fatal(err)
+	}
+
+	err := Record(dir, Attempt{Cycle: 1, Phase: phase.Author, Verdict: phase.NoAnchor, Try: 1})
+
+	if err == nil {
+		t.Fatal("a second write to one attempt succeeded; a verdict was replaced")
+	}
+	back, readErr := Attempts(dir)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(back) != 1 || back[0].Verdict != phase.Draft {
+		t.Errorf("attempts = %+v, want the first verdict intact", back)
+	}
+}
+
+// The same phase can legitimately run twice in one cycle — a DoD FAIL sends a
+// harvest back to report — so a second attempt is a second try rather than a
+// collision, and both are kept.
+func TestASecondAttemptAtOnePhaseIsANewTry(t *testing.T) {
+	dir := t.TempDir()
+	if err := Record(dir, Attempt{Cycle: 1, Phase: phase.Report, Verdict: phase.Win, Try: 1}); err != nil {
+		t.Fatal(err)
+	}
+
+	next := NextTry(mustRead(t, dir), 1, phase.Report)
+	if next != 2 {
+		t.Fatalf("NextTry = %d, want 2", next)
+	}
+	if err := Record(dir, Attempt{Cycle: 1, Phase: phase.Report, Verdict: phase.Diagnosis, Try: next}); err != nil {
+		t.Fatal(err)
+	}
+
+	all := mustRead(t, dir)
+	if len(all) != 2 || all[0].Try != 1 || all[1].Try != 2 {
+		t.Errorf("attempts = %+v, want both tries in order", all)
+	}
+}
+
+// NextTry counts only what it is asked about. A phase in another cycle is
+// another attempt at another question.
+func TestNextTryIsPerCycleAndPerPhase(t *testing.T) {
+	recorded := []Attempt{
+		{Cycle: 1, Phase: phase.Report, Try: 1},
+		{Cycle: 1, Phase: phase.Report, Try: 2},
+		{Cycle: 2, Phase: phase.Report, Try: 1},
+		{Cycle: 1, Phase: phase.Author, Try: 1},
+	}
+
+	for _, tc := range []struct {
+		cycle int
+		phase phase.Name
+		want  int
+	}{
+		{1, phase.Report, 3},
+		{2, phase.Report, 2},
+		{1, phase.Author, 2},
+		{3, phase.Author, 1},
+	} {
+		if got := NextTry(recorded, tc.cycle, tc.phase); got != tc.want {
+			t.Errorf("NextTry(cycle %d, %s) = %d, want %d", tc.cycle, tc.phase, got, tc.want)
+		}
+	}
+}
+
+// The order attempts are read back in is derived from the graph, not from a
+// clock, so it is the same order on a machine whose clock is wrong.
+func TestAttemptsComeBackInTheOrderTheyCanOnlyHaveHappenedIn(t *testing.T) {
+	dir := t.TempDir()
+	// Written out of order on purpose.
+	for _, a := range []Attempt{
+		{Cycle: 2, Phase: phase.Author, Verdict: phase.Draft, Try: 1},
+		{Cycle: 1, Phase: phase.Minibench, Verdict: phase.Requestion, Try: 1, Table: "the baseline reached it"},
+		{Cycle: 1, Phase: phase.Author, Verdict: phase.Draft, Try: 1},
+	} {
+		if err := Record(dir, a); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var got []string
+	for _, a := range mustRead(t, dir) {
+		got = append(got, string(a.Phase))
+	}
+
+	if strings.Join(got, ",") != "author,minibench,author" {
+		t.Errorf("order = %v, want cycle 1's author, then its mini-bench, then cycle 2's author", got)
+	}
+}
+
+// A phase the graph does not know sorts last rather than first, so an
+// unreadable record cannot displace the phase that actually ran.
+func TestAPhaseTheGraphDoesNotKnowSortsLast(t *testing.T) {
+	dir := t.TempDir()
+	for _, a := range []Attempt{
+		{Cycle: 1, Phase: "invented", Verdict: phase.Auto, Try: 1},
+		{Cycle: 1, Phase: phase.Author, Verdict: phase.Draft, Try: 1},
+	} {
+		if err := Record(dir, a); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	all := mustRead(t, dir)
+	if all[0].Phase != phase.Author {
+		t.Errorf("first = %s, want the phase the graph knows", all[0].Phase)
+	}
+}
+
+// A record that could not be read back as a judgment is refused when it is
+// written, where the caller can still fix it.
+func TestAnAttemptThatIsNotAJudgmentIsRefused(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		a    Attempt
+	}{
+		{"no cycle", Attempt{Phase: phase.Author, Verdict: phase.Draft, Try: 1}},
+		{"no try", Attempt{Cycle: 1, Phase: phase.Author, Verdict: phase.Draft}},
+		{"no phase", Attempt{Cycle: 1, Verdict: phase.Draft, Try: 1}},
+		{"no verdict", Attempt{Cycle: 1, Phase: phase.Author, Try: 1}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := Record(t.TempDir(), tc.a); err == nil {
+				t.Error("recorded")
+			}
+		})
+	}
+}
+
+// A repository nothing has decided about yet has no attempts, which is a
+// position rather than a failure.
+func TestARepositoryWithNoAttemptsReadsAsNone(t *testing.T) {
+	all, err := Attempts(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 0 {
+		t.Errorf("attempts = %v, want none", all)
+	}
+}
+
+// A record that is there and cannot be read back is reported rather than
+// skipped. A judgment silently dropped is a repository that reads as never
+// having reached the phase that produced it.
+func TestARecordThatCannotBeReadIsReportedRatherThanSkipped(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		put  func(t *testing.T, path string)
+	}{
+		{"it is not a document", func(t *testing.T, path string) {
+			if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"it cannot be opened", func(t *testing.T, path string) {
+			if os.Geteuid() == 0 {
+				t.Skip("root reads anything")
+			}
+			if err := os.Chmod(path, 0o000); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = os.Chmod(path, 0o644) })
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			a := Attempt{Cycle: 1, Phase: phase.Author, Verdict: phase.Draft, Try: 1}
+			if err := Record(dir, a); err != nil {
+				t.Fatal(err)
+			}
+			tc.put(t, filepath.Join(dir, attemptsDir, a.Name()))
+
+			if _, err := Attempts(dir); err == nil {
+				t.Error("an unreadable record was skipped")
+			}
+		})
+	}
+}
+
+// Anything that is not a record is not read as one.
+func TestOnlyRecordsAreReadOutOfTheAttemptsDirectory(t *testing.T) {
+	dir := t.TempDir()
+	if err := Record(dir, Attempt{Cycle: 1, Phase: phase.Author, Verdict: phase.Draft, Try: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, attemptsDir, "notes.md"), []byte("# by hand\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, attemptsDir, "olds"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if all := mustRead(t, dir); len(all) != 1 {
+		t.Errorf("attempts = %+v, want only the record", all)
+	}
+}
+
+func TestARecordThatCannotBeWrittenIsReported(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, attemptsDir), []byte("in the way"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Record(dir, Attempt{Cycle: 1, Phase: phase.Author, Verdict: phase.Draft, Try: 1}); err == nil {
+		t.Fatal("an attempt was recorded into a file")
+	}
+}
+
+func mustRead(t *testing.T, dir string) []Attempt {
+	t.Helper()
+	all, err := Attempts(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return all
+}
+
+// The order is the graph's, not the filesystem's. Read back alphabetically an
+// expansion comes before the mini-bench that decides whether to expand at all,
+// and the last attempt — which is what a position is read from — would be the
+// wrong one.
+func TestTheOrderIsTheGraphsRatherThanTheAlphabets(t *testing.T) {
+	dir := t.TempDir()
+	for _, a := range []Attempt{
+		{Cycle: 1, Phase: phase.Expand, Verdict: phase.Auto, Try: 1},
+		{Cycle: 1, Phase: phase.Minibench, Verdict: phase.Proceed, Try: 1},
+	} {
+		if err := Record(dir, a); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	all := mustRead(t, dir)
+
+	if all[0].Phase != phase.Minibench || all[1].Phase != phase.Expand {
+		t.Errorf("order = %s then %s, want the mini-bench before the expansion it decides on",
+			all[0].Phase, all[1].Phase)
+	}
+}
+
+// The anchor is one of the three things a record exists to keep — the verdict,
+// the table and the anchor — so it survives the round trip.
+func TestTheAnchorSurvivesTheRecord(t *testing.T) {
+	dir := t.TempDir()
+	if err := Record(dir, Attempt{Cycle: 1, Phase: phase.Author, Verdict: phase.Draft, Try: 1,
+		Anchor: "MediaBrowser.Controller.Entities.BaseItem"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if back := mustRead(t, dir); back[0].Anchor != "MediaBrowser.Controller.Entities.BaseItem" {
+		t.Errorf("anchor = %q, want the one that was recorded", back[0].Anchor)
+	}
+}

--- a/lab/internal/position/position.go
+++ b/lab/internal/position/position.go
@@ -1,0 +1,325 @@
+package position
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/luuuc/sense/lab/internal/phase"
+)
+
+// Standing is what a position amounts to for a caller that has to decide, and
+// each one is an exit code. They are an API rather than a display: this command
+// ends up in a shell loop, and what that loop stops on is this.
+type Standing string
+
+const (
+	// Ready: there is a next phase and something to run it on.
+	Ready Standing = "ready"
+	// Finished: the repository reached the board.
+	Finished Standing = "finished"
+	// Parked: the authoring ceiling, re-entered only by a deliberate human act.
+	Parked Standing = "parked"
+	// Waiting: a PAY. The method worked and the next act spends money, which
+	// the crank does not do. This and Parked are the two most worth telling
+	// apart: one is the method failing on this repository, the other is the
+	// method succeeding and waiting on a wallet.
+	Waiting Standing = "waiting"
+	// Unusable: the last attempt emitted something its phase cannot emit. An
+	// agent misbehaved.
+	Unusable Standing = "unusable"
+	// Missing: the last attempt's verdict is usable and the artifact it owed is
+	// not there. An agent died. Diagnosed differently from Unusable, which is
+	// why it is not the same code.
+	Missing Standing = "missing"
+)
+
+// Position is where one repository stands.
+type Position struct {
+	Repo string
+	// Cycle is the authoring cycle on disk, which is the highest numbered
+	// directory. Derived every time; there is no counter anywhere to drift.
+	Cycle int
+	// Indexed says the repository has been scanned. The index sits beside the
+	// cycles rather than inside one, because a re-entry does not rescan.
+	Indexed bool
+	// Awaiting is the phase to run next: routed from the last verdict where
+	// there is one, and otherwise the first phase of this cycle that owes an
+	// artifact.
+	Awaiting phase.Name
+	// Reached is the furthest phase of this cycle whose artifact exists.
+	Reached  phase.Name
+	Standing Standing
+	// Last is the last attempt recorded in this cycle, if any.
+	Last Attempt
+	// Answer is every rejection this repository has carried, oldest first. The
+	// next attempt reads all of them and not only the last: six attempts
+	// converging is what that makes possible, and six unrelated drafts is what
+	// it prevents.
+	Answer []Attempt
+	// Banked is every cycle that reached the board.
+	Banked []int
+	// Because says why the standing is what it is, in a sentence, for whoever
+	// is reading a stopped loop.
+	Because string
+}
+
+// ToCeiling is how many authoring cycles are left before this repository parks.
+func (p Position) ToCeiling() int { return max(phase.AuthoringCeiling-p.Cycle, 0) }
+
+// Read reports where a repository stands, from its run tree and its attempt
+// records.
+//
+// A repository directory that is not there is not an error: asking where a
+// repository stands before it has been admitted is a fair question with an
+// answer, and the answer is that it awaits its index.
+func Read(campaign, repo string) (Position, error) {
+	dir := filepath.Join(campaign, repo)
+	p := Position{Repo: repo, Indexed: wrote(dir, phaseOf(phase.Index))}
+
+	cycles, err := cycleDirs(dir)
+	if err != nil {
+		return Position{}, err
+	}
+	for _, c := range cycles {
+		at := filepath.Join(dir, strconv.Itoa(c))
+		if wrote(at, phaseOf(phase.Board)) {
+			p.Banked = append(p.Banked, c)
+		}
+		if c > p.Cycle {
+			p.Cycle = c
+		}
+	}
+	if p.Cycle == 0 {
+		// A repository that has opened no cycle directory is in its first one.
+		// Reporting cycle 0 would be a number no rule is written in: the
+		// ceiling counts from 1, and an attempt recorded for cycle 1 before its
+		// directory exists is an attempt in the cycle this repository is in.
+		p.Cycle = 1
+	}
+	attempts, err := Attempts(dir)
+	if err != nil {
+		return Position{}, err
+	}
+	p.Answer = rejections(attempts)
+	p.settle(dir, attempts)
+	return p, nil
+}
+
+// settle works out the next phase and what the position amounts to.
+//
+// The order of the questions is the answer to most of them: parked beats
+// everything because a parked repository is not re-entered by any transition,
+// and banked beats a stale attempt record because the board is on disk.
+func (p *Position) settle(dir string, attempts []Attempt) {
+	cycleDir := filepath.Join(dir, strconv.Itoa(p.Cycle))
+	p.Reached, p.Awaiting = walk(cycleDir)
+	// The last verdict is carried whatever the standing turns out to be.
+	// Whoever finds a parked repository wants to read the verdict that parked
+	// it, and a field only filled in on the paths that route from one would be
+	// blank on exactly the positions somebody is looking at because it stopped.
+	last, decided := lastOf(attempts, p.Cycle)
+	p.Last = last
+
+	switch {
+	case wrote(cycleDir, phaseOf(phase.Handoff)):
+		p.Standing, p.Awaiting = Parked, phase.Done
+		p.Because = fmt.Sprintf("cycle %d wrote a handoff; re-entering a parked repository is a human act, not a transition", p.Cycle)
+		return
+	case slices.Contains(p.Banked, p.Cycle):
+		p.Standing, p.Awaiting = Finished, phase.Done
+		p.Because = fmt.Sprintf("cycle %d reached the board", p.Cycle)
+		return
+	}
+
+	if !p.Indexed {
+		// Nothing under a cycle can be believed before the repository is
+		// scanned, so nothing under one is read as a position. This is checked
+		// after the two endings and before any verdict: a scan is what the
+		// repository is waiting for, whatever else is on disk.
+		p.Standing, p.Awaiting = Ready, phase.Index
+		p.Because = "the repository has not been scanned; the index is what everything after it reads"
+		return
+	}
+
+	if !decided {
+		// Nothing decided in this cycle. The tree walk is the whole answer, and
+		// there is a phase owed.
+		p.Standing = Ready
+		p.Because = fmt.Sprintf("no verdict recorded in cycle %d; %s owes %s", p.Cycle, p.Awaiting, phaseOf(p.Awaiting).Writes)
+		return
+	}
+	p.route(cycleDir, last)
+}
+
+// route reads the last verdict and says where it leads, or why it leads
+// nowhere.
+func (p *Position) route(cycleDir string, last Attempt) {
+	next, err := phase.Next(last.Phase, last.Verdict, p.Cycle)
+	if err != nil {
+		p.Standing, p.Because = Unusable, err.Error()
+		return
+	}
+	if !wrote(cycleDir, phaseOf(last.Phase)) {
+		// The verdict is one the phase may emit and the artifact it owed is not
+		// there. An exit code is a claim; the artifact is the fact.
+		p.Standing = Missing
+		p.Because = fmt.Sprintf("%s emitted %s and did not write %s; the verdict is usable and the phase did not finish",
+			last.Phase, last.Verdict, phaseOf(last.Phase).Writes)
+		return
+	}
+	// Nothing routes to Done here: the two phases that end the loop are the
+	// board and the handoff, and both are recognised from their artifact above
+	// before any verdict is read. A repository is finished because the board is
+	// on disk, not because something said so.
+	p.Awaiting = next
+	switch {
+	case last.Verdict == phase.Pay:
+		p.Standing = Waiting
+		p.Because = "the validation says PAY, and spending is a human act"
+	case next == phase.Handoff:
+		p.Standing = Parked
+		p.Because = fmt.Sprintf("%s emitted %s at cycle %d, which is the authoring ceiling", last.Phase, last.Verdict, p.Cycle)
+	default:
+		p.Standing = Ready
+		p.Because = fmt.Sprintf("%s emitted %s, which routes to %s", last.Phase, last.Verdict, next)
+	}
+}
+
+// rejections is every attempt that left a table behind, oldest first.
+//
+// The table is the test rather than the verdict, and that is deliberate. A
+// re-entry is recognisable from its routing, but a NO-ANCHOR at the authoring
+// ceiling routes to the handoff instead of back to the author and is no less a
+// rejection for it — and a diagnosis carries one too. What makes an attempt
+// something the next one has to answer is that somebody wrote down why it was
+// refused.
+func rejections(attempts []Attempt) []Attempt {
+	var out []Attempt
+	for _, a := range attempts {
+		if a.Table != "" {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+// lastOf is the last attempt recorded in a cycle.
+//
+// Scoped to the cycle the DIRECTORIES say we are in, so a record naming a cycle
+// that was never opened decides nothing. The tree is what says where a
+// repository is; a record says what was judged there.
+func lastOf(attempts []Attempt, cycle int) (Attempt, bool) {
+	for i := len(attempts) - 1; i >= 0; i-- {
+		if attempts[i].Cycle == cycle {
+			return attempts[i], true
+		}
+	}
+	return Attempt{}, false
+}
+
+// walk reports the furthest phase of a cycle whose artifact exists, and the
+// first whose artifact does not. It decides nothing: an artifact is on disk or
+// it is not.
+func walk(cycleDir string) (reached, awaiting phase.Name) {
+	for _, p := range phase.Graph {
+		// The index is per repository rather than per cycle, and the handoff is
+		// arrived at rather than walked to. Looking for either here would
+		// report every cycle as owing one.
+		if p.Name == phase.Index || p.Name == phase.Handoff {
+			continue
+		}
+		if wrote(cycleDir, p) {
+			reached = p.Name
+			continue
+		}
+		if awaiting == "" {
+			awaiting = p.Name
+		}
+	}
+	if awaiting == "" {
+		awaiting = phase.Done
+	}
+	return reached, awaiting
+}
+
+// wrote reports whether a phase's output artifact is under dir.
+func wrote(dir string, p phase.Phase) bool {
+	_, err := os.Stat(filepath.Join(dir, string(p.Name), p.Writes))
+	return err == nil
+}
+
+func phaseOf(name phase.Name) phase.Phase {
+	p, _ := phase.Lookup(name)
+	return p
+}
+
+// cycleDirs is every numbered directory under a repository, which is every
+// authoring cycle it has opened. Anything else in the tree is not a cycle and
+// this walk does not rule on it.
+func cycleDirs(dir string) ([]int, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read the run tree of %s: %w", dir, err)
+	}
+	var out []int
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if n, err := strconv.Atoi(e.Name()); err == nil {
+			out = append(out, n)
+		}
+	}
+	slices.Sort(out)
+	return out, nil
+}
+
+// Render is the page. Nothing parses it: [Read] returns a [Position] and this
+// turns one into a string, because parsing your own report is how a display
+// format silently becomes a data contract.
+func Render(p Position) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "repo:     %s\ncycle:    %d of %d\nindexed:  %s\nreached:  %s\nawaiting: %s\nstanding: %s — %s\n",
+		p.Repo, p.Cycle, phase.AuthoringCeiling, yes(p.Indexed), or(p.Reached, "nothing yet"),
+		or(p.Awaiting, "nothing"), p.Standing, p.Because)
+	if len(p.Banked) > 0 {
+		fmt.Fprintf(&b, "banked:   %v\n", p.Banked)
+	}
+	if len(p.Answer) == 0 {
+		return b.String()
+	}
+	// Every rejection, not only the last. A page that showed the most recent
+	// one would be a page that invites the next attempt to answer one thing.
+	b.WriteString("answer:\n")
+	for _, a := range p.Answer {
+		table := a.Table
+		if table == "" {
+			table = "no table recorded"
+		}
+		fmt.Fprintf(&b, "  cycle %d %s emitted %s: %s\n", a.Cycle, a.Phase, a.Verdict, table)
+	}
+	return b.String()
+}
+
+func yes(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}
+
+// or names a phase, or says what its absence means. A phase that is empty is
+// not "" on the page: an unset field and a real answer must not print alike.
+func or(n phase.Name, absent string) string {
+	if n == "" {
+		return absent
+	}
+	return string(n)
+}

--- a/lab/internal/position/position_test.go
+++ b/lab/internal/position/position_test.go
@@ -1,0 +1,392 @@
+package position
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/lab/internal/phase"
+)
+
+// fixture is the committed campaign: three repositories, one of each shape a
+// real one takes.
+const fixture = "testdata/campaign"
+
+func read(t *testing.T, campaign, repo string) Position {
+	t.Helper()
+	p, err := Read(campaign, repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// The three shapes, read from the tree the jellyfin campaign's layout was copied
+// from. Each is asserted whole rather than field by field across three tests,
+// because what matters is that one tree produces one coherent answer.
+func TestPositionIsReadFromTheCommittedTree(t *testing.T) {
+	for _, tc := range []struct {
+		repo     string
+		cycle    int
+		reached  phase.Name
+		awaiting phase.Name
+		standing Standing
+		last     phase.Verdict
+		answers  int
+		because  string
+	}{
+		{"midcycle", 2, phase.Minibench, phase.Author, Ready, phase.Requestion, 2, "routes to author"},
+		{"parked", 6, phase.Author, phase.Done, Parked, phase.NoAnchor, 1, "handoff"},
+		{"atpay", 1, phase.Validate, phase.Bench, Waiting, phase.Pay, 0, "human"},
+		{"banked", 2, phase.Author, phase.Minibench, Ready, phase.Draft, 0, "routes to minibench"},
+	} {
+		t.Run(tc.repo, func(t *testing.T) {
+			p := read(t, fixture, tc.repo)
+
+			if p.Cycle != tc.cycle {
+				t.Errorf("cycle = %d, want %d", p.Cycle, tc.cycle)
+			}
+			if p.Reached != tc.reached {
+				t.Errorf("reached = %s, want %s", p.Reached, tc.reached)
+			}
+			if p.Awaiting != tc.awaiting {
+				t.Errorf("awaiting = %s, want %s", p.Awaiting, tc.awaiting)
+			}
+			if p.Standing != tc.standing {
+				t.Errorf("standing = %s (%s), want %s", p.Standing, p.Because, tc.standing)
+			}
+			if p.Last.Verdict != tc.last {
+				t.Errorf("last verdict = %q, want %q: the position is read from the last one recorded in this cycle",
+					p.Last.Verdict, tc.last)
+			}
+			if len(p.Answer) != tc.answers {
+				t.Errorf("carried rejections = %d, want %d", len(p.Answer), tc.answers)
+			}
+			if !strings.Contains(p.Because, tc.because) {
+				t.Errorf("because = %q, want it to say %q; a stopped loop is read by whoever finds it", p.Because, tc.because)
+			}
+			if !p.Indexed {
+				t.Error("indexed = false; every repository in the fixture has been scanned")
+			}
+		})
+	}
+}
+
+// A repository that banked a cycle and opened another has work to do. Banking
+// is per cycle, and a check that asked only whether anything had ever been
+// banked would call every re-entry finished.
+func TestBankingOneCycleDoesNotFinishTheNextOne(t *testing.T) {
+	p := read(t, fixture, "banked")
+
+	if p.Standing != Ready {
+		t.Errorf("standing = %s (%s), want a repository with a phase to run", p.Standing, p.Because)
+	}
+	if len(p.Banked) != 1 || p.Banked[0] != 1 {
+		t.Errorf("banked = %v, want the one cycle that reached the board", p.Banked)
+	}
+}
+
+// The rejection is carried with its table, and the table is what the next
+// attempt has to answer. A re-entry that lost it is a fresh guess wearing the
+// previous attempt's number.
+func TestEveryRejectionIsCarriedWithTheTableThatProducedIt(t *testing.T) {
+	p := read(t, fixture, "midcycle")
+
+	if len(p.Answer) != 2 {
+		t.Fatalf("carried = %+v, want both re-questions", p.Answer)
+	}
+	// Oldest first, and both of them: the next attempt reads all of them, not
+	// only the last. Six attempts converging is what that makes possible, and
+	// six unrelated drafts is what it prevents.
+	if a := p.Answer[0]; a.Cycle != 1 || a.Phase != phase.Minibench || !strings.Contains(a.Table, "4 of 4") {
+		t.Errorf("first carried = %+v, want cycle 1's mini-bench with its table", a)
+	}
+	if a := p.Answer[1]; a.Cycle != 2 || !strings.Contains(a.Table, "no more discriminating") {
+		t.Errorf("second carried = %+v, want cycle 2's mini-bench with its own table", a)
+	}
+}
+
+// The cycle is read from the directories, and a record that names a cycle
+// nobody opened does not move it. The tree says where a repository is; a record
+// says what was judged there.
+func TestTheDirectoriesDecideTheCycleAndTheRecordsDoNot(t *testing.T) {
+	campaign := t.TempDir()
+	repo := filepath.Join(campaign, "r")
+	writeArtifact(t, filepath.Join(repo, "index", "index.json"), "{}")
+	writeArtifact(t, filepath.Join(repo, "1", "author", "scenario.draft.yaml"), "name: r\n")
+	writeArtifact(t, filepath.Join(repo, "2", "author", "scenario.draft.yaml"), "name: r\n")
+	record(t, repo, Attempt{Cycle: 2, Phase: phase.Author, Verdict: phase.Draft, Try: 1})
+	// A verdict recorded for a cycle whose directory was never opened.
+	record(t, repo, Attempt{Cycle: 3, Phase: phase.Author, Verdict: phase.NoAnchor, Try: 1})
+
+	p := read(t, campaign, "r")
+
+	if p.Cycle != 2 {
+		t.Errorf("cycle = %d, want the highest directory on disk", p.Cycle)
+	}
+	if p.Standing != Ready || p.Awaiting != phase.Minibench {
+		t.Errorf("standing = %s awaiting %s; the cycle-3 record decided the position", p.Standing, p.Awaiting)
+	}
+}
+
+// A repository that has opened no cycle is in its first. Reporting cycle 0
+// would be a number no rule is written in: the ceiling counts from 1.
+func TestAFreshlyIndexedRepositoryIsInItsFirstCycle(t *testing.T) {
+	campaign := t.TempDir()
+	writeArtifact(t, filepath.Join(campaign, "r", "index", "index.json"), "{}")
+
+	p := read(t, campaign, "r")
+
+	if p.Cycle != 1 || p.Awaiting != phase.Author {
+		t.Errorf("cycle %d awaiting %s, want cycle 1 awaiting the author", p.Cycle, p.Awaiting)
+	}
+	if p.ToCeiling() != phase.AuthoringCeiling-1 {
+		t.Errorf("to the ceiling = %d, want %d", p.ToCeiling(), phase.AuthoringCeiling-1)
+	}
+}
+
+// Nothing under a cycle can be believed before the repository is scanned, so an
+// unscanned one waits on its index whatever else is on disk.
+func TestAnUnscannedRepositoryWaitsOnItsIndex(t *testing.T) {
+	campaign := t.TempDir()
+	writeArtifact(t, filepath.Join(campaign, "r", "1", "author", "scenario.draft.yaml"), "name: r\n")
+
+	p := read(t, campaign, "r")
+
+	if p.Indexed || p.Awaiting != phase.Index {
+		t.Errorf("indexed %v awaiting %s, want it waiting on the scan", p.Indexed, p.Awaiting)
+	}
+}
+
+// A repository that is not there at all is a fair question with an answer.
+func TestARepositoryThatWasNeverAdmittedIsAPositionRatherThanAnError(t *testing.T) {
+	p := read(t, t.TempDir(), "never-heard-of-it")
+
+	if p.Awaiting != phase.Index || p.Standing != Ready {
+		t.Errorf("position = %+v, want it awaiting its index", p)
+	}
+}
+
+// The two refusals are diagnosed differently — an agent that misbehaved against
+// an agent that died — so they are separate standings and separate codes.
+func TestTheTwoRefusalsAreToldApart(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		verdict  phase.Verdict
+		artifact bool
+		want     Standing
+	}{
+		{"a verdict the phase cannot emit", phase.Win, true, Unusable},
+		{"a usable verdict whose artifact is not there", phase.Draft, false, Missing},
+		{"a usable verdict that wrote its artifact", phase.Draft, true, Ready},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			campaign := t.TempDir()
+			repo := filepath.Join(campaign, "r")
+			writeArtifact(t, filepath.Join(repo, "index", "index.json"), "{}")
+			if err := os.MkdirAll(filepath.Join(repo, "1"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if tc.artifact {
+				writeArtifact(t, filepath.Join(repo, "1", "author", "scenario.draft.yaml"), "name: r\n")
+			}
+			record(t, repo, Attempt{Cycle: 1, Phase: phase.Author, Verdict: tc.verdict, Try: 1})
+
+			p := read(t, campaign, "r")
+
+			if p.Standing != tc.want {
+				t.Errorf("standing = %s (%s), want %s", p.Standing, p.Because, tc.want)
+			}
+		})
+	}
+}
+
+// A repository on the board is finished, and it says so from the board on disk
+// rather than from the last thing anybody recorded about it.
+func TestARepositoryOnTheBoardIsFinished(t *testing.T) {
+	campaign := t.TempDir()
+	repo := filepath.Join(campaign, "r")
+	writeArtifact(t, filepath.Join(repo, "index", "index.json"), "{}")
+	writeArtifact(t, filepath.Join(repo, "1", "board", "board.md"), "# board\n")
+
+	p := read(t, campaign, "r")
+
+	if p.Standing != Finished || p.Awaiting != phase.Done {
+		t.Errorf("standing = %s awaiting %s, want a finished repository", p.Standing, p.Awaiting)
+	}
+	if len(p.Banked) != 1 || p.Banked[0] != 1 {
+		t.Errorf("banked = %v, want cycle 1", p.Banked)
+	}
+}
+
+// A parked repository is parked whatever a later record says, because no
+// transition re-enters one: resuming is a human act.
+func TestParkingBeatsAnyVerdictRecordedAfterIt(t *testing.T) {
+	campaign := t.TempDir()
+	repo := filepath.Join(campaign, "r")
+	writeArtifact(t, filepath.Join(repo, "index", "index.json"), "{}")
+	writeArtifact(t, filepath.Join(repo, "1", "handoff", "handoff.md"), "# handoff\n")
+	writeArtifact(t, filepath.Join(repo, "1", "author", "scenario.draft.yaml"), "name: r\n")
+	record(t, repo, Attempt{Cycle: 1, Phase: phase.Author, Verdict: phase.Draft, Try: 1})
+
+	p := read(t, campaign, "r")
+
+	if p.Standing != Parked {
+		t.Errorf("standing = %s, want %s", p.Standing, Parked)
+	}
+}
+
+// An unreadable tree is reported rather than read as an empty position, which
+// would be a repository at the start of its first cycle.
+func TestAnUnreadableTreeIsAnError(t *testing.T) {
+	campaign := t.TempDir()
+	blocked := filepath.Join(campaign, "r")
+	if err := os.WriteFile(blocked, []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Read(campaign, "r"); err == nil {
+		t.Fatal("a file where a repository should be read as a position")
+	}
+}
+
+// The page shows every rejection rather than the most recent one. A page that
+// showed the last would invite the next attempt to answer one thing.
+func TestTheRenderedPageCarriesEveryRejection(t *testing.T) {
+	page := Render(read(t, fixture, "midcycle"))
+
+	for _, want := range []string{"repo:     midcycle", "cycle:    2 of 6", "reached:  minibench",
+		"awaiting: author", "4 of 4", "no more discriminating"} {
+		if !strings.Contains(page, want) {
+			t.Errorf("page = %q, want it to carry %q", page, want)
+		}
+	}
+}
+
+// Nothing is left blank on the page: an unset phase and a real answer must not
+// print alike.
+func TestThePageNamesTheAbsenceOfAPhase(t *testing.T) {
+	page := Render(Position{Repo: "r", Cycle: 1, Standing: Ready, Because: "nothing yet"})
+
+	if strings.Contains(page, "reached:  \n") || strings.Contains(page, "awaiting: \n") {
+		t.Errorf("page = %q, want an absent phase to read as words", page)
+	}
+}
+
+func TestTheBankedCyclesAreOnThePageWhenThereAreAny(t *testing.T) {
+	if page := Render(Position{Repo: "r"}); strings.Contains(page, "banked") {
+		t.Errorf("page = %q, want no banked line for a repository with none", page)
+	}
+	if page := Render(Position{Repo: "r", Banked: []int{1}}); !strings.Contains(page, "banked:   [1]") {
+		t.Errorf("page = %q, want the banked cycle", page)
+	}
+}
+
+func writeArtifact(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func record(t *testing.T, repoDir string, a Attempt) {
+	t.Helper()
+	if err := Record(repoDir, a); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The ceiling parks from the verdict as well as from the artifact. The handoff
+// is written by the phase that runs next, so between the verdict and that phase
+// the position has to know already — otherwise a crank reads "ready" and opens
+// a seventh authoring cycle.
+func TestTheCeilingParksBeforeTheHandoffIsWritten(t *testing.T) {
+	campaign := t.TempDir()
+	repo := filepath.Join(campaign, "r")
+	writeArtifact(t, filepath.Join(repo, "index", "index.json"), "{}")
+	writeArtifact(t, filepath.Join(repo, strconv.Itoa(phase.AuthoringCeiling), "author", "scenario.draft.yaml"), "name: r\n")
+	record(t, repo, Attempt{Cycle: phase.AuthoringCeiling, Phase: phase.Author, Verdict: phase.NoAnchor, Try: 1,
+		Table: "nothing in this repository carries the question"})
+
+	p := read(t, campaign, "r")
+
+	if p.Standing != Parked || p.Awaiting != phase.Handoff {
+		t.Errorf("standing = %s awaiting %s, want it parked at the handoff", p.Standing, p.Awaiting)
+	}
+	if p.ToCeiling() != 0 {
+		t.Errorf("to the ceiling = %d, want none left", p.ToCeiling())
+	}
+}
+
+// A cycle that wrote everything owes nothing, and the walk says so rather than
+// naming a phase that is already done.
+func TestACycleThatWroteEverythingAwaitsNothing(t *testing.T) {
+	dir := t.TempDir()
+	for _, ph := range phase.Graph {
+		if ph.Name == phase.Index || ph.Name == phase.Handoff {
+			continue
+		}
+		writeArtifact(t, filepath.Join(dir, string(ph.Name), ph.Writes), "written\n")
+	}
+
+	reached, awaiting := walk(dir)
+
+	if reached != phase.Board || awaiting != phase.Done {
+		t.Errorf("reached %s awaiting %s, want the board reached and nothing owed", reached, awaiting)
+	}
+}
+
+// A repository directory holds things that are not cycles, and this walk does
+// not rule on them.
+func TestWhatIsNotACycleDirectoryIsNotACycle(t *testing.T) {
+	campaign := t.TempDir()
+	repo := filepath.Join(campaign, "r")
+	writeArtifact(t, filepath.Join(repo, "index", "index.json"), "{}")
+	// A file named like a cycle, which is what the directory check is for: a
+	// name that parses as a number is not a cycle unless it is a directory.
+	writeArtifact(t, filepath.Join(repo, "5"), "not a cycle\n")
+	writeArtifact(t, filepath.Join(repo, "notes.md"), "# by hand\n")
+	writeArtifact(t, filepath.Join(repo, "2", "author", "scenario.draft.yaml"), "name: r\n")
+
+	if p := read(t, campaign, "r"); p.Cycle != 2 {
+		t.Errorf("cycle = %d, want the one numbered directory", p.Cycle)
+	}
+}
+
+// An exit code is a claim; the artifact is the fact. A phase that started and
+// died leaves its directory behind, so the check has to be for the artifact the
+// phase owed and not for the directory it ran in.
+func TestAPhaseDirectoryWithoutItsArtifactIsNotAFinishedPhase(t *testing.T) {
+	campaign := t.TempDir()
+	repo := filepath.Join(campaign, "r")
+	writeArtifact(t, filepath.Join(repo, "index", "index.json"), "{}")
+	// What an agent that started and died leaves: the directory, and something
+	// in it that is not what it owed.
+	writeArtifact(t, filepath.Join(repo, "1", "author", "notes.txt"), "half a thought\n")
+	record(t, repo, Attempt{Cycle: 1, Phase: phase.Author, Verdict: phase.Draft, Try: 1})
+
+	p := read(t, campaign, "r")
+
+	if p.Standing != Missing {
+		t.Errorf("standing = %s (%s), want %s: the phase wrote no scenario", p.Standing, p.Because, Missing)
+	}
+	if p.Reached == phase.Author {
+		t.Error("reached = author; a directory is not an artifact")
+	}
+}
+
+// Past the ceiling there is nothing left to spend. A repository can be resumed
+// by hand into a cycle beyond it, and the count of what remains does not go
+// negative.
+func TestNothingIsLeftPastTheCeiling(t *testing.T) {
+	p := Position{Cycle: phase.AuthoringCeiling + 1}
+
+	if p.ToCeiling() != 0 {
+		t.Errorf("to the ceiling = %d, want none left", p.ToCeiling())
+	}
+}

--- a/lab/internal/position/testdata/README.md
+++ b/lab/internal/position/testdata/README.md
@@ -1,0 +1,14 @@
+# testdata
+
+One campaign, four repositories, one of each shape a real one takes: mid-cycle
+carrying two rejections, parked at the authoring ceiling, waiting at a `PAY`
+nothing has spent, and one that banked a cycle and re-entered into the next.
+
+The layout is copied from the jellyfin campaign's tree — `<repo>/index/`,
+`<repo>/<cycle>/<phase>/`, `<repo>/attempts/` — so what is asserted here is the
+shape that occurs rather than the shape that was convenient. The artifacts are
+trimmed to a line or two each: what position reads is whether they are there.
+
+`midcycle` carries two rejections on purpose. One would let a reader that kept
+only the most recent one pass, and carrying all of them is the property the
+package is written for.

--- a/lab/internal/position/testdata/campaign/atpay/1/author/scenario.draft.yaml
+++ b/lab/internal/position/testdata/campaign/atpay/1/author/scenario.draft.yaml
@@ -1,0 +1,2 @@
+name: atpay-dependents
+repo: atpay

--- a/lab/internal/position/testdata/campaign/atpay/1/expand/scenario.yaml
+++ b/lab/internal/position/testdata/campaign/atpay/1/expand/scenario.yaml
@@ -1,0 +1,2 @@
+name: atpay-dependents
+repo: atpay

--- a/lab/internal/position/testdata/campaign/atpay/1/minibench/minibench.md
+++ b/lab/internal/position/testdata/campaign/atpay/1/minibench/minibench.md
@@ -1,0 +1,3 @@
+# mini-bench
+
+Sense reached 6 of 8, the baseline 2 of 8. PROCEED.

--- a/lab/internal/position/testdata/campaign/atpay/1/preflight/preflight.json
+++ b/lab/internal/position/testdata/campaign/atpay/1/preflight/preflight.json
@@ -1,0 +1,1 @@
+{"gold_rows":18,"quarantined":0}

--- a/lab/internal/position/testdata/campaign/atpay/1/validate/pay-call.md
+++ b/lab/internal/position/testdata/campaign/atpay/1/validate/pay-call.md
@@ -1,0 +1,3 @@
+# pay call
+
+The credit table clears the floor on every row. PAY.

--- a/lab/internal/position/testdata/campaign/atpay/attempts/1-author-1.json
+++ b/lab/internal/position/testdata/campaign/atpay/attempts/1-author-1.json
@@ -1,0 +1,1 @@
+{"cycle":1,"phase":"author","verdict":"DRAFT","try":1}

--- a/lab/internal/position/testdata/campaign/atpay/attempts/1-expand-1.json
+++ b/lab/internal/position/testdata/campaign/atpay/attempts/1-expand-1.json
@@ -1,0 +1,1 @@
+{"cycle":1,"phase":"expand","verdict":"AUTO","try":1}

--- a/lab/internal/position/testdata/campaign/atpay/attempts/1-minibench-1.json
+++ b/lab/internal/position/testdata/campaign/atpay/attempts/1-minibench-1.json
@@ -1,0 +1,1 @@
+{"cycle":1,"phase":"minibench","verdict":"PROCEED","try":1}

--- a/lab/internal/position/testdata/campaign/atpay/attempts/1-preflight-1.json
+++ b/lab/internal/position/testdata/campaign/atpay/attempts/1-preflight-1.json
@@ -1,0 +1,1 @@
+{"cycle":1,"phase":"preflight","verdict":"AUTO","try":1}

--- a/lab/internal/position/testdata/campaign/atpay/attempts/1-validate-1.json
+++ b/lab/internal/position/testdata/campaign/atpay/attempts/1-validate-1.json
@@ -1,0 +1,1 @@
+{"cycle":1,"phase":"validate","verdict":"PAY","try":1}

--- a/lab/internal/position/testdata/campaign/atpay/index/index.json
+++ b/lab/internal/position/testdata/campaign/atpay/index/index.json
@@ -1,0 +1,1 @@
+{"repo":"atpay","revision":"cccc333","files":2137,"symbols":11410,"edges":23698,"embeddings":11410,"languages":{"csharp":{"files":2137,"symbols":11410,"tier":"standard"}},"sense_status":{}}

--- a/lab/internal/position/testdata/campaign/banked/1/author/scenario.draft.yaml
+++ b/lab/internal/position/testdata/campaign/banked/1/author/scenario.draft.yaml
@@ -1,0 +1,2 @@
+name: banked-dependents
+repo: banked

--- a/lab/internal/position/testdata/campaign/banked/1/board/board.md
+++ b/lab/internal/position/testdata/campaign/banked/1/board/board.md
@@ -1,0 +1,3 @@
+# board
+
++0.62 margin, confirmed.

--- a/lab/internal/position/testdata/campaign/banked/2/author/scenario.draft.yaml
+++ b/lab/internal/position/testdata/campaign/banked/2/author/scenario.draft.yaml
@@ -1,0 +1,2 @@
+name: banked-second-question
+repo: banked

--- a/lab/internal/position/testdata/campaign/banked/attempts/1-board-1.json
+++ b/lab/internal/position/testdata/campaign/banked/attempts/1-board-1.json
@@ -1,0 +1,1 @@
+{"cycle":1,"phase":"board","verdict":"AUTO","try":1}

--- a/lab/internal/position/testdata/campaign/banked/attempts/2-author-1.json
+++ b/lab/internal/position/testdata/campaign/banked/attempts/2-author-1.json
@@ -1,0 +1,1 @@
+{"cycle":2,"phase":"author","verdict":"DRAFT","try":1}

--- a/lab/internal/position/testdata/campaign/banked/index/index.json
+++ b/lab/internal/position/testdata/campaign/banked/index/index.json
@@ -1,0 +1,1 @@
+{"repo":"banked","revision":"dddd444","files":1200,"symbols":9000,"edges":15000,"embeddings":9000,"languages":{"ruby":{"files":1200,"symbols":9000,"tier":"full"}},"sense_status":{}}

--- a/lab/internal/position/testdata/campaign/midcycle/1/author/scenario.draft.yaml
+++ b/lab/internal/position/testdata/campaign/midcycle/1/author/scenario.draft.yaml
@@ -1,0 +1,2 @@
+name: midcycle-dependents
+repo: midcycle

--- a/lab/internal/position/testdata/campaign/midcycle/1/minibench/minibench.md
+++ b/lab/internal/position/testdata/campaign/midcycle/1/minibench/minibench.md
@@ -1,0 +1,3 @@
+# mini-bench
+
+The baseline reached the same four rows. REQUESTION.

--- a/lab/internal/position/testdata/campaign/midcycle/2/author/scenario.draft.yaml
+++ b/lab/internal/position/testdata/campaign/midcycle/2/author/scenario.draft.yaml
@@ -1,0 +1,2 @@
+name: midcycle-dependents
+repo: midcycle

--- a/lab/internal/position/testdata/campaign/midcycle/2/minibench/minibench.md
+++ b/lab/internal/position/testdata/campaign/midcycle/2/minibench/minibench.md
@@ -1,0 +1,3 @@
+# mini-bench
+
+Sense reached 3 of 8 and the baseline 3 of 8. REQUESTION.

--- a/lab/internal/position/testdata/campaign/midcycle/attempts/1-author-1.json
+++ b/lab/internal/position/testdata/campaign/midcycle/attempts/1-author-1.json
@@ -1,0 +1,1 @@
+{"cycle":1,"phase":"author","verdict":"DRAFT","try":1,"anchor":"MediaBrowser.Controller.Entities.BaseItem"}

--- a/lab/internal/position/testdata/campaign/midcycle/attempts/1-minibench-1.json
+++ b/lab/internal/position/testdata/campaign/midcycle/attempts/1-minibench-1.json
@@ -1,0 +1,1 @@
+{"cycle":1,"phase":"minibench","verdict":"REQUESTION","try":1,"table":"the baseline cited 4 of 4 discriminator rows; the question is not one Sense answers better","anchor":"MediaBrowser.Controller.Entities.BaseItem"}

--- a/lab/internal/position/testdata/campaign/midcycle/attempts/2-author-1.json
+++ b/lab/internal/position/testdata/campaign/midcycle/attempts/2-author-1.json
@@ -1,0 +1,1 @@
+{"cycle":2,"phase":"author","verdict":"DRAFT","try":1,"anchor":"MediaBrowser.Controller.Entities.BaseItem"}

--- a/lab/internal/position/testdata/campaign/midcycle/attempts/2-minibench-1.json
+++ b/lab/internal/position/testdata/campaign/midcycle/attempts/2-minibench-1.json
@@ -1,0 +1,1 @@
+{"cycle":2,"phase":"minibench","verdict":"REQUESTION","try":1,"table":"both arms cited the same 3 rows; the second question is no more discriminating than the first","anchor":"MediaBrowser.Controller.Entities.BaseItem"}

--- a/lab/internal/position/testdata/campaign/midcycle/index/index.json
+++ b/lab/internal/position/testdata/campaign/midcycle/index/index.json
@@ -1,0 +1,1 @@
+{"repo":"midcycle","revision":"aaaa111","files":902,"symbols":11830,"edges":24810,"embeddings":11830,"languages":{"csharp":{"files":902,"symbols":11830,"tier":"standard"}},"sense_status":{}}

--- a/lab/internal/position/testdata/campaign/parked/6/author/scenario.draft.yaml
+++ b/lab/internal/position/testdata/campaign/parked/6/author/scenario.draft.yaml
@@ -1,0 +1,2 @@
+name: parked-attempt
+repo: parked

--- a/lab/internal/position/testdata/campaign/parked/6/handoff/handoff.md
+++ b/lab/internal/position/testdata/campaign/parked/6/handoff/handoff.md
@@ -1,0 +1,3 @@
+# handoff
+
+Six authoring cycles, no anchor that carries a question. Parked for a human.

--- a/lab/internal/position/testdata/campaign/parked/attempts/6-author-1.json
+++ b/lab/internal/position/testdata/campaign/parked/attempts/6-author-1.json
@@ -1,0 +1,1 @@
+{"cycle":6,"phase":"author","verdict":"NO-ANCHOR","try":1,"table":"no symbol in this repository carries a question the baseline cannot answer"}

--- a/lab/internal/position/testdata/campaign/parked/index/index.json
+++ b/lab/internal/position/testdata/campaign/parked/index/index.json
@@ -1,0 +1,1 @@
+{"repo":"parked","revision":"bbbb222","files":410,"symbols":5120,"edges":9000,"embeddings":5120,"languages":{"go":{"files":410,"symbols":5120,"tier":"full"}},"sense_status":{}}


### PR DESCRIPTION
Stacked on #298. Review that one first; this PR's diff is only its own changes.

## Problem

A repository's position lives in the operator's head. `sense-lab status` answers where a *campaign* stands; nothing answers the question a crank has to answer before it does anything — what is the next phase for this repository, and how many authoring cycles has it already spent.

The old driver answered it with a JSON map of repository to phase, edited by whoever was debugging. That is a decision anyone can change by hand, which made it the one number in the system with no evidence behind it.

## Summary

Position is a function of two inputs, and which input a fact comes from is the whole design.

The run tree holds which artifacts exist and the authoring cycle — already a directory name under `<campaign>/<repo>/<cycle>/`. Derived every time, never stored: a counter beside the fact it counts is a counter that drifts from it.

The attempt records hold the verdict, the table that rejected it and the anchor. Recorded once and never re-derived, because no amount of reading a tree recovers a judgment. One file per attempt, written with `O_EXCL` — append-only as a convention survives until a bad night, and append-only as an open flag survives the bad night.

Out of the two comes a standing, and the standing is an exit code, because this command belongs in a loop.

| Code | Means |
|---|---|
| 0 | there is a phase to run |
| 2 | `-show`: a position was printed and nothing was done |
| 3 | finished: the repository reached the board |
| 4 | parked at the authoring ceiling |
| 5 | waiting on a human: a `PAY` nothing will spend on its own |
| 6 | refused: the last verdict is not one its phase can emit |
| 7 | refused: the verdict is usable and the artifact it owed is not there |

Four and five are the two most worth telling apart: one is the method failing on this repository, the other is the method succeeding and waiting on a wallet. Six and seven are diagnosed differently too — an agent that misbehaved, against an agent that died.

`-show` stops at the announcement, which is the point before an admission writes anything, so it is a preview of what is about to happen rather than a second reading of the same inputs.

## Changes

- `lab/internal/position`: the attempt record and the reader, with a committed fixture campaign carrying one repository of each shape — mid-cycle with two rejections carried, parked at the ceiling, waiting at a `PAY`, and one that banked a cycle and re-entered
- `lab/internal/cli/repocmd.go`: the standing, the codes, and `-show`
- `lab/README.md`: the code table, and what is derived against what is recorded

`sense-lab status` is untouched: it stays campaign-wide, and there is no board across repositories here.

## Test plan

- `make ci` green: coverage floor with no new exception, zero complexity suppressions, lint clean
- new files hold 96.4% and 98.2% line coverage, every function covered
- ten mutations that the first draft of the tests let through are now killed, each verified by making the mutation and watching a named test fail: dropping the graph-order sort, checking the phase directory instead of the artifact it owed, treating any banked cycle as a finished repository, keeping only the last rejection instead of all of them, treating a file named like a cycle as a cycle, never assigning the reached phase or the last verdict, letting the count to the ceiling go negative, and dropping the anchor from the record
- every exit code in the table is asserted, and the loop is asserted to stop on each of the four states that must stop it