### PR TITLE
bench(lab): turn the loop

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -97,6 +97,23 @@ linters:
               desc: "the lab's pure core must not touch the network"
             - pkg: syscall
               desc: "the lab's pure core must not call syscalls directly"
+        # The deciding layer. These packages work out what happens next, and
+        # nothing that decides a next phase may spawn one: the spawner is a
+        # value the edge hands in, and the crank never imports one. `os` is
+        # allowed here and denied in lab-pure above, and the difference is the
+        # point — position reads a run tree by design, and what it may not do is
+        # reach a process.
+        lab-decides:
+          files:
+            - "**/lab/internal/position/**"
+            - "**/lab/internal/crank/**"
+          deny:
+            - pkg: os/exec
+              desc: "the deciding layer must not spawn; the spawner is injected at the edge"
+            - pkg: net
+              desc: "the deciding layer must not touch the network"
+            - pkg: syscall
+              desc: "the deciding layer must not call syscalls directly"
         lab-boundary:
           files:
             - "**/lab/**"

--- a/lab/README.md
+++ b/lab/README.md
@@ -77,6 +77,25 @@ standing, because this command belongs in a loop:
 So `while sense-lab repo <id>; do :; done` stops on a park, on a `PAY` and on
 either refusal, rather than spinning on any of them.
 
+**Turning the loop.** Naming an agent and a model runs the phase the position
+owes, one per invocation:
+
+```bash
+./bin/sense-lab repo -campaign runs/campaigns/<key> -sense ./bin/sense \
+    -agent claude-code -model claude-opus-5 -until <id>
+```
+
+Each phase agent is handed one plan file from `lab/plans/`, under the wall that
+plan declares, in a disposable environment carrying no more than a run arm's
+credential. It writes its artifact and a `verdict.json` beside it; the crank
+reads that document, checks it against the plan's declared verdicts and against
+the artifact being on disk, records the attempt and routes. `-until` takes no
+argument and means crank until it stops on its own.
+
+**The crank stops at the pay call.** `PAY` prints the exact `probe` command and
+exits waiting-on-a-human. `bench`, `report`, `harvest` and `board` stay hand-run:
+an unattended loop that can reach a paid cell is a different product.
+
 Position is derived from the run tree every time — the authoring cycle is a
 directory name — except for the verdicts, which are recorded one file per
 attempt and never rewritten. There is no state file mapping a repository to a

--- a/lab/README.md
+++ b/lab/README.md
@@ -56,8 +56,31 @@ url and the revision — before it writes anything, then clones under
 ```
 
 Running it again on an admitted repository admits nothing and prints where it
-stands. A clone the lab made is moved back to its pin if it has drifted; a clone
-you handed in is read and never written to, and a mismatch there is refused.
+stands: the cycle it is on, the phase it awaits, and every rejection the next
+attempt has to answer. A clone the lab made is moved back to its pin if it has
+drifted; a clone you handed in is read and never written to, and a mismatch
+there is refused.
+
+`-show` prints that page and stops, writing nothing. The exit code carries the
+standing, because this command belongs in a loop:
+
+| Code | Means |
+|---|---|
+| 0 | there is a phase to run |
+| 2 | `-show`: a position was printed and nothing was done |
+| 3 | finished: the repository reached the board |
+| 4 | parked at the authoring ceiling, re-entered only by a deliberate human act |
+| 5 | waiting on a human: a `PAY` nothing will spend on its own |
+| 6 | refused: the last verdict is not one its phase can emit |
+| 7 | refused: the verdict is usable and the artifact it owed is not there |
+
+So `while sense-lab repo <id>; do :; done` stops on a park, on a `PAY` and on
+either refusal, rather than spinning on any of them.
+
+Position is derived from the run tree every time — the authoring cycle is a
+directory name — except for the verdicts, which are recorded one file per
+attempt and never rewritten. There is no state file mapping a repository to a
+phase.
 
 Every run takes a worktree from that clone at the pinned commit, so the clone is
 the only thing that has to exist on disk.

--- a/lab/internal/cli/cli.go
+++ b/lab/internal/cli/cli.go
@@ -28,7 +28,7 @@ const usage = `sense-lab — the bench instrument for Sense
 Usage: sense-lab <command> [flags]
 
 Commands:
-  repo      Admit a repository: resolve it, clone it, pin it and index it
+  repo      Admit a repository, and say where it stands: -show prints and stops
   catalog   Show the subjects, agents, models, repositories and executors in the config
   plan      Show what a campaign would run, and every rejection with its reason
   run       Run one scenario against one repository

--- a/lab/internal/cli/cli.go
+++ b/lab/internal/cli/cli.go
@@ -28,7 +28,7 @@ const usage = `sense-lab — the bench instrument for Sense
 Usage: sense-lab <command> [flags]
 
 Commands:
-  repo      Admit a repository, and say where it stands: -show prints and stops
+  repo      Admit a repository, say where it stands, and run its next phase
   catalog   Show the subjects, agents, models, repositories and executors in the config
   plan      Show what a campaign would run, and every rejection with its reason
   run       Run one scenario against one repository

--- a/lab/internal/cli/crankcmd.go
+++ b/lab/internal/cli/crankcmd.go
@@ -1,0 +1,161 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"time"
+
+	"github.com/luuuc/sense/lab/internal/catalog"
+	"github.com/luuuc/sense/lab/internal/crank"
+	"github.com/luuuc/sense/lab/internal/isolate"
+	"github.com/luuuc/sense/lab/internal/plans"
+	"github.com/luuuc/sense/lab/internal/position"
+	"github.com/luuuc/sense/lab/internal/run"
+)
+
+// plansDir is where the declared plans live, relative to the config directory.
+// The plans are config the way the catalog is: a phase's instructions are a file
+// somebody reviews, never a string in this binary.
+const plansDir = "plans"
+
+// attemptDir names a run directory for one try. The first is unsuffixed, so the
+// ordinary tree reads the way it always has, and a second attempt lands beside
+// the first rather than on top of it: a run's environment is created fresh or
+// not at all, and overwriting one would destroy the evidence of why there was a
+// second attempt.
+func attemptDir(name string, try int) string {
+	if try <= 1 {
+		return name
+	}
+	return fmt.Sprintf("%s-%d", name, try)
+}
+
+// phaseGrace is how long a phase agent gets to stop on its own after its wall.
+// It is here rather than in the plan header because it is not a property of any
+// phase: it is how long a process takes to die.
+const phaseGrace = 30 * time.Second
+
+// turn runs the crank over one repository: one phase, or every phase until it
+// stops on its own.
+//
+// The loop is here rather than inside the crank. `-until` takes no argument and
+// means crank until it stops, so nothing in the dispatcher knows which of the
+// two it is in and no mode is threaded through it.
+func turn(ctx context.Context, f repoFlags, c *catalog.Catalog, id string, stdout, stderr io.Writer) int {
+	k, err := crankFor(f, c, id)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "sense-lab repo: %v\n", err)
+		return exitError
+	}
+	for {
+		r, err := k.Advance(ctx, id)
+		if err != nil {
+			_, _ = fmt.Fprintf(stderr, "sense-lab repo: %v\n", err)
+			return exitError
+		}
+		_, _ = fmt.Fprint(stdout, position.Render(r.After))
+		if r.Note != "" {
+			_, _ = fmt.Fprintf(stdout, "\n%s\n", r.Note)
+		}
+		if code, stop := stopOn[r.After.Standing]; stop {
+			return code
+		}
+		if !f.until {
+			return exitOK
+		}
+	}
+}
+
+// crankFor assembles the wiring once: the declared plans, the repository's
+// checkout, and the spawner. Everything a phase needs comes from here or from
+// its plan, never from Advance's arguments.
+func crankFor(f repoFlags, c *catalog.Catalog, id string) (crank.Crank, error) {
+	loaded, err := plans.Load(filepath.Join(f.config, plansDir))
+	if err != nil {
+		return crank.Crank{}, err
+	}
+	r, ok := c.Repos[id]
+	if !ok {
+		return crank.Crank{}, fmt.Errorf("no repository %q in the catalog", id)
+	}
+	checkout := r.Checkout
+	if checkout == "" {
+		checkout = filepath.Join(f.checkouts, id)
+	}
+	spawn, err := phaseSpawner(f, c)
+	if err != nil {
+		return crank.Crank{}, err
+	}
+	return crank.Crank{Campaign: f.campaign, Plans: loaded, Checkout: checkout, Spawn: spawn}, nil
+}
+
+// phaseSpawner is the real spawner: the one thing in this cycle that reaches a
+// process.
+//
+// It lives here, at the edge, beside the other things that spawn. The crank
+// takes it as a value and never imports one, which is what the depguard rule on
+// the deciding packages holds in place.
+func phaseSpawner(f repoFlags, c *catalog.Catalog) (crank.Spawner, error) {
+	if f.agent == "" || f.model == "" {
+		return nil, fmt.Errorf("-agent and -model say what a phase is run by; without them nothing can be dispatched")
+	}
+	a, m, err := resolveDriver(c, f.agent, f.model)
+	if err != nil {
+		return nil, err
+	}
+	return func(ctx context.Context, j crank.Job) (crank.Ran, error) {
+		return spawnPhase(ctx, f, a, m, j)
+	}, nil
+}
+
+// spawnPhase runs one phase agent under its declared wall, inside a disposable
+// environment carrying no more than a run arm's credential.
+//
+// The agent is spawned in the repository under study, because that is what it
+// reads. It writes its artifact and its verdict into the phase directory it is
+// told about, which is why that directory is named in what it is handed rather
+// than inferred by it.
+func spawnPhase(ctx context.Context, f repoFlags, a catalog.Agent, model catalog.Model, j crank.Job) (crank.Ran, error) {
+	// The same credential a run arm gets, resolved the same way and reaching no
+	// keychain of its own. A phase agent is not a privileged thing.
+	cred, err := cellCredential(ctx, a, model, time.Now().Add(j.Wall+phaseGrace))
+	if err != nil {
+		return crank.Ran{}, err
+	}
+	env, err := isolate.Prepare(isolate.Spec{
+		Root:       filepath.Join(j.Dir, attemptDir("env", j.Try)),
+		Arm:        isolate.Sense,
+		SenseBin:   f.senseBin,
+		HostPath:   os.Getenv("PATH"),
+		AgentEnv:   a.Env,
+		Credential: cred,
+		Route:      credentialRoute(a),
+	})
+	if err != nil {
+		return crank.Ran{}, err
+	}
+	m, err := run.Session(ctx, filepath.Join(j.Dir, attemptDir("session", j.Try)), run.Spec{
+		Dir:   j.Checkout,
+		Name:  a.Binary,
+		Args:  append(slices.Clone(a.HeadlessArgs), a.ModelFlag, model.ID),
+		Stdin: j.Prompt,
+		Env:   env.Environ,
+		Arm:   string(isolate.Sense),
+		Wall:  j.Wall,
+		Grace: phaseGrace,
+	})
+	if err != nil {
+		return crank.Ran{}, err
+	}
+	// The outcome is carried, never interpreted into a verdict. What the phase
+	// decided is read from the document it wrote, because an exit code is a
+	// claim.
+	return crank.Ran{
+		Finished: m.Outcome == run.Completed,
+		Log:      filepath.Join(j.Dir, attemptDir("session", j.Try), "raw", "stdout"),
+	}, nil
+}

--- a/lab/internal/cli/crankcmd_test.go
+++ b/lab/internal/cli/crankcmd_test.go
@@ -1,0 +1,549 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/lab/internal/isolate"
+	"github.com/luuuc/sense/lab/internal/position"
+)
+
+// phaseAgent stands in for the agent a phase is run by. It does what a phase
+// agent does and nothing else: it reads where its artifact and its verdict
+// belong out of what it was handed, writes both, and records the login it was
+// given so a test can read what reached it.
+//
+// The verdict is chosen by phase from the plan's own declarations, so this one
+// script can walk a whole authoring cycle.
+const phaseAgentScript = `#!/bin/sh
+set -e
+in=$(cat)
+art=$(printf '%s\n' "$in" | sed -n 's/^artifact: //p' | head -1)
+ver=$(printf '%s\n' "$in" | sed -n 's/^verdict: //p' | head -1)
+phase=$(printf '%s\n' "$in" | sed -n 's/^phase: //p' | head -1)
+repo=$(printf '%s\n' "$in" | sed -n 's/^repository: //p' | head -1)
+cycle=$(printf '%s\n' "$in" | sed -n 's/^cycle: \([0-9]*\).*/\1/p' | head -1)
+case "$phase" in
+  author) verdict=DRAFT ;;
+  minibench) verdict=PROCEED ;;
+  expand|preflight) verdict=AUTO ;;
+  validate) verdict=PAY ;;
+  *) verdict=AUTO ;;
+esac
+mkdir -p "$(dirname "$art")"
+pwd > "$(dirname "$art")/given-cwd.txt"
+if [ -n "$PHASE_AGENT_SLEEP" ]; then sleep "$PHASE_AGENT_SLEEP"; fi
+if [ -z "$PHASE_AGENT_NO_ARTIFACT" ]; then printf 'what %s wrote\n' "$phase" > "$art"; fi
+printf '{"phase":"%s","repo":"%s","cycle":%s,"verdict":"%s","anchor":"Category"}\n' \
+  "$phase" "$repo" "$cycle" "$verdict" > "$ver"
+# What the phase was actually handed, kept where the test can read it.
+cp "$FAKE_CONFIG_DIR/.credentials.json" "$(dirname "$art")/given-credential.json" 2>/dev/null || true
+printf '%s\n' "$in" > "$(dirname "$art")/given-prompt.txt"
+`
+
+// crankWorld is a repository admitted, scanned, and ready for its first
+// authoring phase, with an agent that can run one.
+type crankWorld struct {
+	admission
+	repo     string
+	campaign string
+	checkout string
+}
+
+func newCrankWorld(t *testing.T, env ...string) crankWorld {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("the stand-in agent is a shell script")
+	}
+	a, id := admitted(t)
+	bin := filepath.Join(t.TempDir(), "phase-agent")
+	if err := os.WriteFile(bin, []byte(phaseAgentScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	artifact(t, filepath.Join(a.config, "agents", "phase", "agent.json"),
+		`{"id":"phase","binary":"`+bin+`","setup_tool":"fake-cli","transcript_format":"assistant-events",`+
+			`"model_flag":"--model","config_dirs":[".fake"],"config_dir_var":"FAKE_CONFIG_DIR",`+
+			`"keychain_service":"Fake-credentials","credential_file":".credentials.json",`+
+			`"credential_fields":["fakeOauth.accessToken","fakeOauth.scopes"],`+
+			`"credential_expiry":"ms:fakeOauth.expiresAt",`+
+			`"headless_args":["-c"],"env":`+quoted(t, env)+`,"supports_mcp":true,"auth_modes":["subscription"]}`)
+	artifact(t, filepath.Join(a.config, "models", "m1.json"),
+		`{"id":"m1","provider":"acme","available_under":["subscription"],"agents":["phase"]}`)
+	// The plans are config, so the world points at the shipped ones.
+	linkPlans(t, a.config)
+	// A host that holds a seat, stated rather than logged in: CI has none.
+	hostHolding(t, aSeatWithNoise(time.Hour), nil)
+	for _, name := range isolate.Credentials() {
+		t.Setenv(name, "")
+	}
+	return crankWorld{admission: a, repo: id, campaign: a.campaign, checkout: checkoutOf(t, a, id)}
+}
+
+func (w crankWorld) run(t *testing.T, extra ...string) (int, string, string) {
+	t.Helper()
+	args := []string{"repo", "-config", w.config, "-campaign", w.campaign, "-checkouts", w.checkouts,
+		"-sense", w.sense, "-agent", "phase", "-model", "m1"}
+	return dispatch(t, append(append(args, extra...), w.repo)...)
+}
+
+func (w crankWorld) phaseDir(name string) string {
+	return filepath.Join(w.campaign, w.repo, "1", name)
+}
+
+// linkPlans points the world's config at the shipped plans. They are loaded from
+// the config directory, so a world with none would test a crank with no graph.
+func linkPlans(t *testing.T, config string) {
+	t.Helper()
+	shipped, err := filepath.Abs(filepath.Join("..", "..", "plans"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(shipped, filepath.Join(config, "plans")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// aSeatWithNoise is a host store carrying the login AND things a run has no
+// business seeing. What reaches the phase is what the allowlist names.
+func aSeatWithNoise(good time.Duration) isolate.Credential {
+	c := aSeat(good)
+	c.Fields["fakeOauth.refreshToken"] = json.RawMessage(`"the-refresh-token"`)
+	c.Fields["otherAccount.accessToken"] = json.RawMessage(`"somebody-elses"`)
+	return c
+}
+
+// One turn of the crank, for real: a phase agent spawned, its verdict read, its
+// artifact checked, the attempt recorded and the position moved.
+func TestTheCrankRunsAPhaseAndTheLoopMoves(t *testing.T) {
+	w := newCrankWorld(t)
+
+	code, stdout, stderr := w.run(t)
+
+	if code != exitOK {
+		t.Fatalf("exit %d: %s%s", code, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "awaiting: minibench") {
+		t.Errorf("stdout = %q, want the loop moved to the next phase", stdout)
+	}
+	if _, err := os.Stat(filepath.Join(w.phaseDir("author"), "scenario.draft.yaml")); err != nil {
+		t.Errorf("the phase's artifact is not there: %v", err)
+	}
+}
+
+// The credential a phase agent is handed carries no more than a run arm's, and
+// it is asserted on the document that reached it rather than on the code that
+// wrote one.
+func TestAPhaseAgentIsHandedNoMoreThanARunArm(t *testing.T) {
+	w := newCrankWorld(t)
+
+	if code, stdout, stderr := w.run(t); code != exitOK {
+		t.Fatalf("exit %d: %s%s", code, stdout, stderr)
+	}
+
+	b, err := os.ReadFile(filepath.Join(w.phaseDir("author"), "given-credential.json"))
+	if err != nil {
+		t.Fatalf("the phase was handed no credential document: %v", err)
+	}
+	given := string(b)
+	if !strings.Contains(given, "accessToken") {
+		t.Errorf("the phase was handed no login at all: %s", given)
+	}
+	for _, forbidden := range []string{"refreshToken", "otherAccount", "the-refresh-token"} {
+		if strings.Contains(given, forbidden) {
+			t.Errorf("the phase was handed %q, which is outside the allowlist: %s", forbidden, given)
+		}
+	}
+}
+
+// `-until` cranks until it stops on its own, and where it stops is the pay call:
+// the phases that spend stay hand-run this cycle.
+func TestUntilCranksToThePayCallAndStops(t *testing.T) {
+	w := newCrankWorld(t)
+
+	code, stdout, stderr := w.run(t, "-until")
+
+	if code != exitWaiting {
+		t.Fatalf("exit %d, want it waiting on a human: %s%s", code, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "sense-lab probe") {
+		t.Errorf("stdout = %q, want the command to run by hand", stdout)
+	}
+	for _, phase := range []string{"author", "minibench", "expand", "preflight", "validate"} {
+		if _, err := os.Stat(filepath.Join(w.phaseDir(phase), "verdict.json")); err != nil {
+			t.Errorf("%s never ran: %v", phase, err)
+		}
+	}
+	if _, err := os.Stat(w.phaseDir("bench")); err == nil {
+		t.Error("the crank reached a phase that spends")
+	}
+}
+
+// The plan reaches the agent, and the facts of the attempt with it. Read off
+// what the agent was handed rather than off what the crank composed.
+func TestThePhaseAgentIsHandedItsPlan(t *testing.T) {
+	w := newCrankWorld(t)
+
+	if code, _, stderr := w.run(t); code != exitOK {
+		t.Fatalf("exit %d: %s", code, stderr)
+	}
+
+	b, err := os.ReadFile(filepath.Join(w.phaseDir("author"), "given-prompt.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	handed := string(b)
+	for _, want := range []string{"repository: " + w.repo, "cycle: 1 of 6", "# author", "## Task"} {
+		if !strings.Contains(handed, want) {
+			t.Errorf("the agent was not handed %q:\n%s", want, handed)
+		}
+	}
+}
+
+// Nothing is dispatched without something to dispatch it with, and the refusal
+// says which flags are missing rather than spawning nothing quietly.
+func TestNoPhaseRunsWithoutAnAgentAndAModel(t *testing.T) {
+	w := newCrankWorld(t)
+
+	code, stdout, _ := dispatch(t, "repo", "-config", w.config, "-campaign", w.campaign,
+		"-checkouts", w.checkouts, "-sense", w.sense, w.repo)
+
+	if code != exitOK {
+		t.Fatalf("exit %d, want the position printed", code)
+	}
+	if !strings.Contains(stdout, "awaiting: author") {
+		t.Errorf("stdout = %q, want the position", stdout)
+	}
+	if _, err := os.Stat(w.phaseDir("author")); err == nil {
+		t.Error("a phase ran with no agent named")
+	}
+}
+
+func TestAnAgentTheCatalogDoesNotKnowIsRefused(t *testing.T) {
+	w := newCrankWorld(t)
+
+	code, _, stderr := dispatch(t, "repo", "-config", w.config, "-campaign", w.campaign,
+		"-checkouts", w.checkouts, "-sense", w.sense, "-agent", "nobody", "-model", "m1", w.repo)
+
+	if code != exitError {
+		t.Fatalf("exit %d, want an error", code)
+	}
+	if !strings.Contains(stderr, "no agent") {
+		t.Errorf("stderr = %q, want it to name what is missing", stderr)
+	}
+}
+
+// A config with no plans is a graph nobody can run, and it is refused rather
+// than dispatched against with an empty prompt.
+func TestAConfigWithNoPlansIsRefused(t *testing.T) {
+	w := newCrankWorld(t)
+	if err := os.Remove(filepath.Join(w.config, "plans")); err != nil {
+		t.Fatal(err)
+	}
+
+	code, _, stderr := w.run(t)
+
+	if code != exitError {
+		t.Fatalf("exit %d, want an error", code)
+	}
+	if !strings.Contains(stderr, "plan") {
+		t.Errorf("stderr = %q, want it to name what is missing", stderr)
+	}
+}
+
+// A second attempt at one phase keeps the first's evidence. A run environment is
+// created fresh or not at all, and overwriting one destroys the record of why
+// there was a second attempt.
+func TestASecondAttemptLandsBesideTheFirst(t *testing.T) {
+	if got := attemptDir("session", 1); got != "session" {
+		t.Errorf("first attempt = %q, want the ordinary name", got)
+	}
+	if got := attemptDir("session", 2); got != "session-2" {
+		t.Errorf("second attempt = %q, want it beside the first", got)
+	}
+}
+
+// A driver named by half is not a driver, and the refusal says so rather than
+// dispatching nothing quietly.
+func TestHalfADriverIsRefused(t *testing.T) {
+	w := newCrankWorld(t)
+
+	code, _, stderr := dispatch(t, "repo", "-config", w.config, "-campaign", w.campaign,
+		"-checkouts", w.checkouts, "-sense", w.sense, "-agent", "phase", w.repo)
+
+	if code != exitError {
+		t.Fatalf("exit %d, want an error", code)
+	}
+	if !strings.Contains(stderr, "-agent and -model") {
+		t.Errorf("stderr = %q, want it to name both flags", stderr)
+	}
+}
+
+// A phase agent that could not be given a login does not run. Two arms of a real
+// cell once exited in about a second with "Not logged in", and a phase agent
+// fails the same way for the same reason.
+func TestAPhaseWithNoCredentialDoesNotRun(t *testing.T) {
+	w := newCrankWorld(t)
+	hostHolding(t, isolate.Credential{}, errors.New("no store on this machine"))
+
+	code, _, stderr := w.run(t)
+
+	if code != exitError {
+		t.Fatalf("exit %d, want an error", code)
+	}
+	if !strings.Contains(stderr, "credential") {
+		t.Errorf("stderr = %q, want it to say what is missing", stderr)
+	}
+	if _, err := os.Stat(filepath.Join(w.phaseDir("author"), "verdict.json")); err == nil {
+		t.Error("a phase ran with no login")
+	}
+}
+
+// A run environment is created fresh or not at all, so one that is already there
+// stops the phase rather than being reused.
+func TestAnEnvironmentThatIsAlreadyThereStopsThePhase(t *testing.T) {
+	w := newCrankWorld(t)
+	artifact(t, filepath.Join(w.phaseDir("author"), "env", "leftover"), "from a previous run\n")
+
+	code, _, stderr := w.run(t)
+
+	if code != exitError {
+		t.Fatalf("exit %d, want an error", code)
+	}
+	if !strings.Contains(stderr, "already exists") {
+		t.Errorf("stderr = %q, want it to say the environment was not fresh", stderr)
+	}
+}
+
+// A repository the catalog does not hold cannot be cranked, whatever a run tree
+// says about it.
+func TestARepositoryTheCatalogDoesNotHoldIsRefused(t *testing.T) {
+	w := newCrankWorld(t)
+	if err := os.Remove(w.repoFile(w.repo)); err != nil {
+		t.Fatal(err)
+	}
+
+	code, _, stderr := w.run(t)
+
+	if code != exitError {
+		t.Fatalf("exit %d, want an error", code)
+	}
+	if !strings.Contains(stderr, "not an admitted id") && !strings.Contains(stderr, "no repository") {
+		t.Errorf("stderr = %q, want it to say the repository is unknown", stderr)
+	}
+}
+
+// A repository the lab cloned has no checkout recorded, and the phase runs in
+// the clone under the lab's own root.
+func TestALabOwnedRepositoryIsCrankedInItsOwnClone(t *testing.T) {
+	w := newCrankWorld(t)
+	clone, _ := sourceRepo(t)
+	if err := os.MkdirAll(w.checkouts, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(clone, filepath.Join(w.checkouts, w.repo)); err != nil {
+		t.Fatal(err)
+	}
+	// No checkout recorded is what says the lab made this clone.
+	artifact(t, w.repoFile(w.repo), `{"id":"`+w.repo+`","url":"https://example.test/`+w.repo+
+		`.git","commit":"`+headOf(t, clone)+`","languages":["go"]}`)
+
+	if code, stdout, stderr := w.run(t); code != exitOK {
+		t.Fatalf("exit %d: %s%s", code, stdout, stderr)
+	}
+
+	b, err := os.ReadFile(filepath.Join(w.phaseDir("author"), "given-prompt.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "repository: "+w.repo) {
+		t.Errorf("the phase was not told which repository it was in:\n%s", b)
+	}
+}
+
+func headOf(t *testing.T, dir string) string {
+	t.Helper()
+	return git(t, dir, "rev-parse", "HEAD")
+}
+
+// No interactive prompt exists anywhere in the run path.
+//
+// The law is cycle 05's and it binds this cycle hardest, because this is the
+// cycle where a confirmation would feel most helpful: the crank is about to
+// spawn something. The printed position before the act is the whole affordance,
+// and a prompt would turn an unattended loop into one that waits forever on a
+// terminal nobody is watching.
+//
+// The probe is over the source rather than over behaviour, because a prompt
+// that is never reached in a test is exactly the one that would be added.
+func TestNothingInTheRunPathReadsFromATerminal(t *testing.T) {
+	for _, at := range []string{
+		filepath.Join("..", "crank"),
+		filepath.Join("..", "position"),
+		filepath.Join("..", "repo"),
+	} {
+		entries, err := os.ReadDir(at)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") || strings.HasSuffix(e.Name(), "_test.go") {
+				continue
+			}
+			b, err := os.ReadFile(filepath.Join(at, e.Name()))
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, forbidden := range []string{"os.Stdin", "bufio.NewScanner(os.", "fmt.Scan"} {
+				if strings.Contains(string(b), forbidden) {
+					t.Errorf("%s/%s reads a terminal (%s); the run path has no interactive prompt in it",
+						at, e.Name(), forbidden)
+				}
+			}
+		}
+	}
+	// And the one file in this package that turns the crank does not either.
+	b, err := os.ReadFile("crankcmd.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), "os.Stdin") {
+		t.Error("crankcmd.go reads a terminal; an unattended loop cannot answer a question")
+	}
+}
+
+// The phase agent runs in the repository under study. One pointed anywhere else
+// reads nothing, and its draft would be about a repository it never opened.
+func TestThePhaseAgentRunsInTheRepositoryUnderStudy(t *testing.T) {
+	w := newCrankWorld(t)
+
+	if code, stdout, stderr := w.run(t); code != exitOK {
+		t.Fatalf("exit %d: %s%s", code, stdout, stderr)
+	}
+
+	b, err := os.ReadFile(filepath.Join(w.phaseDir("author"), "given-cwd.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := filepath.EvalSymlinks(w.checkout)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(b)); got != want {
+		t.Errorf("the phase ran in %q, want the repository under study (%q)", got, want)
+	}
+}
+
+// A phase agent that runs past its wall is recorded as out of clock and the
+// crank stops, rather than holding on it. The wall comes off the plan, so this
+// is driven by editing a declaration.
+func TestARealAgentThatRunsPastItsWallIsRecordedAsOutOfClock(t *testing.T) {
+	w := newCrankWorld(t, "PHASE_AGENT_SLEEP=5")
+	copyPlansWithWall(t, w.config, "author", "1s")
+
+	code, stdout, stderr := w.run(t)
+
+	if code != exitMissing {
+		t.Fatalf("exit %d, want the agent recorded as one that did not finish: %s%s", code, stdout, stderr)
+	}
+	if !strings.Contains(stdout, "past its wall") {
+		t.Errorf("stdout = %q, want it to say the phase ran out of clock", stdout)
+	}
+	recorded := attemptsOf(t, w)
+	if len(recorded) != 1 || recorded[0].Outcome != position.Stalled {
+		t.Errorf("recorded %+v, want one stalled attempt", recorded)
+	}
+}
+
+// An exit code is a claim; the artifact is the fact. A real agent that finished,
+// said the right thing and wrote nothing does not advance.
+func TestARealAgentThatWroteNoArtifactDoesNotAdvance(t *testing.T) {
+	w := newCrankWorld(t, "PHASE_AGENT_NO_ARTIFACT=1")
+
+	code, stdout, stderr := w.run(t)
+
+	if code != exitMissing {
+		t.Fatalf("exit %d, want it held at the missing artifact: %s%s", code, stdout, stderr)
+	}
+	if recorded := attemptsOf(t, w); recorded[0].Artifact != "" {
+		t.Errorf("recorded artifact %q, want none: nothing was accepted", recorded[0].Artifact)
+	}
+}
+
+func attemptsOf(t *testing.T, w crankWorld) []position.Attempt {
+	t.Helper()
+	all, err := position.Attempts(filepath.Join(w.campaign, w.repo))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return all
+}
+
+// copyPlansWithWall replaces the world's symlinked plans with real files, one of
+// them carrying a different wall. It is how a wall is changed the way a person
+// changes one: by editing the declaration.
+func copyPlansWithWall(t *testing.T, config, name, wall string) {
+	t.Helper()
+	at := filepath.Join(config, "plans")
+	if err := os.Remove(at); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(at, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	shipped, err := filepath.Abs(filepath.Join("..", "..", "plans"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(shipped)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		b, err := os.ReadFile(filepath.Join(shipped, e.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if e.Name() == name+".md" {
+			b = wallLine.ReplaceAll(b, []byte("wall: "+wall+"\n"))
+		}
+		if err := os.WriteFile(filepath.Join(at, e.Name()), b, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+var wallLine = regexp.MustCompile(`(?m)^wall: .*\n`)
+
+// checkoutOf is where the world's repository actually is, read from the record
+// the admission wrote rather than assumed.
+func checkoutOf(t *testing.T, a admission, id string) string {
+	t.Helper()
+	var r struct{ Checkout string }
+	readJSON(t, a.repoFile(id), &r)
+	if r.Checkout == "" {
+		return filepath.Join(a.checkouts, id)
+	}
+	return r.Checkout
+}
+
+// quoted renders the agent's declared environment as the catalog spells it. A
+// phase agent's environment is what the catalog says it is, so a test that
+// wants the stand-in to behave differently declares it there.
+func quoted(t *testing.T, env []string) string {
+	t.Helper()
+	b, err := json.Marshal(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(env) == 0 {
+		return "[]"
+	}
+	return string(b)
+}

--- a/lab/internal/cli/repocmd.go
+++ b/lab/internal/cli/repocmd.go
@@ -55,7 +55,10 @@ type repoFlags struct {
 	campaign  string
 	checkouts string
 	senseBin  string
+	agent     string
+	model     string
 	show      bool
+	until     bool
 	name      string
 }
 
@@ -67,7 +70,10 @@ func parseRepoFlags(args []string, stderr io.Writer) (repoFlags, error) {
 	fs.StringVar(&f.campaign, "campaign", "", "the campaign's run tree, where the index artifact lands (required)")
 	fs.StringVar(&f.checkouts, "checkouts", defaultCheckouts, "the lab's own clones root")
 	fs.StringVar(&f.senseBin, "sense", "sense", "the Sense binary that indexes the repository")
+	fs.StringVar(&f.agent, "agent", "", "catalog agent id a phase is run by")
+	fs.StringVar(&f.model, "model", "", "catalog model id a phase is run by")
 	fs.BoolVar(&f.show, "show", false, "print the position and stop, writing nothing")
+	fs.BoolVar(&f.until, "until", false, "crank until it stops on its own, one phase at a time")
 	if err := fs.Parse(args); err != nil {
 		return f, err
 	}
@@ -121,7 +127,13 @@ func admitRepo(ctx context.Context, args []string, stdout, stderr io.Writer) int
 		return exitError
 	}
 	if p.Admitted {
-		return standing(f, p.ID, stdout, exitOK)
+		if f.agent == "" && f.model == "" {
+			// No driver named, so nothing can be dispatched. The position is
+			// the whole answer, which is what this command did before it could
+			// turn the loop at all.
+			return standing(f, p.ID, stdout, exitOK)
+		}
+		return turn(ctx, f, c, p.ID, stdout, stderr)
 	}
 	if code := admitNew(ctx, f, p, stdout, stderr); code != exitOK {
 		return code

--- a/lab/internal/cli/repocmd.go
+++ b/lab/internal/cli/repocmd.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/luuuc/sense/lab/internal/catalog"
+	"github.com/luuuc/sense/lab/internal/position"
 	"github.com/luuuc/sense/lab/internal/repo"
 )
 
@@ -20,6 +22,32 @@ import (
 // it made, and reads what it was given.
 const defaultCheckouts = "runs/checkouts"
 
+// The exit codes `sense-lab repo` answers with. They are its API rather than a
+// display, because this command ends up in a shell loop and what that loop stops
+// on is this:
+//
+//	while sense-lab repo <id>; do :; done
+//
+// It terminates on a park, on a PAY and on either refusal, and `-show` never
+// returns 0 so it cannot be dropped into that loop and spin.
+//
+// Two of them are worth telling apart above all: a park is the method failing on
+// this repository, and a PAY is the method succeeding and waiting on a wallet.
+// So are the two refusals: an agent that misbehaved, against an agent that died.
+//
+// exitShown is the binary's usage code, and that is not a collision in practice:
+// the codes are read with the arguments in hand, and a caller that passed -show
+// knows a position was printed while one that did not knows its flags were
+// wrong.
+const (
+	exitShown    = exitUsage
+	exitFinished = 3
+	exitParked   = 4
+	exitWaiting  = 5
+	exitUnusable = 6
+	exitMissing  = 7
+)
+
 // repoFlags is where a repository is admitted from and where the evidence of it
 // lands.
 type repoFlags struct {
@@ -27,6 +55,7 @@ type repoFlags struct {
 	campaign  string
 	checkouts string
 	senseBin  string
+	show      bool
 	name      string
 }
 
@@ -38,6 +67,7 @@ func parseRepoFlags(args []string, stderr io.Writer) (repoFlags, error) {
 	fs.StringVar(&f.campaign, "campaign", "", "the campaign's run tree, where the index artifact lands (required)")
 	fs.StringVar(&f.checkouts, "checkouts", defaultCheckouts, "the lab's own clones root")
 	fs.StringVar(&f.senseBin, "sense", "sense", "the Sense binary that indexes the repository")
+	fs.BoolVar(&f.show, "show", false, "print the position and stop, writing nothing")
 	if err := fs.Parse(args); err != nil {
 		return f, err
 	}
@@ -79,16 +109,24 @@ func admitRepo(ctx context.Context, args []string, stdout, stderr io.Writer) int
 		return exitError
 	}
 
-	p, err := repo.Prepare(ctx, targetFor(c, r), f.checkouts, announce(stdout))
-	if err != nil {
+	p, err := repo.Prepare(ctx, targetFor(c, r), f.checkouts, announce(stdout, f.show))
+	switch {
+	case errors.Is(err, errShown):
+		// Stopped at the announcement, before anything was written. What a
+		// caller asked to see is the position, so it is printed from what is on
+		// disk rather than from anything this run did.
+		return standing(f, r.ID, stdout, exitShown)
+	case err != nil:
 		_, _ = fmt.Fprintf(stderr, "sense-lab repo: %v\n", err)
 		return exitError
 	}
 	if p.Admitted {
-		_, _ = fmt.Fprint(stdout, position(f.campaign, p))
-		return exitOK
+		return standing(f, p.ID, stdout, exitOK)
 	}
-	return admitNew(ctx, f, p, stdout, stderr)
+	if code := admitNew(ctx, f, p, stdout, stderr); code != exitOK {
+		return code
+	}
+	return standing(f, p.ID, stdout, exitOK)
 }
 
 // targetFor is what admission acts on. A repository the catalog holds brings
@@ -109,12 +147,49 @@ func targetFor(c *catalog.Catalog, r repo.Resolution) repo.Target {
 // rather than three phases later — and it is a statement rather than a prompt,
 // because an interactive question in the run path is what the crank cannot
 // answer.
-func announce(stdout io.Writer) func(repo.Plan) error {
+func announce(stdout io.Writer, show bool) func(repo.Plan) error {
 	return func(p repo.Plan) error {
 		_, _ = fmt.Fprintf(stdout, "id:       %s\nurl:      %s\nrevision: %s\ncheckout: %s (%s)\n\n",
 			p.ID, p.URL, p.Revision, p.Checkout, sentence(p))
+		if show {
+			return errShown
+		}
 		return nil
 	}
+}
+
+// errShown stops an admission at the announcement. -show is the same code path
+// as an admission up to the point where one would write something, which is
+// what makes it a preview of that admission rather than a second reading of the
+// same inputs.
+var errShown = errors.New("shown")
+
+// standing prints where the repository stands and answers with the code that
+// carries it.
+//
+// A position is a fact about the run tree, so it is read back off disk rather
+// than assembled from what this invocation happened to do.
+func standing(f repoFlags, id string, stdout io.Writer, ok int) int {
+	at, err := position.Read(f.campaign, id)
+	if err != nil {
+		_, _ = fmt.Fprintf(stdout, "position: unreadable: %v\n", err)
+		return exitError
+	}
+	_, _ = fmt.Fprint(stdout, position.Render(at))
+	if code, stop := stopOn[at.Standing]; stop {
+		return code
+	}
+	return ok
+}
+
+// stopOn is every standing that ends the loop, and its code. A standing that is
+// not in here is one with a next phase to run.
+var stopOn = map[position.Standing]int{
+	position.Finished: exitFinished,
+	position.Parked:   exitParked,
+	position.Waiting:  exitWaiting,
+	position.Unusable: exitUnusable,
+	position.Missing:  exitMissing,
 }
 
 // sentence says what the checkout is about to have done to it, in words.
@@ -195,17 +270,6 @@ func repoFile(config, id string) string { return filepath.Join(config, "repos", 
 // does not rescan it.
 func indexArtifact(campaign, id string) string {
 	return filepath.Join(campaign, id, "index", "index.json")
-}
-
-// position is what a repository that is already admitted gets instead of an
-// admission: where its checkout is, what it is pinned at, and whether it has
-// been indexed.
-func position(campaign string, p repo.Plan) string {
-	indexed := "no"
-	if _, err := os.Stat(indexArtifact(campaign, p.ID)); err == nil {
-		indexed = "yes"
-	}
-	return fmt.Sprintf("admitted: nothing to do\nindexed:  %s\n", indexed)
 }
 
 // admitSignals runs admission under the same signal handling a session gets. A

--- a/lab/internal/cli/repocmd_test.go
+++ b/lab/internal/cli/repocmd_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -215,7 +216,7 @@ func TestRe_runningOnAnAdmittedRepositoryWritesNothing(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d: %s", code, stderr)
 	}
-	if !strings.Contains(stdout, "admitted: nothing to do") || !strings.Contains(stdout, "indexed:  yes") {
+	if !strings.Contains(stdout, "indexed:  yes") || !strings.Contains(stdout, "awaiting: author") {
 		t.Errorf("stdout = %q, want where the repository stands", stdout)
 	}
 	if read(t, a.repoFile(id)) != before {
@@ -418,8 +419,8 @@ func TestPositionReportsARepositoryThatWasNeverIndexed(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d: %s", code, stderr)
 	}
-	if !strings.Contains(stdout, "indexed:  no") {
-		t.Errorf("stdout = %q, want it to say the repository has no index", stdout)
+	if !strings.Contains(stdout, "indexed:  no") || !strings.Contains(stdout, "awaiting: index") {
+		t.Errorf("stdout = %q, want it to say the repository is waiting on its scan", stdout)
 	}
 }
 
@@ -524,5 +525,142 @@ func blocked(t *testing.T, path string) {
 	}
 	if err := os.WriteFile(filepath.Dir(path), []byte("in the way"), 0o644); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// The exit codes are this command's API, because it ends up in a shell loop:
+//
+//	while sense-lab repo <id>; do :; done
+//
+// Every code is asserted here, and every one that must stop that loop is
+// asserted to be non-zero in the same table — which is the property the loop
+// actually rests on.
+func TestTheExitCodeCarriesTheStanding(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		build func(t *testing.T, repoDir string)
+		show  bool
+		want  int
+	}{
+		{"a repository with a phase to run", func(*testing.T, string) {}, false, 0},
+		{"on the board", func(t *testing.T, dir string) {
+			artifact(t, filepath.Join(dir, "1", "board", "board.md"), "# board\n")
+		}, false, 3},
+		{"parked at the ceiling", func(t *testing.T, dir string) {
+			artifact(t, filepath.Join(dir, "6", "handoff", "handoff.md"), "# handoff\n")
+		}, false, 4},
+		{"waiting at a PAY", func(t *testing.T, dir string) {
+			artifact(t, filepath.Join(dir, "1", "validate", "pay-call.md"), "PAY\n")
+			attempt(t, dir, `{"cycle":1,"phase":"validate","verdict":"PAY","try":1}`)
+		}, false, 5},
+		{"refused: a verdict the phase cannot emit", func(t *testing.T, dir string) {
+			artifact(t, filepath.Join(dir, "1", "author", "scenario.draft.yaml"), "name: r\n")
+			attempt(t, dir, `{"cycle":1,"phase":"author","verdict":"WIN","try":1}`)
+		}, false, 6},
+		{"refused: the artifact the verdict claims is not there", func(t *testing.T, dir string) {
+			artifact(t, filepath.Join(dir, "1", "minibench", "minibench.md"), "# read\n")
+			attempt(t, dir, `{"cycle":1,"phase":"author","verdict":"DRAFT","try":1}`)
+		}, false, 7},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a, id := admitted(t)
+			tc.build(t, filepath.Join(a.campaign, id))
+
+			args := []string{"repo", "-config", a.config, "-campaign", a.campaign,
+				"-checkouts", a.checkouts, "-sense", a.sense}
+			if tc.show {
+				args = append(args, "-show")
+			}
+			code, stdout, stderr := dispatch(t, append(args, id)...)
+
+			if code != tc.want {
+				t.Errorf("exit = %d, want %d\n%s%s", code, tc.want, stdout, stderr)
+			}
+			if !strings.Contains(stdout, "standing:") {
+				t.Errorf("stdout = %q, want the position printed", stdout)
+			}
+		})
+	}
+}
+
+// -show is a preview of the admission, so it stops before the first thing an
+// admission would write. Without that it is a second reading of the inputs
+// rather than a look at what is about to happen.
+func TestShowWritesNothing(t *testing.T) {
+	source, _ := sourceRepo(t)
+	a := newAdmission(t, admissionStatus)
+
+	code, stdout, stderr := dispatch(t, "repo", "-config", a.config, "-campaign", a.campaign,
+		"-checkouts", a.checkouts, "-sense", a.sense, "-show", source)
+
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2: %s", code, stderr)
+	}
+	if !strings.Contains(stdout, "id:       "+filepath.Base(source)) {
+		t.Errorf("stdout = %q, want the resolution it was about to act on", stdout)
+	}
+	if _, err := os.Stat(a.repoFile(filepath.Base(source))); !os.IsNotExist(err) {
+		t.Error("a repository was admitted by a command asked only to show")
+	}
+	if _, err := os.Stat(a.artifact(filepath.Base(source))); !os.IsNotExist(err) {
+		t.Error("a repository was indexed by a command asked only to show")
+	}
+}
+
+// admitted is a repository already in the catalog, with a real checkout at its
+// pin, so a test can put a run tree under it and ask where it stands.
+func admitted(t *testing.T) (admission, string) {
+	t.Helper()
+	source, head := sourceRepo(t)
+	a := newAdmission(t, admissionStatus)
+	id := filepath.Base(source)
+	artifact(t, a.repoFile(id), `{"id":"`+id+`","url":"https://example.test/`+id+`.git","commit":"`+head+
+		`","checkout":"`+source+`","languages":["go"]}`)
+	artifact(t, a.artifact(id), `{"repo":"`+id+`","symbols":40}`)
+	return a, id
+}
+
+func artifact(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func attempt(t *testing.T, repoDir, body string) {
+	t.Helper()
+	var a struct {
+		Cycle int    `json:"cycle"`
+		Phase string `json:"phase"`
+		Try   int    `json:"try"`
+	}
+	if err := json.Unmarshal([]byte(body), &a); err != nil {
+		t.Fatal(err)
+	}
+	artifact(t, filepath.Join(repoDir, "attempts", fmt.Sprintf("%d-%s-%d.json", a.Cycle, a.Phase, a.Try)), body)
+}
+
+// A position that cannot be read is reported rather than answered with a
+// default one, which would be a repository at the start of its first cycle.
+func TestAPositionThatCannotBeReadIsReported(t *testing.T) {
+	a, id := admitted(t)
+	if err := os.RemoveAll(a.campaign); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(a.campaign, []byte("in the way"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	code, stdout, _ := dispatch(t, "repo", "-config", a.config, "-campaign", a.campaign,
+		"-checkouts", a.checkouts, "-sense", a.sense, id)
+
+	if code != 1 {
+		t.Errorf("exit = %d, want the error code", code)
+	}
+	if !strings.Contains(stdout, "unreadable") {
+		t.Errorf("stdout = %q, want it to say the position could not be read", stdout)
 	}
 }

--- a/lab/internal/cli/runcmd.go
+++ b/lab/internal/cli/runcmd.go
@@ -41,17 +41,31 @@ func resolveJob(c *catalog.Catalog, f runFlags) (job, error) {
 	if j.repo, ok = c.Repos[f.repo]; !ok {
 		return j, fmt.Errorf("no repo %q in the catalog; have %v", f.repo, catalog.IDs(c.Repos))
 	}
-	if j.agent, ok = c.Agents[f.agent]; !ok {
-		return j, fmt.Errorf("no agent %q in the catalog; have %v", f.agent, catalog.IDs(c.Agents))
+	agent, model, err := resolveDriver(c, f.agent, f.model)
+	if err != nil {
+		return j, err
 	}
-	if j.model, ok = c.Model(f.model); !ok {
-		return j, fmt.Errorf("no model %q in the catalog; have %v", f.model, catalog.IDs(c.Models))
-	}
-	if !slices.Contains(j.model.Agents, j.agent.ID) {
-		return j, fmt.Errorf("model %s cannot be driven by %s; it names %v",
-			j.model.ID, j.agent.ID, j.model.Agents)
-	}
+	j.agent, j.model = agent, model
 	return j, nil
+}
+
+// resolveDriver turns an agent id and a model id into the pair that can run,
+// and refuses a pair the catalog says cannot. It is separate from the repository
+// lookup because a phase agent is driven without one: it runs against a
+// repository rather than benching it.
+func resolveDriver(c *catalog.Catalog, agentID, modelID string) (catalog.Agent, catalog.Model, error) {
+	a, ok := c.Agents[agentID]
+	if !ok {
+		return a, catalog.Model{}, fmt.Errorf("no agent %q in the catalog; have %v", agentID, catalog.IDs(c.Agents))
+	}
+	m, ok := c.Model(modelID)
+	if !ok {
+		return a, m, fmt.Errorf("no model %q in the catalog; have %v", modelID, catalog.IDs(c.Models))
+	}
+	if !slices.Contains(m.Agents, a.ID) {
+		return a, m, fmt.Errorf("model %s cannot be driven by %s; it names %v", m.ID, a.ID, m.Agents)
+	}
+	return a, m, nil
 }
 
 // A note that used to live beside the compiled-in agent flags, kept because the

--- a/lab/internal/crank/crank.go
+++ b/lab/internal/crank/crank.go
@@ -1,0 +1,258 @@
+package crank
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/luuuc/sense/lab/internal/phase"
+	"github.com/luuuc/sense/lab/internal/plans"
+	"github.com/luuuc/sense/lab/internal/position"
+)
+
+// Job is one phase to run: everything a spawner needs and nothing it could
+// decide with.
+type Job struct {
+	Repo  string
+	Cycle int
+	Phase phase.Name
+	// Dir is where this phase's artifact and verdict belong.
+	Dir string
+	// Checkout is the repository under study, at its pin.
+	Checkout string
+	// Prompt is the plan, with the facts of this attempt in front of it.
+	Prompt string
+	// Wall is how long the agent gets, read from the plan's own header.
+	Wall time.Duration
+	// Try is which attempt at this phase, in this cycle, this is. It is here so
+	// a spawner can keep a second attempt's evidence beside the first's rather
+	// than on top of it: a run directory is created fresh or not at all.
+	Try int
+}
+
+// Ran is what a spawner reports back: whether the agent finished inside its
+// wall, and where what it said was written.
+//
+// It carries no verdict. What a phase decided is read from the document it
+// wrote, never from the process that ran it, because an exit code is a claim.
+type Ran struct {
+	Finished bool
+	Log      string
+}
+
+// Spawner runs one phase agent. The real one lives at the edge, beside the
+// other things that reach a process; the crank never imports one.
+type Spawner func(ctx context.Context, j Job) (Ran, error)
+
+// Crank is the wiring, assembled once. It is a value rather than parameters
+// because [Crank.Advance] takes a repository and a context and nothing else:
+// the moment a phase needs something the others do not, it belongs in that
+// phase's plan or in the spawner, never in this signature.
+type Crank struct {
+	// Campaign is the run tree.
+	Campaign string
+	// Plans are the declared plans, already checked against the graph.
+	Plans []plans.Plan
+	// Checkout is the repository under study, at its pin.
+	Checkout string
+	Spawn    Spawner
+}
+
+// Result is what one turn of the crank did.
+type Result struct {
+	// Before and After are the position on either side of it. A caller reads
+	// After for the exit code, and the pair is what says whether anything moved.
+	Before, After position.Position
+	// Ran is the phase this turn dispatched, empty when it dispatched none.
+	Ran phase.Name
+	// Note is what happened, in a sentence, for whoever is reading a loop that
+	// stopped.
+	Note string
+}
+
+// Advance runs the one phase that comes next for a repository.
+//
+// It reads a position, dispatches at most one phase, records what came back and
+// returns. It never loops: `-until` is a loop in main around this call, so
+// nothing in here knows which of the two it is in and no mode is threaded
+// through it.
+func (c Crank) Advance(ctx context.Context, repo string) (Result, error) {
+	before, err := position.Read(c.Campaign, repo)
+	if err != nil {
+		return Result{}, err
+	}
+	r := Result{Before: before, After: before}
+
+	// The automation stops at the pay call, and it stops the same way whichever
+	// side of the verdict it is on: a PAY that has been recorded, and a phase
+	// that spends being next, are one situation. The crank prints the command
+	// and does not run it. The pain this cycle is aimed at is authoring, and an
+	// unattended crank that can reach a paid cell is a different product with a
+	// different risk.
+	if _, spends := spendCommand(before, repo); before.Standing != position.Ready || spends {
+		if spends {
+			r.After.Standing = position.Waiting
+		}
+		r.Note = note(r.After, repo)
+		return r, nil
+	}
+
+	p, ok := planFor(c.Plans, before.Awaiting)
+	if !ok {
+		return r, fmt.Errorf("no plan for phase %s; a phase with no plan is a phase nobody can run", before.Awaiting)
+	}
+	j := c.job(before, repo, p, c.try(repo, before.Cycle, p.Phase))
+	r.Ran = j.Phase
+
+	ran, err := c.Spawn(ctx, j)
+	if err != nil {
+		return r, fmt.Errorf("run %s for %s: %w", j.Phase, repo, err)
+	}
+	if err := c.record(before, j, p, ran); err != nil {
+		return r, err
+	}
+	after, err := position.Read(c.Campaign, repo)
+	if err != nil {
+		return r, err
+	}
+	r.After = after
+	r.Note = note(after, repo)
+	return r, nil
+}
+
+// note is what a caller prints when the crank stops, and it carries the
+// hand-run command whenever the next phase is one that spends.
+//
+// It is built in one place because the crank stops at the pay call from two
+// directions — arriving at it, and finding itself already there — and a command
+// printed on only one of them is a loop that stops silently every other time.
+func note(at position.Position, repo string) string {
+	line := fmt.Sprintf("%s is %s: %s", repo, at.Standing, at.Because)
+	if command, spends := spendCommand(at, repo); spends {
+		line += fmt.Sprintf("\n\n%s is where the spending starts. Run it by hand:\n\n    %s\n",
+			at.Awaiting, command)
+	}
+	return line
+}
+
+// record reads what the phase left behind, guards it, and writes the attempt.
+//
+// Every path through here records something, and that is deliberate: an
+// invocation that dispatched a phase and recorded nothing leaves the position
+// exactly as it found it, and an unattended loop then runs that phase again,
+// forever, at whatever it costs.
+func (c Crank) record(at position.Position, j Job, p plans.Plan, ran Ran) error {
+	a := position.Attempt{
+		Cycle: j.Cycle, Phase: j.Phase, Try: j.Try,
+		Anchor: at.Last.Anchor, Plan: p.Path, Log: ran.Log,
+	}
+
+	if !ran.Finished {
+		// Out of clock. Cannot-finish-at-budget is a result, and it is recorded
+		// as one rather than waited on: the alternative is a crank that holds
+		// on a hung agent until somebody notices.
+		a.Outcome = position.Stalled
+		return position.Record(filepath.Join(c.Campaign, j.Repo), a)
+	}
+
+	v, err := readVerdict(j.Dir)
+	if err == nil {
+		err = guard(v, j, p)
+	}
+	if err != nil {
+		// The phase said something that is not a verdict for this phase. It is
+		// recorded as refused, with the reason, and the loop stops there.
+		a.Outcome, a.Table = position.Refused, err.Error()
+		return position.Record(filepath.Join(c.Campaign, j.Repo), a)
+	}
+
+	a.Verdict, a.Table = v.Verdict, v.Table
+	if v.Anchor != "" {
+		// A phase that decided an anchor says so; one that did not leaves the
+		// previous attempt's in place. A re-entry that dropped the anchor would
+		// be a fresh guess rather than a second attempt at the same question.
+		a.Anchor = v.Anchor
+	}
+	a.VerdictDoc = filepath.Join(j.Dir, VerdictFile)
+	if wrote(j.Dir, p) {
+		// The artifact is the fact, so it is recorded as accepted only when it
+		// is there. When it is not, the verdict stands and the position reads
+		// the missing artifact for itself.
+		a.Artifact = filepath.Join(j.Dir, p.Writes)
+	}
+	return position.Record(filepath.Join(c.Campaign, j.Repo), a)
+}
+
+// job is the phase to dispatch, assembled from the position and the plan.
+func (c Crank) job(at position.Position, repo string, p plans.Plan, try int) Job {
+	dir := filepath.Join(c.Campaign, repo, strconv.Itoa(at.Cycle), string(p.Phase))
+	return Job{
+		Repo: repo, Cycle: at.Cycle, Phase: p.Phase, Dir: dir, Try: try,
+		Checkout: c.Checkout, Wall: p.Wall, Prompt: prompt(at, repo, dir, p),
+	}
+}
+
+// try is which attempt at this phase, in this cycle, is about to happen. It is
+// worked out before the phase runs so the spawner can be told, and again from
+// the same records when the attempt is recorded.
+func (c Crank) try(repo string, cycle int, name phase.Name) int {
+	attempts, err := position.Attempts(filepath.Join(c.Campaign, repo))
+	if err != nil {
+		// An unreadable record set is the recorder's to report; here it means
+		// only that nothing is known about earlier tries.
+		return 1
+	}
+	return position.NextTry(attempts, cycle, name)
+}
+
+// prompt is the plan, with the facts of this attempt in front of it.
+//
+// Facts only: where things are, which cycle this is, and every rejection so far.
+// Not a sentence of method — that all lives in the plan and is reviewed by
+// reading a file. A binary that adds guidance here is a binary holding opinions
+// nobody can review.
+//
+// Every rejection, oldest first, because reading only the latest is how six
+// attempts oscillated between two failures without landing in between.
+func prompt(at position.Position, repo, dir string, p plans.Plan) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "repository: %s\ncycle: %d of %d\nphase: %s\nartifact: %s\nverdict: %s\n",
+		repo, at.Cycle, phase.AuthoringCeiling, p.Phase, filepath.Join(dir, p.Writes), filepath.Join(dir, VerdictFile))
+	if at.Last.Anchor != "" {
+		fmt.Fprintf(&b, "anchor: %s\n", at.Last.Anchor)
+	}
+	for _, a := range at.Answer {
+		fmt.Fprintf(&b, "rejected in cycle %d by %s (%s): %s\n", a.Cycle, a.Phase, a.Verdict, a.Table)
+	}
+	b.WriteString("\n")
+	b.Write(p.Body)
+	return b.String()
+}
+
+// spending is every phase that costs money, and the crank runs none of them.
+var spending = map[phase.Name]bool{phase.Bench: true, phase.Report: true, phase.Harvest: true, phase.Board: true}
+
+// spendCommand reports whether the next phase spends, and what to run by hand.
+func spendCommand(at position.Position, repo string) (string, bool) {
+	if !spending[at.Awaiting] {
+		return "", false
+	}
+	if at.Awaiting != phase.Bench {
+		return fmt.Sprintf("sense-lab %s (by hand; see lab/plans/%s.md)", at.Awaiting, at.Awaiting), true
+	}
+	return fmt.Sprintf("sense-lab probe -repo %s -scenario lab/scenarios/%s/%s.yaml -out <cell> "+
+		"-agent <agent> -model <model> -checkout <clone> -sense ./bin/sense", repo, repo, repo), true
+}
+
+// planFor is the declared plan for a phase.
+func planFor(loaded []plans.Plan, name phase.Name) (plans.Plan, bool) {
+	for _, p := range loaded {
+		if p.Phase == name {
+			return p, true
+		}
+	}
+	return plans.Plan{}, false
+}

--- a/lab/internal/crank/crank_test.go
+++ b/lab/internal/crank/crank_test.go
@@ -1,0 +1,733 @@
+package crank
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luuuc/sense/lab/internal/phase"
+	"github.com/luuuc/sense/lab/internal/plans"
+	"github.com/luuuc/sense/lab/internal/position"
+)
+
+// agent stands in for a phase agent: it writes whatever the test says the agent
+// wrote, in the directory it was dispatched to.
+//
+// Nothing here asserts that it was called. What the crank did next — the record
+// it wrote, the position that comes out of it — is the whole subject, and a
+// test that asserted a spawn happened would pass against a crank that spawned
+// and then ignored the result.
+type agent struct {
+	verdict  *Verdict
+	artifact bool
+	stalled  bool
+	// jobs is what it was dispatched with, so a test can read what the agent
+	// would have been told rather than what the crank meant to tell it.
+	jobs []Job
+}
+
+func (a *agent) spawn(_ context.Context, j Job) (Ran, error) {
+	a.jobs = append(a.jobs, j)
+	if err := os.MkdirAll(j.Dir, 0o755); err != nil {
+		return Ran{}, err
+	}
+	log := filepath.Join(j.Dir, "phase.log")
+	if err := os.WriteFile(log, []byte("what the agent said\n"), 0o644); err != nil {
+		return Ran{}, err
+	}
+	if a.stalled {
+		return Ran{Finished: false, Log: log}, nil
+	}
+	if a.verdict != nil {
+		b, err := json.Marshal(a.verdict)
+		if err != nil {
+			return Ran{}, err
+		}
+		if err := os.WriteFile(filepath.Join(j.Dir, VerdictFile), b, 0o644); err != nil {
+			return Ran{}, err
+		}
+	}
+	if a.artifact {
+		p, _ := phase.Lookup(j.Phase)
+		if err := os.WriteFile(filepath.Join(j.Dir, p.Writes), []byte("the artifact\n"), 0o644); err != nil {
+			return Ran{}, err
+		}
+	}
+	return Ran{Finished: true, Log: log}, nil
+}
+
+// declared is the shipped plan set, loaded from lab/plans. The tests run against
+// the real declarations rather than a hand-written copy: a plan set that
+// disagreed with the graph would then fail here as well as in its own package.
+func declared(t *testing.T) []plans.Plan {
+	t.Helper()
+	loaded, err := plans.Load(filepath.Join("..", "..", "plans"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return loaded
+}
+
+// campaign is a repository admitted and scanned, ready for its first authoring
+// phase.
+func campaign(t *testing.T) (dir, repo string) {
+	t.Helper()
+	dir, repo = t.TempDir(), "jellyfin"
+	write(t, filepath.Join(dir, repo, "index", "index.json"), `{"repo":"jellyfin","symbols":11410}`)
+	return dir, repo
+}
+
+func cranked(t *testing.T, dir string, a *agent) Crank {
+	t.Helper()
+	return Crank{Campaign: dir, Plans: declared(t), Checkout: t.TempDir(), Spawn: a.spawn}
+}
+
+func advance(t *testing.T, c Crank, repo string) Result {
+	t.Helper()
+	r, err := c.Advance(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r
+}
+
+// The turn: the crank runs the phase the position owes, and the position after
+// it is the next phase. Nothing about this asserts that an agent was spawned —
+// it asserts that the loop moved, which is the only reason to spawn one.
+func TestOneTurnRunsThePhaseThatIsOwedAndMovesOn(t *testing.T) {
+	dir, repo := campaign(t)
+	a := &agent{artifact: true, verdict: &Verdict{Phase: phase.Author, Repo: repo, Cycle: 1,
+		Verdict: phase.Draft, Anchor: "BaseItem"}}
+
+	r := advance(t, cranked(t, dir, a), repo)
+
+	if r.Ran != phase.Author {
+		t.Errorf("ran %s, want the phase the position owed", r.Ran)
+	}
+	if r.After.Awaiting != phase.Minibench {
+		t.Errorf("awaiting %s (%s), want the phase the verdict routes to", r.After.Awaiting, r.After.Because)
+	}
+	if r.After.Standing != position.Ready {
+		t.Errorf("standing %s, want more to do", r.After.Standing)
+	}
+}
+
+// One phase per invocation. `-until` is a loop in main around this call, so a
+// turn that ran two phases would be a mode nobody asked for.
+func TestOneTurnRunsOnePhase(t *testing.T) {
+	dir, repo := campaign(t)
+	a := &agent{artifact: true, verdict: &Verdict{Phase: phase.Author, Repo: repo, Cycle: 1, Verdict: phase.Draft}}
+
+	advance(t, cranked(t, dir, a), repo)
+
+	if len(a.jobs) != 1 {
+		t.Errorf("dispatched %d phases, want one", len(a.jobs))
+	}
+	if recorded := attempts(t, dir, repo); len(recorded) != 1 {
+		t.Errorf("recorded %d attempts, want the one that ran", len(recorded))
+	}
+}
+
+// Every lever cycle 05 declared, driven end to end with no agent, no network
+// and no spend. A lever that routes somewhere the graph does not say would show
+// up here as a position, which is what the crank is for.
+func TestEveryLeverRoutesTheWayTheGraphDeclares(t *testing.T) {
+	for _, lever := range phase.Levers {
+		if spending[lever.From] {
+			// A lever pulled by a phase that spends cannot be driven by the
+			// crank this cycle, and is asserted on where it actually stops.
+			continue
+		}
+		t.Run(lever.Name, func(t *testing.T) {
+			dir, repo := campaign(t)
+			// The lever's cycle is a fact about the tree, so the tree is built
+			// with it rather than a counter being set.
+			for c := 1; c < lever.Cycle; c++ {
+				write(t, filepath.Join(dir, repo, strconv.Itoa(c), "author", "scenario.draft.yaml"), "name: r\n")
+			}
+			reach(t, dir, repo, lever.Cycle, lever.From)
+			a := &agent{artifact: true, verdict: &Verdict{Phase: lever.From, Repo: repo,
+				Cycle: lever.Cycle, Verdict: lever.Verdict, Table: "what this attempt has to answer"}}
+
+			r := advance(t, cranked(t, dir, a), repo)
+
+			if r.Ran != lever.From {
+				t.Fatalf("ran %s, want %s", r.Ran, lever.From)
+			}
+			if r.After.Awaiting != lever.To {
+				t.Errorf("awaiting %s (%s), want %s", r.After.Awaiting, r.After.Because, lever.To)
+			}
+		})
+	}
+}
+
+// The phases that spend are not run, and the list is written down here rather
+// than read from the one the crank uses. A test that asked the same map would
+// move an entry between its own branches when that map lost one, and pass.
+func TestNoPhaseThatSpendsIsEverRun(t *testing.T) {
+	for _, spends := range []phase.Name{phase.Bench, phase.Report, phase.Harvest, phase.Board} {
+		t.Run(string(spends), func(t *testing.T) {
+			dir, repo := campaign(t)
+			reach(t, dir, repo, 1, spends)
+			a := &agent{}
+
+			r := advance(t, cranked(t, dir, a), repo)
+
+			if len(a.jobs) != 0 {
+				t.Errorf("the crank dispatched %s, which spends", spends)
+			}
+			if r.After.Standing != position.Waiting {
+				t.Errorf("standing %s (%s), want it waiting on a human", r.After.Standing, r.After.Because)
+			}
+			if !strings.Contains(r.Note, "by hand") {
+				t.Errorf("note = %q, want it to say what to run", r.Note)
+			}
+		})
+	}
+}
+
+// The levers past the pay call are not driven by the crank at all, and it says
+// so rather than dispatching a phase that spends. The DoD FAIL lever is the one
+// this leaves untested end to end, and it is untested because it is unreachable
+// rather than because it was skipped.
+func TestALeverPulledByAPhaseThatSpendsIsNotDrivenAtAll(t *testing.T) {
+	for _, lever := range phase.Levers {
+		if !spending[lever.From] {
+			continue
+		}
+		t.Run(lever.Name, func(t *testing.T) {
+			dir, repo := campaign(t)
+			reach(t, dir, repo, 1, lever.From)
+			a := &agent{}
+
+			r := advance(t, cranked(t, dir, a), repo)
+
+			if len(a.jobs) != 0 {
+				t.Errorf("the crank dispatched %s, which spends", lever.From)
+			}
+			if r.After.Standing != position.Waiting {
+				t.Errorf("standing %s (%s), want it waiting on a human", r.After.Standing, r.After.Because)
+			}
+			if !strings.Contains(r.Note, "by hand") {
+				t.Errorf("note = %q, want it to say what to run", r.Note)
+			}
+		})
+	}
+}
+
+// The ceiling parks rather than opening a seventh authoring cycle, and a parked
+// repository does not advance again.
+func TestTheCeilingParksAndAParkedRepositoryDoesNotAdvance(t *testing.T) {
+	dir, repo := campaign(t)
+	// Five finished authoring cycles and a sixth open: the position's cycle is a
+	// directory name, so the ceiling is reached by the tree rather than set.
+	for c := 1; c < phase.AuthoringCeiling; c++ {
+		write(t, filepath.Join(dir, repo, strconv.Itoa(c), "author", "scenario.draft.yaml"), "name: r\n")
+	}
+	if err := os.MkdirAll(filepath.Join(dir, repo, strconv.Itoa(phase.AuthoringCeiling)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	a := &agent{artifact: true, verdict: &Verdict{Phase: phase.Author, Repo: repo,
+		Cycle: phase.AuthoringCeiling, Verdict: phase.NoAnchor, Table: "no symbol carries the question"}}
+	c := cranked(t, dir, a)
+
+	if r := advance(t, c, repo); r.After.Standing != position.Parked {
+		t.Fatalf("standing %s (%s), want parked at the ceiling", r.After.Standing, r.After.Because)
+	}
+
+	spawned := len(a.jobs)
+	r := advance(t, c, repo)
+
+	if len(a.jobs) != spawned {
+		t.Error("a parked repository advanced; resuming one is a human act, not a transition")
+	}
+	if r.Ran != "" {
+		t.Errorf("ran %s on a parked repository", r.Ran)
+	}
+}
+
+// The automation stops at the pay call: it prints the command and does not run
+// it. Asserted on the position rather than on whether a spawner was called,
+// because what matters is that nothing moved.
+func TestAPayPrintsTheCommandAndSpendsNothing(t *testing.T) {
+	dir, repo := campaign(t)
+	reach(t, dir, repo, 1, phase.Validate)
+	write(t, filepath.Join(dir, repo, "1", "validate", "pay-call.md"), "PAY\n")
+	attempt(t, dir, repo, position.Attempt{Cycle: 1, Phase: phase.Validate, Verdict: phase.Pay, Try: 1})
+	a := &agent{}
+	c := cranked(t, dir, a)
+	before := advance(t, c, repo).Before
+
+	r := advance(t, c, repo)
+
+	if len(a.jobs) != 0 {
+		t.Error("the crank dispatched a phase past the pay call")
+	}
+	if r.After.Standing != position.Waiting {
+		t.Errorf("standing %s, want it waiting on a human", r.After.Standing)
+	}
+	if !strings.Contains(r.Note, "sense-lab probe") {
+		t.Errorf("note = %q, want the command to run by hand", r.Note)
+	}
+	if r.After.Awaiting != before.Awaiting {
+		t.Errorf("awaiting moved from %s to %s; nothing should have", before.Awaiting, r.After.Awaiting)
+	}
+}
+
+// A phase whose agent runs past its wall is recorded as out of clock, and the
+// crank moves on rather than holding. Cannot-finish-at-budget is a result.
+func TestAPhaseThatRanPastItsWallIsRecordedRatherThanWaitedOn(t *testing.T) {
+	dir, repo := campaign(t)
+	a := &agent{stalled: true}
+
+	r := advance(t, cranked(t, dir, a), repo)
+
+	if r.After.Standing != position.Missing {
+		t.Fatalf("standing %s (%s), want it recorded as an agent that did not finish", r.After.Standing, r.After.Because)
+	}
+	if !strings.Contains(r.After.Because, "phase.log") {
+		t.Errorf("because = %q, want it to name the log", r.After.Because)
+	}
+	recorded := attempts(t, dir, repo)
+	if len(recorded) != 1 || recorded[0].Outcome != position.Stalled {
+		t.Errorf("recorded %+v, want one stalled attempt", recorded)
+	}
+}
+
+// The wall is read from the plan's own header, so changing what a phase gets is
+// an edit to a declaration rather than to code.
+func TestTheWallComesFromTheDeclarationRatherThanFromCode(t *testing.T) {
+	for _, tc := range []struct {
+		name phase.Name
+		wall time.Duration
+	}{
+		// Two phases, because one plan is first in the loaded set and a wall
+		// read off the wrong plan would look right for that one alone.
+		{phase.Author, 4 * time.Minute},
+		{phase.Minibench, 11 * time.Minute},
+	} {
+		t.Run(string(tc.name), func(t *testing.T) {
+			dir, repo := campaign(t)
+			reach(t, dir, repo, 1, tc.name)
+			a := &agent{artifact: true, verdict: &Verdict{Phase: tc.name, Repo: repo, Cycle: 1,
+				Verdict: firstEmitted(t, tc.name)}}
+			c := cranked(t, dir, a)
+			// The same crank, the same code, one line of the declaration
+			// different.
+			c.Plans = withWall(t, c.Plans, tc.name, tc.wall)
+
+			advance(t, c, repo)
+
+			if a.jobs[0].Wall != tc.wall {
+				t.Errorf("wall = %s, want what the plan declares (%s)", a.jobs[0].Wall, tc.wall)
+			}
+		})
+	}
+}
+
+// firstEmitted is a verdict the phase may emit, taken from the graph so a test
+// never hand-copies an enum.
+func firstEmitted(t *testing.T, name phase.Name) phase.Verdict {
+	t.Helper()
+	p, ok := phase.Lookup(name)
+	if !ok || len(p.Verdicts) == 0 {
+		t.Fatalf("no verdicts declared for %s", name)
+	}
+	return p.Verdicts[0]
+}
+
+// The guard: three checks about what the phase says about itself, and one about
+// what is on disk. A verdict about another phase or another repository routes
+// this one, and a verdict outside the declared enum is not a verdict at all.
+func TestTheGuardRefusesAVerdictThatIsNotThisPhasesOwn(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		verdict *Verdict
+		reason  string
+	}{
+		{"it names another phase",
+			&Verdict{Phase: phase.Minibench, Repo: "jellyfin", Cycle: 1, Verdict: phase.Proceed}, "another phase"},
+		{"it names another repository",
+			&Verdict{Phase: phase.Author, Repo: "discourse", Cycle: 1, Verdict: phase.Draft}, "another\nrepository"},
+		{"it names another cycle",
+			&Verdict{Phase: phase.Author, Repo: "jellyfin", Cycle: 4, Verdict: phase.Draft}, "another attempt"},
+		{"it emits what the plan does not declare",
+			&Verdict{Phase: phase.Author, Repo: "jellyfin", Cycle: 1, Verdict: phase.WinConfirmed}, "does not declare"},
+		{"there is no verdict document at all", nil, "has not finished"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir, repo := campaign(t)
+			a := &agent{artifact: true, verdict: tc.verdict}
+
+			r := advance(t, cranked(t, dir, a), repo)
+
+			if r.After.Standing != position.Unusable {
+				t.Fatalf("standing %s (%s), want it refused", r.After.Standing, r.After.Because)
+			}
+			for _, want := range strings.Split(tc.reason, "\n") {
+				if !strings.Contains(r.After.Because, want) {
+					t.Errorf("because = %q, want it to say %q", r.After.Because, want)
+				}
+			}
+		})
+	}
+}
+
+// The declared enum is read off the plan file rather than a list held in Go. A
+// copy of that list here is a list that disagrees with the file somebody edits,
+// so the check is driven by editing the declaration: a verdict the graph knows
+// and the plan no longer declares is refused, and the refusal quotes the plan.
+func TestTheDeclaredEnumIsReadFromThePlanFile(t *testing.T) {
+	dir, repo := campaign(t)
+	a := &agent{artifact: true, verdict: &Verdict{Phase: phase.Author, Repo: repo, Cycle: 1, Verdict: phase.Draft}}
+	c := cranked(t, dir, a)
+	c.Plans = onlyEmits(t, c.Plans, phase.Author, phase.NoAnchor)
+
+	r := advance(t, c, repo)
+
+	if r.After.Standing != position.Unusable {
+		t.Fatalf("standing %s (%s), want it refused against the plan's own list", r.After.Standing, r.After.Because)
+	}
+	if !strings.Contains(r.After.Because, "NO-ANCHOR") {
+		t.Errorf("because = %q, want it to quote what the plan declares", r.After.Because)
+	}
+}
+
+// An exit code is a claim; the artifact is the fact. A phase that finished, said
+// the right thing and wrote nothing does not advance.
+func TestAPhaseThatWroteNoArtifactDoesNotAdvance(t *testing.T) {
+	dir, repo := campaign(t)
+	a := &agent{verdict: &Verdict{Phase: phase.Author, Repo: repo, Cycle: 1, Verdict: phase.Draft}}
+
+	r := advance(t, cranked(t, dir, a), repo)
+
+	if r.After.Standing != position.Missing {
+		t.Fatalf("standing %s (%s), want it held at the missing artifact", r.After.Standing, r.After.Because)
+	}
+	if r.After.Awaiting == phase.Minibench {
+		t.Error("the loop moved on from a phase that wrote nothing")
+	}
+	if recorded := attempts(t, dir, repo); recorded[0].Artifact != "" {
+		t.Errorf("recorded artifact %q, want none: nothing was accepted", recorded[0].Artifact)
+	}
+}
+
+// Each advance records what it READ as well as what it decided, so a park
+// opened six months later shows the chain that produced it rather than a phase
+// name and a date.
+func TestAnAdvanceRecordsThePlanTheVerdictAndTheArtifact(t *testing.T) {
+	dir, repo := campaign(t)
+	a := &agent{artifact: true, verdict: &Verdict{Phase: phase.Author, Repo: repo, Cycle: 1, Verdict: phase.Draft}}
+
+	advance(t, cranked(t, dir, a), repo)
+
+	recorded := attempts(t, dir, repo)[0]
+	for _, tc := range []struct{ what, got string }{
+		{"plan", recorded.Plan},
+		{"verdict document", recorded.VerdictDoc},
+		{"artifact", recorded.Artifact},
+		{"log", recorded.Log},
+	} {
+		if tc.got == "" {
+			t.Errorf("no %s recorded", tc.what)
+			continue
+		}
+		if _, err := os.Stat(tc.got); err != nil {
+			t.Errorf("recorded %s %q, which is not there: %v", tc.what, tc.got, err)
+		}
+	}
+}
+
+// A re-entry keeps the anchor and carries the rejection, and the next attempt
+// reads both — every rejection, oldest first, because reading only the latest is
+// how six attempts oscillate between two failures without landing in between.
+func TestAReEntryKeepsTheAnchorAndCarriesEveryRejection(t *testing.T) {
+	dir, repo := campaign(t)
+	c := cranked(t, dir, &agent{artifact: true, verdict: &Verdict{Phase: phase.Author, Repo: repo,
+		Cycle: 1, Verdict: phase.Draft, Anchor: "MediaBrowser.Controller.Entities.BaseItem"}})
+	advance(t, c, repo)
+
+	// The mini-bench sends it back, and says why.
+	c.Spawn = (&agent{artifact: true, verdict: &Verdict{Phase: phase.Minibench, Repo: repo, Cycle: 1,
+		Verdict: phase.Requestion, Table: "the baseline cited 4 of 4 rows"}}).spawn
+	advance(t, c, repo)
+
+	// The next author attempt is what has to read them.
+	next := &agent{artifact: true, verdict: &Verdict{Phase: phase.Author, Repo: repo, Cycle: 1, Verdict: phase.Draft}}
+	c.Spawn = next.spawn
+	advance(t, c, repo)
+
+	if len(next.jobs) != 1 {
+		t.Fatalf("dispatched %d, want the re-entered author", len(next.jobs))
+	}
+	prompt := next.jobs[0].Prompt
+	if !strings.Contains(prompt, "anchor: MediaBrowser.Controller.Entities.BaseItem") {
+		t.Errorf("the re-entry lost the anchor:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "the baseline cited 4 of 4 rows") {
+		t.Errorf("the re-entry lost the rejection it has to answer:\n%s", prompt)
+	}
+}
+
+// And the loop moves ON from the re-entered phase.
+//
+// This is the failure that made `-until` spin: read back in graph order, the
+// mini-bench that sent work back sorts after the author attempt that answered
+// it, so the position routes from the rejection every turn and the author runs
+// forever, at whatever an agent costs. The turn after a re-entry is the one
+// nothing was checking.
+func TestTheLoopMovesOnFromAReEnteredPhase(t *testing.T) {
+	dir, repo := campaign(t)
+	c := cranked(t, dir, &agent{artifact: true, verdict: &Verdict{Phase: phase.Author, Repo: repo,
+		Cycle: 1, Verdict: phase.Draft, Anchor: "BaseItem"}})
+	advance(t, c, repo)
+	c.Spawn = (&agent{artifact: true, verdict: &Verdict{Phase: phase.Minibench, Repo: repo, Cycle: 1,
+		Verdict: phase.Requestion, Table: "the baseline cited 4 of 4 rows"}}).spawn
+	advance(t, c, repo)
+
+	again := &agent{artifact: true, verdict: &Verdict{Phase: phase.Author, Repo: repo, Cycle: 1, Verdict: phase.Draft}}
+	c.Spawn = again.spawn
+	r := advance(t, c, repo)
+
+	if r.After.Awaiting != phase.Minibench {
+		t.Fatalf("awaiting %s (%s), want the phase after the re-entered author", r.After.Awaiting, r.After.Because)
+	}
+	// And one more turn goes to the mini-bench rather than back to the author.
+	last := &agent{artifact: true, verdict: &Verdict{Phase: phase.Minibench, Repo: repo, Cycle: 1,
+		Verdict: phase.Proceed}}
+	c.Spawn = last.spawn
+	if r := advance(t, c, repo); r.Ran != phase.Minibench {
+		t.Errorf("ran %s, want the loop to have moved on", r.Ran)
+	}
+}
+
+// The phase is dispatched against the repository under study. An agent pointed
+// at nothing reads nothing, and its draft would be about a repository it never
+// opened.
+func TestThePhaseIsDispatchedAgainstTheCheckout(t *testing.T) {
+	dir, repo := campaign(t)
+	a := &agent{artifact: true, verdict: &Verdict{Phase: phase.Author, Repo: repo, Cycle: 1, Verdict: phase.Draft}}
+	c := cranked(t, dir, a)
+
+	advance(t, c, repo)
+
+	if a.jobs[0].Checkout != c.Checkout {
+		t.Errorf("checkout = %q, want the repository under study (%q)", a.jobs[0].Checkout, c.Checkout)
+	}
+}
+
+// The plan reaches the agent verbatim, with the facts of the attempt in front
+// of it. Nothing here composes a method: a sentence added in code is a method
+// nobody can review by reading a file.
+func TestThePlanReachesTheAgentVerbatim(t *testing.T) {
+	dir, repo := campaign(t)
+	a := &agent{artifact: true, verdict: &Verdict{Phase: phase.Author, Repo: repo, Cycle: 1, Verdict: phase.Draft}}
+	c := cranked(t, dir, a)
+	author, _ := planFor(c.Plans, phase.Author)
+
+	advance(t, c, repo)
+
+	if !strings.HasSuffix(a.jobs[0].Prompt, string(author.Body)) {
+		t.Error("the plan did not reach the agent unchanged")
+	}
+	if !strings.Contains(a.jobs[0].Prompt, "verdict: ") {
+		t.Error("the agent was not told where its verdict belongs")
+	}
+}
+
+// A repository with nothing owed is not dispatched against.
+func TestARepositoryThatIsNotReadyIsNotDispatchedAgainst(t *testing.T) {
+	dir, repo := campaign(t)
+	write(t, filepath.Join(dir, repo, "1", "board", "board.md"), "# board\n")
+	a := &agent{}
+
+	r := advance(t, cranked(t, dir, a), repo)
+
+	if len(a.jobs) != 0 {
+		t.Error("a finished repository was dispatched against")
+	}
+	if !strings.Contains(r.Note, "finished") {
+		t.Errorf("note = %q, want it to say why nothing ran", r.Note)
+	}
+}
+
+// A phase with no plan is a phase nobody can run, and that is a refusal rather
+// than a dispatch with an empty prompt.
+func TestAPhaseWithNoPlanIsRefused(t *testing.T) {
+	dir, repo := campaign(t)
+	c := cranked(t, dir, &agent{})
+	c.Plans = without(c.Plans, phase.Author)
+
+	if _, err := c.Advance(context.Background(), repo); err == nil {
+		t.Fatal("a phase with no plan was dispatched")
+	}
+}
+
+// A spawner that fails is the crank's failure, not a verdict.
+func TestASpawnerThatFailsIsNotAVerdict(t *testing.T) {
+	dir, repo := campaign(t)
+	c := cranked(t, dir, &agent{})
+	c.Spawn = func(context.Context, Job) (Ran, error) { return Ran{}, os.ErrPermission }
+
+	if _, err := c.Advance(context.Background(), repo); err == nil {
+		t.Fatal("a spawner that failed was read as a phase that decided something")
+	}
+	if recorded := attempts(t, dir, repo); len(recorded) != 0 {
+		t.Errorf("recorded %+v for a phase that never ran", recorded)
+	}
+}
+
+// An unreadable position is an error rather than a repository at the start of
+// its first cycle.
+func TestAnUnreadablePositionIsAnError(t *testing.T) {
+	dir := t.TempDir()
+	write(t, filepath.Join(dir, "jellyfin"), "not a directory")
+
+	if _, err := cranked(t, dir, &agent{}).Advance(context.Background(), "jellyfin"); err == nil {
+		t.Fatal("a file where a repository should be was cranked")
+	}
+}
+
+// reach writes every artifact up to and including the phase before `to`, which
+// is what makes that phase the one owed.
+func reach(t *testing.T, campaign, repo string, cycle int, to phase.Name) {
+	t.Helper()
+	// The cycle is a directory name, so an open cycle with nothing written in
+	// it is a directory that exists and is empty.
+	if err := os.MkdirAll(filepath.Join(campaign, repo, strconv.Itoa(cycle)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range phase.Graph {
+		if p.Name == to {
+			return
+		}
+		if p.Name == phase.Index || p.Name == phase.Handoff {
+			continue
+		}
+		write(t, filepath.Join(campaign, repo, strconv.Itoa(cycle), string(p.Name), p.Writes), "written\n")
+	}
+	t.Fatalf("%s is not a phase the graph walks to", to)
+}
+
+func write(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func attempt(t *testing.T, campaign, repo string, a position.Attempt) {
+	t.Helper()
+	if err := position.Record(filepath.Join(campaign, repo), a); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func attempts(t *testing.T, campaign, repo string) []position.Attempt {
+	t.Helper()
+	all, err := position.Attempts(filepath.Join(campaign, repo))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return all
+}
+
+// withWall and withEmits change one line of one declaration, which is what a
+// person editing a plan file does.
+func withWall(t *testing.T, loaded []plans.Plan, name phase.Name, wall time.Duration) []plans.Plan {
+	t.Helper()
+	out := append([]plans.Plan(nil), loaded...)
+	for i := range out {
+		if out[i].Phase == name {
+			out[i].Wall = wall
+			return out
+		}
+	}
+	t.Fatalf("no plan for %s", name)
+	return nil
+}
+
+func onlyEmits(t *testing.T, loaded []plans.Plan, name phase.Name, v ...phase.Verdict) []plans.Plan {
+	t.Helper()
+	out := append([]plans.Plan(nil), loaded...)
+	for i := range out {
+		if out[i].Phase == name {
+			out[i].Emits = v
+			return out
+		}
+	}
+	t.Fatalf("no plan for %s", name)
+	return nil
+}
+
+func without(loaded []plans.Plan, name phase.Name) []plans.Plan {
+	var out []plans.Plan
+	for _, p := range loaded {
+		if p.Phase != name {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// A verdict document that is not a document is refused like any other thing
+// that is not a verdict, and the loop stops rather than routing on it.
+func TestAVerdictThatIsNotADocumentIsRefused(t *testing.T) {
+	dir, repo := campaign(t)
+	c := cranked(t, dir, &agent{artifact: true})
+	// The agent writes an artifact and something unreadable where its verdict
+	// belongs, which is what a half-finished write looks like.
+	c.Spawn = func(_ context.Context, j Job) (Ran, error) {
+		if err := os.MkdirAll(j.Dir, 0o755); err != nil {
+			return Ran{}, err
+		}
+		write(t, filepath.Join(j.Dir, VerdictFile), "{not a document")
+		p, _ := phase.Lookup(j.Phase)
+		write(t, filepath.Join(j.Dir, p.Writes), "the artifact\n")
+		return Ran{Finished: true, Log: filepath.Join(j.Dir, "phase.log")}, nil
+	}
+
+	r := advance(t, c, repo)
+
+	if r.After.Standing != position.Unusable {
+		t.Fatalf("standing %s (%s), want it refused", r.After.Standing, r.After.Because)
+	}
+}
+
+// A second attempt at one phase is told which attempt it is, so a spawner can
+// keep the first's evidence rather than writing over it.
+func TestASecondAttemptAtOnePhaseIsToldWhichItIs(t *testing.T) {
+	dir, repo := campaign(t)
+	attempt(t, dir, repo, position.Attempt{Cycle: 1, Phase: phase.Author, Verdict: phase.Draft, Try: 1})
+	// The artifact is missing, so the position holds at the author. A human
+	// clearing that record is not this test's subject: what matters is that the
+	// next dispatch knows it is the second.
+	a := &agent{artifact: true, verdict: &Verdict{Phase: phase.Author, Repo: repo, Cycle: 1, Verdict: phase.Draft}}
+	c := cranked(t, dir, a)
+	c.Campaign = dir
+
+	// The position is Missing, so nothing dispatches. The try is still what the
+	// records say it is, and that is what the spawner would be handed.
+	if got := c.try(repo, 1, phase.Author); got != 2 {
+		t.Errorf("try = %d, want the second", got)
+	}
+}
+
+// An unreadable record set means nothing is known about earlier tries, and the
+// dispatch is the first one rather than a failure inside a counter.
+func TestAnUnreadableRecordSetCountsAsNoEarlierTries(t *testing.T) {
+	dir, repo := campaign(t)
+	write(t, filepath.Join(dir, repo, "attempts", "1-author-1.json"), "{not a document")
+
+	if got := cranked(t, dir, &agent{}).try(repo, 1, phase.Author); got != 1 {
+		t.Errorf("try = %d, want the first", got)
+	}
+}

--- a/lab/internal/crank/verdict.go
+++ b/lab/internal/crank/verdict.go
@@ -1,0 +1,126 @@
+// Package crank turns the loop: it reads a repository's position, runs the one
+// phase that comes next, guards what came back, and records it.
+//
+// Nothing in the binary spawned a phase agent before this. `internal/loop` had
+// no importer, the eleven plans were opened by a human, and the routing rules
+// cycle 05 built and tested were exercised in production by an operator
+// remembering them. That operator is the leak: six authoring cycles on one
+// repository is roughly thirty hand-spawns, each one a chance to skip the plan,
+// read only the latest rejection, or advance on an agent that produced a
+// confident summary and no artifact.
+//
+// # One phase per invocation
+//
+// [Crank.Advance] takes a context and a repository id, and nothing else, ever.
+// The plan, the wall, the checkout and the spawner are resolved from the
+// declared graph and the config. That line is the one that has to hold: an
+// options struct refused in the design and then handed in as six arguments is
+// the same struct, and it is how the retired driver reached 1204 lines, one
+// reasonable parameter at a time.
+//
+// # The binary spawns, and only the binary spawns
+//
+// A phase agent that spawns its own judge is grading itself. Nothing here hands
+// a phase the ability to run another one, and the plans say so as well.
+//
+// # An exit code is a claim; the artifact is the fact
+//
+// A phase reports its own verdict, which makes every phase an unreliable
+// narrator about itself. So four things are checked before anything advances,
+// and the fourth is the one the retired driver learned by hand, at the phase
+// where it happened to bite: the artifact the phase owed is on disk, or the
+// loop does not move.
+package crank
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/luuuc/sense/lab/internal/phase"
+	"github.com/luuuc/sense/lab/internal/plans"
+)
+
+// VerdictFile is what a judgment phase writes beside its artifact.
+//
+// It exists because a verdict used to be prose inside the artifact, which is
+// why a parked campaign could be read by a person and by nothing else. The
+// document is small on purpose: a phase reports what it decided and why, and
+// everything else about where that leads is the graph's.
+const VerdictFile = "verdict.json"
+
+// Verdict is that document.
+type Verdict struct {
+	Phase   phase.Name    `json:"phase"`
+	Repo    string        `json:"repo"`
+	Cycle   int           `json:"cycle"`
+	Verdict phase.Verdict `json:"verdict"`
+	// Table is why, and it is what the next attempt has to answer when this one
+	// sends work back.
+	Table string `json:"table,omitempty"`
+	// Anchor is the symbol the attempt is anchored on, where the phase decides
+	// one. A phase that does not touch the anchor leaves it empty and the
+	// previous one is carried forward.
+	Anchor string `json:"anchor,omitempty"`
+}
+
+// readVerdict reads the document a phase left in its directory.
+func readVerdict(dir string) (Verdict, error) {
+	path := filepath.Join(dir, VerdictFile)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return Verdict{}, fmt.Errorf("read the verdict of this phase: %w. Every phase writes %s; "+
+			"one that did not has not finished, whatever it exited with", err, VerdictFile)
+	}
+	var v Verdict
+	if err := json.Unmarshal(b, &v); err != nil {
+		return Verdict{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	return v, nil
+}
+
+// guard is every check that stands between a phase's own account of itself and
+// the loop moving.
+//
+// Four things about identity and one about the fact, and it stays one function. If this becomes a package,
+// the design took a wrong turn: what it does is compare a document against the
+// job that was dispatched and the plan that was declared, and there is nothing
+// else it is ever allowed to consider.
+//
+// The first three are the phase talking about itself. The fourth is the fact.
+func guard(v Verdict, j Job, p plans.Plan) error {
+	switch {
+	case v.Phase != j.Phase:
+		return fmt.Errorf("the verdict names phase %q and %q was dispatched; a verdict about another phase "+
+			"routes this one", v.Phase, j.Phase)
+	case v.Repo != j.Repo:
+		return fmt.Errorf("the verdict names repository %q and %q was dispatched; a verdict about another "+
+			"repository is a verdict about another campaign", v.Repo, j.Repo)
+	case v.Cycle != j.Cycle:
+		return fmt.Errorf("the verdict names cycle %d and cycle %d was dispatched; the cycle is what the "+
+			"authoring ceiling is counted in, so a verdict about another one is a verdict about another attempt",
+			v.Cycle, j.Cycle)
+	case !emits(p, v.Verdict):
+		return fmt.Errorf("%s emitted %q, which its plan does not declare; it may emit %v",
+			j.Phase, v.Verdict, p.Emits)
+	}
+	return nil
+}
+
+// emits reads the plan's declared enum rather than a list held here. A copy of
+// that list in Go is a list that disagrees with the file somebody edits.
+func emits(p plans.Plan, v phase.Verdict) bool {
+	for _, declared := range p.Emits {
+		if declared == v {
+			return true
+		}
+	}
+	return false
+}
+
+// wrote is the fourth check, and the only one that is not the phase talking.
+func wrote(dir string, p plans.Plan) bool {
+	_, err := os.Stat(filepath.Join(dir, p.Writes))
+	return err == nil
+}

--- a/lab/internal/plans/plans.go
+++ b/lab/internal/plans/plans.go
@@ -20,10 +20,15 @@
 //	reads: scenario.draft.yaml
 //	writes: minibench.md
 //	emits: [PROCEED, REQUESTION, NO-ANCHOR]
+//	wall: 25m
 //	---
 //
 // It is a fixed set of keys rather than general YAML so that a malformed
 // contract fails to parse instead of parsing into something plausible.
+//
+// The wall is here rather than in Go because it is the number somebody would
+// otherwise raise in a hurry to rescue a stalled phase. Declared beside the
+// plan, changing it is an edit to a file that is reviewed.
 //
 // # What the checks can and cannot catch
 //
@@ -41,6 +46,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/luuuc/sense/lab/internal/phase"
 )
@@ -52,6 +58,16 @@ type Plan struct {
 	Reads  string
 	Writes string
 	Emits  []phase.Verdict
+	// Wall is how long this phase's agent gets. It is declared here, beside the
+	// plan the agent runs, and never as a constant in Go: config as data is
+	// this instrument's rule, and a wall held in a variable is the number that
+	// gets raised in a hurry at 3am to rescue a stalled phase — which is what
+	// CANNOT-FINISH-AT-BUDGET IS A RESULT forbids.
+	//
+	// Zero means the phase declares none, and whoever runs it decides what that
+	// means. This package loads; it does not supply defaults for what a file
+	// left out.
+	Wall time.Duration
 	// Body is everything after the header, verbatim. Nothing in this package
 	// writes to it.
 	Body []byte
@@ -88,8 +104,8 @@ func Load(dir string) ([]Plan, error) {
 
 // parse splits a plan into its declared header and its prose.
 //
-// The header is a fixed set of keys rather than general YAML: four fields, one
-// per line, so that a plan whose contract is malformed fails here rather than
+// The header is a fixed set of keys rather than general YAML: one field per
+// line, so that a plan whose contract is malformed fails here rather than
 // parsing into something plausible.
 func parse(b []byte) (Plan, error) {
 	rest, ok := bytes.CutPrefix(b, []byte(fence))
@@ -115,6 +131,12 @@ func parse(b []byte) (Plan, error) {
 			p.Writes = value
 		case "emits":
 			p.Emits = verdicts(value)
+		case "wall":
+			d, err := time.ParseDuration(strings.TrimSpace(value))
+			if err != nil {
+				return Plan{}, fmt.Errorf("wall %q: %w", value, err)
+			}
+			p.Wall = d
 		}
 	}
 	if p.Phase == "" {

--- a/lab/internal/position/attempt.go
+++ b/lab/internal/position/attempt.go
@@ -1,0 +1,186 @@
+// Package position answers the question the crank has to answer before it does
+// anything: what is the next phase for this repository, and how many authoring
+// cycles has it already spent.
+//
+// It answers it from two inputs, and which input a fact comes from is the whole
+// design.
+//
+// The run tree holds which runs exist, what they wrote, and the authoring
+// cycle — which is already a directory name under `<campaign>/<repo>/<cycle>/`.
+// Those are DERIVED, every time, and never stored. A counter beside the fact it
+// counts is a counter that drifts from it, and the drift is invisible.
+//
+// The attempt records hold the verdict of each attempt, the table that rejected
+// it, and the anchor. Those are RECORDED, once, and never re-derived: a verdict
+// is a judgment, and no amount of reading a tree recovers one.
+//
+// The old driver held the same answer in a JSON map of repository to phase,
+// edited by whoever was debugging. That is a decision anyone can change by hand,
+// which made it the one number in the system with no evidence behind it.
+//
+// # It reports and never repairs
+//
+// Nothing here re-scores, re-judges, or tidies a run tree it finds odd. An odd
+// tree is reported as odd. There is no clock, no network and no subprocess, so
+// the same tree gives the same answer on any machine on any day.
+package position
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/luuuc/sense/lab/internal/phase"
+)
+
+// attemptsDir is where a repository's judgments live, beside its cycles rather
+// than inside one: an attempt names its cycle, and a reader that had to walk
+// every cycle directory to collect them would miss the ones whose cycle
+// directory does not exist.
+const attemptsDir = "attempts"
+
+// Attempt is one phase attempt and what it decided.
+//
+// It carries the judgment and nothing derivable. There is no timestamp: the
+// order of attempts is (cycle, phase, try), which the tree and the graph
+// already fix, and a clock in a record is one more thing to be wrong on a
+// machine whose clock is.
+type Attempt struct {
+	Cycle   int           `json:"cycle"`
+	Phase   phase.Name    `json:"phase"`
+	Verdict phase.Verdict `json:"verdict"`
+	// Try distinguishes two attempts at one phase in one cycle, which the graph
+	// allows: a DoD FAIL sends a harvest back to report inside the same cycle.
+	// It is 1-based and it is the caller's, because only the caller knows
+	// whether this is the same attempt being written twice or a new one.
+	Try int `json:"try"`
+	// Table is what rejected this attempt: the mini-bench read, the credit
+	// table that refused to pay, the reason a draft had no anchor. It is what
+	// the next attempt has to answer, and a re-entry without one is a fresh
+	// guess wearing the previous attempt's number.
+	Table  string `json:"table,omitempty"`
+	Anchor string `json:"anchor,omitempty"`
+}
+
+// Name is the attempt's file, and it is the attempt's identity.
+func (a Attempt) Name() string { return fmt.Sprintf("%d-%s-%d.json", a.Cycle, a.Phase, a.Try) }
+
+// Record writes one attempt, and refuses to write over one.
+//
+// The refusal is the open flag rather than a check, because append-only as a
+// convention survives until a bad night and append-only as an O_EXCL survives
+// the bad night. A verdict that has been recorded is history, and history is
+// lost on purpose or not at all.
+func Record(repoDir string, a Attempt) error {
+	if err := a.valid(); err != nil {
+		return err
+	}
+	dir := filepath.Join(repoDir, attemptsDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("prepare %s: %w", dir, err)
+	}
+	b, err := json.MarshalIndent(a, "", "  ")
+	if err != nil {
+		return fmt.Errorf("render the attempt: %w", err)
+	}
+	path := filepath.Join(dir, a.Name())
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return fmt.Errorf("record %s %s try %d: %w. A recorded verdict is not rewritten: "+
+			"if this is a new attempt it is a new try", a.Phase, a.Verdict, a.Try, err)
+	}
+	defer func() { _ = f.Close() }()
+	_, err = f.Write(append(b, '\n'))
+	return err
+}
+
+// valid refuses an attempt that could not be read back as a judgment.
+func (a Attempt) valid() error {
+	switch {
+	case a.Cycle < 1:
+		return fmt.Errorf("attempt at %s is in cycle %d; cycles are 1-based", a.Phase, a.Cycle)
+	case a.Try < 1:
+		return fmt.Errorf("attempt at %s is try %d; tries are 1-based", a.Phase, a.Try)
+	case a.Phase == "":
+		return fmt.Errorf("an attempt with no phase: nothing could say what was decided")
+	case a.Verdict == "":
+		return fmt.Errorf("attempt at %s emitted nothing; a phase that decided nothing did not finish", a.Phase)
+	}
+	return nil
+}
+
+// NextTry is the try number an attempt at this phase and cycle should carry.
+//
+// It is a pure function of what is already recorded rather than a counter, and
+// it is separate from [Record] on purpose: it says what the next attempt would
+// be, and [Record] still refuses if something took that number in between.
+func NextTry(attempts []Attempt, cycle int, p phase.Name) int {
+	next := 1
+	for _, a := range attempts {
+		if a.Cycle == cycle && a.Phase == p && a.Try >= next {
+			next = a.Try + 1
+		}
+	}
+	return next
+}
+
+// Attempts reads every attempt recorded for a repository, in the order they
+// happened: by cycle, then by where the phase sits in the graph, then by try.
+//
+// The order is derived from the graph rather than from a timestamp, so it is
+// the same order on a machine whose clock is wrong.
+func Attempts(repoDir string) ([]Attempt, error) {
+	entries, err := os.ReadDir(filepath.Join(repoDir, attemptsDir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			// A repository nothing has decided about yet. That is a position,
+			// not a failure.
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read the attempts of %s: %w", repoDir, err)
+	}
+	var out []Attempt
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(repoDir, attemptsDir, e.Name())
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", path, err)
+		}
+		var a Attempt
+		if err := json.Unmarshal(b, &a); err != nil {
+			return nil, fmt.Errorf("read %s: %w", path, err)
+		}
+		out = append(out, a)
+	}
+	slices.SortFunc(out, order)
+	return out, nil
+}
+
+// order sorts attempts into the order they can only have happened in.
+func order(a, b Attempt) int {
+	if a.Cycle != b.Cycle {
+		return a.Cycle - b.Cycle
+	}
+	if at, bt := graphIndex(a.Phase), graphIndex(b.Phase); at != bt {
+		return at - bt
+	}
+	return a.Try - b.Try
+}
+
+// graphIndex is where a phase sits in the declared order. A name the graph does
+// not know sorts last rather than first, so an unreadable record cannot displace
+// the phase that actually ran.
+func graphIndex(n phase.Name) int {
+	for i, p := range phase.Graph {
+		if p.Name == n {
+			return i
+		}
+	}
+	return len(phase.Graph)
+}

--- a/lab/internal/position/attempt.go
+++ b/lab/internal/position/attempt.go
@@ -57,13 +57,57 @@ type Attempt struct {
 	// It is 1-based and it is the caller's, because only the caller knows
 	// whether this is the same attempt being written twice or a new one.
 	Try int `json:"try"`
+	// Step is where this attempt sits in the order its cycle happened in,
+	// 1-based, assigned when it is recorded.
+	//
+	// It exists because a cycle is not a walk down the graph. A re-entry sends
+	// work BACK: cycle 1 can hold an author, then a mini-bench that re-questions
+	// it, then the author again — and ordering those by where their phases sit
+	// in the graph puts the mini-bench last, which makes the position route from
+	// the verdict that sent work back rather than from the attempt that
+	// answered it. Measured: the loop then re-ran the author on every turn,
+	// forever, at whatever an agent costs.
+	//
+	// It is recorded rather than derived because there is nothing to derive it
+	// from. The order judgments happened in is known only to whoever was there,
+	// and this package refuses a clock.
+	Step int `json:"step"`
 	// Table is what rejected this attempt: the mini-bench read, the credit
 	// table that refused to pay, the reason a draft had no anchor. It is what
 	// the next attempt has to answer, and a re-entry without one is a fresh
 	// guess wearing the previous attempt's number.
 	Table  string `json:"table,omitempty"`
 	Anchor string `json:"anchor,omitempty"`
+	// Outcome is how the attempt ended when it did not end in a verdict. Empty
+	// is the ordinary case: the phase decided, and Verdict says what.
+	//
+	// The two that are not empty are the two ways an agent fails to produce a
+	// judgment, and they are told apart because they are diagnosed differently.
+	Outcome Outcome `json:"outcome,omitempty"`
+	// Plan, VerdictDoc, Artifact and Log are what this attempt READ and left
+	// behind, as paths. They are recorded rather than derived because a park
+	// opened six months later should show the chain that produced it rather
+	// than a phase name and a date.
+	//
+	// Artifact is empty when the phase wrote none, which is a fact about the
+	// attempt and not a gap in the record.
+	Plan       string `json:"plan,omitempty"`
+	VerdictDoc string `json:"verdict_doc,omitempty"`
+	Artifact   string `json:"artifact,omitempty"`
+	Log        string `json:"log,omitempty"`
 }
+
+// Outcome is how an attempt ended when it produced no verdict.
+type Outcome string
+
+const (
+	// Stalled: the agent ran past its wall. Cannot-finish-at-budget is a
+	// result, so it is recorded as one rather than waited on.
+	Stalled Outcome = "stalled"
+	// Refused: the agent finished and what it wrote is not a verdict for this
+	// phase. An agent that misbehaved, against an agent that died.
+	Refused Outcome = "refused"
+)
 
 // Name is the attempt's file, and it is the attempt's identity.
 func (a Attempt) Name() string { return fmt.Sprintf("%d-%s-%d.json", a.Cycle, a.Phase, a.Try) }
@@ -78,6 +122,15 @@ func Record(repoDir string, a Attempt) error {
 	if err := a.valid(); err != nil {
 		return err
 	}
+	// The step is assigned here, from what is already recorded, because this is
+	// the moment the order is known. A caller cannot be trusted to hold a
+	// counter: one that did would drift the first time an attempt was recorded
+	// by anything else.
+	recorded, err := Attempts(repoDir)
+	if err != nil {
+		return err
+	}
+	a.Step = nextStep(recorded, a.Cycle)
 	dir := filepath.Join(repoDir, attemptsDir)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("prepare %s: %w", dir, err)
@@ -106,10 +159,22 @@ func (a Attempt) valid() error {
 		return fmt.Errorf("attempt at %s is try %d; tries are 1-based", a.Phase, a.Try)
 	case a.Phase == "":
 		return fmt.Errorf("an attempt with no phase: nothing could say what was decided")
-	case a.Verdict == "":
-		return fmt.Errorf("attempt at %s emitted nothing; a phase that decided nothing did not finish", a.Phase)
+	case a.Verdict == "" && a.Outcome == "":
+		return fmt.Errorf("attempt at %s emitted nothing and says nothing about how it ended; "+
+			"a phase that decided nothing did not finish, and that is itself a result to record", a.Phase)
 	}
 	return nil
+}
+
+// nextStep is where the next attempt in a cycle sits in that cycle's order.
+func nextStep(recorded []Attempt, cycle int) int {
+	next := 1
+	for _, a := range recorded {
+		if a.Cycle == cycle && a.Step >= next {
+			next = a.Step + 1
+		}
+	}
+	return next
 }
 
 // NextTry is the try number an attempt at this phase and cycle should carry.
@@ -128,10 +193,11 @@ func NextTry(attempts []Attempt, cycle int, p phase.Name) int {
 }
 
 // Attempts reads every attempt recorded for a repository, in the order they
-// happened: by cycle, then by where the phase sits in the graph, then by try.
+// happened: by cycle, then by the step recorded with each attempt.
 //
-// The order is derived from the graph rather than from a timestamp, so it is
-// the same order on a machine whose clock is wrong.
+// The order comes from the record rather than from a timestamp, so it is the
+// same order on a machine whose clock is wrong — and rather than from the
+// graph, because a cycle that re-enters a phase did not walk the graph in order.
 func Attempts(repoDir string) ([]Attempt, error) {
 	entries, err := os.ReadDir(filepath.Join(repoDir, attemptsDir))
 	if err != nil {
@@ -162,10 +228,17 @@ func Attempts(repoDir string) ([]Attempt, error) {
 	return out, nil
 }
 
-// order sorts attempts into the order they can only have happened in.
+// order sorts attempts into the order they happened in.
+//
+// The step decides. The graph is the tiebreak, for a record written by hand
+// with no step in it: a forward walk is in graph order, so that is the best
+// guess available and it is only ever a guess.
 func order(a, b Attempt) int {
 	if a.Cycle != b.Cycle {
 		return a.Cycle - b.Cycle
+	}
+	if a.Step != b.Step {
+		return a.Step - b.Step
 	}
 	if at, bt := graphIndex(a.Phase), graphIndex(b.Phase); at != bt {
 		return at - bt

--- a/lab/internal/position/attempt_test.go
+++ b/lab/internal/position/attempt_test.go
@@ -1,0 +1,272 @@
+package position
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/lab/internal/phase"
+)
+
+// A recorded verdict is history. Append-only as a convention survives until a
+// bad night; append-only as an open flag survives the bad night, because the
+// second write fails rather than replacing a judgment nobody can recover.
+func TestARecordedAttemptIsNotWrittenOver(t *testing.T) {
+	dir := t.TempDir()
+	first := Attempt{Cycle: 1, Phase: phase.Author, Verdict: phase.Draft, Try: 1, Anchor: "BaseItem"}
+	if err := Record(dir, first); err != nil {
+		t.Fatal(err)
+	}
+
+	err := Record(dir, Attempt{Cycle: 1, Phase: phase.Author, Verdict: phase.NoAnchor, Try: 1})
+
+	if err == nil {
+		t.Fatal("a second write to one attempt succeeded; a verdict was replaced")
+	}
+	back, readErr := Attempts(dir)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if len(back) != 1 || back[0].Verdict != phase.Draft {
+		t.Errorf("attempts = %+v, want the first verdict intact", back)
+	}
+}
+
+// The same phase can legitimately run twice in one cycle — a DoD FAIL sends a
+// harvest back to report — so a second attempt is a second try rather than a
+// collision, and both are kept.
+func TestASecondAttemptAtOnePhaseIsANewTry(t *testing.T) {
+	dir := t.TempDir()
+	if err := Record(dir, Attempt{Cycle: 1, Phase: phase.Report, Verdict: phase.Win, Try: 1}); err != nil {
+		t.Fatal(err)
+	}
+
+	next := NextTry(mustRead(t, dir), 1, phase.Report)
+	if next != 2 {
+		t.Fatalf("NextTry = %d, want 2", next)
+	}
+	if err := Record(dir, Attempt{Cycle: 1, Phase: phase.Report, Verdict: phase.Diagnosis, Try: next}); err != nil {
+		t.Fatal(err)
+	}
+
+	all := mustRead(t, dir)
+	if len(all) != 2 || all[0].Try != 1 || all[1].Try != 2 {
+		t.Errorf("attempts = %+v, want both tries in order", all)
+	}
+}
+
+// NextTry counts only what it is asked about. A phase in another cycle is
+// another attempt at another question.
+func TestNextTryIsPerCycleAndPerPhase(t *testing.T) {
+	recorded := []Attempt{
+		{Cycle: 1, Phase: phase.Report, Try: 1},
+		{Cycle: 1, Phase: phase.Report, Try: 2},
+		{Cycle: 2, Phase: phase.Report, Try: 1},
+		{Cycle: 1, Phase: phase.Author, Try: 1},
+	}
+
+	for _, tc := range []struct {
+		cycle int
+		phase phase.Name
+		want  int
+	}{
+		{1, phase.Report, 3},
+		{2, phase.Report, 2},
+		{1, phase.Author, 2},
+		{3, phase.Author, 1},
+	} {
+		if got := NextTry(recorded, tc.cycle, tc.phase); got != tc.want {
+			t.Errorf("NextTry(cycle %d, %s) = %d, want %d", tc.cycle, tc.phase, got, tc.want)
+		}
+	}
+}
+
+// The order attempts are read back in is derived from the graph, not from a
+// clock, so it is the same order on a machine whose clock is wrong.
+func TestAttemptsComeBackInTheOrderTheyCanOnlyHaveHappenedIn(t *testing.T) {
+	dir := t.TempDir()
+	// Written out of order on purpose.
+	for _, a := range []Attempt{
+		{Cycle: 2, Phase: phase.Author, Verdict: phase.Draft, Try: 1},
+		{Cycle: 1, Phase: phase.Minibench, Verdict: phase.Requestion, Try: 1, Table: "the baseline reached it"},
+		{Cycle: 1, Phase: phase.Author, Verdict: phase.Draft, Try: 1},
+	} {
+		if err := Record(dir, a); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var got []string
+	for _, a := range mustRead(t, dir) {
+		got = append(got, string(a.Phase))
+	}
+
+	if strings.Join(got, ",") != "author,minibench,author" {
+		t.Errorf("order = %v, want cycle 1's author, then its mini-bench, then cycle 2's author", got)
+	}
+}
+
+// A phase the graph does not know sorts last rather than first, so an
+// unreadable record cannot displace the phase that actually ran.
+func TestAPhaseTheGraphDoesNotKnowSortsLast(t *testing.T) {
+	dir := t.TempDir()
+	for _, a := range []Attempt{
+		{Cycle: 1, Phase: "invented", Verdict: phase.Auto, Try: 1},
+		{Cycle: 1, Phase: phase.Author, Verdict: phase.Draft, Try: 1},
+	} {
+		if err := Record(dir, a); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	all := mustRead(t, dir)
+	if all[0].Phase != phase.Author {
+		t.Errorf("first = %s, want the phase the graph knows", all[0].Phase)
+	}
+}
+
+// A record that could not be read back as a judgment is refused when it is
+// written, where the caller can still fix it.
+func TestAnAttemptThatIsNotAJudgmentIsRefused(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		a    Attempt
+	}{
+		{"no cycle", Attempt{Phase: phase.Author, Verdict: phase.Draft, Try: 1}},
+		{"no try", Attempt{Cycle: 1, Phase: phase.Author, Verdict: phase.Draft}},
+		{"no phase", Attempt{Cycle: 1, Verdict: phase.Draft, Try: 1}},
+		{"no verdict", Attempt{Cycle: 1, Phase: phase.Author, Try: 1}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := Record(t.TempDir(), tc.a); err == nil {
+				t.Error("recorded")
+			}
+		})
+	}
+}
+
+// A repository nothing has decided about yet has no attempts, which is a
+// position rather than a failure.
+func TestARepositoryWithNoAttemptsReadsAsNone(t *testing.T) {
+	all, err := Attempts(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 0 {
+		t.Errorf("attempts = %v, want none", all)
+	}
+}
+
+// A record that is there and cannot be read back is reported rather than
+// skipped. A judgment silently dropped is a repository that reads as never
+// having reached the phase that produced it.
+func TestARecordThatCannotBeReadIsReportedRatherThanSkipped(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		put  func(t *testing.T, path string)
+	}{
+		{"it is not a document", func(t *testing.T, path string) {
+			if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"it cannot be opened", func(t *testing.T, path string) {
+			if os.Geteuid() == 0 {
+				t.Skip("root reads anything")
+			}
+			if err := os.Chmod(path, 0o000); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() { _ = os.Chmod(path, 0o644) })
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			a := Attempt{Cycle: 1, Phase: phase.Author, Verdict: phase.Draft, Try: 1}
+			if err := Record(dir, a); err != nil {
+				t.Fatal(err)
+			}
+			tc.put(t, filepath.Join(dir, attemptsDir, a.Name()))
+
+			if _, err := Attempts(dir); err == nil {
+				t.Error("an unreadable record was skipped")
+			}
+		})
+	}
+}
+
+// Anything that is not a record is not read as one.
+func TestOnlyRecordsAreReadOutOfTheAttemptsDirectory(t *testing.T) {
+	dir := t.TempDir()
+	if err := Record(dir, Attempt{Cycle: 1, Phase: phase.Author, Verdict: phase.Draft, Try: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, attemptsDir, "notes.md"), []byte("# by hand\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, attemptsDir, "olds"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if all := mustRead(t, dir); len(all) != 1 {
+		t.Errorf("attempts = %+v, want only the record", all)
+	}
+}
+
+func TestARecordThatCannotBeWrittenIsReported(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, attemptsDir), []byte("in the way"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Record(dir, Attempt{Cycle: 1, Phase: phase.Author, Verdict: phase.Draft, Try: 1}); err == nil {
+		t.Fatal("an attempt was recorded into a file")
+	}
+}
+
+func mustRead(t *testing.T, dir string) []Attempt {
+	t.Helper()
+	all, err := Attempts(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return all
+}
+
+// The order is the graph's, not the filesystem's. Read back alphabetically an
+// expansion comes before the mini-bench that decides whether to expand at all,
+// and the last attempt — which is what a position is read from — would be the
+// wrong one.
+func TestTheOrderIsTheGraphsRatherThanTheAlphabets(t *testing.T) {
+	dir := t.TempDir()
+	for _, a := range []Attempt{
+		{Cycle: 1, Phase: phase.Expand, Verdict: phase.Auto, Try: 1},
+		{Cycle: 1, Phase: phase.Minibench, Verdict: phase.Proceed, Try: 1},
+	} {
+		if err := Record(dir, a); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	all := mustRead(t, dir)
+
+	if all[0].Phase != phase.Minibench || all[1].Phase != phase.Expand {
+		t.Errorf("order = %s then %s, want the mini-bench before the expansion it decides on",
+			all[0].Phase, all[1].Phase)
+	}
+}
+
+// The anchor is one of the three things a record exists to keep — the verdict,
+// the table and the anchor — so it survives the round trip.
+func TestTheAnchorSurvivesTheRecord(t *testing.T) {
+	dir := t.TempDir()
+	if err := Record(dir, Attempt{Cycle: 1, Phase: phase.Author, Verdict: phase.Draft, Try: 1,
+		Anchor: "MediaBrowser.Controller.Entities.BaseItem"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if back := mustRead(t, dir); back[0].Anchor != "MediaBrowser.Controller.Entities.BaseItem" {
+		t.Errorf("anchor = %q, want the one that was recorded", back[0].Anchor)
+	}
+}

--- a/lab/internal/position/attempt_test.go
+++ b/lab/internal/position/attempt_test.go
@@ -86,11 +86,13 @@ func TestNextTryIsPerCycleAndPerPhase(t *testing.T) {
 // clock, so it is the same order on a machine whose clock is wrong.
 func TestAttemptsComeBackInTheOrderTheyCanOnlyHaveHappenedIn(t *testing.T) {
 	dir := t.TempDir()
-	// Written out of order on purpose.
+	// A later cycle recorded first, which is what a hand-repaired tree looks
+	// like. Within a cycle the order is the order they were recorded in; across
+	// cycles it is the cycle.
 	for _, a := range []Attempt{
 		{Cycle: 2, Phase: phase.Author, Verdict: phase.Draft, Try: 1},
-		{Cycle: 1, Phase: phase.Minibench, Verdict: phase.Requestion, Try: 1, Table: "the baseline reached it"},
 		{Cycle: 1, Phase: phase.Author, Verdict: phase.Draft, Try: 1},
+		{Cycle: 1, Phase: phase.Minibench, Verdict: phase.Requestion, Try: 1, Table: "the baseline reached it"},
 	} {
 		if err := Record(dir, a); err != nil {
 			t.Fatal(err)
@@ -105,22 +107,31 @@ func TestAttemptsComeBackInTheOrderTheyCanOnlyHaveHappenedIn(t *testing.T) {
 	if strings.Join(got, ",") != "author,minibench,author" {
 		t.Errorf("order = %v, want cycle 1's author, then its mini-bench, then cycle 2's author", got)
 	}
+	if all := mustRead(t, dir); all[2].Cycle != 2 {
+		t.Errorf("last is in cycle %d, want the later cycle last however it was recorded", all[2].Cycle)
+	}
 }
 
-// A phase the graph does not know sorts last rather than first, so an
-// unreadable record cannot displace the phase that actually ran.
-func TestAPhaseTheGraphDoesNotKnowSortsLast(t *testing.T) {
+// A record written by hand carries no step, and those fall back to the graph's
+// order — which is right for a forward walk and is the best guess available. A
+// phase the graph does not know sorts last rather than first, so an unreadable
+// record cannot displace the phase that actually ran.
+func TestHandWrittenRecordsFallBackToTheGraphsOrder(t *testing.T) {
 	dir := t.TempDir()
-	for _, a := range []Attempt{
-		{Cycle: 1, Phase: "invented", Verdict: phase.Auto, Try: 1},
-		{Cycle: 1, Phase: phase.Author, Verdict: phase.Draft, Try: 1},
+	for name, body := range map[string]string{
+		"1-invented-1.json": `{"cycle":1,"phase":"invented","verdict":"AUTO","try":1}`,
+		"1-author-1.json":   `{"cycle":1,"phase":"author","verdict":"DRAFT","try":1}`,
 	} {
-		if err := Record(dir, a); err != nil {
+		if err := os.MkdirAll(filepath.Join(dir, attemptsDir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, attemptsDir, name), []byte(body), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
 
 	all := mustRead(t, dir)
+
 	if all[0].Phase != phase.Author {
 		t.Errorf("first = %s, want the phase the graph knows", all[0].Phase)
 	}
@@ -234,15 +245,15 @@ func mustRead(t *testing.T, dir string) []Attempt {
 	return all
 }
 
-// The order is the graph's, not the filesystem's. Read back alphabetically an
-// expansion comes before the mini-bench that decides whether to expand at all,
-// and the last attempt — which is what a position is read from — would be the
-// wrong one.
-func TestTheOrderIsTheGraphsRatherThanTheAlphabets(t *testing.T) {
+// The order is the one they were recorded in, not the filesystem's. Read back
+// alphabetically an expansion comes before the mini-bench that decides whether
+// to expand at all, and the last attempt — which is what a position is read
+// from — would be the wrong one.
+func TestTheOrderIsTheOneTheyHappenedInRatherThanTheAlphabets(t *testing.T) {
 	dir := t.TempDir()
 	for _, a := range []Attempt{
-		{Cycle: 1, Phase: phase.Expand, Verdict: phase.Auto, Try: 1},
 		{Cycle: 1, Phase: phase.Minibench, Verdict: phase.Proceed, Try: 1},
+		{Cycle: 1, Phase: phase.Expand, Verdict: phase.Auto, Try: 1},
 	} {
 		if err := Record(dir, a); err != nil {
 			t.Fatal(err)
@@ -254,6 +265,57 @@ func TestTheOrderIsTheGraphsRatherThanTheAlphabets(t *testing.T) {
 	if all[0].Phase != phase.Minibench || all[1].Phase != phase.Expand {
 		t.Errorf("order = %s then %s, want the mini-bench before the expansion it decides on",
 			all[0].Phase, all[1].Phase)
+	}
+}
+
+// And it is not the graph's either, because a cycle that re-enters a phase did
+// not walk the graph in order.
+//
+// This is the failure that made the loop spin: ordered by the graph, the
+// mini-bench that sent work back sorts after the author attempt that answered
+// it, so the position routes from the rejection forever and re-runs the author
+// on every turn, at whatever an agent costs.
+func TestAReEnteredPhaseIsTheLastAttemptRatherThanTheOneThatSentItBack(t *testing.T) {
+	dir := t.TempDir()
+	for _, a := range []Attempt{
+		{Cycle: 1, Phase: phase.Author, Verdict: phase.Draft, Try: 1},
+		{Cycle: 1, Phase: phase.Minibench, Verdict: phase.Requestion, Try: 1, Table: "the baseline reached it"},
+		{Cycle: 1, Phase: phase.Author, Verdict: phase.Draft, Try: 2},
+	} {
+		if err := Record(dir, a); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	all := mustRead(t, dir)
+
+	last := all[len(all)-1]
+	if last.Phase != phase.Author || last.Try != 2 {
+		t.Errorf("last = %s try %d, want the re-entered author", last.Phase, last.Try)
+	}
+}
+
+// The step is what makes that possible, and it is assigned when the attempt is
+// recorded rather than held by a caller.
+func TestEachAttemptIsRecordedWithItsPlaceInTheCycle(t *testing.T) {
+	dir := t.TempDir()
+	for _, a := range []Attempt{
+		{Cycle: 1, Phase: phase.Author, Verdict: phase.Draft, Try: 1},
+		{Cycle: 1, Phase: phase.Minibench, Verdict: phase.Requestion, Try: 1, Table: "no"},
+		{Cycle: 2, Phase: phase.Author, Verdict: phase.Draft, Try: 1},
+	} {
+		if err := Record(dir, a); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	all := mustRead(t, dir)
+
+	// Steps count within a cycle, so a new cycle starts again at one.
+	for i, want := range []int{1, 2, 1} {
+		if all[i].Step != want {
+			t.Errorf("%s in cycle %d is step %d, want %d", all[i].Phase, all[i].Cycle, all[i].Step, want)
+		}
 	}
 }
 

--- a/lab/internal/position/position.go
+++ b/lab/internal/position/position.go
@@ -1,0 +1,325 @@
+package position
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/luuuc/sense/lab/internal/phase"
+)
+
+// Standing is what a position amounts to for a caller that has to decide, and
+// each one is an exit code. They are an API rather than a display: this command
+// ends up in a shell loop, and what that loop stops on is this.
+type Standing string
+
+const (
+	// Ready: there is a next phase and something to run it on.
+	Ready Standing = "ready"
+	// Finished: the repository reached the board.
+	Finished Standing = "finished"
+	// Parked: the authoring ceiling, re-entered only by a deliberate human act.
+	Parked Standing = "parked"
+	// Waiting: a PAY. The method worked and the next act spends money, which
+	// the crank does not do. This and Parked are the two most worth telling
+	// apart: one is the method failing on this repository, the other is the
+	// method succeeding and waiting on a wallet.
+	Waiting Standing = "waiting"
+	// Unusable: the last attempt emitted something its phase cannot emit. An
+	// agent misbehaved.
+	Unusable Standing = "unusable"
+	// Missing: the last attempt's verdict is usable and the artifact it owed is
+	// not there. An agent died. Diagnosed differently from Unusable, which is
+	// why it is not the same code.
+	Missing Standing = "missing"
+)
+
+// Position is where one repository stands.
+type Position struct {
+	Repo string
+	// Cycle is the authoring cycle on disk, which is the highest numbered
+	// directory. Derived every time; there is no counter anywhere to drift.
+	Cycle int
+	// Indexed says the repository has been scanned. The index sits beside the
+	// cycles rather than inside one, because a re-entry does not rescan.
+	Indexed bool
+	// Awaiting is the phase to run next: routed from the last verdict where
+	// there is one, and otherwise the first phase of this cycle that owes an
+	// artifact.
+	Awaiting phase.Name
+	// Reached is the furthest phase of this cycle whose artifact exists.
+	Reached  phase.Name
+	Standing Standing
+	// Last is the last attempt recorded in this cycle, if any.
+	Last Attempt
+	// Answer is every rejection this repository has carried, oldest first. The
+	// next attempt reads all of them and not only the last: six attempts
+	// converging is what that makes possible, and six unrelated drafts is what
+	// it prevents.
+	Answer []Attempt
+	// Banked is every cycle that reached the board.
+	Banked []int
+	// Because says why the standing is what it is, in a sentence, for whoever
+	// is reading a stopped loop.
+	Because string
+}
+
+// ToCeiling is how many authoring cycles are left before this repository parks.
+func (p Position) ToCeiling() int { return max(phase.AuthoringCeiling-p.Cycle, 0) }
+
+// Read reports where a repository stands, from its run tree and its attempt
+// records.
+//
+// A repository directory that is not there is not an error: asking where a
+// repository stands before it has been admitted is a fair question with an
+// answer, and the answer is that it awaits its index.
+func Read(campaign, repo string) (Position, error) {
+	dir := filepath.Join(campaign, repo)
+	p := Position{Repo: repo, Indexed: wrote(dir, phaseOf(phase.Index))}
+
+	cycles, err := cycleDirs(dir)
+	if err != nil {
+		return Position{}, err
+	}
+	for _, c := range cycles {
+		at := filepath.Join(dir, strconv.Itoa(c))
+		if wrote(at, phaseOf(phase.Board)) {
+			p.Banked = append(p.Banked, c)
+		}
+		if c > p.Cycle {
+			p.Cycle = c
+		}
+	}
+	if p.Cycle == 0 {
+		// A repository that has opened no cycle directory is in its first one.
+		// Reporting cycle 0 would be a number no rule is written in: the
+		// ceiling counts from 1, and an attempt recorded for cycle 1 before its
+		// directory exists is an attempt in the cycle this repository is in.
+		p.Cycle = 1
+	}
+	attempts, err := Attempts(dir)
+	if err != nil {
+		return Position{}, err
+	}
+	p.Answer = rejections(attempts)
+	p.settle(dir, attempts)
+	return p, nil
+}
+
+// settle works out the next phase and what the position amounts to.
+//
+// The order of the questions is the answer to most of them: parked beats
+// everything because a parked repository is not re-entered by any transition,
+// and banked beats a stale attempt record because the board is on disk.
+func (p *Position) settle(dir string, attempts []Attempt) {
+	cycleDir := filepath.Join(dir, strconv.Itoa(p.Cycle))
+	p.Reached, p.Awaiting = walk(cycleDir)
+	// The last verdict is carried whatever the standing turns out to be.
+	// Whoever finds a parked repository wants to read the verdict that parked
+	// it, and a field only filled in on the paths that route from one would be
+	// blank on exactly the positions somebody is looking at because it stopped.
+	last, decided := lastOf(attempts, p.Cycle)
+	p.Last = last
+
+	switch {
+	case wrote(cycleDir, phaseOf(phase.Handoff)):
+		p.Standing, p.Awaiting = Parked, phase.Done
+		p.Because = fmt.Sprintf("cycle %d wrote a handoff; re-entering a parked repository is a human act, not a transition", p.Cycle)
+		return
+	case slices.Contains(p.Banked, p.Cycle):
+		p.Standing, p.Awaiting = Finished, phase.Done
+		p.Because = fmt.Sprintf("cycle %d reached the board", p.Cycle)
+		return
+	}
+
+	if !p.Indexed {
+		// Nothing under a cycle can be believed before the repository is
+		// scanned, so nothing under one is read as a position. This is checked
+		// after the two endings and before any verdict: a scan is what the
+		// repository is waiting for, whatever else is on disk.
+		p.Standing, p.Awaiting = Ready, phase.Index
+		p.Because = "the repository has not been scanned; the index is what everything after it reads"
+		return
+	}
+
+	if !decided {
+		// Nothing decided in this cycle. The tree walk is the whole answer, and
+		// there is a phase owed.
+		p.Standing = Ready
+		p.Because = fmt.Sprintf("no verdict recorded in cycle %d; %s owes %s", p.Cycle, p.Awaiting, phaseOf(p.Awaiting).Writes)
+		return
+	}
+	p.route(cycleDir, last)
+}
+
+// route reads the last verdict and says where it leads, or why it leads
+// nowhere.
+func (p *Position) route(cycleDir string, last Attempt) {
+	next, err := phase.Next(last.Phase, last.Verdict, p.Cycle)
+	if err != nil {
+		p.Standing, p.Because = Unusable, err.Error()
+		return
+	}
+	if !wrote(cycleDir, phaseOf(last.Phase)) {
+		// The verdict is one the phase may emit and the artifact it owed is not
+		// there. An exit code is a claim; the artifact is the fact.
+		p.Standing = Missing
+		p.Because = fmt.Sprintf("%s emitted %s and did not write %s; the verdict is usable and the phase did not finish",
+			last.Phase, last.Verdict, phaseOf(last.Phase).Writes)
+		return
+	}
+	// Nothing routes to Done here: the two phases that end the loop are the
+	// board and the handoff, and both are recognised from their artifact above
+	// before any verdict is read. A repository is finished because the board is
+	// on disk, not because something said so.
+	p.Awaiting = next
+	switch {
+	case last.Verdict == phase.Pay:
+		p.Standing = Waiting
+		p.Because = "the validation says PAY, and spending is a human act"
+	case next == phase.Handoff:
+		p.Standing = Parked
+		p.Because = fmt.Sprintf("%s emitted %s at cycle %d, which is the authoring ceiling", last.Phase, last.Verdict, p.Cycle)
+	default:
+		p.Standing = Ready
+		p.Because = fmt.Sprintf("%s emitted %s, which routes to %s", last.Phase, last.Verdict, next)
+	}
+}
+
+// rejections is every attempt that left a table behind, oldest first.
+//
+// The table is the test rather than the verdict, and that is deliberate. A
+// re-entry is recognisable from its routing, but a NO-ANCHOR at the authoring
+// ceiling routes to the handoff instead of back to the author and is no less a
+// rejection for it — and a diagnosis carries one too. What makes an attempt
+// something the next one has to answer is that somebody wrote down why it was
+// refused.
+func rejections(attempts []Attempt) []Attempt {
+	var out []Attempt
+	for _, a := range attempts {
+		if a.Table != "" {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+// lastOf is the last attempt recorded in a cycle.
+//
+// Scoped to the cycle the DIRECTORIES say we are in, so a record naming a cycle
+// that was never opened decides nothing. The tree is what says where a
+// repository is; a record says what was judged there.
+func lastOf(attempts []Attempt, cycle int) (Attempt, bool) {
+	for i := len(attempts) - 1; i >= 0; i-- {
+		if attempts[i].Cycle == cycle {
+			return attempts[i], true
+		}
+	}
+	return Attempt{}, false
+}
+
+// walk reports the furthest phase of a cycle whose artifact exists, and the
+// first whose artifact does not. It decides nothing: an artifact is on disk or
+// it is not.
+func walk(cycleDir string) (reached, awaiting phase.Name) {
+	for _, p := range phase.Graph {
+		// The index is per repository rather than per cycle, and the handoff is
+		// arrived at rather than walked to. Looking for either here would
+		// report every cycle as owing one.
+		if p.Name == phase.Index || p.Name == phase.Handoff {
+			continue
+		}
+		if wrote(cycleDir, p) {
+			reached = p.Name
+			continue
+		}
+		if awaiting == "" {
+			awaiting = p.Name
+		}
+	}
+	if awaiting == "" {
+		awaiting = phase.Done
+	}
+	return reached, awaiting
+}
+
+// wrote reports whether a phase's output artifact is under dir.
+func wrote(dir string, p phase.Phase) bool {
+	_, err := os.Stat(filepath.Join(dir, string(p.Name), p.Writes))
+	return err == nil
+}
+
+func phaseOf(name phase.Name) phase.Phase {
+	p, _ := phase.Lookup(name)
+	return p
+}
+
+// cycleDirs is every numbered directory under a repository, which is every
+// authoring cycle it has opened. Anything else in the tree is not a cycle and
+// this walk does not rule on it.
+func cycleDirs(dir string) ([]int, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read the run tree of %s: %w", dir, err)
+	}
+	var out []int
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if n, err := strconv.Atoi(e.Name()); err == nil {
+			out = append(out, n)
+		}
+	}
+	slices.Sort(out)
+	return out, nil
+}
+
+// Render is the page. Nothing parses it: [Read] returns a [Position] and this
+// turns one into a string, because parsing your own report is how a display
+// format silently becomes a data contract.
+func Render(p Position) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "repo:     %s\ncycle:    %d of %d\nindexed:  %s\nreached:  %s\nawaiting: %s\nstanding: %s — %s\n",
+		p.Repo, p.Cycle, phase.AuthoringCeiling, yes(p.Indexed), or(p.Reached, "nothing yet"),
+		or(p.Awaiting, "nothing"), p.Standing, p.Because)
+	if len(p.Banked) > 0 {
+		fmt.Fprintf(&b, "banked:   %v\n", p.Banked)
+	}
+	if len(p.Answer) == 0 {
+		return b.String()
+	}
+	// Every rejection, not only the last. A page that showed the most recent
+	// one would be a page that invites the next attempt to answer one thing.
+	b.WriteString("answer:\n")
+	for _, a := range p.Answer {
+		table := a.Table
+		if table == "" {
+			table = "no table recorded"
+		}
+		fmt.Fprintf(&b, "  cycle %d %s emitted %s: %s\n", a.Cycle, a.Phase, a.Verdict, table)
+	}
+	return b.String()
+}
+
+func yes(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}
+
+// or names a phase, or says what its absence means. A phase that is empty is
+// not "" on the page: an unset field and a real answer must not print alike.
+func or(n phase.Name, absent string) string {
+	if n == "" {
+		return absent
+	}
+	return string(n)
+}

--- a/lab/internal/position/position.go
+++ b/lab/internal/position/position.go
@@ -158,6 +158,23 @@ func (p *Position) settle(dir string, attempts []Attempt) {
 // route reads the last verdict and says where it leads, or why it leads
 // nowhere.
 func (p *Position) route(cycleDir string, last Attempt) {
+	switch last.Outcome {
+	case Stalled:
+		// An agent that died. It is Missing rather than Unusable because that
+		// is how it is diagnosed: there is a log, and the phase never reached a
+		// judgment.
+		p.Standing = Missing
+		p.Because = fmt.Sprintf("%s ran past its wall and recorded no verdict; its log is %s",
+			last.Phase, orText(last.Log, "not recorded"))
+		return
+	case Refused:
+		// An agent that misbehaved: it finished, and what it wrote is not a
+		// verdict for this phase.
+		p.Standing = Unusable
+		p.Because = fmt.Sprintf("%s was refused: %s", last.Phase, last.Table)
+		return
+	}
+
 	next, err := phase.Next(last.Phase, last.Verdict, p.Cycle)
 	if err != nil {
 		p.Standing, p.Because = Unusable, err.Error()
@@ -313,6 +330,15 @@ func yes(b bool) string {
 		return "yes"
 	}
 	return "no"
+}
+
+// orText is or, for a path. A blank where a file should be named reads as a
+// file called nothing.
+func orText(s, absent string) string {
+	if s == "" {
+		return absent
+	}
+	return s
 }
 
 // or names a phase, or says what its absence means. A phase that is empty is

--- a/lab/internal/position/position_test.go
+++ b/lab/internal/position/position_test.go
@@ -390,3 +390,39 @@ func TestNothingIsLeftPastTheCeiling(t *testing.T) {
 		t.Errorf("to the ceiling = %d, want none left", p.ToCeiling())
 	}
 }
+
+// An attempt that produced no verdict says how it ended, and the two ways it
+// can are told apart because they are diagnosed differently: an agent that died
+// against an agent that misbehaved.
+func TestAnAttemptWithNoVerdictSaysHowItEnded(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		outcome Outcome
+		table   string
+		log     string
+		want    Standing
+		says    string
+	}{
+		{"it ran past its wall", Stalled, "", "runs/1/author/session/raw/stdout", Missing, "runs/1/author"},
+		{"it ran past its wall and left no log", Stalled, "", "", Missing, "not recorded"},
+		{"what it wrote is not a verdict", Refused, "the verdict names another phase", "", Unusable, "another phase"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			campaign := t.TempDir()
+			repo := filepath.Join(campaign, "r")
+			writeArtifact(t, filepath.Join(repo, "index", "index.json"), "{}")
+			writeArtifact(t, filepath.Join(repo, "1", "author", "scenario.draft.yaml"), "name: r\n")
+			record(t, repo, Attempt{Cycle: 1, Phase: phase.Author, Try: 1,
+				Outcome: tc.outcome, Table: tc.table, Log: tc.log})
+
+			p := read(t, campaign, "r")
+
+			if p.Standing != tc.want {
+				t.Errorf("standing = %s (%s), want %s", p.Standing, p.Because, tc.want)
+			}
+			if !strings.Contains(p.Because, tc.says) {
+				t.Errorf("because = %q, want it to carry %q", p.Because, tc.says)
+			}
+		})
+	}
+}

--- a/lab/internal/position/position_test.go
+++ b/lab/internal/position/position_test.go
@@ -1,0 +1,392 @@
+package position
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/luuuc/sense/lab/internal/phase"
+)
+
+// fixture is the committed campaign: three repositories, one of each shape a
+// real one takes.
+const fixture = "testdata/campaign"
+
+func read(t *testing.T, campaign, repo string) Position {
+	t.Helper()
+	p, err := Read(campaign, repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// The three shapes, read from the tree the jellyfin campaign's layout was copied
+// from. Each is asserted whole rather than field by field across three tests,
+// because what matters is that one tree produces one coherent answer.
+func TestPositionIsReadFromTheCommittedTree(t *testing.T) {
+	for _, tc := range []struct {
+		repo     string
+		cycle    int
+		reached  phase.Name
+		awaiting phase.Name
+		standing Standing
+		last     phase.Verdict
+		answers  int
+		because  string
+	}{
+		{"midcycle", 2, phase.Minibench, phase.Author, Ready, phase.Requestion, 2, "routes to author"},
+		{"parked", 6, phase.Author, phase.Done, Parked, phase.NoAnchor, 1, "handoff"},
+		{"atpay", 1, phase.Validate, phase.Bench, Waiting, phase.Pay, 0, "human"},
+		{"banked", 2, phase.Author, phase.Minibench, Ready, phase.Draft, 0, "routes to minibench"},
+	} {
+		t.Run(tc.repo, func(t *testing.T) {
+			p := read(t, fixture, tc.repo)
+
+			if p.Cycle != tc.cycle {
+				t.Errorf("cycle = %d, want %d", p.Cycle, tc.cycle)
+			}
+			if p.Reached != tc.reached {
+				t.Errorf("reached = %s, want %s", p.Reached, tc.reached)
+			}
+			if p.Awaiting != tc.awaiting {
+				t.Errorf("awaiting = %s, want %s", p.Awaiting, tc.awaiting)
+			}
+			if p.Standing != tc.standing {
+				t.Errorf("standing = %s (%s), want %s", p.Standing, p.Because, tc.standing)
+			}
+			if p.Last.Verdict != tc.last {
+				t.Errorf("last verdict = %q, want %q: the position is read from the last one recorded in this cycle",
+					p.Last.Verdict, tc.last)
+			}
+			if len(p.Answer) != tc.answers {
+				t.Errorf("carried rejections = %d, want %d", len(p.Answer), tc.answers)
+			}
+			if !strings.Contains(p.Because, tc.because) {
+				t.Errorf("because = %q, want it to say %q; a stopped loop is read by whoever finds it", p.Because, tc.because)
+			}
+			if !p.Indexed {
+				t.Error("indexed = false; every repository in the fixture has been scanned")
+			}
+		})
+	}
+}
+
+// A repository that banked a cycle and opened another has work to do. Banking
+// is per cycle, and a check that asked only whether anything had ever been
+// banked would call every re-entry finished.
+func TestBankingOneCycleDoesNotFinishTheNextOne(t *testing.T) {
+	p := read(t, fixture, "banked")
+
+	if p.Standing != Ready {
+		t.Errorf("standing = %s (%s), want a repository with a phase to run", p.Standing, p.Because)
+	}
+	if len(p.Banked) != 1 || p.Banked[0] != 1 {
+		t.Errorf("banked = %v, want the one cycle that reached the board", p.Banked)
+	}
+}
+
+// The rejection is carried with its table, and the table is what the next
+// attempt has to answer. A re-entry that lost it is a fresh guess wearing the
+// previous attempt's number.
+func TestEveryRejectionIsCarriedWithTheTableThatProducedIt(t *testing.T) {
+	p := read(t, fixture, "midcycle")
+
+	if len(p.Answer) != 2 {
+		t.Fatalf("carried = %+v, want both re-questions", p.Answer)
+	}
+	// Oldest first, and both of them: the next attempt reads all of them, not
+	// only the last. Six attempts converging is what that makes possible, and
+	// six unrelated drafts is what it prevents.
+	if a := p.Answer[0]; a.Cycle != 1 || a.Phase != phase.Minibench || !strings.Contains(a.Table, "4 of 4") {
+		t.Errorf("first carried = %+v, want cycle 1's mini-bench with its table", a)
+	}
+	if a := p.Answer[1]; a.Cycle != 2 || !strings.Contains(a.Table, "no more discriminating") {
+		t.Errorf("second carried = %+v, want cycle 2's mini-bench with its own table", a)
+	}
+}
+
+// The cycle is read from the directories, and a record that names a cycle
+// nobody opened does not move it. The tree says where a repository is; a record
+// says what was judged there.
+func TestTheDirectoriesDecideTheCycleAndTheRecordsDoNot(t *testing.T) {
+	campaign := t.TempDir()
+	repo := filepath.Join(campaign, "r")
+	writeArtifact(t, filepath.Join(repo, "index", "index.json"), "{}")
+	writeArtifact(t, filepath.Join(repo, "1", "author", "scenario.draft.yaml"), "name: r\n")
+	writeArtifact(t, filepath.Join(repo, "2", "author", "scenario.draft.yaml"), "name: r\n")
+	record(t, repo, Attempt{Cycle: 2, Phase: phase.Author, Verdict: phase.Draft, Try: 1})
+	// A verdict recorded for a cycle whose directory was never opened.
+	record(t, repo, Attempt{Cycle: 3, Phase: phase.Author, Verdict: phase.NoAnchor, Try: 1})
+
+	p := read(t, campaign, "r")
+
+	if p.Cycle != 2 {
+		t.Errorf("cycle = %d, want the highest directory on disk", p.Cycle)
+	}
+	if p.Standing != Ready || p.Awaiting != phase.Minibench {
+		t.Errorf("standing = %s awaiting %s; the cycle-3 record decided the position", p.Standing, p.Awaiting)
+	}
+}
+
+// A repository that has opened no cycle is in its first. Reporting cycle 0
+// would be a number no rule is written in: the ceiling counts from 1.
+func TestAFreshlyIndexedRepositoryIsInItsFirstCycle(t *testing.T) {
+	campaign := t.TempDir()
+	writeArtifact(t, filepath.Join(campaign, "r", "index", "index.json"), "{}")
+
+	p := read(t, campaign, "r")
+
+	if p.Cycle != 1 || p.Awaiting != phase.Author {
+		t.Errorf("cycle %d awaiting %s, want cycle 1 awaiting the author", p.Cycle, p.Awaiting)
+	}
+	if p.ToCeiling() != phase.AuthoringCeiling-1 {
+		t.Errorf("to the ceiling = %d, want %d", p.ToCeiling(), phase.AuthoringCeiling-1)
+	}
+}
+
+// Nothing under a cycle can be believed before the repository is scanned, so an
+// unscanned one waits on its index whatever else is on disk.
+func TestAnUnscannedRepositoryWaitsOnItsIndex(t *testing.T) {
+	campaign := t.TempDir()
+	writeArtifact(t, filepath.Join(campaign, "r", "1", "author", "scenario.draft.yaml"), "name: r\n")
+
+	p := read(t, campaign, "r")
+
+	if p.Indexed || p.Awaiting != phase.Index {
+		t.Errorf("indexed %v awaiting %s, want it waiting on the scan", p.Indexed, p.Awaiting)
+	}
+}
+
+// A repository that is not there at all is a fair question with an answer.
+func TestARepositoryThatWasNeverAdmittedIsAPositionRatherThanAnError(t *testing.T) {
+	p := read(t, t.TempDir(), "never-heard-of-it")
+
+	if p.Awaiting != phase.Index || p.Standing != Ready {
+		t.Errorf("position = %+v, want it awaiting its index", p)
+	}
+}
+
+// The two refusals are diagnosed differently — an agent that misbehaved against
+// an agent that died — so they are separate standings and separate codes.
+func TestTheTwoRefusalsAreToldApart(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		verdict  phase.Verdict
+		artifact bool
+		want     Standing
+	}{
+		{"a verdict the phase cannot emit", phase.Win, true, Unusable},
+		{"a usable verdict whose artifact is not there", phase.Draft, false, Missing},
+		{"a usable verdict that wrote its artifact", phase.Draft, true, Ready},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			campaign := t.TempDir()
+			repo := filepath.Join(campaign, "r")
+			writeArtifact(t, filepath.Join(repo, "index", "index.json"), "{}")
+			if err := os.MkdirAll(filepath.Join(repo, "1"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if tc.artifact {
+				writeArtifact(t, filepath.Join(repo, "1", "author", "scenario.draft.yaml"), "name: r\n")
+			}
+			record(t, repo, Attempt{Cycle: 1, Phase: phase.Author, Verdict: tc.verdict, Try: 1})
+
+			p := read(t, campaign, "r")
+
+			if p.Standing != tc.want {
+				t.Errorf("standing = %s (%s), want %s", p.Standing, p.Because, tc.want)
+			}
+		})
+	}
+}
+
+// A repository on the board is finished, and it says so from the board on disk
+// rather than from the last thing anybody recorded about it.
+func TestARepositoryOnTheBoardIsFinished(t *testing.T) {
+	campaign := t.TempDir()
+	repo := filepath.Join(campaign, "r")
+	writeArtifact(t, filepath.Join(repo, "index", "index.json"), "{}")
+	writeArtifact(t, filepath.Join(repo, "1", "board", "board.md"), "# board\n")
+
+	p := read(t, campaign, "r")
+
+	if p.Standing != Finished || p.Awaiting != phase.Done {
+		t.Errorf("standing = %s awaiting %s, want a finished repository", p.Standing, p.Awaiting)
+	}
+	if len(p.Banked) != 1 || p.Banked[0] != 1 {
+		t.Errorf("banked = %v, want cycle 1", p.Banked)
+	}
+}
+
+// A parked repository is parked whatever a later record says, because no
+// transition re-enters one: resuming is a human act.
+func TestParkingBeatsAnyVerdictRecordedAfterIt(t *testing.T) {
+	campaign := t.TempDir()
+	repo := filepath.Join(campaign, "r")
+	writeArtifact(t, filepath.Join(repo, "index", "index.json"), "{}")
+	writeArtifact(t, filepath.Join(repo, "1", "handoff", "handoff.md"), "# handoff\n")
+	writeArtifact(t, filepath.Join(repo, "1", "author", "scenario.draft.yaml"), "name: r\n")
+	record(t, repo, Attempt{Cycle: 1, Phase: phase.Author, Verdict: phase.Draft, Try: 1})
+
+	p := read(t, campaign, "r")
+
+	if p.Standing != Parked {
+		t.Errorf("standing = %s, want %s", p.Standing, Parked)
+	}
+}
+
+// An unreadable tree is reported rather than read as an empty position, which
+// would be a repository at the start of its first cycle.
+func TestAnUnreadableTreeIsAnError(t *testing.T) {
+	campaign := t.TempDir()
+	blocked := filepath.Join(campaign, "r")
+	if err := os.WriteFile(blocked, []byte("not a directory"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Read(campaign, "r"); err == nil {
+		t.Fatal("a file where a repository should be read as a position")
+	}
+}
+
+// The page shows every rejection rather than the most recent one. A page that
+// showed the last would invite the next attempt to answer one thing.
+func TestTheRenderedPageCarriesEveryRejection(t *testing.T) {
+	page := Render(read(t, fixture, "midcycle"))
+
+	for _, want := range []string{"repo:     midcycle", "cycle:    2 of 6", "reached:  minibench",
+		"awaiting: author", "4 of 4", "no more discriminating"} {
+		if !strings.Contains(page, want) {
+			t.Errorf("page = %q, want it to carry %q", page, want)
+		}
+	}
+}
+
+// Nothing is left blank on the page: an unset phase and a real answer must not
+// print alike.
+func TestThePageNamesTheAbsenceOfAPhase(t *testing.T) {
+	page := Render(Position{Repo: "r", Cycle: 1, Standing: Ready, Because: "nothing yet"})
+
+	if strings.Contains(page, "reached:  \n") || strings.Contains(page, "awaiting: \n") {
+		t.Errorf("page = %q, want an absent phase to read as words", page)
+	}
+}
+
+func TestTheBankedCyclesAreOnThePageWhenThereAreAny(t *testing.T) {
+	if page := Render(Position{Repo: "r"}); strings.Contains(page, "banked") {
+		t.Errorf("page = %q, want no banked line for a repository with none", page)
+	}
+	if page := Render(Position{Repo: "r", Banked: []int{1}}); !strings.Contains(page, "banked:   [1]") {
+		t.Errorf("page = %q, want the banked cycle", page)
+	}
+}
+
+func writeArtifact(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func record(t *testing.T, repoDir string, a Attempt) {
+	t.Helper()
+	if err := Record(repoDir, a); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The ceiling parks from the verdict as well as from the artifact. The handoff
+// is written by the phase that runs next, so between the verdict and that phase
+// the position has to know already — otherwise a crank reads "ready" and opens
+// a seventh authoring cycle.
+func TestTheCeilingParksBeforeTheHandoffIsWritten(t *testing.T) {
+	campaign := t.TempDir()
+	repo := filepath.Join(campaign, "r")
+	writeArtifact(t, filepath.Join(repo, "index", "index.json"), "{}")
+	writeArtifact(t, filepath.Join(repo, strconv.Itoa(phase.AuthoringCeiling), "author", "scenario.draft.yaml"), "name: r\n")
+	record(t, repo, Attempt{Cycle: phase.AuthoringCeiling, Phase: phase.Author, Verdict: phase.NoAnchor, Try: 1,
+		Table: "nothing in this repository carries the question"})
+
+	p := read(t, campaign, "r")
+
+	if p.Standing != Parked || p.Awaiting != phase.Handoff {
+		t.Errorf("standing = %s awaiting %s, want it parked at the handoff", p.Standing, p.Awaiting)
+	}
+	if p.ToCeiling() != 0 {
+		t.Errorf("to the ceiling = %d, want none left", p.ToCeiling())
+	}
+}
+
+// A cycle that wrote everything owes nothing, and the walk says so rather than
+// naming a phase that is already done.
+func TestACycleThatWroteEverythingAwaitsNothing(t *testing.T) {
+	dir := t.TempDir()
+	for _, ph := range phase.Graph {
+		if ph.Name == phase.Index || ph.Name == phase.Handoff {
+			continue
+		}
+		writeArtifact(t, filepath.Join(dir, string(ph.Name), ph.Writes), "written\n")
+	}
+
+	reached, awaiting := walk(dir)
+
+	if reached != phase.Board || awaiting != phase.Done {
+		t.Errorf("reached %s awaiting %s, want the board reached and nothing owed", reached, awaiting)
+	}
+}
+
+// A repository directory holds things that are not cycles, and this walk does
+// not rule on them.
+func TestWhatIsNotACycleDirectoryIsNotACycle(t *testing.T) {
+	campaign := t.TempDir()
+	repo := filepath.Join(campaign, "r")
+	writeArtifact(t, filepath.Join(repo, "index", "index.json"), "{}")
+	// A file named like a cycle, which is what the directory check is for: a
+	// name that parses as a number is not a cycle unless it is a directory.
+	writeArtifact(t, filepath.Join(repo, "5"), "not a cycle\n")
+	writeArtifact(t, filepath.Join(repo, "notes.md"), "# by hand\n")
+	writeArtifact(t, filepath.Join(repo, "2", "author", "scenario.draft.yaml"), "name: r\n")
+
+	if p := read(t, campaign, "r"); p.Cycle != 2 {
+		t.Errorf("cycle = %d, want the one numbered directory", p.Cycle)
+	}
+}
+
+// An exit code is a claim; the artifact is the fact. A phase that started and
+// died leaves its directory behind, so the check has to be for the artifact the
+// phase owed and not for the directory it ran in.
+func TestAPhaseDirectoryWithoutItsArtifactIsNotAFinishedPhase(t *testing.T) {
+	campaign := t.TempDir()
+	repo := filepath.Join(campaign, "r")
+	writeArtifact(t, filepath.Join(repo, "index", "index.json"), "{}")
+	// What an agent that started and died leaves: the directory, and something
+	// in it that is not what it owed.
+	writeArtifact(t, filepath.Join(repo, "1", "author", "notes.txt"), "half a thought\n")
+	record(t, repo, Attempt{Cycle: 1, Phase: phase.Author, Verdict: phase.Draft, Try: 1})
+
+	p := read(t, campaign, "r")
+
+	if p.Standing != Missing {
+		t.Errorf("standing = %s (%s), want %s: the phase wrote no scenario", p.Standing, p.Because, Missing)
+	}
+	if p.Reached == phase.Author {
+		t.Error("reached = author; a directory is not an artifact")
+	}
+}
+
+// Past the ceiling there is nothing left to spend. A repository can be resumed
+// by hand into a cycle beyond it, and the count of what remains does not go
+// negative.
+func TestNothingIsLeftPastTheCeiling(t *testing.T) {
+	p := Position{Cycle: phase.AuthoringCeiling + 1}
+
+	if p.ToCeiling() != 0 {
+		t.Errorf("to the ceiling = %d, want none left", p.ToCeiling())
+	}
+}

--- a/lab/internal/position/testdata/README.md
+++ b/lab/internal/position/testdata/README.md
@@ -1,0 +1,14 @@
+# testdata
+
+One campaign, four repositories, one of each shape a real one takes: mid-cycle
+carrying two rejections, parked at the authoring ceiling, waiting at a `PAY`
+nothing has spent, and one that banked a cycle and re-entered into the next.
+
+The layout is copied from the jellyfin campaign's tree — `<repo>/index/`,
+`<repo>/<cycle>/<phase>/`, `<repo>/attempts/` — so what is asserted here is the
+shape that occurs rather than the shape that was convenient. The artifacts are
+trimmed to a line or two each: what position reads is whether they are there.
+
+`midcycle` carries two rejections on purpose. One would let a reader that kept
+only the most recent one pass, and carrying all of them is the property the
+package is written for.

--- a/lab/internal/position/testdata/campaign/atpay/1/author/scenario.draft.yaml
+++ b/lab/internal/position/testdata/campaign/atpay/1/author/scenario.draft.yaml
@@ -1,0 +1,2 @@
+name: atpay-dependents
+repo: atpay

--- a/lab/internal/position/testdata/campaign/atpay/1/expand/scenario.yaml
+++ b/lab/internal/position/testdata/campaign/atpay/1/expand/scenario.yaml
@@ -1,0 +1,2 @@
+name: atpay-dependents
+repo: atpay

--- a/lab/internal/position/testdata/campaign/atpay/1/minibench/minibench.md
+++ b/lab/internal/position/testdata/campaign/atpay/1/minibench/minibench.md
@@ -1,0 +1,3 @@
+# mini-bench
+
+Sense reached 6 of 8, the baseline 2 of 8. PROCEED.

--- a/lab/internal/position/testdata/campaign/atpay/1/preflight/preflight.json
+++ b/lab/internal/position/testdata/campaign/atpay/1/preflight/preflight.json
@@ -1,0 +1,1 @@
+{"gold_rows":18,"quarantined":0}

--- a/lab/internal/position/testdata/campaign/atpay/1/validate/pay-call.md
+++ b/lab/internal/position/testdata/campaign/atpay/1/validate/pay-call.md
@@ -1,0 +1,3 @@
+# pay call
+
+The credit table clears the floor on every row. PAY.

--- a/lab/internal/position/testdata/campaign/atpay/attempts/1-author-1.json
+++ b/lab/internal/position/testdata/campaign/atpay/attempts/1-author-1.json
@@ -1,0 +1,1 @@
+{"cycle":1,"phase":"author","verdict":"DRAFT","try":1}

--- a/lab/internal/position/testdata/campaign/atpay/attempts/1-expand-1.json
+++ b/lab/internal/position/testdata/campaign/atpay/attempts/1-expand-1.json
@@ -1,0 +1,1 @@
+{"cycle":1,"phase":"expand","verdict":"AUTO","try":1}

--- a/lab/internal/position/testdata/campaign/atpay/attempts/1-minibench-1.json
+++ b/lab/internal/position/testdata/campaign/atpay/attempts/1-minibench-1.json
@@ -1,0 +1,1 @@
+{"cycle":1,"phase":"minibench","verdict":"PROCEED","try":1}

--- a/lab/internal/position/testdata/campaign/atpay/attempts/1-preflight-1.json
+++ b/lab/internal/position/testdata/campaign/atpay/attempts/1-preflight-1.json
@@ -1,0 +1,1 @@
+{"cycle":1,"phase":"preflight","verdict":"AUTO","try":1}

--- a/lab/internal/position/testdata/campaign/atpay/attempts/1-validate-1.json
+++ b/lab/internal/position/testdata/campaign/atpay/attempts/1-validate-1.json
@@ -1,0 +1,1 @@
+{"cycle":1,"phase":"validate","verdict":"PAY","try":1}

--- a/lab/internal/position/testdata/campaign/atpay/index/index.json
+++ b/lab/internal/position/testdata/campaign/atpay/index/index.json
@@ -1,0 +1,1 @@
+{"repo":"atpay","revision":"cccc333","files":2137,"symbols":11410,"edges":23698,"embeddings":11410,"languages":{"csharp":{"files":2137,"symbols":11410,"tier":"standard"}},"sense_status":{}}

--- a/lab/internal/position/testdata/campaign/banked/1/author/scenario.draft.yaml
+++ b/lab/internal/position/testdata/campaign/banked/1/author/scenario.draft.yaml
@@ -1,0 +1,2 @@
+name: banked-dependents
+repo: banked

--- a/lab/internal/position/testdata/campaign/banked/1/board/board.md
+++ b/lab/internal/position/testdata/campaign/banked/1/board/board.md
@@ -1,0 +1,3 @@
+# board
+
++0.62 margin, confirmed.

--- a/lab/internal/position/testdata/campaign/banked/2/author/scenario.draft.yaml
+++ b/lab/internal/position/testdata/campaign/banked/2/author/scenario.draft.yaml
@@ -1,0 +1,2 @@
+name: banked-second-question
+repo: banked

--- a/lab/internal/position/testdata/campaign/banked/attempts/1-board-1.json
+++ b/lab/internal/position/testdata/campaign/banked/attempts/1-board-1.json
@@ -1,0 +1,1 @@
+{"cycle":1,"phase":"board","verdict":"AUTO","try":1}

--- a/lab/internal/position/testdata/campaign/banked/attempts/2-author-1.json
+++ b/lab/internal/position/testdata/campaign/banked/attempts/2-author-1.json
@@ -1,0 +1,1 @@
+{"cycle":2,"phase":"author","verdict":"DRAFT","try":1}

--- a/lab/internal/position/testdata/campaign/banked/index/index.json
+++ b/lab/internal/position/testdata/campaign/banked/index/index.json
@@ -1,0 +1,1 @@
+{"repo":"banked","revision":"dddd444","files":1200,"symbols":9000,"edges":15000,"embeddings":9000,"languages":{"ruby":{"files":1200,"symbols":9000,"tier":"full"}},"sense_status":{}}

--- a/lab/internal/position/testdata/campaign/midcycle/1/author/scenario.draft.yaml
+++ b/lab/internal/position/testdata/campaign/midcycle/1/author/scenario.draft.yaml
@@ -1,0 +1,2 @@
+name: midcycle-dependents
+repo: midcycle

--- a/lab/internal/position/testdata/campaign/midcycle/1/minibench/minibench.md
+++ b/lab/internal/position/testdata/campaign/midcycle/1/minibench/minibench.md
@@ -1,0 +1,3 @@
+# mini-bench
+
+The baseline reached the same four rows. REQUESTION.

--- a/lab/internal/position/testdata/campaign/midcycle/2/author/scenario.draft.yaml
+++ b/lab/internal/position/testdata/campaign/midcycle/2/author/scenario.draft.yaml
@@ -1,0 +1,2 @@
+name: midcycle-dependents
+repo: midcycle

--- a/lab/internal/position/testdata/campaign/midcycle/2/minibench/minibench.md
+++ b/lab/internal/position/testdata/campaign/midcycle/2/minibench/minibench.md
@@ -1,0 +1,3 @@
+# mini-bench
+
+Sense reached 3 of 8 and the baseline 3 of 8. REQUESTION.

--- a/lab/internal/position/testdata/campaign/midcycle/attempts/1-author-1.json
+++ b/lab/internal/position/testdata/campaign/midcycle/attempts/1-author-1.json
@@ -1,0 +1,1 @@
+{"cycle":1,"phase":"author","verdict":"DRAFT","try":1,"anchor":"MediaBrowser.Controller.Entities.BaseItem"}

--- a/lab/internal/position/testdata/campaign/midcycle/attempts/1-minibench-1.json
+++ b/lab/internal/position/testdata/campaign/midcycle/attempts/1-minibench-1.json
@@ -1,0 +1,1 @@
+{"cycle":1,"phase":"minibench","verdict":"REQUESTION","try":1,"table":"the baseline cited 4 of 4 discriminator rows; the question is not one Sense answers better","anchor":"MediaBrowser.Controller.Entities.BaseItem"}

--- a/lab/internal/position/testdata/campaign/midcycle/attempts/2-author-1.json
+++ b/lab/internal/position/testdata/campaign/midcycle/attempts/2-author-1.json
@@ -1,0 +1,1 @@
+{"cycle":2,"phase":"author","verdict":"DRAFT","try":1,"anchor":"MediaBrowser.Controller.Entities.BaseItem"}

--- a/lab/internal/position/testdata/campaign/midcycle/attempts/2-minibench-1.json
+++ b/lab/internal/position/testdata/campaign/midcycle/attempts/2-minibench-1.json
@@ -1,0 +1,1 @@
+{"cycle":2,"phase":"minibench","verdict":"REQUESTION","try":1,"table":"both arms cited the same 3 rows; the second question is no more discriminating than the first","anchor":"MediaBrowser.Controller.Entities.BaseItem"}

--- a/lab/internal/position/testdata/campaign/midcycle/index/index.json
+++ b/lab/internal/position/testdata/campaign/midcycle/index/index.json
@@ -1,0 +1,1 @@
+{"repo":"midcycle","revision":"aaaa111","files":902,"symbols":11830,"edges":24810,"embeddings":11830,"languages":{"csharp":{"files":902,"symbols":11830,"tier":"standard"}},"sense_status":{}}

--- a/lab/internal/position/testdata/campaign/parked/6/author/scenario.draft.yaml
+++ b/lab/internal/position/testdata/campaign/parked/6/author/scenario.draft.yaml
@@ -1,0 +1,2 @@
+name: parked-attempt
+repo: parked

--- a/lab/internal/position/testdata/campaign/parked/6/handoff/handoff.md
+++ b/lab/internal/position/testdata/campaign/parked/6/handoff/handoff.md
@@ -1,0 +1,3 @@
+# handoff
+
+Six authoring cycles, no anchor that carries a question. Parked for a human.

--- a/lab/internal/position/testdata/campaign/parked/attempts/6-author-1.json
+++ b/lab/internal/position/testdata/campaign/parked/attempts/6-author-1.json
@@ -1,0 +1,1 @@
+{"cycle":6,"phase":"author","verdict":"NO-ANCHOR","try":1,"table":"no symbol in this repository carries a question the baseline cannot answer"}

--- a/lab/internal/position/testdata/campaign/parked/index/index.json
+++ b/lab/internal/position/testdata/campaign/parked/index/index.json
@@ -1,0 +1,1 @@
+{"repo":"parked","revision":"bbbb222","files":410,"symbols":5120,"edges":9000,"embeddings":5120,"languages":{"go":{"files":410,"symbols":5120,"tier":"full"}},"sense_status":{}}

--- a/lab/plans/author.md
+++ b/lab/plans/author.md
@@ -3,6 +3,7 @@ phase: author
 reads: slate.md
 writes: scenario.draft.yaml
 emits: [DRAFT, NO-ANCHOR]
+wall: 30m
 ---
 
 # author
@@ -309,3 +310,16 @@ ported into this tree. Naming a path that does not exist would be worse than nam
 computation, because a plan is followed literally. **Cycle 07 binds each step to its command, and
 until it does this plan is followed by hand.** Recorded rather than quietly dropped: the exact
 commands are the part of this plan most likely to be lost in the move.
+
+## Verdict
+
+Write `verdict.json` in this phase's directory, beside the artifact:
+
+```json
+{"phase": "author", "repo": "<repo id>", "cycle": <n>, "verdict": "<one of the emitted>",
+ "table": "<why, in one or two sentences>",
+ "anchor": "<the symbol this attempt is anchored on>"}
+```
+
+The crank reads that file and nothing else to route. A verdict left in prose is a verdict only a
+person can act on, and the loop this phase belongs to runs unattended.

--- a/lab/plans/bench.md
+++ b/lab/plans/bench.md
@@ -3,6 +3,7 @@ phase: bench
 reads: scenario.yaml
 writes: cells.json
 emits: [AUTO]
+wall: 90m
 ---
 
 # bench
@@ -58,3 +59,15 @@ name the arms that are burned or have no result.
 - Do not re-run an arm to get a better number. One retry, never a loop, and a replaced run is
   never scored.
 - Do not spawn a subagent. Only the binary spawns.
+
+## Verdict
+
+Write `verdict.json` in this phase's directory, beside the artifact:
+
+```json
+{"phase": "bench", "repo": "<repo id>", "cycle": <n>, "verdict": "<one of the emitted>",
+ "table": "<why, in one or two sentences>"}
+```
+
+The crank reads that file and nothing else to route. A verdict left in prose is a verdict only a
+person can act on, and the loop this phase belongs to runs unattended.

--- a/lab/plans/board.md
+++ b/lab/plans/board.md
@@ -3,6 +3,7 @@ phase: board
 reads: harvest.json
 writes: board.md
 emits: [AUTO]
+wall: 15m
 ---
 
 # board
@@ -52,3 +53,15 @@ of every arm, and the build the headline column was banked at.
 - Do not re-round a figure, and do not write one that is not in the harvest record.
 - Do not omit an arm because it did poorly. A never-routed arm is a finding.
 - Do not spawn a subagent. Only the binary spawns.
+
+## Verdict
+
+Write `verdict.json` in this phase's directory, beside the artifact:
+
+```json
+{"phase": "board", "repo": "<repo id>", "cycle": <n>, "verdict": "<one of the emitted>",
+ "table": "<why, in one or two sentences>"}
+```
+
+The crank reads that file and nothing else to route. A verdict left in prose is a verdict only a
+person can act on, and the loop this phase belongs to runs unattended.

--- a/lab/plans/expand.md
+++ b/lab/plans/expand.md
@@ -3,6 +3,7 @@ phase: expand
 reads: minibench.md
 writes: scenario.yaml
 emits: [AUTO, REQUESTION]
+wall: 25m
 ---
 
 # expand
@@ -128,3 +129,15 @@ hole in the test set rather than a plan to bend around it.
 The old plan also named its passing verdict `SCENARIO`. That is `AUTO` here, since the graph's
 auto phases are the ones that make no judgement, and this one does not: it either carries the
 discriminator over or it re-questions.
+
+## Verdict
+
+Write `verdict.json` in this phase's directory, beside the artifact:
+
+```json
+{"phase": "expand", "repo": "<repo id>", "cycle": <n>, "verdict": "<one of the emitted>",
+ "table": "<why, in one or two sentences>"}
+```
+
+The crank reads that file and nothing else to route. A verdict left in prose is a verdict only a
+person can act on, and the loop this phase belongs to runs unattended.

--- a/lab/plans/handoff.md
+++ b/lab/plans/handoff.md
@@ -3,6 +3,7 @@ phase: handoff
 reads: campaign.json
 writes: handoff.md
 emits: [AUTO]
+wall: 20m
 ---
 
 # handoff
@@ -119,3 +120,15 @@ six more cycles.
 ## Questioned, not changed
 
 Nothing yet.
+
+## Verdict
+
+Write `verdict.json` in this phase's directory, beside the artifact:
+
+```json
+{"phase": "handoff", "repo": "<repo id>", "cycle": <n>, "verdict": "<one of the emitted>",
+ "table": "<why, in one or two sentences>"}
+```
+
+The crank reads that file and nothing else to route. A verdict left in prose is a verdict only a
+person can act on, and the loop this phase belongs to runs unattended.

--- a/lab/plans/harvest.md
+++ b/lab/plans/harvest.md
@@ -3,6 +3,7 @@ phase: harvest
 reads: report.md
 writes: harvest.json
 emits: [WIN CONFIRMED, DoD FAIL]
+wall: 30m
 ---
 
 # harvest
@@ -84,3 +85,15 @@ Every check here is one that a recorded campaign needed.
 **The RUN steps name what to compute, not which script to invoke**, because those scripts are not
 ported into this tree yet and a plan that names a path which does not exist is worse than one that
 names the computation. Cycle 07 binds each step to its command. See `author.md` for the full note.
+
+## Verdict
+
+Write `verdict.json` in this phase's directory, beside the artifact:
+
+```json
+{"phase": "harvest", "repo": "<repo id>", "cycle": <n>, "verdict": "<one of the emitted>",
+ "table": "<why, in one or two sentences>"}
+```
+
+The crank reads that file and nothing else to route. A verdict left in prose is a verdict only a
+person can act on, and the loop this phase belongs to runs unattended.

--- a/lab/plans/index.md
+++ b/lab/plans/index.md
@@ -3,6 +3,7 @@ phase: index
 reads: repo.json
 writes: index.json
 emits: [AUTO]
+wall: 20m
 ---
 
 # index
@@ -54,3 +55,15 @@ returned.
 - Do not read the SQLite index directly. Sense is reached through the MCP server, because that
   is the channel the benched agent actually has.
 - Do not spawn a subagent. Only the binary spawns.
+
+## Verdict
+
+Write `verdict.json` in this phase's directory, beside the artifact:
+
+```json
+{"phase": "index", "repo": "<repo id>", "cycle": <n>, "verdict": "<one of the emitted>",
+ "table": "<why, in one or two sentences>"}
+```
+
+The crank reads that file and nothing else to route. A verdict left in prose is a verdict only a
+person can act on, and the loop this phase belongs to runs unattended.

--- a/lab/plans/minibench.md
+++ b/lab/plans/minibench.md
@@ -3,6 +3,7 @@ phase: minibench
 reads: scenario.draft.yaml
 writes: minibench.md
 emits: [PROCEED, REQUESTION, NO-ANCHOR]
+wall: 40m
 ---
 
 # minibench
@@ -133,3 +134,16 @@ produced it or it is not a delta.
 **The RUN steps name what to compute, not which script to invoke**, because those scripts are not
 ported into this tree yet and a plan that names a path which does not exist is worse than one that
 names the computation. Cycle 07 binds each step to its command. See `author.md` for the full note.
+
+## Verdict
+
+Write `verdict.json` in this phase's directory, beside the artifact:
+
+```json
+{"phase": "minibench", "repo": "<repo id>", "cycle": <n>, "verdict": "<one of the emitted>",
+ "table": "<why, in one or two sentences>",
+ "anchor": "<the symbol this attempt is anchored on>"}
+```
+
+The crank reads that file and nothing else to route. A verdict left in prose is a verdict only a
+person can act on, and the loop this phase belongs to runs unattended.

--- a/lab/plans/preflight.md
+++ b/lab/plans/preflight.md
@@ -3,6 +3,7 @@ phase: preflight
 reads: scenario.yaml
 writes: preflight.json
 emits: [AUTO]
+wall: 15m
 ---
 
 # preflight
@@ -63,3 +64,15 @@ Two recorded failures have this shape:
 
 - Do not spend anything. This phase reads configuration.
 - Do not spawn a subagent. Only the binary spawns.
+
+## Verdict
+
+Write `verdict.json` in this phase's directory, beside the artifact:
+
+```json
+{"phase": "preflight", "repo": "<repo id>", "cycle": <n>, "verdict": "<one of the emitted>",
+ "table": "<why, in one or two sentences>"}
+```
+
+The crank reads that file and nothing else to route. A verdict left in prose is a verdict only a
+person can act on, and the loop this phase belongs to runs unattended.

--- a/lab/plans/report.md
+++ b/lab/plans/report.md
@@ -3,6 +3,7 @@ phase: report
 reads: cells.json
 writes: report.md
 emits: [WIN, DIAGNOSIS]
+wall: 30m
 ---
 
 # report
@@ -98,3 +99,15 @@ report phase, and the reading of what the numbers mean sits in it. The split is 
 it had a reason — the reading was written after the figures were fixed, so no figure could be
 chosen to suit the sentence — and that property is held here by the rule that every claim is
 quoted output rather than by a phase boundary. Recorded rather than resolved.
+
+## Verdict
+
+Write `verdict.json` in this phase's directory, beside the artifact:
+
+```json
+{"phase": "report", "repo": "<repo id>", "cycle": <n>, "verdict": "<one of the emitted>",
+ "table": "<why, in one or two sentences>"}
+```
+
+The crank reads that file and nothing else to route. A verdict left in prose is a verdict only a
+person can act on, and the loop this phase belongs to runs unattended.

--- a/lab/plans/validate.md
+++ b/lab/plans/validate.md
@@ -3,6 +3,7 @@ phase: validate
 reads: scenario.yaml
 writes: pay-call.md
 emits: [PAY, DO-NOT-PAY]
+wall: 25m
 ---
 
 # validate
@@ -121,3 +122,15 @@ authoring phase rewrites it in place against this credit table.
 **The RUN steps name what to compute, not which script to invoke**, because those scripts are not
 ported into this tree yet and a plan that names a path which does not exist is worse than one that
 names the computation. Cycle 07 binds each step to its command. See `author.md` for the full note.
+
+## Verdict
+
+Write `verdict.json` in this phase's directory, beside the artifact:
+
+```json
+{"phase": "validate", "repo": "<repo id>", "cycle": <n>, "verdict": "<one of the emitted>",
+ "table": "<why, in one or two sentences>"}
+```
+
+The crank reads that file and nothing else to route. A verdict left in prose is a verdict only a
+person can act on, and the loop this phase belongs to runs unattended.


### PR DESCRIPTION
Stacked on #299, which is stacked on #298. Merge in order; this PR's diff is only its own changes.

## Problem

Nothing in the binary spawns a phase agent. `internal/loop` has no importer, the eleven files in `lab/plans/` are opened by a human, and the routing rules cycle 05 built and tested are exercised in production by an operator remembering them.

That operator is the leak. Six authoring cycles on one repository is roughly thirty hand-spawns, each one an opportunity to skip the plan, read only the latest rejection, or advance on an agent that produced a confident summary and no artifact. "The authoring cycle is unattended and bounded" is a law, and it currently describes an intention.

## Summary

`Advance` takes a context and a repository id, and nothing else. It reads a position, runs the one phase that comes next, guards what came back, records it and returns. `-until` is a loop in the caller around that call, so no mode is threaded through the dispatcher.

A phase reports its own verdict, which makes every phase an unreliable narrator about itself. Four things about identity are checked against the job that was dispatched and the plan that was declared — the verdict names this phase, this repository and this cycle, and carries a verdict the plan declares — and then the one thing that is not the phase talking: the artifact it owed is on disk, or nothing advances.

Two numbers left Go. A phase's wall is declared beside the plan its agent runs, because a wall held in a variable is the number that gets raised in a hurry to rescue a stalled phase. And a verdict is now a document a program can read, rather than prose inside an artifact.

The crank stops at the pay call. `PAY` prints the exact command and exits waiting on a human; bench, report, harvest and board stay hand-run, because an unattended loop that can reach a paid cell is a different product with a different risk.

## Changes

- `lab/internal/crank`: the dispatcher, the verdict document and the guard
- `lab/internal/cli/crankcmd.go`: the real spawner, at the edge — a disposable environment carrying no more than a run arm's credential, the agent spawned in the repository under study under its declared wall
- `lab/internal/plans`: a `wall:` key in the plan header; each plan gains the verdict document it owes
- `lab/internal/position`: an attempt records how it ended when it produced no verdict, and where it sits in its cycle
- `.golangci.yml`: the deciding packages may not import `os/exec`, enforced by the linter rather than by review

## A defect this found

Ordered by the graph, a re-entered author sorted *before* the mini-bench that sent it back, so the position routed from the rejection on every turn and `-until` would have re-run the same phase forever, at whatever an agent costs. Attempts now record their place in the cycle, and both the ordering and the turn after a re-entry are asserted.

## Test plan

- `make ci` green: coverage floor with no new exception, zero complexity suppressions, lint clean
- new files hold 95.9–100% line coverage
- the whole crank is exercised with a fake spawner: every lever the crank can reach, the ceiling, a `PAY`, a stalled phase, a refused verdict and a missing artifact — no agent, no network, no spend
- the levers past the pay call are asserted to be refused rather than skipped, against a list written down in the test rather than read from the one the crank uses
- end to end through a real subprocess: a stand-in agent walks author → mini-bench → expand → preflight → validate and stops at the pay call; the credential that reached it is asserted on the document it was handed; an agent that sleeps past a one-second declared wall is recorded as out of clock; an agent that writes no artifact does not advance
- seven mutations that the first draft of the tests let through are now killed, each verified by making the mutation and watching a named test fail
- nothing in the run path reads a terminal, checked over the source